### PR TITLE
fix autoloading issue for cv & civix cli tools

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -423,9 +423,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     // Create a mock $request object
     $autoloader = require_once $root . '/vendor/autoload.php';
-    if ($autoloader === TRUE) {
-      $autoloader = ComposerAutoloaderInitDrupal8::getLoader();
-    }
     // @Todo: do we need to handle case where $_SERVER has no HTTP_HOST key, ie. when run via cli?
     $request = new \Symfony\Component\HttpFoundation\Request(array(), array(), array(), array(), array(), $_SERVER);
 

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -422,7 +422,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     chdir($root);
 
     // Create a mock $request object
-    $autoloader = require_once $root . '/vendor/autoload.php';
+    $autoloader = require_once $root . '/autoload.php';
     // @Todo: do we need to handle case where $_SERVER has no HTTP_HOST key, ie. when run via cli?
     $request = new \Symfony\Component\HttpFoundation\Request(array(), array(), array(), array(), array(), $_SERVER);
 


### PR DESCRIPTION
Remove the $autoloader::getLoader() method call, because the $autoload var already contains that result by requiring the autoload.php from the Drupal 8 web root.

Overview
----------------------------------------
Small update to Drupal8.php file to fix an autoloading issue for cli tools like cv & civix.

Before
----------------------------------------
The autoloader from Drupal was being required. Then the getLoader() was called on a class in the autoloader (which did not exist). But the autoloader already contains the result of that method.

After
----------------------------------------
We removed the getLoader() method on the autoloader class and pass it straight to request component.

