### PR TITLE
Only treat a request as a get request (and hence use GET) if it starts with get

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -68,7 +68,7 @@
       url: CRM.url('civicrm/ajax/rest'),
       dataType: 'json',
       data: params,
-      type: params.action.indexOf('get') < 0 ? 'POST' : 'GET'
+      type: params.action.indexOf('get') === 0 ? 'GET' : 'POST'
     });
     if (status) {
       // Default status messages


### PR DESCRIPTION
Overview
----------------------------------------
Minor fix to api js wrapper when being used with custom actions

Before
----------------------------------------
custom api action 'forget' triggers a 'GET' request, as do 'get', 'getactions', 'getfields' etc

After
----------------------------------------
Only actions beginning with 'get' trigger a GET request. 'forget' gets a POST

Technical Details
----------------------------------------
Current code looks for the word 'get' anywhere in the action so the action 'forget' is also picked up.

Further down we explicitly look for 0 so we should here too.

Comments
----------------------------------------
@colemanw any issue with this?
