### PR TITLE
Permit UI editing of custom data on other entities (here relationship_type) when enabled in an extension

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -269,7 +269,17 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->addClass(CRM_Utils_System::getClassName($this));
 
     $this->assign('snippet', CRM_Utils_Array::value('snippet', $_GET));
+    $this->setTranslatedFields();
   }
+
+  /**
+   * Set translated fields.
+   *
+   * This function is called from the class constructor, allowing us to set
+   * fields on the class that can't be set as properties due to need for
+   * translation or other non-input specific handling.
+   */
+  protected function setTranslatedFields() {}
 
   /**
    * Add one or more css classes to the form.

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -1,0 +1,169 @@
+<?php
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.7                                                |
+  +--------------------------------------------------------------------+
+  | Copyright CiviCRM LLC (c) 2004-2018                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ */
+
+trait CRM_Core_Form_EntityFormTrait {
+  /**
+   * Get entity fields for the entity to be added to the form.
+   *
+   * @var array
+   */
+  public function getEntityFields() {
+    return $this->entityFields;
+  }
+
+  /**
+   * Explicitly declare the form context.
+   */
+  public function getDefaultContext() {
+    return 'create';
+  }
+
+  /**
+   * Get entity fields for the entity to be added to the form.
+   *
+   * @var array
+   */
+  public function getDeleteMessage() {
+    return $this->deleteMessage;
+  }
+
+  /**
+   * Get the entity id being edited.
+   *
+   * @return int|null
+   */
+  public function getEntityId() {
+    return $this->_id;
+  }
+  /**
+   * If the custom data is in the submitted data (eg. added via ajax loaded form) add to form.
+   */
+  public function addCustomDataToForm() {
+    $customisableEntities = CRM_Core_SelectValues::customGroupExtends();
+    if (isset($customisableEntities[$this->getDefaultEntity()])) {
+      CRM_Custom_Form_CustomData::addToForm($this);
+    }
+  }
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickEntityForm() {
+    if ($this->_action & CRM_Core_Action::DELETE) {
+      $this->buildDeleteForm();
+      return;
+    }
+    $this->applyFilter('__ALL__', 'trim');
+    $this->addEntityFieldsToTemplate();
+    $this->assign('entityFields', $this->entityFields);
+    $this->assign('entityID', $this->getEntityId());
+    $this->assign('entityInClassFormat', strtolower(str_replace('_', '-', $this->getDefaultEntity())));
+    $this->assign('entityTable', CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($this->getDefaultEntity())));
+    $this->addCustomDataToForm();
+    $this->addFormButtons();
+  }
+
+  /**
+   * Build the form for any deletion.
+   */
+  protected function buildDeleteForm() {
+    $this->assign('deleteMessage', $this->getDeleteMessage());
+    $this->addFormButtons();
+  }
+
+  /**
+   * Add relevant buttons to the form.
+   */
+  protected function addFormButtons() {
+    if ($this->_action & CRM_Core_Action::VIEW || $this->_action & CRM_Core_Action::PREVIEW) {
+      $this->addButtons(array(
+          array(
+            'type' => 'cancel',
+            'name' => ts('Done'),
+            'isDefault' => TRUE,
+          ),
+        )
+      );
+    }
+    else {
+      $this->addButtons(array(
+          array(
+            'type' => 'next',
+            'name' => $this->_action & CRM_Core_Action::DELETE ? ts('Delete') : ts('Save'),
+            'isDefault' => TRUE,
+          ),
+          array(
+            'type' => 'cancel',
+            'name' => ts('Cancel'),
+          ),
+        )
+      );
+    }
+  }
+
+  /**
+   * Set translated fields.
+   *
+   * This function is called from the class constructor, allowing us to set
+   * fields on the class that can't be set as properties due to need for
+   * translation or other non-input specific handling.
+   */
+  protected function setTranslatedFields() {
+    $this->setEntityFields();
+    $this->setDeleteMessage();
+    $metadata = civicrm_api3($this->getDefaultEntity(), 'getfields', ['action' => 'create']);
+    $this->metadata = $metadata['values'];
+    foreach ($this->metadata as $fieldName => $spec) {
+      if (isset($this->entityFields[$fieldName])) {
+        if ($spec['localizable']) {
+          $this->entityFields[$fieldName]['is_add_translate_dialog'] = TRUE;
+        }
+        if (empty($spec['html'])) {
+          $this->entityFields[$fieldName]['not-auto-addable'] = TRUE;
+        }
+      }
+    }
+  }
+
+  /**
+   * Add defined entity field to template.
+   */
+  protected function addEntityFieldsToTemplate() {
+    foreach ($this->getEntityFields() as $fieldSpec) {
+      if (empty($fieldSpec['not-auto-addable'])) {
+        $this->addField($fieldSpec['name']);
+      }
+    }
+  }
+
+}

--- a/templates/CRM/Core/Form/EntityForm.tpl
+++ b/templates/CRM/Core/Form/EntityForm.tpl
@@ -23,5 +23,24 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* this template is used for adding/editing relationship types  *}
-{include file="CRM/Core/Form/EntityForm.tpl"}
+{* this template is used for adding/editing entities  *}
+<div class="crm-block crm-form-block crm-{$entityInClassFormat}-form-block">
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+  {if $action eq 8}
+    <div class="messages status no-popup">
+      <div class="icon inform-icon"></div>
+      {$deleteMessage|escape}
+    </div>
+  {else}
+    <table class="form-layout-compressed">
+      {foreach from=$entityFields item=fieldSpec}
+        {assign var=fieldName value=$fieldSpec.name}
+        <tr class="crm-{$entityInClassFormat}-form-block-{$fieldName}">
+          {include file="CRM/Core/Form/Field.tpl"}
+        </tr>
+      {/foreach}
+    </table>
+    {include file="CRM/common/customDataBlock.tpl"}
+  {/if}
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -23,5 +23,17 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* this template is used for adding/editing relationship types  *}
-{include file="CRM/Core/Form/EntityForm.tpl"}
+{if $fieldSpec.template}
+  {include file=$fieldSpec.template}
+{else}
+  <td class="label">{$form.$fieldName.label}
+    {if $fieldSpec.help}{assign var=help value=$fieldSpec.help}{capture assign=helpFile}{if $fieldSpec.help}
+      {$fieldSpec.help}
+    {else}''{/if}
+    {/capture}{help id=$help.id file=$help.file}{/if}
+    {if $action == 2 && $fieldSpec.is_add_translate_dialog}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
+  </td>
+  <td>{if $form.$fieldName.html}{if $fieldSpec.formatter === 'crmMoney'}{$form.$fieldName.html|crmMoney}{else}{$form.$fieldName.html}{/if}{else}{$fieldSpec.place_holder}{/if}<br />
+    {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
+  </td>
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Allow custom data to be added to relationship type form via extension & all fields on the form to be modified by extension

Before
----------------------------------------
Limited extension options

After
----------------------------------------
Form can be controlled from extensions - including adding custom data.

Technical Details
----------------------------------------
This is an effort at a way to genericise core forms that basically exist to do crud on an entity. We have a
number of fairly straight forward forms of this type in core and, in order to allow extensions to use
custom fields on a range of entities we should support editing custom data on these core crud forms.

To add custom data support to an entity we need to
a) add the custom data to the form using CRM_Custom_Form_CustomData::addToForm($this);
b) ensure that the entity is saved using an api call not a BAO call
c) add the custom data block to the tpl file - ie  {include file="CRM/common/customDataBlock.tpl"}

(the above is possible due to previous work to add support & simplify)

In this PR the adding of the customData is done in the EntityFormTrait, the api is previously converted
and the custom data is included by using a generic tpl to support metadata applied to the form.

By using metadata on the form we can also give extension writers a lot more control over what
is on the form as they can add to, alter, or remove the metadata in a php hook. This
is the crux of this issue #12078 & it likewise is
looking to use a generic field template to add fields based on metadata. A key difference between the 2 prs
is that one uses divs & the other a table & that might preclude close sharing of the approach.

Example of how to enable custom fields for RelationshipType in an extension.
```
      civicrm_api3('OptionValue', 'create', [
        'option_group_id' => 'cg_extend_objects',
        'name' => 'civicrm_relationship_type',
        'label' => ts('Relationship Type'),
        'value' => 'RelationshipType',
      ]);
```

Comments
----------------------------------------

