### PR TITLE
Fix regression on case export from recent export fix

### DIFF
--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -67,7 +67,7 @@ class CRM_Case_Task extends CRM_Core_Task {
         self::TASK_EXPORT => array(
           'title' => ts('Export cases'),
           'class' => array(
-            'CRM_Export_Form_Select',
+            'CRM_Export_Form_Select_Case',
             'CRM_Export_Form_Map',
           ),
           'result' => FALSE,

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -57,6 +57,11 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
   protected $_componentIds;
 
   /**
+   * @var int
+   */
+  protected $queryMode;
+
+  /**
    * The array that holds all the case ids
    *
    * @var array
@@ -210,7 +215,7 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
    * @return int
    */
   public function getQueryMode() {
-    return CRM_Contact_BAO_Query::MODE_CONTACTS;
+    return $this->queryMode ?: CRM_Contact_BAO_Query::MODE_CONTACTS;
   }
 
 }

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -526,7 +526,7 @@ FROM   {$this->_componentTable}
    * @return int
    */
   public function getQueryMode() {
-    return (int) $this->controller->get('component_mode');
+    return (int) ($this->queryMode ?: $this->controller->get('component_mode'));
   }
 
 }

--- a/CRM/Export/Form/Select/Case.php
+++ b/CRM/Export/Form/Select/Case.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Export_Form_Select_Case extends CRM_Export_Form_Select {
+
+  /**
+   * @var int
+   */
+  protected $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
+
+  /**
+   * Use the form name to create the tpl file name.
+   *
+   * @return string
+   */
+  public function getTemplateFileName() {
+    return 'CRM/Export/Form/Select.tpl';
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fix enotices & fatal error on case export

Before
----------------------------------------
![screenshot 2018-07-20 10 53 46](https://user-images.githubusercontent.com/336308/42974700-72e0061a-8c0c-11e8-8659-74b741757bc5.png)

![screenshot 2018-07-20 11 06 41](https://user-images.githubusercontent.com/336308/42975569-e1893d62-8c10-11e8-853e-99fb15c67974.png)



After
----------------------------------------
![screenshot 2018-07-20 11 30 51](https://user-images.githubusercontent.com/336308/42975468-6538a036-8c10-11e8-905f-971f53058ece.png)

Technical Details
----------------------------------------
I experienced a lot of inconsistency in my testing of this & switching to a component specific class that extended the main one seemed much more reliable - and as a approach it offers the possibility of much cleaner code

Comments
----------------------------------------
I don't think this affects 5.4 rc

@mattwire @lcdservices @kcristiano ping
