### PR TITLE
5.3 - Handle 'Check for Matching Contact(s)' button with ajax

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1360,7 +1360,7 @@ function civicrm_api3_contact_duplicatecheck($params) {
     $params['match'],
     $params['match']['contact_type'],
     $params['rule_type'],
-    array(),
+    CRM_Utils_Array::value('exclude', $params, []),
     CRM_Utils_Array::value('check_permissions', $params),
     CRM_Utils_Array::value('dedupe_rule_id', $params)
   );

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -113,6 +113,7 @@
   CRM.$(function($) {
     var $form = $("form.{/literal}{$form.formClass}{literal}"),
       action = {/literal}{$action|intval}{literal},
+      cid = {/literal}{$contactId|intval}{literal},
       _ = CRM._;
 
     $('.crm-accordion-body').each( function() {
@@ -335,6 +336,7 @@
       if (rule) {
         params.rule_type = rule;
         params.match = match;
+        params.exclude = cid ? [cid] : [];
       } else {
         _.extend(params, match);
       }


### PR DESCRIPTION
Overview
-------
Fixes the 'Check for Matching Contact(s)' button when ajax deduping is enabled

Before
-----
The button would still work if ajax deduping was disabled in system prefs, but didn't work if ajax mode is enabled.

After
----
The button works either way. If ajax mode is enabled, clicking the button will use ajax. Otherwise it does it the old way.