### PR TITLE
dev/core#291 Allow for field size to be set for password fields

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1589,6 +1589,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         return $this->addEntityRef($name, $label, $props, $required);
 
       case 'Password':
+        $props['size'] = isset($props['size']) ? $props['size'] : 60;
         return $this->add('password', $name, $label, $props, $required);
 
       // Check datatypes of fields


### PR DESCRIPTION
Overview
----------------------------------------
Allow for the size of a password field to be set in the props

Before
----------------------------------------
password fields were all of one size

After
----------------------------------------
password fields can be any size.

Technical Details
----------------------------------------
This replicates the setting of the `props['size']` as per text number email etc fields

ping @eileenmcnaughton @monishdeb @totten 