### PR TITLE
(dev/core#281) Fix invoice number in message template

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -80,7 +80,6 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'event_online_receipt', 'type' => 'text'],
           ['name' => 'event_online_receipt', 'type' => 'html'],
           ['name' => 'event_online_receipt', 'type' => 'subject'],
-          ['name' => 'contribution_invoice_receipt', 'type' => 'html'],
         ]
       ],
       [

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -83,6 +83,13 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'contribution_invoice_receipt', 'type' => 'html'],
         ]
       ],
+      [
+        'version' => '5.5.alpha1',
+        'upgrade_descriptor' => ts('Fix invoice number (human readable) instead of id (reference)'),
+        'templates' => [
+          ['name' => 'contribution_invoice_receipt', 'type' => 'html'],
+        ]
+      ]
     ];
   }
 

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -80,6 +80,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'event_online_receipt', 'type' => 'text'],
           ['name' => 'event_online_receipt', 'type' => 'html'],
           ['name' => 'event_online_receipt', 'type' => 'subject'],
+          ['name' => 'contribution_invoice_receipt', 'type' => 'html'],
         ]
       ],
     ];

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -211,7 +211,7 @@
                 <tr>
                   <td colspan = "2"></td>
                   <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Invoice Number: {/ts}</font></td>
-                  <td><font size = "1" align = "right">{$invoice_id}</font></td>
+                  <td><font size = "1" align = "right">{$invoice_number}</font></td>
                 </tr>
                 <tr><td colspan = "5"style = "color:#F5F5F5;"><hr></hr></td></tr>
                 {if $is_pay_later == 1}


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
-------------------

1. Find Contributions with status *Pending*.
2. Choose a contribution record and from bulk actions choose *Invoices - Print or Email*.
3. The invoice still shows invoice id instead of human readable invoice id.

Before
----------------------------------------
![inv_pending_before](https://user-images.githubusercontent.com/3455173/43247215-aae9787e-90d1-11e8-84bc-38ca57398494.png)


After
----------------------------------------
![invoice_after](https://user-images.githubusercontent.com/3455173/43247228-b4be08d8-90d1-11e8-9f03-fd87c245fbf1.png)


Comments
----------------------------------------
Changes were introduced in https://github.com/civicrm/civicrm-core/pull/10298
