### PR TITLE
dev/core#242 Fix display of premiums on contribution page

### DIFF
--- a/CRM/Contribute/BAO/ManagePremiums.php
+++ b/CRM/Contribute/BAO/ManagePremiums.php
@@ -50,7 +50,7 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_BAO_Product {
    * @param array $defaults
    *   (reference ) an assoc array to hold the flattened values.
    *
-   * @return CRM_Contribute_BAO_ManagePremiums
+   * @return CRM_Contribute_BAO_Product
    */
   public static function retrieve(&$params, &$defaults) {
     CRM_Core_Error::deprecatedFunctionWarning('CRM_Contribute_BAO_Product::retrieve');

--- a/CRM/Contribute/BAO/Premium.php
+++ b/CRM/Contribute/BAO/Premium.php
@@ -104,31 +104,33 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
   public static function buildPremiumBlock(&$form, $pageID, $formItems = FALSE, $selectedProductID = NULL, $selectedOption = NULL) {
     $form->add('hidden', "selectProduct", $selectedProductID, array('id' => 'selectProduct'));
 
-    $dao = new CRM_Contribute_DAO_Premium();
-    $dao->entity_table = 'civicrm_contribution_page';
-    $dao->entity_id = $pageID;
-    $dao->premiums_active = 1;
-    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::ADD);
-    $addWhere = "financial_type_id IN (0)";
-    if (!empty($financialTypes)) {
-      $addWhere = "financial_type_id IN (" . implode(',', array_keys($financialTypes)) . ")";
-    }
+    $premiumDao = new CRM_Contribute_DAO_Premium();
+    $premiumDao->entity_table = 'civicrm_contribution_page';
+    $premiumDao->entity_id = $pageID;
+    $premiumDao->premiums_active = 1;
 
-    if ($dao->find(TRUE)) {
-      $premiumID = $dao->id;
+    if ($premiumDao->find(TRUE)) {
+      $premiumID = $premiumDao->id;
       $premiumBlock = array();
-      CRM_Core_DAO::storeValues($dao, $premiumBlock);
+      CRM_Core_DAO::storeValues($premiumDao, $premiumBlock);
 
-      $dao = new CRM_Contribute_DAO_PremiumsProduct();
-      $dao->premiums_id = $premiumID;
-      $dao->whereAdd($addWhere);
-      $dao->orderBy('weight');
-      $dao->find();
+      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::ADD);
+      $addWhere = "financial_type_id IN (0)";
+      if (!empty($financialTypes)) {
+        $addWhere = "financial_type_id IN (" . implode(',', array_keys($financialTypes)) . ")";
+      }
+      $addWhere = "{$addWhere} OR financial_type_id IS NULL";
+
+      $premiumsProductDao = new CRM_Contribute_DAO_PremiumsProduct();
+      $premiumsProductDao->premiums_id = $premiumID;
+      $premiumsProductDao->whereAdd($addWhere);
+      $premiumsProductDao->orderBy('weight');
+      $premiumsProductDao->find();
 
       $products = array();
-      while ($dao->fetch()) {
+      while ($premiumsProductDao->fetch()) {
         $productDAO = new CRM_Contribute_DAO_Product();
-        $productDAO->id = $dao->product_id;
+        $productDAO->id = $premiumsProductDao->product_id;
         $productDAO->is_active = 1;
         if ($productDAO->find(TRUE)) {
           if ($selectedProductID != NULL) {

--- a/CRM/Contribute/BAO/Product.php
+++ b/CRM/Contribute/BAO/Product.php
@@ -134,13 +134,9 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
     $premiumsProduct = new CRM_Contribute_DAO_PremiumsProduct();
     $premiumsProduct->product_id = $productID;
     if ($premiumsProduct->find(TRUE)) {
-      $session = CRM_Core_Session::singleton();
-      $message .= ts('This Premium is being linked to <a href=\'%1\'>Online Contribution page</a>. Please remove it in order to delete this Premium.', array(1 => CRM_Utils_System::url('civicrm/admin/contribute', 'reset=1')), ts('Deletion Error'), 'error');
-      CRM_Core_Session::setStatus($message);
-      return CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/contribute/managePremiums', 'reset=1&action=browse'));
+      throw new CRM_Core_Exception('Cannot delete a Premium that is linked to a Contribution page');
     }
-
-    //delete from financial Type table
+    // delete product
     $premium = new CRM_Contribute_DAO_Product();
     $premium->id = $productID;
     $premium->delete();

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -376,7 +376,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
 
     $this->assertEquals('TEST Premium', $premium->name, 'Check for premium  name.');
 
-    $param = array(
+    $contributionParams = array(
       'contact_id' => $contactId,
       'currency' => 'USD',
       'financial_type_id' => 1,
@@ -395,9 +395,9 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'thankyou_date' => '20080522',
       'sequential' => TRUE,
     );
-    $contribution = $this->callAPISuccess('Contribution', 'create', $param)['values'][0];
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams)['values'][0];
 
-    $this->assertEquals($param['trxn_id'], $contribution['trxn_id'], 'Check for transcation id creation.');
+    $this->assertEquals($contributionParams['trxn_id'], $contribution['trxn_id'], 'Check for transcation id creation.');
     $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     //parameter for adding premium to contribution

--- a/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
@@ -50,7 +50,6 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
     );
 
     $product = CRM_Contribute_BAO_Product::create($params);
-
     $result = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
       'sku', 'id',
       'Database check on updated product record.'
@@ -120,14 +119,13 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
     );
 
     $product = CRM_Contribute_BAO_Product::create($params);
-
     CRM_Contribute_BAO_Product::del($product->id);
 
     $params = array('id' => $product->id);
-    $default = array();
-    $result = CRM_Contribute_BAO_Product::retrieve($params, $defaults);
+    $defaults = array();
+    $retrievedProduct = CRM_Contribute_BAO_Product::retrieve($params, $defaults);
 
-    $this->assertEquals(empty($result), TRUE, 'Verify product record deletion.');
+    $this->assertEquals(empty($retrievedProduct), TRUE, 'Verify product record deletion.');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
If a premium product is created with no financial type and then added to a contribution page it is not displayed because the contribution page is only selecting those with a financial type, but financial type is optional unless you have configured a cost for the product.

Furthermore, if you update the premium product to have a financial type that is not mirrored to the civicrm_premium_product table which contains the configuration for the premium products available on a contribution page.

Before
----------------------------------------
Premium products not displayed on contribution pages if they didn't have a financial type configured when the were added to the contribution page.

After
----------------------------------------
- Premium products displayed on contribution pages whether or not they have a financial type configured.
- Financial type for civicrm_premium_product (stores config for premium products on contribution pages) updated whenever the product is updated.

Technical Details
----------------------------------------
We were filtering by financial type but it is allowed to have a premium product configured with no financial type.

Comments
----------------------------------------
@pradpnayak Could you review please once #12435 and #12436 are merged?
