### PR TITLE
dev/core/#273: Set doNotSms To False When Phone Number Is Given

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1832,6 +1832,7 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     if ($smsProviderParams['To']) {
       // If phone number is specified use it
       $toPhoneNumber = trim($smsProviderParams['To']);
+      $doNotSms = FALSE;
     }
     elseif ($toID) {
       // No phone number specified, so find a suitable one for the contact
@@ -1856,7 +1857,7 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
       );
     }
 
-    $recipient = $smsProviderParams['To'];
+    $recipient = $toPhoneNumber;
     $smsProviderParams['contact_id'] = $toID;
     $smsProviderParams['parent_activity_id'] = $activityID;
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -231,6 +231,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
       $criteria = array(
         'is_opt_out' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_opt_out = 0"),
         'is_deceased' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_deceased <> 1"),
+        'do_not_sms' => CRM_Utils_SQL_Select::fragment()->where("$contact.do_not_sms = 0"),
         'location_filter' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone_type_id = " . CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_Phone', 'phone_type_id', 'Mobile')),
         'phone_not_null' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone IS NOT NULL"),
         'phone_not_empty' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone != ''"),


### PR DESCRIPTION
Overview
----------------------------------------
Related Issue: https://lab.civicrm.org/dev/core/issues/273
Related PR: https://github.com/civicrm/civicrm-core/pull/12554
We are having the same issue after upgrading.
I was about to submit a patch but I saw it was already reported and had a PR (#12554). My fix is a little different (details below) and so I am submitting this anyway.

Before
----------------------------------------
Sending SMS fails (individual and scheduled reminders)

After
----------------------------------------
Sending SMS works 

Technical Details
----------------------------------------
As this is a public static method, other exts can use this method. So
- if this is called with a 'phone number' it will send the SMS to that number (no filtering as it would be done when getting the phone number elsewhere)
- if it is called with a contact ID (and no phone number) we will get the phone number from the contact and also check for filters (including do not sms)
Also I am setting 
$recipient = $toPhoneNumber;
because $smsProviderParams['To'] can be empty but $toPhoneNumber will be set in this line.
