### PR TITLE
dev/core#118 Fix issue using count on non array in Group query builder

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2965,7 +2965,7 @@ class CRM_Contact_BAO_Query {
       $value = NULL;
     }
 
-    if (count($value) > 1) {
+    if (is_array($value) && count($value) > 1) {
       if (strpos($op, 'IN') === FALSE && strpos($op, 'NULL') === FALSE) {
         CRM_Core_Error::fatal(ts("%1 is not a valid operator", array(1 => $op)));
       }


### PR DESCRIPTION
Overview
----------------------------------------
in PHP7.2 count is only able to be used on an array or an object that implements countable. In this case we are checking to see if we have more than 1 value to add in the where clause of the query. It makes sense to check if we are dealing with an array. 

Before
----------------------------------------
PHP7.2 shows error running unit tests

After
----------------------------------------
No error shown 

ping @eileenmcnaughton @monishdeb 