### PR TITLE
dev/core#218 : On Case Type listing page, for reserved ones the, 'More' link don't show any options

### DIFF
--- a/ang/crmCaseType/list.html
+++ b/ang/crmCaseType/list.html
@@ -35,7 +35,7 @@ Required vars: caseTypes
         <span>
           <a class="action-item crm-hover-button" ng-href="#/caseType/{{caseType.id}}">{{ts('Edit')}}</a>
 
-          <span class="btn-slide crm-hover-button">
+          <span class="btn-slide crm-hover-button" ng-show="!caseType.is_reserved || (!caseType.is_active || caseType.is_forked)">
             {{ts('more')}}
             <ul class="panel" style="display: none;">
               <li ng-hide="caseType.is_active">


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Enable CiviCase component.
2. Go to Administer >> CiviCase >> Case Types
3. Click on 'More' action against any reserved Case type

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/42137481-ad7af090-7d8a-11e8-9352-d336b36fa0de.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/42137497-d2bff3dc-7d8a-11e8-9b3f-38cf93bda7ba.gif)
As per expected behavior, show the 'More' action only when : 
1. the case type is not reserved because then you have 'Delete' and Enable/Disable action OR
2. If case-type is reserved then show the more action only if the case-type is forked and/or disable, because then you got 'Revert' and/or 'Enable' option to show

