### PR TITLE
dev/core#229 Fix fatal error on sending test email

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -619,13 +619,13 @@ function civicrm_api3_mailing_send_test($params) {
     FALSE
   );
 
-  $testEmailParams = _civicrm_api3_generic_replace_base_params($params);
+  $testEmailParams = _civicrm_api3_generic_replace_base_params($params, ['id']);
   $testEmailParams['is_test'] = 1;
   $testEmailParams['status'] = 'Scheduled';
   $testEmailParams['scheduled_date'] = CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s'));
   $job = civicrm_api3('MailingJob', 'create', $testEmailParams);
   $testEmailParams['job_id'] = $job['id'];
-  $testEmailParams['emails'] = array_key_exists('test_email', $testEmailParams) ? explode(',', $testEmailParams['test_email']) : NULL;
+  $testEmailParams['emails'] = array_key_exists('test_email', $params) ? explode(',', $params['test_email']) : NULL;
   if (!empty($params['test_email'])) {
     $query = CRM_Utils_SQL_Select::from('civicrm_email e')
         ->select(array('e.id', 'e.contact_id', 'e.email'))
@@ -679,8 +679,6 @@ function civicrm_api3_mailing_send_test($params) {
   }
 
   $isComplete = FALSE;
-  $config = CRM_Core_Config::singleton();
-  $mailerJobSize = Civi::settings()->get('mailerJobSize');
   while (!$isComplete) {
     // Q: In CRM_Mailing_BAO_Mailing::processQueue(), the three runJobs*()
     // functions are all called. Why does Mailing.send_test only call one?

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1863,14 +1863,22 @@ function _civicrm_api3_generic_replace($entity, $params) {
  * Replace base parameters.
  *
  * @param array $params
+ * @param array $unsetParams
  *
  * @return array
  */
-function _civicrm_api3_generic_replace_base_params($params) {
+function _civicrm_api3_generic_replace_base_params($params, $unsetParams = array()) {
   $baseParams = $params;
   unset($baseParams['values']);
   unset($baseParams['sequential']);
   unset($baseParams['options']);
+  if (!empty($unsetParams)) {
+    foreach ($unsetParams as $uParam) {
+      if (array_key_exists($uParam, $baseParams)) {
+        unset($baseParams[$uParam]);
+      }
+    }
+  }
   return $baseParams;
 }
 

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -398,7 +398,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   }
 
   /**
-   *
+   * Test sending a test mailing.
    */
   public function testMailerSendTest_email() {
     $contactIDs['alice'] = $this->individualCreate(array(
@@ -410,8 +410,10 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $mail = $this->callAPISuccess('mailing', 'create', $this->_params);
 
     $params = array('mailing_id' => $mail['id'], 'test_email' => 'alice@example.org', 'test_group' => NULL);
+    // Per https://lab.civicrm.org/dev/core/issues/229 ensure this is not passed through!
+    $params['id'] = $mail['id'];
     $deliveredInfo = $this->callAPISuccess($this->_entity, 'send_test', $params);
-    $this->assertEquals(1, $deliveredInfo['count'], "in line " . __LINE__); // verify mail has been sent to user by count
+    $this->assertEquals(1, $deliveredInfo['count']); // verify mail has been sent to user by count
 
     $deliveredContacts = array_values(CRM_Utils_Array::collect('contact_id', $deliveredInfo['values']));
     $this->assertEquals(array($contactIDs['alice']), $deliveredContacts);


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the fatal error when sending test emails. this is an alternate to https://github.com/civicrm/civicrm-core/pull/12399

Before
----------------------------------------
Fatal error when sending test email

After
----------------------------------------
no fatal

ping @eileenmcnaughton @jmcclelland