### PR TITLE
Export cleanup - pass processor object rather than the query object

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -353,7 +353,7 @@ class CRM_Export_BAO_Export {
     $queryOperator = 'AND'
   ) {
 
-    $processor = new CRM_Export_BAO_ExportProcessor($exportMode);
+    $processor = new CRM_Export_BAO_ExportProcessor($exportMode, $queryOperator);
     $returnProperties = array();
     $paymentFields = $selectedPaymentFields = FALSE;
 
@@ -556,7 +556,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       CRM_Contact_BAO_ProximityQuery::fixInputParams($params);
     }
 
-    list($query, $select, $from, $where, $having) = $processor->runQuery($params, $order, $queryOperator, $returnProperties);
+    list($query, $select, $from, $where, $having) = $processor->runQuery($params, $order, $returnProperties);
 
     if ($mergeSameHousehold == 1) {
       if (empty($returnProperties['id'])) {

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -556,15 +556,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       CRM_Contact_BAO_ProximityQuery::fixInputParams($params);
     }
 
-    $query = new CRM_Contact_BAO_Query($params, $returnProperties, NULL,
-      FALSE, FALSE, $queryMode,
-      FALSE, TRUE, TRUE, NULL, $queryOperator
-    );
-
-    //sort by state
-    //CRM-15301
-    $query->_sort = $order;
-    list($select, $from, $where, $having) = $query->query();
+    list($query, $select, $from, $where, $having) = $processor->runQuery($params, $order, $queryOperator, $returnProperties);
 
     if ($mergeSameHousehold == 1) {
       if (empty($returnProperties['id'])) {
@@ -687,7 +679,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     // for CRM-3157 purposes
     $i18n = CRM_Core_I18n::singleton();
 
-    list($outputColumns, $headerRows, $sqlColumns, $metadata) = self::getExportStructureArrays($returnProperties, $query, $relationQuery, $selectedPaymentFields);
+    list($outputColumns, $headerRows, $sqlColumns, $metadata) = self::getExportStructureArrays($returnProperties, $processor, $relationQuery, $selectedPaymentFields);
 
     $limitReached = FALSE;
     while (!$limitReached) {
@@ -837,7 +829,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           // where other header definitions take place.
           $headerRows = array_merge($headerRows, $paymentHeaders);
           foreach (array_keys($paymentHeaders) as $paymentHdr) {
-            self::sqlColumnDefn($query, $sqlColumns, $paymentHdr);
+            self::sqlColumnDefn($processor, $sqlColumns, $paymentHdr);
           }
         }
 
@@ -1065,15 +1057,15 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
   }
 
   /**
-   * @param $query
+   * @param \CRM_Export_BAO_ExportProcessor $processor
    * @param $sqlColumns
    * @param $field
    */
-  public static function sqlColumnDefn($query, &$sqlColumns, $field) {
+  public static function sqlColumnDefn($processor, &$sqlColumns, $field) {
     if (substr($field, -4) == '_a_b' || substr($field, -4) == '_b_a') {
       return;
     }
-    $queryFields = $query->_fields;
+    $queryFields = $processor->getQueryFields();
 
     $fieldName = CRM_Utils_String::munge(strtolower($field), '_', 64);
     if ($fieldName == 'id') {
@@ -1801,7 +1793,7 @@ WHERE  {$whereClause}";
    * @param array $headerRows
    * @param array $sqlColumns
    *   Columns to go in the temp table.
-   * @param CRM_Contact_BAO_Query $query
+   * @param \CRM_Export_BAO_ExportProcessor $processor
    * @param array|string $value
    * @param array $phoneTypes
    * @param array $imProviders
@@ -1809,9 +1801,9 @@ WHERE  {$whereClause}";
    * @param array $selectedPaymentFields
    * @return array
    */
-  public static function setHeaderRows($field, $headerRows, $sqlColumns, $query, $value, $phoneTypes, $imProviders, $relationQuery, $selectedPaymentFields) {
+  public static function setHeaderRows($field, $headerRows, $sqlColumns, $processor, $value, $phoneTypes, $imProviders, $relationQuery, $selectedPaymentFields) {
 
-    $queryFields = $query->_fields;
+    $queryFields = $processor->getQueryFields();
     // Split campaign into 2 fields for id and title
     if (substr($field, -14) == 'campaign_title') {
       $headerRows[] = ts('Campaign Title');
@@ -1849,22 +1841,22 @@ WHERE  {$whereClause}";
 
           $headerRows[] = $headerName;
 
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
+          self::sqlColumnDefn($processor, $sqlColumns, $headerName);
         }
         elseif ($relationField == 'phone_type_id') {
           $headerName = $field . '-' . 'Phone Type';
           $headerRows[] = $headerName;
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
+          self::sqlColumnDefn($processor, $sqlColumns, $headerName);
         }
         elseif ($relationField == 'provider_id') {
           $headerName = $field . '-' . 'Im Service Provider';
           $headerRows[] = $headerName;
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
+          self::sqlColumnDefn($processor, $sqlColumns, $headerName);
         }
         elseif ($relationField == 'state_province_id') {
           $headerName = $field . '-' . 'state_province_id';
           $headerRows[] = $headerName;
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
+          self::sqlColumnDefn($processor, $sqlColumns, $headerName);
         }
         elseif (is_array($relationValue) && $relationField == 'location') {
           // fix header for location type case
@@ -1884,7 +1876,7 @@ WHERE  {$whereClause}";
               }
               $headerName = $field . '-' . $hdr;
               $headerRows[] = $headerName;
-              self::sqlColumnDefn($query, $sqlColumns, $headerName);
+              self::sqlColumnDefn($processor, $sqlColumns, $headerName);
             }
           }
         }
@@ -1898,7 +1890,7 @@ WHERE  {$whereClause}";
       $headerRows[] = $field;
     }
 
-    self::sqlColumnDefn($query, $sqlColumns, $field);
+    self::sqlColumnDefn($processor, $sqlColumns, $field);
 
     return array($headerRows, $sqlColumns);
   }
@@ -1913,7 +1905,7 @@ WHERE  {$whereClause}";
    * as a step on the refactoring path rather than how it should be.
    *
    * @param array $returnProperties
-   * @param CRM_Contact_BAO_Contact $query
+   * @param \CRM_Export_BAO_ExportProcessor $processor
    * @param string $relationQuery
    * @param array $selectedPaymentFields
    * @return array
@@ -1932,16 +1924,16 @@ WHERE  {$whereClause}";
    *    - b) this code is old & outdated. Submit your answers to circular bin or better
    *       yet find a way to comment them for posterity.
    */
-  public static function getExportStructureArrays($returnProperties, $query, $relationQuery, $selectedPaymentFields) {
+  public static function getExportStructureArrays($returnProperties, $processor, $relationQuery, $selectedPaymentFields) {
     $metadata = $headerRows = $outputColumns = $sqlColumns = array();
     $phoneTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
     $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
 
-    $queryFields = $query->_fields;
+    $queryFields = $processor->getQueryFields();
     foreach ($returnProperties as $key => $value) {
       if ($key != 'location' || !is_array($value)) {
         $outputColumns[$key] = $value;
-        list($headerRows, $sqlColumns) = self::setHeaderRows($key, $headerRows, $sqlColumns, $query, $value, $phoneTypes, $imProviders, $relationQuery, $selectedPaymentFields);
+        list($headerRows, $sqlColumns) = self::setHeaderRows($key, $headerRows, $sqlColumns, $processor, $value, $phoneTypes, $imProviders, $relationQuery, $selectedPaymentFields);
       }
       else {
         foreach ($value as $locationType => $locationFields) {
@@ -1965,8 +1957,8 @@ WHERE  {$whereClause}";
               // Warning: shame inducing hack.
               $metadata[$daoFieldName]['pseudoconstant']['var'] = 'imProviders';
             }
-            self::sqlColumnDefn($query, $sqlColumns, $outputFieldName);
-            list($headerRows, $sqlColumns) = self::setHeaderRows($outputFieldName, $headerRows, $sqlColumns, $query, $value, $phoneTypes, $imProviders, $relationQuery, $selectedPaymentFields);
+            self::sqlColumnDefn($processor, $sqlColumns, $outputFieldName);
+            list($headerRows, $sqlColumns) = self::setHeaderRows($outputFieldName, $headerRows, $sqlColumns, $processor, $value, $phoneTypes, $imProviders, $relationQuery, $selectedPaymentFields);
             if ($actualDBFieldName == 'country' || $actualDBFieldName == 'world_region') {
               $metadata[$daoFieldName] = array('context' => 'country');
             }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -56,6 +56,39 @@ class CRM_Export_BAO_ExportProcessor {
   protected $queryFields = [];
 
   /**
+   * Either AND or OR.
+   *
+   * @var string
+   */
+  protected $queryOperator;
+
+  /**
+   * CRM_Export_BAO_ExportProcessor constructor.
+   *
+   * @param int $exportMode
+   * @param string $queryOperator
+   */
+  public function __construct($exportMode, $queryOperator) {
+    $this->setExportMode($exportMode);
+    $this->setQueryMode();
+    $this->setQueryOperator($queryOperator);
+  }
+
+  /**
+   * @return string
+   */
+  public function getQueryOperator() {
+    return $this->queryOperator;
+  }
+
+  /**
+   * @param string $queryOperator
+   */
+  public function setQueryOperator($queryOperator) {
+    $this->queryOperator = $queryOperator;
+  }
+
+  /**
    * @return array
    */
   public function getQueryFields() {
@@ -67,16 +100,6 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function setQueryFields($queryFields) {
     $this->queryFields = $queryFields;
-  }
-
-  /**
-   * CRM_Export_BAO_ExportProcessor constructor.
-   *
-   * @param int $exportMode
-   */
-  public function __construct($exportMode) {
-    $this->setExportMode($exportMode);
-    $this->setQueryMode();
   }
 
   /**
@@ -142,14 +165,13 @@ class CRM_Export_BAO_ExportProcessor {
   /**
    * @param $params
    * @param $order
-   * @param $queryOperator
    * @param $returnProperties
    * @return array
    */
-  public function runQuery($params, $order, $queryOperator, $returnProperties) {
+  public function runQuery($params, $order, $returnProperties) {
     $query = new CRM_Contact_BAO_Query($params, $returnProperties, NULL,
       FALSE, FALSE, $this->getQueryMode(),
-      FALSE, TRUE, TRUE, NULL, $queryOperator
+      FALSE, TRUE, TRUE, NULL, $this->getQueryOperator()
     );
 
     //sort by state

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -49,6 +49,27 @@ class CRM_Export_BAO_ExportProcessor {
   protected $exportMode;
 
   /**
+   * Array of fields in the main query.
+   *
+   * @var array
+   */
+  protected $queryFields = [];
+
+  /**
+   * @return array
+   */
+  public function getQueryFields() {
+    return $this->queryFields;
+  }
+
+  /**
+   * @param array $queryFields
+   */
+  public function setQueryFields($queryFields) {
+    $this->queryFields = $queryFields;
+  }
+
+  /**
    * CRM_Export_BAO_ExportProcessor constructor.
    *
    * @param int $exportMode
@@ -116,6 +137,27 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function setExportMode($exportMode) {
     $this->exportMode = $exportMode;
+  }
+
+  /**
+   * @param $params
+   * @param $order
+   * @param $queryOperator
+   * @param $returnProperties
+   * @return array
+   */
+  public function runQuery($params, $order, $queryOperator, $returnProperties) {
+    $query = new CRM_Contact_BAO_Query($params, $returnProperties, NULL,
+      FALSE, FALSE, $this->getQueryMode(),
+      FALSE, TRUE, TRUE, NULL, $queryOperator
+    );
+
+    //sort by state
+    //CRM-15301
+    $query->_sort = $order;
+    list($select, $from, $where, $having) = $query->query();
+    $this->setQueryFields($query->_fields);
+    return array($query, $select, $from, $where, $having);
   }
 
 }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -192,8 +192,10 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $pattern = '/as `?([^`,]*)/';
     $queryFieldAliases = array();
     preg_match_all($pattern, $select, $queryFieldAliases, PREG_PATTERN_ORDER);
+    $processor = new CRM_Export_BAO_ExportProcessor(CRM_Contact_BAO_Query::MODE_CONTRIBUTE);
+    $processor->setQueryFields($query->_fields);
 
-    list($outputFields) = CRM_Export_BAO_Export::getExportStructureArrays($returnProperties, $query, $contactRelationshipTypes, '', array());
+    list($outputFields) = CRM_Export_BAO_Export::getExportStructureArrays($returnProperties, $processor, $contactRelationshipTypes, '', array());
     foreach (array_keys($outputFields) as $fieldAlias) {
       if ($fieldAlias == 'Home-country') {
         $this->assertTrue(in_array($fieldAlias . '_id', $queryFieldAliases[1]), 'Country is subject to some funky translate so we make sure country id is present');

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -44,7 +44,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * Basic test to ensure the exportComponents function completes without error.
    */
   public function testExportComponentsNull() {
-    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
+    list($tableName) = CRM_Export_BAO_Export::exportComponents(
       TRUE,
       array(),
       array(),
@@ -192,10 +192,10 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $pattern = '/as `?([^`,]*)/';
     $queryFieldAliases = array();
     preg_match_all($pattern, $select, $queryFieldAliases, PREG_PATTERN_ORDER);
-    $processor = new CRM_Export_BAO_ExportProcessor(CRM_Contact_BAO_Query::MODE_CONTRIBUTE);
+    $processor = new CRM_Export_BAO_ExportProcessor(CRM_Contact_BAO_Query::MODE_CONTRIBUTE, 'AND');
     $processor->setQueryFields($query->_fields);
 
-    list($outputFields) = CRM_Export_BAO_Export::getExportStructureArrays($returnProperties, $processor, $contactRelationshipTypes, '', array());
+    list($outputFields) = CRM_Export_BAO_Export::getExportStructureArrays($returnProperties, $processor, $contactRelationshipTypes, '');
     foreach (array_keys($outputFields) as $fieldAlias) {
       if ($fieldAlias == 'Home-country') {
         $this->assertTrue(in_array($fieldAlias . '_id', $queryFieldAliases[1]), 'Country is subject to some funky translate so we make sure country id is present');
@@ -502,7 +502,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     ));
 
     //create address for contact A
-    $result = $this->callAPISuccess('address', 'create', array(
+    $this->callAPISuccess('address', 'create', array(
       'contact_id' => $contactA['id'],
       'location_type_id' => 'Home',
       'street_address' => 'ABC 12',
@@ -513,7 +513,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     ));
 
     //create address for contact B
-    $result = $this->callAPISuccess('address', 'create', array(
+    $this->callAPISuccess('address', 'create', array(
       'contact_id' => $contactB['id'],
       'location_type_id' => 'Home',
       'street_address' => 'ABC 12',


### PR DESCRIPTION
Overview
----------------------------------------
Export class cleanup

Before
----------------------------------------
$query object passed around

After
----------------------------------------
$processor object passed around

Technical Details
----------------------------------------
The processor object is the class we are migrating the Export functionality to - in a cleaned up manner. A lot of the work on the export class lends itself much better to an OOO class (& cleanly defined functions in a sensible order!). Later refactors will move the functions from which the processor is used onto the processor class itself

Comments
----------------------------------------
@jitendrapurohit if you can
