### PR TITLE
dev/core#297 : fix broken permission 'access my cases and activities'

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -676,7 +676,8 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
     $mask = CRM_Core_Action::mask($permissions);
 
     $caseTypes = CRM_Case_PseudoConstant::caseType('name');
-    foreach ($result->fetchAll() as $key => $case) {
+    foreach ($result->fetchAll() as $case) {
+      $key = $case['case_id'];
       $casesList[$key] = array();
       $casesList[$key]['DT_RowId'] = $case['case_id'];
       $casesList[$key]['DT_RowAttr'] = array('data-entity' => 'case', 'data-id' => $case['case_id']);

--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -207,7 +207,7 @@ class CRM_Case_Page_AJAX {
       'recordsTotal' => $cases['total'],
     );
     unset($cases['total']);
-    $casesDT['data'] = $cases;
+    $casesDT['data'] = array_values($cases);
 
     CRM_Utils_JSON::output($casesDT);
   }


### PR DESCRIPTION
Overview
----------------------------------------
See https://civicrm.stackexchange.com/questions/25950/problem-with-civicase This regression is caused by CRM-21461 changes.


Before
----------------------------------------
The permission 'access my cases and activities' was broken.

After
----------------------------------------
The permission 'access my cases and activities' was fixed.

---

 * [CRM-21461: Case Dashlet enhancement](https://issues.civicrm.org/jira/browse/CRM-21461)