### PR TITLE
Use getter function for entity id as on some forms  is protected.

### DIFF
--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -54,17 +54,18 @@ class CRM_Custom_Form_CustomData {
    */
   public static function addToForm(&$form, $subType = NULL, $subName = NULL, $groupCount = 1) {
     $entityName = $form->getDefaultEntity();
+    $entityID = $form->getEntityId();
 
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {
-      self::preProcess($form, $subName, $subType, $groupCount, $entityName, $form->_id);
+      self::preProcess($form, $subName, $subType, $groupCount, $entityName, $entityID);
       self::buildQuickForm($form);
       self::setDefaultValues($form);
     }
     // need to assign custom data type and subtype to the template
     $form->assign('customDataType', $entityName);
     $form->assign('customDataSubType', $subType);
-    $form->assign('entityID', $form->_id);
+    $form->assign('entityID', $entityID);
   }
 
   /**

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -112,6 +112,15 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   );
 
   /**
+   * Get the entity id being edited.
+   *
+   * @return int|null
+   */
+  public function getEntityId() {
+    return $this->_id;
+  }
+
+  /**
    * Get selected membership type from the form values.
    *
    * @param array $priceSet


### PR DESCRIPTION
Overview
----------------------------------------
Use a getter function to access $this-_id as on some forms it is protected. Follow up to Follow up to https://github.com/civicrm/civicrm-core/pull/12095

Before
----------------------------------------
No change

After
----------------------------------------
no change

Technical Details
----------------------------------------
The affected function was extracted in #12095 & is only called from one place. This is a trivial tweak to it

Comments
----------------------------------------
@mattwire 