### PR TITLE
Rename CRM_Contribute_BAO_ManagePremiums to CRM_Contribute_BAO_Product and deprecate CRM_Contribute_BAO_ManagePremiums

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -123,7 +123,7 @@ class CRM_Admin_Page_AJAX {
           $ret['content'] = ts('Are you sure you want to disable this CiviCRM Profile field?');
           break;
 
-        case 'CRM_Contribute_BAO_ManagePremiums':
+        case 'CRM_Contribute_BAO_Product':
           $ret['content'] = ts('Are you sure you want to disable this premium? This action will remove the premium from any contribution pages that currently offer it. However it will not delete the premium record - so you can re-enable it and add it back to your contribution page(s) at a later time.');
           break;
 

--- a/CRM/Contribute/BAO/Product.php
+++ b/CRM/Contribute/BAO/Product.php
@@ -96,19 +96,26 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
    */
   public static function add(&$params, $ids) {
     $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('premium', $ids));
-    $params = array_merge(array(
-      'id' => $id,
-      'image' => '',
-      'thumbnail' => '',
-      'is_active' => 0,
-      'is_deductible' => FALSE,
-      'currency' => CRM_Core_Config::singleton()->defaultCurrency,
-    ), $params);
+    if (empty($id)) {
+      $defaultParams = [
+        'id' => $id,
+        'image' => '',
+        'thumbnail' => '',
+        'is_active' => 0,
+        'is_deductible' => FALSE,
+        'currency' => CRM_Core_Config::singleton()->defaultCurrency,
+      ];
+      $params = array_merge($defaultParams, $params);
+    }
 
     // Modify the submitted values for 'image' and 'thumbnail' so that we use
     // local URLs for these images when possible.
-    $params['image'] = CRM_Utils_String::simplifyURL($params['image'], TRUE);
-    $params['thumbnail'] = CRM_Utils_String::simplifyURL($params['thumbnail'], TRUE);
+    if (isset($params['image'])) {
+      $params['image'] = CRM_Utils_String::simplifyURL($params['image'], TRUE);
+    }
+    if (isset($params['thumbnail'])) {
+      $params['thumbnail'] = CRM_Utils_String::simplifyURL($params['thumbnail'], TRUE);
+    }
 
     // Save and return
     $premium = new CRM_Contribute_DAO_Product();

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -209,7 +209,7 @@ class CRM_Contribute_Form_AdditionalInfo {
     );
 
     $productDetails = array();
-    CRM_Contribute_BAO_ManagePremiums::retrieve($premiumParams, $productDetails);
+    CRM_Contribute_BAO_Product::retrieve($premiumParams, $productDetails);
     $dao->financial_type_id = CRM_Utils_Array::value('financial_type_id', $productDetails);
     if (!empty($options[$selectedProductID])) {
       $dao->product_option = $options[$selectedProductID][$selectedProductOptionID];

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -50,7 +50,7 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     $defaults = parent::setDefaultValues();
     if ($this->_id) {
       $params = array('id' => $this->_id);
-      CRM_Contribute_BAO_ManagePremiums::retrieve($params, $tempDefaults);
+      CRM_Contribute_BAO_Product::retrieve($params, $tempDefaults);
       $imageUrl = (isset($tempDefaults['image'])) ? $tempDefaults['image'] : "";
       if (isset($tempDefaults['image']) && isset($tempDefaults['thumbnail'])) {
         $defaults['imageUrl'] = $tempDefaults['image'];
@@ -272,7 +272,7 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
 
     // If deleting, then only delete and skip the rest of the post-processing
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Contribute_BAO_ManagePremiums::del($this->_id);
+      CRM_Contribute_BAO_Product::del($this->_id);
       CRM_Core_Session::setStatus(
         ts('Selected Premium Product type has been deleted.'),
         ts('Deleted'), 'info');
@@ -295,7 +295,7 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     $this->_processImages($params);
 
     // Save to database
-    $premium = CRM_Contribute_BAO_ManagePremiums::add($params, $ids);
+    $premium = CRM_Contribute_BAO_Product::add($params, $ids);
 
     CRM_Core_Session::setStatus(
       ts("The Premium '%1' has been saved.", array(1 => $premium->name)),

--- a/CRM/Contribute/Page/ManagePremiums.php
+++ b/CRM/Contribute/Page/ManagePremiums.php
@@ -52,7 +52,7 @@ class CRM_Contribute_Page_ManagePremiums extends CRM_Core_Page_Basic {
    *   Classname of BAO.
    */
   public function getBAOName() {
-    return 'CRM_Contribute_BAO_ManagePremiums';
+    return 'CRM_Contribute_BAO_Product';
   }
 
   /**

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -369,7 +369,7 @@ WHERE ceft.entity_id = %1";
         'id' => $params['oldPremium']['product_id'],
       );
       $productDetails = array();
-      CRM_Contribute_BAO_ManagePremiums::retrieve($premiumParams, $productDetails);
+      CRM_Contribute_BAO_Product::retrieve($premiumParams, $productDetails);
       $params = array(
         'cost' => CRM_Utils_Array::value('cost', $productDetails),
         'currency' => CRM_Utils_Array::value('currency', $productDetails),

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -376,7 +376,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'min_contribution' => 100,
       'is_active' => 1,
     );
-    $premium = CRM_Contribute_BAO_ManagePremiums::add($params, $ids);
+    $premium = CRM_Contribute_BAO_Product::add($params, $ids);
 
     $this->assertEquals('TEST Premium', $premium->name, 'Check for premium  name.');
 
@@ -415,7 +415,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals($contributionProduct->product_id, $premium->id, 'Check for Product id .');
 
     //Delete Product
-    CRM_Contribute_BAO_ManagePremiums::del($premium->id);
+    CRM_Contribute_BAO_Product::del($premium->id);
     $this->assertDBNull('CRM_Contribute_DAO_Product', $premium->name,
       'id', 'name', 'Database check for deleted Product.'
     );

--- a/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
@@ -26,10 +26,10 @@
  */
 
 /**
- * Class CRM_Contribute_BAO_ManagePremiumsTest
+ * Class CRM_Contribute_BAO_ProductTest
  * @group headless
  */
-class CRM_Contribute_BAO_ManagePremiumsTest extends CiviUnitTestCase {
+class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
 
   public function setUp() {
     parent::setUp();
@@ -50,9 +50,9 @@ class CRM_Contribute_BAO_ManagePremiumsTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_ManagePremiums::add($params, $ids);
+    $product = CRM_Contribute_BAO_Product::add($params, $ids);
 
-    $result = $this->assertDBNotNull('CRM_Contribute_BAO_ManagePremiums', $product->id,
+    $result = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
       'sku', 'id',
       'Database check on updated product record.'
     );
@@ -75,10 +75,10 @@ class CRM_Contribute_BAO_ManagePremiumsTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_ManagePremiums::add($params, $ids);
+    $product = CRM_Contribute_BAO_Product::add($params, $ids);
     $params = array('id' => $product->id);
     $default = array();
-    $result = CRM_Contribute_BAO_ManagePremiums::retrieve($params, $default);
+    $result = CRM_Contribute_BAO_Product::retrieve($params, $default);
     $this->assertEquals(empty($result), FALSE, 'Verify products record.');
   }
 
@@ -97,10 +97,10 @@ class CRM_Contribute_BAO_ManagePremiumsTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_ManagePremiums::add($params, $ids);
-    CRM_Contribute_BAO_ManagePremiums::setIsActive($product->id, 0);
+    $product = CRM_Contribute_BAO_Product::add($params, $ids);
+    CRM_Contribute_BAO_Product::setIsActive($product->id, 0);
 
-    $isActive = $this->assertDBNotNull('CRM_Contribute_BAO_ManagePremiums', $product->id,
+    $isActive = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
       'is_active', 'id',
       'Database check on updated for product records is_active.'
     );
@@ -123,13 +123,13 @@ class CRM_Contribute_BAO_ManagePremiumsTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_ManagePremiums::add($params, $ids);
+    $product = CRM_Contribute_BAO_Product::add($params, $ids);
 
-    CRM_Contribute_BAO_ManagePremiums::del($product->id);
+    CRM_Contribute_BAO_Product::del($product->id);
 
     $params = array('id' => $product->id);
     $default = array();
-    $result = CRM_Contribute_BAO_ManagePremiums::retrieve($params, $defaults);
+    $result = CRM_Contribute_BAO_Product::retrieve($params, $defaults);
 
     $this->assertEquals(empty($result), TRUE, 'Verify product record deletion.');
   }

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1436,6 +1436,14 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         //api has special handling on these 2 fields for backward compatibility reasons
         $entity['next_sched_contribution'] = $updateParams['next_sched_contribution_date'];
       }
+      if (isset($updateParams['image'])) {
+        // Image field is passed through simplifyURL function so may be different, do the same here for comparison
+        $entity['image'] = CRM_Utils_String::simplifyURL($updateParams['image'], TRUE);
+      }
+      if (isset($updateParams['thumbnail'])) {
+        // Thumbnail field is passed through simplifyURL function so may be different, do the same here for comparison
+        $entity['thumbnail'] = CRM_Utils_String::simplifyURL($updateParams['thumbnail'], TRUE);
+      }
 
       $update = $this->callAPISuccess($entityName, 'create', $updateParams);
       $checkParams = array(


### PR DESCRIPTION
Overview
----------------------------------------
Ref #12435 @eileenmcnaughton as discussed.

Before
----------------------------------------
CRM_Contribute_BAO_ManagePremiums extends from CRM_Contribute_DAO_Product and is actually the BAO_Product class but has a different name (so the API doesn't use it and any other DAO/BAO magic does not pick it up).  Also, it's really confusing when working with that code!

After
----------------------------------------
CRM_Contribute_BAO_ManagePremiums is deprecated (and extends from the new CRM_Contribute_BAO_Product class).
The CRM_Contribute_BAO_Product class is a renamed copy of the CRM_Contribute_BAO_ManagePremiums class.

Technical Details
----------------------------------------
BAO object named properly for Product entity.

Comments
----------------------------------------
The "Premiums" code has not been touched for around 5 years so I don't think it is used very often!
