### PR TITLE
dev/core#41: Search Builder: Not empty with date or integer custom fields gives a sql warning

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5662,11 +5662,11 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
         return $clause;
 
       case 'IS EMPTY':
-        $clause = " (NULLIF($field, '') IS NULL) ";
+        $clause = ($dataType == 'Date') ? " $field IS NULL " : " (NULLIF($field, '') IS NULL) ";
         return $clause;
 
       case 'IS NOT EMPTY':
-        $clause = " (NULLIF($field, '') IS NOT NULL) ";
+        $clause = ($dataType == 'Date') ? " $field IS NOT NULL " : " (NULLIF($field, '') IS NOT NULL) ";
         return $clause;
 
       case 'IN':
@@ -5677,7 +5677,7 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
         }
 
       default:
-        if (empty($dataType)) {
+        if (empty($dataType) || $dataType == 'Date') {
           $dataType = 'String';
         }
         if (is_array($value)) {

--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -95,18 +95,10 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
     // This array contain list of available fields and their corresponding data type,
     //  later assigned as json string, to be used to filter list of mysql operators
     $fieldNameTypes = [];
-    $dataType = [
-      CRM_Utils_Type::T_STRING => 'String',
-      CRM_Utils_Type::T_TEXT => 'String',
-      CRM_Utils_Type::T_LONGTEXT => 'String',
-      CRM_Utils_Type::T_BOOLEAN => 'Boolean',
-      CRM_Utils_Type::T_DATE => 'Date',
-      CRM_Utils_Type::T_TIMESTAMP => 'Date',
-    ];
     foreach ($fields as $name => $field) {
       // Assign date type to respective field name, which will be later used to modify operator list
-      if (isset($field['type']) && array_key_exists($field['type'], $dataType)) {
-        $fieldNameTypes[$name] = $dataType[$field['type']];
+      if ($type = CRM_Utils_Array::key(CRM_Utils_Array::value('type', $field), CRM_Utils_Type::getValidTypes())) {
+        $fieldNameTypes[$name] = $type;
       }
       // it's necessary to know which of the fields are searchable by label
       if (isset($field['searchByLabel']) && $field['searchByLabel']) {
@@ -477,8 +469,10 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
             $options[substr($field, 0, -3)] = $entity;
           }
         }
-        elseif (!empty($info['data_type']) && in_array($info['data_type'], array('StateProvince', 'Country'))) {
-          $options[$field] = $entity;
+        elseif (!empty($info['data_type'])) {
+          if (in_array($info['data_type'], array('StateProvince', 'Country'))) {
+            $options[$field] = $entity;
+          }
         }
         elseif (in_array(substr($field, 0, 3), array(
               'is_',

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -84,6 +84,28 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
   }
 
   /**
+   * Build the map of custom field's data types and there respective Util type
+   *
+   * @return array
+   *   Data data-type => CRM_Utils_Type
+   */
+  public static function dataToType() {
+    return [
+      'String' => CRM_Utils_Type::T_STRING,
+      'Int' => CRM_Utils_Type::T_INT,
+      'Float' => CRM_Utils_Type::T_FLOAT,
+      'Money' => CRM_Utils_Type::T_FLOAT,
+      'Memo' => CRM_Utils_Type::T_TEXT,
+      'Date' => CRM_Utils_Type::T_DATE,
+      'Boolean' => CRM_Utils_Type::T_BOOLEAN,
+      'StateProvince' => CRM_Utils_Type::T_INT,
+      'Country' => CRM_Utils_Type::T_INT,
+      'Link' => CRM_Utils_Type::T_STRING,
+      'ContactReference' => CRM_Utils_Type::T_INT,
+    ];
+  }
+
+  /**
    * Get data to html array.
    *
    * (Does this caching achieve anything?)
@@ -691,6 +713,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $regexp = preg_replace('/[.,;:!?]/', '', CRM_Utils_Array::value(0, $values));
       $importableFields[$key] = array(
         'name' => $key,
+        'type' => CRM_Utils_Array::value(CRM_Utils_Array::value('data_type', $values), self::dataToType()),
         'title' => CRM_Utils_Array::value('label', $values),
         'headerPattern' => '/' . preg_quote($regexp, '/') . '/',
         'import' => 1,

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -433,7 +433,7 @@ SELECT f.id, f.label, f.data_type,
             break;
 
           case 'Date':
-            $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'String');
+            $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'Date');
             list($qillOp, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $field['label'], $value, $op, array(), CRM_Utils_Type::T_DATE);
             $this->_qill[$grouping][] = "{$field['label']} $qillOp '$qillVal'";
             break;

--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -19,15 +19,16 @@
     var patt = /_1$/; // pattern to check if the change event came from field name
     if (field !== null && patt.test(this.id)) {
       // based on data type remove invalid operators e.g. IS EMPTY doesn't work with Boolean type column
+      var operators = CRM.searchBuilder.generalOperators;
       if ((field in CRM.searchBuilder.fieldTypes) === true) {
-        if (CRM.searchBuilder.fieldTypes[field] == 'Boolean') {
-          CRM.searchBuilder.generalOperators = _.omit(CRM.searchBuilder.generalOperators, ['IS NOT EMPTY', 'IS EMPTY']);
+        if ($.inArray(CRM.searchBuilder.fieldTypes[field], ['Boolean', 'Int']) > -1) {
+          operators = _.omit(operators, ['IS NOT EMPTY', 'IS EMPTY']);
         }
         else if (CRM.searchBuilder.fieldTypes[field] == 'String') {
-          CRM.searchBuilder.generalOperators = _.omit(CRM.searchBuilder.generalOperators, ['>', '<', '>=', '<=']);
+          operators = _.omit(operators, ['>', '<', '>=', '<=']);
         }
       }
-      buildOperator(operator, CRM.searchBuilder.generalOperators);
+      buildOperator(operator, operators);
     }
 
     // These Ops don't get any input field.


### PR DESCRIPTION
Overview
----------------------------------------
Please check the description https://lab.civicrm.org/dev/core/issues/41 
This PR contains 3 improvements, mentioned below in Before/After section.

Before
----------------------------------------
1. The date custom-field when searched with IS EMPTY/IS NOT EMPTY operators, build where clause as ```(NULLIF(date_field, '') IS NULL)```, this trigger MySQL warning when saved as Search Criteria for smart group(s) as `Incorrect datetime value: ''`
2. ContactReference field is treated as string type instead of integer data type.
3. Search builder operators were omitted when we switch string field to an integer field. Like LTE and GTE operators were omitted on operator list when we choose a string field and choosing integer field doesn't retain these two operators:
![test-multiple-before](https://user-images.githubusercontent.com/3735621/41717228-a1cebcde-7576-11e8-8281-a9569a63f5b8.gif) 

After
----------------------------------------
1. The date custom-field when searched with IS EMPTY/IS NOT EMPTY operators, builds where clause as ```date_field IS NULL``` for 'IS EMPTY' operator.
2. ContactReference field is treated as integer type.
3. Search builder operators are not omitted when we choose a different field of respective types:
![test-multiple-before](https://user-images.githubusercontent.com/3735621/41717038-0a121134-7576-11e8-98c3-404e86d28f7c.gif)


Technical Details
----------------------------------------
@eileenmcnaughton  @samuelsov  @bgm @lcdservices 
  
* ```Date Fix```: In schema, there is not a single date/datetime field which stores empty string/0000-00-00 00:00:00 timestamp value. Rather then the default is set to either NULL or CURRENT_TIMESTAMP.  Reason, why I have treated, IS EMPTY/IS NOT EMPTY operators as IS NULL/IS NOT NULL operators respectively.

* ```ContactReference Fix```: When I debugged the ```CRM_Contact_Form_Search_Builder::fields()``` which return the exportable fields and its meta-data, the custom fields don't have any `type` attribute other then `data-type` and if not present then 'Search Builder' treats these attributes as string type. Reason why in the patch I have introduced a new fn ```CRM_Core_BAO_CustomField:: dataToType()``` which returns a mapping list between custom field data-type and corresponding Util Type and it provides us an advantage - All date type custom fields are recognized by Search builder as Date kind and thus convert the corresponding text field filter as datepicker:
![test-multiple-before](https://user-images.githubusercontent.com/3735621/41717580-cb961c3c-7577-11e8-8217-7617d40755ca.gif)

* Can't add UT because it fixes the `Search Builder` UI

