### PR TITLE
Customvalue ID is ignored

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -637,6 +637,10 @@ AND    cf.id IN ( $fieldIDList )
           'extends' => $dao->extends,
         );
 
+        if (!empty($params['id'])) {
+          $cvParam['id'] = $params['id'];
+        }
+
         if ($cvParam['type'] == 'File') {
           $cvParam['file_id'] = $fieldValue['value'];
         }

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableMultipleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableMultipleTest.php
@@ -35,6 +35,20 @@ class CRM_Core_BAO_CustomValueTableMultipleTest extends CiviUnitTestCase {
     $this->assertEquals($params["custom_{$customField['id']}_-1"], $result["custom_{$customField['id']}_1"]);
     $this->assertEquals($params['entityID'], $result['entityID']);
 
+    $updateParams = array(
+      'id' => 1,
+      'entityID' => $contactID,
+      "custom_{$customField['id']}" => 2,
+    );
+    CRM_Core_BAO_CustomValueTable::setValues($updateParams);
+
+    $criteria = array(
+      'id' => 1,
+      'entityID' => $contactID,
+    );
+    $result = CRM_Core_BAO_CustomValueTable::getValues($criteria);
+    $this->assertEquals(2, $result["custom_{$customField['id']}_1"]);
+
     $this->customFieldDelete($customField['id']);
     $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);


### PR DESCRIPTION
Overview
----------------------------------------
Earlier the  ID of custom value table's record was not considered and thus it doesn't allow to update a custom table value record.

Before
----------------------------------------
Doesn't update the custom table value

After
----------------------------------------
Update the custom table value