### PR TITLE
dev/core#43 - Update geocoding setting text to reflect need for Google API key

### DIFF
--- a/api/v3/examples/Setting/GetFields.php
+++ b/api/v3/examples/Setting/GetFields.php
@@ -2313,7 +2313,7 @@ function setting_getfields_expectedresult() {
         ),
         'default' => '',
         'title' => 'Geocoding Provider',
-        'description' => 'You may choose a different webservice for geocoding. This is required if there is no geo-coding plugin for your selected mapping provider. You can leave the Geocoding fields blank if you are using Google as your mapping provider.',
+        'description' => 'You may choose a different webservice for geocoding or select the same service.',
       ),
       'mapAPIKey' => array(
         'add' => '4.7',
@@ -2332,7 +2332,7 @@ function setting_getfields_expectedresult() {
         ),
         'default' => '',
         'title' => 'Map Provider Key',
-        'description' => 'Enter your API Key or Application ID. An API Key is currently optional for Google Maps API, but may be helpful diagnosing any problems and required for higher volumes of requests. Refer to developers.google.com for the latest information.',
+        'description' => 'Enter your API Key or Application ID. An API Key is required for the Google Maps API. Refer to developers.google.com for the latest information.',
       ),
       'mapProvider' => array(
         'add' => '4.7',

--- a/settings/Map.setting.php
+++ b/settings/Map.setting.php
@@ -72,7 +72,7 @@ return array(
     ),
     'default' => NULL,
     'title' => 'Geocoding Provider',
-    'description' => 'You may choose a different webservice for geocoding. This is required if there is no geo-coding plugin for your selected mapping provider. You can leave the Geocoding fields blank if you are using Google as your mapping provider.',
+    'description' => 'You may choose a different webservice for geocoding or select the same service.',
   ),
   'mapAPIKey' => array(
     'add' => '4.7',
@@ -91,7 +91,7 @@ return array(
     ),
     'default' => NULL,
     'title' => 'Map Provider Key',
-    'description' => 'Enter your API Key or Application ID. An API Key is currently optional for Google Maps API, but may be helpful diagnosing any problems and required for higher volumes of requests. Refer to developers.google.com for the latest information.',
+    'description' => 'Enter your API Key or Application ID. An API Key is required for the Google Maps API. Refer to developers.google.com for the latest information.',
   ),
   'mapProvider' => array(
     'add' => '4.7',

--- a/templates/CRM/Admin/Form/Setting/Mapping.tpl
+++ b/templates/CRM/Admin/Form/Setting/Mapping.tpl
@@ -37,12 +37,12 @@
          <tr class="crm-map-form-block-mapAPIKey">
              <td>{$form.mapAPIKey.label}</td>
              <td>{$form.mapAPIKey.html|crmAddClass:huge}<br />
-             <span class="description">{ts}Enter your API Key or Application ID. An API Key is currently optional for Google Maps API, but may be helpful diagnosing any problems and required for higher volumes of requests. Refer to developers.google.com for the latest information.{/ts}</span></td>
+             <span class="description">{ts}Enter your API Key or Application ID. An API Key is required for the Google Maps API.{/ts}</span></td>
          </tr>
          <tr class="crm-map-form-block-geoProvider">
              <td>{$form.geoProvider.label}</td>
              <td>{$form.geoProvider.html}<br />
-             <span class="description">{ts}You may choose a different webservice for geocoding. This is required if there is no geo-coding plugin for your selected mapping provider. You can leave the Geocoding fields blank if you are using Google as your mapping provider.{/ts}</span></td>
+             <span class="description">{ts}You may choose a different webservice for geocoding or select the same service.{/ts}</span></td>
          </tr>
          <tr class="crm-map-form-block-geoAPIKey">
              <td>{$form.geoAPIKey.label}</td>

--- a/templates/CRM/Admin/Form/Setting/Mapping.tpl
+++ b/templates/CRM/Admin/Form/Setting/Mapping.tpl
@@ -37,7 +37,7 @@
          <tr class="crm-map-form-block-mapAPIKey">
              <td>{$form.mapAPIKey.label}</td>
              <td>{$form.mapAPIKey.html|crmAddClass:huge}<br />
-             <span class="description">{ts}Enter your API Key or Application ID. An API Key is required for the Google Maps API.{/ts}</span></td>
+             <span class="description">{ts}Enter your API Key or Application ID. An API Key is required for the Google Maps API. Refer to developers.google.com for the latest information.{/ts}</span></td>
          </tr>
          <tr class="crm-map-form-block-geoProvider">
              <td>{$form.geoProvider.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
The explanatory text on the geocoding settings page indicates that Google doesn't need an API key, but geocoding will no longer work without an API key. Also, the text says you do not need to enter a Geocoding provider if you are using Google as your mapping provider, but this is no longer true.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/40447658-8f6b54be-5e90-11e8-94d2-bf0bbfd470ab.png)
Also the same in the Map Provider Key and Mapping Provider descriptions in the API.

After
----------------------------------------
To come.

