### PR TITLE
Move DAO function to DAO class, call it from Merge class

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2269,6 +2269,54 @@ SELECT contact_id
   }
 
   /**
+   * Get all references to contact table.
+   *
+   * This includes core tables, custom group tables, tables added by the merge
+   * hook and  the entity_tag table.
+   *
+   * Refer to CRM-17454 for information on the danger of querying the information
+   * schema to derive this.
+   */
+  public static function getReferencesToContactTable() {
+    if (isset(\Civi::$statics[__CLASS__]) && isset(\Civi::$statics[__CLASS__]['contact_references'])) {
+      return \Civi::$statics[__CLASS__]['contact_references'];
+    }
+    $contactReferences = [];
+    $coreReferences = CRM_Core_DAO::getReferencesToTable('civicrm_contact');
+    foreach ($coreReferences as $coreReference) {
+      if (!is_a($coreReference, 'CRM_Core_Reference_Dynamic')) {
+        $contactReferences[$coreReference->getReferenceTable()][] = $coreReference->getReferenceKey();
+      }
+    }
+    self::appendCustomTablesExtendingContacts($contactReferences);
+
+    // FixME for time being adding below line statically as no Foreign key constraint defined for table 'civicrm_entity_tag'
+    $contactReferences['civicrm_entity_tag'][] = 'entity_id';
+    \Civi::$statics[__CLASS__]['contact_references'] = $contactReferences;
+    return \Civi::$statics[__CLASS__]['contact_references'];
+  }
+
+  /**
+   * Add custom tables that extend contacts to the list of contact references.
+   *
+   * CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity seems like a safe-ish
+   * function to be sure all are retrieved & we don't miss subtypes or inactive or multiples
+   * - the down side is it is not cached.
+   *
+   * Further changes should be include tests in the CRM_Core_MergerTest class
+   * to ensure that disabled, subtype, multiple etc groups are still captured.
+   *
+   * @param array $cidRefs
+   */
+  public static function appendCustomTablesExtendingContacts(&$cidRefs) {
+    $customValueTables = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity('Contact');
+    $customValueTables->find();
+    while ($customValueTables->fetch()) {
+      $cidRefs[$customValueTables->table_name] = array('entity_id');
+    }
+  }
+
+  /**
    * Lookup the value of a MySQL global configuration variable.
    *
    * @param string $name

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -203,35 +203,23 @@ class CRM_Dedupe_Merger {
   /**
    * Get array tables and fields that reference civicrm_contact.id.
    *
-   * This includes core tables, custom group tables, tables added by the merge
-   * hook and (somewhat randomly) the entity_tag table.
+   * This function calls the merge hook and only exists to wrap the DAO function to support that deprecated call.
+   * The entityTypes hook is the recommended way to add tables to this result.
    *
-   * Refer to CRM-17454 for information on the danger of querying the information
-   * schema to derive this.
-   *
-   * This function calls the merge hook but the entityTypes hook is the recommended
-   * way to add tables to this result.
+   * I thought about adding another hook to alter tableReferences but decided it was unclear if there
+   * are use cases not covered by entityTables and instead we should wait & see.
    */
   public static function cidRefs() {
     if (isset(\Civi::$statics[__CLASS__]) && isset(\Civi::$statics[__CLASS__]['contact_references'])) {
       return \Civi::$statics[__CLASS__]['contact_references'];
     }
-    $contactReferences = array();
-    $coreReferences = CRM_Core_DAO::getReferencesToTable('civicrm_contact');
-    foreach ($coreReferences as $coreReference) {
-      if (!is_a($coreReference, 'CRM_Core_Reference_Dynamic')) {
-        $contactReferences[$coreReference->getReferenceTable()][] = $coreReference->getReferenceKey();
-      }
-    }
-    self::addCustomTablesExtendingContactsToCidRefs($contactReferences);
 
-    // FixME for time being adding below line statically as no Foreign key constraint defined for table 'civicrm_entity_tag'
-    $contactReferences['civicrm_entity_tag'][] = 'entity_id';
+    $contactReferences = $coreReferences = CRM_Core_DAO::getReferencesToContactTable();
 
-    // Allow hook_civicrm_merge() to adjust $cidRefs.
-    // Note that if entities are registered using the entityTypes hook there
-    // is no need to use this hook.
     CRM_Utils_Hook::merge('cidRefs', $contactReferences);
+    if ($contactReferences !== $coreReferences) {
+      Civi::log()->warning("Deprecated hook ::merge in context of 'cidRefs. Use entityTypes instead.", array('civi.tag' => 'deprecated'));
+    }
     \Civi::$statics[__CLASS__]['contact_references'] = $contactReferences;
     return \Civi::$statics[__CLASS__]['contact_references'];
   }
@@ -486,7 +474,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     // getting all custom tables
     $customTables = array();
     if ($customTableToCopyFrom !== NULL) {
-      self::addCustomTablesExtendingContactsToCidRefs($customTables);
+      // @todo this duplicates cidRefs?
+      CRM_Core_DAO::appendCustomTablesExtendingContacts($customTables);
       $customTables = array_keys($customTables);
     }
 
@@ -1922,26 +1911,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         // create/update membership(s) for related contact(s)
         CRM_Member_BAO_Membership::createRelatedMemberships($membershipParams, $dao);
       } // end of if relationshipTypeId
-    }
-  }
-
-  /**
-   * Add custom tables that extend contacts to the list of contact references.
-   *
-   * CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity seems like a safe-ish
-   * function to be sure all are retrieved & we don't miss subtypes or inactive or multiples
-   * - the down side is it is not cached.
-   *
-   * Further changes should be include tests in the CRM_Core_MergerTest class
-   * to ensure that disabled, subtype, multiple etc groups are still captured.
-   *
-   * @param array $cidRefs
-   */
-  public static function addCustomTablesExtendingContactsToCidRefs(&$cidRefs) {
-    $customValueTables = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity('Contact');
-    $customValueTables->find();
-    while ($customValueTables->fetch()) {
-      $cidRefs[$customValueTables->table_name] = array('entity_id');
     }
   }
 

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -945,7 +945,7 @@ COLS;
    * but this is the only entity currently available...
    */
   public function getLogTablesForContact() {
-    $tables = array_keys(CRM_Dedupe_Merger::cidRefs());
+    $tables = array_keys(CRM_Core_DAO::getReferencesToContactTable());
     return array_intersect($tables, $this->tables);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Moves a function to a more logical place, deprecates a specific old hook usage (hook merge in cidRefs context) 

Before
----------------------------------------
Code works & test CRM_Dedupe_MergerTest::getCidRefs passes. Code is less logical

After
----------------------------------------
Code works & test CRM_Dedupe_MergerTest::getCidRefs passes. Code is more logical. Poorly thought out hook call is deprecated and that same hook is no longer called from an unrelated context.

Technical Details
----------------------------------------
This change is primarily moving most of the contents of cidRefs (which is well tested already) to CRM_Core_DAO::getReferencesToContactTable. In addition addCustomTablesExtendingContactsToCidRefs is moved to CRM_Core_DAO (since otherwise the 'self::' call doesn't work.

The CRM_Dedupe_Merger::cidRefs function is retained as, in addition to calling the new function,
 it calls the hook 
```
CRM_Utils_Hook::merge('cidRefs', $contactReferences); 
```
That hook is poorly thought out as the merge hook is called in different contexts with completely different expectations. In this context the entityTypes hook is preferred. After a number releases with it deprecated we can remove the whole function.

In the meantime the unrelated function CRM_Logging_Schema::getLogTablesForContact() no longer calls that hook

Comments
----------------------------------------

