### PR TITLE
(dev/core#174) CRM_Utils_Cache_Redis::flush() - Respect prefixes

### DIFF
--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -142,6 +142,7 @@ class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
    * @return mixed
    */
   public function flush() {
+    // FIXME: Only delete items matching `$this->_prefix`.
     return $this->_cache->flush();
   }
 

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -164,6 +164,7 @@ class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
    * @return mixed
    */
   public function flush() {
+    // FIXME: Only delete items matching `$this->_prefix`.
     return $this->_cache->flush();
   }
 

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -154,7 +154,12 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
    * @return mixed
    */
   public function flush() {
-    return $this->_cache->flushDB();
+    // FIXME: Ideally, we'd map each prefix to a different 'hash' object in Redis,
+    // and this would be simpler. However, that needs to go in tandem with a
+    // more general rethink of cache expiration/TTL.
+
+    $keys = $this->_cache->keys($this->_prefix . '*');
+    return $this->_cache->del($keys);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

When flushing caches for an instance of `CRM_Utils_Cache_Redis`, you should
only delete the items with the matching prefix.

For reference, consider this example:

```
$js_strings = CRM_Utils_Cache::create(array(
  'name' => 'js_strings',
  'type' => array('*memory*', 'SqlGroup', 'ArrayCache'),
));

$community_messages = CRM_Utils_Cache::create(array(
  'name' => 'community_messages',
  'type' => array('*memory*', 'SqlGroup', 'ArrayCache'),
));

$js_strings->flush();
```

If the system is generally configured for Redis, this will give us two instances of `CRM_Utils_Cache_Redis` -- these instances are stored on the same server but use different prefixes.

Before
----------------------------------------

Flushing `js_strings` has the side-effect of flushing everything else in Redis, such as `community_messages`.

After
----------------------------------------

Flushing `js_strings` only flushes `js_strings`.

Comments
----------------------------------------

The example above focuses on two relatively obscure caches (`js_strings` and `community_messages`) because they actually exist today.  In the future, as part of dev/core#174, it will become possible to store sessions in Redis. And then it will be more important -- e.g.  if a user creates a custom-field, you do want to flush one set of data (e.g. the contact-fields cache), but you don't want to flush another (e.g. the user sessions).

The current commit fixes Redis.  Although it's outside the scope of this
commit, here's an assessment of other drivers:

* `APCcache` looks fine -- it already consults the prefix.
* `ArrayCache` looks fine -- data is already scoped within the object.
* `NoCache` looks fine -- it's a null-op for everything.
* `SqlGroup` is loosely right. There's a similar-but-different quirk, but a separate PR will address that.
* `Memcache` and `Memcached` look buggy. I don't have these systems locally, so I haven't tested or patched.
