### PR TITLE
dev/mail#13 - All members should not be excluded from Smart unsubscribe group

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -166,9 +166,10 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         if ($groupType == 'Include') {
           $includeSmartGroupIDs[] = $groupDAO->id;
         }
-        else {
+        else if ($groupType == 'Exclude') {
           $excludeSmartGroupIDs[] = $groupDAO->id;
         }
+        //NOTE: Do nothing for base
       }
     }
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -166,7 +166,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         if ($groupType == 'Include') {
           $includeSmartGroupIDs[] = $groupDAO->id;
         }
-        else if ($groupType == 'Exclude') {
+        elseif ($groupType == 'Exclude') {
           $excludeSmartGroupIDs[] = $groupDAO->id;
         }
         //NOTE: Do nothing for base


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/mail/issues/13

All unsubscribe group members are excluded from a mailing with a  manually specified unsubscribe group (group_type=Base) if the unsubscribe group is a Smart group.

**To reproduce:** Create a smart group with some members in it. Some members may also be added and removed manually as usual. Search for some contacts including some who are in that smart group and choose the action to send/schedule a bulk email. When creating the mail select the Smart group as your unsubscribe group.

**The expected result:** The mailing is not sent to any contacts in the search who are in the smart un-subscribe group with the status "Removed".

Before
----------------------------------------
The result: The mailing is not sent to any contacts in the search who are in the smart un-subscribe group at all.

After
----------------------------------------
The expected result
