### PR TITLE
dev/core#155 Fix optiongroup is_reserved data and use when selecting option group for custom fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2030,6 +2030,8 @@ AND    cf.id = %1";
   /**
    * Get custom option groups.
    *
+   * @deprecated Use the API OptionGroup.get
+   *
    * @param array $includeFieldIds
    *   Ids of custom fields for which option groups must be included.
    *

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -230,6 +230,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         $optionGroup->name = "{$columnName}_" . date('YmdHis');
         $optionGroup->title = $params['label'];
         $optionGroup->is_active = 1;
+        // Don't set reserved as it's not a built-in option group and may be useful for other custom fields.
+        $optionGroup->is_reserved = 0;
         $optionGroup->data_type = $dataType;
         $optionGroup->save();
         $params['option_group_id'] = $optionGroup->id;

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -318,21 +318,26 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     if ($this->_action == CRM_Core_Action::UPDATE) {
       $this->freeze('data_type');
     }
-    $includeFieldIds = NULL;
+
+    $optionGroupParams = [
+      'is_reserved' => 0,
+      'is_active' => 1,
+      'options' => ['limit' => 0, 'sort' => "title ASC"],
+      'return' => ['title'],
+    ];
     if ($this->_action == CRM_Core_Action::UPDATE) {
-      $includeFieldIds = $this->_values['id'];
+      $optionGroupParams['id'] = $this->_values['id'];
     }
-    $optionGroups = CRM_Core_BAO_CustomField::customOptionGroup($includeFieldIds);
-    $emptyOptGroup = FALSE;
-    if (empty($optionGroups)) {
-      $emptyOptGroup = TRUE;
-      $optionTypes = array('1' => ts('Create a new set of options'));
-    }
-    else {
-      $optionTypes = array(
-        '1' => ts('Create a new set of options'),
-        '2' => ts('Reuse an existing set'),
-      );
+    // Get all custom (is_reserved=0) option groups
+    $optionGroupMetadata = civicrm_api3('OptionGroup', 'get', $optionGroupParams);
+
+    // OptionGroup selection
+    $optionTypes = array('1' => ts('Create a new set of options'));
+
+    if (!empty($optionGroupMetadata['values'])) {
+      $emptyOptGroup = FALSE;
+      $optionGroups = CRM_Utils_Array::collect('title', $optionGroupMetadata['values']);
+      $optionTypes['2'] = ts('Reuse an existing set');
 
       $this->add('select',
         'option_group_id',
@@ -342,6 +347,10 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
         ) + $optionGroups
       );
     }
+    else {
+      // No custom (non-reserved) option groups
+      $emptyOptGroup = TRUE;
+    }
 
     $element = &$this->addRadio('option_type',
       ts('Option Type'),
@@ -350,6 +359,10 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
         'onclick' => "showOptionSelect();",
       ), '<br/>'
     );
+    // if empty option group freeze the option type.
+    if ($emptyOptGroup) {
+      $element->freeze();
+    }
 
     $contactGroups = CRM_Core_PseudoConstant::group();
     asort($contactGroups);
@@ -369,11 +382,6 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     );
 
     $this->add('hidden', 'filter_selected', 'Group', array('id' => 'filter_selected'));
-
-    //if empty option group freeze the option type.
-    if ($emptyOptGroup) {
-      $element->freeze();
-    }
 
     // form fields of Custom Option rows
     $defaultOption = array();

--- a/CRM/Upgrade/Incremental/sql/5.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.5.alpha1.mysql.tpl
@@ -7,3 +7,10 @@ ALTER TABLE civicrm_option_group MODIFY COLUMN  is_locked TINYINT(4) NOT NULL DE
 #is_reserved already has a default so is effectively required but let's be explicit.
 UPDATE civicrm_option_group SET `is_reserved` = 0 WHERE `is_reserved` IS NULL;
 ALTER TABLE civicrm_option_group MODIFY COLUMN `is_reserved` tinyint(4) NOT NULL DEFAULT 1 COMMENT 'Is this a predefined system option group (i.e. it can not be deleted)?';
+
+#https://lab.civicrm.org/dev/core/issues/155
+{* Fix is_reserved flag on civicrm_option_group table *}
+UPDATE civicrm_option_group AS cog INNER JOIN civicrm_custom_field AS ccf
+ON cog.id = ccf.option_group_id
+SET cog.is_reserved = 0 WHERE cog.is_active = 1 AND ccf.is_active = 1;
+UPDATE civicrm_option_group SET is_reserved = 1 WHERE name='environment';

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -212,7 +212,7 @@ VALUES
    ('wysiwyg_presets'               , '{ts escape="sql"}WYSIWYG Editor Presets{/ts}'             , NULL, 1, 1, 0),
    ('relative_date_filters'         , '{ts escape="sql"}Relative Date Filters{/ts}'              , NULL, 1, 1, 0),
    ('pledge_status'                 , '{ts escape="sql"}Pledge Status{/ts}'                      , NULL, 1, 1, 1),
-   ('environment'                   , '{ts escape="sql"}Environment{/ts}'                        , NULL, 0, 1, 0);
+   ('environment'                   , '{ts escape="sql"}Environment{/ts}'                        , NULL, 1, 1, 0);
 
 SELECT @option_group_id_pcm            := max(id) from civicrm_option_group where name = 'preferred_communication_method';
 SELECT @option_group_id_act            := max(id) from civicrm_option_group where name = 'activity_type';


### PR DESCRIPTION
Overview
----------------------------------------
(Ref: #12235)

As the is_reserved flag is not being shown in the UI, and is not editable from the UI it has not been used for anything in core even though it is there.

A common use-case is adding an option group and then adding a set of custom fields that use that option group (eg. for surveys) but that is currently not possible via the UI because the query that looks for available option groups is looking ONLY for option groups that are already linked to custom fields - a catch 22!

Before
----------------------------------------
Not possible to create optiongroups via the UI that can be used with custom fields.

After
----------------------------------------
Option groups that are created via the UI can be selected for use with custom fields.
![customfieldoptiongroup](https://user-images.githubusercontent.com/2052161/40686294-c4040e3e-638e-11e8-803e-5b430757b589.png)

Technical Details
----------------------------------------
The is_reserved flag has *always* existed in the database but has not been used and has not been set correctly in some cases.

Comments
----------------------------------------
This *fixes* a common UI workflow where you need to create a set of options for use by a set of custom fields (for multiple choice questions/forms/surveys eg. forms used to calculate health scores etc.).

Currently you have to create the set of options along with the first custom field and you have no control over it's name.  Currently, only when created in this way can you select that option group for use by other custom fields.