### PR TITLE
Ensure 'type' is always set for query field data.

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1537,6 +1537,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
             array(
               'name' => 'organization_name',
               'title' => ts('Current Employer'),
+              'type' => CRM_Utils_Type::T_STRING,
             ),
         ));
 
@@ -1545,6 +1546,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
             'name' => 'location_type',
             'where' => 'civicrm_location_type.name',
             'title' => ts('Location Type'),
+            'type' => CRM_Utils_Type::T_STRING,
           ),
         );
 
@@ -1553,6 +1555,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
             'name' => 'im_provider',
             'where' => 'civicrm_im.provider_id',
             'title' => ts('IM Provider'),
+            'type' => CRM_Utils_Type::T_INT,
           ),
         );
 
@@ -1610,14 +1613,17 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
             'groups' => array(
               'title' => ts('Group(s)'),
               'name' => 'groups',
+              'type' => CRM_Utils_Type::T_TEXT,
             ),
             'tags' => array(
               'title' => ts('Tag(s)'),
               'name' => 'tags',
+              'type' => CRM_Utils_Type::T_TEXT,
             ),
             'notes' => array(
               'title' => ts('Note(s)'),
               'name' => 'notes',
+              'type' => CRM_Utils_Type::T_TEXT,
             ),
           ));
         }

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -472,19 +472,7 @@ class CRM_Contact_BAO_Query {
       $this->_skipPermission = TRUE;
     }
     else {
-      $this->_fields = CRM_Contact_BAO_Contact::exportableFields('All', FALSE, TRUE, TRUE, FALSE, !$skipPermission);
-
-      $fields = CRM_Core_Component::getQueryFields(!$this->_skipPermission);
-      unset($fields['note']);
-      $this->_fields = array_merge($this->_fields, $fields);
-
-      // add activity fields
-      $fields = CRM_Activity_BAO_Activity::exportableFields();
-      $this->_fields = array_merge($this->_fields, $fields);
-
-      // add any fields provided by hook implementers
-      $extFields = CRM_Contact_BAO_Query_Hook::singleton()->getFields();
-      $this->_fields = array_merge($this->_fields, $extFields);
+      $this->setAllFieldMetadata(!$skipPermission);
     }
 
     // basically do all the work once, and then reuse it
@@ -6611,6 +6599,37 @@ AND   displayRelType.is_active = 1
     }
     $select .= implode(', ', $this->_select);
     return $select;
+  }
+
+  /**
+   * Get metadata for all fields accessible by the contact.
+   *
+   * @param bool $isCheckPermissions
+   */
+  public function setAllFieldMetadata($isCheckPermissions) {
+
+    $this->_fields = CRM_Contact_BAO_Contact::exportableFields('All', FALSE, TRUE, TRUE, FALSE, $isCheckPermissions);
+
+    $fields = CRM_Core_Component::getQueryFields($isCheckPermissions);
+    unset($fields['note']);
+    $this->_fields = array_merge($this->_fields, $fields);
+
+    // add activity fields
+    $fields = CRM_Activity_BAO_Activity::exportableFields();
+    $this->_fields = array_merge($this->_fields, $fields);
+
+    // add any fields provided by hook implementers
+    $extFields = CRM_Contact_BAO_Query_Hook::singleton()->getFields();
+    $this->_fields = array_merge($this->_fields, $extFields);
+  }
+
+  /**
+   * Get array of field metadata.
+   *
+   * @return array
+   */
+  public function getFieldMetadata() {
+    return $this->_fields;
   }
 
 }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -821,6 +821,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           'name' => 'contribution_page',
           'where' => 'civicrm_contribution_page.title',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
       );
 
@@ -829,12 +830,14 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           'title' => ts('Contribution Note'),
           'name' => 'contribution_note',
           'data_type' => CRM_Utils_Type::T_TEXT,
+          'type' => CRM_Utils_Type::T_TEXT,
         ),
       );
 
       $extraFields = array(
         'contribution_batch' => array(
           'title' => ts('Batch Name'),
+          'type' => CRM_Utils_Type::T_STRING,
         ),
       );
 
@@ -845,6 +848,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           'name' => 'campaign_title',
           'where' => 'civicrm_campaign.title',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
       );
       $softCreditFields = array(
@@ -853,30 +857,35 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           'title' => ts('Soft Credit For'),
           'where' => 'civicrm_contact_d.display_name',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
         'contribution_soft_credit_amount' => array(
           'name' => 'contribution_soft_credit_amount',
           'title' => ts('Soft Credit Amount'),
           'where' => 'civicrm_contribution_soft.amount',
           'data_type' => CRM_Utils_Type::T_MONEY,
+          'type' => CRM_Utils_Type::T_MONEY,
         ),
         'contribution_soft_credit_type' => array(
           'name' => 'contribution_soft_credit_type',
           'title' => ts('Soft Credit Type'),
           'where' => 'contribution_softcredit_type.label',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
         'contribution_soft_credit_contribution_id' => array(
           'name' => 'contribution_soft_credit_contribution_id',
           'title' => ts('Soft Credit For Contribution ID'),
           'where' => 'civicrm_contribution_soft.contribution_id',
           'data_type' => CRM_Utils_Type::T_INT,
+          'type' => CRM_Utils_Type::T_INT,
         ),
         'contribution_soft_credit_contact_id' => array(
           'name' => 'contribution_soft_credit_contact_id',
           'title' => ts('Soft Credit For Contact ID'),
           'where' => 'civicrm_contact_d.id',
           'data_type' => CRM_Utils_Type::T_INT,
+          'type' => CRM_Utils_Type::T_INT,
         ),
       );
 
@@ -887,6 +896,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           'name' => 'contribution_product_id',
           'where' => 'civicrm_product.id',
           'data_type' => CRM_Utils_Type::T_INT,
+          'type' => CRM_Utils_Type::T_INT,
         ),
       );
 

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -650,6 +650,7 @@ GROUP BY  participant.event_id
           'name' => 'participant_note',
           'headerPattern' => '/(participant.)?note$/i',
           'data_type' => CRM_Utils_Type::T_TEXT,
+          'type' => CRM_Utils_Type::T_TEXT,
         ),
       );
 
@@ -660,6 +661,7 @@ GROUP BY  participant.event_id
           'title' => ts('Participant Status'),
           'name' => 'participant_status',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
       );
       $tmpFields['participant_status_id']['title'] = ts('Participant Status Id');
@@ -671,6 +673,7 @@ GROUP BY  participant.event_id
           'title' => ts('Participant Role'),
           'name' => 'participant_role',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
       );
       $tmpFields['participant_role_id']['title'] = ts('Participant Role Id');
@@ -680,6 +683,7 @@ GROUP BY  participant.event_id
           'title' => ts('Event Type'),
           'name' => 'event_type',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
       );
 

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1158,7 +1158,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         else {
           // set the sql columns for custom data
           if (isset($queryFields[$field]['data_type'])) {
-
+            // @todo strip out this code.
+            CRM_Core_Error::deprecatedFunctionWarning('ensure type is always defined (this is believed to already be the case');
             switch ($queryFields[$field]['data_type']) {
               case 'String':
                 // May be option labels, which could be up to 512 characters

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -733,16 +733,17 @@ GROUP BY  currency
 
       // set title to calculated fields
       $calculatedFields = array(
-        'pledge_total_paid' => array('title' => ts('Total Paid')),
-        'pledge_balance_amount' => array('title' => ts('Balance Amount')),
-        'pledge_next_pay_date' => array('title' => ts('Next Payment Date')),
-        'pledge_next_pay_amount' => array('title' => ts('Next Payment Amount')),
-        'pledge_payment_paid_amount' => array('title' => ts('Paid Amount')),
-        'pledge_payment_paid_date' => array('title' => ts('Paid Date')),
+        'pledge_total_paid' => array('title' => ts('Total Paid'), 'type' => CRM_Utils_Type::T_MONEY),
+        'pledge_balance_amount' => array('title' => ts('Balance Amount'), 'type' => CRM_Utils_Type::T_MONEY),
+        'pledge_next_pay_date' => array('title' => ts('Next Payment Date'), 'type' => CRM_Utils_Type::T_DATE),
+        'pledge_next_pay_amount' => array('title' => ts('Next Payment Amount'), 'type' => CRM_Utils_Type::T_MONEY),
+        'pledge_payment_paid_amount' => array('title' => ts('Paid Amount'), 'type' => CRM_Utils_Type::T_MONEY),
+        'pledge_payment_paid_date' => array('title' => ts('Paid Date'), 'type' => CRM_Utils_Type::T_DATE),
         'pledge_payment_status' => array(
           'title' => ts('Pledge Payment Status'),
           'name' => 'pledge_payment_status',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
       );
 
@@ -751,21 +752,24 @@ GROUP BY  currency
           'title' => ts('Pledge Status'),
           'name' => 'pledge_status',
           'data_type' => CRM_Utils_Type::T_STRING,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
         'pledge_frequency_unit' => array(
           'title' => ts('Pledge Frequency Unit'),
           'name' => 'pledge_frequency_unit',
-          'data_type' => CRM_Utils_Type::T_ENUM,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
         'pledge_frequency_interval' => array(
           'title' => ts('Pledge Frequency Interval'),
           'name' => 'pledge_frequency_interval',
           'data_type' => CRM_Utils_Type::T_INT,
+          'type' => CRM_Utils_Type::T_INT,
         ),
         'pledge_contribution_page_id' => array(
           'title' => ts('Pledge Contribution Page Id'),
           'name' => 'pledge_contribution_page_id',
           'data_type' => CRM_Utils_Type::T_INT,
+          'type' => CRM_Utils_Type::T_INT,
         ),
       );
 

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -709,4 +709,16 @@ civicrm_relationship.is_active = 1 AND
     $this->assertEquals($modparams['member_is_primary'][2], $fv_orig['member_is_primary']);
   }
 
+  /**
+   * Tests that 'type' is defined for all metadata fields.
+   */
+  public function testFieldMetadata() {
+    $query = new CRM_Contact_BAO_Query();
+    $fields = $query->getFieldMetadata();
+    foreach ($fields as $field) {
+      $this->assertTrue(!empty($field['type']), print_r($field, 1));
+      $this->assertTrue(!empty(CRM_Utils_Type::typeToString($field['type'])));
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup metadata for query fields to ensure 'type' is always set

Before
----------------------------------------
Some manually defined fields don't have 'type' defined. No test

After
----------------------------------------
All defined fields  have 'type' defined. Test

Technical Details
----------------------------------------
Historically 'type' was set on core fields but 'data_type' was set on custom fields.

For some time now we have set 'type' on custom fields as well so all the handling one
Export class that was written for them is actually bypassed. However, it seems there are a bunch
of manually defined fields that don't have a 'type' (note that both 'type' and 'title' are
ensured for any fields exposed via the api or DAO fields).

Some of these fields with no 'type' DO have a data_type - but the data_type code would pass right
through the loop that handles it as they use the 'type' constants & the handling
loop uses the custom value strings.

In theory, but not, IMHO in practice, this could result in a shorter varchar being used for fields
In https://issues.civicrm.org/jira/browse/CRM-19222 a field length of 512 was made possible for custom field strings. This would have been broken
for many months since the Custom fields no longer hit that loop by virtue of having a valid type.

I'm actually 99.99% sure I could just remove the deprecated switch statement - since I could not
find a single instance where 'type' is not set AND 'data_type' is valid. It would
give them 'varchar(255)' instead of text.



Comments
----------------------------------------
Separately, I'm not convinced we do ourself any favours by not setting all the
varchar fields to 512 length - it seems to me they take up no more space unless they need to,
in which case more space is better than a hard-fail

https://dev.mysql.com/doc/refman/8.0/en/char.html
