### PR TITLE
Fix activity report to bring it under standardised report testing

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1141,6 +1141,27 @@ class CRM_Report_Form extends CRM_Core_Form {
   }
 
   /**
+   * Create a temporary table.
+   *
+   * This function creates a table AND adds the details to the developer tab & $this->>temporary tables.
+   *
+   * @todo improve presentation on the developer tab since CREATE TEMPORARY is removed.
+   *
+   * @param string $identifier
+   * @param $sql
+   * @param bool $isTrueTemporary
+   *   Is this a mysql temporary table or temporary in a less technical sense.
+   *
+   * @return string
+   */
+  public function createTemporaryTable($identifier, $sql, $isTrueTemporary = TRUE) {
+    $this->addToDeveloperTab($sql);
+    $name = CRM_Utils_SQL_TempTable::build()->setUtf8(TRUE)->setDurable($isTrueTemporary)->createWithQuery($sql)->getName();
+    $this->temporaryTables[$identifier] = ['temporary' => $isTrueTemporary, 'name' => $name];
+    return $name;
+  }
+
+  /**
    * Add columns to report.
    */
   public function addColumns() {

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -91,6 +91,9 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
     $condition = " AND ( v.component_id IS NULL {$include} )";
     $this->activityTypes = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, $condition);
     asort($this->activityTypes);
+
+    // @todo split the 3 different contact tables into their own array items.
+    // this will massively simplify the needs of this report.
     $this->_columns = array(
       'civicrm_contact' => array(
         'dao' => 'CRM_Contact_DAO_Contact',
@@ -394,7 +397,12 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
   /**
    * Build select clause.
    *
-   * @param null $recordType
+   * @todo get rid of $recordType param. It's only because 3 separate contact tables
+   * are mis-declared as one that we need it.
+   *
+   * @param null $recordType deprecated
+   *   Parameter to hack around the bad decision made in construct to misrepresent
+   *   different tables as the same table.
    */
   public function select($recordType = 'target') {
     if (!array_key_exists("contact_{$recordType}", $this->_params['fields']) &&
@@ -416,6 +424,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
 
     $removeKeys = array();
     if ($recordType == 'target') {
+      // @todo - fix up the way the tables are declared in construct & remove this.
       foreach ($this->_selectClauses as $key => $clause) {
         if (strstr($clause, 'civicrm_contact_assignee.') ||
           strstr($clause, 'civicrm_contact_source.') ||
@@ -430,6 +439,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
       }
     }
     elseif ($recordType == 'assignee') {
+      // @todo - fix up the way the tables are declared in construct & remove this.
       foreach ($this->_selectClauses as $key => $clause) {
         if (strstr($clause, 'civicrm_contact_target.') ||
           strstr($clause, 'civicrm_contact_source.') ||
@@ -444,6 +454,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
       }
     }
     elseif ($recordType == 'source') {
+      // @todo - fix up the way the tables are declared in construct & remove this.
       foreach ($this->_selectClauses as $key => $clause) {
         if (strstr($clause, 'civicrm_contact_target.') ||
           strstr($clause, 'civicrm_contact_assignee.') ||
@@ -460,6 +471,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
     elseif ($recordType == 'final') {
       $this->_selectClauses = $this->_selectAliasesTotal;
       foreach ($this->_selectClauses as $key => $clause) {
+        // @todo - fix up the way the tables are declared in construct & remove this.
         if (strstr($clause, 'civicrm_contact_contact_target') ||
           strstr($clause, 'civicrm_contact_contact_assignee') ||
           strstr($clause, 'civicrm_contact_contact_source') ||
@@ -496,97 +508,44 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
 
   /**
    * Build from clause.
-   *
-   * @param string $recordType
+   * @todo remove this function & declare the 3 contact tables separately
    */
-  public function from($recordType = 'target') {
+  public function from() {
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
-    $activityTypeId = CRM_Core_DAO::getFieldValue("CRM_Core_DAO_OptionGroup", 'activity_type', 'id', 'name');
-    $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
-    $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
 
-    if ($recordType == 'target') {
-      $this->_from = "
-        FROM civicrm_activity {$this->_aliases['civicrm_activity']}
-             INNER JOIN civicrm_activity_contact  {$this->_aliases['civicrm_activity_contact']}
-                    ON {$this->_aliases['civicrm_activity']}.id = {$this->_aliases['civicrm_activity_contact']}.activity_id AND
-                       {$this->_aliases['civicrm_activity_contact']}.record_type_id = {$targetID}
-             INNER JOIN civicrm_contact civicrm_contact_target
-                    ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_contact_target.id
-             {$this->_aclFrom}";
+    $this->_from = "
+      FROM civicrm_activity {$this->_aliases['civicrm_activity']}
+           INNER JOIN civicrm_activity_contact  {$this->_aliases['civicrm_activity_contact']}
+                  ON {$this->_aliases['civicrm_activity']}.id = {$this->_aliases['civicrm_activity_contact']}.activity_id AND
+                     {$this->_aliases['civicrm_activity_contact']}.record_type_id = {$targetID}
+           INNER JOIN civicrm_contact civicrm_contact_target
+                  ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_contact_target.id
+           {$this->_aclFrom}";
 
-      if ($this->isTableSelected('civicrm_email')) {
-        $this->_from .= "
-            LEFT JOIN civicrm_email civicrm_email_target
-                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_email_target.contact_id AND
-                      civicrm_email_target.is_primary = 1";
-      }
-
-      if ($this->isTableSelected('civicrm_phone')) {
-        $this->_from .= "
-            LEFT JOIN civicrm_phone civicrm_phone_target
-                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_phone_target.contact_id AND
-                      civicrm_phone_target.is_primary = 1 ";
-      }
-      $this->_aliases['civicrm_contact'] = 'civicrm_contact_target';
+    if ($this->isTableSelected('civicrm_email')) {
+      $this->_from .= "
+          LEFT JOIN civicrm_email civicrm_email_target
+                 ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_email_target.contact_id AND
+                    civicrm_email_target.is_primary = 1";
     }
 
-    if ($recordType == 'assignee') {
-      $this->_from = "
-        FROM civicrm_activity {$this->_aliases['civicrm_activity']}
-             INNER JOIN civicrm_activity_contact {$this->_aliases['civicrm_activity_contact']}
-                    ON {$this->_aliases['civicrm_activity']}.id = {$this->_aliases['civicrm_activity_contact']}.activity_id AND
-                       {$this->_aliases['civicrm_activity_contact']}.record_type_id = {$assigneeID}
-             INNER JOIN civicrm_contact civicrm_contact_assignee
-                    ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_contact_assignee.id
-             {$this->_aclFrom}";
-
-      if ($this->isTableSelected('civicrm_email')) {
-        $this->_from .= "
-            LEFT JOIN civicrm_email civicrm_email_assignee
-                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_email_assignee.contact_id AND
-                      civicrm_email_assignee.is_primary = 1";
-      }
-      if ($this->isTableSelected('civicrm_phone')) {
-        $this->_from .= "
-            LEFT JOIN civicrm_phone civicrm_phone_assignee
-                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_phone_assignee.contact_id AND
-                      civicrm_phone_assignee.is_primary = 1 ";
-      }
-      $this->_aliases['civicrm_contact'] = 'civicrm_contact_assignee';
+    if ($this->isTableSelected('civicrm_phone')) {
+      $this->_from .= "
+          LEFT JOIN civicrm_phone civicrm_phone_target
+                 ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_phone_target.contact_id AND
+                    civicrm_phone_target.is_primary = 1 ";
     }
-
-    if ($recordType == 'source') {
-      $this->_from = "
-        FROM civicrm_activity {$this->_aliases['civicrm_activity']}
-             INNER JOIN civicrm_activity_contact {$this->_aliases['civicrm_activity_contact']}
-                    ON {$this->_aliases['civicrm_activity']}.id = {$this->_aliases['civicrm_activity_contact']}.activity_id AND
-                       {$this->_aliases['civicrm_activity_contact']}.record_type_id = {$sourceID}
-             INNER JOIN civicrm_contact civicrm_contact_source
-                    ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_contact_source.id
-             {$this->_aclFrom}";
-
-      if ($this->isTableSelected('civicrm_email')) {
-        $this->_from .= "
-            LEFT JOIN civicrm_email civicrm_email_source
-                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_email_source.contact_id AND
-                      civicrm_email_source.is_primary = 1";
-      }
-      if ($this->isTableSelected('civicrm_phone')) {
-        $this->_from .= "
-            LEFT JOIN civicrm_phone civicrm_phone_source
-                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_phone_source.contact_id AND
-                      civicrm_phone_source.is_primary = 1 ";
-      }
-      $this->_aliases['civicrm_contact'] = 'civicrm_contact_source';
-    }
+    $this->_aliases['civicrm_contact'] = 'civicrm_contact_target';
 
     $this->joinAddressFromContact();
   }
 
   /**
    * Build where clause.
+   *
+   * @todo get rid of $recordType param. It's only because 3 separate contact tables
+   * are mis-declared as one that we need it.
    *
    * @param string $recordType
    */
@@ -805,10 +764,13 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
       }
     }
 
+    // @todo - all this temp table stuff is here because pre 4.4 the activity contact
+    // form did not exist.
+    // Fixing the way the construct method declares them will make all this redundant.
     // 1. fill temp table with target results
     $this->buildACLClause(array('civicrm_contact_target'));
     $this->select('target');
-    $this->from('target');
+    $this->from();
     $this->customDataFrom();
     $this->where('target');
     $insertCols = implode(',', $this->_selectAliases);
@@ -834,7 +796,8 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     // 3. fill temp table with assignee results
     $this->buildACLClause(array('civicrm_contact_assignee'));
     $this->select('assignee');
-    $this->from('assignee');
+    $this->buildAssigneeFrom();
+
     $this->customDataFrom();
     $this->where('assignee');
     $insertCols = implode(',', $this->_selectAliases);
@@ -846,7 +809,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     // 4. fill temp table with source results
     $this->buildACLClause(array('civicrm_contact_source'));
     $this->select('source');
-    $this->from('source');
+    $this->buildSourceFrom();
     $this->customDataFrom();
     $this->where('source');
     $insertCols = implode(',', $this->_selectAliases);
@@ -930,7 +893,9 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     $activityStatus = CRM_Core_PseudoConstant::activityStatus();
     $priority = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id');
     $viewLinks = FALSE;
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'report');
+    // Would we ever want to retrieve from the form controller??
+    $form = $this->noController ? NULL : $this;
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $form, FALSE, 'report');
     $actUrl = '';
 
     if (CRM_Core_Permission::check('access CiviCRM')) {
@@ -1145,6 +1110,74 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
       }
       $this->assign('sectionTotals', $totals);
     }
+  }
+
+  /**
+   * @todo remove this function & declare the 3 contact tables separately
+   *
+   * (Currently the construct method incorrectly melds them - this is an interim
+   * refactor in order to get this under ReportTemplateTests)
+   */
+  protected function buildAssigneeFrom() {
+    $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
+    $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
+    $this->_from = "
+        FROM civicrm_activity {$this->_aliases['civicrm_activity']}
+             INNER JOIN civicrm_activity_contact {$this->_aliases['civicrm_activity_contact']}
+                    ON {$this->_aliases['civicrm_activity']}.id = {$this->_aliases['civicrm_activity_contact']}.activity_id AND
+                       {$this->_aliases['civicrm_activity_contact']}.record_type_id = {$assigneeID}
+             INNER JOIN civicrm_contact civicrm_contact_assignee
+                    ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_contact_assignee.id
+             {$this->_aclFrom}";
+
+    if ($this->isTableSelected('civicrm_email')) {
+      $this->_from .= "
+            LEFT JOIN civicrm_email civicrm_email_assignee
+                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_email_assignee.contact_id AND
+                      civicrm_email_assignee.is_primary = 1";
+    }
+    if ($this->isTableSelected('civicrm_phone')) {
+      $this->_from .= "
+            LEFT JOIN civicrm_phone civicrm_phone_assignee
+                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_phone_assignee.contact_id AND
+                      civicrm_phone_assignee.is_primary = 1 ";
+    }
+    $this->_aliases['civicrm_contact'] = 'civicrm_contact_assignee';
+    $this->joinAddressFromContact();
+  }
+
+  /**
+   * @todo remove this function & declare the 3 contact tables separately
+   *
+   * (Currently the construct method incorrectly melds them - this is an interim
+   * refactor in order to get this under ReportTemplateTests)
+   */
+  protected function buildSourceFrom() {
+    $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
+    $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
+    $this->_from = "
+        FROM civicrm_activity {$this->_aliases['civicrm_activity']}
+             INNER JOIN civicrm_activity_contact {$this->_aliases['civicrm_activity_contact']}
+                    ON {$this->_aliases['civicrm_activity']}.id = {$this->_aliases['civicrm_activity_contact']}.activity_id AND
+                       {$this->_aliases['civicrm_activity_contact']}.record_type_id = {$sourceID}
+             INNER JOIN civicrm_contact civicrm_contact_source
+                    ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_contact_source.id
+             {$this->_aclFrom}";
+
+    if ($this->isTableSelected('civicrm_email')) {
+      $this->_from .= "
+            LEFT JOIN civicrm_email civicrm_email_source
+                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_email_source.contact_id AND
+                      civicrm_email_source.is_primary = 1";
+    }
+    if ($this->isTableSelected('civicrm_phone')) {
+      $this->_from .= "
+            LEFT JOIN civicrm_phone civicrm_phone_source
+                   ON {$this->_aliases['civicrm_activity_contact']}.contact_id = civicrm_phone_source.contact_id AND
+                      civicrm_phone_source.is_primary = 1 ";
+    }
+    $this->_aliases['civicrm_contact'] = 'civicrm_contact_source';
+    $this->joinAddressFromContact();
   }
 
 }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -35,6 +35,8 @@
 class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
 
+  protected $contactIDs = [];
+
   /**
    * Our group reports use an alter so transaction cleanup won't work.
    *
@@ -773,6 +775,129 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
       'options' => array('metadata' => array('sql')),
     ));
     $this->assertNumberOfContactsInResult(2, $rows, $template);
+  }
+
+  /**
+   * Test activity summary report - requiring all current fields to be output.
+   */
+  public function testActivitySummary() {
+    $this->createContactsWithActivities();
+    $fields = [
+      'contact_source' => '1',
+      'contact_assignee' => '1',
+      'contact_target' => '1',
+      'contact_source_email' => '1',
+      'contact_assignee_email' => '1',
+      'contact_target_email' => '1',
+      'contact_source_phone' => '1',
+      'contact_assignee_phone' => '1',
+      'contact_target_phone' => '1',
+      'activity_type_id' => '1',
+      'activity_subject' => '1',
+      'activity_date_time' => '1',
+      'status_id' => '1',
+      'duration' => '1',
+      'location' => '1',
+      'details' => '1',
+      'priority_id' => '1',
+      'result' => '1',
+      'engagement_level' => '1',
+      'address_name' => '1',
+      'street_address' => '1',
+      'supplemental_address_1' => '1',
+      'supplemental_address_2' => '1',
+      'supplemental_address_3' => '1',
+      'street_number' => '1',
+      'street_name' => '1',
+      'street_unit' => '1',
+      'city' => '1',
+      'postal_code' => '1',
+      'postal_code_suffix' => '1',
+      'country_id' => '1',
+      'state_province_id' => '1',
+      'county_id' => '1',
+    ];
+    $params = [
+      'fields' => $fields,
+      'current_user_op' => 'eq',
+      'current_user_value' => '0',
+      'include_case_activities_op' => 'eq',
+      'include_case_activities_value' => 0,
+      'order_bys' => [1 => ['column' => 'activity_date_time', 'order' => 'ASC'], 2 => ['column' => 'activity_type_id', 'order' => 'ASC']],
+    ];
+
+    $params['report_id'] = 'Activity';
+
+    $rows = $this->callAPISuccess('report_template', 'getrows', $params)['values'];
+    $expected = [
+      'civicrm_contact_contact_source' => 'Łąchowski-Roberts, Anthony',
+      'civicrm_contact_contact_assignee' => '<a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=4\'>Łąchowski-Roberts, Anthony</a>',
+      'civicrm_contact_contact_target' => '<a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3\'>Brzęczysław, Anthony</a>; <a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=4\'>Łąchowski-Roberts, Anthony</a>',
+      'civicrm_contact_contact_source_id' => $this->contactIDs[2],
+      'civicrm_contact_contact_assignee_id' => $this->contactIDs[1],
+      'civicrm_contact_contact_target_id' => $this->contactIDs[0] . ';' . $this->contactIDs[1],
+      'civicrm_email_contact_source_email' => 'anthony_anderson@civicrm.org',
+      'civicrm_email_contact_assignee_email' => 'anthony_anderson@civicrm.org',
+      'civicrm_email_contact_target_email' => 'anthony_anderson@civicrm.org;anthony_anderson@civicrm.org',
+      'civicrm_phone_contact_source_phone' => NULL,
+      'civicrm_phone_contact_assignee_phone' => NULL,
+      'civicrm_phone_contact_target_phone' => NULL,
+      'civicrm_activity_id' => '1',
+      'civicrm_activity_source_record_id' => NULL,
+      'civicrm_activity_activity_type_id' => 'Meeting',
+      'civicrm_activity_activity_subject' => 'Very secret meeting',
+      'civicrm_activity_activity_date_time' => '2018-07-16 03:42:32',
+      'civicrm_activity_status_id' => 'Scheduled',
+      'civicrm_activity_duration' => '120',
+      'civicrm_activity_location' => 'Pennsylvania',
+      'civicrm_activity_details' => 'a test activity',
+      'civicrm_activity_priority_id' => 'Normal',
+      'civicrm_address_address_name' => NULL,
+      'civicrm_address_street_address' => NULL,
+      'civicrm_address_supplemental_address_1' => NULL,
+      'civicrm_address_supplemental_address_2' => NULL,
+      'civicrm_address_supplemental_address_3' => NULL,
+      'civicrm_address_street_number' => NULL,
+      'civicrm_address_street_name' => NULL,
+      'civicrm_address_street_unit' => NULL,
+      'civicrm_address_city' => NULL,
+      'civicrm_address_postal_code' => NULL,
+      'civicrm_address_postal_code_suffix' => NULL,
+      'civicrm_address_country_id' => NULL,
+      'civicrm_address_state_province_id' => NULL,
+      'civicrm_address_county_id' => NULL,
+      'civicrm_contact_contact_source_link' => '/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=' . $this->contactIDs[2],
+      'civicrm_contact_contact_source_hover' => 'View Contact Summary for this Contact',
+      'civicrm_activity_activity_type_id_hover' => 'View Activity Record',
+      'class' => 'status-overdue',
+    ];
+    $row = $rows[0];
+    // This link is not relative - skip for now
+    unset($row['civicrm_activity_activity_type_id_link']);
+
+    $this->assertEquals($expected, $row);
+  }
+
+  /**
+   * Set up some activity data..... use some chars that challenge our utf handling.
+   */
+  public function createContactsWithActivities() {
+    $this->contactIDs[] = $this->individualCreate(['last_name' => 'Brzęczysław']);
+    $this->contactIDs[] = $this->individualCreate(['last_name' => 'Łąchowski-Roberts']);
+    $this->contactIDs[] = $this->individualCreate(['last_name' => 'Łąchowski-Roberts']);
+
+    $this->callAPISuccess('Activity', 'create', [
+      'subject' => 'Very secret meeting',
+      'activity_date_time' => '2018-07-16 03:42:32',
+      'duration' => 120,
+      'location' => 'Pennsylvania',
+      'details' => 'a test activity',
+      'status_id' => 1,
+      'activity_type_id' => 'Meeting',
+      'source_contact_id' => $this->contactIDs[2],
+      'target_contact_id' => array($this->contactIDs[0], $this->contactIDs[1]),
+      'assignee_contact_id' => $this->contactIDs[1],
+    ]);
   }
 
 }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -246,7 +246,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    */
   public static function getReportTemplates() {
     $reportsToSkip = array(
-      'activity' => 'does not respect function signature on from clause',
       'event/income' => 'I do no understand why but error is Call to undefined method CRM_Report_Form_Event_Income::from() in CRM/Report/Form.php on line 2120',
       'contribute/history' => 'Declaration of CRM_Report_Form_Contribute_History::buildRows() should be compatible with CRM_Report_Form::buildRows($sql, &$rows)',
       'activitySummary' => 'We use temp tables for the main query generation and name are dynamic. These names are not available in stats() when called directly.',


### PR DESCRIPTION
Overview
----------------------------------------
Bring activity report under unit testing

Before
----------------------------------------
Report not testable due to from() function signature deviating from parent

After
----------------------------------------
Report testable. From split into 3 separate functions as a reflection of the fact there is almost no shared code in the function

Technical Details
----------------------------------------
I see this as one step towards a refactor. The underlying issue is that pre 4.4 the activity_contact table didn't exist and so temp tables were needed to simulate it. When the activity_contact table was created the underlying messed up logic was never fixed. With this now under testing we can look at how to treat the 3 versions of the contact table as separate tables  (ie. declare them as such in construct) and standardise the report. The new 'from functions' should be temporaray

Comments
----------------------------------------
The is one of 4 remaining reports that are not tested through the api_v3_ReportTemplateTest class against standardised expectations
