### PR TITLE
CRM-14098 Membership reminders: don't exclude people who inherit other memberships

### DIFF
--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -97,7 +97,15 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';
     $query['casContactTableAlias'] = NULL;
+
+    // Leaving this in case of legacy databases
     $query['casDateField'] = str_replace('membership_', 'e.', $schedule->start_action_date);
+
+    // Options currently are just 'join_date', 'start_date', and 'end_date':
+    // they need an alias
+    if (strpos($query['casDateField'], 'e.') !== 0) {
+      $query['casDateField'] = 'e.' . $query['casDateField'];
+    }
 
     // FIXME: Numbers should be constants.
     if (in_array(2, $selectedStatuses)) {

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -113,11 +113,28 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
         ->param('memberTypeValues', $selectedValues);
     }
     else {
+      // FIXME: The membership type is never null, so nobody will ever get a
+      // reminder if no membership types are selected.  Either this should be a
+      // validation on the reminder form or all types should get a reminder if
+      // no types are selected.
       $query->where("e.membership_type_id IS NULL");
     }
 
+    // FIXME: This makes a lot of sense for renewal reminders, but a user
+    // scheduling another kind of reminder might not expect members to be
+    // excluded if they have status overrides.  Ideally there would be some kind
+    // of setting per reminder.
     $query->where("( e.is_override IS NULL OR e.is_override = 0 )");
+
+    // FIXME: Similarly to overrides, excluding contacts who can't edit the
+    // primary member makes sense in the context of renewals (see CRM-11342) but
+    // would be a surprise for other use cases.
     $query->merge($this->prepareMembershipPermissionsFilter());
+
+    // FIXME: A lot of undocumented stuff happens with regard to
+    // `is_current_member`, and this is no exception.  Ideally there would be an
+    // opportunity to pick statuses when setting up the scheduled reminder
+    // rather than making the assumptions here.
     $query->where("e.status_id IN (#memberStatus)")
       ->param('memberStatus', \CRM_Member_PseudoConstant::membershipStatus(NULL, "(is_current_member = 1 OR name = 'Expired')", 'id'));
 

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -314,7 +314,7 @@ class RecipientBuilder {
 
     $addlCheck = \CRM_Utils_SQL_Select::from($query['casAddlCheckFrom'])
       ->select('*')
-      ->merge($query, array('params', 'wheres'))// why only where? why not the joins?
+      ->merge($query, array('params', 'wheres', 'joins'))
       ->merge($this->prepareRepetitionEndFilter($query['casDateField']))
       ->limit(1)
       ->strict()

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1004,6 +1004,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'contact_id' => $membership->contact_id,
       'email' => 'test-member@example.com',
       'location_type_id' => 1,
+      'is_primary' => 1,
     ));
 
     $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
@@ -2091,6 +2092,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'contact_id' => $mainMembership->contact_id,
       'email' => 'test-member@example.com',
       'location_type_id' => 1,
+      'is_primary' => 1,
     ];
     $email = $this->createTestObject('CRM_Core_DAO_Email', $emailParams);
 


### PR DESCRIPTION
Overview
----------------------------------------
Scheduled reminders based upon memberships suppress sending to people with inherited memberships.  However, the way this was done would exclude anyone who inherited *any* membership, even if the scheduled reminder is based upon a membership that they have directly.  The only exception is if they have permission granted through the relationship.

As an example, a site may have two membership organizations and thus allow people to have two memberships in common.  One might be inherited by employees, while the other is direct memberships.

Before
----------------------------------------
If a contact inherits any membership, they will never get a scheduled reminder based upon a membership unless they have edit permissions on the relationship by which they inherit it.  This is even if it's based upon a membership that is not inherited.

After
----------------------------------------
A scheduled reminder is only excluded if

1. The membership triggering the reminder is inherited, and
2. The contact lacks relationship-based permission to edit the membership owner contact

Technical Details
----------------------------------------
The old way also generated a mile-long list of all the contact IDs that inherit any membership and put them in a WHERE clause as `AND NOT IN (...)`.  The new way makes joins based upon the actual memberships involved.

---

 * [CRM-14098: Scheduled reminders silently skipped for contacts with a non-permissioned relationship associated with ANY inherited membership type](https://issues.civicrm.org/jira/browse/CRM-14098)