### PR TITLE
dev/core#176 Odd / Even street number sort column missing from Reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1069,6 +1069,15 @@ class CRM_Report_Form extends CRM_Core_Form {
   }
 
   /**
+   * Getter for $_params.
+   *
+   * @return void|array $params
+   */
+  public function getParams() {
+    return $this->_params;
+  }
+
+  /**
    * Setter for $_id.
    *
    * @param int $instanceID
@@ -5480,6 +5489,16 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'title' => ts($options['prefix_label'] . 'Street Number'),
         'type' => 1,
         'is_fields' => TRUE,
+      ),
+      $options['prefix'] . 'odd_street_number' => array(
+        'title' => ts('Odd / Even Street Number'),
+        'name' => 'odd_street_number',
+        'type' => CRM_Utils_Type::T_INT,
+        'no_display' => TRUE,
+        'required' => TRUE,
+        'dbAlias' => '(address_civireport.street_number % 2)',
+        'is_fields' => TRUE,
+        'is_order_bys' => TRUE,
       ),
       $options['prefix'] . 'street_name' => array(
         'name' => 'street_name',

--- a/CRM/Report/Form/Walklist/Walklist.php
+++ b/CRM/Report/Form/Walklist/Walklist.php
@@ -76,55 +76,6 @@ class CRM_Report_Form_Walklist_Walklist extends CRM_Report_Form {
           ),
         ),
       ),
-      'civicrm_address' => array(
-        'dao' => 'CRM_Core_DAO_Address',
-        'fields' => array(
-          'street_number' => array(
-            'title' => ts('Street Number'),
-            'type' => 1,
-          ),
-          'street_address' => NULL,
-          'city' => NULL,
-          'postal_code' => NULL,
-          'state_province_id' => array(
-            'title' => ts('State/Province'),
-            'default' => TRUE,
-            'type' => CRM_Utils_Type::T_INT,
-          ),
-          'country_id' => array(
-            'title' => ts('Country'),
-          ),
-          'odd_street_number' => array(
-            'title' => ts('Odd/Even Street Number'),
-            'type' => CRM_Utils_Type::T_INT,
-            'no_display' => TRUE,
-            'required' => TRUE,
-            'dbAlias' => '(address_civireport.street_number % 2)',
-          ),
-        ),
-        'filters' => array(
-          'street_number' => array(
-            'title' => ts('Street Number'),
-            'type' => 1,
-            'name' => 'street_number',
-          ),
-          'street_address' => NULL,
-          'city' => NULL,
-        ),
-        'order_bys' => array(
-          'street_name' => array(
-            'title' => ts('Street Name'),
-          ),
-          'street_number' => array(
-            'title' => ts('Street Number'),
-          ),
-          'odd_street_number' => array(
-            'title' => ts('Odd/Even Street Number'),
-            'dbAlias' => 'civicrm_address_odd_street_number',
-          ),
-        ),
-        'grouping' => 'location-fields',
-      ),
       'civicrm_email' => array(
         'dao' => 'CRM_Core_DAO_Email',
         'fields' => array('email' => array('default' => TRUE)),
@@ -135,7 +86,7 @@ class CRM_Report_Form_Walklist_Walklist extends CRM_Report_Form {
         'fields' => array('phone' => NULL),
         'grouping' => 'location-fields',
       ),
-    );
+    ) + $this->getAddressColumns(array('group_bys' => FALSE));
     parent::__construct();
   }
 

--- a/tests/phpunit/CRM/Report/Form/ContactSummaryTest.php
+++ b/tests/phpunit/CRM/Report/Form/ContactSummaryTest.php
@@ -1,0 +1,199 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test Contact Summary report outcome
+ *
+ * @package CiviCRM
+ */
+class CRM_Report_Form_ContactSummaryTest extends CiviReportTestCase {
+  protected $_tablesToTruncate = array(
+    'civicrm_contact',
+    'civicrm_email',
+    'civicrm_phone',
+    'civicrm_address',
+  );
+
+  public function setUp() {
+    parent::setUp();
+    $this->quickCleanup($this->_tablesToTruncate);
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Ensure the new Odd/Event street number sort column works correctly
+   */
+  public function testOddEvenStreetNumber() {
+    // Create 5 contacts where:
+    //  Contact A - Odd Street number - 3
+    //  Contact B - Odd Street number - 5
+    //  Contact C - Even Street number - 2
+    //  Contact D - Even Street number - 4
+    //  Contact E - No Street number
+    $contactIDs = [
+      'odd_street_number_1' => $this->individualCreate([
+        'api.Address.create' => [
+          'location_type_id' => 1,
+          'is_primary' => 1,
+          'street_number' => 3,
+        ]
+      ]),
+      'odd_street_number_2' => $this->individualCreate([
+        'api.Address.create' => [
+          'location_type_id' => 1,
+          'is_primary' => 1,
+          'street_number' => 5,
+        ]
+      ]),
+      'even_street_number_1' => $this->individualCreate([
+        'api.Address.create' => [
+          'location_type_id' => 1,
+          'is_primary' => 1,
+          'street_number' => 2,
+        ]
+      ]),
+      'even_street_number_2' => $this->individualCreate([
+        'api.Address.create' => [
+          'location_type_id' => 1,
+          'is_primary' => 1,
+          'street_number' => 4,
+        ]
+      ]),
+      'no_street_number' => $this->individualCreate(),
+    ];
+
+    $input = [
+      'fields' => [
+        'address_street_number',
+        'address_odd_street_number',
+      ],
+    ];
+    $obj = $this->getReportObject('CRM_Report_Form_Contact_Summary', $input);
+
+    $expectedCases = [
+      // CASE A: Sorting by odd street number in desc order + street number in desc order
+      [
+        'order_bys' => [
+          [
+            'column' => 'address_odd_street_number',
+            'order' => 'DESC',
+          ],
+          [
+            'column' => 'address_street_number',
+            'order' => 'DESC',
+          ],
+        ],
+        'expected_contact_ids' => [
+          $contactIDs['odd_street_number_2'],
+          $contactIDs['odd_street_number_1'],
+          $contactIDs['even_street_number_2'],
+          $contactIDs['even_street_number_1'],
+          $contactIDs['no_street_number'],
+        ],
+        'expected_orderby_clause' => 'ORDER BY (address_civireport.street_number % 2) DESC, address_civireport.street_number DESC',
+      ],
+      // CASE B: Sorting by odd street number in asc order + street number in desc order
+      [
+        'order_bys' => [
+          [
+            'column' => 'address_odd_street_number',
+            'order' => 'ASC',
+          ],
+          [
+            'column' => 'address_street_number',
+            'order' => 'DESC',
+          ],
+        ],
+        'expected_contact_ids' => [
+          $contactIDs['no_street_number'],
+          $contactIDs['even_street_number_2'],
+          $contactIDs['even_street_number_1'],
+          $contactIDs['odd_street_number_2'],
+          $contactIDs['odd_street_number_1'],
+        ],
+        'expected_orderby_clause' => 'ORDER BY (address_civireport.street_number % 2) ASC, address_civireport.street_number DESC',
+      ],
+      // CASE C: Sorting by odd street number in desc order + street number in asc order
+      [
+        'order_bys' => [
+          [
+            'column' => 'address_odd_street_number',
+            'order' => 'DESC',
+          ],
+          [
+            'column' => 'address_street_number',
+            'order' => 'ASC',
+          ],
+        ],
+        'expected_contact_ids' => [
+          $contactIDs['odd_street_number_1'],
+          $contactIDs['odd_street_number_2'],
+          $contactIDs['even_street_number_1'],
+          $contactIDs['even_street_number_2'],
+          $contactIDs['no_street_number'],
+        ],
+        'expected_orderby_clause' => 'ORDER BY (address_civireport.street_number % 2) DESC, address_civireport.street_number ASC',
+      ],
+      // CASE A: Sorting by odd street number in asc order + street number in asc order
+      [
+        'order_bys' => [
+          [
+            'column' => 'address_odd_street_number',
+            'order' => 'ASC',
+          ],
+          [
+            'column' => 'address_street_number',
+            'order' => 'ASC',
+          ],
+        ],
+        'expected_contact_ids' => [
+          $contactIDs['no_street_number'],
+          $contactIDs['even_street_number_1'],
+          $contactIDs['even_street_number_2'],
+          $contactIDs['odd_street_number_1'],
+          $contactIDs['odd_street_number_2'],
+        ],
+        'expected_orderby_clause' => 'ORDER BY (address_civireport.street_number % 2) ASC, address_civireport.street_number ASC',
+      ],
+    ];
+
+    foreach ($expectedCases as $case) {
+      $obj->setParams(array_merge($obj->getParams(), ['order_bys' => $case['order_bys']]));
+      $sql = $obj->buildQuery();
+      $rows = CRM_Core_DAO::executeQuery($sql)->fetchAll();
+
+      // check the order of contact IDs
+      $this->assertEquals($case['expected_contact_ids'], CRM_Utils_Array::collect('civicrm_contact_id', $rows));
+      // check the order clause
+      $this->assertEquals(TRUE, !empty(strstr($sql, $case['expected_orderby_clause'])));
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds new Odd/Even street number sort column 

Before
----------------------------------------
 Odd/Even street number sort column missing

After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/42320183-154d0318-8072-11e8-9bea-ce13a904dda0.gif)

Comments
----------------------------------------
In order to sort Even Street Number column in  ascending order then select:
1. Odd / Even Street Number in ascending order.
2. Street number in ascending order.
3. Street number is not empty.
Please check the screencast above for details.