### PR TITLE
dev/core#278 Fix DB syntax error when try to search deleted cases

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1590,7 +1590,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
  AND civicrm_case.id IN( {$caseID})
  AND civicrm_case.is_deleted     = {$cases['case_deleted']}";
 
-    $query = self::getCaseActivityQuery($type, $userID, $condition, $cases['case_deleted']);
+    $query = self::getCaseActivityQuery($type, $userID, $condition);
 
     $res = CRM_Core_DAO::executeQuery($query);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix DB syntax error when try to search deleted cases.

Before
----------------------------------------
* open Cases > Find Cases
* select Deleted Cases checkbox
* click Search button
* result: DB Error: syntax error

![case-search-deleted](https://user-images.githubusercontent.com/8309610/43189759-ab1a2a62-8ff7-11e8-8433-32a55d218732.png)

After
----------------------------------------
Searching for deleted and non-deleted cases works fine.

Technical Details
----------------------------------------
There was invalid argument in getCaseActivityQuery() method - for $limit argument was used $cases['case_deleted']

Issue
https://lab.civicrm.org/dev/core/issues/278