### PR TITLE
dev/core#118 Fix Count issues with PledgePayment and Pledge BAO tests

### DIFF
--- a/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
+++ b/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
@@ -97,7 +97,7 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
     $defaults = array();
     $paymentid = CRM_Pledge_BAO_PledgePayment::retrieve($params, $defaults);
 
-    $this->assertEquals(count($paymentid), 0, "Pledge Id must be greater than 0");
+    $this->assertEquals(is_null($paymentid), 1, "Pledge Id must be greater than 0");
     $result = CRM_Pledge_BAO_Pledge::deletePledge($payment->pledge_id);
   }
 
@@ -110,7 +110,7 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
     $defaults = array();
     $paymentid = CRM_Pledge_BAO_PledgePayment::retrieve($params, $defaults);
 
-    $this->assertEquals(count($paymentid), 0, "Pledge Id cannot be a string");
+    $this->assertEquals(is_null($paymentid), 1, "Pledge Id cannot be a string");
     $result = CRM_Pledge_BAO_Pledge::deletePledge($payment->pledge_id);
   }
 
@@ -124,7 +124,7 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
     $defaults = array();
     $paymentid = CRM_Pledge_BAO_PledgePayment::retrieve($params, $defaults);
 
-    $this->assertEquals(count($paymentid), 1, "Pledge was retrieved");
+    $this->assertEquals($paymentid->N, 1, "Pledge was retrieved");
     $result = CRM_Pledge_BAO_Pledge::deletePledge($pledgeId);
   }
 
@@ -134,7 +134,8 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
   public function testDeletePledgePaymentsNormal() {
     $payment = CRM_Core_DAO::createTestObject('CRM_Pledge_BAO_PledgePayment');
     $paymentid = CRM_Pledge_BAO_PledgePayment::deletePayments($payment->pledge_id);
-    $this->assertEquals(count($paymentid), 1, "Deleted one payment");
+
+    $this->assertEquals($paymentid, 1, "Deleted one payment");
     $result = CRM_Pledge_BAO_Pledge::deletePledge($payment->pledge_id);
   }
 
@@ -157,7 +158,7 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
   public function testDeletePledgePaymentsNullId() {
     $payment = CRM_Core_DAO::createTestObject('CRM_Pledge_BAO_PledgePayment');
     $paymentid = CRM_Pledge_BAO_PledgePayment::deletePayments(NULL);
-    $this->assertEquals(count($paymentid), 1, "No payments deleted");
+    $this->assertFalse($paymentid, "No payments deleted");
     $result = CRM_Pledge_BAO_Pledge::deletePledge($payment->pledge_id);
   }
 

--- a/tests/phpunit/CRM/Pledge/BAO/PledgeTest.php
+++ b/tests/phpunit/CRM/Pledge/BAO/PledgeTest.php
@@ -103,7 +103,7 @@ class CRM_Pledge_BAO_PledgeTest extends CiviUnitTestCase {
     $params = array('pledge_id' => 0);
     $pledgeId = CRM_Pledge_BAO_Pledge::retrieve($params, $defaults);
 
-    $this->assertEquals(count($pledgeId), 0, "Pledge Id must be greater than 0");
+    $this->assertEquals(is_null($pledgeId), 1, "Pledge Id must be greater than 0");
   }
 
   /**
@@ -114,7 +114,7 @@ class CRM_Pledge_BAO_PledgeTest extends CiviUnitTestCase {
     $params = array('pledge_id' => 'random text');
     $pledgeId = CRM_Pledge_BAO_Pledge::retrieve($params, $defaults);
 
-    $this->assertEquals(count($pledgeId), 0, "Pledge Id must be a string");
+    $this->assertEquals(is_null($pledgeId), 1, "Pledge Id must be a string");
   }
 
   /**
@@ -144,7 +144,7 @@ class CRM_Pledge_BAO_PledgeTest extends CiviUnitTestCase {
 
     $pledgeId = CRM_Pledge_BAO_Pledge::retrieve($pledgeParams, $defaults);
 
-    $this->assertEquals(count($pledgeId), 1, "Pledge was retrieved");
+    $this->assertEquals($pledgeId->N, 1, "Pledge was retrieved");
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In PHP7.2 errors show when count is used on a variable that isn't an array or an object that implements countable. in this case `CRM_Pledge_BAO_Pledge::retrieve()` and `CRM_Pledge_BAO_PledgePayment::retrieve()` return either NULL or a DAO object. In the case of `CRM_Pledge_BAO_PledgePayment::deletePayments` it returns either TRUE or FALSE if its able to delete payments or not

Before
----------------------------------------
Error shown running php7.2

After
----------------------------------------
No error shown running unit tests

ping @eileenmcnaughton @monishdeb