### PR TITLE
dev/core#288 : Use the correct membership date for the notification that appear after completing the membership payment in case pre hook is used

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5213,23 +5213,16 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
         $updatedStatusName = CRM_Utils_Array::value($updatedStatusId,
           CRM_Member_PseudoConstant::membershipStatus()
         );
-        if ($updatedStatusName == 'Cancelled') {
-          $statusMsg .= "<br />" . ts("Membership for %1 has been Cancelled.", array(1 => $userDisplayName));
+
+        $statusNameMsgPart = 'updated';
+        switch ($updatedStatusName) {
+          case 'Cancelled':
+          case 'Expired':
+            $statusNameMsgPart = $updatedStatusName;
+            break;
         }
-        elseif ($updatedStatusName == 'Expired') {
-          $statusMsg .= "<br />" . ts("Membership for %1 has been Expired.", array(1 => $userDisplayName));
-        }
-        else {
-          $endDate = self::getFormattedMembershipEndDateFromContributionId($contributionId);
-          if ($endDate) {
-            $statusMsg .= "<br />" . ts("Membership for %1 has been updated. The membership End Date is %2.",
-                array(
-                  1 => $userDisplayName,
-                  2 => $endDate,
-                )
-              );
-          }
-        }
+
+        $statusMsg .= "<br />" . ts("Membership for %1 has been %2.", array(1 => $userDisplayName, 2 => $statusNameMsgPart));
       }
 
       if ($componentName == 'CiviEvent') {
@@ -5261,25 +5254,6 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
     }
 
     return $statusMsg;
-  }
-
-  private static function getFormattedMembershipEndDateFromContributionId($contributionId) {
-    $endDateResponse = civicrm_api3('MembershipPayment', 'get', [
-      'sequential' => 1,
-      'contribution_id' => $contributionId,
-      'api.Membership.get' => ['id' => '$value.id', 'return' => ['end_date']],
-      'options' => ['limit' => 1, 'sort' => 'id DESC'],
-    ]);
-
-    $endDate = NULL;
-    if (!empty($endDateResponse['values'][0]['api.Membership.get']['count'])) {
-      $endDate = $endDateResponse['values'][0]['api.Membership.get']['values'][0]['end_date'];
-      $endDate = CRM_Utils_Date::customFormat($endDate,
-        '%B %E%f, %Y'
-      );
-    }
-
-    return $endDate;
   }
 
   /**

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2008,7 +2008,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
               );
             }
 
-            $updateResult['membership_end_date'] = CRM_Utils_Date::customFormat($dates['end_date'],
+            $updateResult['membership_end_date'] = CRM_Utils_Date::customFormat($membership->end_date,
               '%B %E%f, %Y'
             );
             $updateResult['updatedComponents']['CiviMember'] = $membership->status_id;


### PR DESCRIPTION
Suppose you have an extension that implements **hook_civicrm_pre** on membership entity that add 1 year (or whatever amount of time) to the membership new end date whenever someone completed a pending payment for the membership, Based on this assume the following example : 


1- You created a pending membership starts today (27/7/2018) and ends in 1 year (26/7/2019).
2- You changed this membership payment (contribution) from "pending" to "completed".


Now without the hook implementation as explained above, the following message will appear : 

```
the contribution record has been saved. 
Membership for "CONTACT NAME" has been updated. The membership End Date is July 26th, 2019.
```

and the membership status will be change from Pending to New, And the end date of the membership will be similar to the one shown in the notification message which is 26/7/2019  which is all good.

But when you have the pre hook implemented as suggest above, the membership end date will be 26/7/2020 (since the hook add one year to the end date) but the notification message will still indicate the old end date which is 26/7/2019. This is wrong and the notification message should show the correct end date that reflects the membership actual end date.



## Update 1

After the discussion below, we decided to remove the end date part from the membership notification for the following reasons : 

1- If someone is paying using a price-set for two memberships, then the notification will show the end date of the last membership only.

2- Removing the end date code make the code much simpler and it does not affect the  functionally nor the usability.