### PR TITLE
dev/core#192 - Search builder fails for != smart group filter

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
@@ -441,7 +441,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE, FALSE, FALSE,
       TRUE, FALSE
     );
-    $expectedWhere = "`civicrm_group_contact_cache_{$group2->id}`.group_id IN (\"{$group2->id}\")";
+    $expectedWhere = "civicrm_group_contact_cache.group_id IN (\"{$group2->id}\")";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id = {$group2->id}");
 
@@ -453,7 +453,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE, FALSE
     );
     //Assert if proper where clause is present.
-    $expectedWhere = "`civicrm_group_contact-{$group->id}`.group_id != {$group->id} AND `civicrm_group_contact_cache_{$group->id}`.group_id IS NULL OR  ( `civicrm_group_contact_cache_{$group->id}`.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
+    $expectedWhere = "civicrm_group_contact.group_id != {$group->id} AND civicrm_group_contact_cache.group_id IS NULL OR  ( civicrm_group_contact_cache.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id != {$group->id}");
 
@@ -464,7 +464,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE,
       FALSE, FALSE
     );
-    $expectedWhere = "`civicrm_group_contact_cache_{$group->id},{$group2->id}`.group_id IN (\"{$group->id}\", \"{$group2->id}\")";
+    $expectedWhere = "civicrm_group_contact_cache.group_id IN (\"{$group->id}\", \"{$group2->id}\")";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id IN ({$group->id}, {$group2->id})");
 
@@ -475,7 +475,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE,
       FALSE, FALSE
     );
-    $expectedWhere = "`civicrm_group_contact-{$group->id}`.group_id NOT IN ( {$group->id} ) AND `civicrm_group_contact_cache_{$group->id}`.group_id IS NULL OR  ( `civicrm_group_contact_cache_{$group->id}`.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
+    $expectedWhere = "civicrm_group_contact.group_id NOT IN ( {$group->id} ) AND civicrm_group_contact_cache.group_id IS NULL OR  ( civicrm_group_contact_cache.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id NOT IN ({$group->id})");
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix smart group in search builder with `!=` operator.

Before
----------------------------------------
Smart Group search on `Search Builder` result incorrect rows with `!=` operator

![image](https://user-images.githubusercontent.com/5929648/41657523-49617d90-74b1-11e8-8bd8-0bd3e010a720.png)

After
----------------------------------------
Correct results are displayed.

Comments
----------------------------------------
Added unit test.

----------------------------------------

Gitlab - https://lab.civicrm.org/dev/core/issues/192