### PR TITLE
dev/financial#25 support partial payments params for event reg fronte…

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -992,6 +992,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       'pan_truncation' => CRM_Utils_Array::value('pan_truncation', $params),
     );
 
+    // dev-core-25
+    if (!empty($params['partial_amount_to_pay']) && $params['partial_amount_to_pay'] > 0 && $params['amount'] > $params['partial_amount_to_pay']) {
+      $contribParams['partial_payment_total'] = CRM_Utils_Array::value('partial_payment_total', $params, CRM_Utils_Array::value('amount', $params));
+      $contribParams['partial_amount_to_pay'] = $params['partial_amount_to_pay'];
+    }
+
     if ($paymentProcessor) {
       $contribParams['payment_instrument_id'] = $paymentProcessor['payment_instrument_id'];
       $contribParams['payment_processor'] = $paymentProcessor['id'];


### PR DESCRIPTION
…nd forms

Overview
----------------------------------------
Adds support for partial_amount_to_pay and partial_payment_total parameters when creating a contribution, passed from frontend registration forms. See: https://lab.civicrm.org/dev/financial/issues/25

Before
----------------------------------------
These parameters are ignored if passed via hook customizations.

After
----------------------------------------
This PR makes no changes to the UI or standard core experience. It simply supports additional parameters that a developer could pass through hooks in order to modify the payment amount, distinct from the contribution amount (total due).
