### PR TITLE
(Forward port) Add Smarty modifier to purify HTML

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.purify.php
+++ b/CRM/Core/Smarty/plugins/modifier.purify.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ * $Id$
+ */
+
+/**
+ * Purify HTML to mitigate against XSS attacks
+ *
+ * @param string $text
+ *   Input text, potentially containing XSS
+ *
+ * @return string
+ *   Output text, containing only clean HTML
+ */
+function smarty_modifier_purify($text) {
+  return CRM_Utils_String::purifyHTML($text);
+}


### PR DESCRIPTION
Overview
----------------------------------------
With this modifier, we can write Smarty code like:

```
    <div>{$untrustedHTML|purify}</div>
```

By using the purify modifier, we've protected against XSS, even if the
output variable contains HTML.

Comments
----------------------------------------
This was originally introduced in 5.3.1 for the security release. This is a forward-port to 5.4 RC.
