### PR TITLE
dev/core#210: Regex filter broken in Search Builder

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2341,7 +2341,7 @@ class CRM_Contact_BAO_Query {
         $this->_where[$grouping][] = CRM_Core_DAO::createSQLFilter($fieldName, $value, $type);
       }
       else {
-        if (!strpos($op, 'IN')) {
+        if (!self::caseImportant($op)) {
           $value = $strtolower($value);
         }
         if ($wildcard) {
@@ -5668,6 +5668,9 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
       case 'IS NOT EMPTY':
         $clause = ($dataType == 'Date') ? " $field IS NOT NULL " : " (NULLIF($field, '') IS NOT NULL) ";
         return $clause;
+
+      case 'RLIKE':
+        return " {$clause} BINARY '{$value}' ";
 
       case 'IN':
       case 'NOT IN':


### PR DESCRIPTION
Overview
----------------------------------------
It would appear that the Regular Expression option in Search builder is broken. This can be reproduced by doing a search builder with the regex expression of [A-Z]{2}$ for the first name. It will pull up any contact that has 2 letters. This is because the regular expression gets transformed into lower case and also REGEXP / RLIKE isn't case sensitive by default unless used with the word BINARY

Search for first name whose first_name starts with 'A':

Before
----------------------------------------
The whereClause build with REGEX operator:
```
 WHERE  (  ( contact_a.first_name RLIKE '^a[a-z]*$' AND contact_a.contact_type = 'individual' )  )  AND (contact_a.is_deleted = 0)   
```

After
----------------------------------------
The whereClause build with REGEX operator:
```
WHERE  (  (  contact_a.first_name RLIKE BINARY '^A[a-z]*$'  AND contact_a.contact_type = 'Individual' )  )  AND (contact_a.is_deleted = 0) 
```

Technical Details
----------------------------------------
This PR reintroduce some of the fixes from https://github.com/civicrm/civicrm-core/pull/11477 and in addition, removes strolower usage in buildclause(). Also added unit test to verify the constructed clause against each kind of operators.

