### PR TITLE
API : Set current domain as a sensible default for payment processor

### DIFF
--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -61,6 +61,7 @@ function _civicrm_api3_payment_processor_create_spec(&$params) {
   $params['payment_processor_type_id']['api.required'] = 1;
   $params['is_default']['api.default'] = 0;
   $params['is_test']['api.default'] = 0;
+  $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
 }
 
 /**

--- a/api/v3/PaymentProcessorType.php
+++ b/api/v3/PaymentProcessorType.php
@@ -56,7 +56,6 @@ function _civicrm_api3_payment_processor_type_create_spec(&$params) {
   $params['class_name']['api.required'] = 1;
   $params['is_active']['api.default'] = 1;
   $params['is_recur']['api.default'] = FALSE;
-  // FIXME bool support // $params['is_recur']['api.required'] = 1;
   $params['name']['api.required'] = 1;
   $params['title']['api.required'] = 1;
   $params['payment_instrument_id']['api.default'] = 'Credit Card';


### PR DESCRIPTION
Overview
----------------------------------------
Change api PaymentProcessor.create action such that domain_id is optional. When id is not present use the current domain as a default.

Before
----------------------------------------
```
    $processor = $this->callAPISuccess('PaymentProcessor', 'create', [
      'payment_processor_type_id' => 'omnipay_PayPal_Express',
    ]);
```
Fails as domain_id is mandatory

After
----------------------------------------
Above passes & current domain id is used.

Technical Details
----------------------------------------
This is consistent with other api - e.g Navigation.

Comments
----------------------------------------

