### PR TITLE
[NFC] Fix leakage of Form entity

### DIFF
--- a/CRM/Member/Form/MembershipConfig.php
+++ b/CRM/Member/Form/MembershipConfig.php
@@ -53,13 +53,6 @@ class CRM_Member_Form_MembershipConfig extends CRM_Core_Form {
    */
   protected $_BAOName;
 
-  /**
-   * Explicitly declare the entity api name.
-   */
-  public function getDefaultEntity() {
-    return 'MembershipType';
-  }
-
   public function preProcess() {
     $this->_id = $this->get('id');
     $this->_BAOName = $this->get('BAOName');

--- a/CRM/Member/Form/MembershipStatus.php
+++ b/CRM/Member/Form/MembershipStatus.php
@@ -29,15 +29,27 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
- *
  */
 
 /**
  * This class generates form components for Membership Type
- *
  */
 class CRM_Member_Form_MembershipStatus extends CRM_Member_Form_MembershipConfig {
+
+
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'MembershipStatus';
+  }
+
+  /**
+   * Explicitly declare the form context.
+   */
+  public function getDefaultContext() {
+    return 'create';
+  }
 
   /**
    * Set default values for the form. MobileProvider that in edit/view mode

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -39,6 +39,21 @@
  */
 class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
 
+
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'MembershipType';
+  }
+
+  /**
+   * Explicitly declare the form context.
+   */
+  public function getDefaultContext() {
+    return 'create';
+  }
+
   /**
    * Max number of contacts we will display for membership-organisation
    */


### PR DESCRIPTION
Overview
----------------------------------------
Minor tidy up - move definition of form entity to the forms being altered rather than the shared form. The MembershipStatus form is incorrectly inheriting 'MembershipType' as the default entity from the shared parent

Before
----------------------------------------
No change

After
----------------------------------------
No change

Technical Details
----------------------------------------
This will not be having an impact on the forms as they don't use addField (yet). Code clean up only

Comments
----------------------------------------
Also added in the default context of create
