### PR TITLE
CIVICRM-902: Creating new address if deleting old location block.

### DIFF
--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -253,7 +253,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
           $values['is_primary'] = 1;
         }
         $values['location_type_id'] = ($defaultLocationType->id) ? $defaultLocationType->id : 1;
-        if (isset($this->_values[$block][$count])) {
+        if (isset($this->_values[$block][$count]) && !$deleteOldBlock) {
           $values['id'] = $this->_values[$block][$count]['id'];
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Adding new location in event with *Create new location* option throws DB error when an address is already added/selected for an event.  

**Steps to reproduce:**

1. Create Event
2. Go to Locations tab and select **Create new location** option
3. Add location with address
4. Click on **Create new location** again.
5. Fill in new address details and Click on save
6. Process hangs up and does not save the new location (Previous location is deleted though).  

This is true even after refreshing the page.

Problem
----------------------------------------
CiviCRM adds id of blocks even if User has selected to create new address.

Before
----------------------------------------
Adding new address with **Create new location** for an Event does not works and User has to refresh the page to readd the details.

After
----------------------------------------
It works now as expected and creates new address successfully with **Create new location** option.

Technical Details
----------------------------------------
This PR checks if `$deleteOldBlock` boolean is set. If yes, it prevents adding block ids.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-902_
