### PR TITLE
core/#170 minimal fix for fatal on soft_credit field

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -717,7 +717,7 @@ UNION ALL
         array_key_exists('civicrm_contribution_contribution_id', $row)
       ) {
         $query = "
-SELECT civicrm_contact_id, civicrm_contact_sort_name, civicrm_contribution_total_amount, civicrm_contribution_currency
+SELECT civicrm_contact_id, civicrm_contact_sort_name, civicrm_contribution_total_amount_sum, civicrm_contribution_currency
 FROM   civireport_contribution_detail_temp2
 WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribution_id']}";
         $this->addToDeveloperTab($query);
@@ -729,7 +729,7 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
             $dao->civicrm_contact_id);
           $string = $string . ($string ? $separator : '') .
             "<a href='{$url}'>{$dao->civicrm_contact_sort_name}</a> " .
-            CRM_Utils_Money::format($dao->civicrm_contribution_total_amount, $dao->civicrm_contribution_currency);
+            CRM_Utils_Money::format($dao->civicrm_contribution_total_amount_sum, $dao->civicrm_contribution_currency);
         }
         $rows[$rowNum]['civicrm_contribution_soft_credits'] = $string;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Contribution detail report errors when soft credits column is exposed


Before
----------------------------------------
Fatal if mode is contributions only & 'soft credits' box is selected

After
----------------------------------------
No fatal

Technical Details
----------------------------------------
We should get this merged & then 
a) do a patch release drop for 5.2 with this 
b) review a fix against master that actually adds unit testing https://github.com/civicrm/civicrm-core/pull/12281

Comments
----------------------------------------
@lcdservices can you test this & we'll get it merged / back ported and then can do some more thorough testing on #12280 - time to finally see this report get reliable
