### PR TITLE
dev/core#155 Allow saving of new option value with value = 0.

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -407,7 +407,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
     $dataType = self::getOptionGroupDataType($self->_gName);
     if ($dataType && $self->_gName !== 'activity_type') {
       $validate = CRM_Utils_Type::validate($fields['value'], $dataType, FALSE);
-      if (!$validate) {
+      if ($validate === FALSE) {
         CRM_Core_Session::setStatus(
           ts('Data Type of the value field for this option value does not match ' . $dataType),
           ts('Value field Data Type mismatch'));

--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -129,7 +129,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       }
     }
 
-    //setDefault of contact types for email greeting, postal greeting, addressee, CRM-4575
+    // setDefault of contact types for email greeting, postal greeting, addressee, CRM-4575
     if (in_array($this->_gName, array(
       'email_greeting',
       'postal_greeting',
@@ -302,7 +302,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       $enabled->freeze();
     }
 
-    //fix for CRM-3552, CRM-4575
+    // fix for CRM-3552, CRM-4575
     $showIsDefaultGroups = array(
       'email_greeting',
       'postal_greeting',
@@ -322,7 +322,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       $this->add('checkbox', 'is_default', ts('Default Option?'));
     }
 
-    //get contact type for which user want to create a new greeting/addressee type, CRM-4575
+    // get contact type for which user want to create a new greeting/addressee type, CRM-4575
     if (in_array($this->_gName, array(
         'email_greeting',
         'postal_greeting',
@@ -341,7 +341,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
 
     if ($this->_gName == 'participant_status') {
       // For Participant Status options, expose the 'filter' field to track which statuses are "Counted", and the Visibility field
-      $element = $this->add('checkbox', 'filter', ts('Counted?'));
+      $this->add('checkbox', 'filter', ts('Counted?'));
       $this->add('select', 'visibility_id', ts('Visibility'), CRM_Core_PseudoConstant::visibility());
     }
     if ($this->_gName == 'participant_role') {
@@ -364,6 +364,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
    *
    * @return array
    *   array of errors / empty array.
+   * @throws \CRM_Core_Exception
    */
   public static function formRule($fields, $files, $self) {
     $errors = array();
@@ -435,7 +436,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       $fieldValues = array('option_group_id' => $this->_gid);
-      $wt = CRM_Utils_Weight::delWeight('CRM_Core_DAO_OptionValue', $this->_id, $fieldValues);
+      CRM_Utils_Weight::delWeight('CRM_Core_DAO_OptionValue', $this->_id, $fieldValues);
 
       if (CRM_Core_BAO_OptionValue::del($this->_id)) {
         if ($this->_gName == 'phone_type') {

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -224,7 +224,7 @@ class CRM_Core_OptionValue {
     }
     $params['option_group_id'] = $optionGroupID;
 
-    if (($action & CRM_Core_Action::ADD) && empty($params['value'])) {
+    if (($action & CRM_Core_Action::ADD) && !isset($params['value'])) {
       $fieldValues = array('option_group_id' => $optionGroupID);
       // use the next available value
       /* CONVERT(value, DECIMAL) is used to convert varchar


### PR DESCRIPTION
Overview
----------------------------------------
Allow saving of new option value with value = 0.

Before
----------------------------------------
Could not save new option value with value=0.
After
----------------------------------------
Can save option value with value=0, no warning that datatype does not match.

Technical Details
----------------------------------------
Code was using empty() and !$variable which both treat 0 as FALSE.  These are changed to !isset() and $variable === FALSE respectively.

Comments
----------------------------------------
Long-standing bug that's been around since 4.6!
