### PR TITLE
dev/core#272 : Fatal Error (Regression) on PCP pages associated with Events

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -196,7 +196,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    */
   public function preProcess() {
     $this->_eventId = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
-    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE);
+    $this->_action = CRM_Utils_Request::retrieve('action', 'Alphanumeric', $this, FALSE, CRM_Core_Action::ADD);
 
     //CRM-4320
     $this->_participantId = CRM_Utils_Request::retrieve('participantId', 'Positive', $this);


### PR DESCRIPTION
Overview
----------------------------------------
There is regression found in Event's PCP as:
![image](https://lab.civicrm.org/dev/core/uploads/e4a44888aa3c6e40764f06c683e27214/image.png)
Regression is caused by https://github.com/civicrm/civicrm-core/pull/12056/files#diff-20d61aa96c8fdcd879d2b760f13ccc74R456 

Before
----------------------------------------
Fatal error on Event's page

After
----------------------------------------
Fixed the error.

Technical Details
----------------------------------------
Here ```addField('pcp_personel_note', ...)``` expects ```$form->_action``` which is not allotted to ```CRM/Event/Form/Registration/Register.php```. This patch assigned a default action to its parent class like we do for all other Civi forms. Alternatively we can provide the 'action' parameter i.e.
```patch
- $page->addField('pcp_personal_note', array('entity' => 'ContributionSoft', 'context' => 'create', 'style' => 'height: 3em; width: 40em;'));
+ $page->addField('pcp_personal_note', array('entity' => 'ContributionSoft', 'context' => 'create', 'action' => 'create', 'style' => 'height: 3em; width: 40em;'));
```
But ideally we should always ensure that a form has action to render form elements for intended purpose.
 
Comments
----------------------------------------
ping @eileenmcnaughton @KarinG 
