### PR TITLE
dev/drupal#7 : Implement universal civicrm.config.php 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ CRM/Core/DAO/.listAll.php
 CRM/Core/DAO/listAll.php
 bin/setup.conf
 civicrm-version.txt
-civicrm.config.php
+civicrm.config-generated.php
 node_modules
 settings_location.php
 sql/case_sample.mysql

--- a/CRM/Core/CodeGen/Config.php
+++ b/CRM/Core/CodeGen/Config.php
@@ -22,11 +22,11 @@ class CRM_Core_CodeGen_Config extends CRM_Core_CodeGen_BaseTask {
     elseif ($this->config->cms !== 'joomla') {
       $configTemplate = $this->findConfigTemplate($this->config->cms);
       if ($configTemplate) {
-        echo "Generating civicrm.config.php\n";
-        copy($configTemplate, '../civicrm.config.php');
+        echo "Generating civicrm.config-generated.php\n";
+        copy($configTemplate, '../civicrm.config-generated.php');
       }
       else {
-        throw new Exception("Failed to locate template for civicrm.config.php");
+        throw new Exception("Failed to locate template for civicrm.config-generated.php");
       }
     }
   }

--- a/Civi/Cv/CmsBootstrap.php
+++ b/Civi/Cv/CmsBootstrap.php
@@ -1,7 +1,7 @@
 <?php
 namespace Civi\Cv;
 
-use Symfony\Component\Console\Output\OutputInterface;
+require_once 'Encoder.php';
 
 /**
  * Bootstrap the CMS runtime.
@@ -37,7 +37,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *     (Default: TRUE aka PWD)
  *   - user: string|NULL. The name of a CMS user to authenticate as.
  *
- * @package Civi
+ * @package Civi\Cv
  */
 class CmsBootstrap {
 
@@ -56,18 +56,6 @@ class CmsBootstrap {
    * @var array|NULL
    */
   protected $bootedCms = NULL;
-
-  /**
-   * Wrapper around OutputInterface::writeln()
-   *
-   * @param string $text
-   * @param int $level
-   */
-  public function writeln($text, $level = OutputInterface::VERBOSITY_NORMAL) {
-    if ($this->output) {
-      $this->output->writeln("<info>[CmsBootstrap]</info> $text", $level);
-    }
-  }
 
   /**
    * @return CmsBootstrap
@@ -99,11 +87,11 @@ class CmsBootstrap {
    * @throws \Exception
    */
   public function bootCms() {
-    $this->writeln("Options: " . Encoder::encode($this->options, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+    echo "Options: " . Encoder::encode($this->options, 'json-pretty') . " \n\n";
 
     if ($this->options['env'] && getenv($this->options['env'])) {
       $cmsExpr = getenv($this->options['env']);
-      $this->writeln("Parse CMS options ($cmsExpr)", OutputInterface::VERBOSITY_DEBUG);
+      echo "Parse CMS options ($cmsExpr) \n\n";
       $cms = array(
         'type' => parse_url($cmsExpr, PHP_URL_SCHEME),
         'path' => '/' . parse_url($cmsExpr, PHP_URL_HOST) . parse_url($cmsExpr, PHP_URL_PATH),
@@ -114,17 +102,17 @@ class CmsBootstrap {
       }
     }
     else {
-      $this->writeln("Find CMS...", OutputInterface::VERBOSITY_DEBUG);
+      echo "Find CMS... \n\n";
       $cms = $this->findCmsRoot($this->getSearchDir());
     }
 
-    $this->writeln("CMS: " . Encoder::encode($cms, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+    echo "CMS: " . Encoder::encode($cms, 'json-pretty') . " \n\n";
     if (empty($cms['path']) || empty($cms['type']) || !file_exists($cms['path'])) {
       throw new \Exception("Failed to parse or find a CMS");
     }
 
     if (PHP_SAPI === "cli") {
-      $this->writeln("Simulate web environment in CLI", OutputInterface::VERBOSITY_DEBUG);
+      echo "Simulate web environment in CLI \n\n";
       $this->simulateWebEnv($this->options['httpHost'], $cms['path'] . '/index.php');
     }
 
@@ -140,7 +128,7 @@ class CmsBootstrap {
       error_reporting(1);
     }
 
-    $this->writeln("Finished", OutputInterface::VERBOSITY_DEBUG);
+    echo "Finished";
     $this->bootedCms = $cms;
     return $this;
   }
@@ -431,7 +419,7 @@ class CmsBootstrap {
         break;
 
       default:
-        $this->output->writeln("<error>Unrecognized UF: " . CIVICRM_UF . "</error>");
+        throw new \Exception("Unrecognized UF: " . CIVICRM_UF);
     }
 
     return \CRM_Core_Session::getLoggedInContactID();

--- a/Civi/Cv/CmsBootstrap.php
+++ b/Civi/Cv/CmsBootstrap.php
@@ -1,0 +1,440 @@
+<?php
+namespace Civi\Cv;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Bootstrap the CMS runtime.
+ *
+ * @code
+ * // Use default bootstrap
+ * require_once '/path/to/CmsBootstrap.php';
+ * Civi\Cv\CmsBootstrap::singleton()->bootCms()->bootCivi();
+ *
+ * // Use custom bootstrap
+ * require_once '/path/to/CmsBootstrap.php';
+ * Civi\Cv\CmsBootstrap::singleton()
+ *   ->addOptions(array(...))
+ *   ->bootCms()
+ *   ->bootCivi();
+ * @endcode
+ *
+ * This class is intended to be run *before* the classloader is available. Therefore, it
+ * must be self-sufficient.
+ *
+ * By default, bootstrap will scan PWD and every ancestor directory to see if it
+ * contains a supported CMS. If you have performance considerations, or if the
+ * directory structure is not amenable to scanning, then set the environment
+ * variable CIVICRM_BOOT (in bashrc and/or httpd vhost).
+ *
+ * The bootstrapper accepts a few options (either via the constructor or addOptions()). They are:
+ *   - env: string|NULL. The environment variable which may contain boot options
+ *     Ex: 'Drupal://var/www' or 'WordPress://admin@var/www'. Set NULL to disable.
+ *     (Default: CIVICRM_BOOT)
+ *   - search: bool|string. Attempt to determine root+settings by searching
+ *     the file system and checking against common Civi directory structures.
+ *     Boolean TRUE means it should use a default (PWD).
+ *     (Default: TRUE aka PWD)
+ *   - user: string|NULL. The name of a CMS user to authenticate as.
+ *
+ * @package Civi
+ */
+class CmsBootstrap {
+
+  protected static $singleton = NULL;
+
+  protected $options = array();
+
+  /**
+   * Symphony OutputInterface provide during booting to enable the command-line
+   * 'v', 'vv' and 'vvv' options
+   * @see http://symfony.com/doc/current/console/verbosity.html
+   */
+  protected $output = FALSE;
+
+  /**
+   * @var array|NULL
+   */
+  protected $bootedCms = NULL;
+
+  /**
+   * Wrapper around OutputInterface::writeln()
+   *
+   * @param string $text
+   * @param int $level
+   */
+  public function writeln($text, $level = OutputInterface::VERBOSITY_NORMAL) {
+    if ($this->output) {
+      $this->output->writeln("<info>[CmsBootstrap]</info> $text", $level);
+    }
+  }
+
+  /**
+   * @return CmsBootstrap
+   */
+  public static function singleton() {
+    if (self::$singleton === NULL) {
+      self::$singleton = new CmsBootstrap(array(
+        'env' => 'CIVICRM_BOOT',
+        'search' => TRUE,
+        'httpHost' => array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : 'localhost',
+        'user' => NULL,
+      ));
+    }
+    return self::$singleton;
+  }
+
+  /**
+   * @param array $options
+   *   See options in class doc.
+   */
+  public function __construct($options = array()) {
+    $this->addOptions($options);
+  }
+
+  /**
+   * Bootstrap the CiviCRM runtime.
+   *
+   * @return CmsBootstrap
+   * @throws \Exception
+   */
+  public function bootCms() {
+    $this->writeln("Options: " . Encoder::encode($this->options, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+
+    if ($this->options['env'] && getenv($this->options['env'])) {
+      $cmsExpr = getenv($this->options['env']);
+      $this->writeln("Parse CMS options ($cmsExpr)", OutputInterface::VERBOSITY_DEBUG);
+      $cms = array(
+        'type' => parse_url($cmsExpr, PHP_URL_SCHEME),
+        'path' => '/' . parse_url($cmsExpr, PHP_URL_HOST) . parse_url($cmsExpr, PHP_URL_PATH),
+      );
+      $cms['path'] = preg_replace(';^//+;', '/', $cms['path']);
+      if (!isset($this->options['user']) && parse_url($cmsExpr, PHP_URL_USER)) {
+        $this->options['user'] = parse_url($cmsExpr, PHP_URL_USER);
+      }
+    }
+    else {
+      $this->writeln("Find CMS...", OutputInterface::VERBOSITY_DEBUG);
+      $cms = $this->findCmsRoot($this->getSearchDir());
+    }
+
+    $this->writeln("CMS: " . Encoder::encode($cms, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+    if (empty($cms['path']) || empty($cms['type']) || !file_exists($cms['path'])) {
+      throw new \Exception("Failed to parse or find a CMS");
+    }
+
+    if (PHP_SAPI === "cli") {
+      $this->writeln("Simulate web environment in CLI", OutputInterface::VERBOSITY_DEBUG);
+      $this->simulateWebEnv($this->options['httpHost'], $cms['path'] . '/index.php');
+    }
+
+    $func = 'boot' . $cms['type'];
+    if (!is_callable([$this, $func])) {
+      throw new \Exception("Failed to locate boot function ($func)");
+    }
+
+    call_user_func([$this, $func],
+      $cms['path'], $this->options['user'], $this->options['httpHost']);
+
+    if (PHP_SAPI === "cli") {
+      error_reporting(1);
+    }
+
+    $this->writeln("Finished", OutputInterface::VERBOSITY_DEBUG);
+    $this->bootedCms = $cms;
+    return $this;
+  }
+
+  /**
+   * Determine what, if any, CMS has been bootstrapped.
+   *
+   * @return string|NULL
+   *   Ex: 'Backdrop', 'Drupal', 'Drupal8', 'Joomla', 'WordPress'.
+   */
+  public function getBootedCmsType() {
+    return isset($this->bootedCms['type']) ? $this->bootedCms['type'] : NULL;
+  }
+
+  /**
+   * Determine what, if any, CMS has been bootstrapped.
+   *
+   * @return string|NULL
+   *   Ex: '/var/www'.
+   */
+  public function getBootedCmsPath() {
+    return isset($this->bootedCms['path']) ? $this->bootedCms['path'] : NULL;
+  }
+
+  /**
+   * @return $this
+   * @throws \Exception
+   */
+  public function bootCivi() {
+    // PRE-CONDITIONS: CMS has already been booted, and Civi is already installed.
+    if (function_exists('civicrm_initialize')) {
+      civicrm_initialize();
+    }
+    // else if Joomla weirdness, do that
+    else {
+      throw new \Exception("This system does not appear to have CiviCRM");
+    }
+
+    if (!empty($this->options['user'])) {
+      $this->ensureUserContact();
+    }
+
+    return $this;
+  }
+
+  public function bootBackdrop($cmsPath, $cmsUser) {
+    if (!file_exists("$cmsPath/core/includes/bootstrap.inc")) {
+      throw new \Exception('Sorry, could not locate Backdrop\'s bootstrap.inc');
+    }
+    chdir($cmsPath);
+    define('BACKDROP_ROOT', $cmsPath);
+    require_once "$cmsPath/core/includes/bootstrap.inc";
+    require_once "$cmsPath/core/includes/config.inc";
+    \backdrop_bootstrap(BACKDROP_BOOTSTRAP_FULL);
+
+    if (!function_exists('module_exists')) {
+      throw new \Exception('Sorry, could not bootstrap Backdrop.');
+    }
+
+    if ($cmsUser) {
+      global $user;
+      $user = \user_load(array('name' => $cmsUser));
+    }
+
+    return $this;
+  }
+
+  public function bootDrupal($cmsPath, $cmsUser) {
+    if (!file_exists("$cmsPath/includes/bootstrap.inc")) {
+      // Sanity check.
+      throw new \Exception('Sorry, could not locate Drupal\'s bootstrap.inc');
+    }
+    chdir($cmsPath);
+    define('DRUPAL_ROOT', $cmsPath);
+    require_once 'includes/bootstrap.inc';
+    \drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
+
+    if (!function_exists('module_exists')) {
+      throw new \Exception('Sorry, could not bootstrap Drupal.');
+    }
+
+    if ($cmsUser) {
+      global $user;
+      $user = \user_load_by_name($cmsUser);
+    }
+
+    return $this;
+  }
+
+  public function bootDrupal8($cmsRootPath, $cmsUser) {
+    if (!file_exists("$cmsRootPath/core/core.services.yml")) {
+      // Sanity check.
+      throw new \Exception('Sorry, could not locate Drupal8\'s core.services.yml');
+    }
+
+    chdir($cmsRootPath);
+    define('DRUPAL_DIR', $cmsRootPath);
+    $autoloader = require_once DRUPAL_DIR . '/autoload.php';
+    $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+    $kernel = \Drupal\Core\DrupalKernel::createFromRequest($request, $autoloader, 'prod');
+    $kernel->boot();
+    $kernel->prepareLegacyRequest($request);
+
+    if (!function_exists('t')) {
+      throw new \Exception('Sorry, could not bootstrap Drupal8.');
+    }
+
+    if ($cmsUser) {
+      $entity_manager = \Drupal::entityManager();
+      $users = $entity_manager->getStorage($entity_manager->getEntityTypeFromClass('Drupal\user\Entity\User'))
+        ->loadByProperties(array(
+          'name' => $cmsUser,
+        ));
+      if (count($users) == 1) {
+        foreach ($users as $uid => $user) {
+          user_login_finalize($user);
+        }
+      }
+      elseif (empty($users)) {
+        throw new \Exception(sprintf("Failed to find Drupal8 user (%s)", $cmsUser));
+      }
+      else {
+        throw new \Exception(sprintf("Found too many Drupal8 users (%d)", count($users)));
+      }
+    }
+
+    return $this;
+  }
+
+  // TODO public function bootJoomla($cmsRootPath, $cmsUser) { }
+
+  /**
+   * @param string $cmsRootPath
+   * @param string $cmsUser
+   * @return $this
+   */
+  public function bootWordPress($cmsRootPath, $cmsUser) {
+    if (!file_exists($cmsRootPath . DIRECTORY_SEPARATOR . 'wp-load.php')) {
+      throw new \Exception('Sorry, could not locate WordPress\'s wp-load.php.');
+    }
+    chdir($cmsRootPath);
+    require_once $cmsRootPath . DIRECTORY_SEPARATOR . 'wp-load.php';
+
+    if (!function_exists('wp_set_current_user')) {
+      throw new \Exception('Sorry, could not bootstrap WordPress.');
+    }
+
+    if ($cmsUser) {
+      wp_set_current_user(NULL, $cmsUser);
+    }
+
+    return $this;
+  }
+
+  /**
+   * @return array
+   *   See options in class doc.
+   */
+  public function getOptions() {
+    return $this->options;
+  }
+
+  /**
+   * @param array $options
+   *   See options in class doc.
+   * @return CmsBootstrap
+   */
+  public function addOptions($options) {
+    $this->options = array_merge($this->options, $options);
+
+    if (!empty($options['output'])) {
+      $this->output = $options['output'];
+    }
+
+    return $this;
+  }
+
+  /**
+   * @param string $searchDir
+   *   The directory from which to begin the upward search.
+   * @return array|NULL
+   *   Ex: ['path' => '/var/www', 'type' => 'WordPress]
+   */
+  protected function findCmsRoot($searchDir) {
+    // A list of file patterns; if one of the patterns matches a give
+    // directory, then we can assume that this directory is the
+    // CMS root.
+    $cmsPatterns = array(
+      'WordPress' => array(
+        // 'wp-includes/version.php',
+        'wp-load.php',
+      ),
+      'Joomla' => array(
+        'administrator/components/com_users/users.php',
+      ),
+      'Drupal' => array(
+        'modules/system/system.module',
+      ),
+      'Drupal8' => array(
+        'core/core.services.yml',
+      ),
+      'Backdrop' => array(
+        'core/modules/layout/layout.module',
+      ),
+    );
+
+    $parts = explode('/', str_replace('\\', '/', $searchDir));
+    while (!empty($parts)) {
+      $basePath = implode('/', $parts);
+
+      foreach ($cmsPatterns as $cmsType => $relPaths) {
+        if (!empty($this->options['cmsType']) && $this->options['cmsType'] != $cmsType) {
+          continue;
+        }
+        foreach ($relPaths as $relPath) {
+          $matches = glob("$basePath/$relPath");
+          if (!empty($matches)) {
+            return array('path' => $basePath, 'type' => $cmsType);
+          }
+        }
+      }
+
+      array_pop($parts);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @return string
+   */
+  protected function getSearchDir() {
+    if ($this->options['search'] === TRUE) {
+      // exec(pwd) works better with symlinked source trees, but it's
+      // probably not portable to Windows.
+      if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        return getcwd();
+      }
+      else {
+        exec('pwd', $output);
+        return trim(implode("\n", $output));
+      }
+    }
+    else {
+      return $this->options['search'];
+    }
+  }
+
+  /**
+   * @param $scriptFile
+   * @param $host
+   */
+  protected function simulateWebEnv($host, $scriptFile) {
+    $_SERVER['SCRIPT_FILENAME'] = $scriptFile;
+    $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
+    $_SERVER['SERVER_SOFTWARE'] = NULL;
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['SERVER_NAME'] = $host;
+    $_SERVER['HTTP_HOST'] = $host;
+    if (ord($_SERVER['SCRIPT_NAME']) != 47) {
+      $_SERVER['SCRIPT_NAME'] = '/' . $_SERVER['SCRIPT_NAME'];
+    }
+  }
+
+  protected function ensureUserContact() {
+    if ($cid = \CRM_Core_Session::getLoggedInContactID()) {
+      return $cid;
+    }
+
+    // Ugh, this codepath.
+    switch (CIVICRM_UF) {
+      case 'Drupal':
+      case 'Drupal6':
+      case 'Backdrop':
+        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['user'], TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      case 'Drupal8':
+        \CRM_Core_BAO_UFMatch::synchronize(\Drupal::currentUser(), TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      case 'Joomla':
+        \CRM_Core_BAO_UFMatch::synchronize(\JFactory::getUser(), TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      case 'WordPress':
+        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['current_user'], TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      default:
+        $this->output->writeln("<error>Unrecognized UF: " . CIVICRM_UF . "</error>");
+    }
+
+    return \CRM_Core_Session::getLoggedInContactID();
+  }
+
+}

--- a/Civi/Cv/Encoder.php
+++ b/Civi/Cv/Encoder.php
@@ -1,0 +1,97 @@
+<?php
+namespace Civi\Cv;
+
+class Encoder {
+
+  /**
+   * Determine the default output mode.
+   *
+   * @param string $fallback
+   *   In case we can't find a default based on a policy, the caller
+   *   can suggest their own fallback.
+   * @return string
+   *   Ex: 'json', 'shell', 'php', 'pretty', 'none'
+   */
+  public static function getDefaultFormat($fallback = 'json-pretty') {
+    $e = getenv('CV_OUTPUT');
+    return $e ? $e : $fallback;
+  }
+
+  /**
+   * Get a list of formats that work with tabular data.
+   *
+   * @return array
+   */
+  public static function getTabularFormats() {
+    $result = self::getFormats();
+    array_unshift($result, 'list');
+    array_unshift($result, 'csv');
+    array_unshift($result, 'table');
+    return $result;
+  }
+
+  /**
+   * Get a list of formats that work general-purpose data (strings,
+   * tables, array-trees, etc).
+   *
+   * @return array
+   */
+  public static function getFormats() {
+    return array(
+      'none',
+      'pretty',
+      'php',
+      'json-pretty',
+      'json-strict',
+      'serialize',
+      'shell',
+    );
+  }
+
+  public static function encode($data, $format) {
+    switch ($format) {
+      case 'none':
+        return '';
+
+      case 'pretty':
+        return print_r($data, 1);
+
+      case 'php':
+        return var_export($data, 1);
+
+      case 'json-pretty':
+        $jsonOptions = (defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0)
+          |
+          (defined('JSON_UNESCAPED_SLASHES') ? JSON_UNESCAPED_SLASHES : 0);
+        return json_encode($data, $jsonOptions);
+
+      case 'json':
+      case 'json-strict':
+        return json_encode($data);
+
+      case 'serialize':
+        return serialize($data);
+
+      case 'shell':
+        if (is_scalar($data)) {
+          return escapeshellarg($data);
+        }
+        elseif (is_array($data)) {
+          // FIXME: This works fine for assoc-arrays but not numerical arrays.
+          $tree = \Civi\Cv\Util\ArrayUtil::implodeTree('_', $data);
+          $buf = '';
+          foreach ($tree as $k => $v) {
+            $buf .= (sprintf("%s=%s\n", $k, escapeshellarg($v)));
+          }
+          return $buf;
+        }
+        else {
+          return gettype($data);
+        }
+
+      default:
+        throw new \RuntimeException('Unknown output format');
+    }
+  }
+
+}

--- a/civicrm.config.php
+++ b/civicrm.config.php
@@ -1,0 +1,11 @@
+<?php
+
+// Use new boot protocol if (a) site-admin requests it (`CIVICRM_BOOT`)
+// or (b) there's no other option.
+if (getenv('CIVICRM_BOOT') || !file_exists(__DIR__ . DIRECTORY_SEPARATOR . `civicrm.config-generated.php`)) {
+  require_once __DIR__ . DIRECTORY_SEPARATOR . 'Civi/Cv/CmsBootstrap.php';
+  \Civi\Cv\CmsBootstrap::singleton()->bootCms()->bootCivi();
+}
+else {
+  require_once __DIR__ . DIRECTORY_SEPARATOR . `civicrm.config-generated.php`;
+}


### PR DESCRIPTION
Overview
----------------------------------------
The file `civicrm.config.php` is currently produced by GenCode, and it's required by various backend scripts (extern/* and bin/*). A naive approach might be to simply commit this file -- however, that's problematic because there are ~4 variants of this file (for civicrm-drupal, civicrm-wordpress, civicrm-joomla, and civicrm-backdrop). Please check the 'Technical Details' for the approach taken here to resolve this.

Technical Details
----------------------------------------
Following changes are made in this PR:
1. In .gitignore, simply rename civicrm.config.php to civicrm.config-generated.php as this the new file that will be generated via GenCode. Additional changes are made in config gencode. 
2. Existing file civicrm.config.php is now part of the Civi codebase and now call desired config file as per fall back policy i.e. if CIVI_BOOT variable is set in environment OR civicrm.config-generated.php doesn't exist then call the universal `CmsBootstrap.php` that uses [CMS-first boot protocol](https://lab.civicrm.org/dev/cloud-native/issues/7). 
3. Copy [Cv/CmsBootstrap](https://github.com/civicrm/cv/blob/master/src/CmsBootstrap.php) and [Cv/Encoder](https://github.com/civicrm/cv/blob/master/src/CmsBootstrap.php) in Civi

