### PR TITLE
ensure that the indexed column is not an FK before deleting the index

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -189,14 +189,15 @@ class CRM_Core_BAO_SchemaHandler {
 
     //create index only for searchable fields during ADD,
     //create index only if field is become searchable during MODIFY,
-    //drop index only if field is no more searchable and index was exist.
+    //drop index only if field is no longer searchable and it does not reference
+    //a forgein key (and indexExist is true)
     if (!empty($params['searchable']) && !$indexExist) {
       $sql .= $separator;
       $sql .= str_repeat(' ', 8);
       $sql .= $prefix;
       $sql .= "INDEX_{$params['name']} ( {$params['name']} )";
     }
-    elseif (empty($params['searchable']) && $indexExist) {
+    elseif (empty($params['searchable']) && empty($params['fk_table_name']) && $indexExist) {
       $sql .= $separator;
       $sql .= str_repeat(' ', 8);
       $sql .= "DROP INDEX INDEX_{$params['name']}";

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -569,11 +569,28 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
     return $r;
   }
 
-  /**
-   * This test is designed to ensure that when a custom field is updated via the
-   * API, params that are not supplied do not revert to the defaults. This was
-   * happening with, for example, is_searchable
-   */
+  public function testMakeSearchableContactReferenceFieldUnsearchable() {
+    $customGroup = $this->customGroupCreate(array(
+      'name' => 'testCustomGroup',
+      'title' => 'testCustomGroup',
+      'extends' => 'Individual',
+    ));
+    $params = array(
+      'name' => 'testCustomField',
+      'label' => 'testCustomField',
+      'custom_group_id' => 'testCustomGroup',
+      'data_type' => 'ContactReference',
+      'html_type' => 'Autocomplete-Select',
+      'is_searchable' => '1',
+    );
+    $result = $this->callAPISuccess('CustomField', 'create', $params);
+    $params = [
+      'id' => $result['id'],
+      'is_searchable' => 0,
+    ];
+    $result = $this->callAPISuccess('CustomField', 'create', $params);
+  }
+
   public function testDisableSearchableContactReferenceField() {
     $customGroup = $this->customGroupCreate(array(
       'name' => 'testCustomGroup',


### PR DESCRIPTION
Before
------

When changing a custom field from searchable to not searchable, CiviCRM tries to remove the index. This causes a fatal error when the column is also a foreign key to another table because the index is needed for the foreign key.

After
-----

We ensure that the column is not an FK before removing the index

Technical details
-----------------

I added a test to CustomFieldTest which exercises this functionality