### PR TITLE
Remove unused code variable

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -240,15 +240,12 @@ SELECT r.payment_processor_id
    *
    * @param int $recurId
    *   Recur contribution id.
-   * @param array $objects
-   *   An array of objects that is to be cancelled like.
-   *                          contribution, membership, event. At least contribution object is a must.
    *
    * @param array $activityParams
    *
    * @return bool
    */
-  public static function cancelRecurContribution($recurId, $objects, $activityParams = array()) {
+  public static function cancelRecurContribution($recurId, $activityParams = array()) {
     if (!$recurId) {
       return FALSE;
     }
@@ -306,16 +303,8 @@ SELECT r.payment_processor_id
         CRM_Activity_BAO_Activity::create($activityParams);
       }
 
-      // if there are associated objects, cancel them as well
-      if (!$objects) {
-        $transaction->commit();
-        return TRUE;
-      }
-      else {
-        // @todo - this is bad! Get the function out of the ipn.
-        $baseIPN = new CRM_Core_Payment_BaseIPN();
-        return $baseIPN->cancelled($objects, $transaction);
-      }
+      $transaction->commit();
+      return TRUE;
     }
     else {
       // if already cancelled, return true

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -224,7 +224,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
         );
       $cancelStatus = CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(
         $this->_subscriptionDetails->recur_id,
-        NULL,
         $activityParams
       );
 

--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -84,7 +84,7 @@ function civicrm_api3_contribution_recur_get($params) {
  */
 function civicrm_api3_contribution_recur_cancel($params) {
   civicrm_api3_verify_one_mandatory($params, NULL, array('id'));
-  return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params['id'], CRM_Core_DAO::$_nullObject) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
+  return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params['id']) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
 }
 
 /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -90,7 +90,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    */
   public function testCancelRecur() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
-    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($contributionRecur['id'], NULL);
+    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($contributionRecur['id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Code readability fix - $objects is passed to cancelRecurContribution but never used, tidy up

Before
----------------------------------------
Code less readable

After
----------------------------------------
Code more readable

Technical Details
----------------------------------------

If $objects is set then the ipn cancelled() function is called. It is never set & the function appears intended to deal with a cancelled payment not a cancelled recurring so this just seems to be a code hangover

I checked the places this is called from
```
$objects is null, $activity_params does not contain 'source_record_id'
      $activityParams
        = array(
          'subject' => $this->_mid ? ts('Auto-renewal membership cancelled') : ts('Recurring contribution cancelled'),
          'details' => $message,
        );
      $cancelStatus = CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(
        $this->_subscriptionDetails->recur_id,
        NULL,
        $activityParams
      );
```
object & activity params are both null
```
  return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params['id'], CRM_Core_DAO::$_nullObject) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
```

object & activity params are both null
```
    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($contributionRecur['id'], NULL);
```

Comments
----------------------------------------
Follow up from #11964
