### PR TITLE
Fix signature on BAO_Product::add to make ids optional

### DIFF
--- a/CRM/Contribute/BAO/ManagePremiums.php
+++ b/CRM/Contribute/BAO/ManagePremiums.php
@@ -85,8 +85,12 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_BAO_Product {
    * @return CRM_Contribute_DAO_Product
    */
   public static function add(&$params, $ids) {
-    CRM_Core_Error::deprecatedFunctionWarning('CRM_Contribute_BAO_Product::add');
-    return parent::add($params, $ids);
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Contribute_BAO_Product::create');
+    $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('premium', $ids));
+    if ($id) {
+      $params['id'] = $id;
+    }
+    return parent::create($params);
   }
 
   /**

--- a/CRM/Contribute/BAO/Product.php
+++ b/CRM/Contribute/BAO/Product.php
@@ -94,7 +94,7 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
    *
    * @return CRM_Contribute_DAO_Product
    */
-  public static function add(&$params, $ids) {
+  public static function add(&$params, $ids = []) {
     $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('premium', $ids));
     if (empty($id)) {
       $defaultParams = [

--- a/CRM/Contribute/BAO/Product.php
+++ b/CRM/Contribute/BAO/Product.php
@@ -88,14 +88,12 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
    * Add a premium product to the database, and return it.
    *
    * @param array $params
-   *   Reference array contains the values submitted by the form.
-   * @param array $ids (deprecated)
-   *   Reference array contains the id.
+   *   Update parameters.
    *
    * @return CRM_Contribute_DAO_Product
    */
-  public static function add(&$params, $ids = []) {
-    $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('premium', $ids));
+  public static function create($params) {
+    $id = CRM_Utils_Array::value('id', $params);
     if (empty($id)) {
       $defaultParams = [
         'id' => $id,

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -287,15 +287,14 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
       $params[$field] = CRM_Utils_Rule::cleanMoney($params[$field]);
     }
 
-    $ids = array();
     if ($this->_action & CRM_Core_Action::UPDATE) {
-      $ids['premium'] = $this->_id;
+      $params['id'] = $this->_id;
     }
 
     $this->_processImages($params);
 
     // Save to database
-    $premium = CRM_Contribute_BAO_Product::add($params, $ids);
+    $premium = CRM_Contribute_BAO_Product::add($params);
 
     CRM_Core_Session::setStatus(
       ts("The Premium '%1' has been saved.", array(1 => $premium->name)),

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -294,7 +294,7 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     $this->_processImages($params);
 
     // Save to database
-    $premium = CRM_Contribute_BAO_Product::add($params);
+    $premium = CRM_Contribute_BAO_Product::create($params);
 
     CRM_Core_Session::setStatus(
       ts("The Premium '%1' has been saved.", array(1 => $premium->name)),

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -372,7 +372,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'min_contribution' => 100,
       'is_active' => 1,
     );
-    $premium = CRM_Contribute_BAO_Product::add($params);
+    $premium = CRM_Contribute_BAO_Product::create($params);
 
     $this->assertEquals('TEST Premium', $premium->name, 'Check for premium  name.');
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -362,10 +362,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   public function testAddPremium() {
     $contactId = $this->individualCreate();
 
-    $ids = array(
-      'premium' => NULL,
-    );
-
     $params = array(
       'name' => 'TEST Premium',
       'sku' => 111,
@@ -376,7 +372,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'min_contribution' => 100,
       'is_active' => 1,
     );
-    $premium = CRM_Contribute_BAO_Product::add($params, $ids);
+    $premium = CRM_Contribute_BAO_Product::add($params);
 
     $this->assertEquals('TEST Premium', $premium->name, 'Check for premium  name.');
 

--- a/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
@@ -49,7 +49,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params);
+    $product = CRM_Contribute_BAO_Product::create($params);
 
     $result = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
       'sku', 'id',
@@ -73,7 +73,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params);
+    $product = CRM_Contribute_BAO_Product::create($params);
     $params = array('id' => $product->id);
     $default = array();
     $result = CRM_Contribute_BAO_Product::retrieve($params, $default);
@@ -94,7 +94,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params);
+    $product = CRM_Contribute_BAO_Product::create($params);
     CRM_Contribute_BAO_Product::setIsActive($product->id, 0);
 
     $isActive = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
@@ -119,7 +119,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params);
+    $product = CRM_Contribute_BAO_Product::create($params);
 
     CRM_Contribute_BAO_Product::del($product->id);
 

--- a/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
@@ -39,7 +39,6 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
    * Check method add()
    */
   public function testAdd() {
-    $ids = array();
     $params = array(
       'name' => 'Test Product',
       'sku' => 'TP-10',
@@ -50,7 +49,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params, $ids);
+    $product = CRM_Contribute_BAO_Product::add($params);
 
     $result = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
       'sku', 'id',
@@ -64,7 +63,6 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
    * Check method retrieve( )
    */
   public function testRetrieve() {
-    $ids = array();
     $params = array(
       'name' => 'Test Product',
       'sku' => 'TP-10',
@@ -75,7 +73,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params, $ids);
+    $product = CRM_Contribute_BAO_Product::add($params);
     $params = array('id' => $product->id);
     $default = array();
     $result = CRM_Contribute_BAO_Product::retrieve($params, $default);
@@ -86,7 +84,6 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
    * Check method setIsActive( )
    */
   public function testSetIsActive() {
-    $ids = array();
     $params = array(
       'name' => 'Test Product',
       'sku' => 'TP-10',
@@ -97,7 +94,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params, $ids);
+    $product = CRM_Contribute_BAO_Product::add($params);
     CRM_Contribute_BAO_Product::setIsActive($product->id, 0);
 
     $isActive = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
@@ -112,7 +109,6 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
    * Check method del( )
    */
   public function testDel() {
-    $ids = array();
     $params = array(
       'name' => 'Test Product',
       'sku' => 'TP-10',
@@ -123,7 +119,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
 
-    $product = CRM_Contribute_BAO_Product::add($params, $ids);
+    $product = CRM_Contribute_BAO_Product::add($params);
 
     CRM_Contribute_BAO_Product::del($product->id);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix signature on BAO_Product::add to make ids optional

Partial reviewer's commit from https://github.com/civicrm/civicrm-core/pull/12437 but I went a bit further with removing $ids from the signature

Before
----------------------------------------
$ids is a required field on Product::add - which is inconsistent with our standards

After
----------------------------------------
$ids is removed. $params is not passed as reference - this is our preferred signature

Technical Details
----------------------------------------
Since the BAO_Product::add function is new we don't need to support $ids. The only code place we call this is

```
  $premium = CRM_Contribute_BAO_Product::add($params);

    CRM_Core_Session::setStatus(
      ts("The Premium '%1' has been saved.", array(1 => $premium->name)),
      ts('Saved'), 'success');
  }
```

so we don't need the (non-std) behaviour of passing $params as a reference

I also renamed BAO_Product::add to create (which is a bit more standard) so it would not have to have the same signature as ManagePremiums which inherits

Comments
----------------------------------------
@mattwire can you OK my additional change here
