### PR TITLE
(dev/core#251) fix batch copy for multi-select fields

### DIFF
--- a/templates/CRM/common/batchCopy.tpl
+++ b/templates/CRM/common/batchCopy.tpl
@@ -98,7 +98,7 @@
         });
       }
       else {
-        if (elementId.is('select') === true && firstElement.parent().find(':input').select().index() >= 1 && firstElement.parent().find('select').select().index < 1) {
+        if (elementId.is('select') === true && firstElement.parent().find(':input').select().index() == 1) {
           // its a multiselect case
           firstElement.parent().find(':input').select().each( function(count) {
             var firstElementValue = $(this).val();


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate :
-------------------------

1. Create a profile with membership type field.
2. Click Find Memberships and select a few members and do Update multiple memberships with above profile.
3. Click on copy icon for membership type, it doesn't copy over 1st row to the rest

Before
----------------------------------------
it resets the first row to first option and copies that not the selected one.

After
----------------------------------------
it copies over the chosen value
