### PR TITLE
dev/core#212 - Contribution Details report fails when 'Is not one of'…

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -926,6 +926,10 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       {$this->_aclFrom}
     ";
 
+    //Join temp table if report is filtered by group. This is specific to 'notin' operator and covered in unit test(ref dev/core#212)
+    if (!empty($this->_params['gid_op']) && $this->_params['gid_op'] == 'notin') {
+      $this->joinGroupTempTable('civicrm_contact', 'id', $this->_aliases['civicrm_contact']);
+    }
     $this->appendAdditionalFromJoins();
   }
 

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -400,6 +400,11 @@ LEFT JOIN $this->tempTableRepeat1 {$this->_aliases['civicrm_contribution']}1
        .{$this->contributionJoinTableColumn}
 LEFT JOIN $this->tempTableRepeat2 {$this->_aliases['civicrm_contribution']}2
        ON {$this->groupByTableAlias}.$fromCol = {$this->_aliases['civicrm_contribution']}2.{$this->contributionJoinTableColumn}";
+
+    //Join temp table if report is filtered by group. This is specific to 'notin' operator and covered in unit test(ref dev/core#212)
+    if (!empty($this->_params['gid_op']) && $this->_params['gid_op'] == 'notin') {
+      $this->joinGroupTempTable('civicrm_contact', 'id', $this->_aliases['civicrm_contact']);
+    }
   }
 
   /**
@@ -825,6 +830,7 @@ GROUP BY    currency
   public function postProcess() {
     $this->beginPostProcess();
 
+    $this->buildGroupTempTable();
     $this->select();
     $this->from();
     $this->where();

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -360,14 +360,15 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
     $this->assertEquals(2, $rows['count'], "Report failed - the sql used to generate the results was " . print_r($rows['metadata']['sql'], TRUE));
 
-    $this->assertContains('DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci
+    $expected = 'DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci
       SELECT SQL_CALC_FOUND_ROWS contact_civireport.id as cid  FROM civicrm_contact contact_civireport    INNER JOIN civicrm_contribution contribution_civireport USE index (received_date) ON contribution_civireport.contact_id = contact_civireport.id
          AND contribution_civireport.is_test = 0
          AND contribution_civireport.receive_date BETWEEN \'20140701000000\' AND \'20150630235959\'
-       
+
        LEFT JOIN civicrm_contribution cont_exclude ON cont_exclude.contact_id = contact_civireport.id
          AND cont_exclude.receive_date BETWEEN \'2015-7-1\' AND \'20160630235959\' WHERE cont_exclude.id IS NULL AND 1 AND ( contribution_civireport.contribution_status_id IN (1) )
-      GROUP BY contact_civireport.id', $rows['metadata']['sql'][0]);
+      GROUP BY contact_civireport.id';
+    $this->assertContains(preg_replace('/\s+/', ' ', $expected), preg_replace('/\s+/', ' ', $rows['metadata']['sql'][0]));
   }
 
   /**
@@ -754,6 +755,25 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     foreach ($rows['values'] as $row) {
       $this->assertEquals(array_pop($count), count($row['rows']), "Report failed to get row count");
     }
+  }
+
+  /**
+   * Test the group filter works on the various reports.
+   *
+   * @dataProvider getMembershipAndContributionReportTemplatesForGroupTests
+   *
+   * @param string $template
+   *   Report template unique identifier.
+   */
+  public function testReportsWithNoTInSmartGroupFilter($template) {
+    $groupID = $this->setUpPopulatedGroup();
+    $rows = $this->callAPISuccess('report_template', 'getrows', array(
+      'report_id' => $template,
+      'gid_value' => array($groupID),
+      'gid_op' => 'notin',
+      'options' => array('metadata' => array('sql')),
+    ));
+    $this->assertNumberOfContactsInResult(2, $rows, $template);
   }
 
 }


### PR DESCRIPTION
… condition is used for Groups field

Overview
----------------------------------------
Fix DB error when contribution detail report is filtered by  `is not one of` Group operator

Before
----------------------------------------
- open Report > Contribution Reports > Contribution Details
- click on Filters tab
- scroll down to Groups field
- change condition to "Is not one of"
- choose at least one group
- click Refresh results
- result: DB Error: no such field

![image](https://user-images.githubusercontent.com/5929648/42218675-04e0633a-7ee7-11e8-879c-c3d40a88e3df.png)

After
----------------------------------------
Filtering on `is not one of` group operator correctly displays all contacts which are not in any selected group.

Technical Details
----------------------------------------
Contribuiton Detail Report uses a custom from clause to build the soft credit rows. It missed the group join if there is a temp table already created.

Comments
----------------------------------------

Added a small unit test to check for any DB failure when group by filter is applied.

Gitlab Ticket - https://lab.civicrm.org/dev/core/issues/212