### PR TITLE
dev/financial#22 Add a flag to indicate that payment is secondary payment

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1797,6 +1797,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $tempParams['invoiceID'] = $membershipContribution->invoice_id;
     $tempParams['trxn_id'] = $membershipContribution->trxn_id;
     $tempParams['contributionID'] = $membershipContribution->id;
+    $tempParams['is_secondary_financial_transaction'] = 1;
 
     if ($form->_values['is_monetary'] && !$form->_params['is_pay_later'] && $minimumFee > 0.0) {
       // At the moment our tests are calling this form in a way that leaves 'object' empty. For


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/financial/issues/22

There was no way for a payment processor to detect this before and it breaks token based processors because they attempt to re-use the same token.

Before
----------------------------------------
Could not reliably detect secondary payment when "Separate Membership Payment" was set.

After
----------------------------------------
Can reliably detect secondary payment when "Separate Membership Payment" is set.

Technical Details
----------------------------------------
This adds a new flag to a `$params` array. It doesn't change anything so nothing will break, it will only affect processors that are subsequently modified to use the flag.
