### PR TITLE
Accessibility #9: Regression - js error due to alertDismissal setting fixed.

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -690,7 +690,7 @@ class CRM_Core_Resources {
         'filters' => self::getEntityRefFilters(),
       ),
       'ajaxPopupsEnabled' => self::singleton()->ajaxPopupsEnabled,
-      'allowAlertAutodismissal' => Civi::settings()->get('allow_alert_autodismissal'),
+      'allowAlertAutodismissal' => (bool) Civi::settings()->get('allow_alert_autodismissal'),
     );
     print CRM_Core_Smarty::singleton()->fetchWith('CRM/common/l10n.js.tpl', $vars);
     CRM_Utils_System::civiExit();

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -33,7 +33,7 @@
   $.datepicker._defaults.dateFormat = CRM.config.dateInputFormat = {$config->dateInputFormat|@json_encode};
   CRM.config.timeIs24Hr = {if $config->timeInputFormat eq 2}true{else}false{/if};
   CRM.config.ajaxPopupsEnabled = {$ajaxPopupsEnabled|@json_encode};
-  CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal};
+  CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal|@json_encode};
 
   // Merge entityRef settings
   CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});


### PR DESCRIPTION
Overview
----------------------------------------
PR #12158 created Regression - js error. This PR fixes the same.

Before
----------------------------------------
There was JS error in **civicrm/ajax/l10n-js** when the setting was disabled.

After
----------------------------------------
JS error is fixed by casting the setting to **bool**.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-856_
