### PR TITLE
Fix mis-reporting of false booleans in reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2433,7 +2433,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * @return mixed
    */
   protected function alterBoolean($value) {
-    $options = array(0 => ts('No'), 1 => ts('Yes'));
+    $options = array(0 => '', 1 => ts('Yes'));
     if (isset($options[$value])) {
       return $options[$value];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/report/issues/4 FALSE booleans are being misrepresented as 'Yes' in Contact reports. 

Before
----------------------------------------
Displaying 'Do not mail' displays 'Yes' even when it is 0 in contact summary report (other reports and fields affected)

After
----------------------------------------
Do not mail shows empty or 'Yes'

Technical Details
----------------------------------------
The issue is the fields are being processed to 'yes' or 'no' per https://github.com/civicrm/civicrm-core/commit/59b19369b75bf68a310ae16130da602a7896cb42#diff-d355cdb00cea3915a3cf306c6c08f6a6R2296 but they are later being processed again to 'yes' or '' based on whether they are empty or not - so the first rounds of processing is causing them to be 'not empty' the second time. 

Note the 2 pieces of code have different approaches - the earlier one only shows positive fields - per code comment

```
        // Since these are essentially 'negative fields' it feels like it
        // makes sense to only highlight the exceptions hence no 'No'.
```

Comments
----------------------------------------
@jaapjansma I'm going to merge this to the rc now to make sure it hits it - if you feel that we should be displaying 'No' instead of blank we can discuss a follow up.

