### PR TITLE
Ensure that the .mysql.tpl file is run for 5.3.alpha1

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveThree.php
@@ -75,6 +75,7 @@ class CRM_Upgrade_Incremental_php_FiveThree extends CRM_Upgrade_Incremental_Base
    * @param string $rev
    */
   public function upgrade_5_3_alpha1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('CRM-19948 - Add created_id column to civicrm_file', 'addFileCreatedIdColumn');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When we create the php upgrade function for a version we must make sure that the runsql is processed

ping @totten @colemanw @eileenmcnaughton @monishdeb @guanhuan 