### PR TITLE
Towards fixing household merge export, extract function, add test, fix prev

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -375,7 +375,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   public function testExportRelationshipsMergeToHousehold() {
     $this->setUpContactExportData();
-    $householdID = $this->householdCreate(['city' => 'Portland', 'state_province_id' => 'Oregan']);
+    $householdID = $this->householdCreate(['api.Address.create' => ['city' => 'Portland', 'state_province_id' => 'Maine', 'location_type_id' => 'Home']]);
 
     $relationshipTypes = $this->callAPISuccess('RelationshipType', 'get', [])['values'];
     $houseHoldTypeID = NULL;
@@ -420,9 +420,10 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     );
     $dao = CRM_Core_DAO::executeQuery("SELECT * FROM {$tableName}");
     while ($dao->fetch()) {
-      // Do some checks here
-      // $this->assertEquals('Portland', $dao->city);
-      // $this->assertEquals('Oregan', $dao0>state_province);
+      $this->assertEquals('Portland', $dao->city);
+      $this->assertEquals('ME', $dao->state_province);
+      $this->assertEquals($householdID, $dao->civicrm_primary_id);
+      $this->assertEquals($householdID, $dao->civicrm_primary_id);
     }
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
Follow up on #12212 - extend testing, further function extraction, fix mistake in that PR

Before
----------------------------------------
functions

After
----------------------------------------
City & State province field tested, function extracted

Technical Details
----------------------------------------
@monishdeb I think I found an error in the previous commit see 
```
|| empty($value[4]))) {
```
https://github.com/civicrm/civicrm-core/blob/b0eb1d74fcad845dba3e3324355781b0b616c899/CRM/Export/BAO/Export.php#L357

but reading the code it should be !empty

Comments
----------------------------------------
This needs to be merged for the 5.3 rc which will be cut tomorrow. Let's see if it can be reviewed in time or we need an rc pr
