### PR TITLE
Make all form tasks inherit from Core_Form_Task

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -32,37 +32,10 @@
  */
 
 /**
- * Class for activity task actions.
+ * Class for activity form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Activity_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
-
-  /**
-   * The array that holds all the contact ids.
-   *
-   * @var array
-   */
-  public $_contactIds;
+class CRM_Activity_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the member ids.

--- a/CRM/Campaign/Form/Task.php
+++ b/CRM/Campaign/Form/Task.php
@@ -34,35 +34,7 @@
 /**
  * This class generates form components for relationship.
  */
-class CRM_Campaign_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The additional clause that we restrict the search.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The task being performed
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The array that holds all the contact ids
-   *
-   * @var array
-   */
-  public $_contactIds;
-
-  /**
-   * The array that holds all the component ids
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Campaign_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the voter ids

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -34,7 +34,7 @@
 /**
  * This class generates form components for search-result tasks.
  */
-class CRM_Contact_Form_Task extends CRM_Core_Form {
+class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The task being performed

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -32,30 +32,10 @@
  */
 
 /**
- * This class generates form components for relationship.
+ * Class for contribute form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Contribute_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the contribution ids.
@@ -63,13 +43,6 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form {
    * @var array
    */
   protected $_contributionIds;
-
-  /**
-   * The array that holds all the contact ids.
-   *
-   * @var array
-   */
-  public $_contactIds;
 
   /**
    * The array that holds all the mapping contribution and contact ids.

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -34,31 +34,10 @@
  */
 
 /**
- * This class generates task actions for CiviEvent
- *
+ * Class for event form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Event_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Event_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the participant ids.

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -36,7 +36,7 @@
 /**
  * This class gets the name of the file to upload
  */
-class CRM_Export_Form_Select extends CRM_Core_Form {
+class CRM_Export_Form_Select extends CRM_Core_Form_Task {
 
   /**
    * Various Contact types.
@@ -69,20 +69,6 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
   public $_exportMode;
 
   public $_componentTable;
-
-  /**
-   * Must be set to entity table name (eg. civicrm_participant) by child class
-   *
-   * @var string
-   */
-  static $tableName = NULL;
-
-  /**
-   * Must be set to entity shortname (eg. event)
-   *
-   * @var string
-   */
-  static $entityShortname = NULL;
 
   /**
    * Build all the data structures needed to build the form.

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -34,31 +34,10 @@
  */
 
 /**
- * This class generates task actions for CiviEvent
- *
+ * Class for grant form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Grant_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the grant ids.

--- a/CRM/Mailing/Form/Task.php
+++ b/CRM/Mailing/Form/Task.php
@@ -32,30 +32,10 @@
  */
 
 /**
- * This class generates form components for relationship
+ * Class for mailing form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Mailing_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Mailing_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * Build all the data structures needed to build the form.

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -34,38 +34,10 @@
  */
 
 /**
- * Class for civimember task actions
- *
+ * Class for member form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Member_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
-
-  /**
-   * The array that holds all the contact ids.
-   *
-   * @var array
-   */
-  public $_contactIds;
+class CRM_Member_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the member ids.

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -32,30 +32,10 @@
  */
 
 /**
- * This class generates task actions for CiviEvent.
+ * Class for pledge form task actions.
+ * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */
-class CRM_Pledge_Form_Task extends CRM_Core_Form {
-
-  /**
-   * The task being performed.
-   *
-   * @var int
-   */
-  protected $_task;
-
-  /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_componentClause = NULL;
-
-  /**
-   * The array that holds all the component ids.
-   *
-   * @var array
-   */
-  protected $_componentIds;
+class CRM_Pledge_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * The array that holds all the pledge ids.


### PR DESCRIPTION
otherwise export can fail when accessed from advanced search because properties are inaccessible.

Overview
----------------------------------------
Since #11536 export form task uses CRM_Core_Form_Task but because we only converted CRM_Case_Form_Task we can get inaccessible properties when running exports on other entity types.

Identified when investigating #12244

Before
----------------------------------------
Form_Task classes mostly inherit from CRM_Core_Form.

After
----------------------------------------
All Form_Task classes inherit from CRM_Core_Form_Task.

Technical Details
----------------------------------------
This is basically just removal of variables declared on each class and using the parent one instead.  We also add comments clarifying that the "plan" is to move more of the code to shared functions in CRM_Core_Form_Task.
