### PR TITLE
Use "text" type mysql field when exporting any id-type field

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -516,6 +516,10 @@ class CRM_Export_BAO_ExportProcessor {
   public function getSqlColumnDefinition($field) {
     $fieldName = $this->getMungedFieldName($field);
     $queryFields = $this->getQueryFields();
+    // special case: civicirm_primary_id exports the contact id and is an index field
+    if ($fieldName == 'civicrm_primary_id') {
+      return "$fieldName varchar(16)";
+    }
     // set the sql columns
     if (isset($queryFields[$field]['type'])) {
       switch ($queryFields[$field]['type']) {


### PR DESCRIPTION
Use text type field when exporting any id-type field that might get converted into text of arbitrary length

Overview
----------------------------------------
Exports of fields that contain "id" type values may contain text of arbitrary length (e.g. values from option groups). 
1. Fix the code so that the previous collection of ad-hoc fixes are replaced by a more comprehensive solution. 
2. Replace the use of varchar(xyz) fields with text type fields to reduce the chance of the row length maximum being reached.

Before
----------------------------------------
Add a gender type "I am not sure and neither are you" (i.e. anything more than 16 characters). You will be unable to export contacts if you include gender in your export fields: you'll get the unhelpful "DB Error Unknown error" fatal error.

After
----------------------------------------
Export now works.

Technical Details
----------------------------------------

1. This PR as per the discussion here: https://lab.civicrm.org/dev/core/issues/181
2. Useful documentation about row length contributions of different field types (i.e. why we're using text instead of varchar) is here: https://dev.mysql.com/doc/refman/8.0/en/column-count-limit.html#row-size-limits.
3. Replaces the code fixes of CRM-12100, CRM-16939, CRM-14398 (at least).

Comments
----------------------------------------
Testing the effects of the change in a large export would be worthwhile, i.e the performance and disk-usage implications.

---

 * [CRM-12100: On export participants, fatal error if shared address belongs to contact with very long name](https://issues.civicrm.org/jira/browse/CRM-12100)
 * [CRM-16939: Current Employer field is cut off at 64 characters on export](https://issues.civicrm.org/jira/browse/CRM-16939)
 * [CRM-14398: Fatal error exporting contributions with campaigns, if campaign name \> 16 chars](https://issues.civicrm.org/jira/browse/CRM-14398)