### PR TITLE
CRM-21816 add unit test on relative dates by membership

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1563,11 +1563,7 @@ class CRM_Contact_BAO_Query {
 
     self::filterCountryFromValuesIfStateExists($formValues);
 
-    foreach ($formValues as $id => &$val) {
-      // CRM-19374 - we don't want to change $val in $formValues.
-      // Assign it to a temp variable which operates while iteration.
-      $values = $val;
-
+    foreach ($formValues as $id => $values) {
       if (self::isAlreadyProcessedForQueryFormat($values)) {
         $params[] = $values;
         continue;


### PR DESCRIPTION
Overview
----------------------------------------
This is a partial of #11737 - it contains the unit test & a very sensible (IMHO) change to how the variables have been assigned. 

Before
----------------------------------------
no test

After
----------------------------------------
test

Technical Details
----------------------------------------
The rest of the fix is excluded (for now) as we have not managed to replicate the bug. Am giving this merge-on-pass & will see how it goes with the whole matrix if we get it merged

Comments
----------------------------------------

---

 * [CRM-21816: Relative dates in searches cause some other conditions to be ignored](https://issues.civicrm.org/jira/browse/CRM-21816)