### PR TITLE
Fixed #141: only check if name exists.

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -115,11 +115,10 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     //validate group title as well as name.
     $title = $fields['title'];
     $name = CRM_Utils_String::munge($title, '_', 64);
-    $query = 'select count(*) from civicrm_custom_group where ( name like %1 OR title like %2 ) and id != %3';
+    $query = 'select count(*) from civicrm_custom_group where ( name like %1) and id != %2';
     $grpCnt = CRM_Core_DAO::singleValueQuery($query, array(
       1 => array($name, 'String'),
-      2 => array($title, 'String'),
-      3 => array((int) $self->_id, 'Integer'),
+      2 => array((int) $self->_id, 'Integer'),
     ));
     if ($grpCnt) {
       $errors['title'] = ts('Custom group \'%1\' already exists in Database.', array(1 => $title));


### PR DESCRIPTION
Overview
----------------------------------------
This will fix the check for duplicate titles of custom groups but leaves the check for duplicate names.

Before
----------------------------------------
I have created two custom groups from within my extension:

- Name: group_areas, Title: Areas
- Name: contact_areas, Title: Areas

When I now edit the custom group it will fail because both custom groups have the same title but a different name. 

After
----------------------------------------
I have created two custom groups from within my extension:

- Name: group_areas, Title: Areas
- Name: contact_areas, Title: Areas

When I now edit the custom group it will be saved successfully.


Comments
----------------------------------------
See discussion at gitlab: https://lab.civicrm.org/dev/core/issues/141

