### PR TITLE
Added code to throw exception on getvalue api call

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -235,6 +235,9 @@ trait Api3TestTrait {
       'debug' => 1,
     );
     $result = $this->civicrm_api($entity, 'getvalue', $params);
+    if (is_array($result) && (!empty($result['is_error']) || isset($result['values']))) {
+      throw new \Exception('Invalid getvalue result' . print_r($result, TRUE));
+    }
     if ($type) {
       if ($type == 'integer') {
         // api seems to return integers as strings


### PR DESCRIPTION
Overview
----------------------------------------
Api/Unit test doesn't fail if getvalue api throws errors (when using $this->callAPISuccessGetValue())

Before
----------------------------------------
No error when $this->callAPISuccessGetValue() failed to retrieve 

After
----------------------------------------
Error when $this->callAPISuccessGetValue() failed to retrieve 
