### PR TITLE
dev/core#34 Add permission details in `title` attribute of icons

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2093,6 +2093,8 @@ AND cc.sort_name LIKE '%$name%'";
     unset($relationships['total_relationships']);
     if (!empty($relationships)) {
 
+      $displayName = CRM_Contact_BAO_Contact::displayName($params['contact_id']);
+
       // format params
       foreach ($relationships as $relationshipId => $values) {
         $relationship = array();
@@ -2131,25 +2133,33 @@ AND cc.sort_name LIKE '%$name%'";
           if (($params['contact_id'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) or
             ($params['contact_id'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
           ) {
-            $relationship['sort_name'] .= ' <i class="crm-i fa-asterisk"></i>';
+            $relationship['sort_name'] .= <<<HEREDOC
+              <i class="crm-i fa-asterisk" title="{$values['display_name']} can be viewed and edited by $displayName"></i>
+HEREDOC;
           }
 
           if (($params['contact_id'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) or
             ($params['contact_id'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
           ) {
-            $relationship['sort_name'] .= ' <i class="crm-i fa-eye"></i>';
+            $relationship['sort_name'] .= <<<HEREDOC
+              <i class="crm-i fa-eye" title="{$values['display_name']} can be viewed by $displayName"></i>
+HEREDOC;
           }
 
           if (($values['cid'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) or
             ($values['cid'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
           ) {
-            $relationship['relation'] .= ' <i class="crm-i fa-asterisk"></i>';
+            $relationship['relation'] .= <<<HEREDOC
+              <i class="crm-i fa-asterisk" title="$displayName can be viewed and edited by {$values['display_name']}"></i>
+HEREDOC;
           }
 
           if (($values['cid'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) or
             ($values['cid'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
           ) {
-            $relationship['relation'] .= ' <i class="crm-i fa-eye"></i>';
+            $relationship['relation'] .= <<<HEREDOC
+              <i class="crm-i fa-eye" title="$displayName can be viewed by {$values['display_name']}"></i>
+HEREDOC;
           }
         }
 

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -662,7 +662,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       $relTypes = CRM_Utils_Array::index(array('name_a_b'), CRM_Core_PseudoConstant::relationshipType('name'));
       if (
         (isset($relTypes['Employee of']) && $relationship->relationship_type_id == $relTypes['Employee of']['id']) ||
-        (isset ($relTypes['Household Member of']) && $relationship->relationship_type_id == $relTypes['Household Member of']['id'])
+        (isset($relTypes['Household Member of']) && $relationship->relationship_type_id == $relTypes['Household Member of']['id'])
       ) {
         $sharedContact = new CRM_Contact_DAO_Contact();
         $sharedContact->id = $relationship->contact_id_a;
@@ -1721,10 +1721,10 @@ SELECT relationship_type_id, relationship_direction
               $membershipValues['skipStatusCal'] = TRUE;
             }
             foreach (array(
-                       'join_date',
-                       'start_date',
-                       'end_date',
-                     ) as $dateField) {
+              'join_date',
+              'start_date',
+              'end_date',
+            ) as $dateField) {
               if (!empty($membershipValues[$dateField])) {
                 $membershipValues[$dateField] = CRM_Utils_Date::processDate($membershipValues[$dateField]);
               }
@@ -2128,26 +2128,26 @@ AND cc.sort_name LIKE '%$name%'";
         }
 
         if ($params['context'] == 'current') {
-          if (($params['contact_id'] == $values['contact_id_a'] AND $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) OR
-            ($params['contact_id'] == $values['contact_id_b'] AND $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
+          if (($params['contact_id'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) or
+            ($params['contact_id'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
           ) {
             $relationship['sort_name'] .= ' <i class="crm-i fa-asterisk"></i>';
           }
 
-          if (($params['contact_id'] == $values['contact_id_a'] AND $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) OR
-            ($params['contact_id'] == $values['contact_id_b'] AND $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
+          if (($params['contact_id'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) or
+            ($params['contact_id'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
           ) {
             $relationship['sort_name'] .= ' <i class="crm-i fa-eye"></i>';
           }
 
-          if (($values['cid'] == $values['contact_id_a'] AND $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) OR
-            ($values['cid'] == $values['contact_id_b'] AND $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
+          if (($values['cid'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) or
+            ($values['cid'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
           ) {
             $relationship['relation'] .= ' <i class="crm-i fa-asterisk"></i>';
           }
 
-          if (($values['cid'] == $values['contact_id_a'] AND $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) OR
-            ($values['cid'] == $values['contact_id_b'] AND $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
+          if (($values['cid'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) or
+            ($values['cid'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
           ) {
             $relationship['relation'] .= ' <i class="crm-i fa-eye"></i>';
           }


### PR DESCRIPTION
Overview
----------------------------------------
I got thinking in regards to the review of #12415 about how to make the permission icons accessible for the visually-impaired.  These changes add a `title` attribute for the `<i>` tags that specifies which contact has what permission over which.  For most people, this will be a tooltip when you hover over the icon.  Screen readers now have something to read in place of the icon.

Before
----------------------------------------
There are icons next to contacts that the other contact has permission to view or edit.

After
----------------------------------------
When you hover over the icon, a tooltip explains explicitly the permissions one contact has over the other. 
![tooltip](https://user-images.githubusercontent.com/1682375/42790116-2c762fec-8937-11e8-9ff6-99ccea35f43e.png)

https://lab.civicrm.org/dev/core/issues/34
