### PR TITLE
dev/core#225  correct is_primary flag and location type for Primary

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -1175,6 +1175,9 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
           $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
           $values['location_type_id'] = (isset($primary) && $primary['count']) ? $primary['values'][0]['location_type_id'] : $defaultLocationType->id;
           $values['is_primary'] = 1;
+          // set default location type id to primary block
+          $params[$blockFieldName][$blockCnt]['location_type_id'] = $values['location_type_id'];
+          $params[$blockFieldName][$blockCnt]['is_primary'] = 1;
         }
 
         if (empty($params['id']) && ($blockCnt == 1)) {


### PR DESCRIPTION
Overview
----------------------------------------
When using the "Update" function of the contact import wizard and indicating a location type of "Primary" for an email address, that email address is created with a location type id of "0"

Before
----------------------------------------
location type id = 0

After
----------------------------------------
Location Type id = default location type id
