### PR TITLE
(dev/core#220) State province/country doesn't show properly in the…

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -867,6 +867,8 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
+      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, NULL, NULL) ? TRUE : $entryFound;
+
     }
   }
 


### PR DESCRIPTION
… history report

Overview
----------------------------------------
State province/country doesn't show properly in the report.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3455173/42146760-945ea07c-7de7-11e8-956b-6b9a724d0fce.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/3455173/42146767-9a853f92-7de7-11e8-978c-04dfbfbb09bb.png)

