### PR TITLE
BAO_Navigation: Respect domain_id param

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -70,6 +70,7 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
     if (empty($params['id'])) {
       $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
       $params['has_separator'] = CRM_Utils_Array::value('has_separator', $params, FALSE);
+      $params['domain_id'] = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
     }
 
     if (!isset($params['id']) ||
@@ -92,8 +93,6 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
     }
 
     $navigation->copyValues($params);
-
-    $navigation->domain_id = CRM_Core_Config::domainID();
 
     $navigation->save();
     return $navigation;

--- a/api/v3/Navigation.php
+++ b/api/v3/Navigation.php
@@ -88,17 +88,6 @@ function civicrm_api3_navigation_get($params) {
 }
 
 /**
- * Adjust metadata for navigation create action.
- *
- * @param array $params
- */
-function _civicrm_api3_navigation_create_spec(&$params) {
-  $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
-  $params['domain_id']['type'] = CRM_Utils_Type::T_INT;
-  $params['domain_id']['title'] = 'Domain ID';
-}
-
-/**
  * Create navigation item.
  *
  * @param array $params

--- a/tests/phpunit/api/v3/NavigationTest.php
+++ b/tests/phpunit/api/v3/NavigationTest.php
@@ -69,6 +69,17 @@ class api_v3_NavigationTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test create function.
+   */
+  public function testDefaultDomain() {
+    $params = array('label' => 'Herd the Cats');
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
+    // Check domain_id has been set per default
+    $params['domain_id'] = CRM_Core_Config::domainID();
+    $this->getAndCheck($params, $result['id'], $this->_entity, TRUE);
+  }
+
+  /**
    * Test delete function.
    */
   public function testDelete() {


### PR DESCRIPTION
Overview
----------------------------------------
_Allow choosing the domain_id when creating or updating a navigation menu item_

Before
----------------------------------------
The BAO would clobber the domain_id whenever creating or updating a navigation menu item.

After
----------------------------------------
It respects the param if set, but will still default to the current domain.