### PR TITLE
CIVICRM-800: Throw exception if checksum is expired on contribution pages.

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2048,6 +2048,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         CRM_Core_Resources::singleton()->addVars('coreForm', array('checksum' => (int) $tempID));
         return $tempID;
       }
+      else {
+        throw new CRM_Core_Exception('The link used to access the website has expired. Please contact us to obtain a new link.');
+      }
     }
     // check if user has permission, CRM-12062
     elseif ($tempID && CRM_Contact_BAO_Contact_Permission::allow($tempID)) {


### PR DESCRIPTION
Overview
----------------------------------------
Membership renewal pages are accessible even after checksum is expired. The page loads OK, but there is no feedback provided to the user that the renewal link has actually expired. Therefore the user is unaware that the page loaded is actually INCORRECT.

Before
----------------------------------------
Renewal pages were getting loaded even if the checksum is expired.

After
----------------------------------------
We throw CRM exception with following message.
**The link used to access the website has expired. Please contact us to obtain a new link**

Comments
----------------------------------------
_Agileware Ref: CIVICRM-800_
