### PR TITLE
dev/core#143 Contact 'World Region' Field not functioning properly in  Search Builder

### DIFF
--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -12,6 +12,7 @@
   function handleUserInputField() {
     var row = $(this).closest('tr');
     var field = $('select[id^=mapper][id$="_1"]', row).val();
+    field = (field === 'world_region') ? 'worldregion_id': field;
     var operator = $('select[id^=operator]', row);
     var op = operator.val();
 


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce:
1. 'Search' -> 'Search Builder'.
2. Search for 'Contacts' -> 'World Region' -> '='.
Upon doing the above, the user is presented with a text box instead of the expected dropdown  menu.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40579861-8892c98a-614f-11e8-899c-65713d1e1cf1.gif)

After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/40579863-91d20330-614f-11e8-8165-6161f05f831f.gif)
