### PR TITLE
dev/core#35 Avoid variable leakage on recurring contribution receipts.

### DIFF
--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -54,7 +54,7 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
     }
 
     $dao = new CRM_Core_DAO_UFJoin();
-    $dao->copyValues($params);
+    $dao->copyValues($params, TRUE);
     if ($params['uf_group_id']) {
       $dao->save();
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3004,15 +3004,20 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    *
    * @param string $name
    * @param int $contributionPageID
+   * @param string $module
    */
-  protected function addProfile($name, $contributionPageID) {
-    $this->callAPISuccess('UFJoin', 'create', array(
+  protected function addProfile($name, $contributionPageID, $module = 'CiviContribute') {
+    $params = [
       'uf_group_id' => $name,
-      'module' => 'CiviContribute',
+      'module' => $module,
       'entity_table' => 'civicrm_contribution_page',
       'entity_id' => $contributionPageID,
       'weight' => 1,
-    ));
+    ];
+    if ($module !== 'CiviContribute') {
+      $params['module_data'] = [$module => []];
+    }
+    $this->callAPISuccess('UFJoin', 'create', $params);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix variable leakage when multiple payments are being processed.

This bug happens if you have more than one tokenised recurring contribution (e.g IATS does tokenised recurring as do eWay, PaymentExpress & a few others) and an earlier contribution is assigned a PCP or soft credit, but one or more later contributions are not.

The later contributions information inserted into their receipt because the email message template variables are not properly cleared


Before
----------------------------------------
Potentially some  recurring contribution receipts are sent out in which pcp or honor settings apply to other donors

After
----------------------------------------
Receipts only honor people if the donor intended to honor them.

Technical Details
----------------------------------------
I was reviewing #11966 which has an overly broad fix that I'm uncomfortable with.  But the fact it has a unit test meant I felt it was worth sinking some time into fixing (I perhaps would not have had I known how long it would take me to get even this far). 

On digging I found the test was not really testing what it purported to be testing, but I got it to the point where it failed without the fix & passed with it which is the goal.

Comments
----------------------------------------
There are potentially other variables leaking but I think we need to build up our tests as we fix them.

See https://lab.civicrm.org/dev/core/issues/35
