### PR TITLE
CRM-159: Add Premium Column to Contributions List

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionRecurPayments.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurPayments.tpl
@@ -11,6 +11,7 @@
           <th class='crm-contact-receive_date'>{ts}Recieved{/ts}</th>
           <th class='crm-contact-thankyou_date'>{ts}Thank-you Sent{/ts}</th>
           <th class='crm-contact-contribution_status'>{ts}Status{/ts}</th>
+          <th class='crm-contact-contribution_premium'>{ts}Premium{/ts}</th>
           <th>&nbsp;</th>
         </tr>
         </thead>
@@ -27,6 +28,7 @@
             { data: 'formatted_receive_date' },
             { data: 'formatted_thankyou_date' },
             { data: 'contribution_status_label' },
+            { data: 'product_name' },
             { data: 'action' }
           ]
         });


### PR DESCRIPTION
Overview
----------------------------------------
List of contributions shown on recurring contribution detail view doesn't show the column for **Premium**, which is visible on Contact's contributions tab.

Before
----------------------------------------
The list of contributions shown on recurring contribution detail view does not have the column for Premium.

![image](https://user-images.githubusercontent.com/21999940/40893093-3d728758-6765-11e8-86b9-65cc98ee6a6c.png)

After
----------------------------------------
Altered the template to include the column and its value.

![image](https://user-images.githubusercontent.com/21999940/40893075-10d124fc-6765-11e8-9ac8-c26ec0efb976.png)

Comments
----------------------------------------
This is related to #11920

---

 * [CRM-159: Log Mtg\/ Log Call should default to status=completed](https://issues.civicrm.org/jira/browse/CRM-159)