### PR TITLE
getCaseRoles not working when supplied relationship id.  civicrm_relationship table name changed to alias name rel because its changed in the actual query

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -869,7 +869,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
     );
 
     if ($relationshipID) {
-      $query .= ' AND civicrm_relationship.id = %3 ';
+      $query .= ' AND rel.id = %3 ';
       $params[3] = array($relationshipID, 'Integer');
     }
     $dao = CRM_Core_DAO::executeQuery($query, $params);


### PR DESCRIPTION
Overview
----------------------------------------
This function call getCaseRoles($contactID, $case_id, $relationshipID); from Case.php file in  \civicrm\CRM\Case\BAO location

CRM_Case_BAO_Case::getCaseRoles($contactID, $case_id, $relationshipID);

throwing error when passing $relationshipID. because actual query changed with alias name but one where condition is not changed with alias name. So updated with alias name to fix this issue.



Before
----------------------------------------
if ($relationshipID) {
      $query .= ' AND civicrm_relationship.id = %3 ';
      $params[3] = array($relationshipID, 'Integer');
    }

After
----------------------------------------

if ($relationshipID) {
      $query .= ' AND rel.id = %3 ';//Changed this alias name "rel" here
      $params[3] = array($relationshipID, 'Integer');
    }


