### PR TITLE
Mailing - ignore case-sensitive string when extracting category from mail template tokens

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -547,9 +547,20 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         $funcStruct['type'] = 'url';
       }
     }
+    elseif (preg_match('/^\{(' . $_categoryString . ')\.(\w+)\}$/', $token, $matches)) {
+      $funcStruct['type'] = $matches[1];
+      $funcStruct['token'] = $matches[2];
+    }
     elseif (preg_match('/^\{(' . $_categoryString . ')\.(\w+)\}$/i', $token, $matches)) {
+      //fix to address issues when token is converted to upercasse string by package rcube_html2text
+      $tokens = CRM_Utils_Token::$_tokens;
       $funcStruct['type'] = strtolower($matches[1]);
       $funcStruct['token'] = strtolower($matches[2]);
+
+      if (!empty($tokens[$funcStruct['type']] && in_array($funcStruct['token'], array_map('strtolower', $tokens[$funcStruct['type']])))) {
+        $token_key = array_search($funcStruct['token'], array_map('strtolower', $tokens[$funcStruct['type']]));
+        $funcStruct['token'] = $tokens[$funcStruct['type']][$token_key];
+      }
     }
     elseif (preg_match('/\\\\\{(\w+\.\w+)\\\\\}|\{\{(\w+\.\w+)\}\}/', $token, $matches)) {
       // we are an escaped token

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -547,9 +547,9 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         $funcStruct['type'] = 'url';
       }
     }
-    elseif (preg_match('/^\{(' . $_categoryString . ')\.(\w+)\}$/', $token, $matches)) {
-      $funcStruct['type'] = $matches[1];
-      $funcStruct['token'] = $matches[2];
+    elseif (preg_match('/^\{(' . $_categoryString . ')\.(\w+)\}$/i', $token, $matches)) {
+      $funcStruct['type'] = strtolower($matches[1]);
+      $funcStruct['token'] = strtolower($matches[2]);
     }
     elseif (preg_match('/\\\\\{(\w+\.\w+)\\\\\}|\{\{(\w+\.\w+)\}\}/', $token, $matches)) {
       // we are an escaped token


### PR DESCRIPTION
Overview
----------------------------------------
It looks like tokens that are 'alone' inside an HTML are accidentally stripped out of the plain text version that CiviCRM generates.

Steps to recreate

* Set outbound emial to redirect to DB
* Create a new mailing with the HTML
```
<html>
<head>
<title></title>
</head>
<body>
<p>Serial BOLD&nbsp;1:&nbsp;<strong>{contact.display_name}</strong></p>
<p>Serial 2:&nbsp;{contact.display_name}</p>
<p>Serial 2:&nbsp;{CONTACT.DISPLAY_NAME}</p>
</body>
</html>
```

* Send it
* Check the civicrm_mailing_spool table
* Inspect the body field
* Notice that it is correct in HTML version, but missing in plain text version


Before
----------------------------------------
Example:
![image](https://user-images.githubusercontent.com/5859294/43250933-6dfd70b6-90b6-11e8-8c44-fe0d2e1c9340.png)

After
----------------------------------------
Example:
![image](https://user-images.githubusercontent.com/5859294/43271197-d3e22c5e-90ee-11e8-8b7b-1dad25487e5a.png)


Technical Details
----------------------------------------
Civi CRM_Utils_String::htmlToText use library: rcube_html2text (file: CRM_Mailing_BAO_Mailing). Library convert html template to text version.

For tags like: strong, b, th, etc.. (look variable: callback_search and method: tags_preg_callback in class rcube_html2text )
method is removing specified tags and return string which is uppercase. 
Example: <strong>token:{contact.display_name}</strong> will be converted to TOKEN:{CONTACT.DISPLAY_NAME}
CiviCrm not processing uppercase tokens.
