### PR TITLE
 (dev/core#174) civicrm_cache - Allow storage of binary data 

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CacheTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CacheTest.php
@@ -31,8 +31,31 @@
  */
 class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
 
-  public function testSetGetItem() {
-    $originalValue = array('abc' => 'def');
+  public function exampleValues() {
+    $binary = '';
+    for ($i = 0; $i < 256; $i++) {
+      $binary .= chr($i);
+    }
+
+    $ex = [];
+
+    $ex[] = [array('abc' => 'def')];
+    $ex[] = [0];
+    $ex[] = ['hello world'];
+    $ex[] = ['Scarabée'];
+    $ex[] = ['Iñtërnâtiônàlizætiøn'];
+    $ex[] = ['これは日本語のテキストです。読めますか'];
+    $ex[] = ['देखें हिन्दी कैसी नजर आती है। अरे वाह ये तो नजर आती है।'];
+    $ex[] = [$binary];
+
+    return $ex;
+  }
+
+  /**
+   * @param $originalValue
+   * @dataProvider exampleValues
+   */
+  public function testSetGetItem($originalValue) {
     CRM_Core_BAO_Cache::setItem($originalValue, __CLASS__, 'testSetGetItem');
 
     $return_1 = CRM_Core_BAO_Cache::getItem(__CLASS__, 'testSetGetItem');

--- a/tests/phpunit/CRM/Core/BAO/CacheTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CacheTest.php
@@ -31,6 +31,18 @@
  */
 class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
 
+  public function testMultiVersionDecode() {
+    $encoders = ['serialize', ['CRM_Core_BAO_Cache', 'encode']];
+    $values = [NULL, 0, 1, TRUE, FALSE, [], ['abcd'], 'ab;cd', new stdClass()];
+    foreach ($encoders as $encoder) {
+      foreach ($values as $value) {
+        $encoded = $encoder($value);
+        $decoded = CRM_Core_BAO_Cache::decode($encoded);
+        $this->assertEquals($value, $decoded, "Failure encoding/decoding value " . var_export($value, 1) . ' with ' . var_export($encoder, 1));
+      }
+    }
+  }
+
   public function exampleValues() {
     $binary = '';
     for ($i = 0; $i < 256; $i++) {


### PR DESCRIPTION
Overview
----------------------------------------
In working on a PSR-16 provider based on the `civicrm_cache` table, the compliance test suite revealed that `civicrm_cache.data` was unable to store binary information. The cache is more useful if it can store binary data...

Before
----------------------------------------
* `civicrm_cache.data` is a MySQL `longtext` column storing the output of `serialize($data)`.

After
----------------------------------------
* `civicrm_cache.data` is a MySQL `longtext` column storing the output of `base64_encode(serialize($data))` (or, if you've just upgraded, possibly `serialize($data)`).

Technical Details
----------------------------------------
* The `serialize` format is not designed for transmission over strictly textual media. It's meant to differentiate among PHP data-types(eg `array` vs `string` vs `int`). If a `string` has binary content, then it's still binary content.
* The output of `serialize()` and `base64_encode()` are quite distinctive. Serialize makes heavy use of punctuation (`;:{}`), whereas base64 is dense alphanumeric (`a-zA-Z0-9+/`). We use this to pre-emptively deal with any weird edge-cases mixing new logic with old content (e.g. reading cached data in the old format in a pre-upgrade environment).
* This replaces #12350. In testing some other work on top of #12350, I encountered some character-set issues with using the binary column.