### PR TITLE
(dev/core#174) Cache-keys for CRM_Utils_Cache_* should avoid reserved chars

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -877,7 +877,7 @@ SELECT g.*
       $aclKeys = array_keys($acls);
       $aclKeys = implode(',', $aclKeys);
 
-      $cacheKey = "$tableName-$aclKeys";
+      $cacheKey = CRM_Core_BAO_Cache::cleanKey("$tableName-$aclKeys");
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
       if (!$ids) {

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -387,6 +387,7 @@ WHERE  type.name IS NOT NULL
     $argString = $all ? 'CRM_CT_GSE_1' : 'CRM_CT_GSE_0';
     $argString .= $isSeparator ? '_1' : '_0';
     $argString .= $separator;
+    $argString = CRM_Core_BAO_Cache::cleanKey($argString);
     if (!array_key_exists($argString, $_cache)) {
       $cache = CRM_Utils_Cache::singleton();
       $_cache[$argString] = $cache->get($argString);

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -200,8 +200,8 @@ WHERE  v.option_group_id = g.id
   /**
    * @return string
    */
-  protected static function createCacheKey() {
-    $cacheKey = "CRM_OG_" . serialize(func_get_args());
+  protected static function createCacheKey($id) {
+    $cacheKey = "CRM_OG_" . preg_replace('/[^a-zA-Z0-9]/', '', $id) . '_' . md5(serialize(func_get_args()));
     return $cacheKey;
   }
 

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -536,7 +536,7 @@ class CRM_Core_PseudoConstant {
     $key = 'id',
     $force = NULL
   ) {
-    $cacheKey = "CRM_PC_{$name}_{$all}_{$key}_{$retrieve}_{$filter}_{$condition}_{$orderby}";
+    $cacheKey = CRM_Core_BAO_Cache::cleanKey("CRM_PC_{$name}_{$all}_{$key}_{$retrieve}_{$filter}_{$condition}_{$orderby}");
     $cache = CRM_Utils_Cache::singleton();
     $var = $cache->get($cacheKey);
     if ($var && empty($force)) {

--- a/CRM/Cxn/CiviCxnHttp.php
+++ b/CRM/Cxn/CiviCxnHttp.php
@@ -54,7 +54,7 @@ class CRM_Cxn_CiviCxnHttp extends \Civi\Cxn\Rpc\Http\PhpHttp {
     $lowVerb = strtolower($verb);
 
     if ($lowVerb === 'get' && $this->cache) {
-      $cachePath = 'get/' . md5($url);
+      $cachePath = 'get_' . md5($url);
       $cacheLine = $this->cache->get($cachePath);
       if ($cacheLine && $cacheLine['expires'] > CRM_Utils_Time::getTimeRaw()) {
         return $cacheLine['data'];
@@ -66,7 +66,7 @@ class CRM_Cxn_CiviCxnHttp extends \Civi\Cxn\Rpc\Http\PhpHttp {
     if ($lowVerb === 'get' && $this->cache) {
       $expires = CRM_Utils_Http::parseExpiration($result[0]);
       if ($expires !== NULL) {
-        $cachePath = 'get/' . md5($url);
+        $cachePath = 'get_' . md5($url);
         $cacheLine = array(
           'url' => $url,
           'expires' => $expires,

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -282,7 +282,7 @@ class CRM_Extension_Mapper {
 
     $moduleExtensions = NULL;
     if ($this->cache && !$fresh) {
-      $moduleExtensions = $this->cache->get($this->cacheKey . '/moduleFiles');
+      $moduleExtensions = $this->cache->get($this->cacheKey . '_moduleFiles');
     }
 
     if (!is_array($moduleExtensions)) {
@@ -315,7 +315,7 @@ class CRM_Extension_Mapper {
       }
 
       if ($this->cache) {
-        $this->cache->set($this->cacheKey . '/moduleFiles', $moduleExtensions);
+        $this->cache->set($this->cacheKey . '_moduleFiles', $moduleExtensions);
       }
     }
     return $moduleExtensions;
@@ -461,7 +461,7 @@ class CRM_Extension_Mapper {
     $this->infos = array();
     $this->moduleExtensions = NULL;
     if ($this->cache) {
-      $this->cache->delete($this->cacheKey . '/moduleFiles');
+      $this->cache->delete($this->cacheKey . '_moduleFiles');
     }
     // FIXME: How can code so code wrong be so right?
     CRM_Extension_System::singleton()->getClassLoader()->refresh();

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -246,7 +246,7 @@ class Manager {
    *   Invalid partials configuration.
    */
   public function getPartials($name) {
-    $cacheKey = "angular-partials::$name";
+    $cacheKey = "angular-partials_$name";
     $cacheValue = $this->cache->get($cacheKey);
     if ($cacheValue === NULL) {
       $cacheValue = ChangeSet::applyResourceFilters($this->getChangeSets(), 'partials', $this->getRawPartials($name));

--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -205,7 +205,7 @@ class SettingsManager {
       return self::getSystemDefaults($entity);
     }
 
-    $cacheKey = 'defaults:' . $entity;
+    $cacheKey = 'defaults_' . $entity;
     $defaults = $this->cache->get($cacheKey);
     if (!is_array($defaults)) {
       $specs = SettingsMetadata::getMetadata(array(

--- a/tests/phpunit/CRM/Core/BAO/CacheTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CacheTest.php
@@ -82,4 +82,24 @@ class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
     $this->assertEquals($originalValue, $return_2);
   }
 
+  public function getCleanKeyExamples() {
+    $es = [];
+    $es[] = ['hello_world and other.planets', 'hello_world and other.planets']; // allowed chars
+    $es[] = ['hello/world+-#@{}', 'hello-2fworld-2b-2d-23-40-7b-7d']; // escaped chars
+    $es[] = ['123456789 123456789 123456789 123456789 123456789 123456789 123', '123456789 123456789 123456789 123456789 123456789 123456789 123']; // long but allowed
+    $es[] = ['123456789 123456789 123456789 123456789 123456789 123456789 1234', '-2a008e182a4dcd1a78f405f30119e5f2']; // too long, md5 fallback
+    $es[] = ['123456789 /23456789 +23456789 -23456789 123456789 123456789', '-1b6baab5961431ed443ab321f5dfa0fb']; // too long, md5 fallback
+    return $es;
+  }
+
+  /**
+   * @param $inputKey
+   * @param $expectKey
+   * @dataProvider getCleanKeyExamples
+   */
+  public function testCleanKeys($inputKey, $expectKey) {
+    $actualKey = CRM_Core_BAO_Cache::cleanKey($inputKey);
+    $this->assertEquals($expectKey, $actualKey);
+  }
+
 }

--- a/tests/phpunit/Civi/Core/SettingsManagerTest.php
+++ b/tests/phpunit/Civi/Core/SettingsManagerTest.php
@@ -132,8 +132,8 @@ class SettingsManagerTest extends \CiviUnitTestCase {
    */
   protected function createManager() {
     $cache = new \CRM_Utils_Cache_Arraycache(array());
-    $cache->set('defaults:domain', $this->domainDefaults);
-    $cache->set('defaults:contact', $this->contactDefaults);
+    $cache->set('defaults_domain', $this->domainDefaults);
+    $cache->set('defaults_contact', $this->contactDefaults);
     foreach ($this->mandates as $entity => $keyValues) {
       foreach ($keyValues as $k => $v) {
         $GLOBALS['civicrm_setting'][$entity][$k] = $v;


### PR DESCRIPTION
Overview
----------------------------------------
PSR-16 defines some characters as supported (`A-Za-z0-9_.`), and some as reserved/forbidden (`{}()/\@:`), and the leaves the remainder to the implimenter.

We have a few scenarios in which reserved characters are passed to an instance of `CRM_Utils_Cache_Interface`. Change them.

>  "A string of at least one character that uniquely identifies
a cached item.  Implementing libraries MUST support keys consisting of the
characters `A-Z`, `a-z`, `0-9`, `_`, and `.`  in any order in UTF-8 encoding and a
length of up to 64 characters.  Implementing libraries MAY support
additional characters and encodings or longer lengths, but must support at
least that minimum.  Libraries are responsible for their own escaping of key
strings as appropriate, but MUST be able to return the original unmodified
key string.  The following characters are reserved for future extensions and
MUST NOT be supported by implementing libraries: `{}()/\@:`"

Before
----------------------------------------
* `CRM_Core_BAO_Cache`, `SettingsManager`, `CRM_Core_OptionGroup`, `CRM_Extension_Mapper` pass keys to `CRM_Utils_Cache_*` that involve reserved characters.

After
----------------------------------------
* `CRM_Core_BAO_Cache`, `SettingsManager`, `CRM_Core_OptionGroup`, `CRM_Extension_Mapper` pass keys to `CRM_Utils_Cache_*` that don't use any reserved characters.

Technical Details
----------------------------------------
* To improve reading/debugging, it's ideal to change delimiters.
* The formulas in `CRM_Core_BAO_Cache` and `CRM_Core_OptionGroup` are a bit more radical (using several reserved characters). Passing these through md5 makes valid keys, but they would be hard to read, so the formula is a little more complicated.
