### PR TITLE
dev/core#117 Replace deprecated each in CiviEvent Participant registr…

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -910,7 +910,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
       if (!$this->_single && !empty($event_id)) {
         $duplicateContacts = 0;
-        while (list($k, $dupeCheckContactId) = each($this->_contactIds)) {
+        foreach ($this->_contactIds as $k => $dupeCheckContactId) {
           // Eliminate contacts that have already been assigned to this event.
           $dupeCheck = new CRM_Event_BAO_Participant();
           $dupeCheck->contact_id = $dupeCheckContactId;


### PR DESCRIPTION
…ation

Overview
----------------------------------------
This replaces the depreciated function each() with a foreach as per Example #2 http://php.net/manual/en/function.each.php 

Before
----------------------------------------
Deprecated function used

After
----------------------------------------
No Deprecated function used

ping @eileenmcnaughton @monishdeb 