### PR TITLE
dev/279 - When Merging two contacts flip, prev, next not working

### DIFF
--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -47,9 +47,9 @@
   </div>
 
   <div class="action-link">
-    {if $prev}<a href="{$prev|escape}" class="crm-hover-button action-item"><i class="crm-i fa-chevron-left"></i> {ts}Previous{/ts}</a>{/if}
-    {if $next}<a href="{$next|escape}" class="crm-hover-button action-item">{ts}Next{/ts} <i class="crm-i fa-chevron-right"></i></a>{/if}
-    <a href="{$flip|escape}" class="action-item crm-hover-button">
+    {if $prev}<a href="{$prev}" class="crm-hover-button action-item"><i class="crm-i fa-chevron-left"></i> {ts}Previous{/ts}</a>{/if}
+    {if $next}<a href="{$next}" class="crm-hover-button action-item">{ts}Next{/ts} <i class="crm-i fa-chevron-right"></i></a>{/if}
+    <a href="{$flip}" class="action-item crm-hover-button">
       <i class="crm-i fa-random"></i>
       {ts}Flip between original and duplicate contacts.{/ts}
     </a>


### PR DESCRIPTION
Affects Joomla and WordPress

Signed-off-by: Kevin Cristiano <kcristiano@tadpole.cc>

Overview
----------------------------------------
When Merging two contacts, Prreevios, Next, and Flip between original and duplicate link not working in Joomla and WordPress

Before
----------------------------------------
When clicking in the links for previous, next, or flip the user would be redirected to the CiviCRM home page

After
----------------------------------------
When clicking on the links the user gets the expected behavior

Technical Details
----------------------------------------
see https://lab.civicrm.org/dev/core/issues/279 and https://chat.civicrm.org/civicrm/pl/inrp143b7jgxmboqozdnxprqae   
From Eileen's comments on the issue: "Have discussed with Kevin on chat - basically our function CRM_Utils_System::url is deeply inconsistent :-( If it is passed a query it url_encodes the keys & values and to escape in smarty would be wrong."

