### PR TITLE
Ensure classes are the same across all workflow templates

### DIFF
--- a/ang/crmMailing/EditMailingCtrl/workflow.html
+++ b/ang/crmMailing/EditMailingCtrl/workflow.html
@@ -66,7 +66,7 @@
           ng-disabled="block.check()"
           crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
           on-yes="delete()">{{ts('Delete Draft')}}</button>
-        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave)" class="crmMailing-btn-secondary">{{ts('Save Draft')}}</button>
+        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave)" class="crmMailing-btn-secondary-outline">{{ts('Save Draft')}}</button>
       </span>
     </div>
   </div>


### PR DESCRIPTION
@eileenmcnaughton just noticed there was a slight inconsistency on this file with the rest for the save draft should be secondary-outline not secondary as per https://github.com/civicrm/civicrm-core/blob/master/ang/crmMailing/EditMailingCtrl/2step.html#L59 this was the only one that was mixed