### PR TITLE
Export minor refactor Move household relationship types to the processor

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -44,24 +44,6 @@ class CRM_Export_BAO_Export {
   /**
    * Key representing the head of household in the relationship array.
    *
-   * e.g. 8_a_b.
-   *
-   * @var string
-   */
-  protected static $headOfHouseholdRelationshipKey;
-
-  /**
-   * Key representing the head of household in the relationship array.
-   *
-   * e.g. 8_a_b.
-   *
-   * @var string
-   */
-  protected static $memberOfHouseholdRelationshipKey;
-
-  /**
-   * Key representing the head of household in the relationship array.
-   *
    * e.g. ['8_b_a' => 'Household Member Is', '8_a_b = 'Household Member Of'.....]
    *
    * @var
@@ -244,7 +226,7 @@ class CRM_Export_BAO_Export {
     $queryOperator = 'AND'
   ) {
 
-    $processor = new CRM_Export_BAO_ExportProcessor($exportMode, $fields, $queryOperator);
+    $processor = new CRM_Export_BAO_ExportProcessor($exportMode, $fields, $queryOperator, $mergeSameHousehold);
     $returnProperties = array();
 
     $phoneTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
@@ -252,9 +234,6 @@ class CRM_Export_BAO_Export {
     // without manually testing the export of IM provider still works.
     $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
     self::$relationshipTypes = $processor->getRelationshipTypes();
-    //also merge Head of Household
-    self::$memberOfHouseholdRelationshipKey = CRM_Utils_Array::key('Household Member of', self::$relationshipTypes);
-    self::$headOfHouseholdRelationshipKey = CRM_Utils_Array::key('Head of Household for', self::$relationshipTypes);
 
     $queryMode = $processor->getQueryMode();
 
@@ -376,15 +355,13 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
       foreach ($returnProperties as $key => $value) {
         if (!$processor->isRelationshipTypeKey($key)) {
-          $returnProperties[self::$memberOfHouseholdRelationshipKey][$key] = $value;
-          $returnProperties[self::$headOfHouseholdRelationshipKey][$key] = $value;
+          foreach ($processor->getHouseholdRelationshipTypes() as $householdRelationshipType) {
+            if (!in_array($key, ['location_type', 'im_provider'])) {
+              $returnProperties[$householdRelationshipType][$key] = $value;
+            }
+          }
         }
       }
-
-      unset($returnProperties[self::$memberOfHouseholdRelationshipKey]['location_type']);
-      unset($returnProperties[self::$memberOfHouseholdRelationshipKey]['im_provider']);
-      unset($returnProperties[self::$headOfHouseholdRelationshipKey]['location_type']);
-      unset($returnProperties[self::$headOfHouseholdRelationshipKey]['im_provider']);
     }
 
     list($relationQuery, $allRelContactArray) = self::buildRelatedContactArray($selectAll, $ids, $exportMode, $componentTable, $returnProperties, $queryMode);
@@ -620,8 +597,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
       // merge the records if they have corresponding households
       if ($mergeSameHousehold) {
-        self::mergeSameHousehold($exportTempTable, $headerRows, $sqlColumns, self::$memberOfHouseholdRelationshipKey);
-        self::mergeSameHousehold($exportTempTable, $headerRows, $sqlColumns, self::$headOfHouseholdRelationshipKey);
+        foreach ($processor->getHouseholdRelationshipTypes() as $householdRelationshipType) {
+          self::mergeSameHousehold($exportTempTable, $sqlColumns, $householdRelationshipType);
+        }
       }
 
       // call export hook
@@ -633,7 +611,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         self::writeCSVFromTable($exportTempTable, $headerRows, $sqlColumns, $exportMode);
       }
       else {
-        // return tableName and sqlColumns in test context
+        // return tableName sqlColumns headerRows in test context
         return array($exportTempTable, $sqlColumns, $headerRows);
       }
 
@@ -1171,18 +1149,15 @@ WHERE  id IN ( $deleteIDString )
    *
    * @param string $exportTempTable
    *   Temporary temp table that stores the records.
-   * @param array $headerRows
-   *   Array of headers for the export file.
    * @param array $sqlColumns
    *   Array of names of the table columns of the temp table.
    * @param string $prefix
    *   Name of the relationship type that is prefixed to the table columns.
    */
-  public static function mergeSameHousehold($exportTempTable, &$headerRows, &$sqlColumns, $prefix) {
+  public static function mergeSameHousehold($exportTempTable, &$sqlColumns, $prefix) {
     $prefixColumn = $prefix . '_';
     $allKeys = array_keys($sqlColumns);
     $replaced = array();
-    $headerRows = array_values($headerRows);
 
     // name map of the non standard fields in header rows & sql columns
     $mappingFields = array(
@@ -1214,9 +1189,6 @@ WHERE  id IN ( $deleteIDString )
     foreach ($replaced as $from => $to) {
       $clause[] = "$from = $to ";
       unset($sqlColumns[$to]);
-      if ($key = CRM_Utils_Array::key($to, $allKeys)) {
-        unset($headerRows[$key]);
-      }
     }
     $query .= implode(",\n", $clause);
     $query .= " WHERE {$replaced['civicrm_primary_id']} != ''";
@@ -1415,6 +1387,9 @@ WHERE  {$whereClause}";
       // @todo - set this correctly in the xml rather than here.
       $headerRows[] = ts('Campaign ID');
     }
+    elseif ($processor->isMergeSameHousehold() && $field === 'id') {
+      $headerRows[] = ts('Household ID');
+    }
     elseif (isset($queryFields[$field]['title'])) {
       $headerRows[] = $queryFields[$field]['title'];
     }
@@ -1438,7 +1413,10 @@ WHERE  {$whereClause}";
             }
           }
 
-          $headerRows[] = $headerName;
+          if (!$processor->isHouseholdMergeRelationshipTypeKey($field)) {
+            // Do not add to header row if we are only generating for merge reasons.
+            $headerRows[] = $headerName;
+          }
 
           self::sqlColumnDefn($processor, $sqlColumns, $headerName);
         }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -122,10 +122,8 @@ class CRM_Export_BAO_Export {
 
   /**
    * Get Query Group By Clause
-   * @param int $exportMode
+   * @param \CRM_Export_BAO_ExportProcessor $processor
    *   Export Mode
-   * @param string $queryMode
-   *   Query Mode
    * @param array $returnProperties
    *   Return Properties
    * @param object $query
@@ -134,8 +132,10 @@ class CRM_Export_BAO_Export {
    * @return string $groupBy
    *   Group By Clause
    */
-  public static function getGroupBy($exportMode, $queryMode, $returnProperties, $query) {
+  public static function getGroupBy($processor, $returnProperties, $query) {
     $groupBy = '';
+    $exportMode = $processor->getExportMode();
+    $queryMode = $processor->getQueryMode();
     if (!empty($returnProperties['tags']) || !empty($returnProperties['groups']) ||
       CRM_Utils_Array::value('notes', $returnProperties) ||
       // CRM-9552
@@ -364,7 +364,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       }
     }
 
-    list($relationQuery, $allRelContactArray) = self::buildRelatedContactArray($selectAll, $ids, $exportMode, $componentTable, $returnProperties, $queryMode);
+    list($relationQuery, $allRelContactArray) = self::buildRelatedContactArray($selectAll, $ids, $processor, $componentTable, $returnProperties);
 
     // make sure the groups stuff is included only if specifically specified
     // by the fields param (CRM-1969), else we limit the contacts outputted to only
@@ -409,7 +409,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
     $queryString = "$select $from $where $having";
 
-    $groupBy = self::getGroupBy($exportMode, $queryMode, $returnProperties, $query);
+    $groupBy = self::getGroupBy($processor, $returnProperties, $query);
 
     $queryString .= $groupBy;
 
@@ -1701,15 +1701,16 @@ WHERE  {$whereClause}";
   /**
    * @param $selectAll
    * @param $ids
-   * @param $exportMode
+   * @param \CRM_Export_BAO_ExportProcessor $processor
    * @param $componentTable
    * @param $returnProperties
-   * @param $queryMode
+   *
    * @return array
    */
-  protected static function buildRelatedContactArray($selectAll, $ids, $exportMode, $componentTable, $returnProperties, $queryMode) {
+  protected static function buildRelatedContactArray($selectAll, $ids, $processor, $componentTable, $returnProperties) {
     $allRelContactArray = $relationQuery = array();
-
+    $queryMode = $processor->getQueryMode();
+    $exportMode = $processor->getExportMode();
     foreach (self::$relationshipTypes as $rel => $dnt) {
       if ($relationReturnProperties = CRM_Utils_Array::value($rel, $returnProperties)) {
         $allRelContactArray[$rel] = array();

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -73,6 +73,13 @@ class CRM_Export_BAO_ExportProcessor {
   protected $requestedFields;
 
   /**
+   * Is the contact being merged into a single household.
+   *
+   * @var bool
+   */
+  protected $isMergeSameHousehold;
+
+  /**
    * Key representing the head of household in the relationship array.
    *
    * e.g. ['8_b_a' => 'Household Member Is', '8_a_b = 'Household Member Of'.....]
@@ -99,13 +106,15 @@ class CRM_Export_BAO_ExportProcessor {
    * @param int $exportMode
    * @param array|NULL $requestedFields
    * @param string $queryOperator
+   * @param bool $isMergeSameHousehold
    */
-  public function __construct($exportMode, $requestedFields, $queryOperator) {
+  public function __construct($exportMode, $requestedFields, $queryOperator, $isMergeSameHousehold = FALSE) {
     $this->setExportMode($exportMode);
     $this->setQueryMode();
     $this->setQueryOperator($queryOperator);
     $this->setRequestedFields($requestedFields);
     $this->setRelationshipTypes();
+    $this->setIsMergeSameHousehold($isMergeSameHousehold);
   }
 
   /**
@@ -158,6 +167,34 @@ class CRM_Export_BAO_ExportProcessor {
     );
   }
 
+  /**
+   * @return bool
+   */
+  public function isMergeSameHousehold() {
+    return $this->isMergeSameHousehold;
+  }
+
+  /**
+   * @param bool $isMergeSameHousehold
+   */
+  public function setIsMergeSameHousehold($isMergeSameHousehold) {
+    $this->isMergeSameHousehold = $isMergeSameHousehold;
+  }
+
+  /**
+   * Return relationship types for household merge.
+   *
+   * @return mixed
+   */
+  public function getHouseholdRelationshipTypes() {
+    if (!$this->isMergeSameHousehold()) {
+      return [];
+    }
+    return [
+      CRM_Utils_Array::key('Household Member of', $this->getRelationshipTypes()),
+      CRM_Utils_Array::key('Head of Household for', $this->getRelationshipTypes()),
+    ];
+  }
 
   /**
    * @param $fieldName
@@ -165,6 +202,15 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function isRelationshipTypeKey($fieldName) {
     return array_key_exists($fieldName, $this->relationshipTypes);
+  }
+
+
+  /**
+   * @param $fieldName
+   * @return bool
+   */
+  public function isHouseholdMergeRelationshipTypeKey($fieldName) {
+    return in_array($fieldName, $this->getHouseholdRelationshipTypes());
   }
 
   /**

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -427,7 +427,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       ['Individual', 'city', ''],
       ['Individual', 'state_province', ''],
     ];
-    list($tableName) = CRM_Export_BAO_Export::exportComponents(
+    list($tableName, $sqlColumns, $headerRows) = CRM_Export_BAO_Export::exportComponents(
       FALSE,
       $this->contactIDs,
       [],
@@ -452,6 +452,17 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       $this->assertEquals($householdID, $dao->civicrm_primary_id);
     }
 
+    $this->assertEquals([
+      0 => 'City',
+      1 => 'State',
+      2 => 'Household ID',
+    ], $headerRows);
+    $this->assertEquals(
+      [
+        'city' => 'city varchar(64)',
+        'state_province' => 'state_province varchar(64)',
+        'civicrm_primary_id' => 'civicrm_primary_id varchar(16)',
+      ], $sqlColumns);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Code clean up on export : move static variables to the new OO processor class

Before
----------------------------------------
Code less maintainable

Uses 
```
protected static $headOfHouseholdRelationshipKey;
protected static $memberOfHouseholdRelationshipKey;
```

After
----------------------------------------
Code more maintainable. Uses

```
$processor->getHouseholdRelationshipTypes()
```


Technical Details
----------------------------------------
This change is comprehensively covered by this test https://github.com/civicrm/civicrm-core/blob/master/tests/phpunit/CRM/Export/BAO/ExportTest.php#L421 

@monishdeb when I went to enable the test I found it was a bit broken in the scenario covered by the test. I don't know how realistic is is but the test was requesting a household merge and additionally for household related fields to be returned. The code was deliberately unsetting the headers & sql columns inconsistently here. I updated so that the headers would never be set for household relationship types when merge to household is configured. This is a code simplification & consistent with what the code was trying to do. However, it's not 100% what the user would expect. I think this is a forwards rather than backwards step though.

Comments
----------------------------------------
Part of larger cleanup - current WIP is #12575

