### PR TITLE
(dev/core#174) Remove reference to unused `modulePaths`

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -356,7 +356,6 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       'TRUNCATE TABLE civicrm_group_contact_cache',
       'TRUNCATE TABLE civicrm_menu',
       'UPDATE civicrm_setting SET value = NULL WHERE name="navigation" AND contact_id IS NOT NULL',
-      'DELETE FROM civicrm_setting WHERE name="modulePaths"', // CRM-10543
     );
 
     foreach ($queries as $query) {


### PR DESCRIPTION
The `CRM_Core_Config::clearDBCache()` flushes this setting, but the setting does not
really exist today.  (Simply grep universe for `modulePaths` to see this.)
If you dig up the JIRA reference, it talks about the internals of v4.2.
There's been a lot of change in how this stuff works since v4.2.