### PR TITLE
(NFC) dev/core#174 - CRM_Utils_System::flushCache - Remove dead code

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -180,7 +180,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
    */
   public function postProcess() {
 
-    CRM_Utils_System::flushCache('CRM_Core_DAO_Job');
+    CRM_Utils_System::flushCache();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Core_BAO_Job::del($this->_id);

--- a/CRM/Admin/Form/LocationType.php
+++ b/CRM/Admin/Form/LocationType.php
@@ -86,7 +86,7 @@ class CRM_Admin_Form_LocationType extends CRM_Admin_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache('CRM_Core_DAO_LocationType');
+    CRM_Utils_System::flushCache();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Core_BAO_LocationType::del($this->_id);

--- a/CRM/Admin/Form/PaymentProcessorType.php
+++ b/CRM/Admin/Form/PaymentProcessorType.php
@@ -203,7 +203,7 @@ class CRM_Admin_Form_PaymentProcessorType extends CRM_Admin_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache('CRM_Financial_DAO_PaymentProcessorType');
+    CRM_Utils_System::flushCache();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Financial_BAO_PaymentProcessorType::del($this->_id);

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -364,7 +364,7 @@ WHERE  title = %1
    * Process the form when submitted.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache('CRM_Core_DAO_Group');
+    CRM_Utils_System::flushCache();
 
     $updateNestingCache = FALSE;
     if ($this->_action & CRM_Core_Action::DELETE) {

--- a/CRM/SMS/Form/Provider.php
+++ b/CRM/SMS/Form/Provider.php
@@ -159,7 +159,7 @@ class CRM_SMS_Form_Provider extends CRM_Core_Form {
    */
   public function postProcess() {
 
-    CRM_Utils_System::flushCache('CRM_SMS_DAO_Provider');
+    CRM_Utils_System::flushCache();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_SMS_BAO_Provider::del($this->_id);

--- a/CRM/Tag/Form/Tag.php
+++ b/CRM/Tag/Form/Tag.php
@@ -113,7 +113,7 @@ class CRM_Tag_Form_Tag extends CRM_Core_Form {
    * @return void
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache('CRM_Core_DAO_Tag');
+    CRM_Utils_System::flushCache();
 
     // array contains the posted values
     // exportvalues is not used because its give value 1 of the checkbox which were checked by default,


### PR DESCRIPTION
Before
------

* The signature of `CRM_Utils_System::flushCache` does not accept arguments.
* Random forms call it with an unused argument.

After
-----

* The signature of `CRM_Utils_System::flushCache` does not accept arguments.
* Random forms call it *without* any arguments.
