### PR TITLE
Remove unused instances of usedTable

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -55,9 +55,8 @@ class CRM_Activity_Form_Task extends CRM_Core_Form_Task {
    * Common pre-process function.
    *
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_activityHolderIds = array();
 
     $values = $form->controller->exportValues($form->get('searchFormName'));

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -94,11 +94,13 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
    * Common pre-processing function.
    *
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_contactIds = array();
     $form->_contactTypes = array();
+
+    $formName = CRM_Utils_System::getClassName($form->controller->getStateMachine());
+    $useTable = ($formName !== 'CRM_Export_StateMachine_Standalone') ? TRUE : FALSE;
 
     $isStandAlone = in_array('task', $form->urlPath) || in_array('standalone', $form->urlPath);
     if ($isStandAlone) {

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -67,9 +67,8 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_contributionIds = array();
 
     $values = $form->controller->exportValues($form->get('searchFormName'));

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -59,9 +59,8 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_participantIds = array();
 
     $values = $form->controller->exportValues($form->get('searchFormName'));

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -59,9 +59,8 @@ class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_grantIds = array();
 
     $values = $form->controller->exportValues('Search');

--- a/CRM/Mailing/Form/Task.php
+++ b/CRM/Mailing/Form/Task.php
@@ -46,9 +46,8 @@ class CRM_Mailing_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
     $form->_task = CRM_Utils_Array::value('task', $values);

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -59,9 +59,8 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
 
   /**
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_memberIds = array();
 
     $values = $form->controller->exportValues($form->get('searchFormName'));

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -55,9 +55,8 @@ class CRM_Pledge_Form_Task extends CRM_Core_Form_Task {
    * Common pre-processing.
    *
    * @param CRM_Core_Form $form
-   * @param bool $useTable
    */
-  public static function preProcessCommon(&$form, $useTable = FALSE) {
+  public static function preProcessCommon(&$form) {
     $form->_pledgeIds = array();
 
     $values = $form->controller->exportValues('Search');


### PR DESCRIPTION
Overview
----------------------------------------
Use an unused variable. 

Before
----------------------------------------
More redundant code

After
----------------------------------------
Less redundant code 

Technical Details
----------------------------------------
@mattwire I just merged #12318 which removes this unused variable from the parent. 

This PR extracts from #12320 to remove from those children where it is unused. Since this is a partial reviewer's commit I will self-merge this but I do think we would be better to switch to the form having a
$isStandalone property with getters & setters.

Comments
----------------------------------------

