### PR TITLE
dev/core/issues/277 Sort recurring contributions by newest first

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -192,7 +192,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
       $contributionRecurResult = civicrm_api3('ContributionRecur', 'get', array(
         'contact_id' => $this->_contactId,
         'contribution_status_id' => array('NOT IN' => CRM_Contribute_BAO_ContributionRecur::getInactiveStatuses()),
-        'options' => ['limit' => 0, 'sort' => 'is_test, start_date ASC'],
+        'options' => ['limit' => 0, 'sort' => 'is_test, start_date DESC'],
       ));
       $recurContributions = CRM_Utils_Array::value('values', $contributionRecurResult);
     }
@@ -214,7 +214,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
       $contributionRecurResult = civicrm_api3('ContributionRecur', 'get', array(
         'contact_id' => $this->_contactId,
         'contribution_status_id' => array('IN' => CRM_Contribute_BAO_ContributionRecur::getInactiveStatuses()),
-        'options' => ['limit' => 0, 'sort' => 'is_test, start_date ASC'],
+        'options' => ['limit' => 0, 'sort' => 'is_test, start_date DESC'],
       ));
       $recurContributions = CRM_Utils_Array::value('values', $contributionRecurResult);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Sort recurring contributions tab by newest first.

Follow up to https://github.com/civicrm/civicrm-core/pull/12553

Before
----------------------------------------
Recurring contributions tab sorted by oldest first (start_date), inconsistent with contributions tab which is sorted by newest first.

After
----------------------------------------
Recurring contributions tab sorted by newest first (start_date), consistent with contributions tab which is sorted by newest first.

Technical Details
----------------------------------------
We just change the sort order for display in the API function.

Comments
----------------------------------------
Consensus agreed on #12553
