### PR TITLE
Remove LOWER from street_address search, rely on mysql to handle.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3558,14 +3558,13 @@ WHERE  $smartGroupClause
     $n = trim($value);
 
     if ($n) {
-      $value = strtolower($n);
       if (strpos($value, '%') === FALSE) {
         // only add wild card if not there
         $value = "%{$value}%";
       }
       $op = 'LIKE';
       // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
-      $this->_where[$grouping][] = self::buildClause('LOWER(civicrm_address.street_address)', $op, $value, 'String');
+      $this->_where[$grouping][] = self::buildClause('civicrm_address.street_address', $op, $value, 'String');
       $this->_qill[$grouping][] = ts('Street') . " $op '$n'";
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Remove LOWER from street_address search, rely on mysql to handle.

Before
----------------------------------------
query for street_address looks like 'my special name' = LOWER(street_address).

Poor performance due to non-use of index
Field cannot handle international strings properly
Where clause works

After
----------------------------------------
query for street_address looks like 'my special name' = LOWER(street_address)

Better performance (uses index)
Small step towards handling international strings properly
Where clause works

Technical Details
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/12494 the use of LOWER
- hurts performance
- fails to return results on some char sets
- messes with REGEX

This is part of a continued (we removed from contribution search fields last year)
staggered approach to removing this old mechanism

Comments
----------------------------------------
@seamuslee001 @monishdeb @colemanw - this is a very small step on the path described in #12494

I would target this for 5.5 & then for 5.6 remove the next LOWER, finally removing all the strtolower's.


