### PR TITLE
Simplify input params on OptionValue::addOptionValue

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -484,8 +484,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
         $params['color'] = 'null';
       }
 
-      $groupParams = array('name' => ($this->_gName));
-      $optionValue = CRM_Core_OptionValue::addOptionValue($params, $groupParams, $this->_action, $this->_id);
+      $optionValue = CRM_Core_OptionValue::addOptionValue($params, $this->_gName, $this->_action, $this->_id);
 
       // CRM-11516
       if (!empty($params['financial_account_id'])) {

--- a/CRM/Campaign/Form/SurveyType.php
+++ b/CRM/Campaign/Form/SurveyType.php
@@ -156,9 +156,8 @@ class CRM_Campaign_Form_SurveyType extends CRM_Admin_Form {
         $params['filter'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'filter', 'id');
       }
 
-      $groupParams = array('name' => ($this->_gName));
       $params['component_id'] = CRM_Core_Component::getComponentID('CiviCampaign');
-      $optionValue = CRM_Core_OptionValue::addOptionValue($params, $groupParams, $this->_action, $this->_id);
+      $optionValue = CRM_Core_OptionValue::addOptionValue($params, $this->_gName, $this->_action, $this->_id);
 
       CRM_Core_Session::setStatus(ts('The Survey type \'%1\' has been saved.', array(1 => $optionValue->label)), ts('Saved'), 'success');
     }

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -187,7 +187,7 @@ class CRM_Core_OptionValue {
    *
    * @param array $params
    *   Array containing exported values from the invoking form.
-   * @param array $groupParams
+   * @param string $optionGroupName
    *   Array containing group fields whose option-values is to retrieved/saved.
    * @param $action
    * @param int $optionValueID Has the id of the optionValue being edited, disabled ..etc.
@@ -196,22 +196,17 @@ class CRM_Core_OptionValue {
    * @return CRM_Core_DAO_OptionValue
    *
    */
-  public static function addOptionValue(&$params, &$groupParams, $action, $optionValueID) {
+  public static function addOptionValue(&$params, $optionGroupName, $action, $optionValueID) {
     $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
     // checking if the group name with the given id or name (in $groupParams) exists
-    if (!empty($groupParams)) {
-      $config = CRM_Core_Config::singleton();
-      $groupParams['is_active'] = 1;
-      $optionGroup = CRM_Core_BAO_OptionGroup::retrieve($groupParams, $defaults);
-    }
+    $groupParams = ['name' => $optionGroupName, 'is_active' => 1];
+    $optionGroup = CRM_Core_BAO_OptionGroup::retrieve($groupParams, $defaults);
 
-    // if the corresponding group doesn't exist, create one, provided $groupParams has 'name' in it.
+    // if the corresponding group doesn't exist, create one.
     if (!$optionGroup->id) {
-      if ($groupParams['name']) {
-        $newOptionGroup = CRM_Core_BAO_OptionGroup::add($groupParams, $defaults);
-        $params['weight'] = 1;
-        $optionGroupID = $newOptionGroup->id;
-      }
+      $newOptionGroup = CRM_Core_BAO_OptionGroup::add($groupParams);
+      $params['weight'] = 1;
+      $optionGroupID = $newOptionGroup->id;
     }
     else {
       $optionGroupID = $optionGroup->id;

--- a/CRM/Report/Form/Register.php
+++ b/CRM/Report/Form/Register.php
@@ -191,8 +191,7 @@ class CRM_Report_Form_Register extends CRM_Core_Form {
       // get the submitted form values.
       $params = $this->controller->exportValues($this->_name);
 
-      $groupParams = array('name' => ('report_template'));
-      $optionValue = CRM_Core_OptionValue::addOptionValue($params, $groupParams, $this->_action, $this->_id);
+      $optionValue = CRM_Core_OptionValue::addOptionValue($params, 'report_template', $this->_action, $this->_id);
       CRM_Core_Session::setStatus(ts('The %1 \'%2\' has been saved.', array(
             1 => 'Report Template',
             2 => $optionValue->label,

--- a/api/v3/ActivityType.php
+++ b/api/v3/ActivityType.php
@@ -72,13 +72,12 @@ function civicrm_api3_activity_type_get($params) {
 function civicrm_api3_activity_type_create($params) {
 
   $action = 1;
-  $groupParams = array('name' => 'activity_type');
 
   if ($optionValueID = CRM_Utils_Array::value('option_value_id', $params)) {
     $action = 2;
   }
 
-  $activityObject = CRM_Core_OptionValue::addOptionValue($params, $groupParams, $action, $optionValueID);
+  $activityObject = CRM_Core_OptionValue::addOptionValue($params, 'activity_type', $action, $optionValueID);
   $activityType = array();
   _civicrm_api3_object_to_array($activityObject, $activityType[$activityObject->id]);
   return civicrm_api3_create_success($activityType, $params, 'activity_type', 'create');


### PR DESCRIPTION
Overview
----------------------------------------
Minor code simplification

Before
----------------------------------------
no change

After
----------------------------------------
code slightly simplified

Technical Details
----------------------------------------
The addOptionValue function is one we should probably deprecate/ remove but towards that we should start to remove it. 
This commit removes some complexity by passing option_group_name rather than
groupParams - which is a more accurate reflection of usage and removes ambiguity around the passing
by reference

Comments
----------------------------------------
@mattwire can you review this one for me. I'm exploring extending the use of entity forms - but in this case I found something confusing so this is a preliminary clean up
