### PR TITLE
dev/core#123 Retrieve existing participant custom fields for import

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -285,7 +285,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
     $session = CRM_Core_Session::singleton();
     $dateType = $session->get('dateTypes');
     $formatted = array('version' => 3);
-    $customFields = CRM_Core_BAO_CustomField::getFields(CRM_Utils_Array::value('contact_type', $params));
+    $customFields = CRM_Core_BAO_CustomField::getFields('Participant');
 
     // don't add to recent items, CRM-4399
     $formatted['skipRecentView'] = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
The date fields are not converted from the import date format to the default date format and thus end up beeing imported with a date value of 0.

See https://lab.civicrm.org/dev/core/issues/123 for details.

Before
----------------------------------------
![grafik](https://user-images.githubusercontent.com/19712240/40245730-baa0c402-5ac6-11e8-8f1d-7ed583c3910a.png)
Notice errors present.

After
----------------------------------------
![grafik](https://user-images.githubusercontent.com/19712240/40245558-5f987190-5ac6-11e8-95fc-3b322a0418a3.png)
Notice errors not present.

Technical Details
----------------------------------------
As per comment from @eileenmcnaughton https://github.com/civicrm/civicrm-core/pull/9072#issuecomment-284967789 there is no need for the custom contact fields, so I've replaced it instead of using an array union.
