### PR TITLE
(dev/core#217) PrevNext - Probe for best available implementation (memory-backed or SQL-backed)

### DIFF
--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -67,22 +67,7 @@ class CRM_Utils_Cache {
    */
   public static function &singleton() {
     if (self::$_singleton === NULL) {
-      $className = 'ArrayCache';   // default to ArrayCache for now
-
-      // Maintain backward compatibility for now.
-      // Setting CIVICRM_USE_MEMCACHE or CIVICRM_USE_ARRAYCACHE will
-      // override the CIVICRM_DB_CACHE_CLASS setting.
-      // Going forward, CIVICRM_USE_xxxCACHE should be deprecated.
-      if (defined('CIVICRM_USE_MEMCACHE') && CIVICRM_USE_MEMCACHE) {
-        $className = 'Memcache';
-      }
-      elseif (defined('CIVICRM_USE_ARRAYCACHE') && CIVICRM_USE_ARRAYCACHE) {
-        $className = 'ArrayCache';
-      }
-      elseif (defined('CIVICRM_DB_CACHE_CLASS') && CIVICRM_DB_CACHE_CLASS) {
-        $className = CIVICRM_DB_CACHE_CLASS;
-      }
-
+      $className = self::getCacheDriver();
       // a generic method for utilizing any of the available db caches.
       $dbCacheClass = 'CRM_Utils_Cache_' . $className;
       $settings = self::getCacheSettings($className);
@@ -238,6 +223,32 @@ class CRM_Utils_Cache {
     }
 
     return $key;
+  }
+
+  /**
+   * @return string
+   *   Ex: 'ArrayCache', 'Memcache', 'Redis'.
+   */
+  public static function getCacheDriver() {
+    $className = 'ArrayCache';   // default to ArrayCache for now
+
+    // Maintain backward compatibility for now.
+    // Setting CIVICRM_USE_MEMCACHE or CIVICRM_USE_ARRAYCACHE will
+    // override the CIVICRM_DB_CACHE_CLASS setting.
+    // Going forward, CIVICRM_USE_xxxCACHE should be deprecated.
+    if (defined('CIVICRM_USE_MEMCACHE') && CIVICRM_USE_MEMCACHE) {
+      $className = 'Memcache';
+      return $className;
+    }
+    elseif (defined('CIVICRM_USE_ARRAYCACHE') && CIVICRM_USE_ARRAYCACHE) {
+      $className = 'ArrayCache';
+      return $className;
+    }
+    elseif (defined('CIVICRM_DB_CACHE_CLASS') && CIVICRM_DB_CACHE_CLASS) {
+      $className = CIVICRM_DB_CACHE_CLASS;
+      return $className;
+    }
+    return $className;
   }
 
 }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -215,6 +215,11 @@ class Container {
     }
 
     $container->setDefinition('prevnext', new Definition(
+      'CRM_Core_PrevNextCache_Interface',
+      [new Reference('service_container')]
+    ))->setFactory(array(new Reference(self::SELF), 'createPrevNextCache'));
+
+    $container->setDefinition('prevnext.driver.sql', new Definition(
       'CRM_Core_PrevNextCache_Sql',
       []
     ));
@@ -402,6 +407,18 @@ class Container {
     ));
 
     return $kernel;
+  }
+
+  /**
+   * @param ContainerInterface $container
+   * @return \CRM_Core_PrevNextCache_Interface
+   */
+  public static function createPrevNextCache($container) {
+    $cacheDriver = \CRM_Utils_Cache::getCacheDriver();
+    $service = 'prevnext.driver.' . strtolower($cacheDriver);
+    return $container->has($service)
+      ? $container->get($service)
+      : $container->get('prevnext.driver.sql');
   }
 
   /**


### PR DESCRIPTION
Overview
-----
You may recall that (eg) `CRM_Utils_Cache_Redis` provides a PSR-16 adapter for storing caches in Redis. That structure is good as a general-purpose cache; however, for PrevNext, we need to support additional methods which are amenable to pagination. This requires a different adapter (written with direct access to Redis functiosn like `ZRANGE`) -- e.g. `CRM_Core_PrevNextCache_Redis`.

This PR allows one to register parallel classes in `CRM/Utils/Cache/{mydriver}` and `CRM/Core/PrevNextCache/{mydriver}`. It is a cherry-pick of some commits from #12377.

This particular PR does not actually register `prevnext.driver.redis` or `prevnext.driver.memcache` or similar, so it has no major functional impact on its own. That will come when we add those classes/services later.

See also: [dev/core#217](https://lab.civicrm.org/dev/core/issues/217)

Before
------

The `prevnext` service is always an instance of `CRM_Core_PrevNextCache_Sql`.

After
-----

If you define `CIVICRM_DB_CACHE_CLASS`, and if there's a corresponding service `prevnext.driver.{mydriver}`, then it will use that service.

Otherwise, it will use `prevnext.driver.sql` (`CRM_Core_PrevNextCache_Sql`) -- which is the current driver.
