### PR TITLE
dev/accessiblity#3 Add aria-label to datepicker element

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -376,6 +376,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if ($type == 'datepicker') {
       $attributes = ($attributes ? $attributes : array());
       $attributes['data-crm-datepicker'] = json_encode((array) $extra);
+      if (!empty($attributes['aria-label']) || $label) {
+        $attributes['aria-label'] = CRM_Utils_Array::value('aria-label', $attributes, $label);
+      }
       $type = "text";
     }
     if ($type == 'select' && is_array($extra)) {

--- a/js/Common.js
+++ b/js/Common.js
@@ -690,6 +690,7 @@ if (!CRM.vars) CRM.vars = {};
         $timeField
           .addClass('crm-form-text crm-form-time')
           .attr('placeholder', $dataField.attr('time-placeholder') === undefined ? ts('Time') : $dataField.attr('time-placeholder'))
+          .attr('aria-label', $dataField.attr('time-placeholder') === undefined ? ts('Time') : $dataField.attr('time-placeholder'))
           .change(updateDataField)
           .timeEntry({
             spinnerImage: '',
@@ -699,7 +700,7 @@ if (!CRM.vars) CRM.vars = {};
       if (settings.date !== false) {
         // Render "number" field for year-only format, calendar popup for all other formats
         $dateField = $('<input type="' + type + '">').insertAfter($dataField);
-        copyAttributes($dataField, $dateField, ['placeholder', 'style', 'class', 'disabled']);
+        copyAttributes($dataField, $dateField, ['placeholder', 'style', 'class', 'disabled', 'aria-label']);
         $dateField.addClass('crm-form-' + type);
         if (hasDatepicker) {
           settings.minDate = settings.minDate ? CRM.utils.makeDate(settings.minDate) : null;


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds aria-label attribute to datepicker date and time field.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40544576-6a909ec6-6046-11e8-958d-38e8be35a8f4.gif)


After
----------------------------------------
![screen shot 2018-05-25 at 6 01 58 pm](https://user-images.githubusercontent.com/3735621/40544416-dbbcb874-6045-11e8-9d51-4d366d47252e.png)


Technical Details
----------------------------------------
As per the datepicker enhancment, aria-label will be added to the date field if provided in attribute:
```php
$this->add(
  'datepicker',
  'field_2',
  ts('Date Field'),
  array(
    'class' => 'some-css-class',
    'aria-label' => ts('Date field'), // optional if label is present
    'time-placeholder' => ts('Time'), // optional
  ),
  TRUE,
  array('time' => FALSE, 'date' => 'mm-dd-yy', 'minDate' => '2000-01-01')
);
```
Whereas time field uses the placeholder.
