### PR TITLE
dev/core#134 Search Builder broken filter for Source Contact ID

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2513,7 +2513,10 @@ AND cl.modified_id  = c.id
       // my case hence we have defined fields as case_*
       if ($name == 'Activity') {
         $exportableFields = CRM_Activity_DAO_Activity::export();
-        $exportableFields['source_contact_id']['title'] = ts('Source Contact ID');
+        $exportableFields['source_contact_id'] = [
+          'title' => ts('Source Contact ID'),
+          'type' => CRM_Utils_Type::T_INT,
+        ];
         $exportableFields['source_contact'] = array(
           'title' => ts('Source Contact'),
           'type' => CRM_Utils_Type::T_STRING,

--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -136,7 +136,13 @@ class CRM_Activity_BAO_Query {
     if (!empty($query->_returnProperties['source_contact'])) {
       $query->_select['source_contact'] = 'source_contact.sort_name as source_contact';
       $query->_element['source_contact'] = 1;
-      $query->_tables['source_contact'] = $query->_whereTables['source_contact'] = 1;
+      $query->_tables['civicrm_activity'] = $query->_tables['source_contact'] = $query->_whereTables['source_contact'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['source_contact_id'])) {
+      $query->_select['source_contact_id'] = 'source_contact.id as source_contact_id';
+      $query->_element['source_contact_id'] = 1;
+      $query->_tables['civicrm_activity'] = $query->_tables['source_contact'] = $query->_whereTables['source_contact'] = 1;
     }
 
     if (!empty($query->_returnProperties['activity_result'])) {
@@ -348,6 +354,14 @@ class CRM_Activity_BAO_Query {
           $query->_qill[$grouping][] = ts('Activities which are not Followup Activities');
         }
         break;
+
+      case 'source_contact':
+      case 'source_contact_id':
+        $columnName = strstr($name, '_id') ? 'id' : 'sort_name';
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("source_contact.{$columnName}", $op, $value, CRM_Utils_Type::typeToString($fields[$name]['type']));
+        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Contact', $columnName, $value, $op);
+        $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$name]['title'], 2 => $op, 3 => $value));
+        break;
     }
   }
 
@@ -402,9 +416,8 @@ class CRM_Activity_BAO_Query {
         $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
         $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
         $from = "
-        LEFT JOIN civicrm_activity_contact ac
-                      ON ( ac.activity_id = civicrm_activity_contact.activity_id AND ac.record_type_id = {$sourceID})
-        INNER JOIN civicrm_contact source_contact ON (ac.contact_id = source_contact.id)";
+        INNER JOIN civicrm_contact source_contact ON
+          (civicrm_activity_contact.contact_id = source_contact.id) AND civicrm_activity_contact.record_type_id = {$sourceID}";
         break;
 
       case 'parent_id':

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -73,18 +73,30 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
     // Ensure that search builder return individual contact as per criteria
     if (!empty($dataSet['context'] == 'builder')) {
       $contactID = $this->individualCreate(['first_name' => 'James', 'last_name' => 'Bond']);
-      $this->callAPISuccess('Address', 'create', [
-        'contact_id' => $contactID,
-        'location_type_id' => "Home",
-        'is_primary' => 1,
-        'country_id' => "IN",
-      ]);
-      $rows = $selector->getRows(CRM_Core_Action::VIEW, 0, 50, '');
-      $this->assertEquals(1, count($rows));
-      $sortChar = $selector->alphabetQuery()->fetchAll();
-      // sort name is stored in '<last_name>, <first_name>' format, as per which the first character would be B of Bond
-      $this->assertEquals('B', $sortChar[0]['sort_name']);
-      $this->assertEquals($contactID, key($rows));
+      if ('Search builder behaviour for Activity' == $dataSet['description']) {
+        $this->callAPISuccess('Activity', 'create', [
+          'activity_type_id' => 'Meeting',
+          'subject' => "Test",
+          'source_contact_id' => $contactID,
+        ]);
+        $rows = CRM_Core_DAO::executeQuery(implode(' ', $sql))->fetchAll();
+        $this->assertEquals(1, count($rows));
+        $this->assertEquals($contactID, $rows[0]['source_contact_id']);
+      }
+      else {
+        $this->callAPISuccess('Address', 'create', [
+          'contact_id' => $contactID,
+          'location_type_id' => "Home",
+          'is_primary' => 1,
+          'country_id' => "IN",
+        ]);
+        $rows = $selector->getRows(CRM_Core_Action::VIEW, 0, 50, '');
+        $this->assertEquals(1, count($rows));
+        $sortChar = $selector->alphabetQuery()->fetchAll();
+        // sort name is stored in '<last_name>, <first_name>' format, as per which the first character would be B of Bond
+        $this->assertEquals('B', $sortChar[0]['sort_name']);
+        $this->assertEquals($contactID, key($rows));
+      }
     }
   }
 
@@ -255,6 +267,26 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
           ),
         ),
       ),
+      array(
+        array(
+          'description' => 'Search builder behaviour for Activity',
+          'class' => 'CRM_Contact_Selector',
+          'settings' => array(),
+          'form_values' => array('source_contact_id' => array('IS NOT NULL' => 1)),
+          'params' => array(),
+          'return_properties' => array(
+            'source_contact_id' => 1,
+          ),
+          'context' => 'builder',
+          'action' => CRM_Core_Action::NONE,
+          'includeContactIds' => NULL,
+          'searchDescendentGroups' => FALSE,
+          'expected_query' => array(
+            0 => 'SELECT contact_a.id as contact_id, source_contact.id as source_contact_id',
+            2 => 'WHERE ( source_contact.id IS NOT NULL ) AND (contact_a.is_deleted = 0)',
+          ),
+        ),
+      ),
     );
   }
 
@@ -380,10 +412,10 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
    * @param array $expectedQuery
    */
   public function wrangleDefaultClauses(&$expectedQuery) {
-    if ($expectedQuery[0] == 'default') {
+    if (CRM_Utils_Array::value(0, $expectedQuery) == 'default') {
       $expectedQuery[0] = $this->getDefaultSelectString();
     }
-    if ($expectedQuery[1] == 'default') {
+    if (CRM_Utils_Array::value(1, $expectedQuery) == 'default') {
       $expectedQuery[1] = $this->getDefaultFromString();
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Search Builder lists the 'Source Contact ID' field but doesn't populate the information nor filter things appropriately. Use any filter in Search Builder with Activity >> Source Contact ID criteria, it will always show empty value below this column.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40363971-abf94b92-5dee-11e8-87e0-5afd99b88f92.gif)

After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/40363893-77a67b62-5dee-11e8-9014-f8148957870d.gif)


