### PR TITLE
CRM-21427 - Add form validation to make it clear we only allow a single website of each type

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -615,6 +615,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $blocks['Address'] = $otherEditOptions['Address'];
     }
 
+    $website_types = array();
     $openIds = array();
     $primaryID = FALSE;
     foreach ($blocks as $name => $label) {
@@ -629,8 +630,17 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           }
 
           if ($dataExists) {
-            // skip remaining checks for website
             if ($name == 'website') {
+              if (!empty($blockValues['website_type_id'])) {
+                if (empty($website_types[$blockValues['website_type_id']])) {
+                  $website_types[$blockValues['website_type_id']] = $blockValues['website_type_id'];
+                }
+                else {
+                  $errors["{$name}[1][website_type_id]"] = ts('Contacts may only have one website of each type at most.');
+                }
+              }
+
+             // skip remaining checks for website
               continue;
             }
 

--- a/CRM/Contact/Form/Inline/Website.php
+++ b/CRM/Contact/Form/Inline/Website.php
@@ -87,6 +87,8 @@ class CRM_Contact_Form_Inline_Website extends CRM_Contact_Form_Inline {
       CRM_Contact_Form_Edit_Website::buildQuickForm($this, $blockId, TRUE);
     }
 
+    $this->addFormRule(array('CRM_Contact_Form_Inline_Website', 'formRule'), $this);
+
   }
 
   /**
@@ -128,4 +130,37 @@ class CRM_Contact_Form_Inline_Website extends CRM_Contact_Form_Inline {
     $this->response();
   }
 
+  /**
+   * Global validation rules for the form.
+   *
+   * @param array $fields
+   *   Posted values of the form.
+   * @param array $errors
+   *   List of errors to be posted back to the form.
+   * @param CRM_Contact_Form_Inline_Website $form
+   *
+   * @return array
+   */
+  public static function formRule($fields, $errors, $form) {
+    $hasData = $errors = array();
+    if (!empty($fields['website']) && is_array($fields['website'])) {
+      $types = array();
+      foreach ($fields['website'] as $instance => $blockValues) {
+        $dataExists = CRM_Contact_Form_Contact::blockDataExists($blockValues);
+
+        if ($dataExists) {
+          $hasData[] = $instance;
+          if (!empty($blockValues['website_type_id'])) {
+            if (empty($types[$blockValues['website_type_id']])) {
+              $types[$blockValues['website_type_id']] = $blockValues['website_type_id'];
+            }
+            else {
+              $errors["website[" . $instance . "][website_type_id]"] = ts('Contacts may only have one website of each type at most.');
+            }
+          }
+        }
+      }
+    }
+    return $errors;
+  }
 }

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -99,7 +99,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
 
     $ids = self::allWebsites($contactID);
     foreach ($params as $key => $values) {
-      if (empty($values['id']) && is_array($ids) && !empty($ids)) {
+      if (empty($values['id']) && is_array($ids) && !empty($ids) && !empty($values['website_type_id'])) {
         foreach ($ids as $id => $value) {
           if (($value['website_type_id'] == $values['website_type_id'])) {
             $values['id'] = $id;


### PR DESCRIPTION
Overview
----------------------------------------

Fix for https://issues.civicrm.org/jira/browse/CRM-21427 where websites tend to "disappear" without warning.

Based on the different existing issues and PRs, this PR mainly attempts to consolidate existing behavior, rather than changing anything too deeply, by showing an error when attempting to enter multiple websites of the same type. This seemed illogical for websites without types, and after some testing it seems we can safely allow multiple websites without types.

Before
----------------------------------------
The second website of any given type will be removed without warning when saving again.

After
----------------------------------------
Websites without type can be added at will without being removed. Websites with a specified type are only allowed to be added once for each type.

Technical Details
----------------------------------------
Not many technical changes, the unique website type is a UI validation. #11428 attempted to allow multiple websites of the same type and was reverted. This is partly because of assumptions about website types in templates. However no such assumption would be made for websites without types, as they've only been allowed since #11683.

As discussed in #11694 (point b), there doesn't appear to be a consensus that multiple websites types should be unique, but the current behavior is still counter-intuitive, as it "fixes" the problem silently in a way. Therefore this PR mainly explicitly prohibits the action that was previously suppressed implicitly.

Comments
----------------------------------------
Tested on  CiviCRM 5.3.1