### PR TITLE
dev/core#122 Wrong Action Links Shown for Reserved and Locked Option Groups

### DIFF
--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -151,7 +151,7 @@ class CRM_Core_BAO_CustomOption {
       );
 
       // disable deletion of option values for locked option groups
-      if ($isGroupLocked) {
+      if (($action & CRM_Core_Action::DELETE) && $isGroupLocked) {
         $action -= CRM_Core_Action::DELETE;
       }
 

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -147,7 +147,7 @@ class CRM_Core_OptionValue {
       }
 
       // disallow deletion of option values for locked groups
-      if ($isGroupLocked) {
+      if (($action & CRM_Core_Action::DELETE) && $isGroupLocked) {
         $action -= CRM_Core_Action::DELETE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------

In #11962 I hid the "delete" link for options in a locked option group. This has a bug as the link action will not have the "delete" link if the option value is reserved:

```
if ($dao->is_reserved) {
  $action = CRM_Core_Action::UPDATE;
}
```

So subtracting the `CRM_Core_Action::DELETE` will result in a negative value for `$action` and more links than expected will be shown.

This can be fixed by first checking if the `CRM_Core_Action::DELETE` flag is active before unsetting it.

Before
----------------------------------------

For batch_mode option group which has all reserved option values:

![image](https://user-images.githubusercontent.com/6374064/40173665-7a25246a-59ca-11e8-89b1-5f56a9f582d5.png)

After
----------------------------------------

For batch_mode option group which has all reserved option values:

![image](https://user-images.githubusercontent.com/6374064/40173695-95196e3e-59ca-11e8-9304-03abecf93784.png)
