### PR TITLE
CRM-20621 - Initial cleanup toward performance improvements

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -340,37 +340,37 @@ class CRM_Admin_Page_AJAX {
         }
       }
       else {
-        $style = '';
-        if ($dao->color) {
-          $style = "background-color: {$dao->color}; color: " . CRM_Utils_Color::getContrast($dao->color);
-        }
         $hasChildTags = empty($childTagIDs[$dao->id]) ? FALSE : TRUE;
         $usedFor = (array) explode(',', $dao->used_for);
-        $result[] = array(
+        $tag = [
           'id' => $dao->id,
           'text' => $dao->name,
-          'icon' => FALSE,
-          'li_attr' => array(
-            'title' => ((string) $dao->description) . ($dao->is_reserved ? ' (*' . ts('Reserved') . ')' : ''),
-            'class' => $dao->is_reserved ? 'is-reserved' : '',
-          ),
-          'a_attr' => array(
-            'style' => $style,
+          'a_attr' => [
             'class' => 'crm-tag-item',
-          ),
+          ],
           'children' => $hasChildTags,
-          'data' => array(
+          'data' => [
             'description' => (string) $dao->description,
             'is_selectable' => (bool) $dao->is_selectable,
             'is_reserved' => (bool) $dao->is_reserved,
             'used_for' => $usedFor,
             'color' => $dao->color ? $dao->color : '#ffffff',
-            'usages' => civicrm_api3('EntityTag', 'getcount', array(
-              'entity_table' => array('IN' => $usedFor),
+            'usages' => civicrm_api3('EntityTag', 'getcount', [
+              'entity_table' => ['IN' => $usedFor],
               'tag_id' => $dao->id,
-            )),
-          ),
-        );
+            ]),
+          ],
+        ];
+        if ($dao->description || $dao->is_reserved) {
+          $tag['li_attr']['title'] = ((string) $dao->description) . ($dao->is_reserved ? ' (*' . ts('Reserved') . ')' : '');
+        }
+        if ($dao->is_reserved) {
+          $tag['li_attr']['class'] = 'is-reserved';
+        }
+        if ($dao->color) {
+          $tag['a_attr']['style'] = "background-color: {$dao->color}; color: " . CRM_Utils_Color::getContrast($dao->color);
+        }
+        $result[] = $tag;
       }
     }
 

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -286,6 +286,7 @@
                   return {parent_id: node.id === '#' ? tagset : node.id};
                 }
               },
+              themes: {icons: false},
               check_callback: true
             },
             'search': {


### PR DESCRIPTION
This is a minor code tidy-up which will result in a smaller payload being sent from the server to the jstree widget when managing tags. It removes empty values and unnecessary information from the json data.

Before
===
No change

After
===
No change

* [CRM-20621: manage tags: the tag usage count is not accurate](https://issues.civicrm.org/jira/browse/CRM-20621)