### PR TITLE
dev/core/issues/228 fix OptionGroup create action to not disable on update

### DIFF
--- a/CRM/Core/BAO/OptionGroup.php
+++ b/CRM/Core/BAO/OptionGroup.php
@@ -88,16 +88,12 @@ class CRM_Core_BAO_OptionGroup extends CRM_Core_DAO_OptionGroup {
    * @return object
    */
   public static function add(&$params, $ids = array()) {
-    if (empty($params['id'])) {
-      $params['id'] = CRM_Utils_Array::value('optionGroup', $ids);
+    if (empty($params['id']) && !empty($ids['optionGroup'])) {
+      CRM_Core_Error::deprecatedFunctionWarning('no $ids array');
+      $params['id'] = $ids['optionGroup'];
     }
-
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-
-    // action is taken depending upon the mode
     $optionGroup = new CRM_Core_DAO_OptionGroup();
     $optionGroup->copyValues($params);;
-
     $optionGroup->save();
     return $optionGroup;
   }

--- a/CRM/Upgrade/Incremental/sql/5.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.5.alpha1.mysql.tpl
@@ -1,1 +1,9 @@
 {* file to handle db changes in 5.5.alpha1 during upgrade *}
+#https://lab.civicrm.org/dev/core/issues/228
+UPDATE civicrm_option_group SET is_active = 0 WHERE is_active IS NULL;
+ALTER TABLE civicrm_option_group MODIFY COLUMN is_active TINYINT(4) NOT NULL DEFAULT 1 COMMENT 'Is this option group active?';
+UPDATE civicrm_option_group SET is_locked = 0 WHERE is_locked IS NULL;
+ALTER TABLE civicrm_option_group MODIFY COLUMN  is_locked TINYINT(4) NOT NULL DEFAULT 1 COMMENT 'A lock to remove the ability to add new options via the UI.';
+#is_reserved already has a default so is effectively required but let's be explicit.
+UPDATE civicrm_option_group SET `is_reserved` = 0 WHERE `is_reserved` IS NULL;
+ALTER TABLE civicrm_option_group MODIFY COLUMN `is_reserved` tinyint(4) NOT NULL DEFAULT 1 COMMENT 'Is this a predefined system option group (i.e. it can not be deleted)?';

--- a/xml/schema/Core/OptionGroup.xml
+++ b/xml/schema/Core/OptionGroup.xml
@@ -61,6 +61,7 @@
     <title>Option Group Is Reserved?</title>
     <type>boolean</type>
     <default>1</default>
+    <required>true</required>
     <comment>Is this a predefined system option group (i.e. it can not be deleted)?</comment>
     <add>1.5</add>
   </field>
@@ -68,12 +69,16 @@
     <name>is_active</name>
     <title>Option Group Is Active?</title>
     <type>boolean</type>
+    <default>1</default>
+    <required>true</required>
     <comment>Is this option group active?</comment>
     <add>1.5</add>
   </field>
   <field>
     <name>is_locked</name>
     <title>Option Group Is Locked</title>
+    <default>0</default>
+    <required>true</required>
     <type>boolean</type>
     <comment>A lock to remove the ability to add new options via the UI.</comment>
     <add>4.5</add>


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/228 the OptionGroup BAO message incorrectly sets is_active to FALSE if not explicitly set, including on update.

Before
----------------------------------------
civicrm_api3('OptionGroup', 'create', ['id' => 4, 'label' => 'Socks are cool']);
results in the group being deactivated

After
----------------------------------------
Above command does not de-activate

Technical Details
----------------------------------------
This follows our standard approach of switching Boolean fields to being mandatory & having a default. Note that the is_reserved field has a default but I updated to mandatory.

Arguably we could leave the 'NOT NULL' part off for existing installs to protect against weirdness.

I made the default for 'is_active' TRUE rather than false since that is consistent with everything else and it's hard to make a case for FALSE. I think the form would enforce this normally anyway.

This also switches the OptionGroup form to use the api (preliminary to supporting custom data on that entity)

Comments
----------------------------------------
@seamuslee001 thoughts - I'll probably have to switch the upgrade script to 5.5