### PR TITLE
Add location_id if missing CRM-20711.

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFour.php
@@ -71,6 +71,8 @@ class CRM_Upgrade_Incremental_php_FiveFour extends CRM_Upgrade_Incremental_Base 
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('Add Cancel Button Setting to the Profile', 'addColumn',
       'civicrm_uf_group', 'add_cancel_button', "tinyint DEFAULT '1' COMMENT 'Should a Cancel button be included in this Profile form.'");
+    $this->addTask('Add location_id if missing to group_contact table (affects some older installs CRM-20711)', 'addColumn',
+      'civicrm_group_contact', 'location_id', "int(10) unsigned DEFAULT NULL COMMENT 'Optional location to associate with this membership'");
   }
 
   /*


### PR DESCRIPTION
Overview
----------------------------------------
On a small number of installs it seems location_id is missing from the group_contact table. This adds if missing

Before
----------------------------------------
Some sites do not have an expected field (location_id) in group_contact table

After
----------------------------------------
Field added to sites missing it

Technical Details
----------------------------------------
Seems to affect a very small number of old sites but the called function should cope if the column exists already

Comments
----------------------------------------
@seamuslee001 this is what we expect here isn't it.
@adixon FYI

---

 * [CRM-20711: Error - DB Constraint Violation - GroupContact, get API](https://issues.civicrm.org/jira/browse/CRM-20711)