### PR TITLE
dev/core#116 Search builder searches on primary addresses are producing unexpected results

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3736,7 +3736,7 @@ WHERE  $smartGroupClause
     }
 
     $countryClause = $countryQill = NULL;
-    if ($values && !empty($value)) {
+    if (in_array($op, array('IS NULL', 'IS NOT NULL', 'IS EMPTY', 'IS NOT EMPTY')) || ($values && !empty($value))) {
       $this->_tables['civicrm_address'] = 1;
       $this->_whereTables['civicrm_address'] = 1;
 


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Contacts > Country > Primary is empty - returns many addresses, many of which have country field AND are set to primary
2. Contacts > Country > Primary is NULL - same as above

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40171284-652844ac-59e8-11e8-9518-c39c6a1a4931.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/40171259-57de10ba-59e8-11e8-8f09-16bc09b7b035.gif)

