### PR TITLE
dev/core#111 Support Custom Data for MembershipType entity

### DIFF
--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -24,15 +24,12 @@
  +--------------------------------------------------------------------+
 *}
 {* this template is used for adding/editing/deleting membership type  *}
+{if $action eq 8}
+  {include file="CRM/Core/Form/EntityForm.tpl"}
+{else}
 <div class="crm-block crm-form-block crm-membership-type-form-block">
 
   <div class="form-item" id="membership_type_form">
-  {if $action eq 8}
-    <div class="messages status no-popup">
-      {ts}WARNING: Deleting this option will result in the loss of all membership records of this type.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
-    </div>
-    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
-  {else}
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout-compressed">
       <tr class="crm-membership-type-form-block-name">


### PR DESCRIPTION
Overview
----------------------------------------
Enable custom data support on the MembershipType form.

Before
----------------------------------------
Could not view/edit custom data on MembershipType form.

After
----------------------------------------
Can view/edit custom data on MembershipType form.

Technical Details
----------------------------------------
- Add generic helper for setDeleteMessage() in EntityFormTrait so we can simplify translation (one string for all forms instead of one for each form).
- Change CRM/Member/Form/MembershipType.php to use MembershipType.create API instead of BAO add (so we can save custom data).
- Change domain_id to non-mandatory for MembershipType.create API and default to current domain (see https://lab.civicrm.org/dev/core/issues/113 for discussion).
- Convert MembershipType form to use EntityFormTrait so we automatically add custom data to the UI and use more generic code.

Comments
----------------------------------------
@eileenmcnaughton This is a follow on from all the previous ones (eg. #12117, #12118).  It should address all the previous issues.  Also note that I'm now using cg_extends to add MembershipType (you'll either need to add it manually, or install this extension: https://github.com/mattwire/uk.co.mjwconsult.variablerecurpayments
Which will setup cg_extends for you as well as provide some handy MembershipType custom fields for testing :-)