### PR TITLE
dev/core#124 Enhancements for events requiring approval

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -208,7 +208,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $this->assignToTemplate();
 
     if ($this->_values['event']['is_monetary'] &&
-      ($this->_params[0]['amount'] || $this->_params[0]['amount'] == 0)
+      ($this->_params[0]['amount'] || $this->_params[0]['amount'] == 0) &&
+      !$this->_requireApproval
     ) {
       $this->_amount = array();
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -177,7 +177,7 @@
        </td>
      </tr>
     {/if}
-    {if $event.is_monetary}
+    {if $event.is_monetary and not $isRequireApproval}
 
       <tr>
        <th {$headerStyle}>

--- a/xml/templates/message_templates/event_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/event_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if $isOnWaitlist}{ts}Wait List Confirmation{/ts}{else}{ts}Registration Confirmation{/ts}{/if} - {$event.event_title}
+{if $isOnWaitlist}{ts}Wait List Confirmation{/ts}{elseif $isRequireApproval}{ts}Registration Request Confirmation{/ts}{else}{ts}Registration Confirmation{/ts}{/if} - {$event.event_title}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -101,7 +101,7 @@
 {if $payer.name}
 You were registered by: {$payer.name}
 {/if}
-{if $event.is_monetary} {* This section for Paid events only.*}
+{if $event.is_monetary and not $isRequireApproval} {* This section for Paid events only.*}
 
 ==========================================================={if $pricesetFieldsCount }===================={/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
For events requiring approval:
1) Avoid warning on confirmation page
2) Improve subject line on pre-approval email
3) Remove fees section on pre-approval email (fees have not been selected yet at this stage)

Before
----------------------------------------
Create an event requiring approvals, and with fees.
Register for the event.
Observe:

1. On the confirmation screen, a warning `Warning: A non-numeric value encountered in XXX/civicrm/CRM/Event/Form/Registration/Confirm.php on line 262`
2. The email received after the initial registration (ie pre-approval) has subject 'Registration Confirmation' - although the registration is not yet confirmed
3. The same email has a Fees section showing a total of 0 - which is misleading since costs are involved but have not been selected at this stage.

After
----------------------------------------
Create event and register as previously.
Observe:

1. No warning on the confirmation screen
2. Pre-approval mail has subject 'Registration Request Confirmation'
3. No Fees section

Technical Details
----------------------------------------
none

Comments
----------------------------------------
none
