### PR TITLE
crmRouteBinder - Don't convert arrays to objects

### DIFF
--- a/ang/crmRouteBinder.js
+++ b/ang/crmRouteBinder.js
@@ -66,7 +66,7 @@
           value = fmt.decode($route.current.params[options.param]);
         }
         else {
-          value = _.isObject(options.default) ? angular.extend({}, options.default) : options.default;
+          value = _.cloneDeep(options.default);
           ignorable[options.param] = fmt.encode(options.default);
         }
         $parse(options.expr).assign(_scope, value);


### PR DESCRIPTION
Overview
----
This fixes a subtle bug I encountered while writing the Api4 explorer.

Before
----
Arrays would be mangled because the function `_.isObject([])` will return `true`.

After
----
Arrays and objects are both treated nicely.