### PR TITLE
dev/accessiblity#3 Add aria-label to form elements of contribution page which don't have accessible labels

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -554,7 +554,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $form->add('checkbox', 'is_recur', ts('I want to contribute this amount'), NULL);
 
     if (!empty($form->_values['is_recur_interval']) || $className == 'CRM_Contribute_Form_Contribution') {
-      $form->add('text', 'frequency_interval', ts('Every'), $attributes['frequency_interval']);
+      $form->add('text', 'frequency_interval', ts('Every'), $attributes['frequency_interval'] + ['aria-label' => ts('Every')]);
       $form->addRule('frequency_interval', ts('Frequency must be a whole number (EXAMPLE: Every 3 months).'), 'integer');
     }
     else {
@@ -595,7 +595,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           }
         }
       }
-      $frequencyUnit = &$form->add('select', 'frequency_unit', NULL, $units);
+      $frequencyUnit = &$form->addElement('select', 'frequency_unit', NULL, $units, ['aria-label' => ts('Frequency Unit')]);
     }
 
     // FIXME: Ideally we should freeze select box if there is only

--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -281,11 +281,11 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       $form->addRadio('is_pledge', ts('Pledge Frequency Interval'), $pledgeOptions,
         NULL, array('<br/>')
       );
-      $form->addElement('text', 'pledge_installments', ts('Installments'), array('size' => 3));
+      $form->addElement('text', 'pledge_installments', ts('Installments'), ['size' => 3, 'aria-label' => ts('Installments')]);
 
       if (!empty($pledgeBlock['is_pledge_interval'])) {
         $form->assign('is_pledge_interval', CRM_Utils_Array::value('is_pledge_interval', $pledgeBlock));
-        $form->addElement('text', 'pledge_frequency_interval', NULL, array('size' => 3));
+        $form->addElement('text', 'pledge_frequency_interval', NULL, ['size' => 3, 'aria-label' => ts('Frequency Intervals')]);
       }
       else {
         $form->add('hidden', 'pledge_frequency_interval', 1);
@@ -299,7 +299,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
           $freqUnits[$val] = !empty($pledgeBlock['is_pledge_interval']) ? "{$frequencyUnits[$val]}(s)" : $frequencyUnits[$val];
         }
       }
-      $form->addElement('select', 'pledge_frequency_unit', NULL, $freqUnits);
+      $form->addElement('select', 'pledge_frequency_unit', NULL, $freqUnits, ['aria-label' => ts('Frequency Units')]);
       // CRM-18854
       if (CRM_Utils_Array::value('is_pledge_start_date_visible', $pledgeBlock)) {
         if (CRM_Utils_Array::value('pledge_start_date', $pledgeBlock)) {

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -39,7 +39,8 @@
             <div class="label">{$form.$paymentField.label}
               {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
             </div>
-            <div class="content">{$form.$paymentField.html}
+            <div class="content">
+                {$form.$paymentField.html}
               {if $paymentField == 'cvv2'}{* @todo move to form assignment*}
                 <span class="cvv2-icon" title="{ts}Usually the last 3-4 digits in the signature area on the back of the card.{/ts}"> </span>
               {/if}

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -27,13 +27,11 @@
 {assign var='hideTotal' value=$quickConfig+$noCalcValueDisplay}
 <div id="pricesetTotal" class="crm-section section-pricesetTotal">
   <div class="label
-  {if $hideTotal},  hiddenElement{/if}" id="pricelabel">
-    <label>
-      {if ( $extends eq 'Contribution' ) || ( $extends eq 'Membership' )}
-      <span id='amount_sum_label'>{ts}Total Amount{/ts}{else}{ts}Total Fee(s){/ts}</span>
-       {if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}
-      {/if}
-    </label>
+{if $hideTotal},  hiddenElement{/if}" id="pricelabel">
+    {if ( $extends eq 'Contribution' ) || ( $extends eq 'Membership' )}
+    <span id='amount_sum_label'>{ts}Total Amount{/ts}{else}{ts}Total Fee(s){/ts}</span>
+     {if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}
+    {/if}
   </div>
   <div class="content calc-value" {if $hideTotal}style="display:none;"{/if} id="pricevalue" ></div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds `aria-label` property to all form elements of test/live contribution page which don't have accessible labels. And these elements are, listed under BEFORE screenshots

Before
----------------------------------------
1. Pledge frequency interval, unit and installments:
![screen shot 2018-05-25 at 5 18 12 pm](https://user-images.githubusercontent.com/3735621/40542888-ab3fbb84-603f-11e8-9cd6-b1a3b9e4010e.png)

2. Recurring frequency interval, unit and installments:
![screen shot 2018-05-25 at 5 19 27 pm](https://user-images.githubusercontent.com/3735621/40542921-d34d279c-603f-11e8-9bdf-de2ea2b45246.png)

4. Total amount label isn't associated with any form element:
![screen shot 2018-05-25 at 5 22 02 pm](https://user-images.githubusercontent.com/3735621/40543019-33884132-6040-11e8-83a0-70cdca5995cc.png)

After
----------------------------------------
1. Pledge frequency interval, unit and installments:
![screen shot 2018-05-25 at 5 08 04 pm](https://user-images.githubusercontent.com/3735621/40542633-82d8a4fe-603e-11e8-8a6f-71e4149cba26.png)

2. Recurring frequency interval, unit and installments:
![screen shot 2018-05-25 at 5 10 55 pm](https://user-images.githubusercontent.com/3735621/40542698-d91a3292-603e-11e8-8337-e807ab196795.png)

4. Removed orphan```<label>``` tag for total amount as per WAI a label always have associated control elements.

Technical Details
----------------------------------------
Here are the techniques I used to fix issues for these form elemetns:
1.  The QF elements whose label are not used in tpl, for those I added `aria-label` property.
```php
 $form->add('text', 'frequency_interval', ts('Every'), $attributes['frequency_interval'] + ['aria-label' => ts('Every')]);
```
2. Removed orphan <label> tag see ```templates/CRM/Price/Form/Calculate.tpl```

