### PR TITLE
Activity tab code refactor

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -341,6 +341,10 @@ function civicrm_api3_activity_get($params) {
   }
 
   $activities = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE, 'Activity', $sql);
+  if ($options['is_count']) {
+    return civicrm_api3_create_success($activities, $params, 'Activity', 'get');
+  }
+
   if (!empty($params['check_permissions']) && !CRM_Core_Permission::check('view all activities')) {
     // @todo get this to work at the query level - see contact_id join above.
     foreach ($activities as $activity) {
@@ -348,9 +352,6 @@ function civicrm_api3_activity_get($params) {
         unset($activities[$activity['id']]);
       }
     }
-  }
-  if ($options['is_count']) {
-    return civicrm_api3_create_success($activities, $params, 'Activity', 'get');
   }
 
   $activities = _civicrm_api3_activity_get_formatResult($params, $activities, $options);


### PR DESCRIPTION
Overview
----------------------------------------
Extract out the main part of getActivities so that getActivitiesCount can share the common parts without doing weird stuff


Before
----------------------------------------
Code winds itself in knots to be shared

After
----------------------------------------
Code has sensible points of being shared.

Technical Details
----------------------------------------

A while back @monishdeb refactored the function to get the count of activities associated with a contact to use the api https://github.com/eileenmcnaughton/civicrm-core/commit/466e3a53e0ed35e3c4721d071b65ca73fdd6def2#diff-a35044abd0f538e4af551c5ae039692d

However we hit a performance snaffu - https://github.com/civicrm/civicrm-core/pull/10261 and we bypassed the new code in order to get the rc stabilised.

However since then @mattwire has worked on the performance of the new functions  (https://github.com/civicrm/civicrm-core/pull/10909) and they have gotten better under most circumstances. WMF has switched over to the new functions as some contacts would no longer load under the old functions.

There are 2 new functions getActivities and getActivitiesCount. The former have also been switched over in core. The later still needs some work for permissioned users & hence this PR has been reduced to a refactor towards switching rather than the original switcharoo.


Comments
----------------------------------------
There is good test coverage on the new function as that was part of it's development.

I am continuing on with fixing up the api handling of permissions to the point where we can switch this across in core - current PR for that is https://github.com/civicrm/civicrm-core/pull/12995

Note I have updated this description to reflect the final PR - some of the comments reflect the original intent to do a switcharoo & were made before either function was switched