### PR TITLE
(dev/core#174) Full PSR-16 compliance for SqlGroup

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -619,14 +619,15 @@ function civicrm_api3_job_cleanup($params) {
   $session   = CRM_Utils_Array::value('session', $params, TRUE);
   $tempTable = CRM_Utils_Array::value('tempTables', $params, TRUE);
   $jobLog    = CRM_Utils_Array::value('jobLog', $params, TRUE);
+  $expired   = CRM_Utils_Array::value('expiredDbCache', $params, TRUE);
   $prevNext  = CRM_Utils_Array::value('prevNext', $params, TRUE);
   $dbCache   = CRM_Utils_Array::value('dbCache', $params, FALSE);
   $memCache  = CRM_Utils_Array::value('memCache', $params, FALSE);
   $tplCache  = CRM_Utils_Array::value('tplCache', $params, FALSE);
   $wordRplc  = CRM_Utils_Array::value('wordRplc', $params, FALSE);
 
-  if ($session || $tempTable || $prevNext) {
-    CRM_Core_BAO_Cache::cleanup($session, $tempTable, $prevNext);
+  if ($session || $tempTable || $prevNext || $expired) {
+    CRM_Core_BAO_Cache::cleanup($session, $tempTable, $prevNext, $expired);
   }
 
   if ($jobLog) {

--- a/tests/phpunit/CRM/Utils/Cache/SqlGroupTest.php
+++ b/tests/phpunit/CRM/Utils/Cache/SqlGroupTest.php
@@ -47,7 +47,9 @@ class CRM_Utils_Cache_SqlGroupTest extends CiviUnitTestCase {
     ));
     $fooValue = array('whiz' => 'bang', 'bar' => 3);
     $a->set('foo', $fooValue);
-    $this->assertEquals($a->get('foo'), array('whiz' => 'bang', 'bar' => 3));
+    $getValue = $a->get('foo');
+    $expectValue = array('whiz' => 'bang', 'bar' => 3);
+    $this->assertEquals($getValue, $expectValue);
 
     $b = new CRM_Utils_Cache_SqlGroup(array(
       'group' => 'testTwoInstance',

--- a/tests/phpunit/E2E/Cache/SqlGroupTest.php
+++ b/tests/phpunit/E2E/Cache/SqlGroupTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_SqlGroup complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_SqlGroupTest extends E2E_Cache_CacheTestCase {
+
+  public function createSimpleCache() {
+    return CRM_Utils_Cache::create([
+      'name' => 'e2e sqlgroup test',
+      'type' => ['SqlGroup'],
+    ]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
#12342 provides nominal compliance with PSR-16; however, some drivers raise exceptions or warnings for new options.

(This is a cherry-pick from #12360.) 

Before
----------------------------------------
* `$cache->set(...$ttl)` would throw an error with any custom TTL.
* `$cache->get(...$default)` would throw an error for any not-NULL default.
* Cache-keys are not validated.
* Some variants of `$cache->set()` / `$cache->get()` handle objects in ways that are unsafe.

After
----------------------------------------
* `SqlGroup` has been fixed to comply (per [SimpleCacheTest](https://github.com/civicrm/civicrm-packages/pull/215/files)), and a unit-test ensures compliance.
