### PR TITLE
dev/mail#21 trim test emails

### DIFF
--- a/ang/crmMailing/BlockPreview.js
+++ b/ang/crmMailing/BlockPreview.js
@@ -21,6 +21,7 @@
           });
         };
         scope.doSend = function doSend(recipient) {
+          recipient = JSON.parse(JSON.stringify(recipient).replace(/\,\s/g, ','));
           scope.$eval(attr.onSend, {
             preview: {recipient: recipient}
           });


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/mail/issues/21
Sending a test email to multiple recipients may result in duplicate contacts being created.

Before
----------------------------------------
If sending a test email to multiple email addresses that are separated by a comma and space, the second+ email may result in a duplicate contact being created.

After
----------------------------------------
No duplicate is created.

Technical Details
----------------------------------------
The comma-separated list of email addresses needed to be trimmed in order to ensure a valid match with existing contacts.