### PR TITLE
Fix for #180: passing the entity ID to the custom hook when deleting a custom value

### DIFF
--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -207,13 +207,18 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
     // first we need to find custom value table, from custom group ID
     $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupID, 'table_name');
 
+    // Retrieve the $entityId so we can pass that to the hook.
+    $entityID = CRM_Core_DAO::singleValueQuery("SELECT entity_id FROM {$tableName} WHERE id = %1", array(
+      1 => array($customValueID, 'Integer'),
+    ));
+
     // delete custom value from corresponding custom value table
     $sql = "DELETE FROM {$tableName} WHERE id = {$customValueID}";
     CRM_Core_DAO::executeQuery($sql);
 
     CRM_Utils_Hook::custom('delete',
       $customGroupID,
-      NULL,
+      $entityID,
       $customValueID
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
When deleting a custom value record from a multiple custom data set. The entityId is not passed to the hook civicrm_custom. This causes some weird behaviours in extensions (for example CiviRules, see: https://github.com/CiviCooP/org.civicoop.civirules/issues/208

See https://lab.civicrm.org/dev/core/issues/180

Before
----------------------------------------
Upon deleting a custom value `$entityID` parameter of the hook civicrm_custom is not set.

After
----------------------------------------

Upon deleting a custom value `$entityID` parameter of the hook civicrm_custom is set to the right value..
