### PR TITLE
dev/core#252 - Add force search parameters in search forms

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -209,10 +209,9 @@ class CRM_Activity_BAO_Query {
         // We no longer expect "subject" as a specific criteria (as of CRM-19447),
         // but we still use activity_subject in Activity.Get API
       case 'activity_subject':
-
         $qillName = $name;
         if (in_array($name, array('activity_engagement_level', 'activity_id'))) {
-          $name = $qillName = str_replace('activity_', '', $name);
+          $name = str_replace('activity_', '', $name);
         }
         if (in_array($name, array('activity_status_id', 'activity_subject', 'activity_priority_id'))) {
           $name = str_replace('activity_', '', $name);
@@ -335,11 +334,11 @@ class CRM_Activity_BAO_Query {
 
       case 'parent_id':
         if ($value == 1) {
-          $query->_where[$grouping][] = "parent_id.parent_id IS NOT NULL";
+          $query->_where[$grouping][] = "civicrm_activity.parent_id IS NOT NULL";
           $query->_qill[$grouping][] = ts('Activities which have Followup Activities');
         }
         elseif ($value == 2) {
-          $query->_where[$grouping][] = "parent_id.parent_id IS NULL";
+          $query->_where[$grouping][] = "civicrm_activity.parent_id IS NULL";
           $query->_qill[$grouping][] = ts('Activities without Followup Activities');
         }
         break;

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -286,7 +286,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     }
 
     $forceParams = [
-      'activity_status_id' => ['name' => 'status', 'type' => 'String'],
+      'activity_status_id' => ['name' => 'status', 'type' => 'Alphanumeric'],
       'followup_parent_id' => ['name' => 'isFollowUp', 'type' => 'Positive'],
       'parent_id' => ['name' => 'hasFollowUp', 'type' => 'Positive'],
     ];
@@ -356,7 +356,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       }
     }
 
-    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'String');
+    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'Alphanumeric');
 
     if ($dateLow) {
       $dateLow = date('m/d/Y', strtotime($dateLow));
@@ -366,7 +366,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       $this->_defaults['activity_date_low'] = $dateLow;
     }
 
-    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'String');
+    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'Alphanumeric');
 
     if ($dateHigh) {
       // Activity date time assumes midnight at the beginning of the date

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -285,22 +285,29 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       return;
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String', $this);
-    if ($status) {
-      $this->_formValues['activity_status_id'] = $status;
-      $this->_defaults['activity_status_id'] = $status;
+    $forceParams = [
+      'activity_status_id' => ['name' => 'status', 'type' => 'String'],
+      'followup_parent_id' => ['name' => 'isFollowUp', 'type' => 'Positive'],
+      'parent_id' => ['name' => 'hasFollowUp', 'type' => 'Positive'],
+    ];
+    foreach ($forceParams as $key => $params) {
+      $value = CRM_Utils_Request::retrieve($params['name'], $params['type'], $this);
+      if ($value) {
+        $this->_formValues[$key] = $this->_defaults[$key] = $value;
+      }
     }
 
     $survey = CRM_Utils_Request::retrieve('survey', 'Positive');
-
+    $activity_type_id = CRM_Utils_Request::retrieve('type', 'Integer', $this);
     if ($survey) {
       $this->_formValues['activity_survey_id'] = $this->_defaults['activity_survey_id'] = $survey;
       $sid = CRM_Utils_Array::value('activity_survey_id', $this->_formValues);
       $activity_type_id = CRM_Core_DAO::getFieldValue('CRM_Campaign_DAO_Survey', $sid, 'activity_type_id');
+    }
 
+    if ($activity_type_id) {
       // since checkbox are replaced by multiple select option
-      $this->_formValues['activity_type_id'] = $activity_type_id;
-      $this->_defaults['activity_type_id'] = $activity_type_id;
+      $this->_formValues['activity_type_id'] = $this->_defaults['activity_type_id'] = $activity_type_id;
     }
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
@@ -310,7 +317,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
         $this->_formValues['contact_id'] = $cid;
 
         $activity_role = CRM_Utils_Request::retrieve('activity_role', 'Positive', $this);
-
         if ($activity_role) {
           $this->_formValues['activity_role'] = $activity_role;
         }

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -393,7 +393,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       return;
     }
     $forceParams = [
-      'contribution_status_id' => ['name' => 'status', 'type' => 'String'],
+      'contribution_status_id' => ['name' => 'status', 'type' => 'Alphanumeric'],
       'financial_type_id' => ['name' => 'fid', 'type' => 'Positive'],
       'contribution_pay_later' => ['name' => 'pay_later', 'type' => 'Boolean'],
     ];

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -392,11 +392,16 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if (!$this->_force) {
       return;
     }
-
-    $status = CRM_Utils_Request::retrieve('status', 'String');
-    if ($status) {
-      $this->_formValues['contribution_status_id'] = array($status => 1);
-      $this->_defaults['contribution_status_id'] = array($status => 1);
+    $forceParams = [
+      'contribution_status_id' => ['name' => 'status', 'type' => 'String'],
+      'financial_type_id' => ['name' => 'fid', 'type' => 'Positive'],
+      'contribution_pay_later' => ['name' => 'pay_later', 'type' => 'Boolean'],
+    ];
+    foreach ($forceParams as $key => $params) {
+      $value = CRM_Utils_Request::retrieve($params['name'], $params['type'], $this);
+      if ($value || ($params['type'] == 'Boolean') && isset($value)) {
+        $this->_formValues[$key] = $this->_defaults[$key] = $value;
+      }
     }
 
     $pcpid = (array) CRM_Utils_Request::retrieve('pcpid', 'String', $this);
@@ -410,7 +415,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     }
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
-
     if ($cid) {
       $cid = CRM_Utils_Type::escape($cid, 'Integer');
       if ($cid > 0) {
@@ -465,7 +469,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if ($contribPageId) {
       $this->_formValues['contribution_page_id'] = $contribPageId;
     }
-
     //give values to default.
     $this->_defaults = $this->_formValues;
   }

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -445,7 +445,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues['participant_relative'] = $this->_defaults['participant_relative'] = 0;
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String');
+    $status = CRM_Utils_Request::retrieve('status', 'Alphanumeric');
     if (isset($status)) {
       if ($status === 'true') {
         $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1");

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -431,8 +431,21 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues['event_name'] = CRM_Event_PseudoConstant::event($event, TRUE);
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String');
+    $registerDate = CRM_Utils_Request::retrieve('register_start', 'Date');
+    if ($registerDate) {
+      list($date) = CRM_Utils_Date::setDateDefaults($registerDate);
+      $this->_formValues['participant_register_date_low'] = $this->_defaults['participant_register_date_low'] = $date;
+    }
+    $registerEndDate = CRM_Utils_Request::retrieve('register_end', 'Date');
+    if ($registerEndDate) {
+      list($date) = CRM_Utils_Date::setDateDefaults($registerEndDate);
+      $this->_formValues['participant_register_date_high'] = $this->_defaults['participant_register_date_high'] = $date;
+    }
+    if ($registerDate || $registerEndDate) {
+      $this->_formValues['participant_relative'] = $this->_defaults['participant_relative'] = 0;
+    }
 
+    $status = CRM_Utils_Request::retrieve('status', 'String');
     if (isset($status)) {
       if ($status === 'true') {
         $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1");
@@ -450,7 +463,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     }
 
     $role = CRM_Utils_Request::retrieve('role', 'String');
-
     if (isset($role)) {
       if ($role === 'true') {
         $roleTypes = CRM_Event_PseudoConstant::participantRole(NULL, "filter = 1");
@@ -479,6 +491,10 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
         // also assign individual mode to the template
         $this->_single = TRUE;
       }
+    }
+    $payLater = CRM_Utils_Request::retrieve('pay_later', 'Boolean', $this);
+    if (isset($payLater)) {
+      $this->_formValues['participant_is_pay_later'] = $payLater;
     }
   }
 

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -331,14 +331,12 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
     }
 
     $membershipType = CRM_Utils_Request::retrieve('type', 'String');
-
     if ($membershipType) {
       $this->_formValues['membership_type_id'] = array($membershipType);
       $this->_defaults['membership_type_id'] = array($membershipType);
     }
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive');
-
     if ($cid) {
       $cid = CRM_Utils_Type::escape($cid, 'Integer');
       if ($cid > 0) {
@@ -351,28 +349,20 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
         $this->_single = TRUE;
       }
     }
-
-    $fromDate = CRM_Utils_Request::retrieve('start', 'Date');
-    if ($fromDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($fromDate);
-      $this->_formValues['member_start_date_low'] = $this->_defaults['member_start_date_low'] = $date;
-    }
-
-    $toDate = CRM_Utils_Request::retrieve('end', 'Date');
-    if ($toDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($toDate);
-      $this->_formValues['member_start_date_high'] = $this->_defaults['member_start_date_high'] = $date;
-    }
-    $joinDate = CRM_Utils_Request::retrieve('join', 'Date');
-    if ($joinDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($joinDate);
-      $this->_formValues['member_join_date_low'] = $this->_defaults['member_join_date_low'] = $date;
-    }
-
-    $joinEndDate = CRM_Utils_Request::retrieve('joinEnd', 'Date');
-    if ($joinEndDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($joinEndDate);
-      $this->_formValues['member_join_date_high'] = $this->_defaults['member_join_date_high'] = $date;
+    foreach (array('start', 'end', 'join') as $field) {
+      $dateLow = CRM_Utils_Request::retrieve($field, 'Date');
+      if ($dateLow) {
+        list($date) = CRM_Utils_Date::setDateDefaults($dateLow);
+        $this->_formValues["member_{$field}_date_low"] = $this->_defaults["member_{$field}_date_low"] = $date;
+      }
+      $dateHigh = CRM_Utils_Request::retrieve("{$field}_high", 'Date');
+      if ($dateHigh) {
+        list($date) = CRM_Utils_Date::setDateDefaults($dateHigh);
+        $this->_formValues["member_{$field}_date_high"] = $this->_defaults["member_{$field}_date_high"] = $date;
+      }
+      if ($dateLow || $dateHigh) {
+        $this->_formValues["member_{$field}_date_relative"] = $this->_defaults["member_{$field}_date_relative"] = 0;
+      }
     }
 
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive',


### PR DESCRIPTION
Overview
----------------------------------------
Add parameters to force search in Activity, Event, Membership & Contribution Search forms

Before
----------------------------------------
Some parameters were missing and cannot be specified in url param to search for the entities.

After
----------------------------------------
Parameters added and can be searched through URL params. Below is the table of field name vs params that can be used in the URL to force the search results.

**1. Contribution Tokens** -

|**Field Name**|**Param in URL**|
| ------------- |:-------------:| 
|    contribution_page_id | pid|
|    financial_type_id | fid|
|    contribution_status_id | status|
|    is_pay_later |pay_later|
|    receive_date_from (receive_date)|start|
|    receive_date_to (receive_date)|end|

Eg of complete search URL - 

    civicrm/contribute/search?reset=1&force=1&status=1&fid=2&pay_later=1&start=20181206&end=20181210

**2. Membership Tokens**

|**Field Name**|**Param in URL**|
| ------------- |:-------------:| 
|    membership_type_id | type |
|    membership_status_id |status|
|    start_date |start & start_high|
|    end_date |end & end_high|    

Eg of complete search URL - 

    civicrm/member/search?reset=1&force=1&type=1&status=1&start=20181002&start_high=20181004&end=20181103&end_high=20181109

**3. Participant Tokens**

|**Field Name**|**Param in URL**|
| ------------- |:-------------:| 
|    event_id | event |
|    status_id |status|
|    role_id |role|
|    is_pay_later |pay_later|    
|    register_date_from |register_start|    
|    register_date_to |register_end|    

Eg of complete search URL -

    civicrm/event/search?reset=1&force=1&event=1&status=2&role=3&pay_later=1&register_start=20181210&register_end=20181214

**4. Activity Tokens**

|**Field Name**|**Param in URL**|
| ------------- |:-------------:| 
|    activity-type id | type|
|    activity_status | status|
|    has a follow-up activity | hasFollowUp|
|    is a follow-up acivity |isFollowUp|
|    start date|dateLow|
|    end date|dateHigh|


Eg of complete search URL -

    civicrm/activity/search?reset=1&force=1&status=1&hasFollowUp=1&isFollowUp=1&dateLow=20181210&dateHigh=20181212&type=3

----------------

Gitlab Issue - https://lab.civicrm.org/dev/core/issues/252