### PR TITLE
Re-instate Dedupe limit functionality & fix select toggle functionality

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -1017,13 +1017,9 @@ LIMIT {$offset}, {$rowCount}
    * Mark dupe pairs as selected from un-selected state or vice-versa, in dupe cache table.
    */
   public static function toggleDedupeSelect() {
-    $rgid = CRM_Utils_Type::escape($_REQUEST['rgid'], 'Integer');
-    $gid  = CRM_Utils_Type::escape($_REQUEST['gid'], 'Integer');
     $pnid = $_REQUEST['pnid'];
     $isSelected = CRM_Utils_Type::escape($_REQUEST['is_selected'], 'Boolean');
-    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $null, FALSE, '{}');
-
-    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, json_decode($criteria, TRUE));
+    $cacheKeyString = CRM_Utils_Request::retrieve('cacheKey', 'Alphanumeric', $null, FALSE);
 
     $params = array(
       1 => array($isSelected, 'Boolean'),

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -182,7 +182,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
         CRM_Dedupe_Merger::resetMergeStats($cacheKeyString);
       }
 
-      $this->_mainContacts = CRM_Dedupe_Merger::getDuplicatePairs($rgid, $gid, !$isConflictMode, 0, $this->isSelected(), '', $isConflictMode, $criteria, TRUE);
+      $this->_mainContacts = CRM_Dedupe_Merger::getDuplicatePairs($rgid, $gid, !$isConflictMode, 0, $this->isSelected(), '', $isConflictMode, $criteria, TRUE, $limit);
 
       if (empty($this->_mainContacts)) {
         if ($isConflictMode) {

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -111,6 +111,8 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     $this->assign('urlQuery', CRM_Utils_System::makeQueryString($urlQry));
     $this->assign('isSelected', $this->isSelected());
     $criteria = json_decode($criteria, TRUE);
+    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria);
+    $this->assign('cacheKey', $cacheKeyString);
 
     if ($context == 'search') {
       $context = 'search';
@@ -120,7 +122,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     if ($action & CRM_Core_Action::RENEW) {
       // empty cache
       if ($rgid) {
-        CRM_Core_BAO_PrevNextCache::deleteItem(NULL, CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria));
+        CRM_Core_BAO_PrevNextCache::deleteItem(NULL, $cacheKeyString);
       }
       $urlQry['action'] = 'update';
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/dedupefind', $urlQry));
@@ -170,9 +172,6 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
       $urlQry['snippet'] = 4;
 
       $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $urlQry, FALSE, NULL, FALSE));
-
-      //reload from cache table
-      $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria);
 
       $stats = CRM_Dedupe_Merger::getMergeStats($cacheKeyString);
       if ($stats) {

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -181,7 +181,7 @@ class CRM_Dedupe_Finder {
    *   array of (cid1, cid2, weight) dupe triples
    */
   public static function dupesInGroup($rgid, $gid, $searchLimit = 0) {
-    $cids = array_keys(CRM_Contact_BAO_Group::getMember($gid, $searchLimit));
+    $cids = array_keys(CRM_Contact_BAO_Group::getMember($gid, TRUE, $searchLimit));
     if (!empty($cids)) {
       return self::dupes($rgid, $cids);
     }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1986,6 +1986,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @param int $rule_group_id
    * @param int $group_id
    * @param bool $reloadCacheIfEmpty
+   *   Should the cache be reloaded if empty - this must be false when in a dedupe action!
    * @param int $batchLimit
    * @param bool $isSelected
    *   Limit to selected pairs.

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2035,7 +2035,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   public static function getMergeCacheKeyString($rule_group_id, $group_id, $criteria = array(), $checkPermissions = TRUE) {
     $contactType = CRM_Dedupe_BAO_RuleGroup::getContactTypeForRuleGroup($rule_group_id);
-    $cacheKeyString = "merge {$contactType}";
+    $cacheKeyString = "merge_{$contactType}";
     $cacheKeyString .= $rule_group_id ? "_{$rule_group_id}" : '_0';
     $cacheKeyString .= $group_id ? "_{$group_id}" : '_0';
     $cacheKeyString .= !empty($criteria) ? md5(serialize($criteria)) : '_0';

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -324,8 +324,7 @@
       var is_selected = CRM.$('.crm-dedupe-select-all').prop('checked') ? 1 : 0;
     }
 
-    var criteria = {/literal}'{$criteria|escape}'{literal};
-    criteria  = criteria.length > 0 ? criteria : 0;
+    var cacheKey = {/literal}'{$cacheKey|escape}'{literal};
 
     var dataUrl = {/literal}"{crmURL p='civicrm/ajax/toggleDedupeSelect' h=0 q='snippet=4'}"{literal};
     var rgid = {/literal}"{$rgid}"{literal};
@@ -334,7 +333,7 @@
     rgid = rgid.length > 0 ? rgid : 0;
     gid  = gid.length > 0 ? gid : 0;
 
-    CRM.$.post(dataUrl, {pnid: id, rgid: rgid, gid: gid, is_selected: is_selected, criteria : criteria}, function (data) {
+    CRM.$.post(dataUrl, {pnid: id, rgid: rgid, gid: gid, is_selected: is_selected, cacheKey : cacheKey}, function (data) {
       // nothing to do for now
     }, 'json');
   }


### PR DESCRIPTION
Overview
----------------------------------------
Follow up fixes to #12193 for obscure dedupe scenarios

Before
----------------------------------------
1) if the parameter 'limit=2' is passed in the url it is not heeded 
2) if the url is being used with 'criteria' the selection of rows does not work on the screen reached after a safe merge has been attempted - eg. this for matches of contact id 506191 
civicrm/contact/dedupefind?reset=1&action=update&rgid=4&criteria=%7B%22contact%22%3A%7B%22id%22%3A%7B%22IN%22%3A%5B%22**506191**%22%5D%7D%7D%7D&limit=1

After
----------------------------------------
1) limit parameter re-instated (note the results are cached so you need to truncate civicrm_prevnext_cache when changing the value). Also note that 'limit' is the number of contacts to try to find matches for - so if a group has 10000 contacts in it the dedupe finder will only seek to find matches for the first contact if limit=1. (for test purposes I'm using a group of contacts who all have the same email address
![merge_limit2](https://user-images.githubusercontent.com/336308/41270644-78f2d812-6e60-11e8-83b8-0fa2369441c9.gif)

2) toggle works again
![merge_limit3](https://user-images.githubusercontent.com/336308/41271092-b0fc934a-6e62-11e8-905d-8be8a93bb301.gif)


Technical Details
----------------------------------------
I've put this against the rc because it is an addendum to a patch already in the rc. The scenarios described are pretty obscure!

Comments
----------------------------------------
@monishdeb are you able to look.
