### PR TITLE
Only auto-renew membership when contribution status is completed

### DIFF
--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2203,12 +2203,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals($contributionRecur['values'][1]['is_test'], $repeatedContribution['values'][2]['is_test']);
     $this->quickCleanUpFinancialEntities();
   }
+
   /**
-   * CRM-19945 Tests repeattransaction is using a completed contribution for the template.
+   * CRM-19945 Tests that Contribute.repeattransaction renews a membership when contribution status=Completed
    *
-   *  ( Tests membership is renewed after repeattransaction. )
    */
-  public function testRepeatTransactionUsesCompleted() {
+  public function testRepeatTransactionMembershipRenewCompletedContribution() {
     list($originalContribution, $membership) = $this->setUpAutoRenewMembership();
 
     $this->callAPISuccess('contribution', 'create', array(
@@ -2222,7 +2222,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->callAPISuccess('membership', 'create', array(
        'id' => $membership['id'],
        'end_date' => 'yesterday',
-       'status_id' => 4,
+       'status_id' => 'Expired',
     ));
 
     $contribution = $this->callAPISuccess('contribution', 'repeattransaction', array(
@@ -2236,13 +2236,83 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'return' => 'status_id',
     ));
 
-    $this->assertEquals('New', CRM_Core_PseudoConstant::getLabel('CRM_Member_BAO_Membership', 'status_id', $membershipStatusId));
+    $membership = $this->callAPISuccess('membership', 'get', array(
+      'id' => $membership['id'],
+    ));
+
+    $this->assertEquals('New', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membershipStatusId));
 
     $lineItem = $this->callAPISuccessGetSingle('LineItem', array('contribution_id' => $contribution['id']));
     $this->assertEquals('civicrm_membership', $lineItem['entity_table']);
     $this->callAPISuccessGetCount('MembershipPayment', array('membership_id' => $membership['id']));
     $this->quickCleanUpFinancialEntities();
     $this->contactDelete($originalContribution['values'][1]['contact_id']);
+  }
+
+  /**
+   * CRM-19945 Tests that Contribute.repeattransaction DOES NOT renew a membership when contribution status=Failed
+   *
+   * @dataProvider contributionStatusProvider
+   */
+  public function testRepeatTransactionMembershipRenewContributionNotCompleted($contributionStatus) {
+    // Completed status should renew so we don't test that here
+    // In Progress status is only for recurring contributions so we don't test that here
+    if (in_array($contributionStatus['name'], ['Completed', 'In Progress'])) {
+      return;
+    }
+    list($originalContribution, $membership) = $this->setUpAutoRenewMembership();
+
+    $this->callAPISuccess('contribution', 'create', array(
+      'contact_id' => $originalContribution['values'][1]['contact_id'],
+      'financial_type_id' => $originalContribution['values'][1]['financial_type_id'],
+      'total_amount' => $originalContribution['values'][1]['total_amount'],
+      'contribution_recur_id' => $originalContribution['values'][1]['contribution_recur_id'],
+      'contribution_status_id' => "Completed",
+    ));
+
+    $this->callAPISuccess('membership', 'create', array(
+      'id' => $membership['id'],
+      'end_date' => 'yesterday',
+      'status_id' => 'Expired',
+    ));
+
+    $contribution = $this->callAPISuccess('contribution', 'repeattransaction', array(
+      'contribution_recur_id' => $originalContribution['values'][1]['contribution_recur_id'],
+      'contribution_status_id' => $contributionStatus['name'],
+      'trxn_id' => 'bobsled',
+    ));
+
+    $updatedMembership = $this->callAPISuccess('membership', 'getsingle', array(
+      'id' => $membership['id'],
+    ));
+
+    $dateTime = new DateTime('yesterday');
+    $this->assertEquals($dateTime->format('Y-m-d'), $updatedMembership['end_date']);
+    $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Expired'), $updatedMembership['status_id']);
+
+    $lineItem = $this->callAPISuccessGetSingle('LineItem', array('contribution_id' => $contribution['id']));
+    $this->assertEquals('civicrm_membership', $lineItem['entity_table']);
+    $this->callAPISuccessGetCount('MembershipPayment', array('membership_id' => $membership['id']));
+    $this->quickCleanUpFinancialEntities();
+    $this->contactDelete($originalContribution['values'][1]['contact_id']);
+  }
+
+  /**
+   * Dataprovider provides contribution status as [optionvalue=>contribution_status_name]
+   * FIXME: buildOptions seems to die in CRM_Core_Config::_construct when in test mode.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function contributionStatusProvider() {
+    $contributionStatuses = civicrm_api3('OptionValue', 'get', [
+      'return' => ["id", "name"],
+      'option_group_id' => "contribution_status",
+    ]);
+    foreach ($contributionStatuses['values'] as $statusName) {
+      $statuses[] = [$statusName];
+    }
+    return $statuses;
   }
 
   /**
@@ -3860,7 +3930,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * CRM-20008 Tests repeattransaction creates pending membership.
    */
-  public function testRepeatTransactionPendingMembership() {
+  public function testRepeatTransactionMembershipCreatePendingContribution() {
     list($originalContribution, $membership) = $this->setUpAutoRenewMembership();
     $this->callAPISuccess('membership', 'create', array(
       'id' => $membership['id'],
@@ -3879,7 +3949,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     // Let's see if the membership payments got created while we're at it.
     $membershipPayments = $this->callAPISuccess('MembershipPayment', 'get', array(
-      'memberhip_id' => $membership['id'],
+      'membership_id' => $membership['id'],
     ));
     $this->assertEquals(2, $membershipPayments['count']);
 
@@ -3889,7 +3959,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'id' => $membership['id'],
       'return' => 'status_id, end_date',
     ));
-    $this->assertEquals('New', CRM_Core_PseudoConstant::getLabel('CRM_Member_BAO_Membership', 'status_id', $membership['status_id']));
+    $this->assertEquals('New', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membership['status_id']));
     $this->assertEquals(date('Y-m-d', strtotime('yesterday + 1 month')), $membership['end_date']);
 
     $this->quickCleanUpFinancialEntities();


### PR DESCRIPTION
Overview
----------------------------------------
This is a partial of #11556 - it contains part of that code tidy up.  This PR does introduce a change in behaviour - namely that previously any contribution status except pending would trigger a membership renewal.  Following this change ONLY a "Completed" contribution will trigger a membership renewal.

Before
----------------------------------------
Membership will be renewed when contribution is in ANY state except "Pending."

After
----------------------------------------
Membership will be renewed ONLY when contribution is in state "Completed".

Technical Details
----------------------------------------
The check for completed status seemed reversed - instead of checking for `status=completed` we were checking for `status != pending`.  Now we check `status=completed`.

Comments
----------------------------------------
CRM-21682/#11556 has been posted to the dev list and been reviewed a number of people.  I believe the concept for this change in behaviour is approved and I think that this is really a bug-fix as I believe that was always the intention here (see function name...)

The diff makes this look like a big change but most of it is indenting - the actual change is just a function signature and removal of if/else.

@eileenmcnaughton partial of #11556

---

 * [CRM-21682: Automatic membership renewal fixes](https://issues.civicrm.org/jira/browse/CRM-21682)