### PR TITLE
Export Add unit test + minor refactor covering specifiable payment output fields for participant export.

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1359,6 +1359,236 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test exported with fields to output specified.
+   *
+   * @dataProvider getAllSpecifiableReturnFields
+   *
+   * @param int $exportMode
+   * @param array $selectedFields
+   * @param array $expected
+   */
+  public function testExportSpecifyFields($exportMode, $selectedFields, $expected) {
+    $this->ensureComponentIsEnabled($exportMode);
+    $this->setUpContributionExportData();
+    list($tableName, $sqlColumns) = $this->doExport($selectedFields, $this->contactIDs[1]);
+    $this->assertEquals($expected, $sqlColumns);
+  }
+
+  /**
+   * Get all return fields (@todo - still being built up.
+   *
+   * @return array
+   */
+  public function getAllSpecifiableReturnFields() {
+    return [
+      [
+        CRM_Export_Form_Select::EVENT_EXPORT,
+        $this->getAllSpecifiableParticipantReturnFields(),
+        [
+          'participant_campaign_id' => 'participant_campaign_id varchar(128)',
+          'participant_contact_id' => 'participant_contact_id varchar(16)',
+          'componentpaymentfield_contribution_status' => 'componentpaymentfield_contribution_status text',
+          'currency' => 'currency varchar(3)',
+          'componentpaymentfield_received_date' => 'componentpaymentfield_received_date text',
+          'default_role_id' => 'default_role_id varchar(16)',
+          'participant_discount_name' => 'participant_discount_name varchar(16)',
+          'event_id' => 'event_id varchar(16)',
+          'event_end_date' => 'event_end_date varchar(32)',
+          'event_start_date' => 'event_start_date varchar(32)',
+          'template_title' => 'template_title varchar(255)',
+          'event_title' => 'event_title varchar(255)',
+          'participant_fee_amount' => 'participant_fee_amount varchar(32)',
+          'participant_fee_currency' => 'participant_fee_currency varchar(3)',
+          'fee_label' => 'fee_label varchar(255)',
+          'participant_fee_level' => 'participant_fee_level longtext',
+          'participant_is_pay_later' => 'participant_is_pay_later varchar(16)',
+          'participant_id' => 'participant_id varchar(16)',
+          'participant_note' => 'participant_note text',
+          'participant_role_id' => 'participant_role_id varchar(128)',
+          'participant_role' => 'participant_role varchar(255)',
+          'participant_source' => 'participant_source varchar(128)',
+          'participant_status_id' => 'participant_status_id varchar(16)',
+          'participant_status' => 'participant_status varchar(255)',
+          'participant_register_date' => 'participant_register_date varchar(32)',
+          'participant_registered_by_id' => 'participant_registered_by_id varchar(16)',
+          'participant_is_test' => 'participant_is_test varchar(16)',
+          'componentpaymentfield_total_amount' => 'componentpaymentfield_total_amount text',
+          'componentpaymentfield_transaction_id' => 'componentpaymentfield_transaction_id varchar(255)',
+          'transferred_to_contact_id' => 'transferred_to_contact_id varchar(16)',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @return array
+   */
+  public function getAllSpecifiableParticipantReturnFields() {
+    return [
+      0 =>
+        [
+          0 => 'Participant',
+          1 => '',
+        ],
+      1 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_campaign_id',
+        ],
+      2 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_contact_id',
+        ],
+      3 =>
+        [
+          0 => 'Participant',
+          1 => 'componentPaymentField_contribution_status',
+        ],
+      4 =>
+        [
+          0 => 'Participant',
+          1 => 'currency',
+        ],
+      5 =>
+        [
+          0 => 'Participant',
+          1 => 'componentPaymentField_received_date',
+        ],
+      6 =>
+        [
+          0 => 'Participant',
+          1 => 'default_role_id',
+        ],
+      7 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_discount_name',
+        ],
+      8 =>
+        [
+          0 => 'Participant',
+          1 => 'event_id',
+        ],
+      9 =>
+        [
+          0 => 'Participant',
+          1 => 'event_end_date',
+        ],
+      10 =>
+        [
+          0 => 'Participant',
+          1 => 'event_start_date',
+        ],
+      11 =>
+        [
+          0 => 'Participant',
+          1 => 'template_title',
+        ],
+      12 =>
+        [
+          0 => 'Participant',
+          1 => 'event_title',
+        ],
+      13 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_fee_amount',
+        ],
+      14 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_fee_currency',
+        ],
+      15 =>
+        [
+          0 => 'Participant',
+          1 => 'fee_label',
+        ],
+      16 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_fee_level',
+        ],
+      17 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_is_pay_later',
+        ],
+      18 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_id',
+        ],
+      19 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_note',
+        ],
+      20 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_role_id',
+        ],
+      21 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_role',
+        ],
+      22 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_source',
+        ],
+      23 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_status_id',
+        ],
+      24 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_status',
+        ],
+      25 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_status',
+        ],
+      26 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_register_date',
+        ],
+      27 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_registered_by_id',
+        ],
+      28 =>
+        [
+          0 => 'Participant',
+          1 => 'participant_is_test',
+        ],
+      29 =>
+        [
+          0 => 'Participant',
+          1 => 'componentPaymentField_total_amount',
+        ],
+      30 =>
+        [
+          0 => 'Participant',
+          1 => 'componentPaymentField_transaction_id',
+        ],
+      31 =>
+        [
+          0 => 'Participant',
+          1 => 'transferred_to_contact_id',
+        ],
+    ];
+  }
+
+  /**
    * @param string $exportMode
    */
   public function setupBaseExportData($exportMode) {


### PR DESCRIPTION
Overview
----------------------------------------
Unit test covering currently specifiable fields for participant export + refactor out $selectedPaymentFields & paymentTableId variables

Before
----------------------------------------
No test. Parameter passed via multiple functions

After
----------------------------------------
Parameter calculated by processor class, significant additional tests

Technical Details
----------------------------------------
The $selectedPaymentFields & paymentTableId variables are set when payment fields ( like contribution status) are specified on participant export. This test + refactor makes that more sane.

The goal here is to have a sensible separation of concerns in the various processing actions

Comments
----------------------------------------
