### PR TITLE
Fix Wordpress merge screen regression Undo overzealous escaping on urls as causing WP regression.

### DIFF
--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -47,9 +47,9 @@
   </div>
 
   <div class="action-link">
-    {if $prev}<a href="{$prev|escape}" class="crm-hover-button action-item"><i class="crm-i fa-chevron-left"></i> {ts}Previous{/ts}</a>{/if}
-    {if $next}<a href="{$next|escape}" class="crm-hover-button action-item">{ts}Next{/ts} <i class="crm-i fa-chevron-right"></i></a>{/if}
-    <a href="{$flip|escape}" class="action-item crm-hover-button">
+    {if $prev}<a href="{$prev}" class="crm-hover-button action-item"><i class="crm-i fa-chevron-left"></i> {ts}Previous{/ts}</a>{/if}
+    {if $next}<a href="{$next}" class="crm-hover-button action-item">{ts}Next{/ts} <i class="crm-i fa-chevron-right"></i></a>{/if}
+    <a href="{$flip}" class="action-item crm-hover-button">
       <i class="crm-i fa-random"></i>
       {ts}Flip between original and duplicate contacts.{/ts}
     </a>


### PR DESCRIPTION
Overview
----------------------------------------
Security release 5.3.2 was overzealous in some of it's escaping, breaking merge links on Wordpress

Before
----------------------------------------
Flip, Prev & next links don't work on Wordpress 5.3

After
----------------------------------------
Flip, Prev & next links do work on Wordpress 5.3


Technical Details
----------------------------------------
Provided urls are generated by passing an array to CRM_System_Url they generate url encoded urls so we shouldn't escape
in the tpl

Comments
----------------------------------------

