### PR TITLE
(dev/core#174) CRM_Utils_Cache - Always use a prefix. Standardize delimiter

### DIFF
--- a/CRM/Cxn/CiviCxnHttp.php
+++ b/CRM/Cxn/CiviCxnHttp.php
@@ -106,4 +106,11 @@ class CRM_Cxn_CiviCxnHttp extends \Civi\Cxn\Rpc\Http\PhpHttp {
     return $result;
   }
 
+  /**
+   * @return \CRM_Utils_Cache_Interface|null
+   */
+  public function getCache() {
+    return $this->cache;
+  }
+
 }

--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -35,6 +35,9 @@
  * Cache is an empty base object, we'll modify the scheme when we have different caching schemes
  */
 class CRM_Utils_Cache {
+
+  const DELIMITER = '/';
+
   /**
    * (Quasi-Private) Treat this as private. It is marked public to facilitate testing.
    *
@@ -83,6 +86,7 @@ class CRM_Utils_Cache {
       // a generic method for utilizing any of the available db caches.
       $dbCacheClass = 'CRM_Utils_Cache_' . $className;
       $settings = self::getCacheSettings($className);
+      $settings['prefix'] = CRM_Utils_Array::value('prefix', $settings, '') . self::DELIMITER . 'default' . self::DELIMITER;
       self::$_singleton = new $dbCacheClass($settings);
     }
     return self::$_singleton;
@@ -186,7 +190,7 @@ class CRM_Utils_Cache {
           if (defined('CIVICRM_DB_CACHE_CLASS') && in_array(CIVICRM_DB_CACHE_CLASS, array('Memcache', 'Memcached', 'Redis'))) {
             $dbCacheClass = 'CRM_Utils_Cache_' . CIVICRM_DB_CACHE_CLASS;
             $settings = self::getCacheSettings(CIVICRM_DB_CACHE_CLASS);
-            $settings['prefix'] = $settings['prefix'] . '_' . $params['name'];
+            $settings['prefix'] = CRM_Utils_Array::value('prefix', $settings, '') . self::DELIMITER . $params['name'] . self::DELIMITER;
             return new $dbCacheClass($settings);
           }
           break;

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -121,12 +121,16 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
    * @param string $key
    */
   public function delete($key) {
-    CRM_Core_BAO_Cache::deleteGroup($this->group, $key);
+    CRM_Core_BAO_Cache::deleteGroup($this->group, $key, FALSE);
+    CRM_Core_BAO_Cache::$_cache = NULL; // FIXME: remove multitier cache
+    CRM_Utils_Cache::singleton()->flush(); // FIXME: remove multitier cache
     unset($this->frontCache[$key]);
   }
 
   public function flush() {
-    CRM_Core_BAO_Cache::deleteGroup($this->group);
+    CRM_Core_BAO_Cache::deleteGroup($this->group, NULL, FALSE);
+    CRM_Core_BAO_Cache::$_cache = NULL; // FIXME: remove multitier cache
+    CRM_Utils_Cache::singleton()->flush(); // FIXME: remove multitier cache
     $this->frontCache = array();
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1416,8 +1416,14 @@ class CRM_Utils_System {
   public static function flushCache() {
     // flush out all cache entries so we can reload new data
     // a bit aggressive, but livable for now
-    $cache = CRM_Utils_Cache::singleton();
-    $cache->flush();
+    CRM_Utils_Cache::singleton()->flush();
+    if (Civi\Core\Container::isContainerBooted()) {
+      Civi::cache('settings')->flush();
+      Civi::cache('js_strings')->flush();
+      Civi::cache('community_messages')->flush();
+      CRM_Extension_System::singleton()->getCache()->flush();
+      CRM_Cxn_CiviCxnHttp::singleton()->getCache()->flush();
+    }
 
     // also reset the various static memory caches
 


### PR DESCRIPTION
"Prefixes" are a way to have one cache-server (e.g. one instance of redis or memcached)
which stores several different data-sets. `CRM_Utils_Cache` uses prefixes in a couple ways:

* (1) General site prefix (controlled via `civicrm.settings.php`)
    * (1a) If you have a single-site deployment, then the general prefix is blank.
    * (1b) If you have a multi-site deployment, then each site should use a different prefix (`mysite_1`, `mysite_2`, etc).
* (2) Within a given deployment, prefixes may indicate different logical data-sets.
    * (2a) `Civi::cache()` or `Civi::cache('default')` or `CRM_Utils_Cache::singleton()` are the `default` data-set.
    * (2b) `CRM_Utils_Cache::create()` can instantiate new, special-purpose
      data-sets. For example, this is used for `Civi::cache('js_strings')`.

This patch addresses two issues:

 * (Functional bug) Flushing the 'default' cache would flush all other caches because the 'default' cache didn't have a distinctive prefix. (*Note: Bug may not manifest on all cache drivers.*)
 * (Aesthetic) The full cache paths don't look consistent because they don't have a standard dlimiter.

To fully understand, it helps to see example cache keys produced in a few
configurations before and after the patch.

See also: https://lab.civicrm.org/dev/core/issues/174

Before
-----------------------------

| |Deployment Type|Logical Cache  |Combined Cache Prefix |Example Cache Item (`foobar`)|
|-|-|---------------|-------|-----------------|
|1a,2a|Single-site|`default`    |(empty-string)|`foobar`|
|1a,2b|Single-site| `js_strings` |`_js_strings`|`_js_stringsfoobar`|
|1b,2a|Multi-site |`default`    |`mysite_1_`|`mysite_1_foobar`|
|1b,2b|Multi-site |`js_strings` |`mysite_1_js_strings`|`mysite_1_js_stringsfoobar`|

* If you have a single-site deployment and try to flush `default`, you inadvertently flush `js_strings` because everything matches the empty-string prefix.
* If you have a multi-site deployment and try to flush `default`, you inadvertently flush `js_strings` because the prefix overlaps.
* The three parts of the key (deployment ID, logical cache, and cache item) are not necessarily separated.

After
-----------------------------

| |Deployment Type|Logical Cache  |Combined Cache Prefix |Example Cache Item (`foobar`)|
|-|-|---------------|-------|-----------------|
|1a,2a|Single-site|`default`    |`/default/`|`/default/foobar`|
|1a,2b|Single-site|`js_strings` |`/js_strings/`|`/js_strings/foobar`|
|1b,2a|Multi-site |`default`    |`mysite_1/default/`|`mysite_1/default/foobar`|
|1b,2b|Multi-site |`js_strings` |`mysite_1/js_strings/`|`mysite_1/js_strings/foobar`|

* If you have a single-site deployment and try to flush `default`, you only flush `default` because the prefixes are distinct.
* If you have a multi-site deployment and try to flush `default`, you only flush `default` because the prefixes are distinct.
* The three parts of the key (deployment ID, logical cache, and cache item) are always separated by `/`.

Comments
--------

When developing this patch, I found it helpful to:

* Enable Redis driver
* Open `redis-cli` and view the list of cache items with `keys *`.
