### PR TITLE
dev/mail#12 Incorrect Total Count on mail summary report

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -665,15 +665,19 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {
       // CRM-16506
-      if (array_key_exists('civicrm_mailing_name', $row) &&
-        array_key_exists('civicrm_mailing_id', $row)
-      ) {
-        $rows[$rowNum]['civicrm_mailing_name_link'] = CRM_Report_Utils_Report::getNextUrl('mailing/detail',
-          'reset=1&force=1&mailing_id_op=eq&mailing_id_value=' . $row['civicrm_mailing_id'],
-          $this->_absoluteUrl, $this->_id, $this->_drilldownReport
-        );
-        $rows[$rowNum]['civicrm_mailing_name_hover'] = ts('View Mailing details for this mailing');
-        $entryFound = TRUE;
+      if (array_key_exists('civicrm_mailing_id', $row)) {
+        if (array_key_exists('civicrm_mailing_name', $row)) {
+          $rows[$rowNum]['civicrm_mailing_name_link'] = CRM_Report_Utils_Report::getNextUrl('mailing/detail',
+            'reset=1&force=1&mailing_id_op=eq&mailing_id_value=' . $row['civicrm_mailing_id'],
+            $this->_absoluteUrl, $this->_id, $this->_drilldownReport
+          );
+          $rows[$rowNum]['civicrm_mailing_name_hover'] = ts('View Mailing details for this mailing');
+          $entryFound = TRUE;
+        }
+        if (array_key_exists('civicrm_mailing_event_opened_open_count', $row)) {
+          $rows[$rowNum]['civicrm_mailing_event_opened_open_count'] = CRM_Mailing_Event_BAO_Opened::getTotalCount($row['civicrm_mailing_id']);
+          $entryFound = TRUE;
+        }
       }
       // skip looking further in rows, if first row itself doesn't
       // have the column we need


### PR DESCRIPTION
Overview
----------------------------------------
When you visit the mail summary report, the Total Count is incorrect which includes the open count of all mailings, instead of its corresponding mail.
However mailing status page show correct count, and the difference w.r.t report is because in later there are lots of left joins, that attributes that bumps up the total open counts by not considering only the counts of a single mail but all.

Before
----------------------------------------
![screen shot 2018-06-01 at 5 29 57 pm](https://user-images.githubusercontent.com/3735621/40857627-4c42e8d0-65f9-11e8-98ff-77c62035caa8.png)

After
----------------------------------------
![screen shot 2018-06-02 at 12 10 40 am](https://user-images.githubusercontent.com/3735621/40857668-71b56746-65f9-11e8-81f1-a01f50a2a9f5.png)


Comments
----------------------------------------
This the screenshot of mailing status which shows correct count:
![screen shot 2018-06-01 at 5 28 48 pm](https://user-images.githubusercontent.com/3735621/40857612-4142d27e-65f9-11e8-9af5-286b73b37569.png)
