### PR TITLE
dev/core#135 Fix first of 2 non numeric issues in CRM_Batch_form_entr…

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -718,7 +718,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           }
         }
 
-        $params['actualBatchTotal'] += $value['total_amount'];
+        $params['actualBatchTotal'] += (float) $value['total_amount'];
 
         unset($value['financial_type']);
         unset($value['payment_instrument']);


### PR DESCRIPTION
…yTest

Overview
----------------------------------------
This fixes a PHP7.1 issue where a non well formed numeric value is encountered

Before
----------------------------------------
Test fails on PHP7.1

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

.
Installing 47demotest_c6lz0 database
...E                                                               5 / 5 (100%)

Time: 37.54 seconds, Memory: 42.25MB

There was 1 error:

1) CRM_Batch_Form_EntryTest::testMembershipRenewalDates
A non well formed numeric value encountered

/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/CRM/Batch/Form/Entry.php:721
/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/CRM/Batch/Form/Entry.php:922
/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/tests/phpunit/CRM/Batch/Form/EntryTest.php:256
/home/seamus/buildkit/build/47.demo/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:192
/home/seamus/buildkit/bin/phpunit5:598

ERRORS!
Tests: 5, Assertions: 143, Errors: 1.
```

After
----------------------------------------
Test still fails on PHP7.1 but at a later point in the batch process on another non well formed numeric value

ping @eileenmcnaughton @monishdeb