### PR TITLE
Preliminary tidy up of  MembershipType form (towards custom data support)

### DIFF
--- a/CRM/Member/Form/MembershipConfig.php
+++ b/CRM/Member/Form/MembershipConfig.php
@@ -69,7 +69,6 @@ class CRM_Member_Form_MembershipConfig extends CRM_Core_Form {
    * Set default values for the form. MobileProvider that in edit/view mode
    * the default values are retrieved from the database
    *
-   *
    * @return array
    *   defaults
    */

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
  *
  */
 
@@ -61,8 +60,8 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
    * Set default values for the form. MobileProvider that in edit/view mode
    * the default values are retrieved from the database
    *
-   *
-   * @return void
+   * @return array
+   *   defaults
    */
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
@@ -111,7 +110,6 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
    * @return void
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
-   * @throws \HTML_QuickForm_Error
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
@@ -330,9 +328,9 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
         'max_related',
       );
 
-      $params = $ids = array();
+      $params = array();
       foreach ($fields as $fld) {
-        $params[$fld] = CRM_Utils_Array::value($fld, $submitted, 'NULL');
+        $params[$fld] = CRM_Utils_Array::value($fld, $submitted, 'null');
       }
 
       if ($params['minimum_fee']) {
@@ -360,7 +358,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
         }
       }
       if (!$hasRelTypeVal) {
-        $params['relationship_type_id'] = $params['relationship_direction'] = $params['max_related'] = 'NULL';
+        $params['relationship_type_id'] = $params['relationship_direction'] = $params['max_related'] = 'null';
       }
 
       if ($params['duration_unit'] == 'lifetime' &&
@@ -370,20 +368,20 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       }
 
       $periods = array('fixed_period_start_day', 'fixed_period_rollover_day');
-      foreach ($periods as $per) {
-        if (!empty($params[$per]['M']) && !empty($params[$per]['d'])) {
-          $mon = $params[$per]['M'];
-          $dat = $params[$per]['d'];
+      foreach ($periods as $period) {
+        if (!empty($params[$period]['M']) && !empty($params[$period]['d'])) {
+          $mon = $params[$period]['M'];
+          $dat = $params[$period]['d'];
           $mon = ($mon < 10) ? '0' . $mon : $mon;
           $dat = ($dat < 10) ? '0' . $dat : $dat;
-          $params[$per] = $mon . $dat;
+          $params[$period] = $mon . $dat;
         }
-        elseif ($per == 'fixed_period_rollover_day' && !empty($params['month_fixed_period_rollover_day'])) {
+        elseif ($period == 'fixed_period_rollover_day' && !empty($params['month_fixed_period_rollover_day'])) {
           $params['fixed_period_rollover_day'] = $params['month_fixed_period_rollover_day']['d'];
           unset($params['month_fixed_period_rollover_day']);
         }
         else {
-          $params[$per] = 'NULL';
+          $params[$period] = 'null';
         }
       }
       $oldWeight = NULL;
@@ -398,10 +396,10 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       );
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
-        $ids['membershipType'] = $this->_id;
+        $params['id'] = $this->_id;
       }
 
-      $membershipType = CRM_Member_BAO_MembershipType::add($params, $ids);
+      $membershipType = CRM_Member_BAO_MembershipType::add($params);
 
       CRM_Core_Session::setStatus(ts('The membership type \'%1\' has been saved.',
         array(1 => $membershipType->name)


### PR DESCRIPTION
Overview
----------------------------------------
Code tidy up (toward work to make custom data available on more forms, if enabled via an extension). Note this is a partial reviewers commit of #12118 - there are still some issues I want to work through but this reduces some 'noise' from those issues

Before
----------------------------------------
no change

After
----------------------------------------
no change

Technical Details
----------------------------------------
This is a reviewers commit on the portion of #12118 that I have reviewed & found straightforward. Adding merge-on-pass.

Changes are
1) using 'null' rather than 'NULL' for api support
2) renaming a variable for readability
3) passing $params['id'] rather than the deprecated $ids['membershipType']

Comments
----------------------------------------
These changes are preliminary to switching to using the api rather than the BAO function, which is necessary to support custom data on entities that are not enabled in core (we are not anticipating new ones would be enabled in core but extensions can now enable custom data on 'almost' any entity by adding a value to the cg_extends option group'
