### PR TITLE
fix of issue dev/core#127 (at gitlab), incorrect cache records for smart groups

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1354,3 +1354,7 @@
   name        : Yashodha Chaku
   organization: CiviDesk
   jira        : yashodha
+
+- github      : hosseinamin
+  name        : Hossein Amin
+  jira        : hosseinamin


### PR DESCRIPTION
Overview
----------------------------------------
There was an issue with creating multiple smart group with related contact component mode.
https://lab.civicrm.org/dev/core/issues/127
filterRelatedContacts at Query.php, was not distinguishing different queries.

Before
----------------------------------------
![screenshot from 2018-06-02 16-09-24](https://user-images.githubusercontent.com/21030850/40874956-23e295d4-6680-11e8-801b-bea5496cd7be.png)

After
----------------------------------------
![screenshot from 2018-06-02 16-13-26](https://user-images.githubusercontent.com/21030850/40874950-05be16a0-6680-11e8-8f25-d1508f03132b.png)


Technical Details
----------------------------------------
I did add a check for already filtered queries at the beginning to prevent multiple calls to filter duplicate it. And it prevents to not distinguish a unique `$arg_sig` for each input.

