### PR TITLE
(WIP) Allow running test suites with automatic CIVICRM_UF

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -51,7 +51,7 @@ define('API_LATEST_VERSION', 3);
  *  Common functions for unit tests
  * @package CiviCRM
  */
-class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
+class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase implements \Civi\Test\HeadlessInterface {
 
   use \Civi\Test\Api3DocTrait;
 
@@ -281,6 +281,10 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     $GLOBALS['_PEAR_ERRORSTACK_OVERRIDE_CALLBACK'] = array();
   }
 
+  public function setUpHeadless() {
+    //    Civi\Test::headless()->apply();
+  }
+
   /**
    *  Common setup functions for all unit tests.
    */
@@ -311,12 +315,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     // disable any left-over test extensions
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_extension WHERE full_name LIKE "test.%"');
 
-    // reset all the caches
-    CRM_Utils_System::flushCache();
-
-    // initialize the object once db is loaded
-    \Civi::reset();
-    $config = CRM_Core_Config::singleton(TRUE, TRUE); // ugh, performance
+    $config = CRM_Core_Config::singleton();
 
     // when running unit tests, use mockup user framework
     $this->hookClass = CRM_Utils_Hook::singleton();

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -16,11 +16,7 @@ if (file_exists('/etc/timezone')) {
 # Crank up the memory
 ini_set('memory_limit', '2G');
 define('CIVICRM_TEST', 1);
-eval(cv('php:boot --level=settings', 'phpcode'));
-
-if (CIVICRM_UF === 'UnitTests') {
-  Civi\Test::headless()->apply();
-}
+eval(cv('php:boot --level=classloader', 'phpcode'));
 
 // ------------------------------------------------------------------------------
 

--- a/tests/phpunit/api/v3/EntityTagACLTest.php
+++ b/tests/phpunit/api/v3/EntityTagACLTest.php
@@ -88,11 +88,31 @@ class api_v3_EntityTagACLTest extends CiviUnitTestCase {
   /**
    * Get the options for the used_for fields.
    *
+   * @param string $mode
+   *   Whether to get options using 'static' source (amenable to use in dataProvider)
+   *   or using a 'dynamic' source (based on latest metadata in a running system).
    * @return array
    */
-  public function getTagOptions() {
-    $options = $this->callAPISuccess('Tag', 'getoptions', array('field' => 'used_for'));
-    return $options['values'];
+  public function getTagOptions($mode = 'static') {
+    if ($mode === 'dynamic') {
+      $options = $this->callAPISuccess('Tag', 'getoptions', array('field' => 'used_for')); // FIXME
+      return $options['values'];
+    }
+    else {
+      return [
+        "civicrm_contact" => "Contacts",
+        "civicrm_activity" => "Activities",
+        "civicrm_case" => "Cases",
+        "civicrm_file" => "Attachments",
+      ];
+    }
+  }
+
+  public function testTagOptionList() {
+    $staticList = $this->getTagOptions('static');
+    $dynamicList = $this->getTagOptions('dynamic');
+    $this->assertEquals($dynamicList, $staticList,
+      'The static list of taggable entitiyes used by EntityTagACLTest should be kept up-to-date with the actual list of entities.');
   }
 
   /**

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -244,7 +244,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * Note that the function needs to
    * be static so cannot use $this->callAPISuccess
    */
-  public static function getReportTemplates() {
+  public static function getReportTemplates($mode = 'static') {
     $reportsToSkip = array(
       'activity' => 'does not respect function signature on from clause',
       'event/income' => 'I do no understand why but error is Call to undefined method CRM_Report_Form_Event_Income::from() in CRM/Report/Form.php on line 2120',
@@ -252,7 +252,218 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
       'activitySummary' => 'We use temp tables for the main query generation and name are dynamic. These names are not available in stats() when called directly.',
     );
 
-    $reports = civicrm_api3('report_template', 'get', array('return' => 'value', 'options' => array('limit' => 500)));
+    if ($mode === 'dynamic') {
+      $reports = civicrm_api3('report_template', 'get', array('return' => 'value', 'options' => array('limit' => 500)));
+    }
+    else {
+      $reports = [
+        "is_error" => 0,
+        "version" => 3,
+        "count" => 50,
+        "values" => [
+          232 => [
+            "id" => "232",
+            "value" => "contact/summary",
+          ],
+          233 => [
+            "id" => "233",
+            "value" => "contact/detail",
+          ],
+          234 => [
+            "id" => "234",
+            "value" => "activity",
+          ],
+          235 => [
+            "id" => "235",
+            "value" => "walklist",
+          ],
+          236 => [
+            "id" => "236",
+            "value" => "contact/currentEmployer",
+          ],
+          237 => [
+            "id" => "237",
+            "value" => "contribute/summary",
+          ],
+          238 => [
+            "id" => "238",
+            "value" => "contribute/detail",
+          ],
+          239 => [
+            "id" => "239",
+            "value" => "contribute/repeat",
+          ],
+          240 => [
+            "id" => "240",
+            "value" => "contribute/organizationSummary",
+          ],
+          241 => [
+            "id" => "241",
+            "value" => "contribute/householdSummary",
+          ],
+          242 => [
+            "id" => "242",
+            "value" => "contribute/topDonor",
+          ],
+          243 => [
+            "id" => "243",
+            "value" => "contribute/sybunt",
+          ],
+          244 => [
+            "id" => "244",
+            "value" => "contribute/lybunt",
+          ],
+          245 => [
+            "id" => "245",
+            "value" => "contribute/softcredit",
+          ],
+          246 => [
+            "id" => "246",
+            "value" => "member/summary",
+          ],
+          247 => [
+            "id" => "247",
+            "value" => "member/detail",
+          ],
+          248 => [
+            "id" => "248",
+            "value" => "member/lapse",
+          ],
+          249 => [
+            "id" => "249",
+            "value" => "event/participantListing",
+          ],
+          250 => [
+            "id" => "250",
+            "value" => "event/summary",
+          ],
+          251 => [
+            "id" => "251",
+            "value" => "event/income",
+          ],
+          252 => [
+            "id" => "252",
+            "value" => "pledge/detail",
+          ],
+          253 => [
+            "id" => "253",
+            "value" => "pledge/pbnp",
+          ],
+          254 => [
+            "id" => "254",
+            "value" => "contact/relationship",
+          ],
+          255 => [
+            "id" => "255",
+            "value" => "case/summary",
+          ],
+          256 => [
+            "id" => "256",
+            "value" => "case/timespent",
+          ],
+          257 => [
+            "id" => "257",
+            "value" => "case/demographics",
+          ],
+          258 => [
+            "id" => "258",
+            "value" => "contact/log",
+          ],
+          259 => [
+            "id" => "259",
+            "value" => "activitySummary",
+          ],
+          260 => [
+            "id" => "260",
+            "value" => "contribute/bookkeeping",
+          ],
+          261 => [
+            "id" => "261",
+            "value" => "grant/detail",
+          ],
+          262 => [
+            "id" => "262",
+            "value" => "event/participantlist",
+          ],
+          263 => [
+            "id" => "263",
+            "value" => "event/incomesummary",
+          ],
+          264 => [
+            "id" => "264",
+            "value" => "case/detail",
+          ],
+          265 => [
+            "id" => "265",
+            "value" => "Mailing/bounce",
+          ],
+          266 => [
+            "id" => "266",
+            "value" => "Mailing/summary",
+          ],
+          267 => [
+            "id" => "267",
+            "value" => "Mailing/opened",
+          ],
+          268 => [
+            "id" => "268",
+            "value" => "Mailing/clicks",
+          ],
+          269 => [
+            "id" => "269",
+            "value" => "logging/contact/summary",
+          ],
+          270 => [
+            "id" => "270",
+            "value" => "logging/contact/detail",
+          ],
+          271 => [
+            "id" => "271",
+            "value" => "grant/statistics",
+          ],
+          272 => [
+            "id" => "272",
+            "value" => "survey/detail",
+          ],
+          273 => [
+            "id" => "273",
+            "value" => "contribute/pcp",
+          ],
+          274 => [
+            "id" => "274",
+            "value" => "pledge/summary",
+          ],
+          275 => [
+            "id" => "275",
+            "value" => "contribute/history",
+          ],
+          276 => [
+            "id" => "276",
+            "value" => "mailing/detail",
+          ],
+          277 => [
+            "id" => "277",
+            "value" => "member/contributionDetail",
+          ],
+          278 => [
+            "id" => "278",
+            "value" => "contribute/recur",
+          ],
+          279 => [
+            "id" => "279",
+            "value" => "contribute/recursummary",
+          ],
+          280 => [
+            "id" => "280",
+            "value" => "contribute/deferredrevenue",
+          ],
+          886 => [
+            "id" => "886",
+            "value" => "volunteer",
+          ],
+        ],
+      ];
+    }
     foreach ($reports['values'] as $report) {
       if (empty($reportsToSkip[$report['value']])) {
         $reportTemplates[] = array($report['value']);
@@ -263,6 +474,16 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     }
 
     return $reportTemplates;
+  }
+
+  /**
+   * Ensure that we have an accurate list of entities for testing.
+   */
+  public function testReportList() {
+    $staticList = $this->getReportTemplates('static');
+    $dynamicList = $this->getReportTemplates('dynamic');
+    $this->assertEquals($dynamicList, $staticList,
+      'The static list of entities used by SyntaxConformanceTest should be kept up-to-date with the actual list of entities.');
   }
 
   /**

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -150,13 +150,147 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
    *
    * @return array
    */
-  public static function entities($skip = array()) {
+  public static function entities($skip = array(), $mode = 'static') {
     // The order of operations in here is screwy. In the case where SYNTAX_CONFORMANCE_ENTITIES is
     // defined, we should be able to parse+return it immediately. However, some weird dependency
     // crept into the system where civicrm_api('Entity','get') must be called as part of entities()
     // (even if its return value is ignored).
 
-    $tmp = civicrm_api('Entity', 'Get', array('version' => 3));
+    if ($mode === 'dynamic') {
+      $tmp = civicrm_api('Entity', 'Get', array('version' => 3));
+    }
+    elseif ($mode === 'static') {
+      $tmp = [
+        'values' => [
+          'Acl',
+          'AclRole',
+          'ActionSchedule',
+          'Activity',
+          'ActivityContact',
+          'ActivityType',
+          'Address',
+          'Attachment',
+          'Batch',
+          'Campaign',
+          'Case',
+          'CaseContact',
+          'CaseType',
+          'Constant',
+          'Contact',
+          'ContactType',
+          'Contribution',
+          'ContributionPage',
+          'ContributionProduct',
+          'ContributionRecur',
+          'ContributionSoft',
+          'Country',
+          'CustomField',
+          'CustomGroup',
+          'CustomSearch',
+          'CustomValue',
+          'Cxn',
+          'CxnApp',
+          'Dashboard',
+          'DashboardContact',
+          'Domain',
+          'Email',
+          'Entity',
+          'EntityBatch',
+          'EntityFinancialAccount',
+          'EntityFinancialTrxn',
+          'EntityTag',
+          'Event',
+          'Extension',
+          'File',
+          'FinancialAccount',
+          'FinancialItem',
+          'FinancialTrxn',
+          'FinancialType',
+          'Grant',
+          'Group',
+          'GroupContact',
+          'GroupNesting',
+          'GroupOrganization',
+          'Im',
+          'Job',
+          'JobLog',
+          'LineItem',
+          'LocBlock',
+          'LocationType',
+          'Logging',
+          'MailSettings',
+          'Mailing',
+          'MailingAB',
+          'MailingComponent',
+          'MailingContact',
+          'MailingEventConfirm',
+          'MailingEventQueue',
+          'MailingEventResubscribe',
+          'MailingEventSubscribe',
+          'MailingEventUnsubscribe',
+          'MailingGroup',
+          'MailingJob',
+          'MailingRecipients',
+          'Mapping',
+          'MappingField',
+          'Membership',
+          'MembershipBlock',
+          'MembershipLog',
+          'MembershipPayment',
+          'MembershipStatus',
+          'MembershipType',
+          'MessageTemplate',
+          'Navigation',
+          'Note',
+          'OpenID',
+          'OptionGroup',
+          'OptionValue',
+          'Order',
+          'Participant',
+          'ParticipantPayment',
+          'ParticipantStatusType',
+          'Payment',
+          'PaymentProcessor',
+          'PaymentProcessorType',
+          'PaymentToken',
+          'Pcp',
+          'Phone',
+          'Pledge',
+          'PledgePayment',
+          'Premium',
+          'PriceField',
+          'PriceFieldValue',
+          'PriceSet',
+          'PrintLabel',
+          'Product',
+          'Profile',
+          'RecurringEntity',
+          'Relationship',
+          'RelationshipType',
+          'ReportInstance',
+          'ReportTemplate',
+          'RuleGroup',
+          'SavedSearch',
+          'Setting',
+          'SmsProvider',
+          'StateProvince',
+          'StatusPreference',
+          'Survey',
+          'SurveyRespondant',
+          'System',
+          'SystemLog',
+          'Tag',
+          'UFField',
+          'UFGroup',
+          'UFJoin',
+          'UFMatch',
+          'User',
+          'Website',
+          'WordReplacement',
+        ]
+      ];
+    }
+
     if (getenv('SYNTAX_CONFORMANCE_ENTITIES')) {
       $tmp = array(
         'values' => explode(' ', getenv('SYNTAX_CONFORMANCE_ENTITIES')),
@@ -172,6 +306,16 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       $entities[] = array($e);
     }
     return $entities;
+  }
+
+  /**
+   * Ensure that we have an accurate list of entities for testing.
+   */
+  public function testEntityList() {
+    $staticList = $this->entities([], 'static');
+    $dynamicList = $this->entities([], 'dynamic');
+    $this->assertEquals($dynamicList, $staticList,
+      'The static list of entities used by SyntaxConformanceTest should be kept up-to-date with the actual list of entities.');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In unit testing, the `CIVICRM_UF` environment variable is used to signal that Civi should start in the headless mode. However, this information makes it more cumbersome to manage test-runners in your IDE, and it's generally redundant -- if a test is flagged as headless, then we should be able to boot headless automatically (without explicitly setting the variable). Same for E2E. In fact, automatic booting works for headless and E2E tests in extensions.

The reason core is different is that some `@dataProvider`s are dynamic, and the environment needs to be setup very early on -- when PHPUnit is scanning for tests. Of course, that's nice in some cases (like SyntaxConformanceTest) because you don't have to worry about the test-list getting out-of-date.

The ideal would be to have some workflow wherein (a) the data-providers are able to operate without a full pre-test boot and (b) the data is easy to keep up-to-date.

Before
----------------------------------------

```
env CIVICRM_UF=UnitTests phpunit4 tests/phpunit/CRM/Core/RegionTest.php
```

After
----------------------------------------
```
phpunit4 tests/phpunit/CRM/Core/RegionTest.php
```

Comments
----------------------------------------
This is WIP/experiment:
* Current patches update various dataProviders in the `api_v3` suite and the `bootstrap.php`/`CiviUnitTestCase.php` to use autoboot.
* Want to see if the full API suite actually works with the patches.
* There are a few more tests that would need patching (probably `CRM_Utils_Migrate_ImportExportTest`, `CRM_Utils_StringTest`, `E2E_Extern_RestTest`).
* I'm not certain the best work-around notation for quasi-static/quasi-dynamic data-providers. This is just the first thing that came to mind.

