### PR TITLE
Caching - Comply with PSR-16 interfaces

### DIFF
--- a/CRM/Utils/Cache/APCcache.php
+++ b/CRM/Utils/Cache/APCcache.php
@@ -124,6 +124,7 @@ class CRM_Utils_Cache_APCcache implements CRM_Utils_Cache_Interface {
         apc_delete($this->_prefix . $name);
       }
     }
+    return TRUE;
   }
 
 }

--- a/CRM/Utils/Cache/APCcache.php
+++ b/CRM/Utils/Cache/APCcache.php
@@ -84,10 +84,14 @@ class CRM_Utils_Cache_APCcache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param $key
+   * @param mixed $default
    *
    * @return mixed
    */
-  public function get($key) {
+  public function get($key, $default = NULL) {
+    if ($default !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::get() only supports NULL default");
+    }
     return apc_fetch($this->_prefix . $key);
   }
 

--- a/CRM/Utils/Cache/APCcache.php
+++ b/CRM/Utils/Cache/APCcache.php
@@ -72,10 +72,14 @@ class CRM_Utils_Cache_APCcache implements CRM_Utils_Cache_Interface {
   /**
    * @param $key
    * @param $value
+   * @param null|int|\DateInterval $ttl
    *
    * @return bool
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
+    }
     if (!apc_store($this->_prefix . $key, $value, $this->_timeout)) {
       return FALSE;
     }

--- a/CRM/Utils/Cache/APCcache.php
+++ b/CRM/Utils/Cache/APCcache.php
@@ -31,6 +31,9 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Utils_Cache_APCcache implements CRM_Utils_Cache_Interface {
+
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
   const DEFAULT_TIMEOUT = 3600;
   const DEFAULT_PREFIX = '';
 

--- a/CRM/Utils/Cache/APCcache.php
+++ b/CRM/Utils/Cache/APCcache.php
@@ -33,6 +33,7 @@
 class CRM_Utils_Cache_APCcache implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
   const DEFAULT_TIMEOUT = 3600;
   const DEFAULT_PREFIX = '';

--- a/CRM/Utils/Cache/APCcache.php
+++ b/CRM/Utils/Cache/APCcache.php
@@ -127,4 +127,8 @@ class CRM_Utils_Cache_APCcache implements CRM_Utils_Cache_Interface {
     return TRUE;
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
 }

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -94,4 +94,8 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
     return TRUE;
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
 }

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -37,6 +37,7 @@
 class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait;
+  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
   /**
    * The cache storage container, an in memory array by default

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -56,9 +56,15 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
   /**
    * @param string $key
    * @param mixed $value
+   * @param null|int|\DateInterval $ttl
+   * @return bool
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
+    }
     $this->_cache[$key] = $value;
+    return TRUE;
   }
 
   /**

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -63,11 +63,12 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param string $key
+   * @param mixed $default
    *
    * @return mixed
    */
-  public function get($key) {
-    return CRM_Utils_Array::value($key, $this->_cache);
+  public function get($key, $default = NULL) {
+    return CRM_Utils_Array::value($key, $this->_cache, $default);
   }
 
   /**

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -89,6 +89,7 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
   public function flush() {
     unset($this->_cache);
     $this->_cache = array();
+    return TRUE;
   }
 
 }

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -81,9 +81,11 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param string $key
+   * @return bool
    */
   public function delete($key) {
     unset($this->_cache[$key]);
+    return TRUE;
   }
 
   public function flush() {

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -36,6 +36,8 @@
  */
 class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
 
+  use CRM_Utils_Cache_NaiveMultipleTrait;
+
   /**
    * The cache storage container, an in memory array by default
    */

--- a/CRM/Utils/Cache/Interface.php
+++ b/CRM/Utils/Cache/Interface.php
@@ -108,4 +108,18 @@ interface CRM_Utils_Cache_Interface {
    */
   public function clear();
 
+  /**
+   * Determines whether an item is present in the cache.
+   *
+   * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+   * and not to be used within your live applications operations for get/set, as this method
+   * is subject to a race condition where your has() will return true and immediately after,
+   * another script can remove it making the state of your app out of date.
+   *
+   * @param string $key The cache item key.
+   *
+   * @return bool
+   */
+  public function has($key);
+
 }

--- a/CRM/Utils/Cache/Interface.php
+++ b/CRM/Utils/Cache/Interface.php
@@ -30,32 +30,14 @@
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
  *
- * CRM_Utils_Cache_Interface
+ * CRM_Utils_Cache_Interface is a long-standing interface used within CiviCRM
+ * for interacting with a cache service. In style and substance, it is extremely
+ * similar to PHP-FIG's SimpleCache interface (PSR-16). Consequently, beginning
+ * with CiviCRM v5.4, this extends \Psr\SimpleCache\CacheInterface.
  *
- * PHP-FIG has been developing a draft standard for caching,
- * PSR-6. The standard has not been ratified yet. When
- * making changes to this interface, please take care to
- * avoid *conflicst* with PSR-6's CacheItemPoolInterface. At
- * time of writing, they do not conflict. Avoiding conflicts
- * will enable more transition paths where Civi
- * simultaneously supports both interfaces in the same
- * implementation.
- *
- * For example, the current interface defines:
- *
- *   function get($key) => mixed $value
- *
- * and PSR-6 defines:
- *
- *   function getItem($key) => ItemInterface $item
- *
- * These are different styles (e.g. "weak item" vs "strong item"),
- * but the two methods do not *conflict*. They can coexist,
- * and you can trivially write adapters between the two.
- *
- * @see https://github.com/php-fig/fig-standards/blob/master/proposed/cache.md
+ * @see https://www.php-fig.org/psr/psr-16/
  */
-interface CRM_Utils_Cache_Interface {
+interface CRM_Utils_Cache_Interface extends \Psr\SimpleCache\CacheInterface {
 
   /**
    * Set the value in the cache.

--- a/CRM/Utils/Cache/Interface.php
+++ b/CRM/Utils/Cache/Interface.php
@@ -86,6 +86,8 @@ interface CRM_Utils_Cache_Interface {
 
   /**
    * Delete all values from the cache.
+   *
+   * @return bool
    */
   public function flush();
 

--- a/CRM/Utils/Cache/Interface.php
+++ b/CRM/Utils/Cache/Interface.php
@@ -81,6 +81,7 @@ interface CRM_Utils_Cache_Interface {
    * Delete a value from the cache.
    *
    * @param string $key
+   * @return bool
    */
   public function delete($key);
 

--- a/CRM/Utils/Cache/Interface.php
+++ b/CRM/Utils/Cache/Interface.php
@@ -88,8 +88,24 @@ interface CRM_Utils_Cache_Interface {
   /**
    * Delete all values from the cache.
    *
+   * NOTE: flush() and clear() should be aliases. flush() is specified by
+   * Civi's traditional interface, and clear() is specified by PSR-16.
+   *
    * @return bool
+   * @see clear
+   * @deprecated
    */
   public function flush();
+
+  /**
+   * Delete all values from the cache.
+   *
+   * NOTE: flush() and clear() should be aliases. flush() is specified by
+   * Civi's traditional interface, and clear() is specified by PSR-16.
+   *
+   * @return bool
+   * @see flush
+   */
+  public function clear();
 
 }

--- a/CRM/Utils/Cache/Interface.php
+++ b/CRM/Utils/Cache/Interface.php
@@ -69,10 +69,11 @@ interface CRM_Utils_Cache_Interface {
    * Get a value from the cache.
    *
    * @param string $key
+   * @param mixed $default
    * @return mixed
-   *   NULL if $key has not been previously set
+   *   The previously set value value, or $default (NULL).
    */
-  public function get($key);
+  public function get($key, $default = NULL);
 
   /**
    * Delete a value from the cache.

--- a/CRM/Utils/Cache/Interface.php
+++ b/CRM/Utils/Cache/Interface.php
@@ -62,8 +62,10 @@ interface CRM_Utils_Cache_Interface {
    *
    * @param string $key
    * @param mixed $value
+   * @param null|int|\DateInterval $ttl
+   * @return bool
    */
-  public function set($key, &$value);
+  public function set($key, $value, $ttl = NULL);
 
   /**
    * Get a value from the cache.

--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -109,10 +109,14 @@ class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
   /**
    * @param $key
    * @param $value
+   * @param null|int|\DateInterval $ttl
    *
    * @return bool
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
+    }
     if (!$this->_cache->set($this->_prefix . $key, $value, FALSE, $this->_timeout)) {
       return FALSE;
     }

--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -150,7 +150,7 @@ class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
   }
 
   /**
-   * @return mixed
+   * @return bool
    */
   public function flush() {
     // FIXME: Only delete items matching `$this->_prefix`.

--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -143,7 +143,7 @@ class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
   /**
    * @param $key
    *
-   * @return mixed
+   * @return bool
    */
   public function delete($key) {
     return $this->_cache->delete($this->_prefix . $key);

--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -157,4 +157,8 @@ class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
     return $this->_cache->flush();
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
 }

--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -31,6 +31,9 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
+
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
   const DEFAULT_HOST = 'localhost';
   const DEFAULT_PORT = 11211;
   const DEFAULT_TIMEOUT = 3600;

--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -121,10 +121,14 @@ class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param $key
+   * @param mixed $default
    *
    * @return mixed
    */
-  public function &get($key) {
+  public function get($key, $default = NULL) {
+    if ($default !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::get() only supports NULL default");
+    }
     $result = $this->_cache->get($this->_prefix . $key);
     return $result;
   }

--- a/CRM/Utils/Cache/Memcache.php
+++ b/CRM/Utils/Cache/Memcache.php
@@ -33,6 +33,7 @@
 class CRM_Utils_Cache_Memcache implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
   const DEFAULT_HOST = 'localhost';
   const DEFAULT_PORT = 11211;

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -31,6 +31,9 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
+
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
   const DEFAULT_HOST = 'localhost';
   const DEFAULT_PORT = 11211;
   const DEFAULT_TIMEOUT = 3600;

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -126,10 +126,14 @@ class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
 
   /**
    * @param $key
+   * @param mixed $default
    *
    * @return mixed
    */
-  public function &get($key) {
+  public function get($key, $default = NULL) {
+    if ($default !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::get() only supports NULL default");
+    }
     $key = $this->cleanKey($key);
     $result = $this->_cache->get($key);
     return $result;

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -172,7 +172,7 @@ class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
   }
 
   /**
-   * @return mixed
+   * @return bool
    */
   public function flush() {
     // FIXME: Only delete items matching `$this->_prefix`.

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -110,11 +110,15 @@ class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
   /**
    * @param $key
    * @param $value
+   * @param null|int|\DateInterval $ttl
    *
    * @return bool
    * @throws Exception
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
+    }
     $key = $this->cleanKey($key);
     if (!$this->_cache->set($key, $value, $this->_timeout)) {
       CRM_Core_Error::debug('Result Code: ', $this->_cache->getResultMessage());

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -179,4 +179,8 @@ class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
     return $this->_cache->flush();
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
 }

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -33,6 +33,7 @@
 class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
   const DEFAULT_HOST = 'localhost';
   const DEFAULT_PORT = 11211;

--- a/CRM/Utils/Cache/NaiveHasTrait.php
+++ b/CRM/Utils/Cache/NaiveHasTrait.php
@@ -29,70 +29,21 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
+ *
+ * The traditional CRM_Utils_Cache_Interface did not support has().
+ * To get drop-in compliance with PSR-16, we use a naive adapter.
+ *
+ * Ideally, these should be replaced with more performant/native versions.
  */
-class CRM_Utils_Cache_NoCache implements CRM_Utils_Cache_Interface {
+trait CRM_Utils_Cache_NaiveHasTrait {
 
-  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
-  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
-
-  /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
-   * Constructor.
-   *
-   * @param array $config
-   *   An array of configuration params.
-   *
-   * @return \CRM_Utils_Cache_NoCache
-   */
-  public function __construct($config) {
-  }
-
-  /**
-   * @param string $key
-   * @param mixed $value
-   * @param null|int|\DateInterval $ttl
-   *
-   * @return bool
-   */
-  public function set($key, $value, $ttl = NULL) {
-    return FALSE;
-  }
-
-  /**
-   * @param string $key
-   * @param mixed $default
-   *
-   * @return null
-   */
-  public function get($key, $default = NULL) {
-    return $default;
-  }
-
-  /**
-   * @param string $key
-   *
-   * @return bool
-   */
-  public function delete($key) {
-    return FALSE;
-  }
-
-  /**
-   * @return bool
-   */
-  public function flush() {
-    return FALSE;
-  }
-
-  public function clear() {
-    return $this->flush();
+  public function has($key) {
+    // This is crazy-talk. If you've got an environment setup where you might
+    // be investigating this, fix your preferred cache driver by
+    // replacing `NaiveHasTrait` with a decent function.
+    $hasDefaultA = ($this->get($key, NULL) === NULL);
+    $hasDefaultB = ($this->get($key, 123) === 123);
+    return !($hasDefaultA && $hasDefaultB);
   }
 
 }

--- a/CRM/Utils/Cache/NaiveMultipleTrait.php
+++ b/CRM/Utils/Cache/NaiveMultipleTrait.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ *
+ * The traditional CRM_Utils_Cache_Interface did not support multiple-key
+ * operations. To get drop-in compliance with PSR-16, we use a naive adapter.
+ * An operation like `getMultiple()` just calls `get()` multiple times.
+ *
+ * Ideally, these should be replaced with more performant/native versions.
+ */
+trait CRM_Utils_Cache_NaiveMultipleTrait {
+
+  /**
+   * Obtains multiple cache items by their unique keys.
+   *
+   * @param iterable $keys A list of keys that can obtained in a single operation.
+   * @param mixed $default Default value to return for keys that do not exist.
+   *
+   * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+   *
+   * @throws \Psr\SimpleCache\InvalidArgumentException
+   *   MUST be thrown if $keys is neither an array nor a Traversable,
+   *   or if any of the $keys are not a legal value.
+   */
+  public function getMultiple($keys, $default = NULL) {
+    $result = [];
+    foreach ($keys as $key) {
+      $result[$key] = $this->get($key, $default);
+    }
+    return $result;
+  }
+
+  /**
+   * Persists a set of key => value pairs in the cache, with an optional TTL.
+   *
+   * @param iterable $values A list of key => value pairs for a multiple-set operation.
+   * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+   *                                       the driver supports TTL then the library may set a default value
+   *                                       for it or let the driver take care of that.
+   *
+   * @return bool True on success and false on failure.
+   *
+   * @throws \Psr\SimpleCache\InvalidArgumentException
+   *   MUST be thrown if $values is neither an array nor a Traversable,
+   *   or if any of the $values are not a legal value.
+   */
+  public function setMultiple($values, $ttl = NULL) {
+    $result = TRUE;
+    foreach ($values as $key => $value) {
+      $result = $this->set($key, $value, $ttl) || $result;
+    }
+    return $result;
+  }
+
+  /**
+   * Deletes multiple cache items in a single operation.
+   *
+   * @param iterable $keys A list of string-based keys to be deleted.
+   *
+   * @return bool True if the items were successfully removed. False if there was an error.
+   *
+   * @throws \Psr\SimpleCache\InvalidArgumentException
+   *   MUST be thrown if $keys is neither an array nor a Traversable,
+   *   or if any of the $keys are not a legal value.
+   */
+  public function deleteMultiple($keys) {
+    $result = TRUE;
+    foreach ($keys as $key) {
+      $result = $this->delete($key) || $result;
+    }
+    return $result;
+  }
+
+}

--- a/CRM/Utils/Cache/NoCache.php
+++ b/CRM/Utils/Cache/NoCache.php
@@ -32,6 +32,8 @@
  */
 class CRM_Utils_Cache_NoCache implements CRM_Utils_Cache_Interface {
 
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
   /**
    * We only need one instance of this object. So we use the singleton
    * pattern and cache the instance in this variable

--- a/CRM/Utils/Cache/NoCache.php
+++ b/CRM/Utils/Cache/NoCache.php
@@ -54,10 +54,11 @@ class CRM_Utils_Cache_NoCache implements CRM_Utils_Cache_Interface {
   /**
    * @param string $key
    * @param mixed $value
+   * @param null|int|\DateInterval $ttl
    *
    * @return bool
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
     return FALSE;
   }
 

--- a/CRM/Utils/Cache/NoCache.php
+++ b/CRM/Utils/Cache/NoCache.php
@@ -63,11 +63,12 @@ class CRM_Utils_Cache_NoCache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param string $key
+   * @param mixed $default
    *
    * @return null
    */
-  public function get($key) {
-    return NULL;
+  public function get($key, $default = NULL) {
+    return $default;
   }
 
   /**

--- a/CRM/Utils/Cache/NoCache.php
+++ b/CRM/Utils/Cache/NoCache.php
@@ -90,4 +90,8 @@ class CRM_Utils_Cache_NoCache implements CRM_Utils_Cache_Interface {
     return FALSE;
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
 }

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -33,6 +33,9 @@
  *
  */
 class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
+
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
   const DEFAULT_HOST    = 'localhost';
   const DEFAULT_PORT    = 6379;
   const DEFAULT_TIMEOUT = 3600;

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -172,4 +172,8 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
     return TRUE;
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
 }

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -113,11 +113,15 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
   /**
    * @param $key
    * @param $value
+   * @param null|int|\DateInterval $ttl
    *
    * @return bool
    * @throws Exception
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
+    }
     if (!$this->_cache->set($this->_prefix . $key, serialize($value), $this->_timeout)) {
       if (PHP_SAPI === 'cli' || (Civi\Core\Container::isContainerBooted() && CRM_Core_Permission::check('view debug output'))) {
         CRM_Core_Error::fatal("Redis set ($key) failed: " . $this->_cache->getLastError());

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -35,6 +35,7 @@
 class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
   const DEFAULT_HOST    = 'localhost';
   const DEFAULT_PORT    = 6379;

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -159,7 +159,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
   }
 
   /**
-   * @return mixed
+   * @return bool
    */
   public function flush() {
     // FIXME: Ideally, we'd map each prefix to a different 'hash' object in Redis,
@@ -167,7 +167,8 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
     // more general rethink of cache expiration/TTL.
 
     $keys = $this->_cache->keys($this->_prefix . '*');
-    return $this->_cache->del($keys);
+    $this->_cache->del($keys);
+    return TRUE;
   }
 
 }

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -133,12 +133,13 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
 
   /**
    * @param $key
+   * @param mixed $default
    *
    * @return mixed
    */
-  public function get($key) {
+  public function get($key, $default = NULL) {
     $result = $this->_cache->get($this->_prefix . $key);
-    return ($result === FALSE) ? NULL : unserialize($result);
+    return ($result === FALSE) ? $default : unserialize($result);
   }
 
   /**

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -152,10 +152,11 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
   /**
    * @param $key
    *
-   * @return mixed
+   * @return bool
    */
   public function delete($key) {
-    return $this->_cache->delete($this->_prefix . $key);
+    $this->_cache->delete($this->_prefix . $key);
+    return TRUE;
   }
 
   /**

--- a/CRM/Utils/Cache/SerializeCache.php
+++ b/CRM/Utils/Cache/SerializeCache.php
@@ -139,4 +139,8 @@ class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
     return TRUE;
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
 }

--- a/CRM/Utils/Cache/SerializeCache.php
+++ b/CRM/Utils/Cache/SerializeCache.php
@@ -109,12 +109,14 @@ class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param string $key
+   * @return bool
    */
   public function delete($key) {
     if (file_exists($this->fileName($key))) {
       unlink($this->fileName($key));
     }
     unset($this->_cache[$key]);
+    return TRUE;
   }
 
   /**

--- a/CRM/Utils/Cache/SerializeCache.php
+++ b/CRM/Utils/Cache/SerializeCache.php
@@ -37,6 +37,7 @@
 class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait;
+  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
   /**
    * The cache storage container, an array by default, stored in a file under templates

--- a/CRM/Utils/Cache/SerializeCache.php
+++ b/CRM/Utils/Cache/SerializeCache.php
@@ -119,11 +119,12 @@ class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param null $key
+   * @return bool
    */
   public function flush($key = NULL) {
     $prefix = "CRM_";
     if (!$handle = opendir(CIVICRM_TEMPLATE_COMPILEDIR)) {
-      return; // die? Error?
+      return FALSE; // die? Error?
     }
     while (FALSE !== ($entry = readdir($handle))) {
       if (substr($entry, 0, 4) == $prefix) {
@@ -133,6 +134,7 @@ class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
     closedir($handle);
     unset($this->_cache);
     $this->_cache = array();
+    return TRUE;
   }
 
 }

--- a/CRM/Utils/Cache/SerializeCache.php
+++ b/CRM/Utils/Cache/SerializeCache.php
@@ -67,10 +67,15 @@ class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
 
   /**
    * @param string $key
+   * @param mixed $default
    *
    * @return mixed
    */
-  public function get($key) {
+  public function get($key, $default = NULL) {
+    if ($default !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::get() only supports NULL default");
+    }
+
     if (array_key_exists($key, $this->_cache)) {
       return $this->_cache[$key];
     }

--- a/CRM/Utils/Cache/SerializeCache.php
+++ b/CRM/Utils/Cache/SerializeCache.php
@@ -36,6 +36,8 @@
  */
 class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
 
+  use CRM_Utils_Cache_NaiveMultipleTrait;
+
   /**
    * The cache storage container, an array by default, stored in a file under templates
    */

--- a/CRM/Utils/Cache/SerializeCache.php
+++ b/CRM/Utils/Cache/SerializeCache.php
@@ -90,13 +90,19 @@ class CRM_Utils_Cache_SerializeCache implements CRM_Utils_Cache_Interface {
   /**
    * @param string $key
    * @param mixed $value
+   * @param null|int|\DateInterval $ttl
+   * @return bool
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
+    }
     if (file_exists($this->fileName($key))) {
-      return;
+      return FALSE; // WTF, write-once cache?!
     }
     $this->_cache[$key] = $value;
-    file_put_contents($this->fileName($key), "<?php //" . serialize($value));
+    $bytes = file_put_contents($this->fileName($key), "<?php //" . serialize($value));
+    return ($bytes !== FALSE);
   }
 
   /**

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -39,6 +39,7 @@
 class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+  use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
   /**
    * The host name of the memcached server.

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -97,10 +97,14 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
 
   /**
    * @param string $key
+   * @param mixed $default
    *
    * @return mixed
    */
-  public function get($key) {
+  public function get($key, $default = NULL) {
+    if ($default !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::get() only supports NULL default");
+    }
     if (!array_key_exists($key, $this->frontCache)) {
       $this->frontCache[$key] = CRM_Core_BAO_Cache::getItem($this->group, $key, $this->componentID);
     }

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -38,6 +38,8 @@
  */
 class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
 
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
   /**
    * The host name of the memcached server.
    *

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -89,10 +89,16 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
   /**
    * @param string $key
    * @param mixed $value
+   * @param null|int|\DateInterval $ttl
+   * @return bool
    */
-  public function set($key, &$value) {
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL) {
+      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
+    }
     CRM_Core_BAO_Cache::setItem($value, $this->group, $key, $this->componentID);
     $this->frontCache[$key] = $value;
+    return TRUE;
   }
 
   /**

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -144,6 +144,7 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
     CRM_Core_BAO_Cache::$_cache = NULL; // FIXME: remove multitier cache
     CRM_Utils_Cache::singleton()->flush(); // FIXME: remove multitier cache
     $this->frontCache = array();
+    return TRUE;
   }
 
   public function prefetch() {

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -131,12 +131,14 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
 
   /**
    * @param string $key
+   * @return bool
    */
   public function delete($key) {
     CRM_Core_BAO_Cache::deleteGroup($this->group, $key, FALSE);
     CRM_Core_BAO_Cache::$_cache = NULL; // FIXME: remove multitier cache
     CRM_Utils_Cache::singleton()->flush(); // FIXME: remove multitier cache
     unset($this->frontCache[$key]);
+    return TRUE;
   }
 
   public function flush() {

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -149,6 +149,10 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
     return TRUE;
   }
 
+  public function clear() {
+    return $this->flush();
+  }
+
   public function prefetch() {
     $this->frontCache = CRM_Core_BAO_Cache::getItems($this->group, $this->componentID);
   }

--- a/Civi.php
+++ b/Civi.php
@@ -26,20 +26,15 @@ class Civi {
   public static $statics = array();
 
   /**
-   * EXPERIMENTAL. Retrieve a named cache instance.
-   *
-   * This interface is flagged as experimental due to political
-   * ambiguity in PHP community -- PHP-FIG has an open but
-   * somewhat controversial draft standard for caching. Based on
-   * the current draft, it's expected that this function could
-   * simultaneously support both CRM_Utils_Cache_Interface and
-   * PSR-6, but that depends on whether PSR-6 changes any more.
+   * Retrieve a named cache instance.
    *
    * @param string $name
    *   The name of the cache. The 'default' cache is biased toward
    *   high-performance caches (eg memcache/redis/apc) when
    *   available and falls back to single-request (static) caching.
    * @return CRM_Utils_Cache_Interface
+   *   NOTE: Beginning in CiviCRM v5.4, the cache instance complies with
+   *   PSR-16 (\Psr\SimpleCache\CacheInterface).
    */
   public static function cache($name = 'default') {
     return \Civi\Core\Container::singleton()->get('cache.' . $name);

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
     "pear/Net_SMTP": "1.6.*",
     "pear/Net_socket": "1.0.*",
     "civicrm/civicrm-setup": "~0.2.0",
-    "guzzlehttp/guzzle": "^6.3"
+    "guzzlehttp/guzzle": "^6.3",
+    "psr/simple-cache": "~1.0.1"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c5441f5ce4c51ed3a8cc326693cd904",
+    "content-hash": "233f9c457d9e7d49a6d96c356e1035f1",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -1130,6 +1130,54 @@
                 "psr-3"
             ],
             "time": "2012-12-21T11:40:51+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
Overview
----------------------------------------

`CRM_Utils_Cache_Interface` is an interface for representing cache services. 
[PSR-16](https://www.php-fig.org/psr/psr-16/) is a standardized interface from [PHP-FIG](https://www.php-fig.org/) for representing cache services. PSR-16 is essentially a (small) superset of `CRM_Utils_Cache_Interface`. This PR aligns `CRM_Utils_Cache_Interface` with PSR-16.

__Motivation__: Among other things, [dev/core#174](https://lab.civicrm.org/dev/core/issues/174) will require the option to store session/form-state in a swappable backend. `CRM_Utils_Cache_Interface` almost provides enough functionality, except that there is no expiration mechanism. That requires updating the contract (i.e. to support `$cache->set($key, $value, $ttl)`). In the short-term, this change helps us get the contract updated. In the longer term, it should improve interoperability with libraries that work with cache services.

Before
----------------------------------------
```php
interface CRM_Utils_Cache_Interface {
  public function set($key, &$value);
  public function get($key);
  public function delete($key);
  public function flush();
}
```

After
----------------------------------------
```php
interface CRM_Utils_Cache_Interface extends \Psr\SimpleCache\CacheInterface {
  public function set($key, $value, $ttl = NULL);   // New optional param. Non-ref.
  public function get($key, $default = NULL);       // New optional param
  public function delete($key);
  public function flush();                             // Deprecated
  public function clear();                             // Alias for flush()
  public function has($key);                           // New
  public function getMultiple($keys, $default = null); // New
  public function setMultiple($values, $ttl = null);   // New
  public function deleteMultiple($keys);               // New
}
```

Technical Details
----------------------------------------
* A caller which worked with the old interface should continue working with the new interface.
* For each of the functions that is changed or added, I've included notes in the corresponding git commit discussing interoperability in more detail.
* One issue in writing this PR is that there are *several existing cache drivers*, and I don't have capacity today for setting-up the dev environment to test all of them carefully. I've handled this as follows:
    * For the new functions (`has`, `getMultiple`, `setMultiple`, `deleteMultiple`), the PR adds generic/non-performant implementations that can be used in any driver. These are flagged `TODO`/`FIXME`.
    * For the new parameters `set(...$ttl...)` and `get(...$default...)`, the defaults match the old/existing semantics, so we just use the old/existing code. *However*, if you try to use these parameters, you might get an exception if the driver doesn't support it. These are flagged `TODO`/`FIXME`.
    * The challenge in updating the existing drivers is *getting a dev environment*. Once you have the environment, it should be pretty easy to patch any `TODO`/`FIXME` bits to get full compliance.
    * Given that some drivers don't fully support every option, one might argue to wait on merging. I don't think this should hold us back because (a) we don't actually have anything that uses the unsupported bits and (b) after merging, the other updates can be done in parallel (different branches/PRs/people) rather than front-loading this PR.
* PHP-FIG actually has two competing standards for cache services (PSR-6 and PSR-16) -- which support different coding styes. This brings in support for the newer PSR-16 because it closely matches the existing `CRM_Utils_Cache_Interface`, which makes it simpler to adapt to.
