### PR TITLE
dev/core#137 Fix Find Deleted Cases 

### DIFF
--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -177,7 +177,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
       $tasks = CRM_Case_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
 
       if (!empty($this->_formValues['case_deleted'])) {
-        unset($tasks[CRM_Case_Task::DELETE]);
+        unset($tasks[CRM_Case_Task::TASK_DELETE]);
       }
       else {
         unset($tasks[CRM_Case_Task::RESTORE_CASES]);


### PR DESCRIPTION
Overview
As identified by @monishdeb "Find Cases" search deleted is no longer working because the wrong constant is being used.

https://lab.civicrm.org/dev/core/issues/137

Before
"The website encountered an unknown error"

After
Find deleted cases returns deleted cases.

Comments
This looks like a regression following clean up of case task in #11759