### PR TITLE
dev/core#117 Replace usage of deprecated each() in Activity Summary R…

### DIFF
--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -684,7 +684,7 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
           }
         }
         $date_suffixes = array('relative', 'from', 'to');
-        while (list(, $suffix) = each($date_suffixes)) {
+        foreach ($date_suffixes as $suffix) {
           if (!empty($this->_params['activity_date_time_' . $suffix])) {
             list($from, $to)
               = $this->getFromTo(


### PR DESCRIPTION
…eport

Overview
----------------------------------------
Does what it says on the box, this is an identical change but just in a different report to https://github.com/civicrm/civicrm-core/pull/12189

Before
----------------------------------------
Deprecated function used

After
----------------------------------------
No deprecated function used

ping @eileenmcnaughton @monishdeb 