### PR TITLE
dev/core#117 Replace useage of deprecated each() in MembershpView for…

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -255,7 +255,12 @@ END AS 'relType'
         $relTypeId = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_type_id']);
         $relDirection = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_direction']);
         foreach ($relTypeId as $rid) {
-          $dir = each($relDirection);
+          $dir = [
+            1 => $relDirection[0],
+            'value' => $relDirection[0],
+            0 => 0,
+            'key' => 0,
+          ];
           $relTypeDir[substr($dir['value'], 0, 1)][] = $rid;
         }
         // build query in 2 parts with a UNION if necessary


### PR DESCRIPTION
…m as per example #1 at http://php.net/manual/en/function.each.php

Overview
----------------------------------------
This removes the usage of the each() function. The each function is different to foreach in general except when used in a `while (list(x, y) = each(blah))` situation. Here i have tried to replicate the output of what each would be as per Example #1 here http://php.net/manual/en/function.each.php specifically the first of the 2 examples in Example #1

Before
----------------------------------------
Deprecated function used

After
----------------------------------------
no depreciated function used

ping @eileenmcnaughton @monishdeb 