### PR TITLE
Revert change to BillingBlock to support hidden fields.

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -821,7 +821,7 @@ abstract class CRM_Core_Payment {
         'name' => 'payment_token',
         'title' => ts('Authorization token'),
         'is_required' => FALSE,
-        'attributes' => ['size' => 10, 'autocomplete' => 'off'],
+        'attributes' => ['size' => 10, 'autocomplete' => 'off', 'id' => 'payment_token'],
       ),
     );
   }

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -39,7 +39,7 @@
             <div class="label">{$form.$paymentField.label}
               {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
             </div>
-            <div class="content">{if $form.$paymentField.html}{$form.$paymentField.html}{else}<input id="{$paymentField}" name="{$paymentField}" type="hidden" />{/if}
+            <div class="content">{$form.$paymentField.html}
               {if $paymentField == 'cvv2'}{* @todo move to form assignment*}
                 <span class="cvv2-icon" title="{ts}Usually the last 3-4 digits in the signature area on the back of the card.{/ts}"> </span>
               {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Partial revert of https://github.com/civicrm/civicrm-core/pull/12332 per feedback from @mattwire 

Before
----------------------------------------
Some processors would have experienced a regression from #12332

After
----------------------------------------
Line causing regression removed, field addition handled differently

Technical Details
----------------------------------------
Per discussion with Matt Wire this is actually unnecessary, if we define 'id' in the payment fields
metadata. This is a bit too much like spooky magic but it ... erm .. works

Comments
----------------------------------------
We could probably handle adding 'id' in the Payment helper classes. OTOH for most processors just one hidden token field is needed so most processor devs may not hit the need to know to add the id attribute

@mattwire please confirm this is 'good to merge'
