### PR TITLE
dev/core#150 : Chain select for country/state in Search Builder does not stay within OR groupings

### DIFF
--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -218,8 +218,9 @@
    * @param mapper: string
    * @param value: integer
    * @param location_type: integer
+   * @param section: section in which the country/state selection change occurred
    */
-  function chainSelect(mapper, value, location_type) {
+  function chainSelect(mapper, value, location_type, section) {
     var apiParams = {
       sequential: 1,
       field: (mapper == 'country_id') ?  'state_province' : 'county',
@@ -228,14 +229,16 @@
     var fieldName = apiParams.field;
     CRM.api3('address', 'getoptions', apiParams, {
       success: function(result) {
-        CRM.searchBuilder.fieldOptions[fieldName] = result.count ? result.values : [];
-        $('select[id^=mapper][id$="_1"]').each(function() {
-          var row = $(this).closest('tr');
-          var op = $('select[id^=operator]', row).val();
-          if ($(this).val() === fieldName && location_type === $('select[id^=mapper][id$="_2"]', row).val()) {
-            buildSelect(row, fieldName, op, true);
-          }
-        });
+        if (result.count) {
+          CRM.searchBuilder.fieldOptions[fieldName] = result.values;
+          $('select[id^=mapper_' + section + '][id$="_1"]').each(function() {
+            var row = $(this).closest('tr');
+            var op = $('select[id^=operator]', row).val();
+            if ($(this).val() === fieldName && location_type === $('select[id^=mapper][id$="_2"]', row).val()) {
+              buildSelect(row, fieldName, op, true);
+            }
+          });
+        }
       }
     });
   }
@@ -311,8 +314,9 @@
         if (value !== '') {
           var mapper = $('#' + $(this).siblings('input').attr('id').replace('value_', 'mapper_') + '_1').val();
           var location_type = $('#' + $(this).siblings('input').attr('id').replace('value_', 'mapper_') + '_2').val();
+          var section = $(this).siblings('input').attr('id').replace('value_', '').split('_')[0];
           if ($.inArray(mapper, ['state_province', 'country']) > -1) {
-            chainSelect(mapper + '_id', value, location_type);
+            chainSelect(mapper + '_id', value, location_type, section);
           }
         }
       })


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes two issues:
1. Upon chain select for country/state affects the list of respective states/counties select field of different "Also include contacts where" sections.
2. If no states/counties are present in the respective selection of country/state then it wipes out the list of these select fields. 

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/40682092-8ac510b8-63a8-11e8-906e-650abf8356c2.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/40682111-95fc4fbe-63a8-11e8-95b9-3664de7441c9.gif)


https://lab.civicrm.org/dev/core/issues/150