### PR TITLE
dev/core/#133 Make Conditions Stricter When Checking If Reply-To Field Is Empty

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1452,7 +1452,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     }
     $mailing->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
 
-    if (!isset($params['replyto_email']) &&
+    if (((!$id && empty($params['replyto_email'])) || !isset($params['replyto_email'])) &&
       isset($params['from_email'])
     ) {
       $params['replyto_email'] = $params['from_email'];


### PR DESCRIPTION
Overview
----------------------------------------
reply-to field is NULL in the following case

- Add a new mailing (or reuse one)
- Select a 'reply to' email (I had to enable "Enable Custom Reply-To" in 'civicrm/admin/mail')
- Fill in other fields as usual
- Under 'Responses' tab, check "Track Replies" checkbox. This brings up a warning message on the top right saying 'reply-to' has been cleared out (but still allows user to save mailing) 
- Proceed to next step and save mailing

Technical Details
----------------------------------------
In CRM_Mailing_BAO_Mailing.php when adding a new mailing (add() method), there is a condition to check if 'reply-to' field is set and if it is not set, then 'from-email' is used.
here instead if using
`if(!isset($params['replyto_email']))`
we should use
`if(empty($params['replyto_email']))`
so that empty string like '' will also be considered and reply-to could not be NULL