### PR TITLE
Allow Drupal 8 vendor folder outside webroot

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -422,7 +422,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     chdir($root);
 
     // Create a mock $request object
-    $autoloader = require_once $root . '/vendor/autoload.php';
+    $autoloader = require_once $root . '/autoload.php';
     if ($autoloader === TRUE) {
       $autoloader = ComposerAutoloaderInitDrupal8::getLoader();
     }


### PR DESCRIPTION
Overview
----------------------------------------
Allow Drupal 8 vendor folder outside webroot

Before
----------------------------------------
Drupal dependencies in vendor folder could not be located outside webroot. Autoloading does not work.

After
----------------------------------------
Drupal dependencies in vendor folder can not be located outside webroot. Autoloading works.
