### PR TITLE
dev/core#195 Add Contribution Counts to Sub-tabs

### DIFF
--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -46,12 +46,12 @@
         <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
           <li id="tab_contributions" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
             <a href="#contributions-subtab" title="{ts}Contributions{/ts}">
-              {ts}Contributions{/ts}
+              {ts}Contributions{/ts} <em>{$rows|@count}</em>
             </a>
           </li>
           <li id="tab_recurring" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
             <a href="#recurring-subtab" title="{ts}Recurring Contributions{/ts}">
-              {ts}Recurring Contributions{/ts}
+              {ts}Recurring Contributions{/ts} <em>{$activeRecurRows|@count}</em>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Overview
----------------------------------------
It would be helpful to be able to see on each sub-tab a count of Contributions / Recurring Contributions, keeping the UX consistent with how the rest of tabs work on Contact's Detail View.

Before
----------------------------------------
No counts were shown on Contribution sub-tabs.

After
----------------------------------------
Added counts to contribution sub-tabs.
