### PR TITLE
(dev/core#174) civicrm_cache - Finish transition from DATETIME to TIMESTAMP

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.4.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.4.alpha1.mysql.tpl
@@ -1,1 +1,13 @@
 {* file to handle db changes in 5.4.alpha1 during upgrade *}
+
+{*
+v4.7.20 updated these colums so that new installs would default to TIMESTAMP instead of DATETIME.
+Status-checks and DoctorWhen have been encouraging a transition, but it wasn't mandated, and there
+was little urgency... because `expired_date` was ignored, and adhoc TTLs on `created_date` had
+generally long windows. Now that we're using `expired_date` in more important ways for 5.4,
+we want to ensure that these values are handled precisely and consistently.
+*}
+
+ALTER TABLE civicrm_cache
+  CHANGE created_date created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT 'When was the cache item created',
+  CHANGE expired_date expired_date  TIMESTAMP NULL DEFAULT NULL COMMENT 'When should the cache item expire';


### PR DESCRIPTION
Overview
----------------------------------------
v4.7.20 (4387c66fa10e7b05921a6f0f6329d58ec8857454) updated the definition of `civicrm_cache` so that `created_date` and `expired_date` would default to TIMESTAMP on new deployments.  For existing deployments, status-checks and DoctorWhen have been encouraging a transition, but it wasn't mandated, and there was little urgency...  because `expired_date` was generally ignored, and adhoc TTLs on `created_date` had generally long windows.

However, in v5.4, we'll be using `expired_date` in more important ways ([dev/core#174](https://lab.civicrm.org/dev/core/issues/174)), and we should ensure that these values are handled precisely and consistently.

Before
------------------------------
* On new deployments (4.7.20+), `created_date` and `expired_date` are TIMESTAMP.
* On upgraded deployments, `created_date` and `expired_date` may be using DATETIME or TIMESTAMP (depending on the particular history and administrative decisions).

After
------------------------------
* On all deployments, `created_date` and `expired_date` are TIMESTAMPs.

Comments
------------------------------
In the interest of full disclosure -- I *expect* there are scenarios in which having `expired_date` as `DATETIME` will lead to bugs in 5.4+, but I haven't empirically proven it.  This patch preemptively reduces the number of edge-cases we have to consider in managing cache TTLs.

Generally, I'm inclined to view the change as safe because (a) all new deployments since 4.7.20 have been using this schema anyway and (b) nothing in `civicrm-core` has been using `expired_date`. 

CC @seamuslee001 (resident expert in timezones). Also, ping @scardinius @systopia. (Grepping `universe`, I found `de.systopia.campaign` does a few direct queries on this table - so maybe you have some thought?)