### PR TITLE
(dev/core#174) api_v3_SettingTest - Remove dead code

### DIFF
--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -351,9 +351,6 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   public function testGetExtensionSetting() {
     $this->hookClass->setHook('civicrm_alterSettingsFolders', array($this, 'setExtensionMetadata'));
     $data = NULL;
-    // the caching of data to all duplicates the caching of data to the empty string
-    CRM_Core_BAO_Cache::setItem($data, 'CiviCRM setting Spec', 'All');
-    CRM_Core_BAO_Cache::setItem($data, 'CiviCRM setting Specs', 'settingsMetadata__');
     Civi::cache('settings')->flush();
     $fields = $this->callAPISuccess('setting', 'getfields', array('filters' => array('group_name' => 'Test Settings')));
     $this->assertArrayHasKey('test_key', $fields['values']);


### PR DESCRIPTION
Overview
----------------------------------------
This unit test is clearing out a non-existent cache item. It's dead-code.

Before
----------------------------------------
* `SettingTest` clears `CiviCRM setting Spec`, which is never populated anyway

After
----------------------------------------
* `CiviCRM setting Spec` has disappeared from the face of the Earth.

Technical Details
----------------------------------------

To see that it the cache item is non-existent, I grepped (case-insensitive) for the expressions:

* `CiviCRM setting Spec`
* `CiviCRM setting `
* `setting spec`

This feels like left-overs from 4.6. In 4.7, the setting cache was reworked. Note that `SettingTest` does clear the newer cache (`Civi::cache('settings')->flush();`).
