### PR TITLE
CRM-20032 event config: payment processor selection requires administer CiviCRM permission

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1367,6 +1367,15 @@ class CRM_Core_Permission {
         'edit contributions',
       ),
     );
+    
+    // Payment Processor Permissions
+    
+    $permissions['payment_processor'] = array(
+      'get' => array(
+        array('access CiviEvent', 'edit all events'),
+        array('administer CiviCRM')
+      ),
+    );
 
     // Pledge permissions
     $permissions['pledge'] = array(

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1368,8 +1368,7 @@ class CRM_Core_Permission {
       ),
     );
     
-    // Payment Processor Permissions
-    
+    // Payment Processor Permissions    
     $permissions['payment_processor'] = array(
       'get' => array(
         array('access CiviEvent', 'edit all events'),

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -85,6 +85,10 @@ function civicrm_api3_payment_processor_delete($params) {
  *   API result array
  */
 function civicrm_api3_payment_processor_get($params) {
+  if ( ( CRM_Core_Permission::check('access CiviEvent') || CRM_Core_Permission::check('edit all events') ) && !CRM_Core_Permission::check('administer CiviCRM') ) {
+    $params['return'] = CRM_Financial_DAO_PaymentProcessor::fieldKeys();
+    unset($params['return']['password']);
+  }
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://issues.civicrm.org/jira/browse/CRM-20032

Before
----------------------------------------
currently, in order to select a payment processor on the event fee tab, you must have the "administer CiviCRM" permission

After
----------------------------------------
in addition to "administer CiviCRM", users with "access CiviEvent" and "Edit All Events" can select payment processor

Technical Details
----------------------------------------
-

Comments
----------------------------------------
-
