### PR TITLE
Export class code cleanup Start building export processor class.

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -131,50 +131,6 @@ class CRM_Export_BAO_Export {
   }
 
   /**
-   * Get Querymode based on ExportMode
-   *
-   * @param int $exportMode
-   *   Export mode.
-   *
-   * @return string $Querymode
-   *   Query Mode
-   */
-  public static function getQueryMode($exportMode) {
-    $queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
-
-    switch ($exportMode) {
-      case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_CONTRIBUTE;
-        break;
-
-      case CRM_Export_Form_Select::EVENT_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_EVENT;
-        break;
-
-      case CRM_Export_Form_Select::MEMBER_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_MEMBER;
-        break;
-
-      case CRM_Export_Form_Select::PLEDGE_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_PLEDGE;
-        break;
-
-      case CRM_Export_Form_Select::CASE_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
-        break;
-
-      case CRM_Export_Form_Select::GRANT_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_GRANT;
-        break;
-
-      case CRM_Export_Form_Select::ACTIVITY_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_ACTIVITY;
-        break;
-    }
-    return $queryMode;
-  }
-
-  /**
    * Get default return property for export based on mode
    *
    * @param int $exportMode
@@ -397,6 +353,7 @@ class CRM_Export_BAO_Export {
     $queryOperator = 'AND'
   ) {
 
+    $processor = new CRM_Export_BAO_ExportProcessor($exportMode);
     $returnProperties = array();
     $paymentFields = $selectedPaymentFields = FALSE;
 
@@ -417,7 +374,7 @@ class CRM_Export_BAO_Export {
     self::$memberOfHouseholdRelationshipKey = CRM_Utils_Array::key('Household Member of', self::$relationshipTypes);
     self::$headOfHouseholdRelationshipKey = CRM_Utils_Array::key('Head of Household for', self::$relationshipTypes);
 
-    $queryMode = self::getQueryMode($exportMode);
+    $queryMode = $processor->getQueryMode();
 
     if ($fields) {
       //construct return properties

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ */
+
+/**
+ * Class CRM_Export_BAO_ExportProcessor
+ *
+ * Class to handle logic of export.
+ */
+class CRM_Export_BAO_ExportProcessor {
+
+  /**
+   * @var int
+   */
+  protected $queryMode;
+
+  /**
+   * @var int
+   */
+  protected $exportMode;
+
+  /**
+   * CRM_Export_BAO_ExportProcessor constructor.
+   *
+   * @param int $exportMode
+   */
+  public function __construct($exportMode) {
+    $this->setExportMode($exportMode);
+    $this->setQueryMode();
+  }
+
+  /**
+   * @return int
+   */
+  public function getQueryMode() {
+    return $this->queryMode;
+  }
+
+  /**
+   * Set the query mode based on the export mode.
+   */
+  public function setQueryMode() {
+
+    switch ($this->getExportMode()) {
+      case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_CONTRIBUTE;
+        break;
+
+      case CRM_Export_Form_Select::EVENT_EXPORT:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_EVENT;
+        break;
+
+      case CRM_Export_Form_Select::MEMBER_EXPORT:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_MEMBER;
+        break;
+
+      case CRM_Export_Form_Select::PLEDGE_EXPORT:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_PLEDGE;
+        break;
+
+      case CRM_Export_Form_Select::CASE_EXPORT:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_CASE;
+        break;
+
+      case CRM_Export_Form_Select::GRANT_EXPORT:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_GRANT;
+        break;
+
+      case CRM_Export_Form_Select::ACTIVITY_EXPORT:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_ACTIVITY;
+        break;
+
+      default:
+        $this->queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
+    }
+  }
+
+  /**
+   * @return int
+   */
+  public function getExportMode() {
+    return $this->exportMode;
+  }
+
+  /**
+   * @param int $exportMode
+   */
+  public function setExportMode($exportMode) {
+    $this->exportMode = $exportMode;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup on export code class

Before
----------------------------------------
Class to fix code less clear

After
----------------------------------------
Path to fix code more clear.

Technical Details
----------------------------------------
A fundamental cause of code mess in the Export class is that it is a mishmash of static functions with variables passed around crazily. This starts the process of moving work to a object oriented class.

I think this migratory approach is the best plan to clean up the code

I did move some vars to being accessed via 'self' but there is leakage across tests so going
full OOO seems like a better approach. This is pretty much the minimum change I can make to start setting up the class but the intent is to move more across & to track the various arrays as properties on that class

Comments
----------------------------------------

