### PR TITLE
dev/core#237 : Hide Drupal8 Administer Menu bar on CiviCRM pages and move navigation js hacks to respective CMS js

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -861,4 +861,13 @@ AND    u.status = 1
     }
   }
 
+  /**
+   * Append Drupal7 js to coreResourcesList.
+   *
+   * @param array $list
+   */
+  public function appendCoreResources(&$list) {
+    $list[] = 'js/crm.drupal7.js';
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -664,4 +664,13 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return \Drupal::languageManager()->getCurrentLanguage()->getId();
   }
 
+  /**
+   * Append Drupal8 js to coreResourcesList.
+   *
+   * @param array $list
+   */
+  public function appendCoreResources(&$list) {
+    $list[] = 'js/crm.drupal8.js';
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -301,15 +301,6 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   }
 
   /**
-   * Append Drupal js to coreResourcesList.
-   *
-   * @param array $list
-   */
-  public function appendCoreResources(&$list) {
-    $list[] = 'js/crm.drupal.js';
-  }
-
-  /**
    * @inheritDoc
    */
   public function flush() {

--- a/css/civicrmNavigation.css
+++ b/css/civicrmNavigation.css
@@ -63,7 +63,7 @@ html>body .innerbox
 }
 
 #civicrm-menu {
-  position:absolute;
+  position:fixed;
   top:0;
   left:0;
   background:#1B1B1B repeat-x;

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -10,8 +10,6 @@ CRM.$(function($) {
         // D7 hack, restore toolbar position (CRM-15341)
         $('#toolbar').css('z-index', '');
       }
-    })
-   .ready(function() {
-     $('#civicrm-menu').css({position: "fixed", top: "0px", 'width': '97%'});
-   });
+    });
+    $('#civicrm-menu').css({'width': '97%'});
 });

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -11,12 +11,7 @@ CRM.$(function($) {
         $('#toolbar').css('z-index', '');
       }
     })
-   // d8 Hack to hide title when it should be (CRM-19960)
    .ready(function() {
-     var pageTitle = $('.page-title');
-     var title = $('.page-title').text();
-     if ('<span id="crm-remove-title" style="display:none">CiviCRM</span>' == title) {
-       pageTitle.hide();
-     }
+     $('#civicrm-menu').css({position: "fixed", top: "0px", 'width': '97%'});
    });
 });

--- a/js/crm.drupal8.js
+++ b/js/crm.drupal8.js
@@ -1,0 +1,14 @@
+// http://civicrm.org/licensing
+CRM.$(function($) {
+   // d8 Hack to hide title when it should be (CRM-19960)
+   $(document).ready(function() {
+     var pageTitle = $('.page-title');
+     if ('<span id="crm-remove-title" style="display:none">CiviCRM</span>' == pageTitle.text()) {
+       pageTitle.hide();
+     }
+
+     $('#civicrm-menu').css({position: "fixed", top: "0px", height: "29px"});
+
+     $('#toolbar-bar').hide();
+   });
+});

--- a/js/crm.drupal8.js
+++ b/js/crm.drupal8.js
@@ -1,14 +1,17 @@
 // http://civicrm.org/licensing
 CRM.$(function($) {
    // d8 Hack to hide title when it should be (CRM-19960)
-   $(document).ready(function() {
-     var pageTitle = $('.page-title');
-     if ('<span id="crm-remove-title" style="display:none">CiviCRM</span>' == pageTitle.text()) {
-       pageTitle.hide();
-     }
+   var pageTitle = $('.page-title');
+   if ('<span id="crm-remove-title" style="display:none">CiviCRM</span>' == pageTitle.text()) {
+     pageTitle.hide();
+   }
 
-     $('#civicrm-menu').css({position: "fixed", top: "0px", height: "29px"});
+   $('#toolbar-bar').hide();
 
-     $('#toolbar-bar').hide();
+   $('.crm-hidemenu').click(function(e) {
+     $('#toolbar-bar').slideDown();
+   });
+   $('#crm-notification-container').on('click', '#crm-restore-menu', function() {
+     $('#toolbar-bar').slideUp();
    });
 });

--- a/js/crm.wordpress.js
+++ b/js/crm.wordpress.js
@@ -17,8 +17,5 @@ CRM.$(function($) {
           $('#wpadminbar').toggle(e.data === 2);
         });
       }
-    })
-    .ready(function() {
-      $('#civicrm-menu').css({position: "fixed", top: "0px"});
-  });
+    });
 });

--- a/js/crm.wordpress.js
+++ b/js/crm.wordpress.js
@@ -17,5 +17,8 @@ CRM.$(function($) {
           $('#wpadminbar').toggle(e.data === 2);
         });
       }
-    });
+    })
+    .ready(function() {
+      $('#civicrm-menu').css({position: "fixed", top: "0px"});
+  });
 });

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -54,30 +54,25 @@
 {/strip}{/capture}// <script> Generated {$smarty.now|date_format:'%d %b %Y %H:%M:%S'}
 {literal}
 (function($) {
-  var menuMarkup = {/literal}{$menuMarkup|@json_encode};
-{if $config->userFramework neq 'Joomla'}{literal}
-  $('body').append(menuMarkup);
-
-  $('#civicrm-menu').css({position: "fixed", top: "0px"});
+  var menuMarkup = {/literal}{$menuMarkup|@json_encode}{literal};
 
   //Track Scrolling
-  $(window).scroll(function () {
-    $('div.sticky-header').css({top: $('#civicrm-menu').height() + "px", position: "fixed"});
-  });
-
-  if ($('#edit-shortcuts').length > 0) {
-    $('#civicrm-menu').css({'width': '97%'});
+  if ($('div.sticky-header').length) {
+    $(window).scroll(function () {
+      $('div.sticky-header').css({top: $('#civicrm-menu').height() + "px", position: "fixed"});
+    });
   }
-{/literal}{else}{* Special menu hacks for Joomla *}{literal}
-  // below div is present in older version of joomla 2.5.x
-  var elementExists = $('div#toolbar-box div.m').length;
-  if (elementExists > 0) {
+
+  if ($('div#toolbar-box div.m').length) {
     $('div#toolbar-box div.m').html(menuMarkup);
   }
-  else {
+  else if ($("#crm-nav-menu-container").length) {
     $("#crm-nav-menu-container").html(menuMarkup).css({'padding-bottom': '10px'});
   }
-{/literal}{/if}{literal}
+  else {
+    $('body').append(menuMarkup);
+  }
+
   // CRM-15493 get the current qfKey
   $("input[name=qfKey]", "#quickSearch").val($('#civicrm-navigation-menu').data('qfkey'));
 
@@ -155,6 +150,9 @@ $('#civicrm-menu').ready(function() {
     });
   $('.crm-hidemenu').click(function(e) {
     $('#civicrm-menu').slideUp();
+    if ($('#toolbar-bar').length) {
+      $('#toolbar-bar').slideDown();
+    }
     if ($('#crm-notification-container').length) {
       var alert = CRM.alert({/literal}'<a href="#" id="crm-restore-menu" style="text-align: center; margin-top: -8px;">{ts escape='js'}Restore CiviCRM Menu{/ts}</a>'{literal}, '', 'none', {expires: 10000});
       $('#crm-restore-menu')
@@ -163,6 +161,9 @@ $('#civicrm-menu').ready(function() {
           e.preventDefault();
           alert.close();
           $('#civicrm-menu').slideDown();
+          if ($('#toolbar-bar').length) {
+            $('#toolbar-bar').slideUp();
+          }
         })
         .parent().css('text-align', 'center').find('.ui-button-text').css({'padding-top': '4px', 'padding-bottom': '4px'})
       ;

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -150,9 +150,6 @@ $('#civicrm-menu').ready(function() {
     });
   $('.crm-hidemenu').click(function(e) {
     $('#civicrm-menu').slideUp();
-    if ($('#toolbar-bar').length) {
-      $('#toolbar-bar').slideDown();
-    }
     if ($('#crm-notification-container').length) {
       var alert = CRM.alert({/literal}'<a href="#" id="crm-restore-menu" style="text-align: center; margin-top: -8px;">{ts escape='js'}Restore CiviCRM Menu{/ts}</a>'{literal}, '', 'none', {expires: 10000});
       $('#crm-restore-menu')
@@ -161,9 +158,6 @@ $('#civicrm-menu').ready(function() {
           e.preventDefault();
           alert.close();
           $('#civicrm-menu').slideDown();
-          if ($('#toolbar-bar').length) {
-            $('#toolbar-bar').slideUp();
-          }
         })
         .parent().css('text-align', 'center').find('.ui-button-text').css({'padding-top': '4px', 'padding-bottom': '4px'})
       ;


### PR DESCRIPTION
Overview
----------------------------------------
The PR introduces the following changes:
1. Hide Drupal8 menu bar on Civi pages
2. Moved the CMS specific navigation changes from tpl to respective CMS js
3. Added Drupal8 js to handle D8 specific changes like hide toolbar, pagetitle.

Before
----------------------------------------
![screen shot 2018-07-13 at 11 20 02 am](https://user-images.githubusercontent.com/3735621/42674818-d9e0e6dc-868e-11e8-8329-2d9e9d9f8022.png)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/42674630-310bdc9c-868e-11e8-870f-a669767d8879.gif)

Comments
----------------------------------------
This patch needs to be tested in all CMSs to ensure it doesn't affect the CiviCRM menu.