### PR TITLE
(dev/core#174) Forms/Sessions - Store state via Civi::cache('session')

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -233,6 +233,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     }
 
     CRM_Core_Config::clearDBCache();
+    Civi::cache('session')->clear(); // This doesn't make a lot of sense to me, but it maintains pre-existing behavior.
     CRM_Utils_System::flushCache();
     CRM_Core_Resources::singleton()->resetCacheCode();
 

--- a/CRM/Admin/Form/Setting/UpdateConfigBackend.php
+++ b/CRM/Admin/Form/Setting/UpdateConfigBackend.php
@@ -65,6 +65,7 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
 
       // clear all caches
       CRM_Core_Config::clearDBCache();
+      Civi::cache('session')->clear();
       CRM_Utils_System::flushCache();
 
       parent::rebuildMenu();

--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -260,6 +260,7 @@ class CRM_Core_BAO_ConfigSetting {
 
     // clear all caches
     CRM_Core_Config::clearDBCache();
+    Civi::cache('session')->clear();
     $moveStatus .= ts('Database cache tables cleared.') . '<br />';
 
     $resetSessionTable = CRM_Utils_Request::retrieve('resetSessionTable',

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -295,6 +295,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
 
     // clear all caches
     self::clearDBCache();
+    Civi::cache('session')->clear();
     CRM_Utils_System::flushCache();
 
     if ($sessionReset) {

--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -286,7 +286,7 @@ class CRM_Core_Session {
       $values = &$this->_session[$this->_key];
     }
     else {
-      $values = CRM_Core_BAO_Cache::getItem('CiviCRM Session', "CiviCRM_{$prefix}");
+      $values = Civi::cache('session')->get("CiviCRM_{$prefix}");
     }
 
     if ($values) {

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -164,6 +164,7 @@ class Container {
       'js_strings' => 'js_strings',
       'community_messages' => 'community_messages',
       'checks' => 'checks',
+      'session' => 'CiviCRM Session',
     );
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $container->setDefinition("cache.{$cacheSvc}", new Definition(


### PR DESCRIPTION
Overview
----------------------------------------
When using forms based on CiviQuickForm (specifically `CRM_Core_Controller`), `CRM_Core_Session` stores form-state via `CRM_Core_BAO_Cache::storeSessionToCache` and `::restoreSessionFromCache`, which in turn calls `CRM_Core_BAO_Cache::setItem()` and `::getItem()`.

However, using `CRM_Core_BAO_Cache::setItem()` and `::getItem()` means that all session state **must** be written to MySQL. For dev/core#174, we seek the **option** to store via Redis/Memcache.


Before
----------------------------------------
* (a) Form/session state is always stored via `CRM_Core_BAO_Cache::setItem()` and `civicrm_cache` table.
* (b) To ensure that old sessions are periodically purged, there is special purpose logic that accesses `civicrm_cache` (roughly `delete where group_name=Sessions and created_date < now()-ttl`).
* (c) On Memcache/Redis-enabled systems, the cache server functions as an extra tier. The DB provides canonical storage for form/session state.

After
----------------------------------------
* (a) Form/session state is stored via `CRM_Utils_CacheInterface`.
    * On a typical server, this defaults to `CRM_Utils_Cache_SqlGroup` and `civicrm_cache` table.
* (b) To ensure that old sessions are periodically purged, the call to `CRM_Utils_CacheInterface::set()` specifies a TTL.
    * It is the responsibility of the cache driver to handle TTLs. With #12360, TTL's are supported in `ArrayCache`, `SqlGroup`, and `Redis`.
* (c) On Memcache/Redis-enabled systems, the cache server provides canonical storage for form/session state.

Comments
----------------------------------------

This should generally be a drop-in replacement (i.e. the TTLs and performance should be the same or better), but there are a couple considerations which leave me ambivalent:

1. ~~The `CRM_Utils_Cache_Memcache` and `CRM_Utils_Cache_Memcached` drivers don't currently support TTL. (Addressing should be somewhat rote after fixing the other cache drivers.)~~ (Resolved)
2. If an administrator currently uses Memcache/Redis, this is a subtle policy change. (In the Before/After, compare item (c).) The significance of this depends a lot on how much you care about the performance-implications of MySQL writes -- and on how reliable your cache-service is. If your cache-service is frequently restarted, or if it's scaled/partitioned in weird ways, then you might prefer the old policy.

If the second point is an issue, then we'd still write this patch in the same basic way, but we'd need another configuration-management patch so that sysadmins can influence the construction of the `cache.session` service. Basically, these are interesting policies for `cache.session`:

```php
// Store only in Redis/Memcache -- or only in MySQL -- or only in ArrayCache.
$sessionCache = CRM_Utils_Cache::create(array(
  'name' => 'CiviCRM Sessions',
  'type' => array('*memory*', 'SqlGroup', 'ArrayCache'),
));

// Strictly store sessions only in MySQL
$sessionCache = CRM_Utils_Cache::create(array(
  'name' => 'CiviCRM Sessions',
  'type' => array('SqlGroup'),
));

// Store canonically in MySQL, but provide other tiers. Same as old policy.
$sql = CRM_Utils_Cache::create(array(
  'name' => 'CiviCRM Sessions',
  'type' => array('SqlGroup'),
));
$memory  = CRM_Utils_Cache::create(array(
  'name' => 'CiviCRM Sessions',
  'type' => array('*memory*', 'ArrayCache),
));
$sessionCache = new CRM_Utils_Cache_Chained([$memory, $sql]);
```

In an ideal world, it'd be fine to expose those configuration options. Practically speaking, we would need (a) an implementation of `CRM_Utils_Cache_Chained` and (b) a configuration mechanism. The thing I'm not sure about is *how much to care* about the above. Treat them as blockers on the critical path (to yield stricter drop-in compatibbility) -- or as nice-to-haves that someone can figure out in a future release?