### PR TITLE
(NFC) CiviUnitTestCase - Fix edge-case for mis-reported error

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -405,7 +405,9 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   protected function tearDown() {
     error_reporting(E_ALL & ~E_NOTICE);
     CRM_Utils_Hook::singleton()->reset();
-    $this->hookClass->reset();
+    if ($this->hookClass) {
+      $this->hookClass->reset();
+    }
     $session = CRM_Core_Session::singleton();
     $session->set('userID', NULL);
 


### PR DESCRIPTION
Suppose you run a test and it encounters an error very early in process --
e.g.  while processing `setUp()`, before constructing the instance of
`$this->hookClass`.  It then proceeds to `tearDown()`. Later, the test
runner will give you a report on the error(s).

This fixes the reporting of the error.

Before
------------

The `tearDown` fails because the missing instance of `$this->hookClass`
raises another error, and test-report shows this misleading reference.

After
------------

The `tearDown` proceeds, and the test-report shows the real cause
of the failure.
