### PR TITLE
dev/core#256 - use unsigned int for temporary recipient ids

### DIFF
--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -102,7 +102,7 @@ WHERE  mailing_id = %1
     CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS  srcMailing_$sourceMailingId");
     $sql = "
 CREATE TEMPORARY TABLE srcMailing_$sourceMailingId
-            (mailing_recipient_id int, id int PRIMARY KEY AUTO_INCREMENT, INDEX(mailing_recipient_id))
+            (mailing_recipient_id int unsigned, id int PRIMARY KEY AUTO_INCREMENT, INDEX(mailing_recipient_id))
             ENGINE=HEAP";
     CRM_Core_DAO::executeQuery($sql);
     $sql = "


### PR DESCRIPTION
Overview
----------------------------------------
This is to solve Gitlab issue 2<sup>8</sup>, which affects (seriously) CiviCRM users who have sent more than 2<sup>31</sup> emails.

Before
----------------------------------------
When submitting an A/B mailing, the whole target group receives version A

After
----------------------------------------
When submitting an A/B mailing, only 50% of the sample group receives version A, the other half version B, and the rest is assigned to Final mailing.

Technical Details
----------------------------------------
The temporary table that holds recipient ids to move from mailing A to mailing B and C should use the column type `int unsigned`, which matches the one used by `civicrm_mailing_recipients`.

Comments
----------------------------------------
This is also a heads up that someone *will* hit 2<sup>32</sup> emails sooner than later, and a number of columns should be migrated to `BIGINT` type at some point.
