### PR TITLE
 Ensure users with the perm "CiviEvent: access CiviEvent " can edit events they have created.

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2085,7 +2085,7 @@ WHERE  ce.loc_block_id = $locBlockId";
       // Search again, but only events created by the user.
       $params['created_id'] = 'user_contact_id';
       $result = civicrm_api3('Event', 'get', $params);
-      $createdEvents = CRM_Utils_Array::collect('title', $result['values']);
+      $createdEvents = array_keys($result['values']);
 
       // Note: for a multisite setup, a user with edit all events, can edit all events
       // including those from other sites

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2064,9 +2064,7 @@ WHERE  ce.loc_block_id = $locBlockId";
    *   the permission that the user has (or null)
    */
   public static function checkPermission($eventId = NULL, $type = CRM_Core_Permission::VIEW) {
-    static $permissions = NULL;
-
-    if (empty($permissions)) {
+    if (!isset(Civi::$statics[__CLASS__]['permissions'])) {
       $params = array(
         'check_permissions' => 1,
         'return' => 'title',
@@ -2090,14 +2088,14 @@ WHERE  ce.loc_block_id = $locBlockId";
       // Note: for a multisite setup, a user with edit all events, can edit all events
       // including those from other sites
       if (CRM_Core_Permission::check('edit all events')) {
-        $permissions[CRM_Core_Permission::EDIT] = array_keys($allEvents);
+        Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::EDIT] = array_keys($allEvents);
       }
       else {
-        $permissions[CRM_Core_Permission::EDIT] = CRM_ACL_API::group(CRM_Core_Permission::EDIT, NULL, 'civicrm_event', $allEvents, $createdEvents);
+        Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::EDIT] = CRM_ACL_API::group(CRM_Core_Permission::EDIT, NULL, 'civicrm_event', $allEvents, $createdEvents);
       }
 
       if (CRM_Core_Permission::check('edit all events')) {
-        $permissions[CRM_Core_Permission::VIEW] = array_keys($allEvents);
+        Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::VIEW] = array_keys($allEvents);
       }
       else {
         if (CRM_Core_Permission::check('access CiviEvent') &&
@@ -2108,25 +2106,25 @@ WHERE  ce.loc_block_id = $locBlockId";
           // at the same time also allow any hook to override if needed.
           $createdEvents = array_keys($allEvents);
         }
-        $permissions[CRM_Core_Permission::VIEW] = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_event', $allEvents, $createdEvents);
+        Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::VIEW] = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_event', $allEvents, $createdEvents);
       }
 
-      $permissions[CRM_Core_Permission::DELETE] = array();
+      Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::DELETE] = array();
       if (CRM_Core_Permission::check('delete in CiviEvent')) {
         // Note: we want to restrict the scope of delete permission to
         // events that are editable/viewable (usecase multisite).
         // We can remove array_intersect once we have ACL support for delete functionality.
-        $permissions[CRM_Core_Permission::DELETE] = array_intersect($permissions[CRM_Core_Permission::EDIT],
-          $permissions[CRM_Core_Permission::VIEW]
+        Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::DELETE] = array_intersect(Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::EDIT],
+          Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::VIEW]
         );
       }
     }
 
     if ($eventId) {
-      return in_array($eventId, $permissions[$type]) ? TRUE : FALSE;
+      return in_array($eventId, Civi::$statics[__CLASS__]['permissions'][$type]) ? TRUE : FALSE;
     }
 
-    return $permissions;
+    return Civi::$statics[__CLASS__]['permissions'];
   }
 
   /**

--- a/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
+++ b/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
@@ -42,8 +42,9 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
 
   public function testEditOwnEvent() {
     CRM_Core_Config::singleton()->userPermissionTemp = ['access civievent', 'access CiviCRM', 'view event info'];
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
     $permissions = CRM_Event_BAO_Event::checkPermission($this->_eventId, CRM_Core_Permission::EDIT);
-    $this->assertEquals($permissions, TRUE);
+    $this->assertTrue($permissions);
   }
 
 }

--- a/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
+++ b/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Event_BAO_EventPermissionsTest
+ * @group headless
+ */
+class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+    $this->_contactId = $this->createLoggedInUser();
+    $event = $this->eventCreate(array(
+      'created_id' => $this->_contactId,
+    ));
+    $this->_eventId = $event['id'];
+  }
+
+  public function testEditOwnEvent() {
+    CRM_Core_Config::singleton()->userPermissionTemp = ['access civievent', 'access CiviCRM', 'view event info'];
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_eventId, CRM_Core_Permission::EDIT);
+    $this->assertEquals($permissions, TRUE);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Users with the permission "CiviEvent: access CiviEvent " should be able to edit events they create (regardless of whether they have the permission "CiviEvent: edit all events"). 

Before
----------------------------------------
Users with the permission "CiviEvent: access CiviEvent" could create but not edit their events.

After
----------------------------------------
Users with the permission "CiviEvent: access CiviEvent" can create AND edit their events.

Technical Details
----------------------------------------
It looks like this commit https://github.com/civicrm/civicrm-core/commit/5836c35a0c6f4bd4a4d4543e55cb987055e01377#diff-57f730edc03717d188e539c92cd1a3d9L2047 changed the way that the $createdEvents array was formatted so that the key was the event id and the value was the title of the event while this line https://github.com/civicrm/civicrm-core/blob/5.2.1/CRM/Event/BAO/Event.php#L2126 expects the value to be the event id.
