### PR TITLE
dev/core/#152 - Remove AdvMulti-Select custom field type

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1246,7 +1246,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
           $htmlType = array(
             'CheckBox',
             'Multi-Select',
-            'AdvMulti-Select',
             'Select',
             'Radio',
             'Multi-Select State/Province',
@@ -1260,7 +1259,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
           }
 
           // check for values for custom fields for checkboxes and multiselect
-          if ($customFields[$customFieldID]['html_type'] == 'CheckBox' || $customFields[$customFieldID]['html_type'] == 'AdvMulti-Select' || $customFields[$customFieldID]['html_type'] == 'Multi-Select') {
+          if ($customFields[$customFieldID]['html_type'] == 'CheckBox' || $customFields[$customFieldID]['html_type'] == 'Multi-Select') {
             $value = trim($value);
             $value = str_replace('|', ',', $value);
             $mulValues = explode(',', $value);

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -99,7 +99,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           'Radio' => 'Radio',
           'CheckBox' => 'CheckBox',
           'Multi-Select' => 'Multi-Select',
-          'AdvMulti-Select' => 'AdvMulti-Select',
           'Autocomplete-Select' => 'Autocomplete-Select',
         ),
         array('Text' => 'Text', 'Select' => 'Select', 'Radio' => 'Radio'),
@@ -167,7 +166,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         break;
 
       case 'CheckBox':
-      case 'AdvMulti-Select':
       case 'Multi-Select':
         if (isset($params['default_checkbox_option'])) {
           $tempArray = array_keys($params['default_checkbox_option']);
@@ -819,7 +817,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       'Multi-Select State/Province',
       'Select Country',
       'Multi-Select Country',
-      'AdvMulti-Select',
       'CheckBox',
       'Radio',
     )));
@@ -828,7 +825,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $options = $field->getOptions($search ? 'search' : 'create');
 
       // Consolidate widget types to simplify the below switch statement
-      if ($search || ($widget !== 'AdvMulti-Select' && strpos($widget, 'Select') !== FALSE)) {
+      if ($search || (strpos($widget, 'Select') !== FALSE)) {
         $widget = 'Select';
       }
 
@@ -967,27 +964,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           );
           $qf->addGroup($operators, $elementName . '_operator');
           $qf->setDefaults(array($elementName . '_operator' => 'or'));
-        }
-        break;
-
-      case 'AdvMulti-Select':
-        $element = $qf->addElement(
-          'advmultiselect',
-          $elementName,
-          $label, $options,
-          array(
-            'size' => 5,
-            'style' => '',
-            'class' => 'advmultiselect',
-            'data-crm-custom' => $dataCrmCustomVal,
-          )
-        );
-
-        $element->setButtonAttributes('add', array('value' => ts('Add >>')));
-        $element->setButtonAttributes('remove', array('value' => ts('<< Remove')));
-
-        if ($useRequired && !$search) {
-          $qf->addRule($elementName, ts('%1 is a required field.', array(1 => $label)), 'required');
         }
         break;
 
@@ -1204,7 +1180,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       case 'Select Country':
       case 'Select State/Province':
       case 'CheckBox':
-      case 'AdvMulti-Select':
       case 'Multi-Select':
       case 'Multi-Select State/Province':
       case 'Multi-Select Country':
@@ -1373,7 +1348,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
     switch ($customField->html_type) {
       case 'CheckBox':
-      case 'AdvMulti-Select':
       case 'Multi-Select':
         $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldId, FALSE);
         $defaults[$elementName] = array();
@@ -1385,9 +1359,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
             if ($customField->html_type == 'CheckBox') {
               $defaults[$elementName][$val['value']] = 1;
             }
-            elseif ($customField->html_type == 'Multi-Select' ||
-              $customField->html_type == 'AdvMulti-Select'
-            ) {
+            elseif ($customField->html_type == 'Multi-Select') {
               $defaults[$elementName][$val['value']] = $val['value'];
             }
           }
@@ -1597,9 +1569,7 @@ SELECT id
       }
     }
 
-    if ($customFields[$customFieldId]['html_type'] == 'Multi-Select' ||
-      $customFields[$customFieldId]['html_type'] == 'AdvMulti-Select'
-    ) {
+    if ($customFields[$customFieldId]['html_type'] == 'Multi-Select') {
       if ($value) {
         $value = CRM_Utils_Array::implodePadded($value);
       }
@@ -1609,7 +1579,6 @@ SELECT id
     }
 
     if (($customFields[$customFieldId]['html_type'] == 'Multi-Select' ||
-        $customFields[$customFieldId]['html_type'] == 'AdvMulti-Select' ||
         $customFields[$customFieldId]['html_type'] == 'CheckBox'
       ) &&
       $customFields[$customFieldId]['data_type'] == 'String' &&

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1386,7 +1386,6 @@ ORDER BY civicrm_custom_group.weight,
 
         switch ($field['html_type']) {
           case 'Multi-Select':
-          case 'AdvMulti-Select':
           case 'CheckBox':
             $defaults[$elementName] = array();
             $customOption = CRM_Core_BAO_CustomOption::getCustomOption($field['id'], $inactiveNeeded);
@@ -1506,7 +1505,6 @@ ORDER BY civicrm_custom_group.weight,
         //added Multi-Select option in the below if-statement
         if ($field['html_type'] == 'CheckBox' ||
           $field['html_type'] == 'Radio' ||
-          $field['html_type'] == 'AdvMulti-Select' ||
           $field['html_type'] == 'Multi-Select'
         ) {
           $groupTree[$groupID]['fields'][$fieldId]['customValue']['data'] = 'NULL';
@@ -1542,10 +1540,6 @@ ORDER BY civicrm_custom_group.weight,
             }
             break;
 
-          //added for Advanced Multi-Select
-
-          case 'AdvMulti-Select':
-            //added for Multi-Select
           case 'Multi-Select':
             if (!empty($v)) {
               $groupTree[$groupID]['fields'][$fieldId]['customValue']['data'] = CRM_Core_DAO::VALUE_SEPARATOR
@@ -1663,7 +1657,6 @@ ORDER BY civicrm_custom_group.weight,
     $htmlType = array(
       'CheckBox',
       'Multi-Select',
-      'AdvMulti-Select',
       'Select',
       'Radio',
     );
@@ -1684,7 +1677,6 @@ ORDER BY civicrm_custom_group.weight,
             $valid = CRM_Core_BAO_CustomValue::typecheck($field['data_type'], $value);
           }
           if ($field['html_type'] == 'CheckBox' ||
-            $field['html_type'] == 'AdvMulti-Select' ||
             $field['html_type'] == 'Multi-Select'
           ) {
             $value = str_replace("|", ",", $value);

--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -155,7 +155,7 @@ class CRM_Core_BAO_CustomOption {
         $action -= CRM_Core_Action::DELETE;
       }
 
-      if (in_array($field->html_type, array('CheckBox', 'AdvMulti-Select', 'Multi-Select'))) {
+      if (in_array($field->html_type, ['CheckBox', 'Multi-Select'])) {
         if (isset($defVal) && in_array($dao->value, $defVal)) {
           $options[$dao->id]['is_default'] = '<img src="' . $config->resourceBase . 'i/check.gif" />';
         }
@@ -291,7 +291,6 @@ WHERE  id = %2";
           );
           break;
 
-        case 'AdvMulti-Select':
         case 'Multi-Select':
         case 'CheckBox':
           $oldString = CRM_Core_DAO::VALUE_SEPARATOR . $oldValue . CRM_Core_DAO::VALUE_SEPARATOR;

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1321,7 +1321,6 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
           elseif (in_array($htmlType, array(
             'CheckBox',
             'Multi-Select',
-            'AdvMulti-Select',
             'Multi-Select State/Province',
             'Multi-Select Country',
           ))) {
@@ -2388,7 +2387,6 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
             switch ($customFields[$customFieldId]['html_type']) {
               case 'Multi-Select State/Province':
               case 'Multi-Select Country':
-              case 'AdvMulti-Select':
               case 'Multi-Select':
                 $v = explode(CRM_Core_DAO::VALUE_SEPARATOR, $details[$name]);
                 foreach ($v as $item) {

--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -171,7 +171,7 @@ class CRM_Core_Page_AJAX_Location {
               $elements["onbehalf_{$key}"]['value'][$k] = $v;
             }
           }
-          elseif (strstr($htmlType, 'Multi-Select') && $htmlType != 'AdvMulti-Select') {
+          elseif (strstr($htmlType, 'Multi-Select')) {
             $elements["onbehalf_{$key}"]['type'] = 'Multi-Select';
             $elements["onbehalf_{$key}"]['value'] = array_values($defaults[$key]);
           }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -203,7 +203,6 @@ class CRM_Core_SelectValues {
       'RichTextEditor' => ts('Rich Text Editor'),
       'Autocomplete-Select' => ts('Autocomplete-Select'),
       'Multi-Select' => ts('Multi-Select'),
-      'AdvMulti-Select' => ts('AdvMulti-Select'),
       'Link' => ts('Link'),
       'ContactReference' => ts('Autocomplete-Select'),
     );

--- a/CRM/Custom/Form/ChangeFieldType.php
+++ b/CRM/Custom/Form/ChangeFieldType.php
@@ -155,7 +155,6 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
     $mutliValueOps = array(
       'CheckBox',
       'Multi-Select',
-      'AdvMulti-Select',
     );
 
     $srcHtmlType = $this->_values['html_type'];
@@ -220,7 +219,6 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
     $mutliValueOps = array(
       'CheckBox' => 'CheckBox',
       'Multi-Select' => 'Multi-Select',
-      'AdvMulti-Select' => 'AdvMulti-Select',
     );
 
     switch ($dataType) {

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -135,7 +135,6 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
           'Radio' => ts('Radio'),
           'CheckBox' => ts('CheckBox'),
           'Multi-Select' => ts('Multi-Select'),
-          'AdvMulti-Select' => ts('Adv Multi-Select (obsolete)'),
           'Autocomplete-Select' => ts('Autocomplete-Select'),
         ),
         array(
@@ -708,7 +707,7 @@ SELECT count(*)
     if (isset($fields['data_type'][1])) {
       $dataField = $fields['data_type'][1];
     }
-    $optionFields = array('Select', 'Multi-Select', 'CheckBox', 'Radio', 'AdvMulti-Select');
+    $optionFields = array('Select', 'Multi-Select', 'CheckBox', 'Radio');
 
     if (isset($fields['option_type']) && $fields['option_type'] == 1) {
       //capture duplicate Custom option values

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -115,7 +115,6 @@ class CRM_Custom_Form_Option extends CRM_Core_Form {
 
       if ($fieldDefaults['html_type'] == 'CheckBox'
         || $fieldDefaults['html_type'] == 'Multi-Select'
-        || $fieldDefaults['html_type'] == 'AdvMulti-Select'
       ) {
         if (!empty($fieldDefaults['default_value'])) {
           $defaultCheckValues = explode(CRM_Core_DAO::VALUE_SEPARATOR,
@@ -434,7 +433,6 @@ SELECT count(*)
       $customField->find(TRUE) &&
       (
         $customField->html_type == 'CheckBox' ||
-        $customField->html_type == 'AdvMulti-Select' ||
         $customField->html_type == 'Multi-Select'
       )
     ) {

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1633,7 +1633,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             break;
 
           case 'CheckBox':
-          case 'AdvMulti-Select':
           case 'Multi-Select':
           case 'Multi-Select Country':
           case 'Multi-Select State/Province':
@@ -1667,7 +1666,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
                   if (in_array($htmlType, array(
                     'CheckBox',
                     'Multi-Select',
-                    'AdvMulti-Select',
                   ))) {
                     $submitted[$key] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR,
                         $mergeValue

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -658,7 +658,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
       if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
         $values[$key] = $value;
         $type = $customFields[$customFieldID]['html_type'];
-        if ($type == 'CheckBox' || $type == 'Multi-Select' || $type == 'AdvMulti-Select') {
+        if ($type == 'CheckBox' || $type == 'Multi-Select') {
           $mulValues = explode(',', $value);
           $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
           $values[$key] = array();

--- a/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
@@ -13,3 +13,6 @@ ALTER TABLE civicrm_custom_field ALTER column is_active SET DEFAULT 1;
 SET @UKCountryId = (SELECT id FROM civicrm_country cc WHERE cc.name = 'United Kingdom');
 INSERT INTO civicrm_state_province (country_id, abbreviation, name)
 VALUES (@UKCountryId, 'MON', 'Monmouthshire');
+
+{* dev/core/#152 *}
+UPDATE `civicrm_custom_field` set `html_type` = "Multi-Select" WHERE `html_type` = "AdvMulti-Select";

--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -863,7 +863,6 @@ function _civicrm_api3_deprecated_add_formatted_param(&$values, &$params) {
           $htmlType = CRM_Utils_Array::value('html_type', $customFields[$customFieldID]);
           switch ($htmlType) {
             case 'CheckBox':
-            case 'AdvMulti-Select':
             case 'Multi-Select':
               if ($val) {
                 $mulValues = explode(',', $val);

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -243,7 +243,7 @@ SELECT count(*)
   }
 
   if (in_array($htmlType, array(
-    'Select', 'Multi-Select', 'CheckBox', 'Radio', 'AdvMulti-Select')) &&
+    'Select', 'Multi-Select', 'CheckBox', 'Radio')) &&
     !isset($errors[$fieldName])
   ) {
     $options = CRM_Core_OptionGroup::valuesByID($fieldDetails['option_group_id']);

--- a/templates/CRM/Custom/Form/ChangeFieldType.tpl
+++ b/templates/CRM/Custom/Form/ChangeFieldType.tpl
@@ -45,7 +45,7 @@
   function checkCustomDataField( ) {
     var srcHtmlType = '{/literal}{$srcHtmlType}{literal}';
     var singleValOps = ['Text', 'Select', 'Radio', 'Autocomplete-Select'];
-    var multiValOps  = ['CheckBox', 'Multi-Select', 'AdvMulti-Select'];
+    var multiValOps  = ['CheckBox', 'Multi-Select'];
     var dstHtmlType = cj('#dst_html_type').val( );
     if ( !dstHtmlType ) {
       return true;

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -184,18 +184,7 @@
 <script type="text/javascript">
   CRM.$(function($) {
     var $form = $('form.{/literal}{$form.formClass}{literal}'),
-      deprecatedNotice,
       dataTypes = {/literal}{$dataTypeKeys|@json_encode}{literal};
-
-    function deprecatedWidgets() {
-      deprecatedNotice && deprecatedNotice.close && deprecatedNotice.close();
-      switch ($('#data_type_1', $form).val()) {
-        case 'AdvMulti-Select':
-          deprecatedNotice = CRM.alert({/literal}'{ts escape="js"}The old "Advance Multi-Select" widget is being phased out and will be removed in a future version of CiviCRM. "Multi-Select" is the recommended substitute.{/ts}', '{ts escape="js"}Obsolete widget{/ts}'{literal}, 'alert', {expires: 0});
-          break;
-      }
-    }
-    $('#data_type_1', $form).each(deprecatedWidgets).change(deprecatedWidgets);
 
     function showSearchRange() {
       var htmlType = $("[name='data_type[1]']", $form).val(),

--- a/tests/phpunit/WebTest/Import/AddressImportTest.php
+++ b/tests/phpunit/WebTest/Import/AddressImportTest.php
@@ -201,12 +201,6 @@ class WebTest_Import_AddressImportTest extends ImportCiviSeleniumTestCase {
     $customField6 = 'Customfield_alp_multiselect' . substr(sha1(rand()), 0, 4);
     $customFieldId6 = $this->_createMultipleValueCustomField($customField6, 'Multi-Select');
 
-    // create custom field - "alphanumeric advmultiselect"
-    $this->click("newCustomField");
-    $this->waitForElementPresent('_qf_Field_done-bottom');
-    $customField7 = 'Customfield_alp_advmultiselect' . substr(sha1(rand()), 0, 4);
-    $customFieldId7 = $this->_createMultipleValueCustomField($customField7, 'AdvMulti-Select');
-
     // create custom field - "alphanumeric autocompleteselect"
     $this->click("newCustomField");
     $this->waitForElementPresent('_qf_Field_done-bottom');
@@ -253,7 +247,6 @@ class WebTest_Import_AddressImportTest extends ImportCiviSeleniumTestCase {
         "custom_{$customFieldId4}" => "$customField4 :: $customGroupTitle",
         "custom_{$customFieldId5}" => "$customField5 :: $customGroupTitle",
         "custom_{$customFieldId6}" => "$customField6 :: $customGroupTitle",
-        "custom_{$customFieldId7}" => "$customField7 :: $customGroupTitle",
         "custom_{$customFieldId8}" => "$customField8 :: $customGroupTitle",
         "custom_{$customFieldId1}" => "$customField1 :: $customGroupTitle",
         "custom_{$customFieldId2}" => "$customField2 :: $customGroupTitle",
@@ -267,7 +260,6 @@ class WebTest_Import_AddressImportTest extends ImportCiviSeleniumTestCase {
           "custom_{$customFieldId4}" => "label1",
           "custom_{$customFieldId5}" => "label1",
           "custom_{$customFieldId6}" => "label1",
-          "custom_{$customFieldId7}" => "label1",
           "custom_{$customFieldId8}" => "label1",
           "custom_{$customFieldId1}" => 1,
           "custom_{$customFieldId2}" => 12345,
@@ -281,7 +273,6 @@ class WebTest_Import_AddressImportTest extends ImportCiviSeleniumTestCase {
         $customField4 => 'label1',
         $customField5 => 'label1',
         $customField6 => 'label1',
-        $customField7 => 'label1',
         $customField8 => 'label1',
         $customField1 => '1',
         $customField2 => '12345',

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -109,7 +109,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     $customFieldDataType = CRM_Core_BAO_CustomField::dataType();
     $dataToHtmlTypes = CRM_Core_BAO_CustomField::dataToHtml();
     $count = 0;
-    $optionSupportingHTMLTypes = array('Select', 'Radio', 'CheckBox', 'AdvMulti-Select', 'Autocomplete-Select', 'Multi-Select');
+    $optionSupportingHTMLTypes = array('Select', 'Radio', 'CheckBox', 'Autocomplete-Select', 'Multi-Select');
 
     foreach ($customFieldDataType as $dataType => $label) {
       switch ($dataType) {


### PR DESCRIPTION
Overview
====
![screenshot from 2018-05-29 15 19 57](https://user-images.githubusercontent.com/2874912/40752706-ab8a32b0-643e-11e8-9f3c-a2e2075df08f.png)
This widget type has been deprecated and this warning has been part of the UI since 2014. This PR finally removes it.

Before
====
The obsolete "AdvMulti-Select" widget was available as a custom field type, but the above warning would pop up when selecting it.

After
====
No longer available. Any custom fields using that type are changed to regular mutli-select (which uses Select2, a much nicer widget).

* https://lab.civicrm.org/dev/core/issues/152