### PR TITLE
 dev/drupal#17: Add Drupal8 support for getUFLocale()

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -529,6 +529,11 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @inheritDoc
    */
   public function getUFLocale() {
+    // Drupal might not be bootstrapped if being called by the REST API.
+    if (!class_exists('Drupal')) {
+      return NULL;
+    }
+
     // return CiviCRM’s xx_YY locale that either matches Drupal’s Chinese locale
     // (for CRM-6281), Drupal’s xx_YY or is retrieved based on Drupal’s xx
     // sometimes for CLI based on order called, this might not be set and/or empty

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -528,6 +528,34 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
+  public function getUFLocale() {
+    // return CiviCRM’s xx_YY locale that either matches Drupal’s Chinese locale
+    // (for CRM-6281), Drupal’s xx_YY or is retrieved based on Drupal’s xx
+    // sometimes for CLI based on order called, this might not be set and/or empty
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    if (empty($language)) {
+      return NULL;
+    }
+
+    if ($language == 'zh-hans') {
+      return 'zh_CN';
+    }
+
+    if ($language == 'zh-hant') {
+      return 'zh_TW';
+    }
+
+    if (preg_match('/^.._..$/', $language)) {
+      return $language;
+    }
+
+    return CRM_Core_I18n_PseudoConstant::longForShort(substr($language, 0, 2));
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getLoggedInUfID() {
     if ($id = \Drupal::currentUser()->id()) {
       return $id;


### PR DESCRIPTION
Overview
----------------------------------------

This makes it possible to support multilingual Drupal8. For example, if a site is available in both French and English, using prefix-based language detection in Drupal8, CiviCRM will automatically select the correct locale as well (i.e. "inheritLocale").

Drupal7 used global variables for language, whereas Drupal8 uses more clearly defined functions. Hence this was not clearly failing before.

To reproduce:

* Enable Drupal locale, bilingual site, enable multi-lingual in CiviCRM, add FR/EN.
* Create a public profile in CiviCRM
* Translate the profile field labels
* Access in French/English.

https://lab.civicrm.org/dev/drupal/issues/17

Before
----------------------------------------

The forms were always in the default site language.

After
----------------------------------------

The forms are in the language of the user.