### PR TITLE
dev/core#142 Add chain select to state and counties in Search Builder

### DIFF
--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -43,7 +43,7 @@
       removeSelect(row);
     }
     else {
-      buildSelect(row, field, op);
+      buildSelect(row, field, op, false);
     }
 
     if ((field in CRM.searchBuilder.fieldTypes) === true &&
@@ -74,8 +74,9 @@
    * Add select list if appropriate for this operation
    * @param row: jQuery object
    * @param field: string
+   * @param skip_fetch: boolean
    */
-  function buildSelect(row, field, op) {
+  function buildSelect(row, field, op, skip_fetch) {
     var multiSelect = '';
     // Operators that will get a single drop down list of choices.
     var dropDownSingleOps = ['=', '!='];
@@ -96,7 +97,13 @@
       .hide()
       .after('<select class="crm-form-' + multiSelect.substr(0, 5) + 'select required" ' + multiSelect + '><option value="">' + ts('Loading') + '...</option></select>');
 
-    fetchOptions(row, field);
+    // Avoid reloading state/county options IF already built, identified by skip_fetch
+    if (skip_fetch) {
+      buildOptions(row, field);
+    }
+    else {
+      fetchOptions(row, field);
+    }
   }
 
   /**
@@ -205,6 +212,33 @@
     }
   }
 
+  /**
+   * Load and build select options for state IF country is chosen OR county options if state is chosen
+   * @param mapper: string
+   * @param value: integer
+   * @param location_type: integer
+   */
+  function chainSelect(mapper, value, location_type) {
+    var apiParams = {
+      sequential: 1,
+      field: (mapper == 'country_id') ?  'state_province' : 'county',
+    };
+    apiParams[mapper] = value;
+    var fieldName = apiParams.field;
+    CRM.api3('address', 'getoptions', apiParams, {
+      success: function(result) {
+        CRM.searchBuilder.fieldOptions[fieldName] = result.count ? result.values : [];
+        $('select[id^=mapper][id$="_1"]').each(function() {
+          var row = $(this).closest('tr');
+          var op = $('select[id^=operator]', row).val();
+          if ($(this).val() === fieldName && location_type === $('select[id^=mapper][id$="_2"]', row).val()) {
+            buildSelect(row, fieldName, op, true);
+          }
+        });
+      }
+    });
+  }
+
   // Initialize display: Hide empty blocks & fields
   var newBlock = CRM.searchBuilder && CRM.searchBuilder.newBlock || 0;
   function initialize() {
@@ -273,6 +307,13 @@
           value = value.join(',');
         }
         $(this).siblings('input').val(value);
+        if (value !== '') {
+          var mapper = $('#' + $(this).siblings('input').attr('id').replace('value_', 'mapper_') + '_1').val();
+          var location_type = $('#' + $(this).siblings('input').attr('id').replace('value_', 'mapper_') + '_2').val();
+          if ($.inArray(mapper, ['state_province', 'country']) > -1) {
+            chainSelect(mapper + '_id', value, location_type);
+          }
+        }
       })
       .on('crmLoad', function() {
         initialize();


### PR DESCRIPTION
Overview
----------------------------------------
The Search Builder state and county fields don't filter with reference to the country or state fields that are within the same AND grouping. The state field displays the states from the countries that have states enabled, and the county field displays all counties in alphabetical order.

Proposal:
1.  Make the states drop-down depend upon a country of the same location type, within the same "AND" grouping. Do the same for the counties with regard to the states. This would require some kind of parameter to be sent to the address/getoptions API to filter the list, but it would make them work in the same way as elsewhere in CiviCRM.
2. If there are no counties present for a state or no state present for a country, then render empty select list.


Before
----------------------------------------
State/Counties don't reload on changing country/state respectively in Search builder for same location type.

After
----------------------------------------
State/Counties reload on changing country/state respectively in Search builder for same location type (here as per screencast check that two location type used Home and Billing)
![test-multiple-after](https://user-images.githubusercontent.com/3735621/40577199-41e1467c-611f-11e8-9a35-e449fa3ce3fb.gif)
