### PR TITLE
Prevent financial transactions from being saved with no payment instr…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3400,6 +3400,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         // change Payment Instrument for a Completed contribution
         // first handle special case when contribution is changed from Pending to Completed status when initial payment
         // instrument is null and now new payment instrument is added along with the payment
+        if (!$params['contribution']->payment_instrument_id) {
+          $params['contribution']->find(TRUE);
+        }
         $params['trxnParams']['payment_instrument_id'] = $params['contribution']->payment_instrument_id;
         $params['trxnParams']['check_number'] = CRM_Utils_Array::value('check_number', $params);
 


### PR DESCRIPTION

Overview
----------------------------------------
Prevent financial transactions from being saved with no payment instrument

https://lab.civicrm.org/dev/core/issues/264

Before
----------------------------------------
Create a completed contribution. 
Edit contribution by increasing contribution amount and net amount. 
This will create a new financial transaction with NO Payment Instrument.

After
----------------------------------------
Payment instrument saved

Technical Details
----------------------------------------
This is a very small fix targetted to be included in 5.4 & the 5.3 security drop. I'm not a fan of how we are passing around the contribution in params /  handling this but loading when not loaded is 
going to prevent the issue

Comments
----------------------------------------
In the big picture we want to freeze total_amount and leave people with  2 options
1) delete & recreate
2) use lineitemeditor extension
https://github.com/JMAConsulting/biz.jmaconsulting.lineitemedit/blob/master/README.md

I think this is not a recent regression but recent changes (the payment edit block) made it more visible. 

I also think this fix is safe and we should include it ASAP (
