### PR TITLE
dev/core#149 - Fatal Error on customvalue get api

### DIFF
--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -145,22 +145,27 @@ function civicrm_api3_custom_value_get($params) {
   unset($params['entity_id'], $params['entity_table']);
   foreach ($params as $id => $param) {
     if ($param && substr($id, 0, 6) == 'return') {
-      $id = substr($id, 7);
-      list($c, $i) = CRM_Utils_System::explode('_', $id, 2);
-      if ($c == 'custom' && is_numeric($i)) {
-        $names['custom_' . $i] = 'custom_' . $i;
-        $id = $i;
+      $returnVal = $param;
+      if (!empty(substr($id, 7))) {
+        $returnVal = substr($id, 7);
       }
-      else {
-        // Lookup names if ID was not supplied
-        list($group, $field) = CRM_Utils_System::explode(':', $id, 2);
-        $id = CRM_Core_BAO_CustomField::getCustomFieldID($field, $group);
-        if (!$id) {
-          continue;
+      foreach ((array) $returnVal as $value) {
+        list($c, $i) = CRM_Utils_System::explode('_', $value, 2);
+        if ($c == 'custom' && is_numeric($i)) {
+          $names['custom_' . $i] = 'custom_' . $i;
+          $fldId = $i;
         }
-        $names['custom_' . $id] = 'custom_' . $i;
+        else {
+          // Lookup names if ID was not supplied
+          list($group, $field) = CRM_Utils_System::explode(':', $value, 2);
+          $fldId = CRM_Core_BAO_CustomField::getCustomFieldID($field, $group);
+          if (!$fldId) {
+            continue;
+          }
+          $names['custom_' . $fldId] = 'custom_' . $i;
+        }
+        $getParams['custom_' . $fldId] = 1;
       }
-      $getParams['custom_' . $id] = 1;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on custom value get api.

Before
----------------------------------------
Custom Value `get` API fails with a fatal error.

    $result = civicrm_api3('CustomValue', 'get', [
      'sequential' => 1,
      'return' => "custom_1",
      'entity_id' => 202,
    ]];

Result -

    "is_error": 1,
    "error_message": "A fatal error was triggered:  is not of type String"



After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Incorrect parameter passed in `civicrm_api3_custom_value_get()` fucntion.

Comments
----------------------------------------
Added unit test.

------------------

Gitlab Issue - https://lab.civicrm.org/dev/core/issues/149