### PR TITLE
sending test message results in error

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -598,6 +598,7 @@ function civicrm_api3_mailing_preview($params) {
 function _civicrm_api3_mailing_send_test_spec(&$spec) {
   $spec['test_group']['title'] = 'Test Group ID';
   $spec['test_email']['title'] = 'Test Email Address';
+  $spec['mailing_id']['api.required'] = TRUE;
 }
 
 /**
@@ -613,19 +614,16 @@ function civicrm_api3_mailing_send_test($params) {
   if (!array_key_exists('test_group', $params) && !array_key_exists('test_email', $params)) {
     throw new API_Exception("Mandatory key(s) missing from params array: test_group and/or test_email field are required");
   }
-  civicrm_api3_verify_mandatory($params,
-    'CRM_Mailing_DAO_MailingJob',
-    array('mailing_id'),
-    FALSE
-  );
+  $testEmailParams = [
+    'mailing_id' => $params['mailing_id'],
+    'is_test' => 1,
+    'status' => 'Scheduled',
+    'scheduled_date' => CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s')),
+  ];
 
-  $testEmailParams = _civicrm_api3_generic_replace_base_params($params);
-  $testEmailParams['is_test'] = 1;
-  $testEmailParams['status'] = 'Scheduled';
-  $testEmailParams['scheduled_date'] = CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s'));
   $job = civicrm_api3('MailingJob', 'create', $testEmailParams);
   $testEmailParams['job_id'] = $job['id'];
-  $testEmailParams['emails'] = array_key_exists('test_email', $testEmailParams) ? explode(',', $testEmailParams['test_email']) : NULL;
+  $testEmailParams['emails'] = array_key_exists('test_email', $params) ? explode(',', $params['test_email']) : NULL;
   if (!empty($params['test_email'])) {
     $query = CRM_Utils_SQL_Select::from('civicrm_email e')
         ->select(array('e.id', 'e.contact_id', 'e.email'))
@@ -679,8 +677,7 @@ function civicrm_api3_mailing_send_test($params) {
   }
 
   $isComplete = FALSE;
-  $config = CRM_Core_Config::singleton();
-  $mailerJobSize = Civi::settings()->get('mailerJobSize');
+
   while (!$isComplete) {
     // Q: In CRM_Mailing_BAO_Mailing::processQueue(), the three runJobs*()
     // functions are all called. Why does Mailing.send_test only call one?

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -398,7 +398,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   }
 
   /**
-   *
+   * Test sending a test mailing.
    */
   public function testMailerSendTest_email() {
     $contactIDs['alice'] = $this->individualCreate(array(
@@ -410,8 +410,10 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $mail = $this->callAPISuccess('mailing', 'create', $this->_params);
 
     $params = array('mailing_id' => $mail['id'], 'test_email' => 'alice@example.org', 'test_group' => NULL);
+    // Per https://lab.civicrm.org/dev/core/issues/229 ensure this is not passed through!
+    $params['id'] = $mail['id'];
     $deliveredInfo = $this->callAPISuccess($this->_entity, 'send_test', $params);
-    $this->assertEquals(1, $deliveredInfo['count'], "in line " . __LINE__); // verify mail has been sent to user by count
+    $this->assertEquals(1, $deliveredInfo['count']); // verify mail has been sent to user by count
 
     $deliveredContacts = array_values(CRM_Utils_Array::collect('contact_id', $deliveredInfo['values']));
     $this->assertEquals(array($contactIDs['alice']), $deliveredContacts);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression in rc whereby test mailings are not sent

https://lab.civicrm.org/dev/core/issues/229

Proposed alternative to https://github.com/civicrm/civicrm-core/pull/12399

Before
----------------------------------------

sending test email fails with: Error in call to Mailing_send_test : job_id is not valid : 440

After
----------------------------------------

send mail works

Technical Details
----------------------------------------

The original MailingJob::Create only handled the 4 params still being handled

 ```
$job = new CRM_Mailing_BAO_MailingJob();
    $job->mailing_id = $params['mailing_id'];
    $job->status = $params['status'];
    $job->scheduled_date = $params['scheduled_date'];
    $job->is_test = $params['is_test'];
    $job->save();
    if ($params['mailing_id']) {
      CRM_Mailing_BAO_Mailing::getRecipients($params['mailing_id']);
      return $job;
    }
    else {
      throw new CRM_Core_Exception("Failed to create job: Unknown mailing ID");
    }
```

