### PR TITLE
Removing related memberships if parent membership type is changed which does not have relation type associated.

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -450,8 +450,8 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
   /**
    * Check the membership extended through relationship.
    *
-   * @param int $membershipId
-   *   Membership id.
+   * @param int $membershipTypeID
+   *   Membership type id.
    * @param int $contactId
    *   Contact id.
    *
@@ -460,9 +460,8 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
    * @return array
    *   array of contact_id of all related contacts.
    */
-  public static function checkMembershipRelationship($membershipId, $contactId, $action = CRM_Core_Action::ADD) {
+  public static function checkMembershipRelationship($membershipTypeID, $contactId, $action = CRM_Core_Action::ADD) {
     $contacts = array();
-    $membershipTypeID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $membershipId, 'membership_type_id');
 
     $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($membershipTypeID);
     $relationships = array();
@@ -1388,7 +1387,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
     $allRelatedContacts = array();
     $relatedContacts = array();
     if (!is_a($membership, 'CRM_Core_Error')) {
-      $allRelatedContacts = CRM_Member_BAO_Membership::checkMembershipRelationship($membership->id,
+      $allRelatedContacts = CRM_Member_BAO_Membership::checkMembershipRelationship($membership->membership_type_id,
         $membership->contact_id,
         CRM_Utils_Array::value('action', $params)
       );

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -68,6 +68,84 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $this->_contactID = $this->_membershipStatusID = $this->_membershipTypeID = NULL;
   }
 
+  /**
+   * Create membership type using given organization id.
+   * @param $organizationId
+   * @return array|int
+   */
+  private function createMembershipType($organizationId, $withRelationship = FALSE) {
+    $membershipType = $this->callAPISuccess('MembershipType', 'create', array(
+      'domain_id' => 1, //Default domain ID
+      'member_of_contact_id' => $organizationId,
+      'financial_type_id' => "Member Dues",
+      'duration_unit' => "year",
+      'duration_interval' => 1,
+      'period_type' => "rolling",
+      'name' => "Organiation Membership Type",
+      'relationship_type_id' => ($withRelationship) ? 5 : NULL,
+      'relationship_direction' => ($withRelationship) ? 'b_a' : NULL,
+    ));
+    return $membershipType["values"][$membershipType["id"]];
+  }
+
+  /**
+   * Get count of related memberships by parent membership id.
+   * @param $membershipId
+   * @return array|int
+   */
+  private function getRelatedMembershipsCount($membershipId) {
+    return $this->callAPISuccess("Membership", "getcount", array(
+      'owner_membership_id' => $membershipId,
+    ));
+  }
+
+  /**
+   * Test to delete related membership when type of parent memebrship is changed which does not have relation type associated.
+   * @throws CRM_Core_Exception
+   */
+  public function testDeleteRelatedMembershipsOnParentTypeChanged() {
+
+    $contactId = $this->individualCreate();
+    $membershipOrganizationId = $this->organizationCreate();
+    $organizationId = $this->organizationCreate();
+
+    // Create relationship between organization and individual contact
+    $this->callAPISuccess('Relationship', 'create', array(
+      'relationship_type_id' => 5, // Employer of relationship
+      'contact_id_a'         => $contactId,
+      'contact_id_b'         => $organizationId,
+      'is_active'            => 1,
+    ));
+
+    // Create two membership types one with relationship and one without.
+    $membershipTypeWithRelationship = $this->createMembershipType($membershipOrganizationId, TRUE);
+    $membershipTypeWithoutRelationship = $this->createMembershipType($membershipOrganizationId);
+
+    // Creating membership of organisation
+    $membership = $this->callAPISuccess("Membership", "create", array(
+      'membership_type_id' => $membershipTypeWithRelationship["id"],
+      'contact_id'         => $organizationId,
+      'status_id'          => $this->_membershipStatusID,
+    ));
+
+    $membership = $membership["values"][$membership["id"]];
+
+    // Check count of related memberships. It should be one for individual contact.
+    $relatedMembershipsCount = $this->getRelatedMembershipsCount($membership["id"]);
+    $this->assertEquals(1, $relatedMembershipsCount, 'Related membership count should be 1.');
+
+    // Update membership by changing it's type. New membership type is without relationship.
+    $membership["membership_type_id"] = $membershipTypeWithoutRelationship["id"];
+    $updatedMembership = $this->callAPISuccess("Membership", "create", $membership);
+
+    // Check count of related memberships again. It should be zero as we changed the membership type.
+    $relatedMembershipsCount = $this->getRelatedMembershipsCount($membership["id"]);
+    $this->assertEquals(0, $relatedMembershipsCount, 'Related membership count should be 0.');
+
+    // Clean up: Delete membership
+    $this->membershipDelete($membership["id"]);
+  }
+
   public function testCreate() {
 
     $contactId = $this->individualCreate();


### PR DESCRIPTION
Overview
----------------------------------------
Inherited membership status is retained after the membership type is changed for the Primary member from a membership type with inherit by Relationship Type enabled to a membership type with no inherit by Relationship Type enabled. 

**Steps to reproduce:**

1. Add membership to organisation which inherits based on relationship "Employee of"
2. Set the membership status to current
3. Add individual contacts and add relationship "Employee of" to the organisation
4. Note that the membership status is inherited from the organisation as the primary member
5. Change the membership type for the organisation to a new membership type which does not have inherit membership based on relationship enabled
6. Note that the individual contacts still have an active membership using the new membership type
7. Expected result is that the individuals do not have a membership after the membership type has been changed.

Before
----------------------------------------
Individual member still have membership event after type of parent membership is changed which does not have relation type associated.

After
----------------------------------------
Membership of Individual member is removed.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-832_