### PR TITLE
dev/core#193: Ensure that tax amount is calculated when checking for order API line items

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4987,14 +4987,15 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
   }
 
   /**
-   * Function to check line items.
+   * Checks if line items total amounts
+   * match the contribution total amount.
    *
    * @param array $params
    *  array of order params.
    *
-   * @return TRUE
-   *
-   * @throws \API_Exception
+   * @return bool
+   *   TRUE if total amount match line item amounts
+   *   or FALSE otherwise
    */
   public static function checkLineItems(&$params) {
     $totalAmount = CRM_Utils_Array::value('total_amount', $params);
@@ -5015,7 +5016,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
       $params['total_amount'] = $lineItemAmount;
     }
     elseif ($totalAmount != $lineItemAmount) {
-      throw new API_Exception("Line item total doesn't match with total amount.");
+      return FALSE;
     }
 
     return TRUE;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4992,6 +4992,8 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
    * @param array $params
    *  array of order params.
    *
+   * @return TRUE
+   *
    * @throws \API_Exception
    */
   public static function checkLineItems(&$params) {
@@ -5003,6 +5005,10 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
           $item['financial_type_id'] = $params['financial_type_id'];
         }
         $lineItemAmount += $item['line_total'];
+
+        if (!empty($item['tax_amount'])) {
+          $lineItemAmount += $item['tax_amount'];
+        }
       }
     }
     if (!isset($totalAmount)) {
@@ -5011,6 +5017,8 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     elseif ($totalAmount != $lineItemAmount) {
       throw new API_Exception("Line item total doesn't match with total amount.");
     }
+
+    return TRUE;
   }
 
   /**

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -77,7 +77,11 @@ function civicrm_api3_order_create(&$params) {
   $entityIds = array();
   if (CRM_Utils_Array::value('line_items', $params) && is_array($params['line_items'])) {
     $priceSetID = NULL;
-    CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    $isLineItemMatchTotalAmount = CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    if (!$isLineItemMatchTotalAmount) {
+      throw new API_Exception("Line item total doesn't match with total amount.");
+    }
+
     foreach ($params['line_items'] as $lineItems) {
       $entityParams = CRM_Utils_Array::value('params', $lineItems, array());
       if (!empty($entityParams) && !empty($lineItems['line_item'])) {

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -806,6 +806,61 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
   }
 
   /**
+   */
+  public function testcheckLineItemsWithCorrectTaxAmountAndCorrectTotalAmountDoesNotThrowAnError() {
+    $params = array(
+      'contact_id' => 1,
+      'receive_date' => '2010-01-20',
+      'total_amount' => 23,
+      'financial_type_id' => 1,
+      'line_items' => array(
+        array(
+          'line_item' => array(
+            array(
+              'entity_table' => 'civicrm_contribution',
+              'label' => 'Test 1',
+              'qty' => 1,
+              'unit_price' => 20,
+              'line_total' => 20,
+              'tax_amount' => 3,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    $this->assertTrue(CRM_Contribute_BAO_Contribution::checkLineItems($params));
+  }
+
+  /**
+   * @expectedException API_Exception
+   */
+  public function testcheckLineItemsWithTaxAmountAndInCorrectTotalAmountDoesThrowAnError() {
+    $params = array(
+      'contact_id' => 1,
+      'receive_date' => '2010-01-20',
+      'total_amount' => 27,
+      'financial_type_id' => 1,
+      'line_items' => array(
+        array(
+          'line_item' => array(
+            array(
+              'entity_table' => 'civicrm_contribution',
+              'label' => 'Test 1',
+              'qty' => 1,
+              'unit_price' => 20,
+              'line_total' => 20,
+              'tax_amount' => 3,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    $this->assertTrue(CRM_Contribute_BAO_Contribution::checkLineItems($params));
+  }
+
+  /**
    * Test activity amount updation.
    */
   public function testActivityCreate() {

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -757,10 +757,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     return array($lineItems, $contributionObject);
   }
 
-  /**
-   * checkLineItems() check if total amount matches the sum of line total
-   */
-  public function testcheckLineItems() {
+  public function testCheckLineItems() {
     $params = array(
       'contact_id' => 202,
       'receive_date' => '2010-01-20',
@@ -793,21 +790,87 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
         ),
       ),
     );
-    try {
-      CRM_Contribute_BAO_Contribution::checkLineItems($params);
-      $this->fail("Missed expected exception");
-    }
-    catch (Exception $e) {
-      $this->assertEquals("Line item total doesn't match with total amount.", $e->getMessage());
-    }
-    $this->assertEquals(3, $params['line_items'][0]['line_item'][0]['financial_type_id']);
-    $params['total_amount'] = 300;
-    CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    $isLineItemMatchTotalAmount = CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    $this->assertFalse($isLineItemMatchTotalAmount);
   }
 
-  /**
-   */
-  public function testcheckLineItemsWithCorrectTaxAmountAndCorrectTotalAmountDoesNotThrowAnError() {
+  public function testCheckLineItemsReturnFalseIfTotalAmountDoesNotMatchLineItemsAmountsIfNoTaxSupplied() {
+    $params = array(
+      'contact_id' => 202,
+      'receive_date' => '2010-01-20',
+      'total_amount' => 100,
+      'financial_type_id' => 3,
+      'line_items' => array(
+        array(
+          'line_item' => array(
+            array(
+              'entity_table' => 'civicrm_contribution',
+              'price_field_id' => 8,
+              'price_field_value_id' => 16,
+              'label' => 'test 1',
+              'qty' => 1,
+              'unit_price' => 100,
+              'line_total' => 100,
+            ),
+            array(
+              'entity_table' => 'civicrm_contribution',
+              'price_field_id' => 8,
+              'price_field_value_id' => 17,
+              'label' => 'Test 2',
+              'qty' => 1,
+              'unit_price' => 200,
+              'line_total' => 200,
+              'financial_type_id' => 1,
+            ),
+          ),
+          'params' => array(),
+        ),
+      ),
+    );
+
+    $isLineItemMatchTotalAmount = CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    $this->assertFalse($isLineItemMatchTotalAmount);
+  }
+
+  public function testCheckLineItemsReturnTrueIfTotalAmountDoesMatchLineItemsAmountsIfNoTaxSupplied() {
+    $params = array(
+      'contact_id' => 202,
+      'receive_date' => '2010-01-20',
+      'total_amount' => 300,
+      'financial_type_id' => 3,
+      'line_items' => array(
+        array(
+          'line_item' => array(
+            array(
+              'entity_table' => 'civicrm_contribution',
+              'price_field_id' => 8,
+              'price_field_value_id' => 16,
+              'label' => 'test 1',
+              'qty' => 1,
+              'unit_price' => 100,
+              'line_total' => 100,
+            ),
+            array(
+              'entity_table' => 'civicrm_contribution',
+              'price_field_id' => 8,
+              'price_field_value_id' => 17,
+              'label' => 'Test 2',
+              'qty' => 1,
+              'unit_price' => 200,
+              'line_total' => 200,
+              'financial_type_id' => 1,
+            ),
+          ),
+          'params' => array(),
+        ),
+      ),
+    );
+
+    $isLineItemMatchTotalAmount = CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    $this->assertTrue($isLineItemMatchTotalAmount);
+  }
+
+  public function testCheckLineItemsReturnTrueIfTotalAmountDoesMatchLineItemsAmountsIfTaxSupplied() {
     $params = array(
       'contact_id' => 1,
       'receive_date' => '2010-01-20',
@@ -829,13 +892,11 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       ),
     );
 
-    $this->assertTrue(CRM_Contribute_BAO_Contribution::checkLineItems($params));
+    $isLineItemMatchTotalAmount = CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    $this->assertTrue($isLineItemMatchTotalAmount);
   }
 
-  /**
-   * @expectedException API_Exception
-   */
-  public function testcheckLineItemsWithTaxAmountAndInCorrectTotalAmountDoesThrowAnError() {
+  public function testCheckLineItemsReturnFalseIfTotalAmountDoesNotMatchLineItemsAmountsIfTaxSupplied() {
     $params = array(
       'contact_id' => 1,
       'receive_date' => '2010-01-20',
@@ -857,7 +918,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       ),
     );
 
-    $this->assertTrue(CRM_Contribute_BAO_Contribution::checkLineItems($params));
+    $isLineItemMatchTotalAmount = CRM_Contribute_BAO_Contribution::checkLineItems($params);
+    $this->assertFalse($isLineItemMatchTotalAmount);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When creating an Order using Order API a check is done to compare Contribution's total_amount against the sum of line item's line_total's. If Contribution total amount and Line Items' total are not equal, Order creation will fail.

Before
----------------------------------------
As we know:

The line item line_total do not include any tax. Tax will be recorded separately in line item tax_amount field.
The contribution total_amount do include tax. A separate contribution tax_amount field also records the amount of tax.


Since the validation only compares the sum of line_totals with contribution total_amount, whenever there is tax, the validation will fail.

For illustration consider following data set that should create 1 contribution with 2 line items for memberships.

```
order_data =
{
    'is_pay_later': True,
    'contact_id': 240L,
    'payment_instrument_id': 6,
    'line_items': [{
                       'line_item': {
                           '42': {
                               'price_field_value_id': 60L,
                               'price_field_id': 36L,
                               'entity_id': 1249L,
                               'tax_amount': 2.0,
                               'line_total': 10.0,
                               'financial_type_id': 2,
                               'label': 'General',
                               'entity_table': 'civicrm_membership',
                               'unit_price': 10,
                               'qty': '1'}}}, {
                       'line_item': {
                           '43': {
                               'price_field_value_id': 61L,
                               'price_field_id': 37L,
                               'entity_id': 1248L,
                               'tax_amount': 1.67,
                               'line_total': 8.33,
                               'financial_type_id': 2,
                               'label': 'Concession',
                               'entity_table': 'civicrm_membership',
                               'unit_price': '8.33',
                               'qty': '1'}}}],
    'tax_amount': 3.67,
    'total_amount': 22.0,
    'contribution_recur_id': 605L,
    'financial_type_id': 2,
    'fee_amount': 0,
    'payment_processor_id': 5L,
    'receive_date': u'2019-08-01',
    'contribution_status_id': 2}
```

Currently Calling the Order API to create Order with the above data results with  "Line item total doesn't match with total amount". This is because total_amount (22.0) <> sum of line_totals (18.33)

After
----------------------------------------
The Line Items check now consider tax_amounts of line_items and order API works fine with the parameters above.


