### PR TITLE
Backdrop - update styles for status messages

### DIFF
--- a/css/backdrop.css
+++ b/css/backdrop.css
@@ -1,15 +1,30 @@
 /* Styles specific to Backdrop CMS */
 
 /* Make status messages work with Backdrop styles */
-.crm-container .messages.status {
+.crm-container :not(.crm-footer) .messages.status {
   background-color: #E9EEBC;
   padding: 0.9em 0.625em 1em 3.438em;
   border: none;
 }
 
-@media only screen and (min-width:34em) {
-  .crm-container .messages.status {
-    padding-left: 4.375em;
-  }
+.crm-container :not(.crm-footer) .messages.status .crm-i {
+  font-size: 1.5rem;
+  color: #fff;
+  background-color: #CFDE56;
+  position: absolute;
+  padding: .4rem;
+  left: 0;
+  top: 0;
+  box-sizing: border-box;
 }
 
+@media only screen and (min-width:34em) {
+  .crm-container :not(.crm-footer) .messages.status {
+    padding-left: 4.375em;
+  }
+  
+  .crm-container :not(.crm-footer) .messages.status .crm-i {
+    font-size: 1.75rem;
+    padding: .5rem;
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Works better with stock status messages and now works with Shoreditch enabled as well.

Before
----------------------------------------
**Standard:**
![before-standard](https://user-images.githubusercontent.com/871421/40670983-3f8e2274-6330-11e8-8338-73a40c9f6604.jpg)

**Shoreditch:**
![before-shoreditch](https://user-images.githubusercontent.com/871421/40670991-48069d00-6330-11e8-9aa5-af1f418bb889.jpg)

After
----------------------------------------
**Both standard and Shoreditch:**
![after](https://user-images.githubusercontent.com/871421/40671021-56f761c8-6330-11e8-9e1c-0f8c1079c107.jpg)
