### PR TITLE
dev/core#162 - Use checksum to access user dashboard

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -69,10 +69,16 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     $session = CRM_Core_Session::singleton();
     $userID = $session->get('userID');
 
+    $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this);
+    $validUser = FALSE;
+    if (empty($userID) && $this->_contactId && $userChecksum) {
+      $validUser = CRM_Contact_BAO_Contact_Utils::validChecksum($this->_contactId, $userChecksum);
+    }
+
     if (!$this->_contactId) {
       $this->_contactId = $userID;
     }
-    elseif ($this->_contactId != $userID) {
+    elseif ($this->_contactId != $userID && !$validUser) {
       if (!CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::VIEW)) {
         CRM_Core_Error::fatal(ts('You do not have permission to access this contact.'));
       }


### PR DESCRIPTION
Overview
----------------------------------------
Allow contact with checksum to load user dashboard.

Before
----------------------------------------
Contact cannot access user dashboard without login.

SE link - https://civicrm.stackexchange.com/questions/8619/using-checksums-to-access-the-civicrm-user-dashboard

After
----------------------------------------
Contact can access user dashboard from a checksum link `/civicrm/user?reset=1&id=<contact_id>&cs=<contact_checksum>`

Comments
----------------------------------------
Need to grant `CiviCRM: access Contact Dashboard` permission for anonymous to load user dashboard with a checksum link.

-------------------------

Gitlab - https://lab.civicrm.org/dev/core/issues/162