### PR TITLE
dev/core#147 Use location type machine name as table alias instead of label

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1013,7 +1013,7 @@ class CRM_Contact_BAO_Query {
       return;
     }
 
-    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $locationTypes = CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');
     $processed = array();
     $index = 0;
 
@@ -2374,7 +2374,7 @@ class CRM_Contact_BAO_Query {
       list($tbName, $fldName) = explode(".", $where);
 
       //get the location name
-      $locationType = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+      $locationType = CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');
       $specialFields = array('email', 'im', 'phone', 'openid', 'phone_ext');
       if (in_array($locType[0], $specialFields)) {
         //hack to fix / special handing for phone_ext
@@ -2800,7 +2800,7 @@ class CRM_Contact_BAO_Query {
           if ($locationTypeName) {
             //we have a join on an location table - possibly in conjunction with search builder - CRM-14263
             $parts = explode('-', $name);
-            $locationTypes = CRM_Core_BAO_Address::buildOptions('location_type_id', 'get');
+            $locationTypes = CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');
             foreach ($locationTypes as $locationTypeID => $locationType) {
               if ($parts[0] == str_replace(' ', '_', $locationType)) {
                 $locationID = $locationTypeID;

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -416,7 +416,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           ),
         );
 
-        $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+        $locationTypes = CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');
 
         foreach ($this->_fields as $name => $field) {
           if (!empty($field['in_selector']) &&
@@ -492,7 +492,16 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           if (trim($phoneType) && !is_numeric($phoneType) && strtolower($phoneType) != $fld) {
             $title .= "-{$phoneType}";
           }
-          $title .= " ($loc)";
+          // fetch Location type label from name as $loc, which will be later used in column header
+          $title .= sprintf(" (%s)",
+            CRM_Core_PseudoConstant::getLabel(
+              'CRM_Core_DAO_Address',
+              'location_type_id',
+              CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_Address', 'location_type_id', $loc)
+            )
+          );
+          // use field name instead of table alias
+          $prop = $fld;
         }
         elseif (isset($this->_query->_fields[$prop]) && isset($this->_query->_fields[$prop]['title'])) {
           $title = $this->_query->_fields[$prop]['title'];

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -1130,7 +1130,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
       return $fields;
     }
 
-    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $locationTypes = CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');
     foreach ($params['mapper'] as $key => $value) {
       foreach ($value as $k => $v) {
         if (isset($v[1])) {


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce, change Display Name of a location type to some Non-ASCII text (or just install civicrm on some Non-ASCII language, in my case Russian). Then go to Search Builder and try to search contacts with phone, or email, or address of that location type.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40666048-73f2622c-637c-11e8-8d8f-78b6ff702061.gif)

After
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40665973-47554bc6-637c-11e8-9bd4-4efac6c97e06.gif)


Technical Details
----------------------------------------
Earlier we use non-ASCII character in location type labels, then this causes a validation issue (which is CORRECT). As per the fix, I have changed the logic to use machine name later used as a table alias + from UI end we already got a form validation in place which prevents a user to from entering a non-alphanumeric character for m/c name so there is no way we could use a non ASCII character in m/c name. 

