### PR TITLE
WIP View test event registrations on contact summary (event tab)

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -332,7 +332,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     }
 
     // We don't show test records in summaries or dashboards
-    if (empty($this->_formValues['participant_test']) && $this->_force) {
+    if (empty($this->_formValues['participant_test']) && $this->_force && ($this->_context !== 'participant')) {
       $this->_formValues["participant_test"] = 0;
     }
 

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -182,9 +182,15 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
   }
 
   public function setContext() {
-    $context = CRM_Utils_Request::retrieve('context',
-      'String', $this, FALSE, 'search'
-    );
+    $urlPath = implode('/', isset($this->urlPath) ? $this->urlPath : NULL);
+    if ($urlPath == 'civicrm/contact/view/participant') {
+      $context = 'participant';
+    }
+    else {
+      $context = CRM_Utils_Request::retrieve('context',
+        'String', $this, FALSE, 'search'
+      );
+    }
     $compContext = CRM_Utils_Request::retrieve('compContext',
       'String', $this
     );


### PR DESCRIPTION
Overview
----------------------------------------
**REQUIRES CONCEPT REVIEW AND APPROVAL**

Show test registrations on event tab in contact summary.  (Related to #12385).

Before
----------------------------------------
Test registrations not shown.

After
----------------------------------------
Test registrations shown.

Technical Details
----------------------------------------
Most of the contact tabs use an implementation of `CRM_Core_Form_Search` to retrieve/show results.  In this case `CRM_Event_Form_Search`.

1. In order to make sure results are always up to date and not cached the `force=1` parameter is automatically passed to the search form class.
2. However, this `force=1` parameter is also used to assume that we don't want test transactions.
3. When `CRM_Event_Form_Search` is triggered from the contact tab the context parameter is not set and defaults to "search" which is used in quite a few other places (where we probably don't want test transactions?).
4. The *correct* context, looking at the `switch($context)` seems to be 'participant' so we set that using urlPath.
5. We can then test if context = participant, and show test transactions if that is the case.

@pradpnayak Could you comment?  Do you think there would be a better way to do this?  It will need to be done for other entities (eg. Pledge, Case).