### PR TITLE
Enable relationships that were set in the future

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1986,6 +1986,31 @@ AND cc.sort_name LIKE '%$name%'";
   }
 
   /**
+   * Set 'is_active' field to TRUE for all relationships whose start date is today (relationships that just started)
+   *
+   * This assumes that expired relationships with a future date are relationships-to-come, and should be activated when
+   * the time comes. Since start_date in the past indicate the relationship may have once been active but has since
+   * been manually disabled, the best we can do is assume that relationships with today's date were once created with
+   * a future date. In other words, the relationship was planned.
+   *
+   * @return bool
+   *   TRUE on success, FALSE if error is encountered.
+   */
+  public static function enablePlannedRelationships() {
+    $query = "SELECT id FROM civicrm_relationship WHERE is_active = 0 AND start_date = CURDATE();";
+
+    $dao = CRM_Core_DAO::executeQuery($query);
+    while ($dao->fetch()) {
+      $result = CRM_Contact_BAO_Relationship::setIsActive($dao->id, TRUE);
+      // Result will be NULL if error occurred. We abort early if error detected.
+      if ($result == NULL) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  /**
    * Function filters the query by possible relationships for the membership type.
    *
    * It is intended to be called when constructing queries for the api (reciprocal & non-reciprocal)

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -665,6 +665,12 @@ function civicrm_api3_job_disable_expired_relationships($params) {
   if (!$result) {
     throw new API_Exception('Failed to disable all expired relationships.');
   }
+
+  $result = CRM_Contact_BAO_Relationship::enablePlannedRelationships();
+  if (!$result) {
+    throw new API_Exception('Failed to enable all planned relationships.');
+  }
+
   return civicrm_api3_create_success(1, $params, 'Job', 'disable_expired_relationships');
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR enables the relationships that are inactive and whose start date is today. This is because we can't enable start dates in the past, as they may be relationships that were previously started and have since been disabled. However relationships that are set to start in the future shouldn't count as "active". Enabling those with the start date of "today" should cover everything but edge cases.

In short, this PR allows people to set a start date in the future when creating the relationship, without enabling it, and have it be enabled automatically.

Before
----------------------------------------
Disabled relationships remain disabled when passing the start date.

After
----------------------------------------
Disabled relationships get activated when passing the start date, provided the scheduled job runs at least once a day.

Technical Details
----------------------------------------
We're expanding the "disable expired relationships" scheduled job because it's the same kind of task on the same entities.