### PR TITLE
dev/financial#27 Paypal_Standard recurring IPNs don't work

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -226,7 +226,6 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       // In future moving to create pending & then complete, but this OK for now.
       // Also consider accepting 'Failed' like other processors.
       $input['contribution_status_id'] = $contributionStatuses['Completed'];
-      $input['invoice_id'] = md5(uniqid(rand(), TRUE));
       $input['original_contribution_id'] = $ids['contribution'];
       $input['contribution_recur_id'] = $ids['contributionRecur'];
 

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -223,17 +223,15 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
         throw new CRM_Core_Exception("Ignore all IPN payments that are not completed");
       }
 
-      $contribution->contact_id = $ids['contact'];
-      $contribution->financial_type_id = $objects['contributionType']->id;
-      $contribution->contribution_page_id = $ids['contributionPage'];
-      $contribution->contribution_recur_id = $ids['contributionRecur'];
-      $contribution->receive_date = $now;
-      $contribution->currency = $objects['contribution']->currency;
-      $contribution->payment_instrument_id = $objects['contribution']->payment_instrument_id;
-      $contribution->amount_level = $objects['contribution']->amount_level;
-      $contribution->campaign_id = $objects['contribution']->campaign_id;
+      // In future moving to create pending & then complete, but this OK for now.
+      // Also consider accepting 'Failed' like other processors.
+      $input['contribution_status_id'] = $contributionStatuses['Completed'];
+      $input['invoice_id'] = md5(uniqid(rand(), TRUE));
+      $input['original_contribution_id'] = $ids['contribution'];
+      $input['contribution_recur_id'] = $ids['contributionRecur'];
 
-      $objects['contribution'] = &$contribution;
+      civicrm_api3('Contribution', 'repeattransaction', $input);
+      return;
     }
 
     $this->single($input, $ids, $objects,
@@ -333,23 +331,12 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $ids['onbehalf_dupe_alert'] = $this->retrieve('onBehalfDupeAlert', 'Integer', FALSE);
     }
 
-    $paymentProcessorID = $this->retrieve('processor_id', 'Integer', FALSE);
-    if (empty($paymentProcessorID)) {
-      $processorParams = array(
-        'user_name' => $this->retrieve('business', 'String', FALSE),
-        'payment_processor_type_id' => CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType', 'PayPal_Standard', 'id', 'name'),
-        'is_test' => empty($input['is_test']) ? 0 : 1,
-      );
+    $paymentProcessorID = self::getPayPalPaymentProcessorID($input, $ids);
 
-      $processorInfo = array();
-      if (!CRM_Financial_BAO_PaymentProcessor::retrieve($processorParams, $processorInfo)) {
-        return FALSE;
-      }
-      $paymentProcessorID = $processorInfo['id'];
-    }
+    Civi::log()->debug('PayPalIPN: Received (ContactID: ' . $ids['contact'] . '; trxn_id: ' . $input['trxn_id'] . ').');
 
     if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
-      return FALSE;
+      return;
     }
 
     self::$_paymentProcessor = &$objects['paymentProcessor'];
@@ -404,6 +391,64 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $input['fee_amount'] = $this->retrieve('mc_fee', 'Money', FALSE);
     $input['net_amount'] = $this->retrieve('settle_amount', 'Money', FALSE);
     $input['trxn_id'] = $this->retrieve('txn_id', 'String', FALSE);
+
+    $paymentDate = $this->retrieve('payment_date', 'String', FALSE);
+    if (!empty($paymentDate)) {
+      $receiveDateTime = new DateTime($paymentDate);
+      $input['receive_date'] = $receiveDateTime->format('YmdHis');
+    }
+  }
+
+
+  /**
+   * Gets PaymentProcessorID for PayPal
+   *
+   * @param array $input
+   * @param array $ids
+   *
+   * @return int
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function getPayPalPaymentProcessorID($input, $ids) {
+    // First we try and retrieve from POST params
+    $paymentProcessorID = $this->retrieve('processor_id', 'Integer', FALSE);
+    if (!empty($paymentProcessorID)) {
+      return $paymentProcessorID;
+    }
+
+    // Then we try and get it from recurring contribution ID
+    if (!empty($ids['contributionRecur'])) {
+      $contributionRecur = civicrm_api3('ContributionRecur', 'getsingle', array(
+        'id' => $ids['contributionRecur'],
+        'return' => ['payment_processor_id'],
+      ));
+      if (!empty($contributionRecur['payment_processor_id'])) {
+        return $contributionRecur['payment_processor_id'];
+      }
+    }
+
+    // This is an unreliable method as there could be more than one instance.
+    // Recommended approach is to use the civicrm/payment/ipn/xx url where xx is the payment
+    // processor id & the handleNotification function (which should call the completetransaction api & by-pass this
+    // entirely). The only thing the IPN class should really do is extract data from the request, validate it
+    // & call completetransaction or call fail? (which may not exist yet).
+
+    Civi::log()->warning('Unreliable method used to get payment_processor_id for PayPal IPN - this will cause problems if you have more than one instance');
+    // Then we try and retrieve based on business email ID
+    $paymentProcessorTypeID = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType', 'PayPal_Standard', 'id', 'name');
+    $processorParams = [
+      'user_name' => $this->retrieve('business', 'String', FALSE),
+      'payment_processor_type_id' => $paymentProcessorTypeID,
+      'is_test' => empty($input['is_test']) ? 0 : 1,
+      'options' => ['limit' => 1],
+      'return' => ['id'],
+    ];
+    $paymentProcessorID = civicrm_api3('PaymentProcessor', 'getvalue', $processorParams);
+    if (empty($paymentProcessorID)) {
+      Throw new CRM_Core_Exception('PayPalIPN: Could not get Payment Processor ID');
+    }
+    return $paymentProcessorID;
   }
 
 }

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -236,16 +236,16 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
           $recur->start_date = $now;
         }
         else {
-          $input['invoice_id'] = md5(uniqid(rand(), TRUE));
-          $input['original_contribution_id'] = $ids['contribution'];
-          $input['contribution_recur_id'] = $ids['contributionRecur'];
-
           if ($input['paymentStatus'] != 'Completed') {
             throw new CRM_Core_Exception("Ignore all IPN payments that are not completed");
           }
+
           // In future moving to create pending & then complete, but this OK for now.
           // Also consider accepting 'Failed' like other processors.
-          $input['contribution_status_id'] = 1;
+          $input['contribution_status_id'] = $contributionStatuses['Completed'];
+          $input['invoice_id'] = md5(uniqid(rand(), TRUE));
+          $input['original_contribution_id'] = $ids['contribution'];
+          $input['contribution_recur_id'] = $ids['contributionRecur'];
 
           civicrm_api3('Contribution', 'repeattransaction', $input);
           return;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2775,8 +2775,24 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
 
   /**
    * Set up initial recurring payment allowing subsequent IPN payments.
+   *
+   * @param array $recurParams (Optional)
+   * @param array $contributionParams (Optional)
    */
-  public function setupRecurringPaymentProcessorTransaction($params = array()) {
+  public function setupRecurringPaymentProcessorTransaction($recurParams = [], $contributionParams = []) {
+    $contributionParams = array_merge([
+        'total_amount' => '200',
+        'invoice_id' => $this->_invoiceID,
+        'financial_type_id' => 'Donation',
+        'contribution_status_id' => 'Pending',
+        'contact_id' => $this->_contactID,
+        'contribution_page_id' => $this->_contributionPageID,
+        'payment_processor_id' => $this->_paymentProcessorID,
+        'is_test' => 0,
+        'skipCleanMoney' => TRUE,
+      ],
+      $contributionParams
+    );
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge(array(
       'contact_id' => $this->_contactID,
       'amount' => 1000,
@@ -2789,18 +2805,8 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'payment_processor_id' => $this->_paymentProcessorID,
       // processor provided ID - use contact ID as proxy.
       'processor_id' => $this->_contactID,
-      'api.contribution.create' => array(
-        'total_amount' => '200',
-        'invoice_id' => $this->_invoiceID,
-        'financial_type_id' => 1,
-        'contribution_status_id' => 'Pending',
-        'contact_id' => $this->_contactID,
-        'contribution_page_id' => $this->_contributionPageID,
-        'payment_processor_id' => $this->_paymentProcessorID,
-        'is_test' => 0,
-        'skipCleanMoney' => TRUE,
-      ),
-    ), $params));
+      'api.contribution.create' => $contributionParams,
+    ), $recurParams));
     $this->_contributionRecurID = $contributionRecur['id'];
     $this->_contributionID = $contributionRecur['values']['0']['api.contribution.create']['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Currently you can setup recurring payments using the Paypal Standard processor, but after the first IPN is processed subsequent IPNs do not get processed because the IPN code does not fully implement code to do so and fails to identify the correct payment processor in CiviCRM if the "business" email does not match.

By replacing the call to completetransaction with one to repeattransaction we have working recurring IPNs for paypal standard.

See: https://lab.civicrm.org/dev/financial/issues/27

- "business" email does not necessarily match the "Merchant Account Email" defined for the payment processor. Currently this causes the IPN to silently fail as it cannot identify the payment processor. Fix: A new function getPayPalPaymentProcessorID() based on the one used by PayPalPro IPN is implemented (a future improvement could be to make this a shared function).
- "receive_date" is being set to the date/time the IPN was processed instead of using the "payment_date" specified in the IPN response. Fix: We now use the "payment_date" if it is available.
- Subsequent contributions not being created. On the client site I tested this on NONE of the subsequent transactions were being processed - I assumed this was because we are using CompleteTransaction function instead of calling the API Contribution.repeattransaction. It may, in part have been caused by the bad lookup for the payment processor (see above). However, on further testing and looking at the testIPNPaymentRecurSuccess() test, whilst I can see that the test "Passes" I can also see that it is not creating the subsequent contributions correctly (they have a different payment_instrument and the total_amount is different for both contributions because it is not using the value passed by the mock IPN response. Fix: I've updated this PR to include improvements to the unit test to make sure we capture those issues - it should pass when run with the other changes in this PR but fail if the other changes are not applied.

Before
----------------------------------------
Paypal Standard recurring IPNs do not work properly

After
----------------------------------------
Paypal Standard recurring IPNs work properly.

Technical Details
----------------------------------------
Switch to calling the internal function completetransaction to the API repeattransaction which is the "correct" thing to do.

Comments
----------------------------------------
This has been tested on a live site, and has been used with nz.co.fuzion.notificationlog to replay six months of IPNs that were received by CiviCRM but not acted on.

