### PR TITLE
dev/core#154 - Can't edit related records when current employer has a…

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1736,6 +1736,10 @@ SELECT relationship_type_id, relationship_direction
               //contact before creating new membership record.
               CRM_Member_BAO_Membership::deleteRelatedMemberships($membershipId, $relatedContactId);
             }
+            //skip status calculation for pay later memberships.
+            if (!empty($membershipValues['status_id']) && $membershipValues['status_id'] == $pendingStatusId) {
+              $membershipValues['skipStatusCal'] = TRUE;
+            }
 
             // check whether we have some related memberships still available
             $query = "

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -631,6 +631,28 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('membership', 'get', $params);
     $this->assertEquals(0, $result['count']);
 
+    //Create pay_later membership for organization.
+    $employerId[2] = $this->organizationCreate(array(), 1);
+    $params = array(
+      'contact_id' => $employerId[2],
+      'membership_type_id' => $membershipTypeId,
+      'source' => 'Test pay later suite',
+      'is_pay_later' => 1,
+      'status_id' => 5,
+    );
+    $organizationMembership = CRM_Member_BAO_Membership::add($params);
+    $organizationMembershipID = $organizationMembership->id;
+    $memberContactId[3] = $this->individualCreate(array('employer_id' => $employerId[2]), 0);
+    // Check that the employee inherited the membership
+    $params = array(
+      'contact_id' => $memberContactId[3],
+      'membership_type_id' => $membershipTypeId,
+    );
+    $result = $this->callAPISuccess('membership', 'get', $params);
+    $this->assertEquals(1, $result['count']);
+    $result = $result['values'][$result['id']];
+    $this->assertEquals($organizationMembershipID, $result['owner_membership_id']);
+
     // Set up params for enable/disable checks
     $relationship1 = $this->callAPISuccess('relationship', 'get', array('contact_id_a' => $memberContactId[1]));
     $params = array(


### PR DESCRIPTION
… pending membership

Overview
----------------------------------------
Fix fatal error while creating a relationship with a contact holding pending membership.

Before
----------------------------------------
Fatal Error on creating current employer relationship with the organization holding pending membership.

Can be replicated using below steps -

- Add membership type with relationship = "Employer of"
- Add this membership to an organization using pay later contribution page.
- Check if membership is created in pending mode with no start & end date.
- Adding current employer relationship to this organization leads to error.

![image](https://user-images.githubusercontent.com/5929648/40971808-6a75a604-68dc-11e8-87e7-b0ed99edcacd.png)


After
----------------------------------------
Fixed. Adding current employer relationship in the last step inherits the membership correctly. 

Technical Details
----------------------------------------
Avoid status calculation for relationship which creates a membership for pay later record. 

Comments
----------------------------------------
Added unit test.

------------

Gitlab - https://lab.civicrm.org/dev/core/issues/154
