### PR TITLE
dev/core#158 group contacts list and export limits results to 500 records

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -32,37 +32,10 @@
  */
 
 /**
- * Class for activity task actions.
+ * Class for activity form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Activity_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
-
-  /**
-   * The array that holds all the contact ids.
-   *
-   * @var array
-   */
-  public $_contactIds;
+class CRM_Activity_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the member ids.

--- a/CRM/Campaign/Form/Task.php
+++ b/CRM/Campaign/Form/Task.php
@@ -34,35 +34,7 @@
 /**
  * This class generates form components for relationship.
  */
-class CRM_Campaign_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The additional clause that we restrict the search.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The task being performed
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The array that holds all the contact ids
-   *
-   * @var array
-   */
-  public $_contactIds;
-
-  /**
-   * The array that holds all the component ids
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Campaign_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the voter ids

--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -41,6 +41,13 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
   static $entityShortname = 'case';
 
   /**
+   * Must be set to queryMode
+   *
+   * @var int
+   */
+  static $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
+
+  /**
    * @inheritDoc
    */
   public function setContactIDs() {

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -491,18 +491,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       $this->assign('ts_all_id', $allRowsRadio->_attributes['id']);
     }
 
-    $selectedContactIds = array();
-    $qfKeyParam = CRM_Utils_Array::value('qfKey', $this->_formValues);
-    // We use ajax to handle selections only if the search results component_mode is set to "contacts"
-    if ($qfKeyParam && ($this->get('component_mode') <= CRM_Contact_BAO_Query::MODE_CONTACTS || $this->get('component_mode') == CRM_Contact_BAO_Query::MODE_CONTACTSRELATED)) {
-      $this->addClass('crm-ajax-selection-form');
-      $qfKeyParam = "civicrm search {$qfKeyParam}";
-      $selectedContactIdsArr = CRM_Core_BAO_PrevNextCache::getSelection($qfKeyParam);
-      $selectedContactIds = array_keys($selectedContactIdsArr[$qfKeyParam]);
-    }
-
-    $this->assign_by_ref('selectedContactIds', $selectedContactIds);
-
     $rows = $this->get('rows');
 
     if (is_array($rows)) {

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -34,7 +34,7 @@
 /**
  * This class generates form components for search-result tasks.
  */
-class CRM_Contact_Form_Task extends CRM_Core_Form {
+class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The task being performed

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -32,30 +32,10 @@
  */
 
 /**
- * This class generates form components for relationship.
+ * Class for contribute form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Contribute_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the contribution ids.
@@ -63,13 +43,6 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form {
    * @var array
    */
   protected $_contributionIds;
-
-  /**
-   * The array that holds all the contact ids.
-   *
-   * @var array
-   */
-  public $_contactIds;
 
   /**
    * The array that holds all the mapping contribution and contact ids.

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -70,10 +70,26 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
    */
   public $_contactIds;
 
-  // Must be set to entity table name (eg. civicrm_participant) by child class
+  /**
+   * Must be set to entity table name (eg. civicrm_participant) by child class
+   *
+   * @var string
+   */
   static $tableName = NULL;
-  // Must be set to entity shortname (eg. event)
+
+  /**
+   * Must be set to entity shortname (eg. event)
+   *
+   * @var string
+   */
   static $entityShortname = NULL;
+
+  /**
+   * Must be set to queryMode
+   *
+   * @var int
+   */
+  static $queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
 
   /**
    * Build all the data structures needed to build the form.
@@ -88,25 +104,24 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
    * Common pre-processing function.
    *
    * @param CRM_Core_Form $form
-   * @param bool $useTable FIXME This parameter could probably be deprecated as it's not used here
    *
    * @throws \CRM_Core_Exception
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_entityIds = array();
 
-    $values = $form->controller->exportValues($form->get('searchFormName'));
+    $searchFormValues = $form->controller->exportValues($form->get('searchFormName'));
 
-    $form->_task = $values['task'];
+    $form->_task = $searchFormValues['task'];
     $className = 'CRM_' . ucfirst($form::$entityShortname) . '_Task';
     $entityTasks = $className::tasks();
     $form->assign('taskName', $entityTasks[$form->_task]);
 
-    $ids = array();
-    if ($values['radio_ts'] == 'ts_sel') {
-      foreach ($values as $name => $value) {
+    $entityIds = array();
+    if ($searchFormValues['radio_ts'] == 'ts_sel') {
+      foreach ($searchFormValues as $name => $value) {
         if (substr($name, 0, CRM_Core_Form::CB_PREFIX_LEN) == CRM_Core_Form::CB_PREFIX) {
-          $ids[] = substr($name, CRM_Core_Form::CB_PREFIX_LEN);
+          $entityIds[] = substr($name, CRM_Core_Form::CB_PREFIX_LEN);
         }
       }
     }
@@ -117,24 +132,22 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
         $sortOrder = $form->get(CRM_Utils_Sort::SORT_ORDER);
       }
 
-      $query = new CRM_Contact_BAO_Query($queryParams, NULL, NULL, FALSE, FALSE,
-        CRM_Contact_BAO_Query::MODE_CASE
-      );
+      $query = new CRM_Contact_BAO_Query($queryParams, NULL, NULL, FALSE, FALSE, $form::$queryMode);
       $query->_distinctComponentClause = " ( " . $form::$tableName . ".id )";
       $query->_groupByComponentClause = " GROUP BY " . $form::$tableName . ".id ";
       $result = $query->searchQuery(0, 0, $sortOrder);
       $selector = $form::$entityShortname . '_id';
       while ($result->fetch()) {
-        $ids[] = $result->$selector;
+        $entityIds[] = $result->$selector;
       }
     }
 
-    if (!empty($ids)) {
-      $form->_componentClause = ' ' . $form::$tableName . '.id IN ( ' . implode(',', $ids) . ' ) ';
-      $form->assign('totalSelected' . ucfirst($form::$entityShortname) . 's', count($ids));
+    if (!empty($entityIds)) {
+      $form->_componentClause = ' ' . $form::$tableName . '.id IN ( ' . implode(',', $entityIds) . ' ) ';
+      $form->assign('totalSelected' . ucfirst($form::$entityShortname) . 's', count($entityIds));
     }
 
-    $form->_entityIds = $form->_componentIds = $ids;
+    $form->_entityIds = $form->_componentIds = $entityIds;
 
     // Some functions (eg. PDF letter tokens) rely on Ids being in specific fields rather than the generic $form->_entityIds
     // So we set that specific field here (eg. for cases $form->_caseIds = $form->_entityIds).

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -34,31 +34,10 @@
  */
 
 /**
- * This class generates task actions for CiviEvent
- *
+ * Class for event form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Event_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Event_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the participant ids.

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -36,7 +36,7 @@
 /**
  * This class gets the name of the file to upload
  */
-class CRM_Export_Form_Select extends CRM_Core_Form {
+class CRM_Export_Form_Select extends CRM_Core_Form_Task {
 
   /**
    * Various Contact types.
@@ -71,20 +71,6 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
   public $_componentTable;
 
   /**
-   * Must be set to entity table name (eg. civicrm_participant) by child class
-   *
-   * @var string
-   */
-  static $tableName = NULL;
-
-  /**
-   * Must be set to entity shortname (eg. event)
-   *
-   * @var string
-   */
-  static $entityShortname = NULL;
-
-  /**
    * Build all the data structures needed to build the form.
    *
    * @param
@@ -110,21 +96,16 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
 
     $stateMachine = $this->controller->getStateMachine();
     $formName = CRM_Utils_System::getClassName($stateMachine);
-    $isStandalone = $formName == 'CRM_Export_StateMachine_Standalone';
+    $this::$queryMode = $this->controller->get('component_mode');
 
     // we need to determine component export
-    $componentName = explode('_', $formName);
     $components = array('Contact', 'Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity');
 
-    if ($isStandalone) {
-      $componentName = array('CRM', $this->controller->get('entity'));
-    }
-
-    $componentMode = $this->controller->get('component_mode');
     // FIXME: This should use a modified version of CRM_Contact_Form_Search::getModeValue but it doesn't have all the contexts
-    switch ($componentMode) {
+    switch ($this::$queryMode) {
       case CRM_Contact_BAO_Query::MODE_CONTRIBUTE:
         $entityShortname = 'Contribute';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_MEMBER:
@@ -134,26 +115,37 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
 
       case CRM_Contact_BAO_Query::MODE_EVENT:
         $entityShortname = 'Event';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_PLEDGE:
         $entityShortname = 'Pledge';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_CASE:
         $entityShortname = 'Case';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_GRANT:
         $entityShortname = 'Grant';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_ACTIVITY:
         $entityShortname = 'Activity';
+        $entityDAOName = $entityShortname;
         break;
 
       default:
+        // FIXME: Code cleanup, we may not need to do this $componentName code here.
+        $componentName = explode('_', $formName);
+        if ($formName == 'CRM_Export_StateMachine_Standalone') {
+          $componentName = array('CRM', $this->controller->get('entity'));
+        }
         $entityShortname = $componentName[1]; // Contact
+        $entityDAOName = $entityShortname;
         break;
     }
 
@@ -206,7 +198,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
       }
     }
 
-    $formTaskClassName::preProcessCommon($this, !$isStandalone);
+    $formTaskClassName::preProcessCommon($this);
 
     // $component is used on CRM/Export/Form/Select.tpl to display extra information for contact export
     ($this->_exportMode == self::CONTACT_EXPORT) ? $component = FALSE : $component = TRUE;

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -106,7 +106,7 @@ class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
     $form->_grantIds = $form->_componentIds = $ids;
 
     //set the context for redirection for any task actions
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $this);
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $form);
     $urlParams = 'force=1';
     if (CRM_Utils_Rule::qfKey($qfKey)) {
       $urlParams .= "&qfKey=$qfKey";

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -34,31 +34,10 @@
  */
 
 /**
- * This class generates task actions for CiviEvent
- *
+ * Class for grant form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Grant_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the grant ids.

--- a/CRM/Mailing/Form/Task.php
+++ b/CRM/Mailing/Form/Task.php
@@ -32,30 +32,10 @@
  */
 
 /**
- * This class generates form components for relationship
+ * Class for mailing form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Mailing_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Mailing_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * Build all the data structures needed to build the form.

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -34,38 +34,10 @@
  */
 
 /**
- * Class for civimember task actions
- *
+ * Class for member form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Member_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
-
-  /**
-   * The array that holds all the contact ids.
-   *
-   * @var array
-   */
-  public $_contactIds;
+class CRM_Member_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the member ids.

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -32,30 +32,10 @@
  */
 
 /**
- * This class generates task actions for CiviEvent.
+ * Class for pledge form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Pledge_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Pledge_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the pledge ids.


### PR DESCRIPTION
Overview
----------------------------------------
Issue: https://lab.civicrm.org/dev/core/issues/158
@lcdservices 

To reproduce:

 create a group and add > 500 contacts to it
 go to the manage groups page and click contacts for that group to get the listing
 select all records and choose the export contacts action
 only 500 records are selected for export

Before
----------------------------------------
Can only export 500 contacts

After
----------------------------------------
Can export "All" contacts.

Technical Details
----------------------------------------
The limit in CRM/Contact/Selector restricts the PrevNextCache to 500.  The PrevNextCache is only used for contact searches and appears to only be used when entering via Manage Groups.

Removing the PrevNextCache allows the contact searches/Manage Group UI to work like every other entity type - where this issue has not occurred.