### PR TITLE
dev/membership#4 - Admin Membership type is displayed on Public contr…

### DIFF
--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -128,7 +128,7 @@
       <tr class="crm-membership-type-form-block-visibility">
         <td class="label">{$form.visibility.label}</td>
         <td>{$form.visibility.html}<br />
-          <span class="description">{ts}Is this membership type available for self-service signups ('Public') or assigned by CiviCRM 'staff' users only ('Admin'){/ts}</span>
+          <span class="description">{ts}Can this membership type be used for self-service signups ('Public'), or is it only for CiviCRM users with 'Edit Contributions' permission ('Admin').{/ts}</span>
         </td>
       </tr>
       <tr class="crm-membership-type-form-block-weight">


### PR DESCRIPTION
…ibution page

Overview
----------------------------------------
Admin membership type displayed on public contribution page. 

Before
----------------------------------------
When visibility of membership type is updated to `Admin`, it is still displayed on front-end contribution pages. Steps to replicate on dmaster -

- Create a membership type.
- Add it to a contribution page.
- Set visibility of the type to `Admin`.
- Navigate to contribution page as a non-admin user- the membership type is still displayed on the page.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Update done to membership type wasn't triggering the change in pricefieldvalue table.

Comments
----------------------------------------
Added unit test.

----------------
Gitlab Issue - https://lab.civicrm.org/dev/membership/issues/4