### PR TITLE
Fix misformatted start_date default on new contribution page

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -336,6 +336,9 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     else {
       $defaults['is_active'] = 1;
       // set current date as start date
+      // @todo look to change to $defaults['start_date'] = date('Ymd His');
+      // main settings form overrides this to implement above but this is left here
+      // 'in case' another extending form uses start_date - for now
       list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults();
     }
 

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -44,6 +44,11 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
    */
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
+    // @todo handle properly on parent.
+    if (!$this->_id) {
+      $defaults['start_date'] = date('Y-m-d H:i:s');
+      unset($defaults['start_time']);
+    }
     $soft_credit_types = CRM_Core_OptionGroup::values('soft_credit_type', TRUE, FALSE, FALSE, NULL, 'name');
 
     if ($this->_id) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix unreleased regression from https://github.com/civicrm/civicrm-core/pull/11881

see https://lab.civicrm.org/dev/core/issues/263

Before
----------------------------------------
Start date field does not populate for new contribution page. Bug on save if not set

After
----------------------------------------
Start date field does populate for new contribution page. Save works

Technical Details
----------------------------------------
This was overlooked when switching the field to datepicker (preferred) in #11881 . Huge thanks to @MegaphoneJon for finding while in rc - seems that because we were focussed on the handling of various start dates we never tried not setting one.

Comments
----------------------------------------
@yashodha @MegaphoneJon can one of you review this?
