### PR TITLE
dev/core#187 Fix typo in CRM_Grant_Form_Task that prevents retrieving session key from URL

### DIFF
--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -127,7 +127,7 @@ class CRM_Grant_Form_Task extends CRM_Core_Form {
     $form->_grantIds = $form->_componentIds = $ids;
 
     //set the context for redirection for any task actions
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $this);
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $form);
     $urlParams = 'force=1';
     if (CRM_Utils_Rule::qfKey($qfKey)) {
       $urlParams .= "&qfKey=$qfKey";


### PR DESCRIPTION
Overview
----------------------------------------
Identified during investigation for dev/core#158

Before
----------------------------------------
Cannot retrieve session key for Grant form task.

After
----------------------------------------
Session key for Grant form task is retrieved just like all other tasks.

Technical Details
----------------------------------------
The wrong object was being used in static context ($this instead of $form).
