### PR TITLE
dev/drupal#19 Drupal8: Implement set UF locale/language (affects mailing tokens)

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -509,7 +509,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $config = CRM_Core_Config::singleton();
     }
 
-    if (property_exists($mailing, 'language') && $mailing->language && $mailing->language != 'en_US') {
+    if (property_exists($mailing, 'language') && $mailing->language && $mailing->language != CRM_Core_I18n::getLocale()) {
       $swapLang = CRM_Utils_AutoClean::swap('global://dbLocale?getter', 'call://i18n/setLocale', $mailing->language);
     }
 

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -709,6 +709,11 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
       return $url;
     }
 
+    // Drupal might not be bootstrapped if being called by the REST API.
+    if (!class_exists('Drupal')) {
+      return NULL;
+    }
+
     $language = $this->getCurrentLanguage();
     if (\Drupal::service('module_handler')->moduleExists('language')) {
       $config = \Drupal::config('language.negotiation')->get('url');
@@ -722,7 +727,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
         //url prefix
         if ($urlType == \Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationUrl::CONFIG_PATH_PREFIX) {
           if (!empty($language)) {
-            if ($addLanguagePart) {
+            if ($addLanguagePart && !empty($config['prefixes'][$language])) {
               $url .= $config['prefixes'][$language] . '/';
             }
             if ($removeLanguagePart) {

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -673,4 +673,26 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $e->list[] = 'js/crm.drupal8.js';
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function setUFLocale($civicrm_language) {
+    $langcode = substr(str_replace('_', '', $civicrm_language), 0, 2);
+    $languageManager = \Drupal::languageManager();
+    $languages = $languageManager->getLanguages();
+
+    if (isset($languages[$langcode])) {
+      $languageManager->setConfigOverrideLanguage($languages[$langcode]);
+
+      // Config must be re-initialized to reset the base URL
+      // otherwise links will have the wrong language prefix/domain.
+      $config = CRM_Core_Config::singleton();
+      $config->free();
+
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
 }


### PR DESCRIPTION


Overview
----------------------------------------
How to reproduce:

1. Create a bilingual Drupal site, with the locale module, with URL-prefix language detection (example.org/fr/civicrm)
2. Enable multi-lingual CiviCRM, with two languages (ex: FR/EN)
3. Send a mailing in French, with the unsubscribe URL token


Expected result: the token should link to the page in French.

Before
----------------------------------------
The token isn't linking to the page in French

After
----------------------------------------
The token is linking to page in French

