### PR TITLE
dev/core#163 Fix issue where disabling a group would block access to …

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2335,7 +2335,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     // get all the groups that this user can access
     // if they dont have universal access
     $groupNames = civicrm_api3('Group', 'get', array(
-      'is_active' => 1,
+      'is_active' => '',
       'check_permissions' => TRUE,
       'return' => array('title', 'id'),
       'options' => array('limit' => 0),


### PR DESCRIPTION
…any mailing reports that group was used for

Overview
----------------------------------------
Disable Group blocks access to mailing reports that group was used for even tho user can access disabled group

Before
----------------------------------------
Mailing report permission error

After
----------------------------------------
No error

ping @eileenmcnaughton @monishdeb 