### PR TITLE
Non functional changes towards shared functions in Core_Form_Task

### DIFF
--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -41,19 +41,21 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
   static $entityShortname = 'case';
 
   /**
-   * Must be set to queryMode
-   *
-   * @var int
-   */
-  static $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
-
-  /**
    * @inheritDoc
    */
   public function setContactIDs() {
     $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_entityIds,
       'civicrm_case_contact', 'case_id'
     );
+  }
+
+  /**
+   * Get the query mode (eg. CRM_Core_BAO_Query::MODE_CASE)
+   *
+   * @return int
+   */
+  public function getQueryMode() {
+    return CRM_Contact_BAO_Query::MODE_CASE;
   }
 
 }

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -94,6 +94,8 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
    * Common pre-processing function.
    *
    * @param CRM_Core_Form $form
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function preProcessCommon(&$form) {
     $form->_contactIds = array();

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -85,13 +85,6 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
   static $entityShortname = NULL;
 
   /**
-   * Must be set to queryMode
-   *
-   * @var int
-   */
-  static $queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
-
-  /**
    * Build all the data structures needed to build the form.
    *
    * @throws \CRM_Core_Exception
@@ -103,7 +96,7 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
   /**
    * Common pre-processing function.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Core_Form_Task $form
    *
    * @throws \CRM_Core_Exception
    */
@@ -132,7 +125,7 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
         $sortOrder = $form->get(CRM_Utils_Sort::SORT_ORDER);
       }
 
-      $query = new CRM_Contact_BAO_Query($queryParams, NULL, NULL, FALSE, FALSE, $form::$queryMode);
+      $query = new CRM_Contact_BAO_Query($queryParams, NULL, NULL, FALSE, FALSE, $form->getQueryMode());
       $query->_distinctComponentClause = " ( " . $form::$tableName . ".id )";
       $query->_groupByComponentClause = " GROUP BY " . $form::$tableName . ".id ";
       $result = $query->searchQuery(0, 0, $sortOrder);
@@ -208,6 +201,16 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
         ),
       )
     );
+  }
+
+  /**
+   * Get the query mode (eg. CRM_Core_BAO_Query::MODE_CASE)
+   * Should be overridden by child classes in most cases
+   *
+   * @return int
+   */
+  public function getQueryMode() {
+    return CRM_Contact_BAO_Query::MODE_CONTACTS;
   }
 
 }

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -94,23 +94,14 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
     $this->_componentIds = array();
     $this->_componentClause = NULL;
 
-    $stateMachine = $this->controller->getStateMachine();
-    $formName = CRM_Utils_System::getClassName($stateMachine);
-    $isStandalone = $formName == 'CRM_Export_StateMachine_Standalone';
-
     // we need to determine component export
-    $componentName = explode('_', $formName);
     $components = array('Contact', 'Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity');
 
-    if ($isStandalone) {
-      $componentName = array('CRM', $this->controller->get('entity'));
-    }
-
-    $componentMode = $this->controller->get('component_mode');
     // FIXME: This should use a modified version of CRM_Contact_Form_Search::getModeValue but it doesn't have all the contexts
-    switch ($componentMode) {
+    switch ($this->getQueryMode()) {
       case CRM_Contact_BAO_Query::MODE_CONTRIBUTE:
         $entityShortname = 'Contribute';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_MEMBER:
@@ -120,31 +111,39 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
 
       case CRM_Contact_BAO_Query::MODE_EVENT:
         $entityShortname = 'Event';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_PLEDGE:
         $entityShortname = 'Pledge';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_CASE:
         $entityShortname = 'Case';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_GRANT:
         $entityShortname = 'Grant';
+        $entityDAOName = $entityShortname;
         break;
 
       case CRM_Contact_BAO_Query::MODE_ACTIVITY:
         $entityShortname = 'Activity';
+        $entityDAOName = $entityShortname;
         break;
 
       default:
+        // FIXME: Code cleanup, we may not need to do this $componentName code here.
+        $formName = CRM_Utils_System::getClassName($this->controller->getStateMachine());
+        $componentName = explode('_', $formName);
+        if ($formName == 'CRM_Export_StateMachine_Standalone') {
+          $componentName = array('CRM', $this->controller->get('entity'));
+        }
         $entityShortname = $componentName[1]; // Contact
+        $entityDAOName = $entityShortname;
         break;
-    }
-
-    if (empty($entityDAOName)) {
-      $entityDAOName = $entityShortname;
     }
 
     if (in_array($entityShortname, $components)) {
@@ -196,7 +195,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
       }
     }
 
-    $formTaskClassName::preProcessCommon($this, !$isStandalone);
+    $formTaskClassName::preProcessCommon($this);
 
     // $component is used on CRM/Export/Form/Select.tpl to display extra information for contact export
     ($this->_exportMode == self::CONTACT_EXPORT) ? $component = FALSE : $component = TRUE;
@@ -344,7 +343,7 @@ FROM   {$this->_componentTable}
    * @return bool|array
    *   mixed true or array of errors
    */
-  static public function formRule($params, $files, $self) {
+  public static function formRule($params, $files, $self) {
     $errors = array();
 
     if (CRM_Utils_Array::value('mergeOption', $params) == self::EXPORT_MERGE_SAME_ADDRESS &&
@@ -372,7 +371,7 @@ FROM   {$this->_componentTable}
   /**
    * Process the uploaded file.
    *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
@@ -519,6 +518,15 @@ FROM   {$this->_componentTable}
     }
 
     return $options;
+  }
+
+  /**
+   * Get the query mode (eg. CRM_Core_BAO_Query::MODE_CASE)
+   *
+   * @return int
+   */
+  public function getQueryMode() {
+    return (int) $this->controller->get('component_mode');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Non functional changes towards shared functions in Core_Form_Task.  This came out of #12273 and #12244

@lcdservices Would you be able to take a look at this one?

Before
----------------------------------------
Less consistent maintain code.

After
----------------------------------------
More consistent code.

Technical Details
----------------------------------------
- Make sure that entityDAOName is set for all entities (it's different for Member) - from #12273.
- Replace $componentMode with $this::$queryMode which needs to be set for Core_Task shared functions.

Comments
----------------------------------------
There are no breaking changes in this code. A reviewer should test exports via advanced search and managed groups for contacts and (two?) other entities eg. Membership and ??