### PR TITLE
dev/core#160 Set the import progress widget to poll the server every …

### DIFF
--- a/templates/CRM/common/importProgress.tpl
+++ b/templates/CRM/common/importProgress.tpl
@@ -66,7 +66,7 @@ CRM.$(function($) {
     });
     $("#importProgressBar" ).progressbar({value:0});
     $("#importProgressBar").show( );
-    loop = window.setInterval(setIntermediate, 5)
+    loop = window.setInterval(setIntermediate, 5000)
   }
 });
 </script>


### PR DESCRIPTION
…5s rather than every 5ms

Overview
----------------------------------------
This sets the interval at which the import progress bar should poll the server to be 5s rather than 5ms

Before
----------------------------------------
Import progress bar could generate an equivilant to a DOS attack on a server as it was polling over 200times a second
After
----------------------------------------
importer only polls the server every 5s 

It appears that the 5 was meant to be s but the js is believing its ms

ping @monishdeb @colemanw @eileenmcnaughton 