### PR TITLE
dev/accessibility#3: Add accessible label on Contact Edit form elements and helpicon

### DIFF
--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -58,7 +58,7 @@ class CRM_Contact_Form_Edit_Email {
     $form->applyFilter('__ALL__', 'trim');
 
     //Email box
-    $form->addField("email[$blockId][email]", array('entity' => 'email'));
+    $form->addField("email[$blockId][email]", array('entity' => 'email', 'aria-label' => ts('Email %1', [1 => $blockId])));
     $form->addRule("email[$blockId][email]", ts('Email is not valid.'), 'email');
     if (isset($form->_contactType) || $blockEdit) {
       //Block type
@@ -77,17 +77,16 @@ class CRM_Contact_Form_Edit_Email {
         $form->addElement('select', "email[$blockId][on_hold]", '', $holdOptions);
       }
       else {
-        $form->addField("email[$blockId][on_hold]", array('entity' => 'email', 'type' => 'advcheckbox'));
+        $form->addField("email[$blockId][on_hold]", array('entity' => 'email', 'type' => 'advcheckbox', 'aria-label' => ts('On Hold for Email %1?', [1 => $blockId])));
       }
 
       //Bulkmail checkbox
       $form->assign('multipleBulk', $multipleBulk);
+      $js = array('id' => "Email_" . $blockId . "_IsBulkmail" , 'aria-label' => ts('Bulk Mailing for Email %1?', [1 => $blockId]));
       if ($multipleBulk) {
-        $js = array('id' => "Email_" . $blockId . "_IsBulkmail");
         $form->addElement('advcheckbox', "email[$blockId][is_bulkmail]", NULL, '', $js);
       }
       else {
-        $js = array('id' => "Email_" . $blockId . "_IsBulkmail");
         if (!$blockEdit) {
           $js['onClick'] = 'singleSelect( this.id );';
         }
@@ -95,7 +94,7 @@ class CRM_Contact_Form_Edit_Email {
       }
 
       //is_Primary radio
-      $js = array('id' => "Email_" . $blockId . "_IsPrimary");
+      $js = array('id' => "Email_" . $blockId . "_IsPrimary", 'aria-label' => ts('Email %1 is primary?', [1 => $blockId]));
       if (!$blockEdit) {
         $js['onClick'] = 'singleSelect( this.id );';
       }

--- a/CRM/Contact/Form/Edit/IM.php
+++ b/CRM/Contact/Form/Edit/IM.php
@@ -61,9 +61,9 @@ class CRM_Contact_Form_Edit_IM {
     $form->addField("im[$blockId][location_type_id]", array('entity' => 'im', 'class' => 'eight', 'placeholder' => NULL, 'option_url' => NULL));
 
     //IM box
-    $form->addField("im[$blockId][name]", array('entity' => 'im'));
+    $form->addField("im[$blockId][name]", array('entity' => 'im', 'aria-label' => ts('Instant Messenger %1', [1 => $blockId])));
     //is_Primary radio
-    $js = array('id' => 'IM_' . $blockId . '_IsPrimary');
+    $js = array('id' => 'IM_' . $blockId . '_IsPrimary', 'aria-label' => ts('Instant Messenger %1 is primary?', [1 => $blockId]));
     if (!$blockEdit) {
       $js['onClick'] = 'singleSelect( this.id );';
     }

--- a/CRM/Contact/Form/Edit/Phone.php
+++ b/CRM/Contact/Form/Edit/Phone.php
@@ -64,8 +64,8 @@ class CRM_Contact_Form_Edit_Phone {
       'placeholder' => NULL,
     ));
     //main phone number with crm_phone class
-    $form->addField("phone[$blockId][phone]", array('entity' => 'phone', 'class' => 'crm_phone twelve'));
-    $form->addField("phone[$blockId][phone_ext]", array('entity' => 'phone'));
+    $form->addField("phone[$blockId][phone]", array('entity' => 'phone', 'class' => 'crm_phone twelve', 'aria-label' => ts('Phone %1', [1 => $blockId])));
+    $form->addField("phone[$blockId][phone_ext]", array('entity' => 'phone', 'aria-label' => ts('Phone Extension %1', [1 => $blockId])));
     if (isset($form->_contactType) || $blockEdit) {
       //Block type select
       $form->addField("phone[$blockId][location_type_id]", array(
@@ -76,7 +76,7 @@ class CRM_Contact_Form_Edit_Phone {
         ));
 
       //is_Primary radio
-      $js = array('id' => 'Phone_' . $blockId . '_IsPrimary', 'onClick' => 'singleSelect( this.id );');
+      $js = array('id' => 'Phone_' . $blockId . '_IsPrimary', 'onClick' => 'singleSelect( this.id );', 'aria-label' => ts('Phone %1 is primary?', [1 => $blockId]));
       $form->addElement('radio', "phone[$blockId][is_primary]", '', '', '1', $js);
     }
     // TODO: set this up as a group, we need a valid phone_type_id if we have a  phone number

--- a/CRM/Contact/Form/Edit/Website.php
+++ b/CRM/Contact/Form/Edit/Website.php
@@ -58,7 +58,7 @@ class CRM_Contact_Form_Edit_Website {
     $form->addField("website[$blockId][website_type_id]", array('entity' => 'website', 'class' => 'eight'));
 
     //Website box
-    $form->addField("website[$blockId][url]", array('entity' => 'website'));
+    $form->addField("website[$blockId][url]", array('entity' => 'website', 'aria-label' => ts('Website URL %1', [1 => $blockId])));
     $form->addRule("website[$blockId][url]", ts('Enter a valid web address beginning with \'http://\' or \'https://\'.'), 'url');
 
   }

--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -92,5 +92,5 @@ function smarty_function_help($params, &$smarty) {
   foreach ($params as &$param) {
     $param = is_bool($param) || is_numeric($param) ? (int) $param : (string) $param;
   }
-  return '<a class="' . $class . '" title="' . $title . '" href="#" onclick=\'CRM.help(' . $name . ', ' . json_encode($params) . '); return false;\'>&nbsp;</a>';
+  return '<a class="' . $class . '" title="' . $title . '" aria-label="' . $title . '" href="#" onclick=\'CRM.help(' . $name . ', ' . json_encode($params) . '); return false;\'>&nbsp;</a>';
 }

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -32,7 +32,7 @@
    * Add a help link to a form label
    */
   function addHelp(title, options) {
-    return title + ' <a href="#" onclick=\'CRM.help("' + title + '", ' + JSON.stringify(options) + '); return false;\' title="' + ts('%1 Help', {1: title}) + '" class="helpicon"></a>';
+    return title + ' <a href="#" onclick=\'CRM.help("' + title + '", ' + JSON.stringify(options) + '); return false;\' title="' + ts('%1 Help', {1: title}) + '" aria-label="' + ts('%1 Help', {1: title}) + '" class="helpicon"></a>';
   }
 
   function watchChanges() {


### PR DESCRIPTION
Overview
----------------------------------------
The PR adds aria-label attribute to all those form elements which don't have accessible labels and also adds this attribute on helpicon links

Before
----------------------------------------
Form elements like Website, Email, IM, Phone etc. don't have accessible labels and thus when tested with WAVE tool, let's say Website field:
![screen shot 2018-06-28 at 11 55 17 pm](https://user-images.githubusercontent.com/3735621/42053278-c4776ea8-7b2e-11e8-827f-57b681b2b8bc.png)

After
----------------------------------------
Adds aria-label on form elements like Website, Email, IM, Phone etc.
![screen shot 2018-06-28 at 11 53 26 pm](https://user-images.githubusercontent.com/3735621/42053217-9ec7912e-7b2e-11e8-814a-398059b571a3.png)
