### PR TITLE
(dev/core#179) Redis - Only send AUTH if there's a password

### DIFF
--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -105,7 +105,9 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
       echo 'Could not connect to redisd server';
       CRM_Utils_System::civiExit();
     }
-    $this->_cache->auth(CIVICRM_DB_CACHE_PASSWORD);
+    if (CRM_Utils_Constant::value('CIVICRM_DB_CACHE_PASSWORD')) {
+      $this->_cache->auth(CIVICRM_DB_CACHE_PASSWORD);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
The Redis driver always sends a password. That's well and good in production. However, if you're doing local development, the dev instance of redis may be configured to allow local-only, unauthenticated connections -- for which no password is available.

Before
----------------------------------------
If you don't use/need a password, the Redis driver sends an inappropriate `AUTH` command.

After
----------------------------------------
If you don't use/need a password, the Redis driver does not send an `AUTH` command. 
