### PR TITLE
(NFC) Ignore generated karma.cv.js file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ civicrm.settings.php
 sql/dummy_processor.mysql
 distmaker/distmaker.conf
 distmaker/out
+/tmp


### PR DESCRIPTION
Ignores a generated file generated through https://github.com/civicrm/civicrm-core/blob/master/karma.conf.js#L6

ping @eileenmcnaughton 