### PR TITLE
dev/core#111 Convert MembershipType form to use API (for custom data support)

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1543,6 +1543,18 @@ INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
   }
 
   /**
+   * Checks if payment processor supports recurring contributions
+   *
+   * @return bool
+   */
+  public function supportsRecurring() {
+    if (!empty($this->_paymentProcessor['is_recur'])) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Should a receipt be sent out for a pending payment.
    *
    * e.g for traditional pay later & ones with a delayed settlement a pending receipt makes sense.

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -422,6 +422,7 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    *  - supportsBackOffice
    *  - supportsLiveMode
    *  - supportsFutureRecurDate
+   *  - supportsRecurring
    *  - supportsCancelRecurring
    *  - supportsRecurContributionsForPledges
    *

--- a/CRM/Member/Form/MembershipConfig.php
+++ b/CRM/Member/Form/MembershipConfig.php
@@ -69,7 +69,6 @@ class CRM_Member_Form_MembershipConfig extends CRM_Core_Form {
    * Set default values for the form. MobileProvider that in edit/view mode
    * the default values are retrieved from the database
    *
-   *
    * @return array
    *   defaults
    */

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1117,7 +1117,7 @@ function _civicrm_api3_format_params_for_create(&$params, $entity) {
   }
   $values = array();
   _civicrm_api3_custom_format_params($params, $values, $entity);
-  $params = array_merge($params, $values);
+  $params = CRM_Utils_Array::crmArrayMerge($params, $values);
 }
 
 /**

--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -150,6 +150,19 @@
       </div>
     </fieldset>
 
+    <div id="customData"></div>
+    {*include custom data js file*}
+    {include file="CRM/common/customData.tpl"}
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function($) {
+        {/literal}
+        CRM.buildCustomData( '{$customDataType}' );
+        {literal}
+      });
+    </script>
+  {/literal}
+
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   {/if}
     <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Convert the MembershipType form to use the API instead of the BAO directly.  This means we can use generic custom data support.

Before
----------------------------------------
MembershipType form uses BAO directly and doesn't support custom data.

After
----------------------------------------
MembershipType form uses MembershipType.create API and supports custom data.

Technical Details
----------------------------------------
The change in api/v3/utils.php from array_merge to CRM_Utils_Array::crmArrayMerge is because array_merge does not do a recursive merge and $params['custom'] gets lost if $values['custom'] is an empty array