### PR TITLE
Wrong key assigned to task action

### DIFF
--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -117,7 +117,7 @@ class CRM_Event_Task extends CRM_Core_Task {
           'class' => 'CRM_Event_Form_Task_Badge',
           'result' => FALSE,
         ),
-        self::TASK_PRINT => array(
+        self::PDF_LETTER => array(
           'title' => ts('PDF letter - print for participants'),
           'class' => 'CRM_Event_Form_Task_PDF',
           'result' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------


After a recent upgrade from 4.7.29 to 5.2.1 (Joomla) I am experiencing the following problem:

After doing an Events/Find Participants search and selecting some or all participants, the "Print selected rows" option in no longer appearing in the Actions dropdown.

An Advanced Search when displaying results as Event Participants also is missing this option. The option does appear when results are displayed as Contacts.

I have verified the same behavior on dmaster.demo (running 5.4.alpha1).

https://civicrm.stackexchange.com/questions/25363/print-selected-rows-option-missing-in-event-participant-listing-dropdown-actio

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/41440503-55d927ee-704c-11e8-8cfb-e85d53cd4d11.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/41440512-5d38d2b4-704c-11e8-997f-fc726447eb4f.png)

Technical Details
----------------------------------------
self::TASK_PRINT was used twice to build task action list therefore 'Print participant row' was over-ridden by 'PDF letter - print for participants'

