### PR TITLE
(dev/core#217) CRM_Contact_Selector::getRows() - Use generator instead of DAO loop

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -579,10 +579,10 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // note that the default action is basic
     if ($rowCount) {
       $cacheKey = $this->buildPrevNextCache($sort);
-      $result = $this->_query->getCachedContacts($cacheKey, $offset, $rowCount, $includeContactIds);
+      $resultSet = $this->_query->getCachedContacts($cacheKey, $offset, $rowCount, $includeContactIds)->fetchGenerator();
     }
     else {
-      $result = $this->_query->searchQuery($offset, $rowCount, $sort, FALSE, $includeContactIds);
+      $resultSet = $this->_query->searchQuery($offset, $rowCount, $sort, FALSE, $includeContactIds)->fetchGenerator();
     }
 
     // process the result of the query
@@ -671,7 +671,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       );
     }
 
-    while ($result->fetch()) {
+    foreach ($resultSet as $result) {
       $row = array();
       $this->_query->convertToPseudoNames($result);
       // the columns we are interested in

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1115,6 +1115,29 @@ FROM   civicrm_domain
   }
 
   /**
+   * Return the results as PHP generator.
+   *
+   * @param string $type
+   *   Whether the generator yields 'dao' objects or 'array's.
+   */
+  public function fetchGenerator($type = 'dao') {
+    while ($this->fetch()) {
+      switch ($type) {
+        case 'dao':
+          yield $this;
+          break;
+
+        case 'array':
+          yield $this->toArray();
+          break;
+
+        default:
+          throw new \RuntimeException("Invalid record type ($type)");
+      }
+    }
+  }
+
+  /**
    * Returns a singular value.
    *
    * @return mixed|NULL

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -422,6 +422,34 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     return $constants;
   }
 
+  public function testFetchGeneratorDao() {
+    $this->individualCreate([], 0);
+    $this->individualCreate([], 1);
+    $this->individualCreate([], 2);
+    $count = 0;
+    $g = CRM_Core_DAO::executeQuery('SELECT contact_type FROM civicrm_contact WHERE contact_type = "Individual" LIMIT 3')
+      ->fetchGenerator();
+    foreach ($g as $row) {
+      $this->assertEquals('Individual', $row->contact_type);
+      $count++;
+    }
+    $this->assertEquals(3, $count);
+  }
+
+  public function testFetchGeneratorArray() {
+    $this->individualCreate([], 0);
+    $this->individualCreate([], 1);
+    $this->individualCreate([], 2);
+    $count = 0;
+    $g = CRM_Core_DAO::executeQuery('SELECT contact_type FROM civicrm_contact WHERE contact_type = "Individual" LIMIT 3')
+      ->fetchGenerator('array');
+    foreach ($g as $row) {
+      $this->assertEquals('Individual', $row['contact_type']);
+      $count++;
+    }
+    $this->assertEquals(3, $count);
+  }
+
   /**
    * @dataProvider serializationMethods
    */


### PR DESCRIPTION
Overview
----------------------------------------
For dev/core#217, we'll want to replace the SQL-backed prevnext cache with a memory-backed prevnext cache. A memory-backed prevnext cache may struggle storing a `DAO` instances -- but it should be quite capable of storing `array()` or `stdClass`. The selector shouldn't be tightly coupled to DAO.

Before
----------------------------------------
* `CRM_Contact_Selector` loops through the list of contacts using DAO loop idiom (`while ($dao->fetch())`).
* Any source of contacts must be based in the DB/DAO.

After
----------------------------------------
* `CRM_Contact_Selector` loops through the list of contacts using a [PHP generator](http://php.net/manual/en/language.generators.overview.php).
* It would be possible to replace `$resultSet` with a different generator -- one that yields instances of `stdClass` instead of `DAO`.

Comments
----------------------------------------
See also:
* https://lab.civicrm.org/dev/core/issues/217
* https://github.com/civicrm/civicrm-core/pull/12377
* http://php.net/manual/en/language.generators.overview.php
