### PR TITLE
dev/core#155 Fix optiongroup is_reserved data and use when selecting option group for custom fields

### DIFF
--- a/CRM/Admin/Form/OptionGroup.php
+++ b/CRM/Admin/Form/OptionGroup.php
@@ -110,22 +110,24 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
   public function postProcess() {
     CRM_Utils_System::flushCache();
 
-    $params = $this->exportValues();
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Core_BAO_OptionGroup::del($this->_id);
       CRM_Core_Session::setStatus(ts('Selected option group has been deleted.'), ts('Record Deleted'), 'success');
     }
     else {
-
-      $params = $ids = array();
       // store the submitted values in an array
       $params = $this->exportValues();
 
-      if ($this->_action & CRM_Core_Action::UPDATE) {
-        $ids['optionGroup'] = $this->_id;
+      // If we are adding option group via UI it should not be marked reserved.
+      if (!isset($params['is_reserved'])) {
+        $params['is_reserved'] = 0;
       }
 
-      $optionGroup = CRM_Core_BAO_OptionGroup::add($params, $ids);
+      if ($this->_action & CRM_Core_Action::UPDATE) {
+        $params['id'] = $this->_id;
+      }
+
+      $optionGroup = CRM_Core_BAO_OptionGroup::add($params);
       CRM_Core_Session::setStatus(ts('The Option Group \'%1\' has been saved.', array(1 => $optionGroup->name)), ts('Saved'), 'success');
     }
   }

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2034,6 +2034,8 @@ AND    cf.id = %1";
   /**
    * Get custom option groups.
    *
+   * @deprecated Use the API OptionGroup.get
+   *
    * @param array $includeFieldIds
    *   Ids of custom fields for which option groups must be included.
    *

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -317,21 +317,26 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     if ($this->_action == CRM_Core_Action::UPDATE) {
       $this->freeze('data_type');
     }
-    $includeFieldIds = NULL;
+
+    $optionGroupParams = array(
+      'is_reserved' => 0,
+      'is_active' => 1,
+      'options' => array('limit' => 0, 'sort' => "title ASC"),
+    );
     if ($this->_action == CRM_Core_Action::UPDATE) {
-      $includeFieldIds = $this->_values['id'];
+      $optionGroupParams['id'] = $this->_values['id'];
     }
-    $optionGroups = CRM_Core_BAO_CustomField::customOptionGroup($includeFieldIds);
-    $emptyOptGroup = FALSE;
-    if (empty($optionGroups)) {
-      $emptyOptGroup = TRUE;
-      $optionTypes = array('1' => ts('Create a new set of options'));
-    }
-    else {
-      $optionTypes = array(
-        '1' => ts('Create a new set of options'),
-        '2' => ts('Reuse an existing set'),
-      );
+
+    // OptionGroup selection
+    $optionTypes = array('1' => ts('Create a new set of options'));
+    // Get all custom (is_reserved=0) option groups
+    $optionGroupMetadata = civicrm_api3('OptionGroup', 'get', $optionGroupParams);
+    if (!empty($optionGroupMetadata['values'])) {
+      $emptyOptGroup = FALSE;
+      foreach ($optionGroupMetadata['values'] as $id => $metadata) {
+        $optionGroups[$id] = $metadata['title'];
+      }
+      $optionTypes['2'] = ts('Reuse an existing set');
 
       $this->add('select',
         'option_group_id',
@@ -341,6 +346,10 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
         ) + $optionGroups
       );
     }
+    else {
+      // No custom (non-reserved) option groups
+      $emptyOptGroup = TRUE;
+    }
 
     $element = &$this->addRadio('option_type',
       ts('Option Type'),
@@ -349,6 +358,10 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
         'onclick' => "showOptionSelect();",
       ), '<br/>'
     );
+    // if empty option group freeze the option type.
+    if ($emptyOptGroup) {
+      $element->freeze();
+    }
 
     $contactGroups = CRM_Core_PseudoConstant::group();
     asort($contactGroups);
@@ -368,11 +381,6 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     );
 
     $this->add('hidden', 'filter_selected', 'Group', array('id' => 'filter_selected'));
-
-    //if empty option group freeze the option type.
-    if ($emptyOptGroup) {
-      $element->freeze();
-    }
 
     // form fields of Custom Option rows
     $defaultOption = array();

--- a/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
@@ -13,3 +13,9 @@ ALTER TABLE civicrm_custom_field ALTER column is_active SET DEFAULT 1;
 SET @UKCountryId = (SELECT id FROM civicrm_country cc WHERE cc.name = 'United Kingdom');
 INSERT INTO civicrm_state_province (country_id, abbreviation, name)
 VALUES (@UKCountryId, 'MON', 'Monmouthshire');
+
+{* Fix is_reserved flag on civicrm_option_group table *}
+UPDATE civicrm_option_group AS cog INNER JOIN civicrm_custom_field AS ccf
+ON cog.id = ccf.option_group_id
+SET cog.is_reserved = 0 WHERE cog.is_active = 1 AND ccf.is_active = 1;
+UPDATE civicrm_option_group SET is_reserved = 1 WHERE name='environment';

--- a/sql/civicrm_sample_custom_data.mysql
+++ b/sql/civicrm_sample_custom_data.mysql
@@ -43,7 +43,7 @@ INSERT INTO `civicrm_custom_group` (`name`, `title`, `extends`, `style`, `collap
 -- * create option group for storing custom options for custom fields
 -- *
 -- *******************************************************/
-INSERT INTO  `civicrm_option_group` (`name`, `title`, `is_reserved`, `is_active`) VALUES ('custom_most_important_issue', 'Most Important Issue', 1, 1), ( 'custom_marital_status', 'Marital Status', 1, 1);
+INSERT INTO  `civicrm_option_group` (`name`, `title`, `is_reserved`, `is_active`) VALUES ('custom_most_important_issue', 'Most Important Issue', 0, 1), ( 'custom_marital_status', 'Marital Status', 1, 1);
 
 SELECT @option_most_id    := max(id) from civicrm_option_group where name = 'custom_most_important_issue';
 SELECT @option_marital_id := max(id) from civicrm_option_group where name = 'custom_marital_status';
@@ -78,7 +78,7 @@ CREATE TABLE `civicrm_value_constituent_information_1` (`id` int(10) unsigned NO
 
 -- Fall Fundraiser Dinner participants’ custom data
 
-INSERT INTO civicrm_option_group  ( name, title, is_active, is_reserved ) VALUES  ('soup_selection', 'Soup Selection', 1, 1);
+INSERT INTO  `civicrm_option_group` (`name`, `title`, `is_reserved`, `is_active`) VALUES  ('soup_selection', 'Soup Selection', 0, 1);
 SELECT @ogid := MAX(id) FROM civicrm_option_group;
 
 INSERT INTO civicrm_custom_group ( name, title,  extends, extends_entity_column_id, extends_entity_column_value, style, is_active, table_name) VALUES ('Food_Preference', 'Food Preference', 'Participant', 2, '1', 'Inline', 1, 'civicrm_value_food_preference_2');
@@ -97,7 +97,7 @@ INSERT INTO `civicrm_custom_group` (`name`, `title`, `extends`, `extends_entity_
 
 SELECT @cgid_contribution := MAX(id) FROM civicrm_custom_group;
 
-INSERT INTO civicrm_option_group  ( name, title, is_active ) VALUES ('how_long_have_you_been_a_donor', 'How long have you been a donor?', 1);
+INSERT INTO  `civicrm_option_group` (`name`, `title`, `is_reserved`, `is_active`) VALUES ('how_long_have_you_been_a_donor', 'How long have you been a donor?', 0, 1);
 
 SELECT @ogid_contribution := MAX(id) FROM civicrm_option_group;
 

--- a/templates/CRM/Admin/Page/OptionGroup.tpl
+++ b/templates/CRM/Admin/Page/OptionGroup.tpl
@@ -36,20 +36,31 @@
 {if $rows}
 
 <div id="browseValues">
-    {strip}
+  {if $action ne 1 and $action ne 2}
+    <div class="action-link">
+      {crmButton q="action=add&reset=1" id="newOptionGroup"  icon="plus-circle"}{ts}Add Option Group{/ts}{/crmButton}
+      {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
+    </div>
+  {/if}
+
+  {strip}
   {* handle enable/disable actions*}
    {include file="CRM/common/enableDisableApi.tpl"}
     <table cellpadding="0" cellspacing="0" border="0">
         <tr class="columnheader">
-        <th>{ts}Title{/ts}</th>
-        <th>{ts}Name{/ts}</th>
-        <th></th>
+          <th>{ts}Title{/ts}</th>
+          <th>{ts}Name{/ts}</th>
+          <th>{ts}Reserved{/ts}</th>
+          <th>{ts}Enabled?{/ts}</th>
+          <th></th>
         </tr>
         {foreach from=$rows item=row}
-      <tr id="optionGroup-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
-            <td class="crm-admin-optionGroup-title">{if $row.title}{$row.title}{else}( {ts}none{/ts} ){/if}</td>
-            <td class="crm-admin-optionGroup-name">{$row.name}</td>
-            <td><a href="{crmURL p="civicrm/admin/options" q="gid=`$row.id`&reset=1"}" title="{ts}View and Edit Options{/ts}">{ts}Options{/ts}</a></td>
+        <tr id="optionGroup-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+          <td class="crm-admin-optionGroup-title">{if $row.title}{$row.title}{else}( {ts}none{/ts} ){/if}</td>
+          <td class="crm-admin-optionGroup-name">{$row.name}</td>
+          <td class="crm-admin-optionGroup-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+          <td class="crm-admin-optionGroup-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+          <td><a href="{crmURL p="civicrm/admin/options" q="gid=`$row.id`&reset=1"}" title="{ts}View and Edit Options{/ts}">{ts}Options{/ts}</a></td>
         </tr>
         {/foreach}
     </table>
@@ -59,10 +70,10 @@
       <div class="action-link">
           {crmButton q="action=add&reset=1" id="newOptionGroup"  icon="plus-circle"}{ts}Add Option Group{/ts}{/crmButton}
           {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
-        </div>
+      </div>
     {/if}
 </div>
-{elseif $action NEQ 1 && $action NEQ 2}
+{elseif $action ne 1 and $action ne 2}
     <div class="messages status no-popup">
         <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
         {capture assign=crmURL}{crmURL p='civicrm/admin/optionGroup' q="action=add&reset=1"}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
*Review after #12233 is merged.*

As the is_reserved flag is not being shown in the UI, and is not editable from the UI it has not been used for anything in core even though it is there.

A common use-case is adding an option group and then adding a set of custom fields that use that option group (eg. for surveys) but that is currently not possible via the UI because the query that looks for available option groups is looking ONLY for option groups that are already linked to custom fields - a catch 22!

Before
----------------------------------------
Not possible to create optiongroups via the UI that can be used with custom fields.

After
----------------------------------------
Option groups that are created via the UI can be selected for use with custom fields.
![customfieldoptiongroup](https://user-images.githubusercontent.com/2052161/40686294-c4040e3e-638e-11e8-803e-5b430757b589.png)

