### PR TITLE
Follow up to PR 12160 to update the DB version of the templates

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -79,6 +79,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'contribution_online_receipt', 'type' => 'html'],
           ['name' => 'event_online_receipt', 'type' => 'text'],
           ['name' => 'event_online_receipt', 'type' => 'html'],
+          ['name' => 'event_online_receipt', 'type' => 'subject'],
         ]
       ],
     ];


### PR DESCRIPTION
This just updates the DB version of the event registration templates following the changes in PR 12160
