### PR TITLE
Update variable name as per upgraded Mime_mail package to support PHP7.2

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -584,7 +584,7 @@ function civicrm_api3_mailing_preview($params) {
   return civicrm_api3_create_success(array(
     'id' => $params['id'],
     'contact_id' => $contactID,
-    'subject' => $mime->headers['Subject'],
+    'subject' => $mime->headers()['Subject'],
     'body_html' => $mime->getHTMLBody(),
     'body_text' => $mime->getTXTBody(),
   ));

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -584,7 +584,7 @@ function civicrm_api3_mailing_preview($params) {
   return civicrm_api3_create_success(array(
     'id' => $params['id'],
     'contact_id' => $contactID,
-    'subject' => $mime->_headers['Subject'],
+    'subject' => $mime->headers['Subject'],
     'body_html' => $mime->getHTMLBody(),
     'body_text' => $mime->getTXTBody(),
   ));


### PR DESCRIPTION
Overview
----------------------------------------
This changes the variable that is being set in Mail_Mime, this PR is dependent on https://github.com/civicrm/civicrm-packages/pull/205/files but that PR needs this PR to pass all unit tests. @eileenmcnaughton @monishdeb @totten @JoeMurray  to support PHP7.2 we need to upgrade the Mail_Mime and Mail_MimeDecode packages. Packages PR 205 does this however this also changes a number of variables from having the `_` prefix to declaring the private nature of them in the doc block. I have done a grep and this is the only reference to the headers this way in the core repo. 

We will need to make sure we merge both PRs sequentially to and at the same time to make sure we don't have any problems

