### PR TITLE
(dev/core#177) Redis::get() should return NULL for undefined cache keys

### DIFF
--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -130,7 +130,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
    */
   public function get($key) {
     $result = $this->_cache->get($this->_prefix . $key);
-    return unserialize($result);
+    return ($result === FALSE) ? NULL : unserialize($result);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
The docs for  `CRM_Utils_Cache_Interface::get()` specify that the return value should be `NULL`
if the key does not exist. This fixes it to comply (and to align it with other drivers).

See also: https://lab.civicrm.org/dev/core/issues/177

Before
----------------------------------------
On a Redis-based deployment, `Civi::cache()->get('unknown-key')` returns `FALSE`.

After
----------------------------------------
On a Redis-based deployment, `Civi::cache()->get('unknown-key')` returns `NULL`.

Technical Details
----------------------------------------
The internal call to `$this->_cache->get()` returns either FALSE or a string (serialized data). It wound up returning an overall value of `FALSE` because `unserialize(FALSE)===FALSE`).

