### PR TITLE
CustomValue gettree api - More accurate permission check

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1473,6 +1473,10 @@ class CRM_Core_Permission {
     $permissions['option_value'] = $permissions['uf_group'];
     $permissions['option_group'] = $permissions['option_value'];
 
+    $permissions['custom_value'] = array(
+      'gettree' => array('access CiviCRM'),
+    );
+
     $permissions['message_template'] = array(
       'get' => array('access CiviCRM'),
       'create' => array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates'),

--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -341,6 +341,7 @@ function civicrm_api3_custom_value_gettree($params) {
   if ($ret || !empty($params['check_permissions'])) {
     $entityData = civicrm_api3($params['entity_type'], 'getsingle', array(
       'id' => $params['entity_id'],
+      'check_permissions' => !empty($params['check_permissions']),
       'return' => array_merge(array('id'), array_values($ret)),
     ));
     foreach ($ret as $param => $key) {


### PR DESCRIPTION
Overview
----
Fix for https://github.com/civicrm/org.civicrm.civicase/issues/110

Before
----
Cannot call the `gettree` api from ajax without `administer CiviCRM` permission.

After
----
Can call the `gettree` api from ajax with permission to view the main object.