### PR TITLE
[NFC] minor function tidy up - stop using  $ids array

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -450,7 +450,6 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       }
     }
     else {
-      $ids = array();
       $params = $this->exportValues();
 
       // allow multiple defaults within group.

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -196,8 +196,7 @@ class CRM_Core_OptionValue {
    * @return CRM_Core_DAO_OptionValue
    *
    */
-  public static function addOptionValue(&$params, &$groupParams, &$action, &$optionValueID) {
-    $ids = array();
+  public static function addOptionValue(&$params, &$groupParams, $action, $optionValueID) {
     $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
     // checking if the group name with the given id or name (in $groupParams) exists
     if (!empty($groupParams)) {
@@ -245,9 +244,9 @@ class CRM_Core_OptionValue {
       $params['name'] = $params['label'];
     }
     if ($action & CRM_Core_Action::UPDATE) {
-      $ids['optionValue'] = $optionValueID;
+      $params['id'] = $optionValueID;
     }
-    $optionValue = CRM_Core_BAO_OptionValue::add($params, $ids);
+    $optionValue = CRM_Core_BAO_OptionValue::add($params);
     return $optionValue;
   }
 

--- a/CRM/Report/Form/Register.php
+++ b/CRM/Report/Form/Register.php
@@ -190,7 +190,6 @@ class CRM_Report_Form_Register extends CRM_Core_Form {
     else {
       // get the submitted form values.
       $params = $this->controller->exportValues($this->_name);
-      $ids = array();
 
       $groupParams = array('name' => ('report_template'));
       $optionValue = CRM_Core_OptionValue::addOptionValue($params, $groupParams, $this->_action, $this->_id);


### PR DESCRIPTION
Overview
----------------------------------------
Very minor code tidy up - we no longer like the $ids array to be passed

Before
----------------------------------------
no change

After
----------------------------------------
no change

Technical Details
----------------------------------------
Just deprecating passing $ids into OptionValue::create

Comments
----------------------------------------

