### PR TITLE
dev/report#5 - Fix mailing report unique count issue

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2185,6 +2185,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
                'forward',
                'reply',
                'opened',
+               'opened_unique',
                'optout',
              ) as $key) {
       $url = 'mailing/detail';
@@ -2222,6 +2223,12 @@ ORDER BY   civicrm_email.is_bulkmail DESC
           break;
 
         case 'opened':
+          $url = "mailing/opened";
+          $searchFilter .= "&mailing_open_status=Y";
+          $reportFilter .= "&distinct=0"; // do not use group by clause in report, because same report used for total and unique open
+          break;
+
+        case 'opened_unique':
           $url = "mailing/opened";
           $searchFilter .= "&mailing_open_status=Y";
           break;

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -289,13 +289,19 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
   }
 
   public function groupBy() {
-    $groupBys = empty($this->_params['charts']) ? array("civicrm_mailing_event_queue.email_id") : array("{$this->_aliases['civicrm_mailing']}.id");
-
-    if (!empty($this->_params['unique_opens_value'])) {
-      $groupBys[] = "civicrm_mailing_event_queue.id";
+    $groupBys = array();
+    // Do not use group by clause if distinct = 0 mentioned in url params. flag is used in mailing report screen, default value is TRUE
+    // this report is used to show total opened and unique opened
+    if (CRM_Utils_Request::retrieve('distinct', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, TRUE)) {
+      $groupBys = empty($this->_params['charts']) ? array("civicrm_mailing_event_queue.email_id") : array("{$this->_aliases['civicrm_mailing']}.id");
+      if (!empty($this->_params['unique_opens_value'])) {
+        $groupBys[] = "civicrm_mailing_event_queue.id";
+      }
     }
-    $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, $groupBys);
-    $this->_groupBy = "GROUP BY " . implode(', ', $groupBys);
+    if (!empty($groupBys)) {
+      $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, $groupBys);
+      $this->_groupBy = "GROUP BY " . implode(', ', $groupBys);
+    }
   }
 
   public function postProcess() {

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -37,7 +37,7 @@
   {if $report.mailing.open_tracking}
     <tr><td class="label"><a href="{$report.event_totals.links.opened}&distinct=1">{ts}Unique Opens{/ts}</a></td>
         <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%)</td>
-        <td>{$report.event_totals.actionlinks.opened}</td></tr>
+        <td>{$report.event_totals.actionlinks.opened_unique}</td></tr>
     <tr><td class="label"><a href="{$report.event_totals.links.opened}">{ts}Total Opens{/ts}</a></td>
         <td>{$report.event_totals.total_opened}</td>
         <td>{$report.event_totals.actionlinks.opened}</td></tr>

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -140,6 +140,19 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test getrows on Mailing Opened report.
+   */
+  public function testReportTemplateGetRowsMailingUniqueOpened() {
+    $description = "Retrieve rows from a mailing opened report template.";
+    $result = $this->callAPIAndDocument('report_template', 'getrows', array(
+      'report_id' => 'Mailing/opened',
+      'options' => array('metadata' => array('labels', 'title')),
+    ), __FUNCTION__, __FILE__, $description, 'Getrows');
+
+    $this->assertEquals(4, $result['count']);
+  }
+
+  /**
    * Test api to get rows from reports.
    *
    * @dataProvider getReportTemplates


### PR DESCRIPTION
Overview
----------------------------------------
Mailing -> Scheduled and Sent Mailings -> Report
Unique Opens  -> Report
Total Opens   -> Report
Before
----------------------------------------
Both Report showing same count (Unique report is in-correct)

After
----------------------------------------
Unique Opens Report has less value as compared to Total Opens
