### PR TITLE
(dev/core#217) PrevNext - Allow swapping getPositions (etal) for contact-search

### DIFF
--- a/CRM/Campaign/Form/Task.php
+++ b/CRM/Campaign/Form/Task.php
@@ -65,7 +65,7 @@ class CRM_Campaign_Form_Task extends CRM_Core_Form_Task {
     else {
       $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $this);
       $cacheKey = "civicrm search {$qfKey}";
-      $allCids = CRM_Core_BAO_PrevNextCache::getSelection($cacheKey, "getall");
+      $allCids = Civi::service('prevnext')->getSelection($cacheKey, "getall");
       $ids = array_keys($allCids[$cacheKey]);
       $this->assign('totalSelectedVoters', count($ids));
     }

--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -271,7 +271,7 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
 
     if (!$crmPID) {
       $cacheKey = "civicrm search {$this->_key}";
-      CRM_Core_BAO_PrevNextCache::deleteItem(NULL, $cacheKey, 'civicrm_contact');
+      Civi::service('prevnext')->deleteItem(NULL, $cacheKey, 'civicrm_contact');
 
       $sql = $this->_query->searchQuery(0, 0, $sort,
         FALSE, FALSE,

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1013,7 +1013,10 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     CRM_Utils_Recent::delContact($id);
     self::updateContactCache($id, empty($restore));
 
-    // delete any dupe cache entry
+    // delete any prevnext/dupe cache entry
+    // These two calls are redundant in default deployments, but they're
+    // meaningful if "prevnext" is memory-backed.
+    Civi::service('prevnext')->deleteItem($id);
     CRM_Core_BAO_PrevNextCache::deleteItem($id);
 
     $transaction->commit();

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -917,6 +917,9 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
       return;
     }
     if ($isEmptyPrevNextTable) {
+      // These two calls are redundant in default deployments, but they're
+      // meaningful if "prevnext" is memory-backed.
+      Civi::service('prevnext')->deleteItem();
       CRM_Core_BAO_PrevNextCache::deleteItem();
     }
     // clear acl cache if any.

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -782,7 +782,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     ) {
       //reset the cache table for new search
       $cacheKey = "civicrm search {$this->controller->_key}";
-      CRM_Core_BAO_PrevNextCache::deleteItem(NULL, $cacheKey);
+      Civi::service('prevnext')->deleteItem(NULL, $cacheKey);
     }
 
     //get the button name

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -497,7 +497,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     if ($qfKeyParam && ($this->get('component_mode') <= CRM_Contact_BAO_Query::MODE_CONTACTS || $this->get('component_mode') == CRM_Contact_BAO_Query::MODE_CONTACTSRELATED)) {
       $this->addClass('crm-ajax-selection-form');
       $qfKeyParam = "civicrm search {$qfKeyParam}";
-      $selectedContactIdsArr = CRM_Core_BAO_PrevNextCache::getSelection($qfKeyParam);
+      $selectedContactIdsArr = Civi::service('prevnext')->getSelection($qfKeyParam);
       $selectedContactIds = array_keys($selectedContactIdsArr[$qfKeyParam]);
     }
 

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -273,7 +273,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     ) {
       $sel = CRM_Utils_Array::value('radio_ts', self::$_searchFormValues);
       $form->assign('searchtype', $sel);
-      $result = CRM_Core_BAO_PrevNextCache::getSelectedContacts();
+      $result = self::getSelectedContactNames();
       $form->assign("value", $result);
     }
 
@@ -475,6 +475,29 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
       ));
       $this->_contactIds = array_keys($result['values']);
     }
+  }
+
+  /**
+   * @return array
+   *   List of contact names.
+   *   NOTE: These are raw values from the DB. In current data-model, that means
+   *   they are pre-encoded HTML.
+   */
+  private static function getSelectedContactNames() {
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
+    $cacheKey = "civicrm search {$qfKey}";
+
+    $cids = array();
+    // Gymanstic time!
+    foreach (Civi::service('prevnext')->getSelection($cacheKey) as $cacheKey => $values) {
+      $cids = array_unique(array_merge($cids, array_keys($values)));
+    }
+
+    $result = CRM_Utils_SQL_Select::from('civicrm_contact')
+      ->where('id IN (#cids)', ['cids' => $cids])
+      ->execute()
+      ->fetchMap('id', 'sort_name');
+    return $result;
   }
 
   /**

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -172,7 +172,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
       // rather than prevnext cache table for most of the task actions except export where we rebuild query to fetch
       // final result set
       if ($useTable) {
-        $allCids = CRM_Core_BAO_PrevNextCache::getSelection($cacheKey, "getall");
+        $allCids = Civi::service('prevnext')->getSelection($cacheKey, "getall");
       }
       else {
         $allCids[$cacheKey] = self::getContactIds($form);
@@ -233,7 +233,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
       }
       else {
         // fetching selected contact ids of passed cache key
-        $selectedCids = CRM_Core_BAO_PrevNextCache::getSelection($cacheKey);
+        $selectedCids = Civi::service('prevnext')->getSelection($cacheKey);
         foreach ($selectedCids[$cacheKey] as $selectedCid => $ignore) {
           if ($useTable) {
             $insertString[] = " ( {$selectedCid} ) ";

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -966,17 +966,17 @@ LIMIT {$offset}, {$rowCount}
           $elements[$key] = self::_convertToId($element);
         }
         CRM_Utils_Type::escapeAll($elements, 'Integer');
-        CRM_Core_BAO_PrevNextCache::markSelection($cacheKey, $actionToPerform, $elements);
+        Civi::service('prevnext')->markSelection($cacheKey, $actionToPerform, $elements);
       }
       else {
-        CRM_Core_BAO_PrevNextCache::markSelection($cacheKey, $actionToPerform);
+        Civi::service('prevnext')->markSelection($cacheKey, $actionToPerform);
       }
     }
     elseif ($variableType == 'single') {
       $cId = self::_convertToId($name);
       CRM_Utils_Type::escape($cId, 'Integer');
       $action = ($state == 'checked') ? 'select' : 'unselect';
-      CRM_Core_BAO_PrevNextCache::markSelection($cacheKey, $action, $cId);
+      Civi::service('prevnext')->markSelection($cacheKey, $action, $cId);
     }
     $contactIds = CRM_Core_BAO_PrevNextCache::getSelection($cacheKey);
     $countSelectionCids = count($contactIds[$cacheKey]);

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -978,7 +978,7 @@ LIMIT {$offset}, {$rowCount}
       $action = ($state == 'checked') ? 'select' : 'unselect';
       Civi::service('prevnext')->markSelection($cacheKey, $action, $cId);
     }
-    $contactIds = CRM_Core_BAO_PrevNextCache::getSelection($cacheKey);
+    $contactIds = Civi::service('prevnext')->getSelection($cacheKey);
     $countSelectionCids = count($contactIds[$cacheKey]);
 
     $arrRet = array('getCount' => $countSelectionCids);

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -117,7 +117,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
       'nextPrevError' => 0,
     );
     if ($qfKey) {
-      $pos = CRM_Core_BAO_PrevNextCache::getPositions("civicrm search $qfKey",
+      $pos = Civi::service('prevnext')->getPositions("civicrm search $qfKey",
         $this->_contactId,
         $this->_contactId
       );

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -900,7 +900,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter', 'String');
 
     //for text field pagination selection save
-    $countRow = CRM_Core_BAO_PrevNextCache::getCount($cacheKey, NULL, "entity_table = 'civicrm_contact'");
+    $countRow = Civi::service('prevnext')->getCount($cacheKey);
     // $sortByCharacter triggers a refresh in the prevNext cache
     if ($sortByCharacter && $sortByCharacter != 'all') {
       $cacheKey .= "_alphabet";

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -881,7 +881,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // check for current != previous to ensure cache is not reset if paging is done without changing
     // sort criteria
     if (!$pageNum || (!empty($currentSortID) && $currentSortID != $previousSortID)) {
-      CRM_Core_BAO_PrevNextCache::deleteItem(NULL, $cacheKey, 'civicrm_contact');
+      Civi::service('prevnext')->deleteItem(NULL, $cacheKey, 'civicrm_contact');
       // this means it's fresh search, so set pageNum=1
       if (!$pageNum) {
         $pageNum = 1;

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -448,8 +448,8 @@ AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
    * @deprecated
    * @see CRM_Core_PrevNextCache_Sql::getSelection()
    */
-  public static function getSelection($cacheKey, $action = 'get', $entity_table = 'civicrm_contact') {
-    return Civi::service('prevnext')->getSelection($cacheKey, $action, $entity_table);
+  public static function getSelection($cacheKey, $action = 'get') {
+    return Civi::service('prevnext')->getSelection($cacheKey, $action);
   }
 
   /**

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -453,30 +453,6 @@ AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
   }
 
   /**
-   * @return array
-   */
-  public static function getSelectedContacts() {
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
-    $cacheKey = "civicrm search {$qfKey}";
-    $query = "
-SELECT *
-FROM   civicrm_prevnext_cache
-WHERE  cacheKey LIKE %1
-  AND  is_selected=1
-  AND  cacheKey NOT LIKE %2
-";
-    $params1[1] = array("{$cacheKey}%", 'String');
-    $params1[2] = array("{$cacheKey}_alphabet%", 'String');
-    $dao = CRM_Core_DAO::executeQuery($query, $params1);
-
-    $val = array();
-    while ($dao->fetch()) {
-      $val[] = $dao->data;
-    }
-    return $val;
-  }
-
-  /**
    * Flip 2 contacts in the prevNext cache.
    *
    * @param array $prevNextId

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -439,60 +439,6 @@ AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
   }
 
   /**
-   * Save checkbox selections.
-   *
-   * @param $cacheKey
-   * @param string $action
-   * @param array $cIds
-   * @param string $entity_table
-   */
-  public static function markSelection($cacheKey, $action = 'unselect', $cIds = NULL, $entity_table = 'civicrm_contact') {
-    if (!$cacheKey) {
-      return;
-    }
-    $params = array();
-
-    $entity_whereClause = " AND entity_table = '{$entity_table}'";
-    if ($cIds && $cacheKey && $action) {
-      if (is_array($cIds)) {
-        $cIdFilter = "(" . implode(',', $cIds) . ")";
-        $whereClause = "
-WHERE cacheKey LIKE %1
-AND (entity_id1 IN {$cIdFilter} OR entity_id2 IN {$cIdFilter})
-";
-      }
-      else {
-        $whereClause = "
-WHERE cacheKey LIKE %1
-AND (entity_id1 = %2 OR entity_id2 = %2)
-";
-        $params[2] = array("{$cIds}", 'Integer');
-      }
-      if ($action == 'select') {
-        $whereClause .= "AND is_selected = 0";
-        $sql = "UPDATE civicrm_prevnext_cache SET is_selected = 1 {$whereClause} {$entity_whereClause}";
-        $params[1] = array("{$cacheKey}%", 'String');
-      }
-      elseif ($action == 'unselect') {
-        $whereClause .= "AND is_selected = 1";
-        $sql = "UPDATE civicrm_prevnext_cache SET is_selected = 0 {$whereClause} {$entity_whereClause}";
-        $params[1] = array("%{$cacheKey}%", 'String');
-      }
-      // default action is reseting
-    }
-    elseif (!$cIds && $cacheKey && $action == 'unselect') {
-      $sql = "
-UPDATE civicrm_prevnext_cache
-SET    is_selected = 0
-WHERE  cacheKey LIKE %1 AND is_selected = 1
-       {$entity_whereClause}
-";
-      $params[1] = array("{$cacheKey}%", 'String');
-    }
-    CRM_Core_DAO::executeQuery($sql, $params);
-  }
-
-  /**
    * Get the selections.
    *
    * @param string $cacheKey

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -438,47 +438,18 @@ AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
     CRM_Core_DAO::executeQuery($sql, $params);
   }
 
+
   /**
    * Get the selections.
    *
-   * @param string $cacheKey
-   *   Cache key.
-   * @param string $action
-   *   Action.
-   *  $action : get - get only selection records
-   *            getall - get all the records of the specified cache key
-   * @param string $entity_table
-   *   Entity table.
+   * NOTE: This stub has been preserved because one extension in `universe`
+   * was referencing the function.
    *
-   * @return array|NULL
+   * @deprecated
+   * @see CRM_Core_PrevNextCache_Sql::getSelection()
    */
   public static function getSelection($cacheKey, $action = 'get', $entity_table = 'civicrm_contact') {
-    if (!$cacheKey) {
-      return NULL;
-    }
-    $params = array();
-
-    $entity_whereClause = " AND entity_table = '{$entity_table}'";
-    if ($cacheKey && ($action == 'get' || $action == 'getall')) {
-      $actionGet = ($action == "get") ? " AND is_selected = 1 " : "";
-      $sql = "
-SELECT entity_id1, entity_id2 FROM civicrm_prevnext_cache
-WHERE cacheKey LIKE %1
-      $actionGet
-      $entity_whereClause
-ORDER BY id
-";
-      $params[1] = array("{$cacheKey}%", 'String');
-
-      $contactIds = array($cacheKey => array());
-      $cIdDao = CRM_Core_DAO::executeQuery($sql, $params);
-      while ($cIdDao->fetch()) {
-        if ($cIdDao->entity_id1 == $cIdDao->entity_id2) {
-          $contactIds[$cacheKey][$cIdDao->entity_id1] = 1;
-        }
-      }
-      return $contactIds;
-    }
+    return Civi::service('prevnext')->getSelection($cacheKey, $action, $entity_table);
   }
 
   /**

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -84,4 +84,15 @@ interface CRM_Core_PrevNextCache_Interface {
    */
   public function getSelection($cacheKey, $action = 'get');
 
+  /**
+   * Get the previous and next keys.
+   *
+   * @param string $cacheKey
+   * @param int $id1
+   * @param int $id2
+   *
+   * @return array
+   */
+  public function getPositions($cacheKey, $id1, $id2);
+
 }

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -64,13 +64,11 @@ interface CRM_Core_PrevNextCache_Interface {
    * @param string $cacheKey
    * @param string $action
    *   Ex: 'select', 'unselect'.
-   * @param array|int|NULL $cIds
+   * @param array|int|NULL $ids
    *   A list of contact IDs to (un)select.
    *   To unselect all contact IDs, use NULL.
-   * @param string $entity_table
-   *   Ex: 'civicrm_contact'.
    */
-  public function markSelection($cacheKey, $action = 'unselect', $cIds = NULL, $entity_table = 'civicrm_contact');
+  public function markSelection($cacheKey, $action, $ids = NULL);
 
   /**
    * Get the selections.

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -76,14 +76,12 @@ interface CRM_Core_PrevNextCache_Interface {
    * @param string $cacheKey
    *   Cache key.
    * @param string $action
-   *   Action.
-   *  $action : get - get only selection records
-   *            getall - get all the records of the specified cache key
-   * @param string $entity_table
-   *   Entity table.
+   *   One of the following:
+   *   - 'get' - get only selection records
+   *   - 'getall' - get all the records of the specified cache key
    *
    * @return array|NULL
    */
-  public function getSelection($cacheKey, $action = 'get', $entity_table = 'civicrm_contact');
+  public function getSelection($cacheKey, $action = 'get');
 
 }

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -104,4 +104,12 @@ interface CRM_Core_PrevNextCache_Interface {
    */
   public function deleteItem($id = NULL, $cacheKey = NULL, $entityTable = 'civicrm_contact');
 
+  /**
+   * Get count of matching rows.
+   *
+   * @param string $cacheKey
+   * @return int
+   */
+  public function getCount($cacheKey);
+
 }

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -72,4 +72,20 @@ interface CRM_Core_PrevNextCache_Interface {
    */
   public function markSelection($cacheKey, $action = 'unselect', $cIds = NULL, $entity_table = 'civicrm_contact');
 
+  /**
+   * Get the selections.
+   *
+   * @param string $cacheKey
+   *   Cache key.
+   * @param string $action
+   *   Action.
+   *  $action : get - get only selection records
+   *            getall - get all the records of the specified cache key
+   * @param string $entity_table
+   *   Entity table.
+   *
+   * @return array|NULL
+   */
+  public function getSelection($cacheKey, $action = 'get', $entity_table = 'civicrm_contact');
+
 }

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -95,4 +95,13 @@ interface CRM_Core_PrevNextCache_Interface {
    */
   public function getPositions($cacheKey, $id1, $id2);
 
+  /**
+   * Delete an item from the prevnext cache table based on the entity.
+   *
+   * @param int $id
+   * @param string $cacheKey
+   * @param string $entityTable
+   */
+  public function deleteItem($id = NULL, $cacheKey = NULL, $entityTable = 'civicrm_contact');
+
 }

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -58,4 +58,18 @@ interface CRM_Core_PrevNextCache_Interface {
    */
   public function fillWithArray($cacheKey, $rows);
 
+  /**
+   * Save checkbox selections.
+   *
+   * @param string $cacheKey
+   * @param string $action
+   *   Ex: 'select', 'unselect'.
+   * @param array|int|NULL $cIds
+   *   A list of contact IDs to (un)select.
+   *   To unselect all contact IDs, use NULL.
+   * @param string $entity_table
+   *   Ex: 'civicrm_contact'.
+   */
+  public function markSelection($cacheKey, $action = 'unselect', $cIds = NULL, $entity_table = 'civicrm_contact');
+
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -83,10 +83,10 @@ INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cache
    * @param array|int|NULL $cIds
    *   A list of contact IDs to (un)select.
    *   To unselect all contact IDs, use NULL.
-   * @param string $entity_table
-   *   Ex: 'civicrm_contact'.
    */
-  public function markSelection($cacheKey, $action = 'unselect', $cIds = NULL, $entity_table = 'civicrm_contact') {
+  public function markSelection($cacheKey, $action, $cIds = NULL) {
+    $entity_table = 'civicrm_contact';
+
     if (!$cacheKey) {
       return;
     }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -175,4 +175,20 @@ ORDER BY id
     }
   }
 
+  /**
+   * Get the previous and next keys.
+   *
+   * @param string $cacheKey
+   * @param int $id1
+   * @param int $id2
+   *
+   * NOTE: I don't really get why there are two ID columns, but we'll
+   * keep passing them through as a matter of safe-refactoring.
+   *
+   * @return array
+   */
+  public function getPositions($cacheKey, $id1, $id2) {
+    return CRM_Core_BAO_PrevNextCache::getPositions($cacheKey, $id1, $id2);
+  }
+
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -202,4 +202,14 @@ ORDER BY id
     CRM_Core_BAO_PrevNextCache::deleteItem($id, $cacheKey, $entityTable);
   }
 
+  /**
+   * Get count of matching rows.
+   *
+   * @param string $cacheKey
+   * @return int
+   */
+  public function getCount($cacheKey) {
+    return CRM_Core_BAO_PrevNextCache::getCount($cacheKey, NULL, "entity_table = 'civicrm_contact'");
+  }
+
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -191,4 +191,15 @@ ORDER BY id
     return CRM_Core_BAO_PrevNextCache::getPositions($cacheKey, $id1, $id2);
   }
 
+  /**
+   * Delete an item from the prevnext cache table based on the entity.
+   *
+   * @param int $id
+   * @param string $cacheKey
+   * @param string $entityTable
+   */
+  public function deleteItem($id = NULL, $cacheKey = NULL, $entityTable = 'civicrm_contact') {
+    CRM_Core_BAO_PrevNextCache::deleteItem($id, $cacheKey, $entityTable);
+  }
+
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -74,4 +74,62 @@ INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cache
     return TRUE;
   }
 
+  /**
+   * Save checkbox selections.
+   *
+   * @param string $cacheKey
+   * @param string $action
+   *   Ex: 'select', 'unselect'.
+   * @param array|int|NULL $cIds
+   *   A list of contact IDs to (un)select.
+   *   To unselect all contact IDs, use NULL.
+   * @param string $entity_table
+   *   Ex: 'civicrm_contact'.
+   */
+  public function markSelection($cacheKey, $action = 'unselect', $cIds = NULL, $entity_table = 'civicrm_contact') {
+    if (!$cacheKey) {
+      return;
+    }
+    $params = array();
+
+    $entity_whereClause = " AND entity_table = '{$entity_table}'";
+    if ($cIds && $cacheKey && $action) {
+      if (is_array($cIds)) {
+        $cIdFilter = "(" . implode(',', $cIds) . ")";
+        $whereClause = "
+WHERE cacheKey LIKE %1
+AND (entity_id1 IN {$cIdFilter} OR entity_id2 IN {$cIdFilter})
+";
+      }
+      else {
+        $whereClause = "
+WHERE cacheKey LIKE %1
+AND (entity_id1 = %2 OR entity_id2 = %2)
+";
+        $params[2] = array("{$cIds}", 'Integer');
+      }
+      if ($action == 'select') {
+        $whereClause .= "AND is_selected = 0";
+        $sql = "UPDATE civicrm_prevnext_cache SET is_selected = 1 {$whereClause} {$entity_whereClause}";
+        $params[1] = array("{$cacheKey}%", 'String');
+      }
+      elseif ($action == 'unselect') {
+        $whereClause .= "AND is_selected = 1";
+        $sql = "UPDATE civicrm_prevnext_cache SET is_selected = 0 {$whereClause} {$entity_whereClause}";
+        $params[1] = array("%{$cacheKey}%", 'String');
+      }
+      // default action is reseting
+    }
+    elseif (!$cIds && $cacheKey && $action == 'unselect') {
+      $sql = "
+UPDATE civicrm_prevnext_cache
+SET    is_selected = 0
+WHERE  cacheKey LIKE %1 AND is_selected = 1
+       {$entity_whereClause}
+";
+      $params[1] = array("{$cacheKey}%", 'String');
+    }
+    CRM_Core_DAO::executeQuery($sql, $params);
+  }
+
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -138,15 +138,15 @@ WHERE  cacheKey LIKE %1 AND is_selected = 1
    * @param string $cacheKey
    *   Cache key.
    * @param string $action
-   *   Action.
-   *  $action : get - get only selection records
-   *            getall - get all the records of the specified cache key
-   * @param string $entity_table
-   *   Entity table.
+   *   One of the following:
+   *   - 'get' - get only selection records
+   *   - 'getall' - get all the records of the specified cache key
    *
    * @return array|NULL
    */
-  public function getSelection($cacheKey, $action = 'get', $entity_table = 'civicrm_contact') {
+  public function getSelection($cacheKey, $action = 'get') {
+    $entity_table = 'civicrm_contact';
+
     if (!$cacheKey) {
       return NULL;
     }


### PR DESCRIPTION
Overview
----------------------------------------
The PrevNext BAO provides three functions (`getPositions()`, `deleteItem()`, and `getCount()`) which are used in two disjoint use-cases -- contact-search and dedupe/merge. This PR makes the methods swappable *but only for purposes of the contact-search use-case*.

Relations:
* This is a cherry-pick from #12377.
* To avoid merge-conflicts, this PR extends/depends on #12556. In reviewing the commit list, you can recognize the items relevant to this PR as the last three commits ("Allow swapping ... for purposes of ...")
* Main issue: [dev/core#217](https://lab.civicrm.org/dev/core/issues/217).

Before
----------------------------------------
* `getPositions()`, `deleteItem()`, and `getCount()` are defined in `CRM_Core_BAO_PrevNextCache`.
* Both contact-search and dedupe/merge use-cases use `CRM_Core_BAO_PrevNextCache`.

After
----------------------------------------
* `getPositions()`, `deleteItem()`, and `getCount()` are defined in `CRM_Core_BAO_PrevNextCache`.
* For the dedupe/merge use-case, one still calls the original  `CRM_Core_BAO_PrevNextCache`.
* `getPositions()`, `deleteItem()`, and `getCount()` are defined in `CRM_Core_PrevNextCache_{Interface,Sql}`. (These basically just delegate to the BAO.)
* For the contact-search use-case, one now calls the newer `CRM_Core_PrevNextCache_{Interface,Sql}`.