### PR TITLE
dev/core#239 : Fix title dialog box on hovering form element on Event's configuration backend form

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Registration.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.hlp
@@ -31,7 +31,6 @@
 {ts 1=$ppUrl}If you want to provide an Online Registration page for this event, check the first box below and then complete the fields on this form. You can offer online registration for both Paid and Free events. Paid events require that you have configured a <a href="%1">payment processor</a> for your site.{/ts}
 {ts}You may also configure events to require administrative approval prior to participants completing the registration process. To enable this feature you must first enable the Participant Statuses used by the approval work-flow (Administer » CiviEvent » Participant Statuses). Then reload this form and check 'Require participant approval?'.{/ts}
 {/htxt}
-
 {htxt id="event-profile-title"}
   {ts}Profile{/ts}
 {/htxt}
@@ -51,14 +50,12 @@
         {ts 1=$docLinkCustom 2=$docLinkProfile}Refer to the online documentation for more details on creating %1 and %2.{/ts}
 </p>
 {/htxt}
-
 {htxt id="id-link_text-title"}
   {ts}Registration Link{/ts}
 {/htxt}
 {htxt id="id-link_text"}
 {ts}Display text for link from Event Information to Event Registration pages (e.g. 'Register Now!').{/ts}
 {/htxt}
-
 {htxt id="id-allow_multiple-title"}
   {ts}Multiple Participants{/ts}
 {/htxt}
@@ -66,7 +63,6 @@
 <p>{ts}Check this box to allow users to register themselves AND additional participants for an event. When this feature is enabled, users have the option to specify the number of additional participants they are registering for. If this is a paid event, they can select a different event fees for each participant - and will be charged the total of those fees. If a profile is included - they will complete the profile information for each participant.{/ts}</p>
 <p>{ts}You can use different profile for the person who is registering than for "Additional Participants". For example, you may want to require an email address from the person entering the registration while not requiring (or even requesting) emails for additional participants (i.e. their "guests").{/ts}</p>
 {/htxt}
-
 {htxt id="id-max_additional-title"}
   {ts}Maximum Additional Participants{/ts}
 {/htxt}
@@ -74,35 +70,30 @@
   <p>{ts}Limit the number of additional participants that can be registered in a single booking.{/ts}</p>
   <p>{ts}Eg: if you choose '2' then the lead booker can bring 2 guests; there would be a limit of 3 participants in total per booking.{/ts}</p>
 {/htxt}
-
 {htxt id="id-allow_same_email-title"}
   {ts}Allow Shared Email{/ts}
 {/htxt}
 {htxt id="id-allow_same_email"}
 <p>{ts}Check this box to allow a user to register multiple participants using the same email address. Alternatively, if you want additional participants to be registered <strong>without requiring an email address to be entered for each person</strong> - check the "Register multiple participants" option, AND include a profile in this registration form which <strong>includes First Name and Last Name fields</strong>.{/ts}</p>
 {/htxt}
-
 {htxt id="id-dedupe_rule_group_id-title"}
   {ts}Duplicate Matching Rule{/ts}
 {/htxt}
 {htxt id="id-dedupe_rule_group_id"}
 <p>{ts}By default, your event will use the Unsupervised duplicate matching rule to match participants in anonymous registrations with existing individuals. You may select another rule to use for this event instead. Make sure that your included profile(s) contain the fields needed by your matching rule.{/ts}</p>
 {/htxt}
-
 {htxt id="id-requires_approval-title"}
   {ts}Require Approval{/ts}
 {/htxt}
 {htxt id="id-requires_approval"}
 {ts}Check this box to require administrative approval for all the participants who self-register, prior to being able to complete the registration process. Participants will be placed in 'Awaiting Approval' status. You can review and approve participants from 'Find Participants' - select the 'Participant status - change' task. Approved participants will move to 'Pending from approval' status, and will be sent an email with a link to complete their registration (including paying event fees - if any). {/ts}
 {/htxt}
-
 {htxt id="id-expiration_time-title"}
   {ts}Time Limit{/ts}
 {/htxt}
 {htxt id="id-expiration_time"}
 {ts}Time limit <strong>in hours</strong> for confirming/finishing registration by participants with any of the pending statuses. Enter 0 (or leave empty) to disable this feature.{/ts}
 {/htxt}
-
 {htxt id="id-allow_selfcancelxfer-title"}
   {ts}Allow Self-service Cancellation or Transfer?{/ts}
 {/htxt}
@@ -110,7 +101,6 @@
   <p>{ts}Check this box if you want to allow registered participants to either cancel their registration OR transfer it to another participant. If this feature is enabled, event confirmation emails will include a link to a Cancel or Transfer form.{/ts}</p>
   <p>{ts}<strong>Automated refunds for cancellations are NOT currently supported.</strong> Participants who have paid for an event will be notified that cancellations are not refundable.{/ts}</p>
 {/htxt}
-
 {htxt id="id-selfcancelxfer_time-title"}
   {ts}Cancellation or Transfer Time Limit{/ts}
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Go to 'Manage Event' page
2. Click on 'Online Registration' of any existing/new event configuration page.
3. Hover on any helpicon

Before
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/42372020-c1ad09d4-812e-11e8-96fb-016f5d0f97d1.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/42372087-efee6432-812e-11e8-9e8e-28d737233bca.gif)


