### PR TITLE
dev/core#244 Allow use of custom fields of type select without specifying an optiongroup

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -402,6 +402,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $this->find(TRUE);
     }
 
+    // This will hold the list of options in format key => label
+    $options = [];
+
     if (!empty($this->option_group_id)) {
       $options = CRM_Core_OptionGroup::valuesByID(
         $this->option_group_id,
@@ -420,9 +423,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
     elseif ($this->data_type === 'Boolean') {
       $options = $context == 'validate' ? array(0, 1) : CRM_Core_SelectValues::boolean();
-    }
-    else {
-      return FALSE;
     }
     CRM_Utils_Hook::customFieldOptions($this->id, $options, FALSE);
     CRM_Utils_Hook::fieldOptions($this->getEntity(), "custom_{$this->id}", $options, array('context' => $context));


### PR DESCRIPTION
Overview
----------------------------------------
For an extension I had a requirement to add a "Select Month" custom field.  The options are populated dynamically using hook_civicrm_fieldOptions and there is no need for an option group to be associated with them (manually specifying the months of the year in an optiongroup means they won't be updated to match the current locale).

Additionally, if populated dynamically using the hook_civicrm_fieldOptions and there is an optiongroup associated with the field, the "Edit options" element is automatically added to the UI which is not desirable and does not work properly as the optiongroup is not populated.

There is a single line in CRM_Core_BAO_CustomField::getOptions which causes the function to return before calling hooks if the element is a Select and doesn't have an option group defined which makes it impossible to populate the field using hooks. Removing this allows the hook to populate the custom field values and everything works.

For an example see https://github.com/mattwire/uk.co.mjwconsult.variablerecurpayments (Edit a Membership Type and select the Pro-Rata Start Month).

https://github.com/civicrm/civicrm-core/pull/12439 is also required.

Before
----------------------------------------
Could not dynamically populate a custom field of type select using hooks without specifying an optiongroup as well.

After
----------------------------------------
Can dynamically populate a custom field of type select using hooks without specifying an optiongroup (create the custom field via XML or API).

Technical Details
----------------------------------------
The code makes an assumption in one place that a select element will have an optiongroup.  But this unnecessarily restricts the ability to dynamically populate the fields.

https://lab.civicrm.org/dev/core/issues/244