### PR TITLE
CRM-21425 make inbound emails editable

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2834,6 +2834,22 @@ INNER JOIN  civicrm_option_group grp ON ( grp.id = val.option_group_id AND grp.n
   }
 
   /**
+   * Checks if user has permissions to edit inbound e-mails, either bsic info
+   * or both basic information and content.
+   *
+   * @return bool
+   */
+  public function checkEditInboundEmailsPermissions() {
+    if (CRM_Core_Permission::check('edit inbound email basic information')
+      || CRM_Core_Permission::check('edit inbound email basic information and content')
+    ) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
    * Wrapper for ajax activity selector.
    *
    * @param array $params

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -523,7 +523,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       // We filter out alternatives, in case this is a stored e-mail, before sending to front-end
-      $this->_values['details'] = CRM_Utils_String::stripAlternatives($this->_values['details']);
+      $this->_values['details'] = CRM_Utils_String::stripAlternatives($this->_values['details']) ?: '';
 
       if ($this->_activityTypeName === 'Inbound Email' &&
         !CRM_Core_Permission::check('edit inbound email basic information and content')

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -516,10 +516,20 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         $params = array('id' => $this->_activityId);
         CRM_Activity_BAO_Activity::retrieve($params, $this->_values);
       }
+
       $this->set('values', $this->_values);
     }
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
+      // We filter out alternatives, in case this is a stored e-mail, before sending to front-end
+      $this->_values['details'] = CRM_Utils_String::stripAlternatives($this->_values['details']);
+
+      if ($this->_activityTypeName === 'Inbound Email' &&
+        !CRM_Core_Permission::check('edit inbound email basic information and content')
+      ) {
+        $this->_fields['details']['type'] = 'static';
+      }
+
       CRM_Core_Form_RecurringEntity::preProcess('civicrm_activity');
     }
 

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -308,6 +308,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       CRM_Activity_BAO_Activity::checkPermission($this->_activityId, CRM_Core_Action::UPDATE)
     ) {
       $this->assign('permission', 'edit');
+      $this->assign('allow_edit_inbound_emails', CRM_Activity_BAO_Activity::checkEditInboundEmailsPermissions());
     }
 
     if (!$this->_activityTypeId && $this->_activityId) {

--- a/CRM/Activity/Page/Tab.php
+++ b/CRM/Activity/Page/Tab.php
@@ -131,6 +131,7 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
 
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->assign('action', $this->_action);
+    $this->assign('allow_edit_inbound_emails', $this->checkEditInboundEmailsPermissions());
 
     // also create the form element for the activity links box
     $controller = new CRM_Core_Controller_Simple(
@@ -141,6 +142,22 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
     );
     $controller->setEmbedded(TRUE);
     $controller->run();
+  }
+
+  /**
+   * Checks if user has permissions to edit inbound e-mails, either bsic info
+   * or both basic information and content.
+   *
+   * @return bool
+   */
+  private function checkEditInboundEmailsPermissions() {
+    if (CRM_Core_Permission::check('edit inbound email basic information')
+      || CRM_Core_Permission::check('edit inbound email basic information and content')
+    ) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
   public function delete() {

--- a/CRM/Activity/Page/Tab.php
+++ b/CRM/Activity/Page/Tab.php
@@ -131,7 +131,7 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
 
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->assign('action', $this->_action);
-    $this->assign('allow_edit_inbound_emails', $this->checkEditInboundEmailsPermissions());
+    $this->assign('allow_edit_inbound_emails', CRM_Activity_BAO_Activity::checkEditInboundEmailsPermissions());
 
     // also create the form element for the activity links box
     $controller = new CRM_Core_Controller_Simple(
@@ -142,22 +142,6 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
     );
     $controller->setEmbedded(TRUE);
     $controller->run();
-  }
-
-  /**
-   * Checks if user has permissions to edit inbound e-mails, either bsic info
-   * or both basic information and content.
-   *
-   * @return bool
-   */
-  private function checkEditInboundEmailsPermissions() {
-    if (CRM_Core_Permission::check('edit inbound email basic information')
-      || CRM_Core_Permission::check('edit inbound email basic information and content')
-    ) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
   public function delete() {

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -181,6 +181,13 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
       case 'Inbound Email':
         $url = 'civicrm/contact/view/activity';
         $qsView = "atype={$activityTypeId}&action=view&reset=1&id=%%id%%&cid=%%cid%%&context=%%cxt%%{$extraParams}";
+
+        if (CRM_Core_Permission::check('edit inbound email basic information')
+          || CRM_Core_Permission::check('edit inbound email basic information and content')
+        ) {
+          $showDelete = $showUpdate = TRUE;
+          $qsUpdate = "atype={$activityTypeId}&action=update&reset=1&id=%%id%%&cid=%%cid%%&context=%%cxt%%{$extraParams}";
+        }
         break;
 
       case 'Open Case':

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2745,6 +2745,12 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
       //allow edit operation.
       $allowEditNames = array('Open Case');
 
+      if (CRM_Core_Permission::check('edit inbound email basic information') ||
+        CRM_Core_Permission::check('edit inbound email basic information and content')
+      ) {
+        $allowEditNames[] = 'Inbound Email';
+      }
+
       // do not allow File on Case
       $doNotFileNames = array(
         'Open Case',

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -761,6 +761,14 @@ class CRM_Core_Permission {
       'delete activities' => array(
         $prefix . ts('Delete activities'),
       ),
+      'edit inbound email basic information' => array(
+        $prefix . ts('edit inbound email basic information'),
+        ts('Edit all inbound email activities (for visible contacts) basic information. Content editing not allowed.'),
+      ),
+      'edit inbound email basic information and content' => array(
+        $prefix . ts('edit inbound email basic information and content'),
+        ts('Edit all inbound email activities (for visible contacts) basic information and content.'),
+      ),
       'access CiviCRM' => array(
         $prefix . ts('access CiviCRM backend and API'),
         ts('Master control for access to the main CiviCRM backend and API. Give to trusted roles only.'),

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -152,15 +152,9 @@
   </tr>
   <tr class="crm-activity-form-block-details">
     <td class="label">{$form.details.label}</td>
-    {if $activityTypeName eq "Print PDF Letter"}
-      <td class="view-value">
-      {$form.details.html}
-      </td>
-      {else}
-      <td class="view-value">
-       {$form.details.html|crmStripAlternatives|nl2br}
-      </td>
-    {/if}
+    <td class="view-value">
+     {$form.details.html}
+    </td>
   </tr>
   <tr class="crm-activity-form-block-priority_id">
     <td class="label">{$form.priority_id.label}</td><td class="view-value">{$form.priority_id.html}</td>
@@ -247,7 +241,7 @@
   {/if} {* End Delete vs. Add / Edit action *}
   </table>
   <div class="crm-submit-buttons">
-  {if $action eq 4 && $activityTName neq 'Inbound Email'}
+  {if $action eq 4 && ($activityTName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
     {if !$context }
       {assign var="context" value='activity'}
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
On some business cases, it may be required to be able to edit an activity type of 'Inbound E-mail', for example, to add an observation or edit some custom fields to implement some kind of workflow. However, this is currently not possible, as the prohibition for this type of activities is hard-coded in several parts within CiviCRM.

NOTE: This is the same pr as #11282 but with the merge conflict fixed. See the documentation on #11282  and 
CRM-21425 for more info

Before
-------------------------------------
Restrictions to make 'Inbound E-mail' activities uneditable were hard-coded into several parts of the CRM, making it impossible for users to edit these types of activities.

After
------------------------------------
Two new permission are added to core to restrict editing inbound emails instead of the restrictions being hardcoded

1. edit inbound email basic information - Edit all inbound email activities (for visible contacts) basic information. Content editing not allowed.'
2. edit inbound email basic information and content - Edit all inbound email activities (for visible contacts) basic information and content.')
---

 * [CRM-21425: Make 'Inbound E-mail' Activities Editable](https://issues.civicrm.org/jira/browse/CRM-21425)