### PR TITLE
dev/core#219 Improve consistency displaying "Test Transactions"

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -158,7 +158,9 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     if ($this->_contactId) {
       $displayName = CRM_Contact_BAO_Contact::displayName($this->_contactId);
       $this->assign('displayName', $displayName);
-      $this->ajaxResponse['tabCount'] = CRM_Contact_BAO_Contact::getCountComponent('contribution', $this->_contactId);
+      $tabCount = CRM_Contact_BAO_Contact::getCountComponent('contribution', $this->_contactId);
+      $this->assign('tabCount', $tabCount);
+      $this->ajaxResponse['tabCount'] = $tabCount;
     }
   }
 
@@ -391,8 +393,6 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     if (!CRM_Core_Key::valid($qfKey)) {
       $qfKey = NULL;
     }
-
-    $session = CRM_Core_Session::singleton();
 
     switch ($context) {
       case 'user':

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -59,9 +59,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     $membership = array();
     $dao = new CRM_Member_DAO_Membership();
     $dao->contact_id = $this->_contactId;
-    $dao->is_test = 0;
     $dao->whereAdd($addWhere);
-    //$dao->orderBy('name');
     $dao->find();
 
     //CRM--4418, check for view, edit, delete

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -68,6 +68,11 @@
   </div>
 </div>
 <table class="crm-info-panel">
+  {if $is_test}
+    <div class="help">
+      <strong>{ts}This is a TEST transaction{/ts}</strong>
+    </div>
+  {/if}
   <tr>
     <td class="label">{ts}From{/ts}</td>
     <td class="bold"><a href="{crmURL p='civicrm/contact/view' q="cid=$contact_id"}">{$displayName}</a></td>

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -28,6 +28,11 @@
 
 {if $action eq 4} {* when action is view *}
     {if $recur}
+        {if $recur.is_test}
+        <div class="help">
+          <strong>{ts}This is a TEST transaction{/ts}</strong>
+        </div>
+        {/if}
         <h3>{ts}View Recurring Payment{/ts}</h3>
         <div class="crm-block crm-content-block crm-recurcontrib-view-block">
           <table class="crm-info-panel">

--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -46,7 +46,7 @@
         <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
           <li id="tab_contributions" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
             <a href="#contributions-subtab" title="{ts}Contributions{/ts}">
-              {ts}Contributions{/ts} <em>{$rows|@count}</em>
+              {ts}Contributions{/ts} <em>{$tabCount}</em>
             </a>
           </li>
           <li id="tab_recurring" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">

--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -45,8 +45,14 @@
         {/if}
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
+
+    {if $is_test}
+    <div class="help">
+      <strong>{ts}This is a TEST transaction{/ts}</strong>
+    </div>
+    {/if}
     <table class="crm-info-panel">
-        <tr><td class="label">{ts}Member{/ts}</td><td class="bold"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contact_id&context=$context"}" title="{ts}View contact summary{/ts}">{$displayName}</td></tr>
+      <tr><td class="label">{ts}Member{/ts}</td><td class="bold"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contact_id&context=$context"}" title="{ts}View contact summary{/ts}">{$displayName}</td></tr>
         {if $owner_display_name}
             <tr><td class="label">{ts}By Relationship{/ts}</td><td>{$relationship}&nbsp;&nbsp;<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$owner_contact_id&context=$context"}" title="{ts}View primary member contact summary{/ts}">{$owner_display_name}</a>&nbsp;</td></tr>
         {/if}

--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -59,7 +59,7 @@
         </td>
     {/if}
     <td class="crm-membership-type crm-membership-type_{$row.membership_type}">
-        {$row.membership_type}
+        {$row.membership_type}{if $row.is_test} ({ts}test{/ts}){/if}
         {if $row.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
     </td>
     <td class="crm-membership-join_date">{$row.join_date|truncate:10:''|crmDate}</td>

--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -86,7 +86,7 @@
             {foreach from=$activeMembers item=activeMember}
             <tr id="crm-membership_{$activeMember.id}" class="{cycle values="odd-row,even-row"} {$activeMember.class} crm-membership">
                 <td class="crm-membership-membership_type">
-                    {$activeMember.membership_type}
+                    {$activeMember.membership_type}{if $activeMember.is_test} ({ts}test{/ts}){/if}
                     {if $activeMember.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
                 </td>
                 <td class="crm-membership-join_date" data-order="{$activeMember.join_date}">{$activeMember.join_date|crmDate}</td>
@@ -135,9 +135,10 @@
             </thead>
             {foreach from=$inActiveMembers item=inActiveMember}
             <tr id="crm-membership_{$inActiveMember.id}" class="{cycle values="odd-row,even-row"} {$inActiveMember.class} crm-membership">
-                <td class="crm-membership-membership_type">{$inActiveMember.membership_type}
-        {if $inActiveMember.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
-    </td>
+                <td class="crm-membership-membership_type">
+                    {$inActiveMember.membership_type}{if $inActiveMember.is_test} ({ts}test{/ts}){/if}
+                    {if $inActiveMember.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
+                </td>
                 <td class="crm-membership-join_date" data-order="{$inActiveMember.join_date}">{$inActiveMember.join_date|crmDate}</td>
                 <td class="crm-membership-start_date" data-order="{$inActiveMember.start_date}">{$inActiveMember.start_date|crmDate}</td>
                 <td class="crm-membership-end_date" data-order="{$inActiveMember.end_date}">{$inActiveMember.end_date|crmDate}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Show test memberships for consistency with contributions/recurs. Add text to show if a contribution/recur/membership is a test when viewing details.
See: https://lab.civicrm.org/dev/core/issues/219

Before
----------------------------------------
Membership tab:
![localhost_8000_civicrm_contact_view_reset 1 cid 203 2](https://user-images.githubusercontent.com/2052161/42138202-6eb93bdc-7d71-11e8-9e21-e4cd670737d7.png)

Membership View (contribution and recur are similar):
![localhost_8000_civicrm_contact_view_reset 1 cid 203 3](https://user-images.githubusercontent.com/2052161/42138206-773c6748-7d71-11e8-830e-41db91f67efe.png)

After
----------------------------------------
Membership tab:
![localhost_8000_civicrm_contact_view_reset 1 cid 203 8](https://user-images.githubusercontent.com/2052161/42138219-cc4975c8-7d71-11e8-9e9e-01821a0de5fc.png)

Membership View (contribution and recur are similar):
![localhost_8000_civicrm_contact_view_reset 1 cid 203 6](https://user-images.githubusercontent.com/2052161/42138220-d8c33082-7d71-11e8-86be-ce2b842aeafd.png)


Technical Details
----------------------------------------
* Changes only impact UI.
* The count on the tab is not affected (it does not include test memberships).

Comments
----------------------------------------
The lack of visible test memberships easily leads to confusion, especially given that the related contribution/recurring contributions are visible.  I have been caught out by this a few times myself, thinking that the memberships were not created (they were, but you have to find them through advanced search and select test memberships.