### PR TITLE
CRM-21682 Support multiple memberships for recurring

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1164,10 +1164,8 @@ AND civicrm_membership.is_test = %2";
       $currentMembership
     );
 
-    if (empty($status) ||
-      empty($status['id'])
-    ) {
-      CRM_Core_Error::fatal(ts('Oops, it looks like there is no valid membership status corresponding to the membership start and end dates for this membership. Contact the site administrator for assistance.'));
+    if (empty($status) || empty($status['id'])) {
+      throw new CRM_Core_Exception(ts('Oops, it looks like there is no valid membership status corresponding to the membership start and end dates for this membership. Contact the site administrator for assistance.'));
     }
 
     $currentMembership['today_date'] = $today;


### PR DESCRIPTION
Overview
----------------------------------------
This is a partial from #11556 that allows multiple memberships to be linked to a recurring.

Before
----------------------------------------
When repeattransaction is called ONLY the membership linked to the original contribution will be renewed (if the contribution is in the correct state (ie. Completed - see Before/After)). loadRelatedObjects only loads one membership but the code is expected all memberships to be loaded so does handle multiple memberships if passed in.

After
----------------------------------------
When repeattransaction is called: If the contribution has a recurring contribution ID then ALL memberships linked to that recurring contribution will be renewed. If the contribution has no recurring contribution then the membership linked to the original contribution will be renewed (if the contribution is in the correct state (ie. Completed - see Before/After) AND the other conditions are met (ie. state, frequency)).

Technical Details
----------------------------------------
Most of the code assumes multiple memberships are supported, but the loadRelatedObjects() function only returns a single membership ID.

Comments
----------------------------------------
This fixes an inconsistency in core processing of membership renewals.

---

 * [CRM-21682: Automatic membership renewal fixes](https://issues.civicrm.org/jira/browse/CRM-21682)