### PR TITLE
dev/mail#11 Add pre/post hook for CRM_Mailing_BAO_MailingJob

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -72,7 +72,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     $jobDAO = new CRM_Mailing_BAO_MailingJob();
     $jobDAO->copyValues($params, TRUE);
     $jobDAO->save();
-    if (!empty($params['mailing_id'])) {
+    if (!empty($params['mailing_id']) && empty($params['_skip_evil_bao_auto_recipients_'])) {
       CRM_Mailing_BAO_Mailing::getRecipients($params['mailing_id']);
     }
     CRM_Utils_Hook::post($op, 'MailingJob', $jobDAO->id, $jobDAO);
@@ -165,7 +165,6 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       }
 
       /* Queue up recipients for the child job being launched */
-
       if ($job->status != 'Running') {
         $transaction = new CRM_Core_Transaction();
 
@@ -283,11 +282,11 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
 
         $transaction = new CRM_Core_Transaction();
 
-        $saveJob = new CRM_Mailing_DAO_MailingJob();
-        $saveJob->id = $job->id;
-        $saveJob->end_date = date('YmdHis');
-        $saveJob->status = 'Complete';
-        $saveJob->save();
+        self::create([
+          'id' => $job->id,
+          'end_date' => date('YmdHis'),
+          'status' => 'Complete',
+        ]);
 
         $mailing->reset();
         $mailing->id = $job->mailing_id;

--- a/CRM/Mailing/BAO/Spool.php
+++ b/CRM/Mailing/BAO/Spool.php
@@ -87,26 +87,23 @@ class CRM_Mailing_BAO_Spool extends CRM_Mailing_DAO_Spool {
         return PEAR::raiseError('Unable to create spooled mailing.');
       }
 
-      $job = new CRM_Mailing_BAO_MailingJob();
-      $job->is_test = 0;  // if set to 1 it doesn't show in the UI
-      $job->status = 'Complete';
-      $job->scheduled_date = CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s'));
-      $job->start_date = $job->scheduled_date;
-      $job->end_date = $job->scheduled_date;
-      $job->mailing_id = $mailing->id;
-      $job->save();
-      $job_id = $job->id; // need this for parent_id below
+      $saveJob = new CRM_Mailing_DAO_MailingJob();
 
-      $job = new CRM_Mailing_BAO_MailingJob();
-      $job->is_test = 0;
-      $job->status = 'Complete';
-      $job->scheduled_date = CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s'));
-      $job->start_date = $job->scheduled_date;
-      $job->end_date = $job->scheduled_date;
-      $job->mailing_id = $mailing->id;
-      $job->parent_id = $job_id;
-      $job->job_type = 'child';
-      $job->save();
+      $jobParams = array(
+        'is_test' => 0,
+        'scheduled_date' => date('YmdHis'),
+        'start_date' => date('YmdHis'),
+        'end_date' => date('YmdHis'),
+        'mailing_id' => $mailing->id,
+        'status' => 'Complete',
+      );
+      $job = CRM_Mailing_BAO_MailingJob::create($jobParams);
+
+      $jobParams = array_merge($jobParams, array(
+        'parent_id' => $job->id,
+        'job_type' => 'child',
+      ));
+      $job = CRM_Mailing_BAO_MailingJob::create($jobParams);
       $job_id = $job->id; // this is the one we want for the spool
 
       if (is_array($recipient)) {


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds pre/post hook for ```CRM_Mailing_BAO_MailingJob```

Before
----------------------------------------
1. No pre/post hook call on CRM_Mailing_BAO_MailingJob create or delete
2. No delete fn present
3. Directly call CRM_Mailing_BAO_MailingJob object to save/delete mailingJob record. 

After
----------------------------------------
1. Call the pre/post hook inside CRM_Mailing_BAO_MailingJob::create()
2. Add CRM_Mailing_BAO_MailingJob::deleteMailingJob to delete Mailing Jobs and add pre/post delete hook
3. Replace all the DAO call with corresponding create and delete fn in the codebase.

