### PR TITLE
(dev/core/98) Searching by any Address fields with location type other than primary throw DB error

### DIFF
--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -72,9 +72,12 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
     }
     // Ensure that search builder return individual contact as per criteria
     if (!empty($dataSet['context'] == 'builder')) {
-      $contactID = $this->individualCreate();
+      $contactID = $this->individualCreate(['first_name' => 'James', 'last_name' => 'Bond']);
       $rows = $selector->getRows(CRM_Core_Action::VIEW, 0, 50, '');
       $this->assertEquals(1, count($rows));
+      $sortChar = $selector->alphabetQuery()->fetchAll();
+      // sort name is stored in '<last_name>, <first_name>' format, as per which the first character would be B of Bond
+      $this->assertEquals('B', $sortChar[0]['sort_name']);
       $this->assertEquals($contactID, key($rows));
     }
   }


### PR DESCRIPTION
Backport https://github.com/civicrm/civicrm-core/pull/12074/files as this has been confirmed to fix the regression reported on 5.0 & 5.1 (from 4.7.31 or similar) https://lab.civicrm.org/dev/core/issues/106