### PR TITLE
[PHPUnit test only] Adding in assertions re: Line Item and Contribution data-integrity.

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1345,7 +1345,9 @@ Expires: ',
 
     // ensure that total_amount at the Contribution level matches line_total + tax_amount at the Line Item Level
     $contribution = $this->callAPISuccessGetSingle('Contribution',
-      array('contribution_id' => 1, 'return' => array('tax_amount', 'total_amount'),
+      array(
+        'contribution_id' => 1,
+        'return' => array('tax_amount', 'total_amount'),
       )
     );
     $this->assertEquals($contribution['total_amount'], $lineItem['line_total'] + $lineItem['tax_amount']);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -551,7 +551,6 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    * Test the submit function of the membership form on membership type change.
    *  Check if the related contribuion is also updated if the minimum_fee didn't match
    */
-  // KG
   public function testContributionUpdateOnMembershipTypeChange() {
     // Step 1: Create a Membership via backoffice whose with 50.00 payment
     $form = $this->getForm();
@@ -1285,7 +1284,6 @@ Expires: ',
    * CRM-21656: Test the submit function of the membership form if Sale Tax is enabled.
    * Check that the tax rate isn't reapplied to line item's unit price and total amount
    */
-  // KG
   public function testLineItemAmountOnSaleTax() {
     $this->enableTaxAndInvoicing();
     $this->relationForFinancialTypeWithFinancialAccount(2);


### PR DESCRIPTION
Overview
----------------------------------------
In 4.7.27 - one of our large professional association clients observed a data integrity issue were after Edit Contribution the Line Item subtotals + their Tax Amount no longer added up to Contribution total_amount [not talking rounding errors - June 2018 is off by > $9.5k]. The good news is that we've not yet observed it in 5.3.x since. However I could not find any tests that would secure/lock in data integrity between Line Items and Contribution totals.

Before
----------------------------------------
Unit test `testLineItemAmountOnSaleTax` -> checks that `$lineItem['qty']` and `$lineItem['tax_amount']` are unaffected upon a simple Save of the Edit Contribution form; 

After
----------------------------------------
Unit test `testLineItemAmountOnSaleTax` -> now also checks that `$lineItem['unit_price']` and `$lineItem['line_total']` are also unaffected upon a simple Save of the Edit Contribution form; 

In addition 
Unit test `testLineItemAmountOnSaleTax` -> now also checks that `$contribution['total_amount'] = $lineItem['line_total'] + $lineItem['tax_amount'];`

In addition 
Unit test `testLineItemAmountOnSaleTax` -> now also checks that `$contribution['tax_amount'] = $lineItem['tax_amount'];`

Technical Details
----------------------------------------
The tests I've added Fail on my local/buildkit - the unit_price and line_total are 55.00 after saving the Contribution Form [before saving the form -> lines 1323 - 1324 they were 50.00] - see screenshot:

![image](https://user-images.githubusercontent.com/5340555/43530772-9be1e818-956b-11e8-9196-8580119117bc.png)


Comments
----------------------------------------
Of course I realize we can't merge in a failing test - so want to here:
a) check to see if Jenkins agrees
b) get consensus that the additional assertions here are correct
