### PR TITLE
(dev/core#174) APCcache - Updates to comply with PSR-16

### DIFF
--- a/tests/phpunit/E2E/Cache/APCcacheTest.php
+++ b/tests/phpunit/E2E/Cache/APCcacheTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_APCcache complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_APCcacheTest extends E2E_Cache_CacheTestCase {
+
+  public function createSimpleCache() {
+    if (!function_exists('apc_store')) {
+      $this->markTestSkipped('This environment does not have the APC extension.');
+    }
+
+    if (PHP_SAPI === 'cli') {
+      $c = (string) ini_get('apc.enable_cli');
+      if ($c != 1 && strtolower($c) !== 'on') {
+        $this->markTestSkipped('This environment is not configured to use APC cache service. Set apc.enable_cli=on');
+      }
+    }
+
+    $config = [
+      'prefix' => 'foozball/',
+    ];
+    $c = new CRM_Utils_Cache_APCcache($config);
+    return $c;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
#12342 provides nominal compliance with PSR-16; however, some drivers raise exceptions or warnings for new options.

(This is a cherry-pick from #12360.) 

Before
----------------------------------------
* `$cache->set(...$ttl)` would throw an error with any custom TTL.
* `$cache->get(...$default)` would throw an error for any not-NULL default.
* Cache-keys are not validated.
* Some variants of `$cache->set()` / `$cache->get()` handle objects in ways that are unsafe.

After
----------------------------------------
* `APCcache` has been fixed to comply (per [SimpleCacheTest](https://github.com/civicrm/civicrm-packages/pull/215/files)), and a unit-test ensures compliance.

Technical Details
----------------------------------------
One notable quirk is that APC retains expired records until the following page-request. To comply with the TTL semantics of the test suite, we have to double-store/double-check the expiration time.
