### PR TITLE
api - CustomValue::get - add handling for comma separated return fields

### DIFF
--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -149,7 +149,10 @@ function civicrm_api3_custom_value_get($params) {
       if (!empty(substr($id, 7))) {
         $returnVal = substr($id, 7);
       }
-      foreach ((array) $returnVal as $value) {
+      if (!is_array($returnVal)) {
+        $returnVal = explode(',', $returnVal);
+      }
+      foreach ($returnVal as $value) {
         list($c, $i) = CRM_Utils_System::explode('_', $value, 2);
         if ($c == 'custom' && is_numeric($i)) {
           $names['custom_' . $i] = 'custom_' . $i;


### PR DESCRIPTION
Overview
----------------------------------------
The API call fails when using dirictly in API explorer:

![](https://lab.civicrm.org/dev/core/uploads/142b60a1551c11bf34f32b47bd9ae42e/image.png)

GitLab Issue: https://lab.civicrm.org/dev/core/issues/296

Before
----------------------------------------
```
{
   "is_error": 1,
    "error_message": "'name' specified in OR group but not added to params"
}
```

After
----------------------------------------
```
    {
    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": [
        {
            "entity_id": "203",
            "latest": "Edu",
            "id": "1",
            "0": "Edu"
        },
        {
            "entity_id": "203",
            "latest": "S",
            "id": "2",
            "0": "S"
        }
    ]
}
```

**Has unit tests** for variants of return definitions: array, comma-separated and list of return parameters.

Technical
----------------------------------------
Unit test `testGetCustomValueReturnMultipleApiExplorer` fails without 55000cc71e570d72abbedba1370b9de55076cf72.

Comments
----------------------------------------
Not sure if the tests should be more verbose ...
