### PR TITLE
dev/accessiblity#3 Remove orphan label tag from Event pages

### DIFF
--- a/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
+++ b/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
@@ -34,7 +34,7 @@
     {/if}
     </td>
   </tr>
-  <tr><td><label>{ts}When{/ts}</label></td>
+  <tr><td>{ts}When{/ts}</td>
       <td width="90%">
         {$event.event_start_date|crmDate}
         {if $event.event_end_date}
@@ -51,7 +51,7 @@
 
   {if $isShowLocation}
     {if $location.address.1}
-      <tr><td><label>{ts}Location{/ts}</label></td>
+      <tr><td>{ts}Location{/ts}</td>
           <td>
             {$location.address.1.display|nl2br}
             {if ( $event.is_map &&
@@ -66,7 +66,7 @@
   {/if}{*End of isShowLocation condition*}
 
   {if $location.phone.1.phone || $location.email.1.email}
-    <tr><td><label>{ts}Contact{/ts}</label></td>
+    <tr><td>{ts}Contact{/ts}</td>
         <td>
         {* loop on any phones and emails for this event *}
            {foreach from=$location.phone item=phone}

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -115,7 +115,7 @@
   {/if}
   <div class="clear"></div>
   <div class="crm-section event_date_time-section">
-      <div class="label"><label>{ts}When{/ts}</label></div>
+      <div class="label">{ts}When{/ts}</div>
       <div class="content">
             <abbr class="dtstart" title="{$event.event_start_date|crmDate}">
             {$event.event_start_date|crmDate}</abbr>
@@ -140,7 +140,7 @@
 
         {if $location.address.1}
             <div class="crm-section event_address-section">
-                <div class="label"><label>{ts}Location{/ts}</label></div>
+                <div class="label">{ts}Location{/ts}</div>
                 <div class="content">{$location.address.1.display|nl2br}</div>
                 <div class="clear"></div>
             </div>
@@ -164,7 +164,7 @@
 
   {if $location.phone.1.phone || $location.email.1.email}
       <div class="crm-section event_contact-section">
-          <div class="label"><label>{ts}Contact{/ts}</label></div>
+          <div class="label">{ts}Contact{/ts}</div>
           <div class="content">
               {* loop on any phones and emails for this event *}
               {foreach from=$location.phone item=phone}
@@ -186,7 +186,7 @@
 
   {if $event.is_monetary eq 1 && $feeBlock.value}
       <div class="crm-section event_fees-section">
-          <div class="label"><label>{$event.fee_label}</label></div>
+          <div class="label">{$event.fee_label}</div>
           <div class="content">
               <table class="form-layout-compressed fee_block-table">
                   {foreach from=$feeBlock.value name=fees item=value}


### PR DESCRIPTION
Overview
----------------------------------------
This PR removes orphan labels, which means remove those labels which aren't associated with any control form elements.

Before
----------------------------------------
![screen shot 2018-05-30 at 4 15 22 pm](https://user-images.githubusercontent.com/3735621/40715905-c8260936-6424-11e8-92be-1403aaca756d.png)

After
----------------------------------------
![screen shot 2018-05-30 at 4 14 20 pm](https://user-images.githubusercontent.com/3735621/40715911-d23fb30e-6424-11e8-9b15-e3488feeb387.png)


