### PR TITLE
(NFC) Fix cannot use count() on object that doesn't implement countab…

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -64,8 +64,10 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
 
     $params["contact_id"] = $contact2Id;
     $contributionsOfSoftContact = CRM_Contribute_BAO_ContributionSoft::retrieve($params, $values);
-    $this->assertEquals(1, count($contributionsOfMainContact), 'Contribution not added for primary contact');
-    $this->assertEquals(1, count($contributionsOfSoftContact), 'Soft Contribution not added for secondary contact');
+    $this->assertEquals(1, $contributionsOfMainContact->N, 'Contribution not added for primary contact');
+    $this->assertEquals(1, $contributionsOfSoftContact->N, 'Soft Contribution not added for secondary contact');
+    $this->callAPISuccess('ContributionSoft', 'Delete', ['id' => $contributionsOfSoftContact->id]);
+    $this->callAPISuccess('Contribution', 'Delete', ['id' => $contributionsOfMainContact->id]);
   }
   /**
    * Run the import parser.


### PR DESCRIPTION
…le in tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php

Overview
----------------------------------------
This fixes an issue running the test suite against PHP7.2 whereby we were trying to use count on a DB Result object which doesn't implement countable. This throws a warning in PHP7.2

Before
----------------------------------------
Warning thrown running test

After
----------------------------------------
No warning thrown

ping @eileenmcnaughton @monishdeb @totten 