### PR TITLE
CRM-20703 - Event Contribution Created When No Payment Option Provided

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -372,6 +372,11 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
         $errors['pay_later_receipt'] = ts('Please enter the instructions to be sent to the contributor when they choose to \'pay later\'.');
       }
     }
+    else {
+       if (empty($fields['payment_processor'])) {
+         $errors['payment_processor'] = ts('You have listed fixed contribution options or selected a price set, but no payment option has been selected. Please select at least one payment processor and/or enable the pay later option.');
+        }
+      }
 
     // don't allow price set w/ membership signup, CRM-5095
     if ($priceSetId = CRM_Utils_Array::value('price_set_id', $fields)) {

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -522,6 +522,11 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
           $errors['pay_later_receipt'] = ts('Please enter the Pay Later instructions to be displayed to your users.');
         }
       }
+      else {
+        if (empty($values['payment_processor'])) {
+          $errors['payment_processor'] = ts('You have indicated that this is a paid event, but no payment option has been selected. If this is not a paid event, please select the "No" option at the top of the page. If this is a paid event, please select at least one payment processor and/or enable the pay later option.');
+        }
+      }
     }
     return empty($errors) ? TRUE : $errors;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Steps to relicate:

1. Create a paid event with no pay later and no payment processors.
2. You are allowed to save the event.
3. No form rule is triggered.

Before
----------------------------------------
![event_before](https://user-images.githubusercontent.com/3455173/40781556-f3f36ed4-64f9-11e8-9e4d-d2f2a5f9539d.png)

After
----------------------------------------
![event_after](https://user-images.githubusercontent.com/3455173/40781567-fab7ffa0-64f9-11e8-9afa-72bd3fb21d71.png)

---

 * [CRM-20703: Event Contribution Created When No Payment Option Provided](https://issues.civicrm.org/jira/browse/CRM-20703)