### PR TITLE
Fix false negatives in checkResourceUrl()

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -910,7 +910,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     $arrowUrl = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'packages/jquery/css/images/arrow.png';
     $headers = get_headers($arrowUrl);
     $fileExists = stripos($headers[0], "200 OK") ? 1 : 0;
-    if (!$fileExists) {
+    if ($fileExists === FALSE) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('The Resource URL is not set correctly. Please set the <a href="%1">CiviCRM Resource URL</a>.',


### PR DESCRIPTION
Overview
----------------------------------------
Without this proposed fix, I'm receiving false errors about the CiviCRM Resource URL not being set correctly.

Before
----------------------------------------
I can access http://coastaltrails.org/wp-content/plugins/civicrm/civicrm/packages/jquery/css/images/arrow.png But WITHOUT the fix, I get an error 
```
The Resource URL is not set correctly. Please set the CiviCRM Resource URL.
```
I have CiviCRM Resource URL set to `[civicrm.root]/`

My URL Variables are calculated as:
```
[cms.root]	http://coastaltrails.org/
[civicrm.root]	http://coastaltrails.org/wp-content/plugins/civicrm/civicrm/
[civicrm.files]	http://coastaltrails.org/wp-content/uploads/civicrm/
These variables are computed automatically using civicrm.settings.php and its options, such as CIVICRM_TEMPLATE_COMPILEDIR.
```

After
----------------------------------------
No Error on CiviCRM System Status page. Footer 'system status' is not Red

Technical Details
----------------------------------------
The stripos() function will return '0' if the needle string is the first thing found in the haystack. Thus, you must use equivalence rather than a true/false test where "position zero" evaluates to false. 

Comments
----------------------------------------
Tested on Civi 5.3.0 on WordPress 4.9.7
