### PR TITLE
Extend fiscal year relative options to better match other periods

### DIFF
--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -87,4 +87,90 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     $this->assertEquals($expectedTo, $calculatedTo);
   }
 
+  /**
+   * Test relativeToAbsolute function on a range of fiscal year options.
+   *
+   * Go backwards one year at a time through the sequence.
+   */
+  public function testRelativeToAbsoluteFiscalYear() {
+    $sequence = ['this', 'previous', 'previous_before'];
+    Civi::settings()->set('fiscalYearStart', ['M' => 7, 'd' => 1]);
+    $fiscalYearStartYear = (strtotime('now') > strtotime((date('Y-07-01')))) ? date('Y') : (date('Y') - 1);
+
+    foreach ($sequence as $relativeString) {
+      $date = CRM_Utils_Date::relativeToAbsolute($relativeString, 'fiscal_year');
+      $this->assertEquals([
+        'from' => $fiscalYearStartYear . '0701',
+        'to' => ($fiscalYearStartYear + 1) . '0630'
+      ], $date, 'relative term is ' . $relativeString);
+
+      $fiscalYearStartYear--;
+    }
+  }
+
+  /**
+   * Test relativeToAbsolute function on a range of year options.
+   *
+   * Go backwards one year at a time through the sequence.
+   */
+  public function testRelativeToAbsoluteYear() {
+    $sequence = ['this', 'previous', 'previous_before'];
+    $year = date('Y');
+
+    foreach ($sequence as $relativeString) {
+      $date = CRM_Utils_Date::relativeToAbsolute($relativeString, 'year');
+      $this->assertEquals([
+        'from' => $year . '0101',
+        'to' => $year . '1231',
+      ], $date, 'relative term is ' . $relativeString);
+
+      $year--;
+    }
+  }
+
+  /**
+   * Test relativeToAbsolute function on a range of year options.
+   *
+   * Go backwards one year at a time through the sequence.
+   */
+  public function testRelativeToAbsoluteYearRange() {
+    $sequence = ['previous_2'];
+    $lastYear = (date('Y') - 1);
+
+    foreach ($sequence as $relativeString) {
+      $date = CRM_Utils_Date::relativeToAbsolute($relativeString, 'year');
+      // For previous 2 years the range is e.g 2016-01-01 to 2017-12-31 so we have to subtract
+      // one from the range count to reflect the calendar year being one less apart due
+      // to it being from the beginning of one to the end of the next.
+      $offset = (substr($relativeString, -1, 1)) - 1;
+      $this->assertEquals([
+        'from' => $lastYear - $offset . '0101',
+        'to' => $lastYear  . '1231',
+      ], $date, 'relative term is ' . $relativeString);
+    }
+  }
+
+  /**
+   * Test relativeToAbsolute function on a range of year options.
+   *
+   * Go backwards one year at a time through the sequence.
+   */
+  public function testRelativeToAbsoluteFiscalYearRange() {
+    $sequence = ['previous_2', 'previous_3', 'previous_4'];
+    Civi::settings()->set('fiscalYearStart', ['M' => 7, 'd' => 1]);
+    $lastFiscalYearEnd = (strtotime('now') > strtotime((date('Y-07-01')))) ? (date('Y')) : (date('Y') - 1);
+
+    foreach ($sequence as $relativeString) {
+      $date = CRM_Utils_Date::relativeToAbsolute($relativeString, 'fiscal_year');
+      // For previous 2 years the range is e.g 2015-07-01 to 2017-06-30 so we have to subtract
+      // one from the range count to reflect the calendar year being one less apart due
+      // to it being from the beginning of one to the end of the next.
+      $offset = (substr($relativeString, -1, 1));
+      $this->assertEquals([
+        'from' => $lastFiscalYearEnd - $offset . '0701',
+        'to' => $lastFiscalYearEnd  . '0630',
+      ], $date, 'relative term is ' . $relativeString);
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds relative date handling for fiscal_year.previous_before, fiscal_year.previous_2, fiscal_year.previous_3, fiscal_year.previous_n at the function level and adds unit tests (but does not expose)

Before
----------------------------------------
CRM_Utils_Date::relativeToAbsolute cannot parse previous.before et al

After
----------------------------------------
CRM_Utils_Date::relativeToAbsolute can parse previous.before et al, unit tests

Technical Details
----------------------------------------
This comes out of my effort to review #11592 and to see if it is mergeable. In digging I concluded I would NOT be comfortable merging additional handling options without unit tests (I'm undecided on adding new options to the core option value set & I note there is an extension proposal in the mix). 

I do agree it's logical for the CRM_Utils_Date::relativeToAbsolute function to handle the same options for fiscal_year as for others and I added 3 of the proposed options with unit tests : 

(based on a current date of  ie. in May 2018 & financial year end 30 June) 

fiscal_year.previous_before - the fiscal year before the previous one -  1 Jul 2015 to 30 June 2016
fiscal_year.previous_2 - the 2 fiscal years before this one - ie.                1 Jul 2015 to 30 June 2017 
fiscal_year.previous_3 - the 3 fiscal years before this one -                      1 Jul 2014 to 30 June 2017 

(fiscal_year.previous_205 could also be handled by the code loop but I only test to previous_4)

Comments
----------------------------------------
I think this is mergeable as a partial of #11592 and because it enhances the code by adding unit tests. However, I will only keep it open for a month if not merged as it is a reviewer's commit.

I don't feel comfortable adding more options without more unit tests.
