### PR TITLE
dev/core/issues/189, fixed smarty error

### DIFF
--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {assign var=isRecordPayment value=1 }
-{assign var=isShowBillingBlock value=($action neq 2)}
+{capture assign="isShowBillingBlock"}{if $action neq 2}1{else}0{/if}{/capture}
 {if $paid} {* We retrieve this tpl when event is selected - keep it empty if event is not paid *}
     <table class="form-layout">
     {if $priceSet}


### PR DESCRIPTION
Overview
----------------------------------------
Recently upgraded a site to 5.2.1 in WordPress 4.9.6. When the user tries to register a event participant in the back-end the fee selections price set does not load after the event is selected. All works fine on front end pages and if you edit an existing registration you are able to change the fee selections.

Checked another site with the same setup and the results are the same.

The results are the same if you try from the contact record either using the register button or the submit CC payment with registration button.

Do not see anything in the CiviCRM logs.
https://civicrm.stackexchange.com/questions/25394/event-fees-not-loading-when-registering-in-back-end

https://lab.civicrm.org/dev/core/issues/189

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/41556809-63c12ebe-7359-11e8-8a85-3ab13802242c.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/41556826-68f0a9aa-7359-11e8-9039-c20dbf73df9a.png)


Technical Details
----------------------------------------
From Php error log
[Tue Jun 19 00:21:46.010459 2018] [:error] [pid 10807] [client 127.0.0.1:59798] PHP Fatal error:  Smarty error: [in CRM/Event/Form/EventFees.tpl line 27]: syntax error: expecting '=' after attribute name 'neq' (Smarty_Compiler.class.php, line 1558) in /var/www/html/staging.org/wp-content/plugins/civicrm/civicrm/packages/Smarty/Smarty.class.php on line 1100, referer: http://localhost/staging.org/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fparticipant%2Fadd&reset=1&action=add&context=standalone
