### PR TITLE
Fail softly when moving between branches

### DIFF
--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -25,6 +25,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
 /**
  *
  * @package CRM
@@ -222,8 +224,13 @@ class CRM_Utils_Check {
       $maxSeverity = max(1, $message->getLevel());
       break;
     }
-
-    Civi::cache('checks')->set('systemStatusCheckResult', $maxSeverity);
+    try {
+      Civi::cache('checks')->set('systemStatusCheckResult', $maxSeverity);
+    }
+    catch (ServiceNotFoundException $e) {
+      // As of 5.4 this could happen in dev environments as switching between codebase versions
+      // affects the cache mechanism. This is not the place to hard fail.
+    }
 
     return ($max) ? $maxSeverity : $messages;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Removes a source of confusion / troubleshooting for devs switching branch between 5.4 & earlier versions

Before
----------------------------------------
Hard fail after doing work on 5.3 & then switching back to 5.4

After
----------------------------------------
A few e-notices but no hard fail

Technical Details
----------------------------------------
As of 5.4 there is a difference in the caching mechanisms from previous versions. Switching between branches is a dev-specific activity, but can result in hard-fails due to this change. Soften the effect

Comments
----------------------------------------
@totten I think this is worth mitigating
