### PR TITLE
dev/core#259 OptionGroup Admin UI workflow improvements

### DIFF
--- a/CRM/Admin/Form/OptionGroup.php
+++ b/CRM/Admin/Form/OptionGroup.php
@@ -78,7 +78,7 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
       CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionGroup', 'description')
     );
 
-    $this->addSelect('data_type', array('options' => CRM_Utils_Type::dataTypes()), TRUE);
+    $this->addSelect('data_type', array('options' => CRM_Utils_Type::dataTypes()), empty($this->_values['is_reserved']));
 
     $element = $this->add('checkbox', 'is_active', ts('Enabled?'));
     if ($this->_action & CRM_Core_Action::UPDATE) {
@@ -96,8 +96,12 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
           $element->freeze();
         }
       }
+
+      $this->add('checkbox', 'is_reserved', ts('Reserved?'));
+      $this->freeze('is_reserved');
+
       if (!empty($this->_values['is_reserved'])) {
-        $this->freeze(array('name', 'is_active'));
+        $this->freeze(array('name', 'is_active', 'data_type'));
       }
     }
 
@@ -118,12 +122,13 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
       // store the submitted values in an array
       $params = $this->exportValues();
 
-      // If we are adding option group via UI it should not be marked reserved.
-      if (!isset($params['is_reserved'])) {
-        $params['is_reserved'] = 0;
+      if ($this->_action & CRM_Core_Action::ADD) {
+        // If we are adding option group via UI it should not be marked reserved.
+        if (!isset($params['is_reserved'])) {
+          $params['is_reserved'] = 0;
+        }
       }
-
-      if ($this->_action & CRM_Core_Action::UPDATE) {
+      elseif ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;
       }
 

--- a/templates/CRM/Admin/Form/OptionGroup.tpl
+++ b/templates/CRM/Admin/Form/OptionGroup.tpl
@@ -52,6 +52,10 @@
               <td class="label">{$form.is_active.label}</td>
               <td>{$form.is_active.html}</td>
           </tr>
+        <tr class="crm-admin-optiongroup-form-block-is_reserved">
+          <td class="label">{$form.is_reserved.label}</td>
+          <td>{$form.is_reserved.html}</td>
+        </tr>
       </table>
      {/if}
      <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Admin/Page/OptionGroup.tpl
+++ b/templates/CRM/Admin/Page/OptionGroup.tpl
@@ -60,7 +60,10 @@
           <td class="crm-admin-optionGroup-name">{$row.name}</td>
           <td class="crm-admin-optionGroup-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crm-admin-optionGroup-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td><a href="{crmURL p="civicrm/admin/options" q="gid=`$row.id`&reset=1"}" title="{ts}View and Edit Options{/ts}">{ts}Options{/ts}</a></td>
+          <td>
+            <a href="{crmURL p="civicrm/admin/options" q="id=`$row.id`&action=update&reset=1"}" class="action-item crm-hover-button" title="{ts}OptionGroup settings{/ts}">{ts}Settings{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/options" q="gid=`$row.id`&reset=1"}" class="action-item crm-hover-button" title="{ts}View and Edit Options{/ts}">{ts}Edit Options{/ts}</a>
+          </td>
         </tr>
         {/foreach}
     </table>

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -175,7 +175,7 @@
       {if $isLocked ne 1}
         {crmButton p="civicrm/admin/options/$gName" q='action=add&reset=1' class="new-option" icon="plus-circle"}{ts 1=$gLabel}Add %1{/ts}{/crmButton}
       {/if}
-      {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
+      {crmButton p="civicrm/admin/options" q="action=browse&reset=1" class="next no-popup" icon="check"}{ts}Done{/ts}{/crmButton}
     </div>
 </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Ref: https://lab.civicrm.org/dev/core/issues/259

Various improvements to the "flow" of the option groups admin pages.

Before
----------------------------------------
* No option to edit option group settings (eg. change the label).
* When clicking "Done" editing options, redirect to the option groups list instead of the default admin page.

After
----------------------------------------
* Add option to edit option group settings (the code was already in place, but not exposed in UI).
  * Display "is_reserved" status on option group settings.
  * Don't allow changing data type on reserved option groups.
  * On update optiongroup don't touch is_reserved.
![localhost_8000_civicrm_admin_options_action browse reset 1 4](https://user-images.githubusercontent.com/2052161/42726000-43ca3642-8785-11e8-9ea3-d0228ceb558e.png)

![localhost_8000_civicrm_admin_options_action browse reset 1 5](https://user-images.githubusercontent.com/2052161/42726002-48fc8520-8785-11e8-9ebc-9267444e510f.png)

* When clicking "Done" editing options, redirect to the option groups list instead of the default admin page.
![localhost_8000_civicrm_admin_options_action browse reset 1 6](https://user-images.githubusercontent.com/2052161/42726010-6995ac9e-8785-11e8-8823-111f71f52d07.png)


Technical Details
----------------------------------------
UI only changes that enable editing option groups parameters.

Comments
----------------------------------------
If you are working with multiple option groups, the UI has always been a bit difficult to navigate and various functions are not possible via the UI (such as changing the label of an option group).
