### PR TITLE
Issue #93 Update CRM_Utils_Rule::mysqlOrderBy() to accommodate more than 2 joins

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -157,7 +157,7 @@ class CRM_Utils_Rule {
     // at all, so we split and loop over.
     $parts = explode(',', $str);
     foreach ($parts as $part) {
-      if (!preg_match('/^((`[\w-]{1,64}`|[\w-]{1,64})\.)?(`[\w-]{1,64}`|[\w-]{1,64})( (asc|desc))?$/i', trim($part))) {
+      if (!preg_match('/^((`[\w-]{1,64}`|[\w-]{1,64})\.)+?(`[\w-]{1,64}`|[\w-]{1,64})( (asc|desc))?$/i', trim($part))) {
         return FALSE;
       }
     }

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -157,7 +157,7 @@ class CRM_Utils_Rule {
     // at all, so we split and loop over.
     $parts = explode(',', $str);
     foreach ($parts as $part) {
-      if (!preg_match('/^((`[\w-]{1,64}`|[\w-]{1,64})\.)+?(`[\w-]{1,64}`|[\w-]{1,64})( (asc|desc))?$/i', trim($part))) {
+      if (!preg_match('/^((`[\w-]{1,64}`|[\w-]{1,64})\.)*(`[\w-]{1,64}`|[\w-]{1,64})( (asc|desc))?$/i', trim($part))) {
         return FALSE;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Lets API users to sort results by multiple joins.

Before
----------------------------------------
Current rule only allows 2 joins in sorting options. (eg: In Membership API, contact_id.gender_id)

After
----------------------------------------
Allows multiple joins to be used. (eg: In Membership API, contact_id.gender_id.label)

Technical Details
----------------------------------------
Changed regex in CRM_Utils_Rule::mysqlOrderBy() 

Comments
----------------------------------------
No unit testing done
