### PR TITLE
dev/core/#/258 Fix message update routine.

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -138,6 +138,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ON reserved.workflow_id = default_template.workflow_id
         WHERE reserved.workflow_id = $workFlowID
         AND reserved.is_reserved = 1 AND default_template.is_default = 1 AND reserved.id <> default_template.id
+        AND reserved.msg_{$template['type']} = default_template.msg_{$template['type']}
       ");
       if ($defaultTemplateID) {
         $templatesToUpdate[] = $defaultTemplateID;

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -4,7 +4,7 @@
  * Class CRM_UF_Page_ProfileEditorTest
  * @group headless
  */
-class CRM_Upgrade_Incremental_Base_Test extends CiviUnitTestCase {
+class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
 
   /**
    * Test message upgrade process.
@@ -24,7 +24,7 @@ class CRM_Upgrade_Incremental_Base_Test extends CiviUnitTestCase {
 
     foreach ($templates as $template) {
       $msg_text = $this->callAPISuccessGetValue('MessageTemplate', ['id' => $template['id'], 'return' => 'msg_text']);
-      $this->assertContains('{ts}Membership Information{/ts}', $msg_text);
+      $this->assertContains('{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}', $msg_text);
       if ($msg_text !== $originalText) {
         // Reset value for future tests.
         $this->callAPISuccess('MessageTemplate', 'create', ['msg_text' => $originalText, 'id' => $template['id']]);
@@ -54,7 +54,7 @@ class CRM_Upgrade_Incremental_Base_Test extends CiviUnitTestCase {
     foreach ($templates as $template) {
       $msg_text = $this->callAPISuccessGetValue('MessageTemplate', ['id' => $template['id'], 'return' => 'msg_text']);
       if ($template['is_reserved']) {
-        $this->assertTrue(strstr($msg_text, '{ts}Membership Information{/ts}'));
+        $this->assertContains('{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}', $msg_text);
       }
       else {
         $this->assertEquals('great what a silly sausage you are', $msg_text);
@@ -73,7 +73,11 @@ class CRM_Upgrade_Incremental_Base_Test extends CiviUnitTestCase {
   public function testMessageTemplateGetUpgradeMessages() {
     $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates('5.4.alpha1');
     $messages = $messageTemplateObject->getUpgradeMessages();
-    $this->assertEquals(['Memberships - Receipt (on-line)' => 'Use email greeting at top where available'], $messages);
+    $this->assertEquals([
+      'Memberships - Receipt (on-line)' => 'Use email greeting at top where available',
+      'Contributions - Receipt (on-line)' => 'Use email greeting at top where available',
+      'Events - Registration Confirmation and Receipt (on-line)' => 'Use email greeting at top where available',
+    ], $messages);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
5.4 unreleased regression - customised message templates being overwritten

https://lab.civicrm.org/dev/core/issues/258

Before
----------------------------------------
1) customise Contributions - Receipt (on-line) on a 5.3 install
2) upgrade to 5.4 
3) note the customised msg_template is updated (and the reserved one is)

After
----------------------------------------
1) customise Contributions - Receipt (on-line) on a 5.3 install
2) upgrade to 5.4 
3) note the customised msg_template is not updated (but the reserved one is)

Technical Details
----------------------------------------
The test class was misnamed leading to it being deemed to be 'working' when it was not actually running :-(. Other changes are because further templates were added to the 5.4 update after this

Comments
----------------------------------------

For background prior to 5.4 we didn't ship the xml directory and updates to message templates required a lot of work for the reviewer as the tpl was copied to the install dir where the diff could not be easily viewed. Unfortunately the new mechanism had a bug