### PR TITLE
CRM-21632 - {membership.fee} prints out in documents with 9 decimal p…

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1762,6 +1762,7 @@ class CRM_Utils_Token {
               'id' => $membership['membership_type_id'],
               'return' => 'minimum_fee',
             ));
+          $value = CRM_Utils_Money::format($value, NULL, NULL, TRUE);
         }
         catch (CiviCRM_API3_Exception $e) {
           // we can anticipate we will get an error if the minimum fee is set to 'NULL' because of the way the


### PR DESCRIPTION
…laces

Overview
----------------------------------------
Membership fee prints out in documents with 9 decimal places due to recent changes

Before
----------------------------------------
![fee_before](https://user-images.githubusercontent.com/3455173/40441550-068d0756-5edf-11e8-8d9c-b39ab2395532.png)


After
----------------------------------------
![change_after](https://user-images.githubusercontent.com/3455173/40468515-3fda0682-5f4b-11e8-8df0-761991631c04.png)
