### PR TITLE
Find CKEditor relative to the resource URL

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -734,7 +734,7 @@ class CRM_Core_Resources {
       CRM_Admin_Page_CKEditorConfig::setConfigDefault();
       $items[] = array(
         'config' => array(
-          'wysisygScriptLocation' => Civi::paths()->getUrl("[civicrm.root]/js/wysiwyg/crm.ckeditor.js"),
+          'wysisygScriptLocation' => $config->userFrameworkResourceURL . "/js/wysiwyg/crm.ckeditor.js",
           'CKEditorCustomConfig' => CRM_Admin_Page_CKEditorConfig::getConfigUrl(),
         ),
       );


### PR DESCRIPTION
In order to use CiviCRM with the vendor directory, the CKEditor code gets copied into the webroot (so the browser can access it) and so it needs to be found relative to the Resource URL (which is web accessible) rather than the CiviCRM root (which isn't).

See https://lab.civicrm.org/dev/drupal/issues/9