### PR TITLE
(dev/core#178) Redis - Report error messages

### DIFF
--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -117,7 +117,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
    */
   public function set($key, &$value) {
     if (!$this->_cache->set($this->_prefix . $key, serialize($value), $this->_timeout)) {
-      CRM_Core_Error::fatal("Redis set failed, wondering why?, $key", $value);
+      CRM_Core_Error::fatal("Redis set ($key) failed: " . $this->_cache->getLastError(), $value);
       return FALSE;
     }
     return TRUE;

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -117,7 +117,13 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
    */
   public function set($key, &$value) {
     if (!$this->_cache->set($this->_prefix . $key, serialize($value), $this->_timeout)) {
-      CRM_Core_Error::fatal("Redis set ($key) failed: " . $this->_cache->getLastError(), $value);
+      if (PHP_SAPI === 'cli' || (Civi\Core\Container::isContainerBooted() && CRM_Core_Permission::check('view debug output'))) {
+        CRM_Core_Error::fatal("Redis set ($key) failed: " . $this->_cache->getLastError());
+      }
+      else {
+        Civi::log()->error("Redis set ($key) failed: " . $this->_cache->getLastError());
+        CRM_Core_Error::fatal("Redis set ($key) failed");
+      }
       return FALSE;
     }
     return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
If the Redis server returns an error message (e.g. due to malformed requests or credentials), the substance of this message is invisible to the site administrator.

See also: https://lab.civicrm.org/dev/core/issues/178

Before
----------------------------------------
The reported error is opaque -- specifying that some `$key`  was unavailable, but not reporting *why* it was unavailable.

After
----------------------------------------
The reported includes the reason provided by Redis.
