### PR TITLE
Update navigation menu items to use FontAwesome

### DIFF
--- a/css/civicrmNavigation.css
+++ b/css/civicrmNavigation.css
@@ -115,12 +115,14 @@ div.menu-item {
   padding: 1px 10px 1px 4px;
   height: auto;
 }
-img.menu-item-arrow{
+#civicrm-menu .menu-item-arrow,
+#root-menu-div .menu-item-arrow {
   position: absolute;
   right: 4px;
-  top: 8px;
+  top: 6px;
 }
-#civicrm-menu i {
+#civicrm-menu i,
+#root-menu-div i {
   margin-right: 5px;
 }
 li.menu-separator{

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -84,7 +84,6 @@
 $('#civicrm-menu').ready(function() {
   $('#root-menu-div .outerbox').css({'margin-top': '6px'});
   $('#root-menu-div .menu-ul li').css({'padding-bottom': '2px', 'margin-top': '2px'});
-  $('img.menu-item-arrow').css({top: '4px'});
   $("#civicrm-menu >li").each(function(i){
     $(this).attr("tabIndex",i+2);
   });
@@ -208,7 +207,7 @@ $('#civicrm-menu').ready(function() {
   // Close menu after selecting an item
   $('#root-menu-div').on('click', 'a', $.Menu.closeAll);
 });
-$('#civicrm-menu').menuBar({arrowSrc: CRM.config.resourceBase + 'packages/jquery/css/images/arrow.png'});
+$('#civicrm-menu').menuBar({arrowClass: 'crm-i fa-caret-right'});
 $(window).on("beforeunload", function() {
   $('.crm-logo-sm', '#civicrm-menu').addClass('crm-i fa-spin');
 });


### PR DESCRIPTION
Overview
----

This updates the menu "caret" icon to use FontAwesome instead of an image file.

Before
----

Unnecessary image loading, caused problems with Shoreditch.

After
-----

Menu looks the same, but works better with Shoreditch and icon is a bit sharper.