### PR TITLE
NFC - Deprecate duplicate function

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -96,7 +96,7 @@ class CRM_Core_BAO_ConfigSetting {
       $urlVar = 'task';
     }
 
-    if ($isUpgrade && CRM_Core_DAO::checkFieldExists('civicrm_domain', 'config_backend')) {
+    if ($isUpgrade && CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_domain', 'config_backend')) {
       $domain->selectAdd('config_backend');
     }
     else {

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -633,8 +633,8 @@ MODIFY      {$columnName} varchar( $length )
    * @return bool
    */
   public static function checkIfFieldExists($tableName, $columnName, $i18nRewrite = TRUE) {
-    $query = "SHOW COLUMNS FROM $tableName LIKE %1";
-    $dao = CRM_Core_DAO::executeQuery($query, [1 => [$columnName, 'String']], TRUE, NULL, FALSE, $i18nRewrite);
+    $query = "SHOW COLUMNS FROM $tableName LIKE '%1'";
+    $dao = CRM_Core_DAO::executeQuery($query, [1 => [$columnName, 'Alphanumeric']], TRUE, NULL, FALSE, $i18nRewrite);
     $result = $dao->fetch() ? TRUE : FALSE;
     $dao->free();
     return $result;

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -627,18 +627,17 @@ MODIFY      {$columnName} varchar( $length )
    *
    * @param string $tableName
    * @param string $columnName
+   * @param bool $i18nRewrite
+   *   Whether to rewrite the query on multilingual setups.
    *
    * @return bool
    */
-  public static function checkIfFieldExists($tableName, $columnName) {
-    $result = CRM_Core_DAO::executeQuery(
-      "SHOW COLUMNS FROM $tableName LIKE %1",
-      array(1 => array($columnName, 'String'))
-    );
-    if ($result->fetch()) {
-      return TRUE;
-    }
-    return FALSE;
+  public static function checkIfFieldExists($tableName, $columnName, $i18nRewrite = TRUE) {
+    $query = "SHOW COLUMNS FROM $tableName LIKE %1";
+    $dao = CRM_Core_DAO::executeQuery($query, [1 => [$columnName, 'String']], TRUE, NULL, FALSE, $i18nRewrite);
+    $result = $dao->fetch() ? TRUE : FALSE;
+    $dao->free();
+    return $result;
   }
 
   /**

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1673,12 +1673,12 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
   public static function getModuleUFGroup($moduleName = NULL, $count = 0, $skipPermission = TRUE, $op = CRM_Core_Permission::VIEW, $returnFields = NULL) {
     $selectFields = array('id', 'title', 'created_id', 'is_active', 'is_reserved', 'group_type');
 
-    if (CRM_Core_DAO::checkFieldExists('civicrm_uf_group', 'description')) {
+    if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_uf_group', 'description')) {
       // CRM-13555, since description field was added later (4.4), and to avoid any problems with upgrade
       $selectFields[] = 'description';
     }
 
-    if (CRM_Core_DAO::checkFieldExists('civicrm_uf_group', 'frontend_title')) {
+    if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_uf_group', 'frontend_title')) {
       $selectFields[] = 'frontend_title';
     }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -849,6 +849,9 @@ class CRM_Core_DAO extends DB_DataObject {
   /**
    * Check if there is a given column in a specific table.
    *
+   * @deprecated
+   * @see CRM_Core_BAO_SchemaHandler::checkIfFieldExists
+   *
    * @param string $tableName
    * @param string $columnName
    * @param bool $i18nRewrite
@@ -858,16 +861,7 @@ class CRM_Core_DAO extends DB_DataObject {
    *   true if exists, else false
    */
   public static function checkFieldExists($tableName, $columnName, $i18nRewrite = TRUE) {
-    $query = "
-SHOW COLUMNS
-FROM $tableName
-LIKE %1
-";
-    $params = array(1 => array($columnName, 'String'));
-    $dao = CRM_Core_DAO::executeQuery($query, $params, TRUE, NULL, FALSE, $i18nRewrite);
-    $result = $dao->fetch() ? TRUE : FALSE;
-    $dao->free();
-    return $result;
+    return CRM_Core_BAO_SchemaHandler::checkIfFieldExists($tableName, $columnName, $i18nRewrite);
   }
 
   /**

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -265,7 +265,7 @@ class CRM_Core_I18n_Schema {
       // add new columns
       foreach ($hash as $column => $type) {
         // CRM-7854: skip existing columns
-        if (CRM_Core_DAO::checkFieldExists($table, "{$column}_{$locale}", FALSE)) {
+        if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists($table, "{$column}_{$locale}", FALSE)) {
           continue;
         }
         $queries[] = "ALTER TABLE {$table} ADD {$column}_{$locale} {$type}";

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -317,7 +317,7 @@ class CRM_Core_Menu {
       $menu->find(TRUE);
 
       if (!CRM_Core_Config::isUpgradeMode() ||
-        CRM_Core_DAO::checkFieldExists('civicrm_menu', 'module_data', FALSE)
+        CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_menu', 'module_data', FALSE)
       ) {
         // Move unrecognized fields to $module_data.
         $module_data = array();

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -1140,7 +1140,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    * @return bool
    */
   public static function addMailingTemplateType() {
-    if (!CRM_Core_DAO::checkFieldExists('civicrm_mailing', 'template_type', FALSE)) {
+    if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_mailing', 'template_type', FALSE)) {
       CRM_Core_DAO::executeQuery('
         ALTER TABLE civicrm_mailing
         ADD COLUMN `template_type` varchar(64)  NOT NULL DEFAULT \'traditional\' COMMENT \'The language/processing system used for email templates.\',

--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -277,7 +277,7 @@ WHERE ccp.financial_type_id IS NULL and cp.cost > 0');
    */
   public function upgrade_4_3_alpha2($rev) {
     //CRM-11847
-    $isColumnPresent = CRM_Core_DAO::checkFieldExists('civicrm_dedupe_rule_group', 'is_default');
+    $isColumnPresent = CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_dedupe_rule_group', 'is_default');
     if ($isColumnPresent) {
       CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_dedupe_rule_group DROP COLUMN is_default');
     }
@@ -300,7 +300,7 @@ WHERE ccp.financial_type_id IS NULL and cp.cost > 0');
     // CRM-12002
     if (
       CRM_Core_DAO::checkTableExists('log_civicrm_line_item') &&
-      CRM_Core_DAO::checkFieldExists('log_civicrm_line_item', 'label')
+      CRM_Core_BAO_SchemaHandler::checkIfFieldExists('log_civicrm_line_item', 'label')
     ) {
       CRM_Core_DAO::executeQuery('ALTER TABLE `log_civicrm_line_item` CHANGE `label` `label` VARCHAR(255) NULL DEFAULT NULL');
     }
@@ -335,7 +335,7 @@ WHERE ccp.financial_type_id IS NULL and cp.cost > 0');
     // CRM-12205
     if (
       CRM_Core_DAO::checkTableExists('log_civicrm_financial_trxn') &&
-      CRM_Core_DAO::checkFieldExists('log_civicrm_financial_trxn', 'trxn_id')
+      CRM_Core_BAO_SchemaHandler::checkIfFieldExists('log_civicrm_financial_trxn', 'trxn_id')
     ) {
       CRM_Core_DAO::executeQuery('ALTER TABLE `log_civicrm_financial_trxn` CHANGE `trxn_id` `trxn_id` VARCHAR(255) NULL DEFAULT NULL');
     }
@@ -343,7 +343,7 @@ WHERE ccp.financial_type_id IS NULL and cp.cost > 0');
     // CRM-12367 - add this column to single lingual sites only
     $upgrade = new CRM_Upgrade_Form();
     if (!$upgrade->multilingual &&
-      !CRM_Core_DAO::checkFieldExists('civicrm_premiums', 'premiums_nothankyou_label')
+      !CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_premiums', 'premiums_nothankyou_label')
     ) {
       $query = "
 ALTER TABLE civicrm_premiums
@@ -925,7 +925,7 @@ AND TABLE_SCHEMA = %1
       }
     }
     // check if column contact_id is present or not in civicrm_financial_account
-    $fieldExists = CRM_Core_DAO::checkFieldExists('civicrm_financial_account', 'contact_id', FALSE);
+    $fieldExists = CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_financial_account', 'contact_id', FALSE);
     if (!$fieldExists) {
       $query = "
 ALTER TABLE civicrm_financial_account

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -139,7 +139,7 @@ class SettingsBag {
 
     $isUpgradeMode = \CRM_Core_Config::isUpgradeMode();
 
-    if ($isUpgradeMode && empty($this->contactId) && \CRM_Core_DAO::checkFieldExists('civicrm_domain', 'config_backend', FALSE)) {
+    if ($isUpgradeMode && empty($this->contactId) && \CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_domain', 'config_backend', FALSE)) {
       $config_backend = \CRM_Core_DAO::singleValueQuery('SELECT config_backend FROM civicrm_domain WHERE id = %1',
         array(1 => array($this->domainId, 'Positive')));
       $oldSettings = \CRM_Upgrade_Incremental_php_FourSeven::convertBackendToSettings($this->domainId, $config_backend);
@@ -373,7 +373,7 @@ class SettingsBag {
     if (!isset(\Civi::$statics[__CLASS__]['upgradeMode'])) {
       \Civi::$statics[__CLASS__]['upgradeMode'] = \CRM_Core_Config::isUpgradeMode();
     }
-    if (\Civi::$statics[__CLASS__]['upgradeMode'] && \CRM_Core_DAO::checkFieldExists('civicrm_setting', 'group_name')) {
+    if (\Civi::$statics[__CLASS__]['upgradeMode'] && \CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_setting', 'group_name')) {
       $dao->group_name = 'placeholder';
     }
 

--- a/Civi/Core/SqlTrigger/StaticTriggers.php
+++ b/Civi/Core/SqlTrigger/StaticTriggers.php
@@ -89,7 +89,7 @@ class StaticTriggers {
 
       if (\CRM_Core_Config::isUpgradeMode() && isset($trigger['upgrade_check'])) {
         $uc = $trigger['upgrade_check'];
-        if (!\CRM_Core_DAO::checkFieldExists($uc['table'], $uc['column'])
+        if (!\CRM_Core_BAO_SchemaHandler::checkIfFieldExists($uc['table'], $uc['column'])
         ) {
           continue;
         }

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -145,7 +145,7 @@ class TimestampTriggers {
     // In the past, this was a version-based check, but checkFieldExists()
     // seems more robust.
     if (\CRM_Core_Config::isUpgradeMode()) {
-      if (!\CRM_Core_DAO::checkFieldExists($this->getTableName(),
+      if (!\CRM_Core_BAO_SchemaHandler::checkIfFieldExists($this->getTableName(),
         $this->getCreatedDate())
       ) {
         return;


### PR DESCRIPTION
Summary
---
As @eileenmcnaughton noted in https://github.com/civicrm/org.civicrm.module.cividiscount/pull/173, there are 2 basically identical functions. This PR deprecates one of them.

Technical Details
----
Grepping around, both functions are used equally often, but according to the git history, the one in `CRM_Core_DAO` is much older. I was tempted to favor that one because of its grandfatherly status, but I think `CRM_Core_BAO_SchemaHandler` is a better location, so I'm favoring that one to reduce bloat in `CRM_Core_DAO`.

The one in `CRM_Core_DAO` had an additional param so I copied it over to the favored function.

I've also pushed up stricter validation; switching from "String" which performs no validation to "Alphanumeric" which checks against the only sensible characters a table column ought to contain.