### PR TITLE
dev/core#158 group contacts list and export limits results to 500 records

### DIFF
--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -157,6 +157,10 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
         break;
     }
 
+    if (empty($entityDAOName)) {
+      $entityDAOName = $entityShortname;
+    }
+
     if (in_array($entityShortname, $components)) {
       $this->_exportMode = constant('CRM_Export_Form_Select::' . strtoupper($entityShortname) . '_EXPORT');
       $formTaskClassName = "CRM_{$entityShortname}_Form_Task";
@@ -184,7 +188,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
       $values = $this->controller->exportValues('Custom');
     }
     else {
-      if (in_array($entityShortname, $components)) {
+      if (in_array($entityShortname, $components) && $entityShortname !== 'Contact') {
         $values = $this->controller->exportValues('Search');
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
This is an alternative to #12244 - it fixes an intra-rc regression caused by this change 
https://github.com/civicrm/civicrm-core/pull/12110/files#diff-35d8774ba8df60e417bb7f9d95f5578dL112

Before
----------------------------------------
From Manage groups screen only 500 contacts exported. E-notices
![screenshot 2018-06-07 00 29 16](https://user-images.githubusercontent.com/336308/41039555-e4971cb2-69ed-11e8-9463-522c666f1e89.png)


After
----------------------------------------
All contacts export - even when more than 500 are in the group

Technical Details
----------------------------------------
The issue was that 
```
$values = $this->controller->exportValues('Search');
```
 was not working as the form for contact is 'Basic' thus the 'export all records' was being lost, with flow on effects.

The reason it was lost was $components went from
```
$components = array('Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity');
```
to 
```
$components = array('Contact', 'Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity');
```
So the line 
```
if (in_array($entityShortname, $components)) {
```
was not returning the correct resuls

Comments
----------------------------------------
This really needs to be fixed for tomorrow's release. I have a high degree of confidence having exported from both the basic screen & manage groups & based on stepping through the code & seeing it fail to populate and being able to find the specific recent error causing it.
Hence, I am going to self-merge this to ensure it is in the release

ping @lcdservices @mattwire @kcristiano 
