### PR TITLE
NFC Ignore temp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ civicrm.settings.php
 sql/dummy_processor.mysql
 distmaker/distmaker.conf
 distmaker/out
+tmp/


### PR DESCRIPTION
Overview
----------------------------------------
This adds the temp directory which is created via https://github.com/civicrm/civicrm-core/blob/4.6/karma.conf.js#L7 to the gitignore file