### PR TITLE
dev/core#126 Add support for contact id as a basic report filter.

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5299,6 +5299,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'is_order_bys' => TRUE,
         'is_group_bys' => TRUE,
         'is_fields' => TRUE,
+        'is_filters' => TRUE,
       ),
       $options['prefix'] . 'external_identifier' => array(
         'name' => 'external_identifier',


### PR DESCRIPTION
Overview
----------------------------------------
Re-introduce support for contact id being passed through to the contribution detail report via the url.

This worked in 4.7.29 but regressed in 4.7.30. I think this qualifies as a non-recent regression which means it gets prioritised by the product maintenance team to be fixed but we target the master branch rather than trying to get it into the existing rc (as we would for a recent regression) 
This is to address a declared regression https://lab.civicrm.org/dev/core/issues/126 (in 4.7.30) and also to improve flexibility

Before
----------------------------------------
String in url &force=1&id_op=eq&id_value=34 does not result in filtering

After
----------------------------------------
Report is filtered (by contact_id = 34) when above url is present. This is the string that is in the url from the soft credit report

Technical Details
----------------------------------------


Comments
----------------------------------------
This also exposes contact id as a basic report filter, which I think is a positive by-product
