### PR TITLE
dev/core#230 : set mapping id null on delete action

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.4.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.4.alpha1.mysql.tpl
@@ -11,3 +11,11 @@ we want to ensure that these values are handled precisely and consistently.
 ALTER TABLE civicrm_cache
   CHANGE created_date created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT 'When was the cache item created',
   CHANGE expired_date expired_date  TIMESTAMP NULL DEFAULT NULL COMMENT 'When should the cache item expire';
+
+
+-- core/issues/230
+ALTER TABLE `civicrm_saved_search`
+  DROP FOREIGN KEY FK_civicrm_saved_search_mapping_id;
+
+ALTER TABLE `civicrm_saved_search`
+  ADD CONSTRAINT `FK_civicrm_saved_search_mapping_id` FOREIGN KEY (`mapping_id`) REFERENCES `civicrm_mapping` (`id`) ON DELETE SET NULL;

--- a/xml/schema/Contact/SavedSearch.xml
+++ b/xml/schema/Contact/SavedSearch.xml
@@ -55,6 +55,7 @@
     <name>mapping_id</name>
     <table>civicrm_mapping</table>
     <key>id</key>
+    <onDelete>SET NULL</onDelete>
     <add>1.5</add>
   </foreignKey>
   <field>


### PR DESCRIPTION
Overview
----------------------------------------
On Delete set mapping_id to NULL

Before
----------------------------------------
DB Error:
`DELETE FROM civicrm_mapping  WHERE (  civicrm_mapping.id = 5 )  [nativecode=1451 ** Cannot delete or update a parent row: a foreign key constraint fails (`civicrm_saved_search`, CONSTRAINT `FK_civicrm_saved_search_mapping_id` FOREIGN KEY (`mapping_id`) REFERENCES `civicrm_mapping` (`id`))]`

After
----------------------------------------
No DB Error

