### PR TITLE
dev/cloud-native#12: Define the BASE URL via an environment variable at run time

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -228,12 +228,6 @@ if (!defined('CIVICRM_UF_BASEURL')) {
   }
 }
 
-//if (!defined('CIVICRM_UF_BASEURL')) {
-//  $currenthost = "http://".$_SERVER['HTTP_HOST'];
-//  $currentpath = preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME']));
-//  define( 'CIVICRM_UF_BASEURL'      , $currenthost.$currentpath);
-//}
-
 /**
  * Define any CiviCRM Settings Overrides per http://wiki.civicrm.org/confluence/display/CRMDOC/Override+CiviCRM+Settings
  *

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -219,12 +219,20 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
  *  define( 'CIVICRM_UF_BASEURL'      , '%%baseURL%%');
  *}
 */
-
 if (!defined('CIVICRM_UF_BASEURL')) {
-  $currenthost = "http://".$_SERVER['HTTP_HOST'];
-  $currentpath = preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME']));
-  define( 'CIVICRM_UF_BASEURL'      , $currenthost.$currentpath);
+  if (getenv('CIVICRM_UF_BASEURL')) {
+    define('CIVICRM_UF_BASEURL', getenv('CIVICRM_UF_BASEURL'));
+  }
+  else {
+    define('CIVICRM_UF_BASEURL', '%%baseURL%%');
+  }
 }
+
+//if (!defined('CIVICRM_UF_BASEURL')) {
+//  $currenthost = "http://".$_SERVER['HTTP_HOST'];
+//  $currentpath = preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME']));
+//  define( 'CIVICRM_UF_BASEURL'      , $currenthost.$currentpath);
+//}
 
 /**
  * Define any CiviCRM Settings Overrides per http://wiki.civicrm.org/confluence/display/CRMDOC/Override+CiviCRM+Settings

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -214,9 +214,16 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
  * Front-end site:
  *      define( 'CIVICRM_UF_BASEURL' , 'http://www.example.com/joomla/');
  *
- */
+ *
+ * if (!defined('CIVICRM_UF_BASEURL')) {
+ *  define( 'CIVICRM_UF_BASEURL'      , '%%baseURL%%');
+ *}
+*/
+
 if (!defined('CIVICRM_UF_BASEURL')) {
-  define( 'CIVICRM_UF_BASEURL'      , '%%baseURL%%');
+  $currenthost = "http://".$_SERVER['HTTP_HOST'];
+  $currentpath = preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME']));
+  define( 'CIVICRM_UF_BASEURL'      , $currenthost.$currentpath);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Making it easy to provide the absolute system path at runtime from the environment in CiviCRM rather than hardcoded in a file

Before
----------------------------------------
CiviCRM was outputting URLs when it could/should be outputting paths. This is important because URLs (absolute ones) get in the way of reverse proxying which is something cloud providers typically want to do.

After
----------------------------------------
Canonical hostname and port are now defined and stored as environmental variables. 