### PR TITLE
dev/translation#5 Fix bug where customised location type labels result in data not being exported

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1020,11 +1020,27 @@ class CRM_Contact_BAO_Query {
     $addressCustomFields = CRM_Core_BAO_CustomField::getFieldsForImport('Address');
     $addressCustomFieldIds = array();
 
-    foreach ($this->_returnProperties['location'] as $name => $elements) {
+    foreach ($this->_returnProperties['location'] as $locationKey => $elements) {
+      if (is_numeric($locationKey) && !in_array($locationKey, $locationTypes)) {
+        // Historically we have expected the form layer to convert to an integer in
+        // order to convert back here. However, bug reports indicated this is not
+        // always reliable as some methods of getting location types return labels
+        // not names - which appear to work, until they don't.
+        // We should migrate to supporting the location being keyed by 'id'
+        // Note this format currently only comes from export and it's implicit
+        // in using it that unit test coverage must exist (as it does for the export
+        // class, and that the column name could change.)
+        $locationTypeId = $locationKey;
+        $name = $locationTypes[$locationTypeId];
+      }
+      else {
+        $name = $locationKey;
+        $locationTypeId = array_search($name, $locationTypes);
+      }
+
       $lCond = self::getPrimaryCondition($name);
 
       if (!$lCond) {
-        $locationTypeId = array_search($name, $locationTypes);
         if ($locationTypeId === FALSE) {
           continue;
         }

--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -398,7 +398,7 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
     }
 
     $this->_params = $this->convertFormValues($this->_formValues);
-    $this->_returnProperties = &$this->returnProperties();
+    $this->_returnProperties = $this->returnProperties();
 
     // CRM-10338 check if value is empty array
     foreach ($this->_params as $k => $v) {

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -315,9 +315,7 @@ class CRM_Export_BAO_Export {
     $queryMode = $processor->getQueryMode();
 
     if ($fields) {
-      //construct return properties
-      $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
-
+      //Construct return properties.
       foreach ($fields as $key => $value) {
         $fieldName = CRM_Utils_Array::value(1, $value);
         if (!$fieldName) {
@@ -330,13 +328,13 @@ class CRM_Export_BAO_Export {
         elseif (is_numeric(CRM_Utils_Array::value(2, $value))) {
           $locTypeId = $value[2];
           if ($fieldName == 'phone') {
-            $returnProperties['location'][$locationTypes[$locTypeId]]['phone-' . CRM_Utils_Array::value(3, $value)] = 1;
+            $returnProperties['location'][$locTypeId]['phone-' . CRM_Utils_Array::value(3, $value)] = 1;
           }
           elseif ($fieldName == 'im') {
-            $returnProperties['location'][$locationTypes[$locTypeId]]['im-' . CRM_Utils_Array::value(3, $value)] = 1;
+            $returnProperties['location'][$locTypeId]['im-' . CRM_Utils_Array::value(3, $value)] = 1;
           }
           else {
-            $returnProperties['location'][$locationTypes[$locTypeId]][$fieldName] = 1;
+            $returnProperties['location'][$locTypeId][$fieldName] = 1;
           }
         }
         else {
@@ -1689,7 +1687,8 @@ WHERE  {$whereClause}";
         }
         elseif (is_array($relationValue) && $relationField == 'location') {
           // fix header for location type case
-          foreach ($relationValue as $ltype => $val) {
+          foreach ($relationValue as $locationTypeID => $val) {
+            $ltype = CRM_Core_PseudoConstant::getName('CRM_Core_BAO_Address', 'location_type_id', $locationTypeID);
             foreach (array_keys($val) as $fld) {
               $type = explode('-', $fld);
 
@@ -1765,7 +1764,8 @@ WHERE  {$whereClause}";
         list($headerRows, $sqlColumns) = self::setHeaderRows($key, $headerRows, $sqlColumns, $processor, $value, $phoneTypes, $imProviders, $relationQuery, $selectedPaymentFields);
       }
       else {
-        foreach ($value as $locationType => $locationFields) {
+        foreach ($value as $locationTypeID => $locationFields) {
+          $locationType = CRM_Core_PseudoConstant::getName('CRM_Core_BAO_Address', 'location_type_id', $locationTypeID);
           foreach (array_keys($locationFields) as $locationFieldName) {
             $type = explode('-', $locationFieldName);
 
@@ -1851,7 +1851,8 @@ WHERE  {$whereClause}";
         $row[$relPrefix] = $relDAO->contact_id;
       }
       elseif (is_array($relationValue) && $relationField == 'location') {
-        foreach ($relationValue as $ltype => $val) {
+        foreach ($relationValue as $locationTypeID => $val) {
+          $ltype = CRM_Core_PseudoConstant::getName('CRM_Core_BAO_Address', 'location_type_id', $locationTypeID);
           foreach (array_keys($val) as $fld) {
             $type = explode('-', $fld);
             $fldValue = "{$ltype}-" . $type[0];

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -63,6 +63,13 @@ class CRM_Export_BAO_ExportProcessor {
   protected $queryOperator;
 
   /**
+   * Array of properties to retrieve for relationships.
+   *
+   * @var array
+   */
+  protected $relationshipReturnProperties = [];
+
+  /**
    * CRM_Export_BAO_ExportProcessor constructor.
    *
    * @param int $exportMode
@@ -180,6 +187,87 @@ class CRM_Export_BAO_ExportProcessor {
     list($select, $from, $where, $having) = $query->query();
     $this->setQueryFields($query->_fields);
     return array($query, $select, $from, $where, $having);
+  }
+
+  /**
+   * Add the field to relationship return properties & return it.
+   *
+   * This function is doing both setting & getting which is yuck but it is an interim
+   * refactor.
+   *
+   * @param array $value
+   * @param string $relationshipKey
+   *
+   * @return array
+   */
+  public function setRelationshipReturnProperties($value, $relationshipKey) {
+    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $relPhoneTypeId = $relIMProviderId = NULL;
+    if (!empty($value[2])) {
+      $relationField = CRM_Utils_Array::value(2, $value);
+      if (trim(CRM_Utils_Array::value(3, $value))) {
+        $relLocTypeId = CRM_Utils_Array::value(3, $value);
+      }
+      else {
+        $relLocTypeId = 'Primary';
+      }
+
+      if ($relationField == 'phone') {
+        $relPhoneTypeId = CRM_Utils_Array::value(4, $value);
+      }
+      elseif ($relationField == 'im') {
+        $relIMProviderId = CRM_Utils_Array::value(4, $value);
+      }
+    }
+    elseif (!empty($value[4])) {
+      $relationField = CRM_Utils_Array::value(4, $value);
+      $relLocTypeId = CRM_Utils_Array::value(5, $value);
+      if ($relationField == 'phone') {
+        $relPhoneTypeId = CRM_Utils_Array::value(6, $value);
+      }
+      elseif ($relationField == 'im') {
+        $relIMProviderId = CRM_Utils_Array::value(6, $value);
+      }
+    }
+    if (in_array($relationField, $this->getValidLocationFields()) && is_numeric($relLocTypeId)) {
+      if ($relPhoneTypeId) {
+        $this->relationshipReturnProperties[$relationshipKey]['location'][$locationTypes[$relLocTypeId]]['phone-' . $relPhoneTypeId] = 1;
+      }
+      elseif ($relIMProviderId) {
+        $this->relationshipReturnProperties[$relationshipKey]['location'][$locationTypes[$relLocTypeId]]['im-' . $relIMProviderId] = 1;
+      }
+      else {
+        $this->relationshipReturnProperties[$relationshipKey]['location'][$locationTypes[$relLocTypeId]][$relationField] = 1;
+      }
+    }
+    else {
+      $this->relationshipReturnProperties[$relationshipKey][$relationField] = 1;
+    }
+    return $this->relationshipReturnProperties[$relationshipKey];
+  }
+
+  /**
+   * Get the default location fields to request.
+   *
+   * @return array
+   */
+  public function getValidLocationFields() {
+    return [
+      'street_address',
+      'supplemental_address_1',
+      'supplemental_address_2',
+      'supplemental_address_3',
+      'city',
+      'postal_code',
+      'postal_code_suffix',
+      'geo_code_1',
+      'geo_code_2',
+      'state_province',
+      'country',
+      'phone',
+      'email',
+      'im',
+    ];
   }
 
 }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -201,7 +201,6 @@ class CRM_Export_BAO_ExportProcessor {
    * @return array
    */
   public function setRelationshipReturnProperties($value, $relationshipKey) {
-    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
     $relPhoneTypeId = $relIMProviderId = NULL;
     if (!empty($value[2])) {
       $relationField = CRM_Utils_Array::value(2, $value);
@@ -231,13 +230,13 @@ class CRM_Export_BAO_ExportProcessor {
     }
     if (in_array($relationField, $this->getValidLocationFields()) && is_numeric($relLocTypeId)) {
       if ($relPhoneTypeId) {
-        $this->relationshipReturnProperties[$relationshipKey]['location'][$locationTypes[$relLocTypeId]]['phone-' . $relPhoneTypeId] = 1;
+        $this->relationshipReturnProperties[$relationshipKey]['location'][$relLocTypeId]['phone-' . $relPhoneTypeId] = 1;
       }
       elseif ($relIMProviderId) {
-        $this->relationshipReturnProperties[$relationshipKey]['location'][$locationTypes[$relLocTypeId]]['im-' . $relIMProviderId] = 1;
+        $this->relationshipReturnProperties[$relationshipKey]['location'][$relLocTypeId]['im-' . $relIMProviderId] = 1;
       }
       else {
-        $this->relationshipReturnProperties[$relationshipKey]['location'][$locationTypes[$relLocTypeId]][$relationField] = 1;
+        $this->relationshipReturnProperties[$relationshipKey]['location'][$relLocTypeId][$relationField] = 1;
       }
     }
     else {

--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -233,6 +233,15 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
         CRM_Core_BAO_Mapping::saveMappingFields($params, $saveMapping->id);
       }
     }
+    $returnProperties = $this->get('returnProperties');
+    if (isset($returnProperties['location'])) {
+      // Re-key location types. One day stop keying by name earlier on.
+      foreach ($returnProperties['location'] as $key => $value) {
+        $locationTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Address', 'location_type_id', $key);
+        $returnProperties['location'][$locationTypeID] = $value;
+        unset($returnProperties['location'][$key]);
+      }
+    }
 
     //get the csv file
     CRM_Export_BAO_Export::exportComponents($this->get('selectAll'),
@@ -240,7 +249,7 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
       (array) $this->get('queryParams'),
       $this->get(CRM_Utils_Sort::SORT_ORDER),
       $mapperKeys,
-      $this->get('returnProperties'),
+      $returnProperties,
       $this->get('exportMode'),
       $this->get('componentClause'),
       $this->get('componentTable'),

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -482,7 +482,13 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   public function testExportIMData() {
     // Use default providers.
     $providers = ['AIM', 'GTalk', 'Jabber', 'MSN', 'Skype', 'Yahoo'];
-    $locationTypes = ['Billing', 'Home', 'Main', 'Other'];
+    // Main sure labels are not all anglo chars.
+    $mainLocationTypeID = $this->callAPISuccessGetValue('Location_type', [
+      'name' => 'Main',
+      'return' => 'id',
+      'api.LocationType.Create' => ['display_name' => 'Méin'],
+    ]);
+    $locationTypes = ['Billing' => 'Billing', 'Home' => 'Home', 'Main' => 'Méin', 'Other' => 'Other'];
 
     $this->contactIDs[] = $this->individualCreate();
     $this->contactIDs[] = $this->individualCreate();
@@ -490,12 +496,12 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->contactIDs[] = $this->organizationCreate();
     foreach ($this->contactIDs as $contactID) {
       foreach ($providers as $provider) {
-        foreach ($locationTypes as $locationType) {
+        foreach ($locationTypes as $locationName => $locationLabel) {
           $this->callAPISuccess('IM', 'create', [
             'contact_id' => $contactID,
-            'location_type_id' => $locationType,
+            'location_type_id' => $locationName,
             'provider_id' => $provider,
-            'name' => $locationType . $provider . $contactID,
+            'name' => $locationName . $provider . $contactID,
           ]);
         }
       }
@@ -520,7 +526,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
 
     $fields = [['Individual', 'contact_id']];
     // ' ' denotes primary location type.
-    foreach (array_merge($locationTypes, [' ']) as $locationType) {
+    foreach (array_keys(array_merge($locationTypes, [' ' => ['Primary']])) as $locationType) {
       $fields[] = [
         'Individual',
         'im_provider',

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -568,9 +568,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       }
     }
 
-    // early return for now until we solve a leakage issue.
-    return;
-
     $this->assertEquals([
       'billing_im_provider' => 'billing_im_provider text',
       'billing_im_screen_name' => 'billing_im_screen_name text',


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/translation/issues/5 

How to reproduce:


Add a location type "Expédition", where name = expedition and display_name = expédition.
Go to the member dashboard, click to list all active members
Edit one of the contacts, so that they have an address of type "expédition"
Back in the search results, export all results
Select a custom mapping:


Display name
City, location type = Expédition




Result: the city is empty (for that contact that was edited).

If we remove the accent from the display name, it works fine. Also, it doesn't seem to be a mismatch issue between the name / display_name, because if it's "Expedition123" it works fine.

Note - the issues is not actually the special chars but the fact display_name !=== name

Before
----------------------------------------
Empty fields

After
----------------------------------------
Fields populated

Technical Details
----------------------------------------
This PR includes the commit in https://github.com/civicrm/civicrm-core/pull/12521 as that is a pre-requisite to test passing. If that is merged first I will rebase this. If this is merged first I will close that.

There is an issue with the code using the label and name of location types (and other things but not in scope at the moment) indiscriminately. This change switches to keying by ID rather than label/name and supports it in the query object. The test cover is pretty intensive here.


Comments
----------------------------------------
@mlutfy this is a bug you reported. I'm doing clean up & improving testing on that code so picked it up
