### PR TITLE
Recipient phone number is invalid or recipient does not want to receive SMS" error and Contacts with DoNotSms preference failing to filter out during Mass Sms in 5.x

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1826,7 +1826,6 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     $activityID,
     $sourceContactID = NULL
   ) {
-    $doNotSms = TRUE;
     $toPhoneNumber = NULL;
 
     if ($smsProviderParams['To']) {
@@ -1841,14 +1840,12 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
       if (!empty($toPhoneNumbers)) {
         $toPhoneNumberDetails = reset($toPhoneNumbers);
         $toPhoneNumber = CRM_Utils_Array::value('phone', $toPhoneNumberDetails);
-        // Contact allows to send sms
-        $doNotSms = FALSE;
       }
     }
 
     // make sure both phone are valid
     // and that the recipient wants to receive sms
-    if (empty($toPhoneNumber) or $doNotSms) {
+    if (empty($toPhoneNumber) {
       return PEAR::raiseError(
         'Recipient phone number is invalid or recipient does not want to receive SMS',
         NULL,

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -230,6 +230,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     if ($isSMSmode) {
       $criteria = array(
         'is_opt_out' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_opt_out = 0"),
+        'do_not_sms' => CRM_Utils_SQL_Select::fragment()->where("$contact.do_not_sms = 0"),
         'is_deceased' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_deceased <> 1"),
         'location_filter' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone_type_id = " . CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_Phone', 'phone_type_id', 'Mobile')),
         'phone_not_null' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone IS NOT NULL"),


### PR DESCRIPTION
**https://lab.civicrm.org/dev/core/issues/273**

**Reason for changes**: veda-consulting/org.civicrm.sms.clickatell#20 (comment)

**Overview**
civicrm/CRM/Activity/BAO/Activity.php is failing in function sendSMSMessage(Because $doNotSms = TRUE;)
1>Fix for the error-"Recipient phone number is invalid or recipient does not want to receive SMS" while sending Sms to individual.
2>Fix for filtering out contacts with preference "donotsms" while mass sms

**Before:**
$doNotSms = TRUE; in civicrm/CRM/Activity/BAO/Activity.php

'do_not_sms' => CRM_Utils_SQL_Select::fragment()->where("$contact.do_not_sms = 0"), missing in civicrm/CRM/BAO/Mailing.php in function ($isSMSmode) {}

**After:**
$doNotSms = TRUE; - This flag is removed altogether in civicrm/CRM/Activity/BAO/Activity.php

'do_not_sms' => CRM_Utils_SQL_Select::fragment()->where("$contact.do_not_sms = 0") is included within if ($isSMSmode) {} in civicrm/CRM/BAO/Mailing.php