### PR TITLE
Skip check for format method when there is no valid geocoding provider

### DIFF
--- a/CRM/Utils/GeocodeProvider.php
+++ b/CRM/Utils/GeocodeProvider.php
@@ -84,7 +84,7 @@ class CRM_Utils_GeocodeProvider {
       // or extend a base class. While we identify and implement a geocoding
       // abstraction library (rather than continue to roll our own), we settle for
       // this check.
-      if (!method_exists($provider, 'format')) {
+      if (!method_exists($provider, 'format') && $provider !== FALSE) {
         Civi::log()->error('Configured geocoder is invalid, must provide a format method', ['geocode_class' => $provider]);
         $provider = FALSE;
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/293

When no geocoding provider is set (buildkit and those who actually dont use it), the error log is filled with errors that the provider is invalid.

Before
----------------------------------------
CiviCRM log file is filled with: 
```
Date  [error] Configured geocoder is invalid, must provide a format method
Array
(
    [geocode_class] => 
)
```
After
----------------------------------------
Error log is clean.
