### PR TITLE
dev/drupal#9 : Allow vendor directory outside of docroot

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -422,7 +422,14 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     chdir($root);
 
     // Create a mock $request object
-    $autoloader = require_once $root . '/vendor/autoload.php';
+    $autoload_possible_paths = array($root, $root . "/..");
+    foreach ($autoload_possible_paths as $autoload_path) {
+      $autoload_path .= '/vendor/autoload.php';
+      if (file_exists($autoload_path)) {
+        break;
+      }
+    }
+    $autoloader = require_once $autoload_path;
     if ($autoloader === TRUE) {
       $autoloader = ComposerAutoloaderInitDrupal8::getLoader();
     }


### PR DESCRIPTION
It's considered best practice with composer-based webapps to keep the vendor directory outside the webroot. This change looks for it in the directory above.

BEFORE
------------------------
You cannot keep vendor directory outside the webroot.

AFTER
-----------------------
You can add vendor directory above the webroot.