### PR TITLE
Cleanup redundant array functions

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -965,38 +965,58 @@ class CRM_Utils_Array {
   }
 
   /**
-   * Get a single value from an array-tre.
+   * Get a single value from an array-tree.
    *
-   * @param array $arr
-   *   Ex: array('foo'=>array('bar'=>123)).
-   * @param array $pathParts
-   *   Ex: array('foo',bar').
-   * @return mixed|NULL
+   * @param array $values
+   *   Ex: ['foo' => ['bar' => 123]].
+   * @param array $path
+   *   Ex: ['foo', 'bar'].
+   * @param mixed $default
+   * @return mixed
    *   Ex 123.
    */
-  public static function pathGet($arr, $pathParts) {
-    $r = $arr;
-    foreach ($pathParts as $part) {
-      if (!isset($r[$part])) {
-        return NULL;
+  public static function pathGet($values, $path, $default = NULL) {
+    foreach ($path as $key) {
+      if (!is_array($values) || !isset($values[$key])) {
+        return $default;
       }
-      $r = $r[$part];
+      $values = $values[$key];
     }
-    return $r;
+    return $values;
+  }
+
+  /**
+   * Check if a key isset which may be several layers deep.
+   *
+   * This is a helper for when the calling function does not know how many layers deep
+   * the path array is so cannot easily check.
+   *
+   * @param array $values
+   * @param array $path
+   * @return bool
+   */
+  public static function pathIsset($values, $path) {
+    foreach ($path as $key) {
+      if (!is_array($values) || !isset($values[$key])) {
+        return FALSE;
+      }
+      $values = $values[$key];
+    }
+    return TRUE;
   }
 
   /**
    * Set a single value in an array tree.
    *
-   * @param array $arr
-   *   Ex: array('foo'=>array('bar'=>123)).
+   * @param array $values
+   *   Ex: ['foo' => ['bar' => 123]].
    * @param array $pathParts
-   *   Ex: array('foo',bar').
+   *   Ex: ['foo', 'bar'].
    * @param $value
    *   Ex: 456.
    */
-  public static function pathSet(&$arr, $pathParts, $value) {
-    $r = &$arr;
+  public static function pathSet(&$values, $pathParts, $value) {
+    $r = &$values;
     $last = array_pop($pathParts);
     foreach ($pathParts as $part) {
       if (!isset($r[$part])) {
@@ -1161,16 +1181,10 @@ class CRM_Utils_Array {
    * @param array $array
    * @param array $path
    * @return bool
-   * @throws \CRM_Core_Exception
+   * @deprecated
    */
   public static function recursiveIsset($array, $path) {
-    foreach ($path as $key) {
-      if (!is_array($array) || !isset($array[$key])) {
-        return FALSE;
-      }
-      $array = $array[$key];
-    }
-    return TRUE;
+    return self::pathIsset($array, $path);
   }
 
   /**
@@ -1185,16 +1199,10 @@ class CRM_Utils_Array {
    * @param mixed $default
    *   Value to return if not found.
    * @return bool
-   * @throws \CRM_Core_Exception
+   * @deprecated
    */
   public static function recursiveValue($array, $path, $default = NULL) {
-    foreach ($path as $key) {
-      if (!is_array($array) || !isset($array[$key])) {
-        return $default;
-      }
-      $array = $array[$key];
-    }
-    return $array;
+    return self::pathGet($array, $path, $default);
   }
 
   /**
@@ -1208,20 +1216,10 @@ class CRM_Utils_Array {
    * @param array $source
    *
    * @return array
+   * @deprecated
    */
   public static function recursiveBuild($path, $value, $source = []) {
-    $arrayKey = array_shift($path);
-    // Recurse through array keys
-    if ($path) {
-      if (!isset($source[$arrayKey])) {
-        $source[$arrayKey] = [];
-      }
-      $source[$arrayKey] = self::recursiveBuild($path, $value, $source[$arrayKey]);
-    }
-    // Final iteration
-    else {
-      $source[$arrayKey] = $value;
-    }
+    self::pathSet($source, $path, $value);
     return $source;
   }
 


### PR DESCRIPTION
Deprecate some redundant functions for removal, as noted by @totten in https://github.com/civicrm/civicrm-core/pull/12187