### PR TITLE
dev/core/#/233 Expose information about where a contact has been merged to

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -306,7 +306,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
    */
   public static function setTitle($contactId, $isDeleted = FALSE) {
     static $contactDetails;
-    $displayName = $contactImage = NULL;
+    $contactImage = NULL;
     if (!isset($contactDetails[$contactId])) {
       list($displayName, $contactImage) = self::getContactDetails($contactId);
       $contactDetails[$contactId] = array(
@@ -327,6 +327,15 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     }
     if ($isDeleted) {
       $title = "<del>{$title}</del>";
+      $mergedTo = civicrm_api3('Contact', 'getmergedto', ['contact_id' => $contactId, 'api.Contact.get' => ['return' => 'display_name']]);
+      if ($mergedTo['count']) {
+        $mergedToContactID = $mergedTo['id'];
+        $mergedToDisplayName = $mergedTo['values'][$mergedToContactID]['api.Contact.get']['values'][0]['display_name'];
+        $title .= ' ' . ts('(This contact has been merged to <a href="%1">%2</a>)', [
+            1 => CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $mergedToContactID]),
+            2 => $mergedToDisplayName,
+          ]);
+      }
     }
 
     // Inline-edit places its own title on the page


### PR DESCRIPTION
Overview
----------------------------------------
Exposes information about what contact a contact deleted by merge has been merged from. Via the api it exposes this and also which contacts have been merged into a given contact.

Before
----------------------------------------
Poor visibility on where a contact has been deleted as part of a merge
![screenshot 2018-07-17 17 25 11](https://user-images.githubusercontent.com/336308/42798081-626737ea-89e6-11e8-8b0b-6dde80e6cabc.png)


After
----------------------------------------
Merged nature is much clearer.
![screenshot 2018-07-17 17 25 27](https://user-images.githubusercontent.com/336308/42798089-6b358bb0-89e6-11e8-88c5-8f658b469416.png)

 In addition the calculus for the 'merged to' & 'merged from' is exposed via api

Technical Details
----------------------------------------
We have a fairly opaque data structure for linking merged contacts to the contacts they have been merged to. There have been various discussions about changing it so I feel like the ownership of exposing this relationship should sit  in core.

Examples of where this could be used by an extension are
1) extended reports offers an address history report (which can be a contact summary tab) - it should provide this history across multiple contacts
2) various privacy extensions should find and delete data for contacts deleted by merge as well as the current contact.

The apis used here (open to any form of bikeshedding on action name / params) are:
```
$result = civicrm_api3('Contact', 'getmergedto', ['contact_id' => $contactID]);

$result = [
  'values' => [5 => ['id' => 5],
  'count'.....
];
```
```
$result = civicrm_api3('Contact', 'getmergedfrom', ['contact_id' => $contactID]);

$result = [
  'values' => [5 => ['id' => 5], 6 => ['id' => 6]]
  'count'.....
];
```
In each case result is an array of **one** (getmergedto) or **n** (getmergedfrom) contact records, with only 'id' populated.



Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/233

@totten @colemanw @jkingsnorth
