### PR TITLE
dev/cloud-native/issues#18: Soften messages for read-only extensionsDir

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -453,16 +453,16 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     if (!empty($notWritable)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('The %1 is not writable.  Please check your file permissions.', array(
+        ts('The %1 is not writable. Writing to Settings file has been disabled by admin. Please check your file permissions.', array(
           1 => implode(', ', $notWritable),
           'count' => count($notWritable),
-          'plural' => 'The following directories are not writable: %1.  Please check your file permissions.',
+          'plural' => 'The following directories are not writable: %1. Writing to Settings file has been disabled by admin. Please check your file permissions.',
         )),
         ts('Directory not writable', array(
           'count' => count($notWritable),
           'plural' => 'Directories not writable',
         )),
-        \Psr\Log\LogLevel::ERROR,
+        \Psr\Log\LogLevel::NOTICE,
         'fa-ban'
       );
     }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -564,7 +564,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         ts('Your extensions directory (%1) is read-only. If you would like to perform downloads or upgrades, then change the file permissions.',
           array(1 => $basedir)),
         ts('Read-Only Extensions'),
-        \Psr\Log\LogLevel::WARNING,
+        \Psr\Log\LogLevel::NOTICE,
         'fa-plug'
       );
       return $messages;


### PR DESCRIPTION
Overview
----------------------------------------
Improve messaging when someone has a different policy for managing extensionsDir.  Most of the messaging update has already been done. There is only one message ("Read-Only Extensions"). It still encourages web-writable policy, but it lowers the severity and presents it a choice ("if you want X, do Y").

Before
----------------------------------------
The message that is displayed is a `warning` when the directory is "Read-Only" which implies something is wrong.

After
----------------------------------------
The message that is displayed is a `notice` when the directory is "Read-Only". `notice` says it's merely out of the ordinary

Comments
----------------------------------------
This a continuation of this PR [#11895](https://github.com/civicrm/civicrm-core/pull/11895).

 [dev/cloud-native#18](https://lab.civicrm.org/dev/cloud-native/issues/18) 
