### PR TITLE
Make sure Joomla timezone is set for cron jobs

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -589,6 +589,14 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       define('JDEBUG', FALSE);
     }
 
+    // Set timezone for Joomla on Cron
+    $config = JFactory::getConfig();
+    $timezone = $config->get('offset');
+    if ($timezone) {
+      date_default_timezone_set($timezone);
+      CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+    }
+
     // CRM-14281 Joomla wasn't available during bootstrap, so hook_civicrm_config never executes.
     $config = CRM_Core_Config::singleton();
     CRM_Utils_Hook::config($config);


### PR DESCRIPTION
Overview
----------------------------------------
When running CiviCRM on Joomla the timezone is not being set correctly when running cron from the command line (eg. via a server cron job).

Example:
`/usr/local/bin/ea-php70 /path/to/site/administrator/components/com_civicrm/civicrm/bin/cli.php -s urltosite.org -u cronjob_user -p cronjob_pwd -e Job -a execute >/dev/null 2>&1`

The impact of this is that currently (ie. during British Summer Time (BST)) when you view the list of cron jobs the last_run date is one hour behind when it was actually run - but when you view the job log for each job the start/end date/time is correct and current.

So, for example at 11:00 the mailings job says it was last run at 10:00 but the mailings job log says started at 11:00:05, ended at 11:00:15.

Before
----------------------------------------
The CRON job is always being executed with timezone set to UTC.

After
----------------------------------------
The CRON job is executed using the same timezone as Joomla (and the same timezone that is configured for Joomla/CiviCRM/database when running via web).

Technical Details
----------------------------------------
A similar "fix" was added to the Wordpress loadBootStrap() function a few years ago.

Comments
----------------------------------------
It is likely that this issue may/may not arise depending on specific server timezone configurations.  In this case this is a shared WHM/cpanel server which I only have access to the cpanel account.

The configured Joomla timezone is Europe/London and PHP is also configured for both the domain and home directory to be Europe/London.

The timezone check in CiviCRM passes both before and after this PR because the environment is configured properly when run via web.

I think this *may* also have an impact on some IPN transactions as I've seen them with the wrong time in the past from PayPal.  However, I have not investigated this further at this stage.
