### PR TITLE
dev/core#221, check if the grouptree is not empty

### DIFF
--- a/CRM/Custom/Form/Preview.php
+++ b/CRM/Custom/Form/Preview.php
@@ -109,7 +109,7 @@ class CRM_Custom_Form_Preview extends CRM_Core_Form {
    * @return void
    */
   public function buildQuickForm() {
-    if (is_array($this->_groupTree[$this->_groupId])) {
+    if (is_array($this->_groupTree) && !empty($this->_groupTree[$this->_groupId])) {
       foreach ($this->_groupTree[$this->_groupId]['fields'] as & $field) {
         //add the form elements
         CRM_Core_BAO_CustomField::addQuickFormElement($this, $field['element_name'], $field['id'], CRM_Utils_Array::value('is_required', $field));


### PR DESCRIPTION
Overview
----------------------------------------
When a new empty custom data set is created and clicked on preview it gives following warning on the preview page

Before
![customdatapreview](https://user-images.githubusercontent.com/30790755/42149269-1e0bbdc2-7df3-11e8-983b-549260f5dc10.png)

Technical Details
----------------------------------------
Checked if the custom data group tree is not empty and is an array.