### PR TITLE
(dev/core#223) Expose prefix and suffix in reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5374,6 +5374,22 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'title' => $options['prefix_label'] . ts('Nick Name'),
         'is_fields' => TRUE,
       ),
+      $options['prefix'] . 'prefix_id' => array(
+        'name' => 'prefix_id',
+        'title' => $options['prefix_label'] . ts('Prefix'),
+        'options' => CRM_Contact_BAO_Contact::buildOptions('prefix_id'),
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+      ),
+      $options['prefix'] . 'suffix_id' => array(
+        'name' => 'suffix_id',
+        'title' => $options['prefix_label'] . ts('Suffix'),
+        'options' => CRM_Contact_BAO_Contact::buildOptions('suffix_id'),
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+      ),
       $options['prefix'] . 'gender_id' => array(
         'name' => 'gender_id',
         'title' => $options['prefix_label'] . ts('Gender'),


### PR DESCRIPTION
Overview
----------------------------------------
Add prefix and suffix to _getContactColumns_ method.

Before
----------------------------------------
![prefix_before](https://user-images.githubusercontent.com/3455173/42160097-9f2b8c0a-7e13-11e8-9b08-66bceaeafcad.png)

After
----------------------------------------
![pre_after](https://user-images.githubusercontent.com/3455173/42160100-a431b044-7e13-11e8-910b-6ff6be16893f.png)


