### PR TITLE
(dev/core#217) PrevNext - Define and use fillWithSql()/fillWithArray()

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -281,18 +281,19 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
         $this->_campaignFromClause
       );
       list($select, $from) = explode(' FROM ', $sql);
-      $insertSQL = "
-INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
-SELECT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.display_name
+      $selectSQL = "
+      SELECT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.display_name
 FROM {$from}
 ";
-      $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-      $result = CRM_Core_DAO::executeQuery($insertSQL);
-      unset($errorScope);
 
-      if (is_a($result, 'DB_Error')) {
+      try {
+        Civi::service('prevnext')->fillWithSql($cacheKey, $selectSQL);
+      }
+      catch (CRM_Core_Exception $e) {
+        // Heavy handed, no? Seems like this merits an explanation.
         return;
       }
+
       // also record an entry in the cache key table, so we can delete it periodically
       CRM_Core_BAO_Cache::setItem($cacheKey, 'CiviCRM Search PrevNextCache', $cacheKey);
     }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1039,17 +1039,11 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // the other alternative of running the FULL query will just be incredibly inefficient
     // and slow things down way too much on large data sets / complex queries
 
-    $insertSQL = "
-INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
-SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.sort_name
-";
+    $selectSQL = "SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.sort_name";
 
-    $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $insertSQL, $sql);
+    $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $selectSQL, $sql);
     try {
-      $result = CRM_Core_DAO::executeQuery($sql, [], FALSE, NULL, FALSE, TRUE, TRUE);
-      if (is_a($result, 'DB_Error')) {
-        throw new CRM_Core_Exception($result->message);
-      }
+      Civi::service('prevnext')->fillWithSql($cacheKey, $sql);
     }
     catch (CRM_Core_Exception $e) {
       if ($coreSearch) {

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1083,18 +1083,17 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $dao = CRM_Core_DAO::executeQuery($sql);
 
     // build insert query, note that currently we build cache for 500 (self::CACHE_SIZE) contact records at a time, hence below approach
-    $insertValues = array();
+    $rows = [];
     while ($dao->fetch()) {
-      $insertValues[] = "('civicrm_contact', {$dao->contact_id}, {$dao->contact_id}, '{$cacheKey}', '" . CRM_Core_DAO::escapeString($dao->sort_name) . "')";
+      $rows[] = [
+        'entity_table' => 'civicrm_contact',
+        'entity_id1' => $dao->contact_id,
+        'entity_id2' => $dao->contact_id,
+        'data' => $dao->sort_name,
+      ];
     }
 
-    //update pre/next cache using single insert query
-    if (!empty($insertValues)) {
-      $sql = 'INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data ) VALUES
-' . implode(',', $insertValues);
-
-      $result = CRM_Core_DAO::executeQuery($sql);
-    }
+    Civi::service('prevnext')->fillWithArray($cacheKey, $rows);
   }
 
   /**

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -33,4 +33,14 @@
  */
 interface CRM_Core_PrevNextCache_Interface {
 
+  /**
+   * Store the results of a SQL query in the cache.
+   *
+   * @param string $sql
+   *   A SQL query. The query *MUST* be a SELECT statement which yields
+   *   the following columns (in order): entity_table, entity_id1, entity_id2, cacheKey, data
+   * @return bool
+   */
+  public function fillWithSql($cacheKey, $sql);
+
 }

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -36,11 +36,26 @@ interface CRM_Core_PrevNextCache_Interface {
   /**
    * Store the results of a SQL query in the cache.
    *
+   * @param string $cacheKey
    * @param string $sql
    *   A SQL query. The query *MUST* be a SELECT statement which yields
    *   the following columns (in order): entity_table, entity_id1, entity_id2, cacheKey, data
    * @return bool
    */
   public function fillWithSql($cacheKey, $sql);
+
+  /**
+   * Store the contents of an array in the cache.
+   *
+   * @param string $cacheKey
+   * @param array $rows
+   *   A list of cache records. Each record should have keys:
+   *    - entity_table
+   *    - entity_id1
+   *    - entity_id2
+   *    - data
+   * @return bool
+   */
+  public function fillWithArray($cacheKey, $rows);
 
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -52,4 +52,26 @@ INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cache
     return TRUE;
   }
 
+  public function fillWithArray($cacheKey, $rows) {
+    if (empty($rows)) {
+      return;
+    }
+
+    $insert = CRM_Utils_SQL_Insert::into('civicrm_prevnext_cache')
+      ->columns([
+        'entity_table',
+        'entity_id1',
+        'entity_id2',
+        'cacheKey',
+        'data'
+      ]);
+
+    foreach ($rows as &$row) {
+      $insert->row($row + ['cacheKey' => $cacheKey]);
+    }
+
+    CRM_Core_DAO::executeQuery($insert->toSQL());
+    return TRUE;
+  }
+
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -31,4 +31,25 @@
  * Store the previous/next cache in a special-purpose SQL table.
  */
 class CRM_Core_PrevNextCache_Sql implements CRM_Core_PrevNextCache_Interface {
+
+  /**
+   * Store the results of a SQL query in the cache.
+   *
+   * @param string $sql
+   *   A SQL query. The query *MUST* be a SELECT statement which yields
+   *   the following columns (in order): entity_table, entity_id1, entity_id2, cacheKey, data
+   * @return bool
+   * @throws CRM_Core_Exception
+   */
+  public function fillWithSql($cacheKey, $sql) {
+    $insertSQL = "
+INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
+";
+    $result = CRM_Core_DAO::executeQuery($insertSQL . $sql, [], FALSE, NULL, FALSE, TRUE, TRUE);
+    if (is_a($result, 'DB_Error')) {
+      throw new CRM_Core_Exception($result->message);
+    }
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Update the `PrevNext` interface to define methods `fillWithSql()` and `fillWithArray()`. Update all (`F1`) existing contact-search screens to use these methods.

This is a cherry-pick from #12377.

See also: [dev/core#217](https://lab.civicrm.org/dev/core/issues/217)

Before
----------------------------------------

`CRM_Contact_Selector` (advanced search, et al) and `CRM_Campaign_Selector_Search` (reserve respondents, etc) fill the PrevNext cache by directly inserting to the SQL table `civicrm_prevnext_cache`

After
----------------------------------------
`CRM_Contact_Selector` (advanced search, et al) and `CRM_Campaign_Selector_Search` (reserve respondents, etc) fill the PrevNext cache by calling either `Civi::service('prevnext')->fillWithSql()` or `Civi::service('prevnext')->fillWithArray()`

Comments
----------------------------------------

__(`F1`)__ In keeping with the general scoping of the dev/core#217, this PR only revises code used by the search UI -- it doesn't touch dedupe. For dedupe, the main concern is that it should continue writing directly to SQL. Since we only touch search UI code, this PR should have no impact on dedupe.