### PR TITLE
dev/core#227 Fix issue where on some extened groups the multiple reco…

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -147,7 +147,9 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
           'is_multiple'
         );
 
-        if ($params['is_multiple'] != $isMultiple) {
+        // dev/core#227 Fix issue where is_multiple in params maybe an empty string if checkbox is not rendered on the form.
+        $paramsIsMultiple = empty($params['is_multiple']) ? 0 : 1;
+        if ($paramsIsMultiple != $isMultiple) {
           $tableNameNeedingIndexUpdate = CRM_Core_DAO::getFieldValue(
             'CRM_Core_DAO_CustomGroup',
             $params['id'],

--- a/tests/phpunit/api/v3/CustomGroupTest.php
+++ b/tests/phpunit/api/v3/CustomGroupTest.php
@@ -314,6 +314,15 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test an update when is_multiple is an emtpy string this can occur in form submissions for custom groups that extend activites.
+   * dev/core#227.
+   */
+  public function testCustomGroupEmptyisMultipleUpdate() {
+    $customGroup = $this->callAPISuccess('CustomGroup', 'create', array_merge($this->_params, ['is_multiple' => 0]));
+    $this->callAPISuccess('CustomGroup', 'create', ['id' => $customGroup['id'], 'is_multiple' => '']);
+  }
+
+  /**
    * Check with Activity - Meeting Type
    */
   public function testCustomGroupCreateActivityMeeting() {


### PR DESCRIPTION
…rds checkbox doesn't show this causes empty string to be passed in which was causing problems when working out if we needed to make changes to the custom value table

Overview
----------------------------------------
When submitting the custom group setting form for custom groups extending activities the is_multiple checkbox doesn't show this causes an empty string to be passed through or is_multiple. This is replicated through the API. The test fails without the patch

Before
----------------------------------------
Hard fail when trying to edit the custom group settings for any custom groups extending activities

After
----------------------------------------
no hard fail

ping @eileenmcnaughton @monishdeb 