### PR TITLE
(dev/core#174) Full PSR-16 compliance for ArrayCache, SqlGroup, Redis, Memcache, APC

### DIFF
--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -39,10 +39,14 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
   use CRM_Utils_Cache_NaiveMultipleTrait;
   use CRM_Utils_Cache_NaiveHasTrait; // TODO Native implementation
 
+  const DEFAULT_TIMEOUT = 3600;
+
   /**
    * The cache storage container, an in memory array by default
    */
   protected $_cache;
+
+  protected $_expires;
 
   /**
    * Constructor.
@@ -54,6 +58,7 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
    */
   public function __construct($config) {
     $this->_cache = array();
+    $this->_expires = array();
   }
 
   /**
@@ -61,12 +66,12 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
    * @param mixed $value
    * @param null|int|\DateInterval $ttl
    * @return bool
+   * @throws \Psr\SimpleCache\InvalidArgumentException
    */
   public function set($key, $value, $ttl = NULL) {
-    if ($ttl !== NULL) {
-      throw new \RuntimeException("FIXME: " . __CLASS__ . "::set() should support non-NULL TTL");
-    }
-    $this->_cache[$key] = $value;
+    CRM_Utils_Cache::assertValidKey($key);
+    $this->_cache[$key] = $this->reobjectify($value);
+    $this->_expires[$key] = CRM_Utils_Date::convertCacheTtlToExpires($ttl, self::DEFAULT_TIMEOUT);
     return TRUE;
   }
 
@@ -75,28 +80,45 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
    * @param mixed $default
    *
    * @return mixed
+   * @throws \Psr\SimpleCache\InvalidArgumentException
    */
   public function get($key, $default = NULL) {
-    return CRM_Utils_Array::value($key, $this->_cache, $default);
+    CRM_Utils_Cache::assertValidKey($key);
+    if (isset($this->_expires[$key]) && is_numeric($this->_expires[$key]) && $this->_expires[$key] <= time()) {
+      return $default;
+    }
+    if (array_key_exists($key, $this->_cache)) {
+      return $this->reobjectify($this->_cache[$key]);
+    }
+    return $default;
   }
 
   /**
    * @param string $key
    * @return bool
+   * @throws \Psr\SimpleCache\InvalidArgumentException
    */
   public function delete($key) {
+    CRM_Utils_Cache::assertValidKey($key);
+
     unset($this->_cache[$key]);
+    unset($this->_expires[$key]);
     return TRUE;
   }
 
   public function flush() {
     unset($this->_cache);
+    unset($this->_expires);
     $this->_cache = array();
     return TRUE;
   }
 
   public function clear() {
     return $this->flush();
+  }
+
+  private function reobjectify($value) {
+    return is_object($value) ? unserialize(serialize($value)) : $value;
   }
 
 }

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -619,14 +619,15 @@ function civicrm_api3_job_cleanup($params) {
   $session   = CRM_Utils_Array::value('session', $params, TRUE);
   $tempTable = CRM_Utils_Array::value('tempTables', $params, TRUE);
   $jobLog    = CRM_Utils_Array::value('jobLog', $params, TRUE);
+  $expired   = CRM_Utils_Array::value('expiredDbCache', $params, TRUE);
   $prevNext  = CRM_Utils_Array::value('prevNext', $params, TRUE);
   $dbCache   = CRM_Utils_Array::value('dbCache', $params, FALSE);
   $memCache  = CRM_Utils_Array::value('memCache', $params, FALSE);
   $tplCache  = CRM_Utils_Array::value('tplCache', $params, FALSE);
   $wordRplc  = CRM_Utils_Array::value('wordRplc', $params, FALSE);
 
-  if ($session || $tempTable || $prevNext) {
-    CRM_Core_BAO_Cache::cleanup($session, $tempTable, $prevNext);
+  if ($session || $tempTable || $prevNext || $expired) {
+    CRM_Core_BAO_Cache::cleanup($session, $tempTable, $prevNext, $expired);
   }
 
   if ($jobLog) {

--- a/tests/phpunit/CRM/Utils/Cache/SqlGroupTest.php
+++ b/tests/phpunit/CRM/Utils/Cache/SqlGroupTest.php
@@ -47,7 +47,9 @@ class CRM_Utils_Cache_SqlGroupTest extends CiviUnitTestCase {
     ));
     $fooValue = array('whiz' => 'bang', 'bar' => 3);
     $a->set('foo', $fooValue);
-    $this->assertEquals($a->get('foo'), array('whiz' => 'bang', 'bar' => 3));
+    $getValue = $a->get('foo');
+    $expectValue = array('whiz' => 'bang', 'bar' => 3);
+    $this->assertEquals($getValue, $expectValue);
 
     $b = new CRM_Utils_Cache_SqlGroup(array(
       'group' => 'testTwoInstance',

--- a/tests/phpunit/E2E/Cache/APCcacheTest.php
+++ b/tests/phpunit/E2E/Cache/APCcacheTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_APCcache complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_APCcacheTest extends E2E_Cache_CacheTestCase {
+
+  public function createSimpleCache() {
+    if (!function_exists('apc_store')) {
+      $this->markTestSkipped('This environment does not have the APC extension.');
+    }
+
+    if (PHP_SAPI === 'cli') {
+      $c = (string) ini_get('apc.enable_cli');
+      if ($c != 1 && strtolower($c) !== 'on') {
+        $this->markTestSkipped('This environment is not configured to use APC cache service. Set apc.enable_cli=on');
+      }
+    }
+
+    $config = [
+      'prefix' => 'foozball/',
+    ];
+    $c = new CRM_Utils_Cache_APCcache($config);
+    return $c;
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/ArrayCacheTest.php
+++ b/tests/phpunit/E2E/Cache/ArrayCacheTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_ArrayCache complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_ArrayCacheTest extends E2E_Cache_CacheTestCase {
+
+  public function createSimpleCache() {
+    return CRM_Utils_Cache::create([
+      'name' => 'e2e arraycache test',
+      'type' => ['ArrayCache'],
+    ]);
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/ConfiguredMemoryTest.php
+++ b/tests/phpunit/E2E/Cache/ConfiguredMemoryTest.php
@@ -34,11 +34,18 @@
  */
 class E2E_Cache_ConfiguredMemoryTest extends E2E_Cache_CacheTestCase {
 
-  public function createSimpleCache() {
+  /**
+   * @return bool
+   */
+  public static function isMemorySupported() {
     $cache = Civi::cache('default');
+    return ($cache instanceof CRM_Utils_Cache_Redis || $cache instanceof CRM_Utils_Cache_Memcache || $cache instanceof CRM_Utils_Cache_Memcached);
+  }
 
-    if ($cache instanceof CRM_Utils_Cache_Redis || $cache instanceof CRM_Utils_Cache_Memcache || $cache instanceof  CRM_Utils_Cache_Memcached) {
-      return $cache;
+  public function createSimpleCache() {
+    $isMemorySupported = self::isMemorySupported();
+    if ($isMemorySupported) {
+      return Civi::cache('default');
     }
     else {
       $this->markTestSkipped('This environment is not configured to use a memory-backed cache service.');

--- a/tests/phpunit/E2E/Cache/ConfiguredMemoryTest.php
+++ b/tests/phpunit/E2E/Cache/ConfiguredMemoryTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_{Redis,Memcache} complies with PSR-16.
+ *
+ * NOTE: Only works if the local system is configured to use one of
+ * those services.
+ *
+ * @group e2e
+ */
+class E2E_Cache_ConfiguredMemoryTest extends E2E_Cache_CacheTestCase {
+
+  public function createSimpleCache() {
+    $cache = Civi::cache('default');
+
+    if ($cache instanceof CRM_Utils_Cache_Redis || $cache instanceof CRM_Utils_Cache_Memcache || $cache instanceof  CRM_Utils_Cache_Memcached) {
+      return $cache;
+    }
+    else {
+      $this->markTestSkipped('This environment is not configured to use a memory-backed cache service.');
+    }
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/SqlGroupTest.php
+++ b/tests/phpunit/E2E/Cache/SqlGroupTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_SqlGroup complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_SqlGroupTest extends E2E_Cache_CacheTestCase {
+
+  public function createSimpleCache() {
+    return CRM_Utils_Cache::create([
+      'name' => 'e2e sqlgroup test',
+      'type' => ['SqlGroup'],
+    ]);
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/TwoInstancesTest.php
+++ b/tests/phpunit/E2E/Cache/TwoInstancesTest.php
@@ -1,0 +1,192 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * If you make two instances of a cache driver, do they coexist as you would expect?
+ *
+ * @group e2e
+ */
+class E2E_Cache_TwoInstancesTest extends CiviEndToEndTestCase {
+
+  /**
+   * @var Psr\SimpleCache\CacheInterface;
+   */
+  protected $a, $b;
+
+  protected function setUp() {
+    parent::setUp();
+    $this->a = $this->b = NULL;
+  }
+
+  protected function tearDown() {
+    parent::tearDown();
+    if ($this->a) {
+      $this->a->clear();
+    }
+    if ($this->b) {
+      $this->b->clear();
+    }
+  }
+
+  /**
+   * Get a list of cache-creation specs.
+   */
+  public function getSingleGenerators() {
+    $exs = [];
+    $exs[] = [
+      ['type' => ['SqlGroup'], 'name' => 'TwoInstancesTest_SameSQL'],
+    ];
+    $exs[] = [
+      ['type' => ['*memory*'], 'name' => 'TwoInstancesTest_SameMem'],
+    ];
+    return $exs;
+  }
+
+  /**
+   * Add item to one cache instance then read with another.
+   *
+   * @param array $cacheDef
+   *   Cache definition. See CRM_Utils_Cache::create().
+   * @dataProvider getSingleGenerators
+   */
+  public function testSingle_reload($cacheDef) {
+    if (!E2E_Cache_ConfiguredMemoryTest::isMemorySupported() && $cacheDef['type'] === ['*memory*']) {
+      $this->markTestSkipped('This environment is not configured to use a memory-backed cache service.');
+    }
+
+    $a = $this->a = CRM_Utils_Cache::create($cacheDef);
+    $a->set('foo', 1234);
+    $this->assertEquals(1234, $a->get('foo'));
+
+    $b = $this->b = CRM_Utils_Cache::create($cacheDef + ['prefetch' => TRUE]);
+    $this->assertEquals(1234, $b->get('foo'));
+
+    $b = $this->b = CRM_Utils_Cache::create($cacheDef + ['prefetch' => FALSE]);
+    $this->assertEquals(1234, $b->get('foo'));
+  }
+
+  /**
+   * Get a list of distinct cache-creation specs.
+   */
+  public function getTwoGenerators() {
+    $exs = [];
+    $exs[] = [
+      ['type' => ['SqlGroup'], 'name' => 'testTwo_a'],
+      ['type' => ['SqlGroup'], 'name' => 'testTwo_b'],
+    ];
+    $exs[] = [
+      ['type' => ['*memory*'], 'name' => 'testTwo_a'],
+      ['type' => ['*memory*'], 'name' => 'testTwo_b'],
+    ];
+    $exs[] = [
+      ['type' => ['*memory*'], 'name' => 'testTwo_drv'],
+      ['type' => ['SqlGroup'], 'name' => 'testTwo_drv'],
+    ];
+    return $exs;
+  }
+
+  /**
+   * Add items to the two caches. Then clear the first.
+   *
+   * @param array $cacheA
+   *   Cache definition. See CRM_Utils_Cache::create().
+   * @param array $cacheB
+   *   Cache definition. See CRM_Utils_Cache::create().
+   * @dataProvider getTwoGenerators
+   */
+  public function testDiff_clearA($cacheA, $cacheB) {
+    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    $a->set('foo', 1234);
+    $b->set('foo', 5678);
+    $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
+    $this->assertEquals(5678, $b->get('foo'), 'Check value B after initial setup');
+
+    $a->clear();
+    $this->assertEquals(NULL, $a->get('foo'), 'Check value A after clearing A');
+    $this->assertEquals(5678, $b->get('foo'), 'Check value B after clearing A');
+  }
+
+  /**
+   * Add items to the two caches. Then clear the second.
+   *
+   * @param array $cacheA
+   *   Cache definition. See CRM_Utils_Cache::create().
+   * @param array $cacheB
+   *   Cache definition. See CRM_Utils_Cache::create().
+   * @dataProvider getTwoGenerators
+   */
+  public function testDiff_clearB($cacheA, $cacheB) {
+    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    $a->set('foo', 1234);
+    $b->set('foo', 5678);
+    $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
+    $this->assertEquals(5678, $b->get('foo'), 'Check value B after initial setup');
+
+    $b->clear();
+    $this->assertEquals(1234, $a->get('foo'), 'Check value A after clearing B');
+    $this->assertEquals(NULL, $b->get('foo'), 'Check value B after clearing B');
+  }
+
+  /**
+   * Add items to the two caches. Then reload both caches and read from each.
+   *
+   * @param array $cacheA
+   *   Cache definition. See CRM_Utils_Cache::create().
+   * @param array $cacheB
+   *   Cache definition. See CRM_Utils_Cache::create().
+   * @dataProvider getTwoGenerators
+   */
+  public function testDiff_reload($cacheA, $cacheB) {
+    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    $a->set('foo', 1234);
+    $b->set('foo', 5678);
+    $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
+    $this->assertEquals(5678, $b->get('foo'), 'Check value B after initial setup');
+
+    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
+    $this->assertEquals(5678, $b->get('foo'), 'Check value B after initial setup');
+  }
+
+  /**
+   * @param $cacheA
+   * @param $cacheB
+   * @return array
+   */
+  protected function createTwoCaches($cacheA, $cacheB) {
+    if (!E2E_Cache_ConfiguredMemoryTest::isMemorySupported() && $cacheA['type'] === ['*memory*']) {
+      $this->markTestSkipped('This environment is not configured to use a memory-backed cache service.');
+    }
+    if (!E2E_Cache_ConfiguredMemoryTest::isMemorySupported() && $cacheB['type'] === ['*memory*']) {
+      $this->markTestSkipped('This environment is not configured to use a memory-backed cache service.');
+    }
+
+    $a = $this->a = CRM_Utils_Cache::create($cacheA);
+    $b = $this->b = CRM_Utils_Cache::create($cacheB);
+    return array($a, $b);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
#12342 provides nominal compliance with PSR-16; however, some drivers raise exceptions or warnings for new options . This PR ensures more complete support for PSR-16 in three drivers (`ArrayCache`, `SqlGroup`, and `Redis`).

(~~__Depends__: The patches here work/are cogent, but I've flagged it "Blocked" because it depends/includes other open PRs: #12342, #12348, #12354~~)

Before
----------------------------------------
* `ArrayCache`, `SqlGroup`, `Redis`, `Memcache`, `Memcached`, and `APCcache` are not tested for compliance -- and would not pass if they were because:
    * `$cache->set(...$ttl)` would throw an error any custom TTL.
    * `$cache->get(...$default)` woudl throw an error for any not-NULL default.
    * Cache-keys are not validated.
    * Some variants of `$cache->set()` / `$cache->get()` handle objects in ways that are unsafe.
    * In some variants, `$cache->flush()` is overzealous (Memcache); in others, underzealous (APCcache).

After
----------------------------------------
* `ArrayCache`, `SqlGroup`, `Redis`, `Memcache`, `Memcached`, and `APCcache` have been fixed to comply (per [SimpleCacheTest](https://github.com/civicrm/civicrm-packages/pull/215/files)), and they comply.

Technical Details
----------------------------------------
* `SqlGroup` is substantially rewritten. It no longer wraps around `CRM_Core_BAO_Cache` - instead, it does SQL queries which are similar in nature and uses its own front-cache.
    * The interface and implementation of `CRM_Core_BAO_Cache` do not support TTL/expiration. Adding support effectively requires patching every function to respect TTL in reading+writing both DB and thread-local front-cache. And in the long-run, it's better to maintain that kind of logic in framework that is standard compliant.
    * I was concerned about a theoretical issue -- if `CRM_Core_BAO_Cache` and `CRM_Utils_Cache_SqlGroup` wrap the same DB table but have different front-caches, and if you tried accessing the same records through both interfaces, then there could be cache-coherence bugs. However, if we consider [the audit of caches](https://lab.civicrm.org/dev/core/issues/174#note_5812), it becomes less of a concern. Why? Because the use-cases are XOR. (Ex: The `dashboard` cache always uses BAO to read/write cache-rows. Ex: The `js_strings` cache always uses OOP to read/write cache-rows.)
    * At some point, we may want to fully flip the relationship around (e.g. `BAO_Cache` could just be a thin wrapper for `SqlGroup` which we provide for backward compatibility). However, that will make even bigger PR that's harder to review en masse.
* The test coverage for `SqlGroup` and `ArrayCache` should work intuitively. For `Redis`, `Memcache`, and `Memcached`, the test needs a particular environment to run -- which isn't universally available. The `ConfiguredMemoryTest` will run against whatever cache service is enabled in `civicrm.settings.php` -- and if no service is configured, it will be skipped. (`APCcache` is similar, although the specific environmental requirements differ.) For the tests which don't run in the CI environment, I've confirmed they pass locally.
