### PR TITLE
Entity form : Establish methodology to allow default values to be passed in on the url

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -132,6 +132,47 @@ trait CRM_Core_Form_EntityFormTrait {
   }
 
   /**
+   * Get the defaults for the entity.
+   */
+  protected function getEntityDefaults() {
+    $defaults = [];
+    if ($this->_action != CRM_Core_Action::DELETE &&
+      $this->getEntityId()
+    ) {
+      $params = ['id' => $this->getEntityId()];
+      $baoName = $this->_BAOName;
+      $baoName::retrieve($params, $defaults);
+    }
+    foreach ($this->entityFields as $fieldSpec) {
+      $value = CRM_Utils_Request::retrieveValue($fieldSpec['name'], $this->getValidationTypeForField($fieldSpec['name']));
+      if ($value !== FALSE) {
+        $defaults[$fieldSpec['name']] = $value;
+      }
+    }
+    return $defaults;
+  }
+
+  /**
+   * Get the validation rule to apply to a function.
+   *
+   * Alphanumeric is designed to always be safe & for now we just return
+   * that but in future we can use tighter rules for types like int, bool etc.
+   *
+   * @param string $fieldName
+   *
+   * @return string|int|bool
+   */
+  protected function getValidationTypeForField($fieldName) {
+    switch ($this->metadata[$fieldName]['type']) {
+      case CRM_Utils_Type::T_BOOLEAN:
+        return 'Boolean';
+
+      default:
+        return 'Alphanumeric';
+    }
+  }
+
+  /**
    * Set translated fields.
    *
    * This function is called from the class constructor, allowing us to set

--- a/CRM/Member/Form/MembershipStatus.php
+++ b/CRM/Member/Form/MembershipStatus.php
@@ -106,13 +106,7 @@ class CRM_Member_Form_MembershipStatus extends CRM_Core_Form {
    * @return array
    */
   public function setDefaultValues() {
-    $defaults = array();
-
-    if ($this->getEntityId()) {
-      $params = array('id' => $this->getEntityId());
-      $baoName = $this->_BAOName;
-      $baoName::retrieve($params, $defaults);
-    }
+    $defaults = $this->getEntityDefaults();
 
     if ($this->_action & CRM_Core_Action::ADD) {
       $defaults['is_active'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Establish methodology to allow default values to be passed in on the url where the new EntityForm trait is used & by extension later other forms that use the fieldsArray format

Before
----------------------------------------
Cannot accept values from the url 

After
----------------------------------------
Very limited ability to accept values from the url  civicrm/admin/member/membershipStatus?action=update&reset=1&label=bob&is_admin=1
pre-fills **label** & **is_admin**

Technical Details
----------------------------------------
This is an extension of the standard developed in https://lab.civicrm.org/dev/core/issues/115 with the intent of determining a safe, easy to implement way, to allow variables to be passed via the url. It relies on some cleanup & I hope https://github.com/civicrm/civicrm-core/pull/12184 will be merged allowing me to rebase this to the essentials.

Basically the idea is that as long as that values coming in from the url are safe provided they are only letters, numbers & _. We should accept those 'easily' (but leave anything that can't work within that out of spec). Otherwise we risk people adding url-acceptable fields in more ad hoc ways.

Comments
----------------------------------------

