### PR TITLE
Link to option group page from option group menu item

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.5.alpha1.mysql.tpl
@@ -14,3 +14,5 @@ UPDATE civicrm_option_group AS cog INNER JOIN civicrm_custom_field AS ccf
 ON cog.id = ccf.option_group_id
 SET cog.is_reserved = 0 WHERE cog.is_active = 1 AND ccf.is_active = 1;
 UPDATE civicrm_option_group SET is_reserved = 1 WHERE name='environment';
+
+UPDATE civicrm_navigation SET url = 'civicrm/admin/options?action=browse&reset=1' WHERE name = 'Dropdown Options' AND domain_id = {$domainID};

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -322,7 +322,7 @@ VALUES
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
 VALUES
-    ( @domainID, NULL, '{ts escape="sql" skip="true"}Dropdown Options{/ts}', 'Dropdown Options', 'administer CiviCRM', '', @CustomizelastID, '1', NULL, 8 );
+    ( @domainID, 'civicrm/admin/options?action=browse&reset=1', '{ts escape="sql" skip="true"}Dropdown Options{/ts}', 'Dropdown Options', 'administer CiviCRM', '', @CustomizelastID, '1', NULL, 8 );
 
 SET @optionListlastID:=LAST_INSERT_ID();
 INSERT INTO civicrm_navigation


### PR DESCRIPTION
Overview
-----
Adds a link to a page that is otherwise very hard to find.

Before
-----
Can't directly get to the "Option Groups" page.

After
-----
Menu item which looks like it ought to link to it, does in fact link to it.