### PR TITLE
Towards dev/financial/#16 Paypal unreliable getting payment processor type

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -104,6 +104,17 @@ abstract class CRM_Core_Payment {
   protected $cancelUrl;
 
   /**
+   * Processor type label.
+   *
+   * (Deprecated parameter but used in some messages).
+   *
+   * @deprecated
+   *
+   * @var string
+   */
+  public $_processorName;
+
+  /**
    * The profile configured to show on the billing form.
    *
    * Currently only the pseudo-profile 'billing' is supported but hopefully in time we will take an id and


### PR DESCRIPTION
Overview
----------------------------------------
Second reviewer's commit of #12007 - code standardisation in paypal class to prevent e-notices & missing details in messages

Before
----------------------------------------
PHP notice on some payment submissions (eg. via webform_civicrm) and use of "non-standard" param.

After
----------------------------------------
No PHP notice and uses standard parameter so it works with all payment submissions that use standard methods to populate the payment processor array ($this->_paymentProcessor).

Related: #12091

Technical Details
----------------------------------------

Comments
----------------------------------------
@mattwire if you can confirm this still seems good to you I will merge it. I basically went through your commit & re-did it - removing the problematic line in isSupported & fixing this incorrect change
https://github.com/civicrm/civicrm-core/pull/12091/files#diff-96a0ea19e8ac102ef100c35b3b3d1c31R506

I feel OK about this now (as a reviewer's commit)
