### PR TITLE
Removing related memberships if parent membership type is changed which does not have relation type associated.

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -450,8 +450,8 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
   /**
    * Check the membership extended through relationship.
    *
-   * @param int $membershipId
-   *   Membership id.
+   * @param int $membershipTypeID
+   *   Membership type id.
    * @param int $contactId
    *   Contact id.
    *
@@ -460,10 +460,8 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
    * @return array
    *   array of contact_id of all related contacts.
    */
-  public static function checkMembershipRelationship($membershipId, $contactId, $action = CRM_Core_Action::ADD) {
+  public static function checkMembershipRelationship($membershipTypeID, $contactId, $action = CRM_Core_Action::ADD) {
     $contacts = array();
-    $membershipTypeID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $membershipId, 'membership_type_id');
-
     $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($membershipTypeID);
     $relationships = array();
     if (isset($membershipType['relationship_type_id'])) {
@@ -1820,7 +1818,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
     $allRelatedContacts = array();
     $relatedContacts = array();
     if (!is_a($membership, 'CRM_Core_Error')) {
-      $allRelatedContacts = CRM_Member_BAO_Membership::checkMembershipRelationship($membership->id,
+      $allRelatedContacts = CRM_Member_BAO_Membership::checkMembershipRelationship($membership->membership_type_id,
         $membership->contact_id,
         CRM_Utils_Array::value('action', $params)
       );


### PR DESCRIPTION
Overview
----------------------------------------
Inherited membership status is retained after the membership type is changed for the Primary member from a membership type with inherit by Relationship Type enabled to a membership type with no inherit by Relationship Type enabled. 

**Steps to reproduce:**

1. Add membership to organisation which inherits based on relationship "Employee of"
2. Set the membership status to current
3. Add individual contacts and add relationship "Employee of" to the organisation
4. Note that the membership status is inherited from the organisation as the primary member
5. Change the membership type for the organisation to a new membership type which does not have inherit membership based on relationship enabled
6. Note that the individual contacts still have an active membership using the new membership type
7. Expected result is that the individuals do not have a membership after the membership type has been changed.

Before
----------------------------------------
Individual member still have membership event after type of parent membership is changed which does not have relation type associated.

After
----------------------------------------
Membership of Individual member is removed.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-832_