### PR TITLE
Don't duplicate activity when filing on case

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -302,8 +302,8 @@ class CRM_Activity_Page_AJAX {
     $mainActivity->activity_date_time = $actDateTime;
     // Make sure this is current revision.
     $mainActivity->is_current_revision = TRUE;
-    // Drop all relations.
-    $mainActivity->parent_id = $mainActivity->original_id = NULL;
+    $mainActivity->original_id = $otherActivity->id;
+    $otherActivity->is_current_revision = FALSE;
 
     $mainActivity->save();
     $mainActivityId = $mainActivity->id;
@@ -327,7 +327,6 @@ class CRM_Activity_Page_AJAX {
           1 => $params['caseID'],
         )) . ' ' . $otherActivity->subject;
       }
-      $otherActivity->activity_date_time = $actDateTime;
       $otherActivity->save();
 
       $caseActivity->free();


### PR DESCRIPTION
Overview
----------------------------------------
When filing an activity on a case via the "File On Case" link on the activity tab/activity detail view an odd set of parameters is set which results in two separate activities - one which is on the case and one which is not.


Before
----------------------------------------
* original_id is not set on new activity.
* is_current_revision is not set to FALSE on original activity.

![localhost_8000_civicrm_activity_search__qf_search_display true qfkey 30a4eae1de7276c7c6d8ff53f91bfe6e_7178](https://user-images.githubusercontent.com/2052161/43654753-3ac165a6-9744-11e8-9c97-503b1c7718d1.png)


After
----------------------------------------
* original_id is set on new activity.
* is_current_revision is set to FALSE on original activity.

![localhost_8000_civicrm_activity_search__qf_search_display true qfkey 30a4eae1de7276c7c6d8ff53f91bfe6e_7178 1](https://user-images.githubusercontent.com/2052161/43654748-380aa7a0-9744-11e8-99b5-373d153ef3a2.png)


Technical Details
----------------------------------------
AFTER is consistent with how case activities are normally handled, ie activity is duplicated, is_current_revision set to false on old activity and original_id set on new activity.  UI (searches etc) expect this to be the case.
