### PR TITLE
CRM-21120 Add environment check for existence of mcrypt function

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -121,6 +121,27 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
+   * @return array
+   */
+  public function checkPhpEcrypt() {
+    $messages = array();
+    $test_pass = 'iAmARandomString';
+    $encrypted_test_pass = CRM_Utils_Crypt::encrypt($test_pass);
+    if ($encrypted_test_pass == base64_encode($test_pass)) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('Your PHP does not include the recommended encryption functions. Some passwords will not be stored encrypted, and if you have recently upgraded from a PHP that does include these functions, your encrypted passwords will not be decrypted correctly. If you are using PHP 7.0 or earlier, you probably want to include the "%1" extension.',
+          array('1' => 'mcrypt')
+        ),
+        ts('PHP Missing Extension "mcrypt"'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+    return $messages;
+  }
+
+  /**
    * Check that the MySQL time settings match the PHP time settings.
    *
    * @return array<CRM_Utils_Check_Message> an empty array, or a list of warnings


### PR DESCRIPTION
Overview
----------------------------------------
This is a resubmit of https://github.com/civicrm/civicrm-core/pull/10918 by @adixon 

Before
----------------------------------------
When Mcrypt extension isn't available no alert shown

After
----------------------------------------
Alert shown now when Mcrypt extension isn't available. 

ping @eileenmcnaughton @totten @colemanw 

To test this, check out the branch on a local buildkit build, Observe no warning message in the status checks. Edit the php that is used by the web server to disable mcrypt and restart web server. Observe that a warning now shows.

---

 * [CRM-21120: Warn if no crypt functions available](https://issues.civicrm.org/jira/browse/CRM-21120)