### PR TITLE
Added Participant Role pseudoconstants

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -100,6 +100,12 @@ class CRM_Core_PseudoConstant {
   private static $group;
 
   /**
+   * ParticipantRoles
+   * @var array
+   */
+  private static $participantRoles;
+
+  /**
    * RelationshipType
    * @var array
    */
@@ -1039,6 +1045,27 @@ WHERE  id = %1";
     }
 
     return self::$relationshipType[$cacheKey];
+  }
+
+  /**
+   * Returns participant roles in the form value => label.
+   *
+   * @return array
+   */
+  public static function &participantRoles() {
+    if (!isset(self::$participantRoles)) {
+      $participantRoles = array();
+      $participantRolesRaw = civicrm_api3('OptionValue', 'get', array(
+        'sequential' => 1,
+        'option_group_id' => 'participant_role',
+      ));
+      foreach($participantRolesRaw['values'] as $eachParticipantRole) {
+        $participantRoles[$eachParticipantRole['value']] = $eachParticipantRole['label'];
+      }
+
+      self::$participantRoles = $participantRoles;
+    }
+    return self::$participantRoles;
   }
 
   /**


### PR DESCRIPTION
Added Participant Role pseudoconstants for use in CiviCRM Drupal Views. Specifically so that View relationships can be created from an Event to a participant's Contact record with certain Participant Roles.

This needs to be merged before https://github.com/civicrm/civicrm-drupal/pull/534

Overview
----------------------------------------
Provides the most rudimentary pseudoconstants of Participant Roles.

Before
----------------------------------------
It was not possible in Drupal Views to add an Event to a Participant record by a Views relationship.

After
----------------------------------------
It is now possible in Drupal Views to create a relationship between Events and Participants.

Technical Details
----------------------------------------
It is noted that some pseudoconstants have a "cache key", not used in this PR. This is not felt to be important here, however. If necessary this could be included in a subsequent patch, but would make the Drupal Views work notably more complex. I've stuck to old PHP array syntax as it will be some time before everyone upgrades.

Comments
----------------------------------------
This is a newly introduced function, and accordingly is (famous last words) highly unlikely to break anything. I'm kind of surprised it's not in all already.

This needs to be added to support this Drupal Views PR: https://github.com/civicrm/civicrm-drupal/pull/534