### PR TITLE
Icons in colored boxes for relationship permissions

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2130,36 +2130,36 @@ AND cc.sort_name LIKE '%$name%'";
         }
 
         if ($params['context'] == 'current') {
-          if (($params['contact_id'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) or
-            ($params['contact_id'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
-          ) {
-            $relationship['sort_name'] .= <<<HEREDOC
-              <i class="crm-i fa-asterisk" title="{$values['display_name']} can be viewed and edited by $displayName"></i>
-HEREDOC;
-          }
+          $smarty = CRM_Core_Smarty::singleton();
 
-          if (($params['contact_id'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) or
-            ($params['contact_id'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
-          ) {
-            $relationship['sort_name'] .= <<<HEREDOC
-              <i class="crm-i fa-eye" title="{$values['display_name']} can be viewed by $displayName"></i>
-HEREDOC;
-          }
+          $contactCombos = [
+            [
+              'permContact' => $params['contact_id'],
+              'permDisplayName' => $displayName,
+              'otherContact' => $values['cid'],
+              'otherDisplayName' => $values['display_name'],
+              'columnKey' => 'sort_name',
+            ],
+            [
+              'permContact' => $values['cid'],
+              'permDisplayName' => $values['display_name'],
+              'otherContact' => $params['contact_id'],
+              'otherDisplayName' => $displayName,
+              'columnKey' => 'relation',
+            ],
+          ];
 
-          if (($values['cid'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::EDIT) or
-            ($values['cid'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::EDIT)
-          ) {
-            $relationship['relation'] .= <<<HEREDOC
-              <i class="crm-i fa-asterisk" title="$displayName can be viewed and edited by {$values['display_name']}"></i>
-HEREDOC;
-          }
-
-          if (($values['cid'] == $values['contact_id_a'] and $values['is_permission_a_b'] == CRM_Contact_BAO_Relationship::VIEW) or
-            ($values['cid'] == $values['contact_id_b'] and $values['is_permission_b_a'] == CRM_Contact_BAO_Relationship::VIEW)
-          ) {
-            $relationship['relation'] .= <<<HEREDOC
-              <i class="crm-i fa-eye" title="$displayName can be viewed by {$values['display_name']}"></i>
-HEREDOC;
+          foreach ($contactCombos as $combo) {
+            foreach ([CRM_Contact_BAO_Relationship::EDIT, CRM_Contact_BAO_Relationship::VIEW] as $permType) {
+              $smarty->assign('permType', $permType);
+              if (($combo['permContact'] == $values['contact_id_a'] and $values['is_permission_a_b'] == $permType)
+                || ($combo['permContact'] == $values['contact_id_b'] and $values['is_permission_b_a'] == $permType)
+              ) {
+                $smarty->assign('permDisplayName', $combo['permDisplayName']);
+                $smarty->assign('otherDisplayName', $combo['otherDisplayName']);
+                $relationship[$combo['columnKey']] .= $smarty->fetch('CRM/Contact/Page/View/RelationshipPerm.tpl');
+              }
+            }
           }
         }
 

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2118,6 +2118,10 @@ a.crm-i:hover {
   color: #6177D5;
 }
 
+.crm-i.crm-i-green {
+  color: #86c661;
+}
+
 .crm-i-button {
   position: relative;
 }

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -57,34 +57,18 @@
                 {if $row.is_permission_a_b}
                   <div>
                   {if $row.rtype EQ 'a_b' AND $is_contact_id_a}
-                    {if $row.is_permission_a_b == 1}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 permDisplayName=$displayName otherDisplayName=$row.display_name}
-                    {else}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 permDisplayName=$displayName otherDisplayName=$row.display_name}
-                    {/if}
+                    {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=$row.is_permission_a_b permDisplayName=$displayName otherDisplayName=$row.display_name displayText=true}
                   {else}
-                    {if $row.is_permission_a_b == 1}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 otherDisplayName=$displayName permDisplayName=$row.display_name}
-                    {else}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 otherDisplayName=$displayName permDisplayName=$row.display_name}
-                    {/if}
+                    {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=$row.is_permission_a_b otherDisplayName=$displayName permDisplayName=$row.display_name displayText=true}
                   {/if}
                   </div>
                 {/if}
                 {if $row.is_permission_b_a}
                   <div>
                   {if $row.rtype EQ 'a_b' AND $is_contact_id_a}
-                    {if $row.is_permission_b_a == 1}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 otherDisplayName=$displayName permDisplayName=$row.display_name}
-                    {else}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 otherDisplayName=$displayName permDisplayName=$row.display_name}
-                    {/if}
+                    {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=$row.is_permission_b_a otherDisplayName=$displayName permDisplayName=$row.display_name displayText=true}
                   {else}
-                    {if $row.is_permission_b_a == 1}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 permDisplayName=$displayName otherDisplayName=$row.display_name}
-                    {else}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 permDisplayName=$displayName otherDisplayName=$row.display_name}
-                    {/if}
+                    {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=$row.is_permission_b_a permDisplayName=$displayName otherDisplayName=$row.display_name displayText=true}
                   {/if}
                   </div>
                 {/if}

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -58,15 +58,15 @@
                   <div>
                   {if $row.rtype EQ 'a_b' AND $is_contact_id_a}
                     {if $row.is_permission_a_b == 1}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} <i class="crm-i fa-asterisk"></i>
+                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 permDisplayName=$displayName otherDisplayName=$row.display_name}
                     {else}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} <i class="crm-i fa-eye"></i>
+                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 permDisplayName=$displayName otherDisplayName=$row.display_name}
                     {/if}
                   {else}
                     {if $row.is_permission_a_b == 1}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} <i class="crm-i fa-asterisk"></i>
+                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 otherDisplayName=$displayName permDisplayName=$row.display_name}
                     {else}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} <i class="crm-i fa-eye"></i>
+                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 otherDisplayName=$displayName permDisplayName=$row.display_name}
                     {/if}
                   {/if}
                   </div>
@@ -75,15 +75,15 @@
                   <div>
                   {if $row.rtype EQ 'a_b' AND $is_contact_id_a}
                     {if $row.is_permission_b_a == 1}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} <i class="crm-i fa-asterisk"></i>
+                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 otherDisplayName=$displayName permDisplayName=$row.display_name}
                     {else}
-                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} <i class="crm-i fa-eye"></i>
+                      {ts 1=$row.display_name 2=$displayName}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 otherDisplayName=$displayName permDisplayName=$row.display_name}
                     {/if}
                   {else}
                     {if $row.is_permission_b_a == 1}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} <i class="crm-i fa-asterisk"></i>
+                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view and update information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 permDisplayName=$displayName otherDisplayName=$row.display_name}
                     {else}
-                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} <i class="crm-i fa-eye"></i>
+                      {ts 1=$displayName 2=$row.display_name}<strong>%1</strong> can view information about <strong>%2</strong>{/ts} {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 permDisplayName=$displayName otherDisplayName=$row.display_name}
                     {/if}
                   {/if}
                   </div>

--- a/templates/CRM/Contact/Page/View/Relationship.tpl
+++ b/templates/CRM/Contact/Page/View/Relationship.tpl
@@ -38,11 +38,8 @@
     <h3>{ts}Current Relationships{/ts}</h3>
     {include file="CRM/Contact/Page/View/RelationshipSelector.tpl" context="current"}
     <div id="permission-legend" class="crm-content-block">
-      <span class="label">Permissioned Relationships: </span>&nbsp;
-      <i class="crm-i fa-eye"></i>
-      {ts}This contact can be viewed by the other.{/ts}&nbsp;
-      <i class="crm-i fa-asterisk"></i>
-      {ts}This contact can be viewed and updated by the other.{/ts}
+      <span class="label">Permissioned Relationships: </span>
+      {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 afterText=true}
     </div>
 
     <div class="spacer"></div>

--- a/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
@@ -25,19 +25,37 @@
 *}
 {* Partial for displaying permissions associated with a relationship *}
 
+{if $displayText}
 {if $permType eq 1}
-{include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2}
+{ts 1=$permDisplayName 2=$otherDisplayName}<strong>%1</strong> can view and update information about <strong>%2</strong>.{/ts}
+{else}
+{ts 1=$permDisplayName 2=$otherDisplayName}<strong>%1</strong> can view information about <strong>%2</strong>.{/ts}
+{/if}
 {/if}
 
+{if $permType eq 1}
+{include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 displayText=false}
+{/if}
+
+{if $permDisplayName and $otherDisplayName}
 {capture assign="permText"}
 {if $permType eq 1}
-{ts 1=$permDisplayName 2=$otherDisplayName}%2 can be edited by %1{/ts}
+{ts 1=$permDisplayName 2=$otherDisplayName}%2 can be edited by %1.{/ts}
 {else}
-{ts 1=$permDisplayName 2=$otherDisplayName}%2 can be viewed by %1{/ts}
+{ts 1=$permDisplayName 2=$otherDisplayName}%2 can be viewed by %1.{/ts}
 {/if}
 {/capture}
+{/if}
 
 <span class="fa-stack" title="{$permText}">
   <i class="crm-i fa-square fa-stack-2x {if $permType eq 1}crm-i-blue{else}crm-i-green{/if}"></i>
   <i class="crm-i {if $permType eq 1}fa-pencil{else}fa-eye{/if} fa-inverse fa-stack-1x"></i>
 </span>
+
+{if $afterText}
+{if $permType eq 1}
+{ts}This contact can be edited by the other.{/ts}
+{else}
+{ts}This contact can be viewed by the other.{/ts}
+{/if}
+{/if}

--- a/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
@@ -1,0 +1,43 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{* Partial for displaying permissions associated with a relationship *}
+
+{if $permType eq 1}
+{include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2}
+{/if}
+
+{capture assign="permText"}
+{if $permType eq 1}
+{ts 1=$permDisplayName 2=$otherDisplayName}%2 can be edited by %1{/ts}
+{else}
+{ts 1=$permDisplayName 2=$otherDisplayName}%2 can be viewed by %1{/ts}
+{/if}
+{/capture}
+
+<span class="fa-stack" title="{$permText}">
+  <i class="crm-i fa-square fa-stack-2x"></i>
+  <i class="crm-i {if $permType eq 1}fa-pencil{else}fa-eye{/if} fa-inverse fa-stack-1x"></i>
+</span>

--- a/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
@@ -38,6 +38,6 @@
 {/capture}
 
 <span class="fa-stack" title="{$permText}">
-  <i class="crm-i fa-square fa-stack-2x"></i>
+  <i class="crm-i fa-square fa-stack-2x {if $permType eq 1}crm-i-blue{else}crm-i-green{/if}"></i>
   <i class="crm-i {if $permType eq 1}fa-pencil{else}fa-eye{/if} fa-inverse fa-stack-1x"></i>
 </span>

--- a/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
@@ -25,14 +25,6 @@
 *}
 {* Partial for displaying permissions associated with a relationship *}
 
-{if $displayText}
-{if $permType eq 1}
-{ts 1=$permDisplayName 2=$otherDisplayName}<strong>%1</strong> can view and update information about <strong>%2</strong>.{/ts}
-{else}
-{ts 1=$permDisplayName 2=$otherDisplayName}<strong>%1</strong> can view information about <strong>%2</strong>.{/ts}
-{/if}
-{/if}
-
 {if $permType eq 1}
 {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=2 displayText=false}
 {/if}
@@ -52,6 +44,16 @@
   <i class="crm-i {if $permType eq 1}fa-pencil{else}fa-eye{/if} fa-inverse fa-stack-1x"></i>
 </span>
 
+{* Used for viewing a relationship *}
+{if $displayText}
+{if $permType eq 1}
+{ts 1=$permDisplayName 2=$otherDisplayName}<strong>%1</strong> can view and update information about <strong>%2</strong>.{/ts}
+{else}
+{ts 1=$permDisplayName 2=$otherDisplayName}<strong>%1</strong> can view information about <strong>%2</strong>.{/ts}
+{/if}
+{/if}
+
+{* Used for legend on relationships tab *}
 {if $afterText}
 {if $permType eq 1}
 {ts}This contact can be edited by the other.{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
This follows on some conversation between @colemanw, @aydun, @eileenmcnaughton, and me in #12415 regarding how creepy [`fa-eye`](https://fontawesome.com/v4.7.0/icon/eye) is.

Before
----------------------------------------
An eye appears for view-only relationship permissions and an asterisk for view-and-edit permissions.

After
----------------------------------------
An eye appears within a green square for view-only relationship permissions and both that and a pencil in a blue square appear for view-and-edit permissions.

![image](https://user-images.githubusercontent.com/1682375/43023164-d96926ac-8c37-11e8-9049-4cb5456150c6.png)

![image](https://user-images.githubusercontent.com/1682375/43023208-06bdab32-8c38-11e8-84b3-2b81d57dc745.png)

Technical Details
----------------------------------------
All rendering of these icons and their titles is now handled by a new Smarty template, simplifying future changes.
