### PR TITLE
Make domain_id optional in membership_type api.

### DIFF
--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -59,8 +59,7 @@ function civicrm_api3_membership_type_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_membership_type_create_spec(&$params) {
-  // todo could set default here probably
-  $params['domain_id']['api.required'] = 1;
+  $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
   $params['member_of_contact_id']['api.required'] = 1;
   $params['financial_type_id']['api.required'] = 1;
   $params['name']['api.required'] = 1;

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -126,9 +126,9 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test update fails with no ID.
+   * Domain ID can be intuited..
    */
-  public function testUpdateWithoutId() {
+  public function testCreateWithoutDomainId() {
     $params = array(
       'name' => '60+ Membership',
       'description' => 'people above 60 are given health instructions',
@@ -141,8 +141,18 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
       'visibility' => 'public',
     );
 
-    $membershipType = $this->callAPIFailure('membership_type', 'create', $params);
-    $this->assertEquals($membershipType['error_message'], 'Mandatory key(s) missing from params array: domain_id');
+    $membershipType = $this->callAPISuccess('membership_type', 'create', $params);
+    $domainID = $this->callAPISuccessGetValue('MembershipType', ['return' => 'domain_id', 'id' => $membershipType['id']]);
+    $this->assertEquals(CRM_Core_Config::domainID(), $domainID);
+
+    $this->callAPISuccess('membership_type', 'create', ['domain_id' => 2, 'id' => $membershipType['id']]);
+    $domainID = $this->callAPISuccessGetValue('MembershipType', ['return' => 'domain_id', 'id' => $membershipType['id']]);
+    $this->assertEquals(2, $domainID);
+
+    $this->callAPISuccess('membership_type', 'create', ['id' => $membershipType['id'], 'description' => 'Cool member']);
+    $domainID = $this->callAPISuccessGetValue('MembershipType', ['return' => 'domain_id', 'id' => $membershipType['id']]);
+    $this->assertEquals(2, $domainID);
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Change domain_id from a required parameter in membership_type api to an optional one

Before
----------------------------------------
domain_id is required

After
----------------------------------------
domain_id is calculated as being the current domain (if not set & for new transactions)

Technical Details
----------------------------------------


Comments
----------------------------------------
This is in support of #12439 & making domain_id optional @mattwire 
