### PR TITLE
Export code: Fix 1 enotice, add hundreds of lines of test

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1729,9 +1729,6 @@ WHERE  {$whereClause}";
     elseif ($field == 'provider_id') {
       $headerRows[] = ts('IM Service Provider');
     }
-    elseif (substr($field, 0, 5) == 'case_' && $queryFields['case'][$field]['title']) {
-      $headerRows[] = $queryFields['case'][$field]['title'];
-    }
     elseif (array_key_exists($field, self::$relationshipTypes)) {
       foreach ($value as $relationField => $relationValue) {
         // below block is same as primary block (duplicate)


### PR DESCRIPTION
Overview
----------------------------------------
Export code: Fix 1 enotice, add hundreds of lines of test

Before
----------------------------------------
![screenshot 2018-07-20 10 53 46](https://user-images.githubusercontent.com/336308/42974700-72e0061a-8c0c-11e8-8659-74b741757bc5.png)


After
----------------------------------------
![screenshot 2018-07-20 11 30 51](https://user-images.githubusercontent.com/336308/42975468-6538a036-8c10-11e8-905f-971f53058ece.png)

Technical Details
----------------------------------------
I experienced a lot of inconsistency in my testing of this & switching to a component specific class that extended the main one seemed much more reliable - and as a approach it offers the possibility of much cleaner code

Comments
----------------------------------------
I don't think this affects 5.4 rc

@mattwire @lcdservices @kcristiano ping
