### PR TITLE
dev/mail#20 : Preview screen doesn't open until recipients list is built on mail compose screen

### DIFF
--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -262,7 +262,7 @@
       // @param mailing Object (per APIv3)
       // @return Promise an object with "subject", "body_text", "body_html"
       preview: function preview(mailing) {
-        return this.getPreviewContent(qApi, mailing)
+        return this.getPreviewContent(qApi, mailing);
       },
 
       // @param backend
@@ -275,20 +275,11 @@
           });
         }
         else {
-          // Protect against races in saving and previewing by chaining create+preview.
-          var params = angular.extend({}, mailing, mailing.recipients, {
-            id: mailing.id,
-            'api.Mailing.preview': {
-              id: '$value.id'
-            }
-          });
-          delete params.scheduled_date;
-          delete params.recipients; // the content was merged in
-          params._skip_evil_bao_auto_recipients_ = 1; // skip recipient rebuild on mail preview
-          return backend('Mailing', 'create', params).then(function(result) {
-            mailing.modified_date = result.values[result.id].modified_date;
+          var params = angular.extend({}, mailing);
+          delete params.id;
+          return backend('Mailing', 'preview', params).then(function(result) {
             // changes rolled back, so we don't care about updating mailing
-            return result.values[result.id]['api.Mailing.preview'].values;
+            return result.values;
           });
         }
       },

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -262,8 +262,15 @@
       // @param mailing Object (per APIv3)
       // @return Promise an object with "subject", "body_text", "body_html"
       preview: function preview(mailing) {
+        return this.getPreviewContent(qApi, mailing)
+      },
+
+      // @param backend
+      // @param mailing Object (per APIv3)
+      // @return preview content
+      getPreviewContent: function getPreviewContent(backend, mailing) {
         if (CRM.crmMailing.workflowEnabled && !CRM.checkPerm('create mailings') && !CRM.checkPerm('access CiviMail')) {
-          return qApi('Mailing', 'preview', {id: mailing.id}).then(function(result) {
+          return backend('Mailing', 'preview', {id: mailing.id}).then(function(result) {
             return result.values;
           });
         }
@@ -278,7 +285,7 @@
           delete params.scheduled_date;
           delete params.recipients; // the content was merged in
           params._skip_evil_bao_auto_recipients_ = 1; // skip recipient rebuild on mail preview
-          return qApi('Mailing', 'create', params).then(function(result) {
+          return backend('Mailing', 'create', params).then(function(result) {
             mailing.modified_date = result.values[result.id].modified_date;
             // changes rolled back, so we don't care about updating mailing
             return result.values[result.id]['api.Mailing.preview'].values;
@@ -451,7 +458,7 @@
         };
         var result = null;
         var p = crmMailingMgr
-          .preview(mailing)
+          .getPreviewContent(CRM.api3, mailing)
           .then(function (content) {
             var options = CRM.utils.adjustDialogDefaults({
               autoOpen: false,

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -547,21 +547,22 @@ function civicrm_api3_mailing_event_open($params) {
  * @throws \API_Exception
  */
 function civicrm_api3_mailing_preview($params) {
-  civicrm_api3_verify_mandatory($params,
-    'CRM_Mailing_DAO_Mailing',
-    array('id'),
-    FALSE
-  );
-
   $fromEmail = NULL;
   if (!empty($params['from_email'])) {
     $fromEmail = $params['from_email'];
   }
 
-  $session = CRM_Core_Session::singleton();
   $mailing = new CRM_Mailing_BAO_Mailing();
-  $mailing->id = $params['id'];
-  $mailing->find(TRUE);
+  $mailingID = CRM_Utils_Array::value('id', $params);
+  if ($mailingID) {
+    $mailing->id = $mailingID;
+    $mailing->find(TRUE);
+  }
+  else {
+    $mailing->copyValues($params);
+  }
+
+  $session = CRM_Core_Session::singleton();
 
   CRM_Mailing_BAO_Mailing::tokenReplace($mailing);
 


### PR DESCRIPTION
Overview
----------------------------------------
To replicate the issue:

1. Create a new mailing and fill out everything but not the Recipients field.
2. Now select a recipients group that is either very large or is based on a complex smart group. after selecting it -- click preview HTML/Text.

Before
----------------------------------------
The preview window will not open until the recipient count query has completed. This can also be replicated by setting up a mailing with a large/complex group, saving it, then continuing it and immediately clicking preview. the window will not open until the query completes.

After
----------------------------------------
Preview action doesn't wait for recipient built to complete and opens the preview window instantly.

Technical Details
----------------------------------------
As per the change it directly calls API and doesn't rely on Promise queue to deliver the result in sequence.