### PR TITLE
dev/core/issues/211 Fix mis-allocation of financial transactions when editing payment method on a completed payment

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -204,13 +204,13 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
       }
 
       foreach (array($previousFinanciaTrxn, $newFinancialTrxn) as $financialTrxnParams) {
-        civicrm_api3('FinancialTrxn', 'create', $financialTrxnParams);
+        $financialTrxn = civicrm_api3('FinancialTrxn', 'create', $financialTrxnParams);
         $trxnParams = array(
           'total_amount' => $financialTrxnParams['total_amount'],
           'contribution_id' => $this->_contributionID,
         );
         $contributionTotalAmount = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $this->_contributionID, 'total_amount');
-        CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $submittedValues['id'], $contributionTotalAmount);
+        CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $financialTrxn['id'], $contributionTotalAmount);
       }
     }
     else {

--- a/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
@@ -87,7 +87,7 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
     $expectedPaymentParams = array(
       array(
         'total_amount' => 50.00,
-        'financial_type' => 'Donation,Donation,Donation',
+        'financial_type' => 'Donation',
         'payment_instrument' => 'Check',
         'status' => 'Completed',
         'receive_date' => '2015-04-21 23:27:00',
@@ -95,7 +95,7 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
       ),
       array(
         'total_amount' => -50.00,
-        'financial_type' => NULL,
+        'financial_type' => 'Donation',
         'payment_instrument' => 'Check',
         'status' => 'Completed',
         'receive_date' => $params['trxn_date'],
@@ -103,7 +103,7 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
       ),
       array(
         'total_amount' => 50.00,
-        'financial_type' => NULL,
+        'financial_type' => 'Donation',
         'payment_instrument' => sprintf('Credit Card (Visa: %s)', $params['pan_truncation']),
         'status' => 'Completed',
         'receive_date' => $params['trxn_date'],


### PR DESCRIPTION
Overview
----------------------------------------
When editing the payment instrument (e.g from Check to Cash) on a completed donation the financial trxn records do not have the correct links - causing them to show as rows without a financial account.

This issue has been in the payment edit form for almost a year (and locked in by unit tests!). Recently, however, we promoted the payment edit form to be  the 'main flow'( #10776 ) and this caused it to be experienced as a 'new' bug.

 https://lab.civicrm.org/dev/core/issues/211 

Before
----------------------------------------
Financial account now showing on all rows after editing payment instrument id
![screenshot 2018-07-04 12 06 30](https://user-images.githubusercontent.com/336308/42250047-b6671892-7f82-11e8-9d96-0e2c5c0885d6.png)



After
----------------------------------------
Financial account showing on all rows after editing payment instrument id
![screenshot 2018-07-04 12 04 41](https://user-images.githubusercontent.com/336308/42249996-7c53bbba-7f82-11e8-9abd-24a3f309e011.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
@monishdeb @pradpnayak need your input here

chat description
"If you edit a contribution's payment detail, and click update, it updates but stays on that page. if you then click cancel to try and get back to the main contribution edit screen, it gives an error. That's the first problem.  Second problem: once the payment detail is updated, instead of replacing the transaction id, it is appending it to the contribution record in civicrm_contribution.  Third problem: updating the payment detail causes multiple lines in the payment details section of the contribution, with lots of duplication there."
https://chat.civicrm.org/civicrm/pl/ej15u57mrbnwpxdd3g6r7m6h4o

I could only reproduce item described as the third problem
