### PR TITLE
CiviCase, added reference of activities from different timelines.

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -242,6 +242,8 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     // set activity sets
     if (isset($xml->ActivitySets)) {
       $definition['activitySets'] = array();
+      $definition['timelineActivityTypes'] = array();
+
       foreach ($xml->ActivitySets->ActivitySet as $activitySetXML) {
         // parse basic properties
         $activitySet = array();
@@ -257,7 +259,11 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
         if (isset($activitySetXML->ActivityTypes)) {
           $activitySet['activityTypes'] = array();
           foreach ($activitySetXML->ActivityTypes->ActivityType as $activityTypeXML) {
-            $activitySet['activityTypes'][] = json_decode(json_encode($activityTypeXML), TRUE);
+            $activityType = json_decode(json_encode($activityTypeXML), TRUE);
+            $activitySet['activityTypes'][] = $activityType;
+            if ($activitySetXML->timeline) {
+              $definition['timelineActivityTypes'][] = $activityType;
+            }
           }
         }
         $definition['activitySets'][] = $activitySet;

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -261,6 +261,8 @@
     $scope.caseType.definition.caseRoles = $scope.caseType.definition.caseRoles || [];
     $scope.caseType.definition.statuses = $scope.caseType.definition.statuses || [];
 
+    $scope.caseType.definition.timelineActivityTypes = $scope.caseType.definition.timelineActivityTypes || [];
+
     $scope.selectedStatuses = {};
     _.each(apiCalls.caseStatuses.values, function (status) {
       $scope.selectedStatuses[status.name] = !$scope.caseType.definition.statuses.length || $scope.caseType.definition.statuses.indexOf(status.name) > -1;
@@ -288,14 +290,27 @@
     }
 
     function addActivityToSet(activitySet, activityTypeName) {
-      activitySet.activityTypes.push({
-        name: activityTypeName,
-        label: $scope.activityTypes[activityTypeName].label,
-        status: 'Scheduled',
-        reference_activity: 'Open Case',
-        reference_offset: '1',
-        reference_select: 'newest'
-      });
+      var activity = {
+          name: activityTypeName,
+          label: $scope.activityTypes[activityTypeName].label,
+          status: 'Scheduled',
+          reference_activity: 'Open Case',
+          reference_offset: '1',
+          reference_select: 'newest'
+      };
+      activitySet.activityTypes.push(activity);
+      if(typeof activitySet.timeline !== "undefined" && activitySet.timeline == "1") {
+        $scope.caseType.definition.timelineActivityTypes.push(activity);
+      }
+    }
+
+    function resetTimelineActivityTypes() {
+        $scope.caseType.definition.timelineActivityTypes = [];
+        angular.forEach($scope.caseType.definition.activitySets, function(activitySet) {
+            angular.forEach(activitySet.activityTypes, function(activityType) {
+                $scope.caseType.definition.timelineActivityTypes.push(activityType);
+            });
+        });
     }
 
     function createActivity(name, callback) {
@@ -363,6 +378,7 @@
       var idx = _.indexOf(array, item);
       if (idx != -1) {
         array.splice(idx, 1);
+        resetTimelineActivityTypes();
       }
     };
 
@@ -462,6 +478,7 @@
     if (!$scope.isForkable()) {
       CRM.alert(ts('The CiviCase XML file for this case-type prohibits editing the definition.'));
     }
+
   });
 
   crmCaseType.controller('CaseTypeListCtrl', function($scope, crmApi, caseTypes) {

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -39,7 +39,7 @@ Required vars: activitySet
         ui-jq="select2"
         ui-options="{dropdownAutoWidth : true}"
         ng-model="activity.reference_activity"
-        ng-options="activityType.name as activityType.label for activityType in activitySet.activityTypes"
+        ng-options="activityType.name as activityType.label for activityType in caseType.definition.timelineActivityTypes"
         >
         <option value="">-- Case Start --</option>
       </select>

--- a/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
@@ -23,6 +23,7 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
         'activitySets' => array(),
         'activityTypes' => array(),
         'caseRoles' => array(),
+        'timelineActivityTypes' => array(),
       )),
       'xml' => file_get_contents(__DIR__ . '/xml/empty-lists.xml'),
     );
@@ -41,6 +42,9 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
               array('name' => 'Open Case', 'status' => 'Completed'),
             ),
           ),
+        ),
+        'timelineActivityTypes' => array(
+          array('name' => 'Open Case', 'status' => 'Completed'),
         ),
         'caseRoles' => array(
           array('name' => 'First role', 'creator' => 1, 'manager' => 1),
@@ -78,6 +82,15 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
               array('name' => 'First act'),
               array('name' => 'Second act'),
             ),
+          ),
+        ),
+        'timelineActivityTypes' => array(
+          array('name' => 'Open Case', 'status' => 'Completed'),
+          array(
+            'name' => 'Meeting',
+            'reference_activity' => 'Open Case',
+            'reference_offset' => 1,
+            'reference_select' => 'newest',
           ),
         ),
         'caseRoles' => array(

--- a/tests/phpunit/api/v3/CaseTypeTest.php
+++ b/tests/phpunit/api/v3/CaseTypeTest.php
@@ -54,6 +54,9 @@ class api_v3_CaseTypeTest extends CiviCaseTestCase {
             ),
           ),
         ),
+        'timelineActivityTypes' => array(
+          array('name' => 'Open Case', 'status' => 'Completed'),
+        ),
         'caseRoles' => array(
           array('name' => 'First role', 'creator' => 1, 'manager' => 1),
         ),


### PR DESCRIPTION
Overview
----------------------------------------
CiviCase documentation implies that when creating an (optional) timeline for a case type in addition to the Standard Timeline, you should be able to specify ANY activity available to the case as a reference activity.

However the interface as it stands only allows you to select activities already contained WITHIN the current timeline which defeats the purpose.

If you adjust the XML definition directly in the civicrm_case_type table to use another activity type (of different timeline), and then add the timeline to a case, it works exactly as documented.

Steps to reproduce
----------------------------------------

1. Create a case type
2. Add couple of activities on standard timeline
3. Add new timeline
4. Add couple of activities on new timeline
5. Activities on standard timeline cannot reference activities from new timeline and vice versa

Before
----------------------------------------
In each timeline we can select only activities already contained WITHIN the current timeline. There is no option to select activity from another timeline.

After
----------------------------------------
Now we can reference activities from other timeline which works on both addition and deletion. 

Comments
----------------------------------------
_Agileware Ref: CIVICRM-874_
