### PR TITLE
Deprecate  array on ManagePremiums

### DIFF
--- a/CRM/Contribute/BAO/ManagePremiums.php
+++ b/CRM/Contribute/BAO/ManagePremiums.php
@@ -90,14 +90,15 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_DAO_Product {
    *
    * @param array $params
    *   Reference array contains the values submitted by the form.
-   * @param array $ids
+   * @param array $ids (deprecated)
    *   Reference array contains the id.
    *
    * @return CRM_Contribute_DAO_Product
    */
-  public static function add(&$params, &$ids) {
+  public static function add(&$params, $ids) {
+    $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('premium', $ids));
     $params = array_merge(array(
-      'id' => CRM_Utils_Array::value('premium', $ids),
+      'id' => $id,
       'image' => '',
       'thumbnail' => '',
       'is_active' => 0,


### PR DESCRIPTION
Overview
----------------------------------------
Per our standards - discourage passing of $ids to Add object

Before
----------------------------------------
$ids encouraged

After
----------------------------------------
$ids is secondary method

Technical Details
----------------------------------------
@mattwire I looked at https://github.com/civicrm/civicrm-core/pull/12435/files but it just left me too nervous. I will comment more there but I think in general we have deprecated $ids array before ditching in & deprecated methods & classes before removing them.

Comments
----------------------------------------

