### PR TITLE
Make contact name into a link on Manage Case for single client

### DIFF
--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -60,7 +60,9 @@
           <table class="form-layout-compressed">
             {foreach from=$caseRoles.client item=client}
               <tr class="crm-case-caseview-display_name">
-                <td class="label-left bold" style="padding: 0px; border: none;">{$client.display_name}</td>
+                <td class="label-left bold" style="padding: 0px; border: none;">
+                  <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts}View contact record{/ts}">{$client.display_name}</a>
+                </td>
               </tr>
               {if $client.phone}
                 <tr class="crm-case-caseview-phone">


### PR DESCRIPTION
Overview
----------------------------------------
This makes it consistent with multiple clients assigned to the case.  Without this there is no direct link back to the client contact record.

Before
----------------------------------------
![localhost_8000_civicrm_contact_view_case_contact_name](https://user-images.githubusercontent.com/2052161/43654317-c11cf5cc-9742-11e8-8b12-42156c6d328e.png)


After
----------------------------------------
![localhost_8000_civicrm_contact_view_case_contact_link](https://user-images.githubusercontent.com/2052161/43654324-c617089c-9742-11e8-86da-f74d23018886.png)


Technical Details
----------------------------------------
Single line change to a template

