### PR TITLE
dev/core#38 Fix inappropriate limit on participant.getcount

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -819,7 +819,7 @@ function _civicrm_api3_get_options_from_params(&$params, $queryObject = FALSE, $
 
   $options = array(
     'offset' => CRM_Utils_Rule::integer($offset) ? $offset : NULL,
-    'limit' => CRM_Utils_Rule::integer($limit) ? $limit : NULL,
+    'limit' => (!$is_count && CRM_Utils_Rule::integer($limit)) ? $limit : NULL,
     'is_count' => $is_count,
     'return' => !empty($returnProperties) ? $returnProperties : array(),
   );

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -99,6 +99,23 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
+   * Check that getCount can count past 25.
+   */
+  public function testGetCountLimit() {
+    $contactIDs = [];
+
+    for ($count = $this->callAPISuccessGetCount('Participant', []); $count < 27; $count++) {
+      $contactIDs[] = $contactID = $this->individualCreate();
+      $this->participantCreate(['contact_id' => $contactID, 'event_id' => $this->_eventID]);
+    }
+    $this->callAPISuccessGetCount('Participant', [], 27);
+
+    foreach ($contactIDs as $contactID) {
+      $this->callAPISuccess('Contact', 'delete', ['id' => $contactID]);
+    }
+  }
+
+  /**
    * Test get participants with role_id.
    */
   public function testGetParticipantWithRole() {


### PR DESCRIPTION
Overview
----------------------------------------
Fix API Participant getcount returns 25 when it should be higher


Before
----------------------------------------
DB with 27 participants returns 25 with participant.getcount api call (no criteria)

After
----------------------------------------
Above call returns 25

Technical Details
----------------------------------------

Comments
----------------------------------------
