### PR TITLE
(NFC) Disable tests performing quick search with no orderby as provin…

### DIFF
--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -121,6 +121,8 @@ class CRM_Utils_SQL {
 
   /**
    * Is the Database set up to handle acceents.
+   * @warning This function was introduced in attempt to determine the reason why the test getInternationalStrings was failing on ubu1604 but passing on ubu1204-5
+   * This function should not be used as the basis of further work as the reasoning is not perfact and is giving false failures.
    * @return bool
    */
   public static function supportStorageOfAccents() {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2734,12 +2734,13 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'first_contact' => $firstAlphabeticalContactBySortName,
         'second_contact' => $secondAlphabeticalContactBySortName,
       ),
-      'bob_search_no_orderby' => array(
-        'search_parameters' => array('name' => 'bob'),
-        'settings' => array('includeWildCardInName' => TRUE, 'includeOrderByClause' => FALSE),
-        'first_contact' => $firstContactByID,
-        'second_contact' => $secondContactByID,
-      ),
+      // This test has been disabled as is proving to be problematic to reproduce due to MySQL sorting issues between different versions
+      // 'bob_search_no_orderby' => array(
+      //  'search_parameters' => array('name' => 'bob'),
+      //  'settings' => array('includeWildCardInName' => TRUE, 'includeOrderByClause' => FALSE),
+      //  'first_contact' => $firstContactByID,
+      //  'second_contact' => $secondContactByID,
+      //),
       'bob_search_no_wildcard' => array(
         'search_parameters' => array('name' => 'bob'),
         'settings' => array('includeWildCardInName' => FALSE, 'includeOrderByClause' => TRUE),
@@ -2766,12 +2767,13 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'first_contact' => $firstAlphabeticalContactFirstNameBob,
         'second_contact' => $secondAlphabeticalContactFirstNameBob,
       ),
-      'first_name_search_no_orderby' => array(
-        'search_parameters' => array('name' => 'bob', 'field_name' => 'first_name'),
-        'settings' => array('includeWildCardInName' => TRUE, 'includeOrderByClause' => FALSE),
-        'first_contact' => $firstByIDContactFirstNameBob,
-        'second_contact' => $secondByIDContactFirstNameBob,
-      ),
+      // This test has been disabled as is proving to be problematic to reproduce due to MySQL sorting issues between different versions
+      //'first_name_search_no_orderby' => array(
+      //  'search_parameters' => array('name' => 'bob', 'field_name' => 'first_name'),
+      //  'settings' => array('includeWildCardInName' => TRUE, 'includeOrderByClause' => FALSE),
+      //  'first_contact' => $firstByIDContactFirstNameBob,
+      //  'second_contact' => $secondByIDContactFirstNameBob,
+      //),
       'email_search_basic' => array(
         'search_parameters' => array('name' => 'bob', 'field_name' => 'email', 'table_name' => 'eml'),
         'settings' => array('includeWildCardInName' => FALSE, 'includeOrderByClause' => TRUE),
@@ -2919,7 +2921,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccess('Setting', 'create', array('includeOrderByClause' => FALSE));
     $result = $this->callAPISuccess('contact', 'getquick', array('name' => 'bob'));
     $this->assertEquals('Bob, Bob', $result['values'][0]['sort_name']);
-    $this->assertEquals('E Bobby, Bobby', $result['values'][1]['sort_name']);
+    // This test has been disabled as is proving to be problematic to reproduce due to MySQL sorting issues between different versions
+    //$this->assertEquals('E Bobby, Bobby', $result['values'][1]['sort_name']);
   }
 
   /**


### PR DESCRIPTION
…g to be problematic on different MySQL versions and add in warning in regards to the usage of CRM_Utils_SQL::supportStorageOfAccents()

ping @eileenmcnaughton @totten 
