### PR TITLE
Fix incorrect operator on previous Export fix

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -354,7 +354,7 @@ class CRM_Export_BAO_Export {
           continue;
         }
 
-        if (array_key_exists($relationshipTypes, $contactRelationshipTypes) && (!empty($value[2]) || empty($value[4]))) {
+        if (array_key_exists($relationshipTypes, $contactRelationshipTypes) && (!empty($value[2]) || !empty($value[4]))) {
           $relPhoneTypeId = $relIMProviderId = NULL;
           if (!empty($value[2])) {
             $relationField = CRM_Utils_Array::value(2, $value);


### PR DESCRIPTION
Overview
----------------------------------------
Follow up fix to https://github.com/civicrm/civicrm-core/pull/12212 where I used the wrong operator on $value[4]

Before
----------------------------------------
code has different meaning to pre-refactor

After
----------------------------------------
code has same meaning

Technical Details
----------------------------------------
This re-instates the original code more closely but on testing through the UI I can't see any way that $value[2] would be empty if $value[4] is not ie the elseif actually seems unreachable to me - so perhaps we don't need this & should instead remove the possibility of it. Hmmm

```
          if (!empty($value[2])) {
            $relationField = CRM_Utils_Array::value(2, $value);
            if (trim(CRM_Utils_Array::value(3, $value))) {
              $relLocTypeId = CRM_Utils_Array::value(3, $value);
            }
            else {
              $relLocTypeId = 'Primary';
            }

            if ($relationField == 'phone') {
              $relPhoneTypeId = CRM_Utils_Array::value(4, $value);
            }
            elseif ($relationField == 'im') {
              $relIMProviderId = CRM_Utils_Array::value(4, $value);
            }
          }
          elseif (!empty($value[4])) {
            $relationField = CRM_Utils_Array::value(4, $value);
            $relLocTypeId = CRM_Utils_Array::value(5, $value);
            if ($relationField == 'phone') {
              $relPhoneTypeId = CRM_Utils_Array::value(6, $value);
            }
            elseif ($relationField == 'im') {
              $relIMProviderId = CRM_Utils_Array::value(6, $value);
            }
          }
```

Comments
----------------------------------------
@monishdeb per https://github.com/civicrm/civicrm-core/pull/12272 do you agree we need this in the rc?
