### PR TITLE
Add upgrade function for message templates that does not involve copying the whole template

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -769,6 +769,7 @@ SET    version = '$version'
     foreach ($revisions as $rev) {
       if (version_compare($currentVer, $rev) < 0) {
         $versionObject = $this->incrementalPhpObject($rev);
+        CRM_Upgrade_Incremental_General::updateMessageTemplate($preUpgradeMessage, $rev);
         if (is_callable(array($versionObject, 'setPreUpgradeMessage'))) {
           $versionObject->setPreUpgradeMessage($preUpgradeMessage, $rev, $currentVer);
         }

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -184,6 +184,18 @@ class CRM_Upgrade_Incremental_Base {
   }
 
   /**
+   * Do any relevant message template updates.
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @param string $version
+   */
+  public static function updateMessageTemplates($ctx, $version) {
+    $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates($version);
+    $messageTemplateObject->updateTemplates();
+
+  }
+
+  /**
    * Drop a column from a table if it exist.
    *
    * @param CRM_Queue_TaskContext $ctx

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -118,12 +118,36 @@ class CRM_Upgrade_Incremental_General {
   }
 
   /**
+   * Perform any message template updates. 5.0+.
+   * @param $message
+   * @param $version
+   */
+  public static function updateMessageTemplate(&$message, $version) {
+    if (version_compare($version, 5.0, '<')) {
+      return;
+    }
+    $messageObj = new CRM_Upgrade_Incremental_MessageTemplates($version);
+    $messages = $messageObj->getUpgradeMessages();
+    if (empty($messages)) {
+      return;
+    }
+    $message .= '<br />' . ts("The default copies of the message templates listed below will be updated to handle new features or correct a problem. Your installation has customized versions of these message templates, and you will need to apply the updates manually after running this upgrade. <a href='%1' style='color:white; text-decoration:underline; font-weight:bold;' target='_blank'>Click here</a> for detailed instructions. %2", array(
+        1 => 'http://wiki.civicrm.org/confluence/display/CRMDOC/Message+Templates#MessageTemplates-UpgradesandCustomizedSystemWorkflowTemplates',
+        2 => '<ul><l>' . implode('</li><li>', $messages) . '</li></ul>',
+      ));
+
+    $messageObj->updateTemplates();
+  }
+
+  /**
    * @param $message
    * @param $latestVer
    * @param $currentVer
    */
   public static function checkMessageTemplate(&$message, $latestVer, $currentVer) {
-
+    if (version_compare($currentVer, 5.0, '>')) {
+      return;
+    }
     $sql = "SELECT orig.workflow_id as workflow_id,
              orig.msg_title as title
             FROM civicrm_msg_template diverted JOIN civicrm_msg_template orig ON (

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -106,7 +106,9 @@ class CRM_Upgrade_Incremental_MessageTemplates {
     $messages = [];
     foreach ($updates as $key => $value) {
       $templateLabel = civicrm_api3('OptionValue', 'getvalue', [
-        'return' => 'label', 'name' => $value['name'], 'options' => ['limit' => 1]
+        'return' => 'label',
+        'name' => $value['name'],
+        'options' => ['limit' => 1],
       ]);
       $messages[$templateLabel] = $value['upgrade_descriptor'];
     }

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -1,0 +1,147 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ */
+class CRM_Upgrade_Incremental_MessageTemplates {
+
+  /**
+   * Version we are upgrading to.
+   *
+   * @var string
+   */
+  protected $upgradeVersion;
+
+  /**
+   * @return string
+   */
+  public function getUpgradeVersion() {
+    return $this->upgradeVersion;
+  }
+
+  /**
+   * @param string $upgradeVersion
+   */
+  public function setUpgradeVersion($upgradeVersion) {
+    $this->upgradeVersion = $upgradeVersion;
+  }
+
+  /**
+   * CRM_Upgrade_Incremental_MessageTemplates constructor.
+   *
+   * @param string $upgradeVersion
+   */
+  public function __construct($upgradeVersion) {
+    $this->setUpgradeVersion($upgradeVersion);
+  }
+
+  /**
+   * Get any templates that have been updated.
+   *
+   * @return array
+   */
+  protected function getTemplateUpdates() {
+    return [
+      [
+        'version' => '5.4.alpha1',
+        'upgrade_descriptor' => ts('Use email greeting at top where available'),
+        'templates' => [
+          ['name' => 'membership_online_receipt', 'type' => 'text'],
+          ['name' => 'membership_online_receipt', 'type' => 'html'],
+        ]
+      ],
+    ];
+  }
+
+  /**
+   * Get any required template updates.
+   *
+   * @return array
+   */
+  public function getTemplatesToUpdate() {
+    $templates = $this->getTemplateUpdates();
+    $return = [];
+    foreach ($templates as $templateArray) {
+      if ($templateArray['version'] === $this->getUpgradeVersion()) {
+        foreach ($templateArray['templates'] as $template) {
+          $return[$template['name'] . '_' . $template['type']] = array_merge($template, $templateArray);
+        }
+      }
+    }
+    return $return;
+  }
+
+  /**
+   * Get the upgrade messages.
+   */
+  public function getUpgradeMessages() {
+    $updates = $this->getTemplatesToUpdate();
+    $messages = [];
+    foreach ($updates as $key => $value) {
+      $templateLabel = civicrm_api3('OptionValue', 'getvalue', [
+        'return' => 'label', 'name' => $value['name'], 'options' => ['limit' => 1]
+      ]);
+      $messages[$templateLabel] = $value['upgrade_descriptor'];
+    }
+    return $messages;
+  }
+
+  /**
+   * Update message templates.
+   */
+  public function updateTemplates() {
+    $templates = $this->getTemplatesToUpdate();
+    foreach ($templates as $template) {
+      $workFlowID = CRM_Core_DAO::singleValueQuery("SELECT MAX(id) as id FROM civicrm_option_value WHERE name = %1", [
+        1 => [$template['name'], 'String'],
+      ]);
+      $content = file_get_contents(\Civi::paths()->getPath('[civicrm.root]/xml/templates/message_templates/' . $template['name'] . '_' . $template['type'] . '.tpl'));
+      $templatesToUpdate = [];
+      $templatesToUpdate[] = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_msg_template WHERE workflow_id = $workFlowID AND is_reserved = 1");
+      $defaultTemplateID = CRM_Core_DAO::singleValueQuery("
+        SELECT default_template.id FROM civicrm_msg_template reserved
+        LEFT JOIN civicrm_msg_template default_template
+          ON reserved.workflow_id = default_template.workflow_id
+        WHERE reserved.workflow_id = $workFlowID
+        AND reserved.is_reserved = 1 AND default_template.is_default = 1 AND reserved.id <> default_template.id
+      ");
+      if ($defaultTemplateID) {
+        $templatesToUpdate[] = $defaultTemplateID;
+      }
+
+      CRM_Core_DAO::executeQuery("
+        UPDATE civicrm_msg_template SET msg_{$template['type']} = %1 WHERE id IN (" . implode(',', $templatesToUpdate) . ")", [
+          1 => [$content, 'String']
+          ]
+      );
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Class CRM_UF_Page_ProfileEditorTest
+ * @group headless
+ */
+class CRM_Upgrade_Incremental_Base_Test extends CiviUnitTestCase {
+
+  /**
+   * Test message upgrade process.
+   */
+  public function testMessageTemplateUpgrade() {
+    $workFlowID = civicrm_api3('OptionValue', 'getvalue', ['return' => 'id', 'name' => 'membership_online_receipt', 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
+
+    $templates = $this->callAPISuccess('MessageTemplate', 'get', ['workflow_id' => $workFlowID])['values'];
+    foreach ($templates as $template) {
+      $originalText = $template['msg_text'];
+      $this->callAPISuccess('MessageTemplate', 'create', ['msg_text' => 'great what a cool member you are', 'id' => $template['id']]);
+      $msg_text = $this->callAPISuccessGetValue('MessageTemplate', ['id' => $template['id'], 'return' => 'msg_text']);
+      $this->assertEquals('great what a cool member you are', $msg_text);
+    }
+    $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates('5.4.alpha1');
+    $messageTemplateObject->updateTemplates();
+
+    foreach ($templates as $template) {
+      $msg_text = $this->callAPISuccessGetValue('MessageTemplate', ['id' => $template['id'], 'return' => 'msg_text']);
+      $this->assertContains('{ts}Membership Information{/ts}', $msg_text);
+      if ($msg_text !== $originalText) {
+        // Reset value for future tests.
+        $this->callAPISuccess('MessageTemplate', 'create', ['msg_text' => $originalText, 'id' => $template['id']]);
+      }
+    }
+  }
+
+  /**
+   * Test message upgrade process only edits the default if the template is customised.
+   */
+  public function testMessageTemplateUpgradeAlreadyCustomised() {
+    $workFlowID = civicrm_api3('OptionValue', 'getvalue', ['return' => 'id', 'name' => 'membership_online_receipt', 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
+
+    $templates = $this->callAPISuccess('MessageTemplate', 'get', ['workflow_id' => $workFlowID])['values'];
+    foreach ($templates as $template) {
+      if ($template['is_reserved']) {
+        $originalText = $template['msg_text'];
+        $this->callAPISuccess('MessageTemplate', 'create', ['msg_text' => 'great what a cool member you are', 'id' => $template['id']]);
+      }
+      else {
+        $this->callAPISuccess('MessageTemplate', 'create', ['msg_text' => 'great what a silly sausage you are', 'id' => $template['id']]);
+      }
+    }
+    $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates('5.4.alpha1');
+    $messageTemplateObject->updateTemplates();
+
+    foreach ($templates as $template) {
+      $msg_text = $this->callAPISuccessGetValue('MessageTemplate', ['id' => $template['id'], 'return' => 'msg_text']);
+      if ($template['is_reserved']) {
+        $this->assertTrue(strstr($msg_text, '{ts}Membership Information{/ts}'));
+      }
+      else {
+        $this->assertEquals('great what a silly sausage you are', $msg_text);
+      }
+
+      if ($msg_text !== $originalText) {
+        // Reset value for future tests.
+        $this->callAPISuccess('MessageTemplate', 'create', ['msg_text' => $originalText, 'id' => $template['id']]);
+      }
+    }
+  }
+
+  /**
+   * Test function for messages on upgrade.
+   */
+  public function testMessageTemplateGetUpgradeMessages() {
+    $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates('5.4.alpha1');
+    $messages = $messageTemplateObject->getUpgradeMessages();
+    $this->assertEquals(['Memberships - Receipt (on-line)' => 'Use email greeting at top where available'], $messages);
+  }
+
+}

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -1,3 +1,4 @@
+{if $contact.email_greeting}{$contact.email_greeting},{/if}
 {if $receipt_text}
 {$receipt_text}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Improved upgrade process for message templates

Before
----------------------------------------
We have to create a copy of the message template in the upgrades directory, leaving the possibility of it getting mis-copied or out of date.

After
----------------------------------------
Declare updates in an array, leave files in their original location, rely on version control for tracking

Technical Details
----------------------------------------
This is still very much WIP & likely doesn't work as yet & current questions are
1) how to make sure the process is called each upgrade iteration & 
2) where best to test - can I just test the class & functions or do I need something more directly in the upgrade test

Comments
----------------------------------------
@seamuslee001 @totten any thoughts - goal is to make pr's like this much simpler - https://github.com/civicrm/civicrm-core/pull/11674
