### PR TITLE
Auto-open tagest fields

### DIFF
--- a/CRM/Core/Form/Tag.php
+++ b/CRM/Core/Form/Tag.php
@@ -85,6 +85,7 @@ class CRM_Core_Form_Tag {
           'data-entity_table' => $entityTable,
           'data-entity_id' => $entityId,
           'class' => "crm-$mode-tagset",
+          'select' => array('minimumInputLength' => 0),
         ));
 
         if ($entityId) {


### PR DESCRIPTION
Overview
=====

Makes it easier to see what's in a tagset by opening the widget when clicking on it, as opposed to waiting till the user types.

Before
====
When clicking on a tagset field, you are prompted to type somthing before any tags display. This screenshot is from the "New Individual" form:
![screenshot from 2018-06-01 21 31 11](https://user-images.githubusercontent.com/2874912/40869117-57165816-65e3-11e8-86b1-3425992fe22f.png)

After
====
When clicking on a tagset field, the first 10 tags appear (alphabetically). Scrolling down will show more than 10, allowing you to browse the entire list via the "infinite scroll" feature of select2. You can still type in the search box to filter the results, as before.
![screenshot from 2018-06-01 21 32 15](https://user-images.githubusercontent.com/2874912/40869126-87a2b588-65e3-11e8-9ee6-3db7d903a23d.png)

Comments
====
I don't know why I didn't think to do this in the first place; it's much nicer.

https://civicrm.stackexchange.com/questions/20688/how-can-i-make-tags-in-tagsets-visible-to-users-who-want-to-tag-contacts/