### PR TITLE
Fix e-notice, remove legacy code pattern

### DIFF
--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -217,7 +217,7 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form {
    */
   public function setContactIDs() {
     if (!$this->_includesSoftCredits) {
-      $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent(
+      $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent(
         $this->_contributionIds,
         'civicrm_contribution'
       );


### PR DESCRIPTION
Overview
----------------------------------------
Remove a code warning

![screenshot 2018-06-11 10 33 07](https://user-images.githubusercontent.com/336308/41207936-7a4f1012-6d71-11e8-95f7-e12034f76a80.png)

Before
----------------------------------------
Code works, warning appears

After
----------------------------------------
Code works, no warning

Technical Details
----------------------------------------
It's legacy construct...

Comments
----------------------------------------

