### PR TITLE
Further removal of instance of using LOWER() rather than relying on mysql non-case-sensitivity.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2235,6 +2235,7 @@ class CRM_Contact_BAO_Query {
       $this->_qill[$grouping][] = "$field[title] $op \"$value\"";
     }
     elseif ($name === 'email_greeting') {
+      CRM_Core_Error::deprecatedFunctionWarning('pass in email_greeting_id or email_greeting_display');
       $filterCondition = array('greeting_type' => 'email_greeting');
       $this->optionValueQuery(
         $name, $op, $value, $grouping,
@@ -2244,6 +2245,7 @@ class CRM_Contact_BAO_Query {
       );
     }
     elseif ($name === 'postal_greeting') {
+      CRM_Core_Error::deprecatedFunctionWarning('pass in postal_greeting_id or postal_greeting_display');
       $filterCondition = array('greeting_type' => 'postal_greeting');
       $this->optionValueQuery(
         $name, $op, $value, $grouping,
@@ -2253,6 +2255,7 @@ class CRM_Contact_BAO_Query {
       );
     }
     elseif ($name === 'addressee') {
+      CRM_Core_Error::deprecatedFunctionWarning('pass in addressee_id or addressee_display');
       $filterCondition = array('greeting_type' => 'addressee');
       $this->optionValueQuery(
         $name, $op, $value, $grouping,
@@ -5965,8 +5968,8 @@ AND   displayRelType.is_active = 1
       }
     }
     else {
-      // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
-      $wc = self::caseImportant($op) ? "LOWER({$field['where']})" : "{$field['where']}";
+      CRM_Core_Error::deprecatedFunctionWarning('pass $ids to this method');
+      $wc = "{$field['where']}";
     }
     if (in_array($name, $pseudoFields)) {
       if (!in_array($name, array('gender_id', 'prefix_id', 'suffix_id', 'communication_style_id'))) {


### PR DESCRIPTION
Overview
----------------------------------------
This is part of a phased process of removing LOWER from core mysql queries. So far we are only aware of downsides to using it but out of cautiousness are removing it slowly over releases

Before
----------------------------------------
Calls to filter on email_greeting, postal_greeting, address have LOWER applied (resulting in unindexed searches)

After
----------------------------------------
LOWER not applied, mysql case insensitive search relied on

Technical Details
----------------------------------------

Per #12494  & # 12503 the use of LOWER

hurts performance
fails to return results on some char sets
messes with REGEX

This is part of a continued (we removed from contribution search fields last year)
staggered approach to removing this old mechanism

Comments
----------------------------------------

Note I could not find any way to hit this line of code so I added deprecation notices. I looked in advanced search, search builder, api explorer & I created a search profile per the screen shot 

![screenshot 2018-08-02 14 06 11](https://user-images.githubusercontent.com/336308/43558362-3c80151e-965d-11e8-99d7-d2595f6b7906.png)
