### PR TITLE
this is not a fix, 

### DIFF
--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -280,7 +280,7 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
         ON civicrm_mailing_job.mailing_id = {$this->_aliases['civicrm_mailing']}.id
         AND civicrm_mailing_job.is_test = 0
     ";
-    $this->joinPhoneFromContact();
+    //$this->joinPhoneFromContact();
   }
 
   public function where() {


### PR DESCRIPTION
it's a hack to get the report to stop making this error

Call to undefined method CRM_Report_Form_Mailing_Opened::joinPhoneFromContact()
modules/civicrm/CRM/Report/Form/Mailing/Opened.php on line 283

Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
