### PR TITLE
dev/core#151: Allow to Edit Recurring Contributions From Membership

### DIFF
--- a/CRM/Member/Page/RecurringContributions.php
+++ b/CRM/Member/Page/RecurringContributions.php
@@ -112,14 +112,18 @@ class CRM_Member_Page_RecurringContributions extends CRM_Core_Page {
    */
   private function setActionsForRecurringContribution($recurID, &$recurringContribution) {
     $action = array_sum(array_keys($this->recurLinks($recurID)));
+
     // no action allowed if it's not active
     $recurringContribution['is_active'] = ($recurringContribution['contribution_status_id'] != 3);
+
     if ($recurringContribution['is_active']) {
       $details = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurringContribution['id'], 'recur');
       $hideUpdate = $details->membership_id & $details->auto_renew;
-      if ($hideUpdate || empty($details->processor_id)) {
+
+      if ($hideUpdate) {
         $action -= CRM_Core_Action::UPDATE;
       }
+
       $recurringContribution['action'] = CRM_Core_Action::formLink(
         $this->recurLinks($recurID),
         $action,


### PR DESCRIPTION
## Overview
The table added to view recurring contributions form the membership details view (https://lab.civicrm.org/dev/core/issues/38) was never showing the 'Edit' action. The table shown when looking at recurring contributions from within a membership should behave exactly as the table shown on a contact's **Contributions** tab.

## Before
The table added to view recurring contributions form the membership details view was never showing the 'Edit' action, even though the user had all necessary permissions.

## After
Eliminated a condition that was checking if recurring contributions had an associated payment processor, however this field was never available to be checked. Fixed by eliminating this check, as it is no longer needed.

## Notes
Issue on tracker:
https://lab.civicrm.org/dev/core/issues/151