### PR TITLE
PriceField: show pre/post help if not empty, not if isset.

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -413,10 +413,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           if ($field->is_display_amounts) {
             $opt['label'] = !empty($opt['label']) ? $opt['label'] . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
             $preHelpText = $postHelpText = '';
-            if (isset($opt['help_pre'])) {
+            if (!empty($opt['help_pre'])) {
               $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span>: ';
             }
-            if (isset($opt['help_post'])) {
+            if (!empty($opt['help_post'])) {
               $postHelpText = ': <span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
             }
             if (isset($taxAmount) && $invoicing) {


### PR DESCRIPTION
Overview
----------------------------------------

In PriceSets, if a Radio field OPTION has an empty pre/post help, a weird empty `:` is shown on the screen.

This only seems to happen in multi-lingual mode, where the database-layer translation functions can sometimes save an empty string, instead of setting a null value.

To reproduce:

* Enable multi-lingual, add a second language
* Go to a priceset, add a radio button option
* On one of the radio options, set both a pre/post help, save
* then edit again, and remove that pre/post help.

You'll get this:

![civicrm-priceset-option-help](https://user-images.githubusercontent.com/254741/42599201-7ec48208-852c-11e8-992d-ccc0b0e819d9.png)

Direct link to a priceset on dmaster : https://dmaster.demo.civicrm.org/civicrm/admin/price/field?reset=1&action=browse&sid=9

To view the `:`, you can use the preview mode of a priceset.

Before
----------------------------------------

An awkward lone `:` was displayed.

After
----------------------------------------

Less awkward.

Technical Details
----------------------------------------

Sure, we could debug the obscure SQL triggers can handle multi-lingual, but this seemed like a fairly safe trivial fix.

Comments
----------------------------------------

Bug and fix by @mmyriam.