### PR TITLE
Reduce config required to use Redis.

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -368,7 +368,12 @@ if (!defined('CIVICRM_DB_CACHE_HOST')) {
  * The standard port for Memcache & APCCache is 11211. For Redis it is 6379.
  */
 if (!defined('CIVICRM_DB_CACHE_PORT')) {
-  define('CIVICRM_DB_CACHE_PORT', 11211 );
+  if (CIVICRM_DB_CACHE_CLASS === 'Redis') {
+    define('CIVICRM_DB_CACHE_PORT', 6379 );
+  }
+  else {
+    define('CIVICRM_DB_CACHE_PORT', 11211);
+  }
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Specifying the default port sensibly removes one config step & makes sysadmins happier

Before
----------------------------------------
Sysadmins had to specify the port if using Redis

After
----------------------------------------
Sysadmins only have to specify the port if using Redis & it is non-standard

Technical Details
----------------------------------------
Note this will only apply to new installs

Comments
----------------------------------------
@totten this came off testing your Redis patch
