### PR TITLE
dev/core#295 - Allow default 'from' email to be  set in New email form

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -89,7 +89,11 @@ class CRM_Contact_Form_Task_EmailCommon {
     }
 
     $form->_emails = $fromEmailValues;
+    $defaults = array();
     $form->_fromEmails = $fromEmailValues;
+    if (!Civi::settings()->get('allow_mail_from_logged_in_contact')) {
+      $defaults['from_email_address'] = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
+    }
     if (is_numeric(key($form->_fromEmails))) {
       // Add signature
       $defaultEmail = civicrm_api3('email', 'getsingle', array('id' => key($form->_fromEmails)));
@@ -100,8 +104,8 @@ class CRM_Contact_Form_Task_EmailCommon {
       if (!empty($defaultEmail['signature_text'])) {
         $defaults['text_message'] = "\n\n--\n" . $defaultEmail['signature_text'];
       }
-      $form->setDefaults($defaults);
     }
+    $form->setDefaults($defaults);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Allow default from email address to be set as default on the "New Email" form.

Before
----------------------------------------
Default From address is not loaded as default on the email form. 

SE Post - https://civicrm.stackexchange.com/questions/25562/why-does-the-default-from-email-address-not-show-as-the-first-option-when-usin

After
----------------------------------------
If `Allow Mail to be sent from logged in contact's email address` is disabled in settings, default `from` address is loaded on the form.

----------------

Gitlab issue - https://lab.civicrm.org/dev/core/issues/295