### PR TITLE
WIP: dev/core#215: fix duplicate pcp listing on dashboard.

### DIFF
--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -184,7 +184,7 @@ FROM civicrm_pcp_block block
 LEFT JOIN civicrm_pcp pcp ON pcp.pcp_block_id = block.id
 WHERE block.is_active = 1
 {$clause}
-GROUP BY block.id, pcp.id
+GROUP BY block.id
 ORDER BY target_entity_type, target_entity_id
 ";
     $pcpBlockDao = CRM_Core_DAO::executeQuery($query);


### PR DESCRIPTION
Overview
----------------------------------------
Remove GROUP BY on a column which is guaranteed to be different for every user-created pcp page (pcp.id)

Before
----------------------------------------
On the contact dashboard, each pcp-enabled contribution page is listed multiple times if it has multiple user-created pcp pages.

After
----------------------------------------
Dashboard duplicates do not appear.

Technical Details
----------------------------------------

Comments
----------------------------------------
I'm unaware of what side effects this may produce. WIP for now until tests pass.