### PR TITLE
dev/core#161 : Implementing preSave_table_name hook

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -536,6 +536,10 @@ class CRM_Core_DAO extends DB_DataObject {
    * @return CRM_Core_DAO
    */
   public function save($hook = TRUE) {
+    if ($hook) {
+      CRM_Utils_Hook::preSave($this);
+    }
+
     if (!empty($this->id)) {
       $this->update();
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1364,6 +1364,19 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
+  public static function preSave(&$dao) {
+    $hookName = 'civicrm_preSave_' . $dao->getTableName();
+    return self::singleton()->invoke(array('dao'), $dao,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $hookName
+    );
+  }
+
+  /**
+   * @param CRM_Core_DAO $dao
+   *
+   * @return mixed
+   */
   public static function postSave(&$dao) {
     $hookName = 'civicrm_postSave_' . $dao->getTableName();
     return self::singleton()->invoke(array('dao'), $dao,


### PR DESCRIPTION
Overview
----------------------------------------
Adding a new hook : 

 **hook_civicrm_preSave_table_name**

that runs before writing to a table with assoisated DAO.

Before
----------------------------------------
Currently there is only **postSave_table_name** hook that run after a write operation on a core table that has an associated DAO. But in some cases it is useful to have a hook that run before the write operation.

After
----------------------------------------
A new hook similar to **hook_civicrm_postSave_table_name** hook with the name **hook_civicrm_preSave_table_name** is added.

* https://lab.civicrm.org/dev/core/issues/161


