### PR TITLE
dev/core/issues/202, check if default currency is set

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1868,7 +1868,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $setDefaultCurrency = TRUE
   ) {
     $currencies = CRM_Core_OptionGroup::values('currencies_enabled');
-    if (!array_key_exists($defaultCurrency, $currencies)) {
+    if (!empty($defaultCurrency) && !array_key_exists($defaultCurrency, $currencies)) {
       Civi::log()->warning('addCurrency: Currency ' . $defaultCurrency . ' is disabled but still in use!');
       $currencies[$defaultCurrency] = $defaultCurrency;
     }


### PR DESCRIPTION
Overview
----------------------------------------
This is something i noticed on drupal7, CiviCRM 5.2.1 fresh install where i don't have default currency set under(Settings - Localization). The currency field on New Contribution and elsewhere shows an empty option 

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/41781625-f72a27f4-762f-11e8-9c3f-aa223824ea77.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/41781635-fc0dc924-762f-11e8-9926-22c527e98819.png)

Technical Details
----------------------------------------
Added condition to check if default currency is set or not

