### PR TITLE
dev/core#148 Activity Separation field changes the default behaviour

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -617,6 +617,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     if (empty($defaults['status_id'])) {
       $defaults['status_id'] = CRM_Core_OptionGroup::getDefaultValue('activity_status');
     }
+
+    $defaults['separation'] = 'combined';
     return $defaults;
   }
 
@@ -738,8 +740,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         'separation',
         ts('Activity Separation'),
         array(
-          'separate' => ts('Create separate activities for each contact'),
           'combined' => ts('Create one activity with all contacts together'),
+          'separate' => ts('Create separate activities for each contact'),
         )
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
Activity Separation field was recently added. Some of the users without realizing might select the first option that is _Create separate activities for each contact_ which might confuse them since that's not how it behaved earlier.

Before
----------------------------------------
![activity_before](https://user-images.githubusercontent.com/3455173/40642425-b6366aa8-633a-11e8-9e16-b6dc1992d320.png)

After
----------------------------------------
![activity_after](https://user-images.githubusercontent.com/3455173/40642438-ba7cb75c-633a-11e8-88cc-1cfb5f2b17a6.png)

