### PR TITLE
Fix unreleased regression - fatal when editing relationship type Employer

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -50,6 +50,8 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
    *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
    *  - template - use a field specific template to render this field
    *  - required
+   *  - is_freeze (field should be frozen).
+   *
    * @var array
    */
   protected $entityFields = [];
@@ -102,6 +104,8 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
+    $isReserved = ($this->_id && CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', $this->_id, 'is_reserved'));
+    $this->entityFields['is_active']['is_freeze'] = $isReserved;
 
     self::buildQuickEntityForm();
     if ($this->_action & CRM_Core_Action::DELETE) {
@@ -116,25 +120,14 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
     );
 
     $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements(FALSE, TRUE, '__');
-
-    // add select for contact type
-    $this->add('select', 'contact_types_a', ts('Contact Type A') . ' ',
-      array(
-        '' => ts('All Contacts'),
-      ) + $contactTypes
-    );
-    $this->add('select', 'contact_types_b', ts('Contact Type B') . ' ',
-      array(
-        '' => ts('All Contacts'),
-      ) + $contactTypes
-    );
-
-    //only selected field should be allow for edit, CRM-4888
-    if ($this->_id &&
-      CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', $this->_id, 'is_reserved')
-    ) {
-      foreach (array('contactTypeA', 'contactTypeB', 'isActive') as $field) {
-        $$field->freeze();
+    foreach (['contact_types_a' => ts('Contact Type A'), 'contact_types_b' => ts('Contact Type B')] as $name => $label) {
+      $element = $this->add('select', $name, $label . ' ',
+        array(
+          '' => ts('All Contacts'),
+        ) + $contactTypes
+      );
+      if ($isReserved) {
+        $element->freeze();
       }
     }
 

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -161,7 +161,10 @@ trait CRM_Core_Form_EntityFormTrait {
   protected function addEntityFieldsToTemplate() {
     foreach ($this->getEntityFields() as $fieldSpec) {
       if (empty($fieldSpec['not-auto-addable'])) {
-        $this->addField($fieldSpec['name'], [], CRM_Utils_Array::value('required', $fieldSpec));
+        $element = $this->addField($fieldSpec['name'], [], CRM_Utils_Array::value('required', $fieldSpec));
+        if (!empty($fieldSpec['is_freeze'])) {
+          $element->freeze();
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix unreleased regression - fatal when editing relationship type Employer

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
![screenshot 2018-06-05 14 07 43](https://user-images.githubusercontent.com/336308/40951134-d5f4ff14-68c9-11e8-92a5-dad9cb1fee77.png)


After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
![screenshot 2018-06-05 14 07 58](https://user-images.githubusercontent.com/336308/40951144-df49ee9e-68c9-11e8-80ad-e33aa9f0e34e.png)


Technical Details
----------------------------------------
A recent PR removed the assignment of elements to a variable, not realising they were used later in the $$field construct. This only shows up for reserved relationship types. I fixed it to a cleaner construct.

Comments
----------------------------------------

