### PR TITLE
5.3

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1827,7 +1827,6 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     $activityID,
     $sourceContactID = NULL
   ) {
-    $doNotSms = TRUE;
     $toPhoneNumber = NULL;
 
     if ($smsProviderParams['To']) {
@@ -1843,13 +1842,12 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
         $toPhoneNumberDetails = reset($toPhoneNumbers);
         $toPhoneNumber = CRM_Utils_Array::value('phone', $toPhoneNumberDetails);
         // Contact allows to send sms
-        $doNotSms = FALSE;
-      }
+        }
     }
 
     // make sure both phone are valid
     // and that the recipient wants to receive sms
-    if (empty($toPhoneNumber) or $doNotSms) {
+    if (empty($toPhoneNumber)) {
       return PEAR::raiseError(
         'Recipient phone number is invalid or recipient does not want to receive SMS',
         NULL,

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -255,7 +255,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     // Give the context.
     if (!isset($this->_context)) {
-      $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+      $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
       if (CRM_Contact_Form_Search::isSearchContext($this->_context)) {
         $this->_context = 'search';
       }

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -42,7 +42,7 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
   public function preProcess() {
     // Get the activity values.
     $activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     // Check for required permissions, CRM-6264.

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -87,7 +87,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
 
     $this->assign("context", $this->_context);
 

--- a/CRM/Activity/Page/Tab.php
+++ b/CRM/Activity/Page/Tab.php
@@ -63,7 +63,7 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
    */
   public function edit() {
     // used for ajax tabs
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $context);
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'Integer', $this);
@@ -159,7 +159,7 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
    * Perform actions and display for activities.
    */
   public function run() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
     $action = CRM_Utils_Request::retrieve('action', 'String', $this);
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -50,7 +50,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     parent::buildQuickForm();
     $this->_mappingID = $mappingID = NULL;
     $providersCount = CRM_SMS_BAO_Provider::activeProviderCount();
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     //CRM-16777: Don't provide access to administer schedule reminder page, with user that does not have 'administer CiviCRM' permission
     if (empty($this->_context) && !CRM_Core_Permission::check('administer CiviCRM')) {

--- a/CRM/Batch/Page/AJAX.php
+++ b/CRM/Batch/Page/AJAX.php
@@ -54,7 +54,7 @@ class CRM_Batch_Page_AJAX {
    * @deprecated
    */
   public static function getBatchList() {
-    $context = isset($_REQUEST['context']) ? CRM_Utils_Type::escape($_REQUEST['context'], 'String') : NULL;
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric');
     if ($context != 'financialBatch') {
       $sortMapper = array(
         0 => 'title',

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -76,7 +76,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       CRM_Utils_System::permissionDenied();
     }
 
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $this->assign('context', $this->_context);
 

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -47,7 +47,7 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
       CRM_Utils_System::permissionDenied();
     }
 
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $this->assign('context', $this->_context);
 

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -81,7 +81,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     //useful when we are being driven by the wizard framework
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
 
     //operation for state machine.

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -60,7 +60,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
   public function preProcess() {
     parent::preProcess();
 
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $this->assign('context', $this->_context);
 

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -63,7 +63,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
   public function preProcess() {
     $caseIds = CRM_Utils_Request::retrieve('caseid', 'String', $this);
     $this->_caseId = explode(',', $caseIds);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     if (!$this->_context) {
       $this->_context = 'caseActivity';
     }

--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -62,7 +62,7 @@ class CRM_Case_Form_Activity_OpenCase {
       return;
     }
 
-    $form->_context = CRM_Utils_Request::retrieve('context', 'String', $form);
+    $form->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $form);
     $form->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $form);
     $form->assign('context', $form->_context);
 

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -77,7 +77,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
       CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
     }
 
-    $fulltext = CRM_Utils_Request::retrieve('context', 'String');
+    $fulltext = CRM_Utils_Request::retrieve('context', 'Alphanumeric');
     if ($fulltext == 'fulltext') {
       $this->assign('fulltext', $fulltext);
     }

--- a/CRM/Case/Form/EditClient.php
+++ b/CRM/Case/Form/EditClient.php
@@ -42,7 +42,7 @@ class CRM_Case_Form_EditClient extends CRM_Core_Form {
   public function preProcess() {
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     //get current client name.
     $this->assign('currentClientName', CRM_Contact_BAO_Contact::displayName($cid));

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -97,7 +97,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
 
     $this->assign('context', $this->_context);
 

--- a/CRM/Case/Page/CaseDetails.php
+++ b/CRM/Case/Page/CaseDetails.php
@@ -41,7 +41,7 @@ class CRM_Case_Page_CaseDetails extends CRM_Core_Page {
    */
   public function run() {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $this->assign('action', $this->_action);
     $this->assign('context', $this->_context);

--- a/CRM/Case/Page/Tab.php
+++ b/CRM/Case/Page/Tab.php
@@ -59,7 +59,7 @@ class CRM_Case_Page_Tab extends CRM_Core_Page {
     }
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     if ($this->_contactId) {
       $this->assign('contactId', $this->_contactId);
@@ -178,7 +178,7 @@ class CRM_Case_Page_Tab extends CRM_Core_Page {
    */
   public function run() {
     $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullArray);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     if ($context == 'standalone' && !$contactID) {
       $this->_action = CRM_Core_Action::ADD;

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -235,7 +235,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
         // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container
         CRM_Utils_System::setTitle($displayName);
-        $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+        $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
         $qfKey = CRM_Utils_Request::retrieve('key', 'String', $this);
 
         $urlParams = 'reset=1&cid=' . $this->_contactId;
@@ -1055,7 +1055,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/contact/add', $resetStr));
     }
     else {
-      $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+      $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
       $qfKey = CRM_Utils_Request::retrieve('key', 'String', $this);
       //validate the qfKey
       $urlParams = 'reset=1&cid=' . $contact->id;

--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -70,7 +70,7 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
   public function preProcess() {
     $this->_contactId = $this->get('contactId');
     $this->_groupContactId = $this->get('groupContactId');
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
   }
 
   /**

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -555,7 +555,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     }
 
     // assign context to drive the template display, make sure context is valid
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
     if (!CRM_Utils_Array::value($this->_context, self::validContext())) {
       $this->_context = 'search';
     }

--- a/CRM/Contact/Form/Task/Delete.php
+++ b/CRM/Contact/Form/Task/Delete.php
@@ -150,7 +150,7 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
 
     if ($this->_single) {
       // also fix the user context stack in case the user hits cancel
-      $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'basic');
+      $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'basic');
       if ($context == 'search' && CRM_Utils_Rule::qfKey($this->_searchKey)) {
         $urlParams = "&context=$context&key=$this->_searchKey";
       }
@@ -200,7 +200,7 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
     $session = CRM_Core_Session::singleton();
     $currentUserId = $session->get('userID');
 
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'basic');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'basic');
     $urlParams = 'force=1';
     $urlString = "civicrm/contact/search/$context";
 

--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -96,7 +96,7 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
   public function preProcess() {
     // store case id if present
     $this->_caseId = CRM_Utils_Request::retrieve('caseid', 'String', $this, FALSE);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $cid = CRM_Utils_Request::retrieve('cid', 'String', $this, FALSE);
 

--- a/CRM/Contact/Form/Task/Map.php
+++ b/CRM/Contact/Form/Task/Map.php
@@ -63,7 +63,7 @@ class CRM_Contact_Form_Task_Map extends CRM_Contact_Form_Task {
       $this, FALSE
     );
     $this->assign('profileGID', $profileGID);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $type = 'Contact';
     if ($cid) {

--- a/CRM/Contact/Form/Task/SMS.php
+++ b/CRM/Contact/Form/Task/SMS.php
@@ -53,7 +53,7 @@ class CRM_Contact_Form_Task_SMS extends CRM_Contact_Form_Task {
 
   public function preProcess() {
 
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE);
 

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -415,7 +415,7 @@ LIMIT {$offset}, {$rowCount}
           // send query to hook to be modified if needed
           CRM_Utils_Hook::contactListQuery($query,
             $name,
-            CRM_Utils_Request::retrieve('context', 'String'),
+            CRM_Utils_Request::retrieve('context', 'Alphanumeric'),
             CRM_Utils_Request::retrieve('cid', 'Positive')
           );
 
@@ -440,7 +440,7 @@ LIMIT {$offset}, {$rowCount}
           // send query to hook to be modified if needed
           CRM_Utils_Hook::contactListQuery($query,
             $name,
-            CRM_Utils_Request::retrieve('context', 'String'),
+            CRM_Utils_Request::retrieve('context', 'Alphanumeric'),
             CRM_Utils_Request::retrieve('cid', 'Positive')
           );
 
@@ -510,7 +510,7 @@ LIMIT {$offset}, {$rowCount}
       // send query to hook to be modified if needed
       CRM_Utils_Hook::contactListQuery($query,
         $name,
-        CRM_Utils_Request::retrieve('context', 'String'),
+        CRM_Utils_Request::retrieve('context', 'Alphanumeric'),
         CRM_Utils_Request::retrieve('cid', 'Positive')
       );
 
@@ -1050,7 +1050,7 @@ LIMIT {$offset}, {$rowCount}
    */
   public static function getContactRelationships() {
     $contactID = CRM_Utils_Type::escape($_GET['cid'], 'Integer');
-    $context = CRM_Utils_Type::escape($_GET['context'], 'String');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric');
     $relationship_type_id = CRM_Utils_Type::escape(CRM_Utils_Array::value('relationship_type_id', $_GET), 'Integer', FALSE);
 
     if (!CRM_Contact_BAO_Contact_Permission::allow($contactID)) {

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -84,7 +84,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     $this->initialize();
     $gid = CRM_Utils_Request::retrieve('gid', 'Positive', $this, FALSE, 0);
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 0);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $limit = CRM_Utils_Request::retrieve('limit', 'Integer', $this);
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);

--- a/CRM/Contact/Page/DedupeRules.php
+++ b/CRM/Contact/Page/DedupeRules.php
@@ -101,7 +101,7 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
   public function run() {
     $id = $this->getIdAndAction();
 
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE);
     if ($context == 'nonDupe') {
       CRM_Core_Session::setStatus(ts('Selected contacts have been marked as not duplicates'), ts('Changes Saved'), 'success');
     }

--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -217,7 +217,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
   }
 
   public function setContext() {
-    $context = CRM_Utils_Request::retrieve('context', 'String',
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric',
       $this, FALSE, 'search'
     );
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3400,6 +3400,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         // change Payment Instrument for a Completed contribution
         // first handle special case when contribution is changed from Pending to Completed status when initial payment
         // instrument is null and now new payment instrument is added along with the payment
+        if (!$params['contribution']->payment_instrument_id) {
+          $params['contribution']->find(TRUE);
+        }
         $params['trxnParams']['payment_instrument_id'] = $params['contribution']->payment_instrument_id;
         $params['trxnParams']['check_number'] = CRM_Utils_Array::value('check_number', $params);
 

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -475,7 +475,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       $cid = CRM_Utils_Request::retrieve('cid', 'Integer');
       $mid = CRM_Utils_Request::retrieve('mid', 'Integer');
       $qfkey = CRM_Utils_Request::retrieve('key', 'String');
-      $context = CRM_Utils_Request::retrieve('context', 'String');
+      $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric');
       if ($cid) {
         switch ($context) {
           case 'contribution':

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -248,7 +248,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
     $this->assign('contactID', $this->_contactID);
     CRM_Core_Resources::singleton()->addVars('coreForm', array('contact_id' => (int) $this->_contactID));
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');
-    $this->_mode = empty($this->_mode) ? CRM_Utils_Request::retrieve('mode', 'String', $this) : $this->_mode;
+    $this->_mode = empty($this->_mode) ? CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this) : $this->_mode;
     $this->assign('isBackOffice', $this->isBackOffice);
     $this->assignPaymentRelatedVariables();
   }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -258,7 +258,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->_compContext = CRM_Utils_Request::retrieve('compContext', 'String', $this);
 
     //set the contribution mode.
-    $this->_mode = CRM_Utils_Request::retrieve('mode', 'String', $this);
+    $this->_mode = CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
 
     $this->assign('contributionMode', $this->_mode);
     if ($this->_action & CRM_Core_Action::DELETE) {

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -250,7 +250,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->assign('isUsePaymentBlock', TRUE);
     }
 
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $this->_context);
 
     $this->_compId = CRM_Utils_Request::retrieve('compId', 'Positive', $this);

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -42,7 +42,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
   public function preProcess() {
     $id = $this->get('id');
     $params = array('id' => $id);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $context);
 
     $values = CRM_Contribute_BAO_Contribution::getValuesWithMappings($params);

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -83,7 +83,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
 
     $this->assign("context", $this->_context);
 

--- a/CRM/Contribute/Page/PaymentInfo.php
+++ b/CRM/Contribute/Page/PaymentInfo.php
@@ -35,7 +35,7 @@ class CRM_Contribute_Page_PaymentInfo extends CRM_Core_Page {
     $this->_component = CRM_Utils_Request::retrieve('component', 'String', $this, TRUE);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, TRUE);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, TRUE);
     $this->_cid = CRM_Utils_Request::retrieve('cid', 'String', $this, TRUE);
 
     $this->assign('cid', $this->_cid);

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -248,7 +248,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
    */
   public function edit() {
     // set https for offline cc transaction
-    $mode = CRM_Utils_Request::retrieve('mode', 'String', $this);
+    $mode = CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
     if ($mode == 'test' || $mode == 'live') {
       CRM_Utils_System::redirectToSSL();
     }

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -266,7 +266,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
   }
 
   public function preProcess() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
@@ -324,7 +324,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
 
   public function setContext() {
     $qfKey = CRM_Utils_Request::retrieve('key', 'String', $this);
-    $context = CRM_Utils_Request::retrieve('context', 'String',
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric',
       $this, FALSE, 'search'
     );
     $compContext = CRM_Utils_Request::retrieve('compContext', 'String', $this);

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -476,6 +476,8 @@ LEFT JOIN civicrm_custom_field ON (civicrm_custom_field.custom_group_id = civicr
       $in = "'$entityType'";
     }
 
+    $params = array();
+    $sqlParamKey = 1;
     if (!empty($subTypes)) {
       foreach ($subTypes as $key => $subType) {
         $subTypeClauses[] = self::whereListHas("civicrm_custom_group.extends_entity_column_value", self::validateSubTypeByEntity($entityType, $subType));
@@ -492,7 +494,9 @@ WHERE civicrm_custom_group.is_active = 1
   AND $subTypeClause
 ";
       if ($subName) {
-        $strWhere .= " AND civicrm_custom_group.extends_entity_column_id = {$subName} ";
+        $strWhere .= " AND civicrm_custom_group.extends_entity_column_id = %{$sqlParamKey}";
+        $params[$sqlParamKey] = array($subName, 'String');
+        $sqlParamKey = $sqlParamKey + 1;
       }
     }
     else {
@@ -506,11 +510,10 @@ WHERE civicrm_custom_group.is_active = 1
       }
     }
 
-    $params = array();
     if ($groupID > 0) {
       // since we want a specific group id we add it to the where clause
-      $strWhere .= " AND civicrm_custom_group.id = %1";
-      $params[1] = array($groupID, 'Integer');
+      $strWhere .= " AND civicrm_custom_group.id = %{$sqlParamKey}";
+      $params[$sqlParamKey] = array($groupID, 'Integer');
     }
     elseif (!$groupID) {
       // since groupID is false we need to show all Inline groups

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -329,7 +329,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function fatal($message = NULL, $code = NULL, $email = NULL) {
     $vars = array(
-      'message' => htmlspecialchars($message),
+      'message' => $message,
       'code' => $code,
     );
 

--- a/CRM/Core/Page/AJAX.php
+++ b/CRM/Core/Page/AJAX.php
@@ -98,9 +98,8 @@ class CRM_Core_Page_AJAX {
       $id = CRM_Utils_Type::escape($_REQUEST['id'], 'Integer');
     }
 
-    if (!empty($_REQUEST['context'])) {
-      $context = CRM_Utils_Type::escape($_REQUEST['context'], 'String');
-    }
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric');
+
     // return false if $id is null and
     // $context is not civicrm_event or civicrm_contribution_page
     if (!$id || !in_array($context, array('civicrm_event', 'civicrm_contribution_page'))) {

--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -471,6 +471,10 @@ class CRM_Core_Session {
     $session = self::singleton();
     $session->initialize();
 
+    // Sanitize any HTML we're displaying. This helps prevent reflected XSS in error messages.
+    $text = CRM_Utils_String::purifyHTML($text);
+    $title = CRM_Utils_String::purifyHTML($title);
+
     // default options
     $options += array('unique' => TRUE);
 

--- a/CRM/Core/Smarty/plugins/modifier.purify.php
+++ b/CRM/Core/Smarty/plugins/modifier.purify.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ * $Id$
+ */
+
+/**
+ * Purify HTML to mitigate against XSS attacks
+ *
+ * @param string $text
+ *   Input text, potentially containing XSS
+ *
+ * @return string
+ *   Output text, containing only clean HTML
+ */
+function smarty_modifier_purify($text) {
+  return CRM_Utils_String::purifyHTML($text);
+}

--- a/CRM/Dashlet/Page/Activity.php
+++ b/CRM/Dashlet/Page/Activity.php
@@ -50,7 +50,7 @@ class CRM_Dashlet_Page_Activity extends CRM_Core_Page {
     $this->assign('contactID', $contactID);
     $this->assign('contactId', $contactID);
 
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'dashlet');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'dashlet');
     $this->assign('context', $context);
 
     // a user can always view their own activity

--- a/CRM/Dashlet/Page/AllCases.php
+++ b/CRM/Dashlet/Page/AllCases.php
@@ -45,7 +45,7 @@ class CRM_Dashlet_Page_AllCases extends CRM_Core_Page {
    * @return void
    */
   public function run() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'dashlet');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'dashlet');
     $this->assign('context', $context);
 
     //check for civicase access.

--- a/CRM/Dashlet/Page/GettingStarted.php
+++ b/CRM/Dashlet/Page/GettingStarted.php
@@ -70,7 +70,7 @@ class CRM_Dashlet_Page_GettingStarted extends CRM_Core_Page {
    * List gettingStarted page as dashlet.
    */
   public function run() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'dashlet');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'dashlet');
 
     // Assign smarty variables.
     $this->assign('context', $context);

--- a/CRM/Dashlet/Page/MyCases.php
+++ b/CRM/Dashlet/Page/MyCases.php
@@ -45,7 +45,7 @@ class CRM_Dashlet_Page_MyCases extends CRM_Core_Page {
    * @return void
    */
   public function run() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'dashlet');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'dashlet');
     $this->assign('context', $context);
 
     //check for civicase access.

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -223,7 +223,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     // @todo eliminate this duplication.
     $this->_contactId = $this->_contactID;
     $this->_eID = CRM_Utils_Request::retrieve('eid', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $this->_context);
 
     if ($this->_contactID) {

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -97,7 +97,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
     $this->_ssID = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);
     $this->assign("context", $this->_context);
 

--- a/CRM/Event/Form/Task/Badge.php
+++ b/CRM/Event/Form/Task/Badge.php
@@ -57,7 +57,7 @@ class CRM_Event_Form_Task_Badge extends CRM_Event_Form_Task {
    * @return void
    */
   public function preProcess() {
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     if ($this->_context == 'view') {
       $this->_single = TRUE;
 

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -59,7 +59,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     }
 
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'register');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'register');
     $this->assign('context', $context);
 
     // Sometimes we want to suppress the Event Full msg

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -95,7 +95,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
    */
   public function edit() {
     // set https for offline cc transaction
-    $mode = CRM_Utils_Request::retrieve('mode', 'String', $this);
+    $mode = CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
     if ($mode == 'test' || $mode == 'live') {
       CRM_Utils_System::redirectToSSL();
     }

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -119,7 +119,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
   }
 
   public function preProcess() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 

--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -47,7 +47,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->set("context", $context);
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     parent::preProcess();

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -267,7 +267,7 @@ class CRM_Financial_Page_AJAX {
     $rowCount = isset($_REQUEST['iDisplayLength']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayLength'], 'Integer') : 25;
     $sort = isset($_REQUEST['iSortCol_0']) ? CRM_Utils_Array::value(CRM_Utils_Type::escape($_REQUEST['iSortCol_0'], 'Integer'), $sortMapper) : NULL;
     $sortOrder = isset($_REQUEST['sSortDir_0']) ? CRM_Utils_Type::escape($_REQUEST['sSortDir_0'], 'String') : 'asc';
-    $context = isset($_REQUEST['context']) ? CRM_Utils_Type::escape($_REQUEST['context'], 'String') : NULL;
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric');
     $entityID = isset($_REQUEST['entityID']) ? CRM_Utils_Type::escape($_REQUEST['entityID'], 'String') : NULL;
     $notPresent = isset($_REQUEST['notPresent']) ? CRM_Utils_Type::escape($_REQUEST['notPresent'], 'String') : NULL;
     $statusID = isset($_REQUEST['statusID']) ? CRM_Utils_Type::escape($_REQUEST['statusID'], 'String') : NULL;

--- a/CRM/Financial/Page/FinancialBatch.php
+++ b/CRM/Financial/Page/FinancialBatch.php
@@ -74,7 +74,7 @@ class CRM_Financial_Page_FinancialBatch extends CRM_Core_Page_Basic {
    * Finally it calls the parent's run method.
    */
   public function run() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->set("context", $context);
 
     $id = $this->getIdAndAction();

--- a/CRM/Grant/Form/Grant.php
+++ b/CRM/Grant/Form/Grant.php
@@ -75,7 +75,7 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
     if ($this->_id) {
       $this->_grantType = CRM_Core_DAO::getFieldValue('CRM_Grant_DAO_Grant', $this->_id, 'grant_type_id');
     }
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $this->assign('action', $this->_action);
     $this->assign('context', $this->_context);

--- a/CRM/Grant/Form/GrantView.php
+++ b/CRM/Grant/Form/GrantView.php
@@ -47,7 +47,7 @@ class CRM_Grant_Form_GrantView extends CRM_Core_Form {
   public function preProcess() {
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $context);
 
     $values = array();

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -91,7 +91,7 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
 
     $this->assign("context", $this->_context);
 

--- a/CRM/Grant/Page/Tab.php
+++ b/CRM/Grant/Page/Tab.php
@@ -102,7 +102,7 @@ class CRM_Grant_Page_Tab extends CRM_Contact_Page_View {
    * @return void
    */
   public function preProcess() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
@@ -151,7 +151,7 @@ class CRM_Grant_Page_Tab extends CRM_Contact_Page_View {
   }
 
   public function setContext() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_id = CRM_Utils_Request::retrieve('id', 'Integer', $this);
     $session = CRM_Core_Session::singleton();
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -232,6 +232,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         "mg.group_type = 'Include'",
         'mg.search_id IS NULL',
         "$contact.is_opt_out = 0",
+		"$contact.do_not_sms = 0",
         "$contact.is_deceased <> 1",
         "$entityTable.phone_type_id = " . CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_Phone', 'phone_type_id', 'Mobile'),
         "$entityTable.phone IS NOT NULL",

--- a/CRM/Mailing/Page/Event.php
+++ b/CRM/Mailing/Page/Event.php
@@ -63,7 +63,7 @@ class CRM_Mailing_Page_Event extends CRM_Core_Page {
     // check that the user has permission to access mailing id
     CRM_Mailing_BAO_Mailing::checkPermission($mailing_id);
 
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     if ($context == 'activitySelector') {
       $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);

--- a/CRM/Mailing/Page/Report.php
+++ b/CRM/Mailing/Page/Report.php
@@ -110,7 +110,7 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
     CRM_Mailing_BAO_Mailing::getMailingContent($report, $this);
 
     // assign backurl
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     if ($context == 'activitySelector') {

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -112,7 +112,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     $params = array();
     $params['context'] = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'membership');
     $params['id'] = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $params['mode'] = CRM_Utils_Request::retrieve('mode', 'String', $this);
+    $params['mode'] = CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
 
     $this->setContextVariables($params);
 

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -110,7 +110,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
     parent::preProcess();
     $params = array();
-    $params['context'] = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'membership');
+    $params['context'] = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'membership');
     $params['id'] = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     $params['mode'] = CRM_Utils_Request::retrieve('mode', 'String', $this);
 

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -166,7 +166,7 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
     $this->contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     // Make sure context is assigned to template for condition where we come here view civicrm/membership/view
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $context);
 
     if ($this->membershipID) {

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -92,7 +92,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
 
     $this->assign("context", $this->_context);
 

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -306,7 +306,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
   }
 
   public function preProcess() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
@@ -390,7 +390,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    * @param int $contactId
    */
   public static function setContext(&$form, $contactId = NULL) {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $form, FALSE, 'search');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $form, FALSE, 'search');
 
     $qfKey = CRM_Utils_Request::retrieve('key', 'String', $form);
 

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -264,7 +264,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    */
   public function edit() {
     // set https for offline cc transaction
-    $mode = CRM_Utils_Request::retrieve('mode', 'String', $this);
+    $mode = CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
     if ($mode == 'test' || $mode == 'live') {
       CRM_Utils_System::redirectToSSL();
     }

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -50,7 +50,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
     $this->_component = CRM_Utils_Request::retrieve('component', 'String', $this);
     $this->assign('component', $this->_component);
 
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $this->_context);
 
     $this->_pageId = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);

--- a/CRM/PCP/Form/PCP.php
+++ b/CRM/PCP/Form/PCP.php
@@ -66,7 +66,7 @@ class CRM_PCP_Form_PCP extends CRM_Core_Form {
 
     //give the context.
     if (!isset($this->_context)) {
-      $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+      $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     }
 
     $this->assign('context', $this->_context);

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -75,7 +75,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $this, FALSE, 'add'
     );
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     // check for action permissions.
     if (!CRM_Core_Permission::checkActionPermission('CiviPledge', $this->_action)) {

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -79,7 +79,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
 
     $this->assign("context", $this->_context);
 

--- a/CRM/Pledge/Page/Payment.php
+++ b/CRM/Pledge/Page/Payment.php
@@ -39,7 +39,7 @@ class CRM_Pledge_Page_Payment extends CRM_Core_Page {
    */
   public function run() {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $this->assign('action', $this->_action);
     $this->assign('context', $this->_context);

--- a/CRM/Pledge/Page/Tab.php
+++ b/CRM/Pledge/Page/Tab.php
@@ -94,7 +94,7 @@ class CRM_Pledge_Page_Tab extends CRM_Core_Page {
   }
 
   public function preProcess() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
@@ -156,7 +156,7 @@ class CRM_Pledge_Page_Tab extends CRM_Core_Page {
    * @param $form
    */
   public static function setContext(&$form) {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $form, FALSE, 'search');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $form, FALSE, 'search');
 
     $qfKey = CRM_Utils_Request::retrieve('key', 'String', $form);
     // validate the qfKey

--- a/CRM/Price/Page/Set.php
+++ b/CRM/Price/Page/Set.php
@@ -224,7 +224,7 @@ class CRM_Price_Page_Set extends CRM_Core_Page {
   public function preview($sid) {
     $controller = new CRM_Core_Controller_Simple('CRM_Price_Form_Preview', ts('Preview Price Set'), NULL);
     $session = CRM_Core_Session::singleton();
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     if ($context == 'field') {
       $session->pushUserContext(CRM_Utils_System::url('civicrm/admin/price/field', "action=browse&sid={$sid}"));
     }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -195,7 +195,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     $this->_id = $this->get('id');
     $this->_profileIds = $this->get('profileIds');
     $this->_grid = CRM_Utils_Request::retrieve('grid', 'Integer', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     //unset from session when $_GET doesn't have it
     //except when the form is submitted

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -62,7 +62,7 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
     $this->assign('onPopupClose', $this->_onPopupClose);
 
     //set the context for the profile
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     //set the block no
     $this->_blockNo = CRM_Utils_Request::retrieve('blockNo', 'String', $this);

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -930,7 +930,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     $activityStatus = CRM_Core_PseudoConstant::activityStatus();
     $priority = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id');
     $viewLinks = FALSE;
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'report');
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'report');
     $actUrl = '';
 
     if (CRM_Core_Permission::check('access CiviCRM')) {

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -406,7 +406,7 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
    * @param $action
    */
   public function setContext($id, $action) {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     //we need to differentiate context for update and preview profile.
     if (!$context && !($action & (CRM_Core_Action::UPDATE | CRM_Core_Action::PREVIEW))) {

--- a/CRM/Upgrade/Incremental/php/FiveThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveThree.php
@@ -75,6 +75,7 @@ class CRM_Upgrade_Incremental_php_FiveThree extends CRM_Upgrade_Incremental_Base
    * @param string $rev
    */
   public function upgrade_5_3_alpha1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('CRM-19948 - Add created_id column to civicrm_file', 'addFileCreatedIdColumn');
   }
 

--- a/CRM/Upgrade/Incremental/sql/5.3.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.0.mysql.tpl
@@ -1,1 +1,18 @@
 {* file to handle db changes in 5.3.0 during upgrade *}
+ALTER TABLE civicrm_custom_group ALTER column is_multiple SET DEFAULT 0;
+UPDATE civicrm_custom_group SET is_multiple = 0 WHERE is_multiple IS NULL;
+ALTER TABLE civicrm_custom_group ALTER column is_active SET DEFAULT 1;
+ALTER TABLE civicrm_custom_field ALTER column is_view SET DEFAULT 0;
+UPDATE civicrm_custom_field SET is_view = 0 WHERE is_view IS NULL;
+ALTER TABLE civicrm_custom_field ALTER column is_required SET DEFAULT 0;
+UPDATE civicrm_custom_field SET is_required = 0 WHERE is_required IS NULL;
+ALTER TABLE civicrm_custom_field ALTER column is_searchable SET DEFAULT 0;
+UPDATE civicrm_custom_field SET is_searchable = 0 WHERE is_required IS NULL;
+ALTER TABLE civicrm_custom_field ALTER column is_active SET DEFAULT 1;
+
+SET @UKCountryId = (SELECT id FROM civicrm_country cc WHERE cc.name = 'United Kingdom');
+INSERT INTO civicrm_state_province (country_id, abbreviation, name)
+VALUES (@UKCountryId, 'MON', 'Monmouthshire');
+
+{* dev/core/#152 *}
+UPDATE `civicrm_custom_field` set `html_type` = "Multi-Select" WHERE `html_type` = "AdvMulti-Select";

--- a/CRM/Upgrade/Incremental/sql/5.3.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.0.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.3.0 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.3.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.1.mysql.tpl
@@ -1,0 +1,19 @@
+{* file to handle db changes in 5.3.1 during upgrade *}
+{* Re run upgrades from 5.3.0 Just in case they were missed somehow due to dodgy tarball *}
+ALTER TABLE civicrm_custom_group ALTER column is_multiple SET DEFAULT 0;
+UPDATE civicrm_custom_group SET is_multiple = 0 WHERE is_multiple IS NULL;
+ALTER TABLE civicrm_custom_group ALTER column is_active SET DEFAULT 1;
+ALTER TABLE civicrm_custom_field ALTER column is_view SET DEFAULT 0;
+UPDATE civicrm_custom_field SET is_view = 0 WHERE is_view IS NULL;
+ALTER TABLE civicrm_custom_field ALTER column is_required SET DEFAULT 0;
+UPDATE civicrm_custom_field SET is_required = 0 WHERE is_required IS NULL;
+ALTER TABLE civicrm_custom_field ALTER column is_searchable SET DEFAULT 0;
+UPDATE civicrm_custom_field SET is_searchable = 0 WHERE is_required IS NULL;
+ALTER TABLE civicrm_custom_field ALTER column is_active SET DEFAULT 1;
+
+SET @UKCountryId = (SELECT id FROM civicrm_country cc WHERE cc.name = 'United Kingdom');
+INSERT IGNORE INTO civicrm_state_province (country_id, abbreviation, name)
+VALUES (@UKCountryId, 'MON', 'Monmouthshire');
+
+{* dev/core/#152 *}
+UPDATE `civicrm_custom_field` set `html_type` = "Multi-Select" WHERE `html_type` = "AdvMulti-Select";

--- a/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
@@ -1,18 +1,1 @@
 {* file to handle db changes in 5.3.alpha1 during upgrade *}
-ALTER TABLE civicrm_custom_group ALTER column is_multiple SET DEFAULT 0;
-UPDATE civicrm_custom_group SET is_multiple = 0 WHERE is_multiple IS NULL;
-ALTER TABLE civicrm_custom_group ALTER column is_active SET DEFAULT 1;
-ALTER TABLE civicrm_custom_field ALTER column is_view SET DEFAULT 0;
-UPDATE civicrm_custom_field SET is_view = 0 WHERE is_view IS NULL;
-ALTER TABLE civicrm_custom_field ALTER column is_required SET DEFAULT 0;
-UPDATE civicrm_custom_field SET is_required = 0 WHERE is_required IS NULL;
-ALTER TABLE civicrm_custom_field ALTER column is_searchable SET DEFAULT 0;
-UPDATE civicrm_custom_field SET is_searchable = 0 WHERE is_required IS NULL;
-ALTER TABLE civicrm_custom_field ALTER column is_active SET DEFAULT 1;
-
-SET @UKCountryId = (SELECT id FROM civicrm_country cc WHERE cc.name = 'United Kingdom');
-INSERT INTO civicrm_state_province (country_id, abbreviation, name)
-VALUES (@UKCountryId, 'MON', 'Monmouthshire');
-
-{* dev/core/#152 *}
-UPDATE `civicrm_custom_field` set `html_type` = "Multi-Select" WHERE `html_type` = "AdvMulti-Select";

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "jquery-validation": "~1.13",
     "datatables": "~1.10",
     "jstree": "~3",
-    "ckeditor": "~4.5",
+    "ckeditor": "~4.9",
     "font-awesome": "~4",
     "angular-bootstrap": "^2.5.0",
     "angular-sanitize": "~1.5.0",

--- a/js/wysiwyg/crm.ckeditor.js
+++ b/js/wysiwyg/crm.ckeditor.js
@@ -55,7 +55,7 @@
     function initialize() {
       var
         browseUrl = CRM.config.resourceBase + "packages/kcfinder/browse.php?cms=civicrm",
-        uploadUrl = CRM.config.resourceBase + "packages/kcfinder/upload.php?cms=civicrm",
+        uploadUrl = CRM.config.resourceBase + "packages/kcfinder/upload.php?cms=civicrm&format=json",
         preset = $(item).data('preset') || 'default',
         // This variable is always an array but a legacy extension could be setting it as a string.
         customConfig = (typeof CRM.config.CKEditorCustomConfig === 'string') ? CRM.config.CKEditorCustomConfig :

--- a/release-notes/5.3.1.md
+++ b/release-notes/5.3.1.md
@@ -1,0 +1,19 @@
+# CiviCRM 5.3.1
+
+Released July 18, 2018
+
+- **[Security advisories](#security)**
+- **[Features](#features)**
+- **[Bugs resolved](#bugs)**
+- **[Miscellany](#misc)**
+- **[Credits](#credits)**
+
+## <a name="security"></a>Security advisories
+
+- **[CIVI-SA-2018-01](https://civicrm.org/advisory/civi-sa-2018-01-sql-injection-in-get-cases-ajax-api)** SQL injection in get-cases AJAX API
+- **[CIVI-SA-2018-02](https://civicrm.org/advisory/civi-sa-2018-02-reflected-xss-in-contribution-reports)** Reflected XSS in Contribution Reports
+- **[CIVI-SA-2018-03](https://civicrm.org/advisory/civi-sa-2018-03-reflected-xss-in-error-message)** Reflected XSS in error message
+- **[CIVI-SA-2018-04](https://civicrm.org/advisory/civi-sa-2018-04-sql-injection-in-custom-groups)** SQL injection in Custom Groups
+- **[CIVI-SA-2018-05](https://civicrm.org/advisory/civi-sa-2018-05-reflected-xss-in-contact-merge-screen)** Reflected XSS in Contact Merge Screen
+- **[CIVI-SA-2018-06](https://civicrm.org/advisory/civi-sa-2018-06-reflected-xss-in-context-parameter)** Reflected XSS in "New Membership" Form
+

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.3.0',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.3.1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.3.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.3.0',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -341,7 +341,7 @@ function updateContactInfo(blockNo, prefix) {
   {/literal}
   {if $contactFields}
   {foreach from=$contactFields item=val key=fldName}
-  var fldName = "{$fldName}";
+  var fldName = {$fldName|@json_encode};
   {literal}
   if (returnProperties) {
     returnProperties = returnProperties + ',';

--- a/templates/CRM/Case/Audit/Audit.tpl
+++ b/templates/CRM/Case/Audit/Audit.tpl
@@ -154,7 +154,7 @@ There's the potential for collisions (two different labels having the same short
 
        if ( button.name == 'case_report' ) {
             var dataUrl = {/literal}"{crmURL p='civicrm/case/report/print' h=0 q='caseID='}"{literal}+id;
-            dataUrl     = dataUrl + '&cid={/literal}{$clientID}{literal}'+'&asn={/literal}{$activitySetName}{literal}';
+            dataUrl     = dataUrl + '&cid={/literal}{$clientID}{literal}&asn=' + {/literal}{$activitySetName|@json_encode}{literal};
             var redact  = '{/literal}{$_isRedact}{literal}'
 
             var isRedact = 1;

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -112,7 +112,7 @@
   <script type="text/javascript" >
   CRM.$(function($) {
     var $form = $("form.{/literal}{$form.formClass}{literal}"),
-      action = "{/literal}{$action}{literal}",
+      action = {/literal}{$action|@json_encode}{literal},
       _ = CRM._;
 
     $('.crm-accordion-body').each( function() {

--- a/templates/CRM/Contact/Form/CustomData.tpl
+++ b/templates/CRM/Contact/Form/CustomData.tpl
@@ -41,10 +41,10 @@
     <script type="text/javascript">
       CRM.$(function() {
         {/literal}
-        var customValueCount = "{$customValueCount}",
-          groupID = "{$groupID}",
-          contact_type = "{$contact_type}",
-          contact_subtype = "{$contact_subtype}",
+        var customValueCount = {$customValueCount|@json_encode},
+          groupID = {$groupID|@json_encode},
+          contact_type = {$contact_type|@json_encode},
+          contact_subtype = {$contact_subtype|@json_encode},
           i = 1;
         {literal}
         // FIXME: This is pretty terrible. Loading each item at a time via ajax.

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -47,16 +47,16 @@
   </div>
 
   <div class="action-link">
-    {if $prev}<a href="{$prev}" class="crm-hover-button action-item"><i class="crm-i fa-chevron-left"></i> {ts}Previous{/ts}</a>{/if}
-    {if $next}<a href="{$next}" class="crm-hover-button action-item">{ts}Next{/ts} <i class="crm-i fa-chevron-right"></i></a>{/if}
-    <a href="{$flip}" class="action-item crm-hover-button">
+    {if $prev}<a href="{$prev|escape}" class="crm-hover-button action-item"><i class="crm-i fa-chevron-left"></i> {ts}Previous{/ts}</a>{/if}
+    {if $next}<a href="{$next|escape}" class="crm-hover-button action-item">{ts}Next{/ts} <i class="crm-i fa-chevron-right"></i></a>{/if}
+    <a href="{$flip|escape}" class="action-item crm-hover-button">
       <i class="crm-i fa-random"></i>
       {ts}Flip between original and duplicate contacts.{/ts}
     </a>
   </div>
 
   <div class="action-link">
-    <a href="#" class="action-item crm-hover-button crm-notDuplicate" title={ts}Mark this pair as not a duplicate.{/ts} onClick="processDupes( {$main_cid}, {$other_cid}, 'dupe-nondupe', 'merge-contact', '{$browseUrl}' );return false;">
+    <a href="#" class="action-item crm-hover-button crm-notDuplicate" title={ts}Mark this pair as not a duplicate.{/ts} onClick="processDupes( {$main_cid|escape}, {$other_cid|escape}, 'dupe-nondupe', 'merge-contact', '{$browseUrl}' );return false;">
       <i class="crm-i fa-times-circle"></i>
       {ts}Mark this pair as not a duplicate.{/ts}
     </a>
@@ -72,9 +72,9 @@
   <table class="row-highlight">
     <tr class="columnheader">
       <th>&nbsp;</th>
-      <th><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$other_cid"}">{$other_name}</a> ({ts}duplicate{/ts})</th>
+      <th><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$other_cid"}">{$other_name|escape}</a> ({ts}duplicate{/ts})</th>
       <th>{ts}Mark All{/ts}<br />=={$form.toggleSelect.html} ==&gt;</th>
-      <th><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$main_cid"}">{$main_name}</a></th>
+      <th><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$main_cid"}">{$main_name|escape}</a></th>
       <th width="300">Add/overwrite?</th>
     </tr>
 
@@ -95,7 +95,7 @@
       {if !isset($row.main) && !isset($row.other)}
         <tr style="background-color: #fff !important; border-bottom:1px solid #ccc !important;" class="no-data">
           <td>
-            <strong>{$row.title}</strong>
+            <strong>{$row.title|escape}</strong>
           </td>
       {else}
         {if $row.main eq $row.other}
@@ -104,7 +104,7 @@
            <tr class="crm-row-error {cycle values="odd-row,even-row"}">
         {/if}
           <td>
-            {$row.title}
+            {$row.title|escape}
           </td>
         {/if}
 
@@ -121,9 +121,9 @@
               <span>
             {/if}
             {if !is_array($row.other)}
-              {$row.other}
+              {$row.other|escape}
             {elseif $row.other.fileName}
-              {$row.other.fileName}
+              {$row.other.fileName|escape}
             {else}
               {', '|implode:$row.other}
             {/if}
@@ -145,15 +145,15 @@
               {strip}
                 {if $row.title|substr:0:5 == "Email"   OR
                     $row.title|substr:0:7 == "Address"}
-                  <span style="white-space: pre" id="main_{$blockName}_{$blockId}">
+                  <span style="white-space: pre" id="main_{$blockName|escape}_{$blockId|escape}">
                 {else}
-                  <span id="main_{$blockName}_{$blockId}">
+                  <span id="main_{$blockName|escape}_{$blockId|escape}">
                 {/if}
                 {* @TODO check if this is ever an array or a fileName? *}
                 {if !is_array($row.main)}
-                  {$row.main}
+                  {$row.main|escape}
                 {elseif $row.main.fileName}
-                  {$row.main.fileName}
+                  {$row.main.fileName|escape}
                 {else}
                   {', '|implode:$row.main}
                 {/if}
@@ -204,9 +204,9 @@
             <td>
               <span>
                 {if !is_array($row.main)}
-                  {$row.main}
+                  {$row.main|escape}
                 {elseif $row.main.fileName}
-                  {$row.main.fileName}
+                  {$row.main.fileName|escape}
                 {else}
                   {', '|implode:$row.main}
                 {/if}

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -311,7 +311,7 @@
     }
 
     // Update operation description
-    var operation_description = "{/literal}{ts}add{/ts}{literal}";
+    var operation_description = "{/literal}{ts escape='js'}add{/ts}{literal}";
     var add_new_check_length = this_controls.find(".location_operation_checkbox input:checked").length;
     if (mainBlock != false) {
       if (add_new_check_length > 0) {

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -175,7 +175,7 @@
             var select = $(this).next();
             $('option', select).each(function() {
               if ($(this).attr('value') == defaultLocationType
-              && $(this).text() == "{/literal}{$defaultLocationTypeLabel}{literal}") {
+                && $(this).text() == {/literal}{$defaultLocationTypeLabel|@json_encode}{literal}) {
                 select.val(defaultLocationType);
               }
             });

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -121,7 +121,7 @@
     {literal}
     <script type="text/javascript">
 
-    var url = "{/literal}{$dataUrl}{literal}";
+    var url = {/literal}{$dataUrl|@json_encode}{literal};
 
       CRM.$(function($) {
         showHideByValue( 'is_email_receipt', '', 'notice', 'table-row', 'radio', false );

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -385,7 +385,7 @@
       }
     }
 
-  var url = "{/literal}{$dataUrl}{literal}";
+  var url = {/literal}{$dataUrl|@json_encode}{literal};
 
   {/literal}
     {if $context eq 'standalone' and $outBound_option != 2 }
@@ -520,7 +520,7 @@ function buildAmount( priceSetId, financialtypeIds ) {
     // show/hide price set amount and total amount.
     cj("#totalAmountORPriceSet").show( );
     cj("#totalAmount").show( );
-    var choose = "{/literal}{ts}Choose price set{/ts}{literal}";
+    var choose = "{/literal}{ts escape='js'}Choose price set{/ts}{literal}";
     cj("#price_set_id option[value='']").html( choose );
 
     cj('label[for="total_amount"]').text('{/literal}{ts}Total Amount{/ts}{literal}');
@@ -554,7 +554,7 @@ function buildAmount( priceSetId, financialtypeIds ) {
 
   cj( "#totalAmountORPriceSet" ).hide( );
   cj( "#totalAmount").hide( );
-  var manual = "{/literal}{ts}Manual contribution amount{/ts}{literal}";
+  var manual = "{/literal}{ts escape='js'}Manual contribution amount{/ts}{literal}";
   cj("#price_set_id option[value='']").html( manual );
 
   cj('label[for="total_amount"]').text('{/literal}{ts}Price Sets{/ts}{literal}');

--- a/templates/CRM/Contribute/Page/PaymentInfo.tpl
+++ b/templates/CRM/Contribute/Page/PaymentInfo.tpl
@@ -36,7 +36,7 @@ CRM.$(function($) {
         $("#payment-info").html(html).trigger('crmLoad');
       }
     });
-
+    // Fixme: Possible bug - the following line won't be processed by smarty because it's in a literal block
     var taxAmount = "{$totalTaxAmount}";
     if (taxAmount) {
       $('.total_amount-section').show();

--- a/templates/CRM/Custom/Form/ChangeFieldType.tpl
+++ b/templates/CRM/Custom/Form/ChangeFieldType.tpl
@@ -43,7 +43,7 @@
 {literal}
 <script type="text/Javascript">
   function checkCustomDataField( ) {
-    var srcHtmlType = '{/literal}{$srcHtmlType}{literal}';
+    var srcHtmlType = {/literal}{$srcHtmlType|@json_encode}{literal};
     var singleValOps = ['Text', 'Select', 'Radio', 'Autocomplete-Select'];
     var multiValOps  = ['CheckBox', 'Multi-Select'];
     var dstHtmlType = cj('#dst_html_type').val( );

--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -93,7 +93,7 @@ CRM.$(function($) {
 
   $('#extends_0').each(showHideStyle).change(showHideStyle);
 
-  var isGroupEmpty = "{/literal}{$isGroupEmpty}{literal}";
+  var isGroupEmpty = {/literal}{$isGroupEmpty|@json_encode}{literal};
   if (isGroupEmpty) {
     showRange(true);
   }

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -404,7 +404,7 @@
             return;
           }
 
-          var participantId  = "{/literal}{$participantId}{literal}";
+          var participantId  = {/literal}{$participantId|@json_encode}{literal};
 
           if (participantId) {
             dataUrl += '&participantId=' + participantId;

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -398,8 +398,8 @@
       // elsewhere some script determines if there is a paying contact the
       // email should go to instead (e.g gift membership). This should be checked for here
       // and that merged into that code as currently behaviour is inconsistent.
-      var emailExists = '{$emailExists}';
-      var isStandalone = ('{$context}' == 'standalone');
+      var emailExists = {$emailExists|json_encode};
+      var isStandalone = {if $context == 'standalone'}true{else}false{/if};
       var isEmailEnabledForSite = {if $isEmailEnabledForSite}true{else}false{/if};
 
       {literal}

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -299,11 +299,10 @@
         // skip this for test and live modes because financial type is set automatically
         cj("#financial_type_id").val(allMemberships[memType]['financial_type_id']);
         var term = cj('#num_terms').val();
-        var taxRates = '{/literal}{$taxRates}{literal}';
-        var taxTerm = '{/literal}{$taxTerm}{literal}';
-        var taxRates = JSON.parse(taxRates);
+        var taxRates = {/literal}{$taxRates}{literal};
+        var taxTerm = {/literal}{$taxTerm|@json_encode}{literal};
         var taxRate = taxRates[allMemberships[memType]['financial_type_id']];
-        var currency = '{/literal}{$currency}{literal}';
+        var currency = {/literal}{$currency|@json_encode}{literal};
         var taxAmount = (taxRate/100)*allMemberships[memType]['total_amount_numeric'];
         taxAmount = isNaN (taxAmount) ? 0:taxAmount;
         if (term) {
@@ -541,10 +540,10 @@
       var action = {/literal}'{$action}'{literal};
 
       //for update lets hide it when not already recurring.
-      if ( action == 2 ) {
+      if (action == 2) {
         //user can't cancel auto renew by unchecking.
-        if ( cj("#auto_renew").prop('checked' ) ) {
-          cj("#auto_renew").attr( 'readonly', true );
+        if (cj("#auto_renew").prop('checked')) {
+          cj("#auto_renew").attr('readonly', true);
         }
         else {
           cj("#autoRenew").hide( );
@@ -552,16 +551,22 @@
       }
 
       //we should do all auto renew for cc memberships.
-      if ( !mode ) return;
+      if (!mode) {
+        return;
+      }
 
       //get the required values in case missing.
-      if ( !processorId )  processorId = cj( '#payment_processor_id' ).val( );
-      if ( !membershipType ) membershipType = parseInt( cj('#membership_type_id_1').val( ) );
+      if (!processorId) {
+        processorId = cj( '#payment_processor_id' ).val( );
+      }
+      if (!membershipType) {
+        membershipType = parseInt( cj('#membership_type_id_1').val( ) );
+      }
 
       //we don't have both required values.
-      if ( !processorId || !membershipType ) {
-        cj("#auto_renew").prop('checked', false );
-        cj("#autoRenew").hide( );
+      if (!processorId || !membershipType) {
+        cj("#auto_renew").prop('checked', false);
+        cj("#autoRenew").hide();
         showEmailOptions();
         return;
       }
@@ -570,26 +575,24 @@
       var autoRenewOptions = {/literal}{$autoRenewOptions}{literal};
       var currentOption    = autoRenewOptions[membershipType];
 
-      if ( !currentOption || !recurProcessors[processorId] ) {
+      if (!currentOption || !recurProcessors[processorId]) {
         cj("#auto_renew").prop('checked', false );
         cj("#autoRenew").hide();
         return;
       }
 
-      if ( currentOption == 1 ) {
-        cj("#autoRenew").show( );
-        if ( cj("#auto_renew").attr( 'readonly' ) ) {
-          cj("#auto_renew").prop('checked', false );
-          cj("#auto_renew").removeAttr( 'readonly' );
+      if (currentOption == 1) {
+        cj("#autoRenew").show();
+        if (cj("#auto_renew").attr('readonly')) {
+          cj("#auto_renew").prop('checked', false).removeAttr('readonly');
         }
       }
       else if ( currentOption == 2 ) {
-        cj("#autoRenew").show( );
-        cj("#auto_renew").prop('checked', true );
-        cj("#auto_renew").attr( 'readonly', true );
+        cj("#autoRenew").show();
+        cj("#auto_renew").prop('checked', true).attr('readonly', true);
       }
       else {
-        cj("#auto_renew").prop('checked', false );
+        cj("#auto_renew").prop('checked', false);
         cj("#autoRenew").hide( );
       }
       showEmailOptions();
@@ -599,21 +602,18 @@
 
     {literal}
 
-    var customDataType = '{/literal}{$customDataType}{literal}';
+    var customDataType = {/literal}{$customDataType|@json_encode}{literal};
 
     // load form during form rule.
     {/literal}{if $buildPriceSet}{literal}
-    cj( "#totalAmountORPriceSet" ).hide( );
-    cj( "#mem_type_id" ).hide( );
-    cj('#total_amount').attr("readonly", true);
-    cj( "#num_terms_row" ).hide( );
-    cj(".crm-membership-form-block-financial_type_id-mode").hide();
+      cj("#totalAmountORPriceSet, #mem_type_id, #num_terms_row, .crm-membership-form-block-financial_type_id-mode").hide();
+      cj('#total_amount').attr("readonly", true);
     {/literal}{/if}{literal}
 
     function buildAmount( priceSetId ) {
-  if ( !priceSetId ) {
-    priceSetId = cj("#price_set_id").val( );
-  }
+      if (!priceSetId) {
+        priceSetId = cj("#price_set_id").val();
+      }
         var fname = '#priceset';
         if ( !priceSetId ) {
         cj('#membership_type_id_1').val(0);
@@ -624,7 +624,7 @@
 
         // show/hide price set amount and total amount.
         cj( "#mem_type_id").show( );
-        var choose = "{/literal}{ts}Choose price set{/ts}{literal}";
+        var choose = "{/literal}{ts escape='js'}Choose price set{/ts}{literal}";
         cj("#price_set_id option[value='']").html( choose );
         cj( "#totalAmountORPriceSet" ).show( );
         cj('#total_amount').removeAttr("readonly");
@@ -632,16 +632,13 @@
         cj(".crm-membership-form-block-financial_type_id-mode").show();
 
         {/literal}{if $allowAutoRenew}{literal}
-        cj('#autoRenew').hide();
-        var autoRenew = cj("#auto_renew");
-        autoRenew.removeAttr( 'readOnly' );
-        autoRenew.prop('checked', false );
+          cj('#autoRenew').hide();
+          cj("#auto_renew").removeAttr('readOnly').prop('checked', false );
         {/literal}{/if}{literal}
         return;
       }
 
-      cj( "#total_amount" ).val( '' );
-      cj('#total_amount').attr("readonly", true);
+      cj( "#total_amount" ).val('').attr("readonly", true);
 
       var dataUrl = {/literal}"{crmURL h=0 q='snippet=4'}"{literal} + '&priceSetId=' + priceSetId;
 
@@ -655,7 +652,7 @@
 
       cj( "#totalAmountORPriceSet" ).hide( );
       cj( "#mem_type_id" ).hide( );
-      var manual = "{/literal}{ts}Manual membership and price{/ts}{literal}";
+      var manual = "{/literal}{ts escape='js'}Manual membership and price{/ts}{literal}";
       cj("#price_set_id option[value='']").html( manual );
       cj( "#num_terms_row" ).hide( );
       cj(".crm-membership-form-block-financial_type_id-mode").hide();
@@ -711,14 +708,12 @@
         {/literal}{if $allowAutoRenew}{literal}
         cj('#autoRenew').hide();
         var autoRenew = cj("#auto_renew");
-        autoRenew.removeAttr( 'readOnly' );
-        autoRenew.prop('checked', false );
-        if ( autoRenewOption == 1 ) {
+        autoRenew.removeAttr('readOnly').prop('checked', false );
+        if (autoRenewOption == 1) {
           cj('#autoRenew').show();
         }
-        else if ( autoRenewOption == 2 ) {
-          autoRenew.attr( 'readOnly', true );
-          autoRenew.prop('checked',  true );
+        else if (autoRenewOption == 2) {
+          autoRenew.attr('readOnly', true).prop('checked',  true );
           cj('#autoRenew').show();
         }
         {/literal}{/if}{literal}

--- a/templates/CRM/Profile/Form/GreetingType.tpl
+++ b/templates/CRM/Profile/Form/GreetingType.tpl
@@ -27,7 +27,7 @@
 <span>{$form.$n.html|crmAddClass:big}</span>&nbsp;<span id="{$customGreeting}_html" class="hiddenElement">{$form.$customGreeting.html|crmAddClass:big}</span>
 
 <script type="text/javascript">
-var fieldName = '{$n}';
+var fieldName = {$n|@json_encode};
 {literal}
 cj( "#" + fieldName ).change( function( ) {
     var fldName = cj(this).attr( 'id' );

--- a/templates/CRM/Report/Form/Statistics.tpl
+++ b/templates/CRM/Report/Form/Statistics.tpl
@@ -33,13 +33,13 @@
       {foreach from=$statistics.groups item=row}
         <tr>
           <th class="statistics" scope="row">{$row.title}</th>
-          <td>{$row.value}</td>
+          <td>{$row.value|escape}</td>
         </tr>
       {/foreach}
       {foreach from=$statistics.filters item=row}
         <tr>
           <th class="statistics" scope="row">{$row.title}</th>
-          <td>{$row.value}</td>
+          <td>{$row.value|escape}</td>
         </tr>
       {/foreach}
     </table>
@@ -53,11 +53,11 @@
         <th class="statistics" scope="row">{$row.title}</th>
         <td>
           {if $row.type eq 1024}
-            {$row.value|crmMoney}
+            {$row.value|crmMoney|escape}
           {elseif $row.type eq 2}
-            {$row.value}
+            {$row.value|escape}
           {else}
-            {$row.value|crmNumberFormat}
+            {$row.value|crmNumberFormat|escape}
           {/if}
 
         </td>

--- a/templates/CRM/Report/Form/Tabs/Developer.tpl
+++ b/templates/CRM/Report/Form/Tabs/Developer.tpl
@@ -1,4 +1,4 @@
 <div id="report-tab-set-developer" class="civireport-criteria">
   <p><b>{ts}Class used{/ts}: {$report_class}</b></p>
-  <pre>{$sql}</pre>
+  <pre>{$sql|purify}</pre>
 </div>

--- a/templates/CRM/common/deferredFinancialType.tpl
+++ b/templates/CRM/common/deferredFinancialType.tpl
@@ -30,9 +30,9 @@
 CRM.$(function($) {
   var more = $('.crm-button input.validate').click(function(e) {
     var message = "{/literal} {if $context eq 'Event'}
-        {ts}Note: Revenue for this event registration will not be deferred as the financial type does not have a deferred revenue account setup for it. If you want the revenue to be deferred, please select a different Financial Type with a Deferred Revenue account setup for it, or setup a Deferred Revenue account for this Financial Type.{/ts}
+        {ts escape='js'}Note: Revenue for this event registration will not be deferred as the financial type does not have a deferred revenue account setup for it. If you want the revenue to be deferred, please select a different Financial Type with a Deferred Revenue account setup for it, or setup a Deferred Revenue account for this Financial Type.{/ts}
       {else if $context eq 'MembershipType'}
-        {ts}Note: Revenue for these types of memberships will not be deferred as the financial type does not have a deferred revenue account setup for it. If you want the revenue to be deferred, please select a different Financial Type with a Deferred Revenue account setup for it, or setup a Deferred Revenue account for this Financial Type.{/ts}
+        {ts escape='js'}Note: Revenue for these types of memberships will not be deferred as the financial type does not have a deferred revenue account setup for it. If you want the revenue to be deferred, please select a different Financial Type with a Deferred Revenue account setup for it, or setup a Deferred Revenue account for this Financial Type.{/ts}
       {/if}
     {literal}";
     var deferredFinancialType = {/literal}{$deferredFinancialType|@json_encode}{literal};

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -29,7 +29,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-  <title>{$pageTitle}</title>
+  <title>{$pageTitle|escape}</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <base href="{$config->resourceBase}" />
   <style type="text/css" media="screen">
@@ -50,10 +50,10 @@
 {/if}
 <div class="messages status no-popup">  <i class="crm-i fa-exclamation-triangle crm-i-red"></i>
  <span class="status-fatal">{ts}Sorry, due to an error, we are unable to fulfill your request at the moment. You may want to contact your administrator or service provider with more details about what action you were performing when this occurred.{/ts}</span>
-    <div class="crm-section crm-error-message">{$message}</div>
+    <div class="crm-section crm-error-message">{$message|escape}</div>
     {if $error.message && $message != $error.message}
         <hr style="solid 1px" />
-        <div class="crm-section crm-error-message">{$error.message}</div>
+        <div class="crm-section crm-error-message">{$error.message|escape}</div>
     {/if}
     {if ($code OR $mysql_code OR $errorDetails) AND $config->debug}
         <div class="crm-accordion-wrapper collapsed crm-fatal-error-details-block">
@@ -62,13 +62,13 @@
          </div><!-- /.crm-accordion-header -->
          <div class="crm-accordion-body">
             {if $code}
-                <div class="crm-section">{ts}Error Code:{/ts} {$code}</div>
+                <div class="crm-section">{ts}Error Code:{/ts} {$code|purify}</div>
             {/if}
             {if $mysql_code}
-                <div class="crm-section">{ts}Database Error Code:{/ts} {$mysql_code}</div>
+                <div class="crm-section">{ts}Database Error Code:{/ts} {$mysql_code|purify}</div>
             {/if}
             {if $errorDetails}
-                <div class="crm-section">{ts}Additional Details:{/ts} {$errorDetails}</div>
+                <div class="crm-section">{ts}Additional Details:{/ts} {$errorDetails|purify}</div>
             {/if}
          </div><!-- /.crm-accordion-body -->
         </div><!-- /.crm-accordion-wrapper -->

--- a/templates/CRM/common/importProgress.tpl
+++ b/templates/CRM/common/importProgress.tpl
@@ -36,7 +36,7 @@ CRM.$(function($) {
     }
   });
   function setIntermediate() {
-    var dataUrl = "{/literal}{$statusUrl}{literal}";
+    var dataUrl = {/literal}{$statusUrl|@json_encode}{literal};
     $.getJSON(dataUrl, function(response) {
       var dataStr = response.toString();
       var result  = dataStr.split(",");

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -64,7 +64,7 @@
    */
   function skipPaymentMethod() {
     var isHide = false;
-    var isMultiple = '{/literal}{$event.is_multiple_registrations}{literal}';
+    var isMultiple = {/literal}{$event.is_multiple_registrations|@json_encode}{literal};
     var alwaysShowFlag = (isMultiple && cj("#additional_participants").val());
     var alwaysHideFlag = (cj("#bypass_payment").val() == 1);
     var total_amount_tmp =  cj('#pricevalue').data('raw-total');

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.3.0</version_no>
+  <version_no>5.3.1</version_no>
 </version>

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.3.beta1</version_no>
+  <version_no>5.3.0</version_no>
 </version>


### PR DESCRIPTION
Reason for changes : **https://github.com/veda-consulting/org.civicrm.sms.clickatell/issues/20#issuecomment-404499746**

Overview
----------
civicrm/CRM/Activity/BAO/Activity.php is failing in function sendSMSMessage(Because $doNotSms = TRUE;)
1>Fix for the error-"Recipient phone number is invalid or recipient does not want to receive SMS" while sending Sms to individual.
2>Fix for filtering out contacts with preference "donotsms" while mass sms

Before
-------
$doNotSms = TRUE; in civicrm/CRM/Activity/BAO/Activity.php

"$contact.do_not_sms = 0", not included or missing in civicrm/CRM/BAO/Mailing.php in function ($isSMSmode) {}

After
-----
$doNotSms = TRUE; - This flag is removed altogether in civicrm/CRM/Activity/BAO/Activity.php

"$contact.do_not_sms = 0", is included within if ($isSMSmode) {}
in civicrm/CRM/BAO/Mailing.php 
