### PR TITLE
dev/financial#23 Don't lookup payment processor for 0 amount as there isn't one defined!

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2405,7 +2405,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $ids
     ));
 
-    if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id) {
+    if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id && (!empty($input['total_amount']))) {
       $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',
         $this->contribution_page_id,
         'payment_processor'

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2469,6 +2469,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           'trxn_id' => CRM_Utils_Array::value('trxn_id', $result),
           'payment_processor_id' => $this->_paymentProcessor['id'],
           'is_transactional' => FALSE,
+          'total_amount' => $this->_amount,
           'fee_amount' => CRM_Utils_Array::value('fee_amount', $result),
           'receive_date' => CRM_Utils_Array::value('receive_date', $result),
           'card_type_id' => CRM_Utils_Array::value('card_type_id', $result),

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -533,6 +533,7 @@ function civicrm_api3_contribution_completetransaction(&$params) {
   if (isset($params['payment_processor_id'])) {
     $input['payment_processor_id'] = $params['payment_processor_id'];
   }
+  $input['total_amount'] = CRM_Utils_Array::value('total_amount', $params);
   $contribution = new CRM_Contribute_BAO_Contribution();
   $contribution->id = $params['id'];
   if (!$contribution->find(TRUE)) {


### PR DESCRIPTION
Overview
----------------------------------------
See: https://lab.civicrm.org/dev/financial/issues/23

When submitting a contribution page with 0 amount the payment processor is not set. However, the submission still tries to lookup a payment processor by ID and hits the following e-notice in CRM/Contribute/BAO/Contribution.php: 
$CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage.


Before
----------------------------------------
e-notice in CRM/Contribute/BAO/Contribution.php: 
$CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage when amount=0.

After
----------------------------------------
No e-notice in CRM/Contribute/BAO/Contribution.php: 
$CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage when amount=0.

Technical Details
----------------------------------------
If we have a 0 amount the payment processor ID is not set but we try and look it up anyway.
