### PR TITLE
dev/core#131 Stop Monmouthshire from breaking upgrades

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
@@ -11,7 +11,7 @@ UPDATE civicrm_custom_field SET is_searchable = 0 WHERE is_required IS NULL;
 ALTER TABLE civicrm_custom_field ALTER column is_active SET DEFAULT 1;
 
 SET @UKCountryId = (SELECT id FROM civicrm_country cc WHERE cc.name = 'United Kingdom');
-INSERT INTO civicrm_state_province (country_id, abbreviation, name)
+INSERT IGNORE INTO civicrm_state_province (country_id, abbreviation, name)
 VALUES (@UKCountryId, 'MON', 'Monmouthshire');
 
 {* dev/core/#152 *}


### PR DESCRIPTION
Overview
----------------------------------------
Monmouthshire might already exist in the DB. So the 'INSERT' statement fails and breaks the upgrade.

Before
----------------------------------------
If Monmouthshire already exists, the upgrade fails fatally.

After
----------------------------------------
If Monmouthshire already exists, the upgrade continues gracefully.

Technical Details
----------------------------------------
Use INSERT IGNORE instead - this convention is used elsewhere with states/provinces being added to the DB.