### PR TITLE
dev/core#117 Replace deprecated each() function in CiviCase

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -975,8 +975,8 @@ LIMIT  1
     $extends = array('case');
     $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
     $caseCustomFields = array();
-    while (list($gid, $group_values) = each($groupTree)) {
-      while (list($id, $field_values) = each($group_values['fields'])) {
+    foreach ($groupTree as $gid => $group_values) {
+      foreach ($group_values['fields'] as $id => $field_values) {
         if (array_key_exists($id, $customValues)) {
           $caseCustomFields[$gid]['title'] = $group_values['title'];
           $caseCustomFields[$gid]['values'][$id] = array(


### PR DESCRIPTION
Overview
---------------------------------------
Does what it says in the title each() is deprecated in PHP7.2 

Before
----------------------------------------
Deprecated function is used

After
----------------------------------------
non deprecated function is used

ping @eileenmcnaughton @colemanw @monishdeb 
