### PR TITLE
dev/core/issues/232, Some smart groups and some searches not returning any contacts

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1612,7 +1612,7 @@ class CRM_Contact_BAO_Query {
         $contactType = array();
         $subType = array();
         foreach ((array) $values as $key => $type) {
-          $types = explode('__', is_numeric($type) ? $key : $type);
+          $types = explode('__', is_numeric($type) ? $key : $type, 2);
           $contactType[$types[0]] = $types[0];
           // Add sub-type if specified
           if (!empty($types[1])) {

--- a/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -246,7 +246,7 @@ contact_a.sort_name    as sort_name,
       $this->_formValues
     );
     if ($contact_type != NULL) {
-      $contactType = explode('__', $contact_type);
+      $contactType = explode('__', $contact_type, 2);
       if (count($contactType) > 1) {
         $clause[] = "contact_a.contact_type = '$contactType[0]' AND contact_a.contact_sub_type = '$contactType[1]'";
       }

--- a/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
@@ -1,0 +1,94 @@
+<?php
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 5                                                  |
+  +--------------------------------------------------------------------+
+  | Copyright CiviCRM LLC (c) 2004-2018                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for CRM_Contact_BAO_Group BAO
+ *
+ * @package CiviCRM
+ * @group headless
+ */
+class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
+
+  /**
+   * Test contact sub type search.
+   */
+  public function testContactSubtype() {
+    foreach (['Contact_sub_type', 'Contact2__sub__type'] as $contactSubType) {
+      $subType = $this->callAPISuccess('ContactType', 'create', [
+        'name' => $contactSubType,
+        'label' => $contactSubType,
+        'is_active' => 1,
+        'parent_id' => "Individual",
+      ]);
+      // Contact Type api munge name in create mode
+      // Therefore updating the name in update mode
+      $this->callAPISuccess('ContactType', 'create', [
+        'name' => $contactSubType,
+        'id' => $subType['id'],
+      ]);
+    }
+    $this->searchContacts('Contact_sub_type');
+    $this->searchContacts('Contact2__sub__type');
+  }
+
+  protected function searchContacts($contactSubType) {
+    // create contact
+    $params = [
+      'first_name' => 'Peter' . substr(sha1(rand()), 0, 4),
+      'last_name' => 'Lastname',
+      'contact_type' => 'Individual',
+      'contact_sub_type' => $contactSubType,
+    ];
+    $contacts = $this->callAPISuccess('Contact', 'create', $params);
+    $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements(TRUE);
+    foreach ($contactTypes as $contactType => $ignore) {
+      if (strpos($contactType, $contactSubType) !== FALSE) {
+        $formValues = [
+          'contact_type' => $contactType,
+        ];
+        break;
+      }
+    }
+    CRM_Contact_BAO_Query::convertFormValues($formValues);
+    $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($formValues));
+    list($select, $from, $where, $having) = $query->query();
+    // get and assert contact count
+    $contactsResult = CRM_Core_DAO::executeQuery(sprintf('SELECT DISTINCT contact_a.id %s %s', $from, $where))->fetchAll();
+    foreach ($contactsResult as $key => $value) {
+      $contactsResult[$key] = $value['id'];
+    }
+    // assert the contacts count
+    $this->assertEquals(1, count($contactsResult));
+    // assert the contact IDs
+    $expectedResult = [$contacts['id']];
+    $this->checkArrayEquals($expectedResult, $contactsResult);
+    // get and assert qill string
+    $qill = trim(implode($query->getOperator(), CRM_Utils_Array::value(0, $query->qill())));
+    $this->assertEquals("Contact Type In IndividualANDContact Subtype Like {$contactSubType}", $qill);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/232

Before
----------------------------------------
Return no result when searched with contact sub type having name ='City_Farm__Community_Garden'

After
----------------------------------------
Return results when searched with contact sub type having name ='City_Farm__Community_Garden'


Technical Details
----------------------------------------

Since the name field as two '_' and the [code](https://github.com/civicrm/civicrm-core/commit/46b3417a0#diff-e54381bfdf51e31cab376c71ca0d66ffR1516) explodes the string using '__' it tries to search contact sub type IN ('City_Farm'). Hence the search doesn't show any results. 