### PR TITLE
Only set defaults when creating a custom field (not when editing one)

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -274,13 +274,15 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
     $customField = new CRM_Core_DAO_CustomField();
     $customField->copyValues($params);
-    $customField->is_required = CRM_Utils_Array::value('is_required', $params, FALSE);
-    $customField->is_searchable = CRM_Utils_Array::value('is_searchable', $params, FALSE);
-    $customField->in_selector = CRM_Utils_Array::value('in_selector', $params, FALSE);
-    $customField->is_search_range = CRM_Utils_Array::value('is_search_range', $params, FALSE);
-    //CRM-15792 - Custom field gets disabled if is_active not set
-    $customField->is_active = CRM_Utils_Array::value('is_active', $params, TRUE);
-    $customField->is_view = CRM_Utils_Array::value('is_view', $params, FALSE);
+    if ($op == 'create') {
+      $customField->is_required = CRM_Utils_Array::value('is_required', $params, FALSE);
+      $customField->is_searchable = CRM_Utils_Array::value('is_searchable', $params, FALSE);
+      $customField->in_selector = CRM_Utils_Array::value('in_selector', $params, FALSE);
+      $customField->is_search_range = CRM_Utils_Array::value('is_search_range', $params, FALSE);
+      //CRM-15792 - Custom field gets disabled if is_active not set
+      $customField->is_active = CRM_Utils_Array::value('is_active', $params, TRUE);
+      $customField->is_view = CRM_Utils_Array::value('is_view', $params, FALSE);
+    }
     $customField->save();
 
     // make sure all values are present in the object for further processing

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -569,4 +569,31 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
     return $r;
   }
 
+  /**
+   * This test is designed to ensure that when a custom field is updated via the
+   * API, params that are not supplied do not revert to the defaults. This was
+   * happening with, for example, is_searchable
+   */
+  public function testDisableSearchableContactReferenceField() {
+    $customGroup = $this->customGroupCreate(array(
+      'name' => 'testCustomGroup',
+      'title' => 'testCustomGroup',
+      'extends' => 'Individual',
+    ));
+    $params = array(
+      'name' => 'testCustomField',
+      'label' => 'testCustomField',
+      'custom_group_id' => 'testCustomGroup',
+      'data_type' => 'ContactReference',
+      'html_type' => 'Autocomplete-Select',
+      'is_searchable' => '1',
+    );
+    $result = $this->callAPISuccess('CustomField', 'create', $params);
+    $params = [
+      'id' => $result['id'],
+      'is_active' => 0,
+    ];
+    $result = $this->callAPISuccess('CustomField', 'create', $params);
+  }
+
 }


### PR DESCRIPTION
Before
----------------------------------------

When editing a custom field via the API, any values that were not supplied would revert to the default


After
----------------------------------------

When editing current values are loaded via the ->find() method.


See test for more details