### PR TITLE
Dev/Core#117 Fix use of each() function in Recur Report

### DIFF
--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -293,7 +293,7 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
     // installments * intervals using the mysql date_add function, along
     // with the interval unit (e.g. DATE_ADD(start_date, INTERVAL 12 * 1 MONTH)
     $date_suffixes = array('relative', 'from', 'to');
-    while (list(, $suffix) = each($date_suffixes)) {
+    foreach ($date_suffixes as $suffix) {
       $isBreak = FALSE;
       // Check to see if the user wants to search by calculated date.
       if (!empty($this->_params['calculated_end_date_' . $suffix])) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the use of the depreciated function each() in the recur repor. 

Before
----------------------------------------
Report Test fails on php7.2
```
        <failure type="PHPUnit_Framework_ExpectationFailedException">api_v3_ReportTemplateTest::testReportTemplateGetRowsAllReports with data set #46 ('contribute/recur')
Failure in api call for report_template getrows:  The each() function is deprecated. This message will be suppressed on further calls
#0 [internal function]: PHPUnit_Util_ErrorHandler::handleError(8192, 'The each() func...', '/home/seamus/bu...', 296, Array)
#1 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/CRM/Report/Form/Contribute/Recur.php(296): each(Array)
#2 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/CRM/Report/Form.php(2817): CRM_Report_Form_Contribute_Recur-&gt;where()
#3 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/api/v3/ReportTemplate.php(154): CRM_Report_Form-&gt;buildQuery()
#4 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/api/v3/ReportTemplate.php(115): _civicrm_api3_report_template_getrows(Array)
#5 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_report_template_getrows(Array)
#6 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/Civi/API/Kernel.php(169): Civi\API\Provider\MagicFunctionProvider-&gt;invoke(Array)
#7 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/Civi/API/Kernel.php(100): Civi\API\Kernel-&gt;runRequest(Array)
#8 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/api/api.php(23): Civi\API\Kernel-&gt;runSafe('report_template', 'getrows', Array, NULL)
#9 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/Civi/Test/Api3TestTrait.php(259): civicrm_api('report_template', 'getrows', Array)
#10 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/Civi/Test/Api3TestTrait.php(151): CiviUnitTestCase-&gt;civicrm_api('report_template', 'getrows', Array)
#11 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/tests/phpunit/api/v3/ReportTemplateTest.php(161): CiviUnitTestCase-&gt;callAPISuccess('report_template', 'getrows', Array)
#12 [internal function]: api_v3_ReportTemplateTest-&gt;testReportTemplateGetRowsAllReports('contribute/recu...')
#13 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/Framework/TestCase.php(1062): ReflectionMethod-&gt;invokeArgs(Object(api_v3_ReportTemplateTest), Array)
#14 /home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php(192): PHPUnit_Framework_TestCase-&gt;runTest()
#15 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/Framework/TestCase.php(913): CiviUnitTestCase-&gt;runTest()
#16 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/Framework/TestResult.php(686): PHPUnit_Framework_TestCase-&gt;runBare()
#17 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/Framework/TestCase.php(868): PHPUnit_Framework_TestResult-&gt;run(Object(api_v3_ReportTemplateTest))
#18 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/Framework/TestSuite.php(733): PHPUnit_Framework_TestCase-&gt;run(Object(PHPUnit_Framework_TestResult))
#19 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/Framework/TestSuite.php(733): PHPUnit_Framework_TestSuite-&gt;run(Object(PHPUnit_Framework_TestResult))
#20 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/Framework/TestSuite.php(733): PHPUnit_Framework_TestSuite-&gt;run(Object(PHPUnit_Framework_TestResult))
#21 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/TextUI/TestRunner.php(517): PHPUnit_Framework_TestSuite-&gt;run(Object(PHPUnit_Framework_TestResult))
#22 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/TextUI/Command.php(186): PHPUnit_TextUI_TestRunner-&gt;doRun(Object(PHPUnit_Framework_TestSuite), Array, true)
#23 phar:///home/seamus/buildkit/bin/phpunit5/phpunit/TextUI/Command.php(116): PHPUnit_TextUI_Command-&gt;run(Array, true)
#24 /home/seamus/buildkit/bin/phpunit5(598): PHPUnit_TextUI_Command::main()
#25 {main}
Failed asserting that 1 matches expected 0.

/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/Civi/Test/Api3TestTrait.php:94
/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/Civi/Test/Api3TestTrait.php:152
/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/tests/phpunit/api/v3/ReportTemplateTest.php:161
/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:192
/home/seamus/buildkit/bin/phpunit5:598
</failure>
```

After
----------------------------------------
Test passes

ping @monishdeb @eileenmcnaughton somehow this one wasn't picked up in my earlier testing making me thing we just recently enabled testing on this report. Again this is php7.2 but the code change makes sense and 