### PR TITLE
(dev/core#255) Changes to copied event location reflects in original …

### DIFF
--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -225,10 +225,9 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
       CRM_Core_DAO::setFieldValue('CRM_Event_DAO_Event', $this->_id,
         'loc_block_id', 'null'
       );
-
-      $this->_values['address'] = array();
     }
 
+    $this->_values['address'] = array();
     // if 'create new loc' optioin is selected OR selected new loc is different
     // from old one, go ahead and delete the old loc provided thats not being
     // used by any other event


### PR DESCRIPTION
…event location

Overview
----------------------------------------
Steps to replicate:


1. Create an event X with location A.
2. Create copy of event X say Y and go to location tab for event Y (which will now show location A).
3. Click _Create new location_ radio and then click _Use existing location_, choose option B.
4. Check event X also has location B.

Before
----------------------------------------
 changed event location rather than create new location - original event location gets changed as well.

After
----------------------------------------
only copied event location gets changed.