### PR TITLE
dev/cloud-native/issues#17: Moving the cache for `CRM_Extension_Browser` out of the filesystem and use a `SqlGroup` instead.

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -117,8 +117,8 @@ class CRM_Extension_Browser {
     $file = $this->getTsPath();
     if (file_exists($file)) {
       unlink($file);
-      }
     }
+  }
 
   /**
    * Determine whether downloading is supported.
@@ -281,20 +281,20 @@ class CRM_Extension_Browser {
      * @return string
      * @throws \CRM_Extension_Exception
      */
-  private function grabRemoteJson() {
+    private function grabRemoteJson() {
 
       ini_set('default_socket_timeout', self::CHECK_TIMEOUT);
       set_error_handler(array('CRM_Extension_Browser', 'downloadError'));
 
       if (!ini_get('allow_url_fopen')) {
         ini_set('allow_url_fopen', 1);
-    }
+      }
 
-    if (FALSE === $this->getRepositoryUrl()) {
-      // don't check if the user has configured civi not to check an external
-      // url for extensions. See CRM-10575.
-      return array();
-    }
+      if (FALSE === $this->getRepositoryUrl()) {
+        // don't check if the user has configured civi not to check an external
+        // url for extensions. See CRM-10575.
+        return array();
+      }
 
     $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
     $url = $this->getRepositoryUrl() . $this->indexPath;

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -63,12 +63,10 @@ const CHECK_TIMEOUT = 5;
  * @var CRM_Utils_Cache_Interface
  */
 protected $cache;
-
 /**
  * Create default instance.
  * @return CRM_Extension_Browser
  */
-
 public static function create() {
   return new CRM_Extension_Browser(
     Civi::cache('extension_browser'),

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -116,9 +116,9 @@ class CRM_Extension_Browser {
   public function refresh() {
     $file = $this->getTsPath();
     if (file_exists($file)) {
-    unlink($file);
+      unlink($file);
+      }
     }
-  }
 
   /**
    * Determine whether downloading is supported.
@@ -274,20 +274,20 @@ class CRM_Extension_Browser {
       return $extension;
     }
 
-  /**
-   * Connects to public server and grabs the list of publicly available
-   * extensions.
-   *
-   * @return string
-   * @throws \CRM_Extension_Exception
-   */
+    /**
+     * Connects to public server and grabs the list of publicly available
+     * extensions.
+     *
+     * @return string
+     * @throws \CRM_Extension_Exception
+     */
   private function grabRemoteJson() {
 
-    ini_set('default_socket_timeout', self::CHECK_TIMEOUT);
-    set_error_handler(array('CRM_Extension_Browser', 'downloadError'));
+      ini_set('default_socket_timeout', self::CHECK_TIMEOUT);
+      set_error_handler(array('CRM_Extension_Browser', 'downloadError'));
 
-    if (!ini_get('allow_url_fopen')) {
-      ini_set('allow_url_fopen', 1);
+      if (!ini_get('allow_url_fopen')) {
+        ini_set('allow_url_fopen', 1);
     }
 
     if (FALSE === $this->getRepositoryUrl()) {
@@ -329,5 +329,5 @@ class CRM_Extension_Browser {
   public static function downloadError($errorNumber, $errorString) {
   }
 
-}
+  }
 }

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -80,9 +80,8 @@ public static function create() {
  * @param string $indexPath
  *  Relative path of the 'index' file within the repository.
  *  Local path in which to cache files.
- * @param CRM_Utils_Cache_Interface $cache
+ *
  */
-
 public function __construct($cache, $client, $repoUrl, $indexPath) {
   $this->repoUrl = $repoUrl;
   // $this->cacheDir = $cacheDir;
@@ -235,7 +234,7 @@ private function _discoverRemote() {
  * @return string
  */
 
-/**   
+/**
 private function grabCachedJson() {
      $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this-   >getRepositoryUrl());
      $json = NULL;
@@ -247,8 +246,7 @@ private function grabCachedJson() {
      }
      return $json;
    }
-*/
-
+ */
 public function grabCachedJson() {
   $isChanged = FALSE;
   $extension = $this->cache->get('Extension_Browser');
@@ -331,4 +329,5 @@ public function grabCachedJson() {
   public static function downloadError($errorNumber, $errorString) {
   }
 
+ }
 }

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -154,7 +154,7 @@ class CRM_Extension_Browser {
    * Get a list of all available extensions.
    *
    * @return array
-   *($key => CRM_Extension_Info)
+   * ($key => CRM_Extension_Info)
    */
   public function getExtensions() {
     if (!$this->isEnabled() || count($this->checkRequirements())) {
@@ -330,4 +330,5 @@ class CRM_Extension_Browser {
     }
 
   }
+
 }

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -74,205 +74,205 @@ class CRM_Extension_Browser {
     );
   }
 
-/**
- * @param string $repoUrl
- *  URL of the remote repository.
- * @param string $indexPath
- *  Relative path of the 'index' file within the repository.
- *  Local path in which to cache files.
- *
- */
-public function __construct($cache, $client, $repoUrl, $indexPath) {
-  $this->repoUrl = $repoUrl;
-  // $this->cacheDir = $cacheDir;
-  $this->cache = $cache;
-  // $this->client = $client;
-  $this->indexPath = empty($indexPath) ? self::SINGLE_FILE_PATH : $indexPath;
-  // if ($cacheDir && !file_exists($cacheDir) && is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
-  // CRM_Utils_File::createDir($cacheDir, FALSE);
-  // }
-}
+  /**
+   * @param string $repoUrl
+   *  URL of the remote repository.
+   * @param string $indexPath
+   *  Relative path of the 'index' file within the repository.
+   *  Local path in which to cache files.
+   *
+   */
+  public function __construct($cache, $client, $repoUrl, $indexPath) {
+    $this->repoUrl = $repoUrl;
+    // $this->cacheDir = $cacheDir;
+    $this->cache = $cache;
+    // $this->client = $client;
+    $this->indexPath = empty($indexPath) ? self::SINGLE_FILE_PATH : $indexPath;
+    // if ($cacheDir && !file_exists($cacheDir) && is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
+    // CRM_Utils_File::createDir($cacheDir, FALSE);
+    // }
+  }
 
-/**
- * Determine whether the system policy allows downloading new extensions.
- * This is reflection of *policy* and *intent*; it does not indicate whether
- * the browser will actually *work*. For that, see checkRequirements().
- * @return bool
- */
-public function isEnabled() {
-  return (FALSE !== $this->getRepositoryUrl());
-}
+  /**
+   * Determine whether the system policy allows downloading new extensions.
+   * This is reflection of *policy* and *intent*; it does not indicate whether
+   * the browser will actually *work*. For that, see checkRequirements().
+   * @return bool
+   */
+  public function isEnabled() {
+    return (FALSE !== $this->getRepositoryUrl());
+  }
 
-/**
- * @return string
- */
-public function getRepositoryUrl() {
-  return $this->repoUrl;
-}
+  /**
+   * @return string
+   */
+  public function getRepositoryUrl() {
+    return $this->repoUrl;
+  }
 
-/**
- * Refresh the cache of remotely-available extensions.
- */
-public function refresh() {
-  $file = $this->getTsPath();
-  if (file_exists($file)) {
+  /**
+   * Refresh the cache of remotely-available extensions.
+   */
+  public function refresh() {
+    $file = $this->getTsPath();
+    if (file_exists($file)) {
     unlink($file);
-  }
-}
-
-/**
- * Determine whether downloading is supported.
- *
- * @return array
- *   List of error messages; empty if OK.
- */
-public function checkRequirements() {
-  if (!$this->isEnabled()) {
-    return array();
-  }
-
-  $errors = array();
-
-  // if (!$this->cacheDir || !is_dir($this->cacheDir) || !is_writable($this->cacheDir)) {
-  //   $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
-  //   $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
-  //   $errors[] = array(
-  //     'title' => ts('Directory Unwritable'),
-  //     'message' => ts('Your extensions cache directory (%1) is not web server writable. Please go to the <a href="%2">path setting page</a> and correct it.<br/>',
-  //       array(
-  //         1 => $this->cacheDir,
-  //         2 => $url,
-  //       )
-  //     ),
-  //   );
-  // }
-
-  return $errors;
-}
-
-/**
- * Get a list of all available extensions.
- *
- * @return array
- *   ($key => CRM_Extension_Info)
- */
-public function getExtensions() {
-  if (!$this->isEnabled() || count($this->checkRequirements())) {
-    return array();
-  }
-
-  $exts = array();
-
-  $remote = $this->_discoverRemote();
-  if (is_array($remote)) {
-    foreach ($remote as $dc => $e) {
-      $exts[$e->key] = $e;
     }
   }
 
-  return $exts;
-}
+  /**
+   * Determine whether downloading is supported.
+   *
+   * @return array
+   *   List of error messages; empty if OK.
+   */
+  public function checkRequirements() {
+    if (!$this->isEnabled()) {
+      return array();
+    }
 
-/**
- * Get a description of a particular extension.
- *
- * @param string $key
- *   Fully-qualified extension name.
- *
- * @return CRM_Extension_Info|NULL
- */
-public function getExtension($key) {
-  // TODO optimize performance -- we don't need to fetch/cache the entire repo
-  $exts = $this->getExtensions();
-  if (array_key_exists($key, $exts)) {
-    return $exts[$key];
-  }
-  else {
-    return NULL;
-  }
-}
+    $errors = array();
 
-/**
- * @return array
- * @throws CRM_Extension_Exception_ParseException
- */
-private function _discoverRemote() {
-  $tsPath = $this->getTsPath();
-  $timestamp = FALSE;
+    // if (!$this->cacheDir || !is_dir($this->cacheDir) || !is_writable($this->cacheDir)) {
+    //   $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
+    //   $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
+    //   $errors[] = array(
+    //     'title' => ts('Directory Unwritable'),
+    //     'message' => ts('Your extensions cache directory (%1) is not web server writable. Please go to the <a href="%2">path setting page</a> and correct it.<br/>',
+    //       array(
+    //         1 => $this->cacheDir,
+    //         2 => $url,
+    //       )
+    //     ),
+    //   );
+    // }
 
-  if (file_exists($tsPath)) {
-    $timestamp = file_get_contents($tsPath);
+    return $errors;
   }
 
-  // 3 minutes ago for now
-  $outdated = (int) $timestamp < (time() - 180) ? TRUE : FALSE;
+  /**
+   * Get a list of all available extensions.
+   *
+   * @return array
+   *($key => CRM_Extension_Info)
+   */
+  public function getExtensions() {
+    if (!$this->isEnabled() || count($this->checkRequirements())) {
+      return array();
+    }
 
-  if (!$timestamp || $outdated) {
-    $remotes = json_decode($this->grabRemoteJson(), TRUE);
+    $exts = array();
+
+    $remote = $this->_discoverRemote();
+    if (is_array($remote)) {
+      foreach ($remote as $dc => $e) {
+        $exts[$e->key] = $e;
+      }
+    }
+
+    return $exts;
   }
-  else {
-    $remotes = json_decode($this->grabCachedJson(), TRUE);
-  }
 
-  $this->_remotesDiscovered = array();
-  foreach ((array) $remotes as $id => $xml) {
-    $ext = CRM_Extension_Info::loadFromString($xml);
-    $this->_remotesDiscovered[] = $ext;
-  }
-
-  if (file_exists(dirname($tsPath))) {
-    file_put_contents($tsPath, (string) time());
-  }
-
-  return $this->_remotesDiscovered;
-}
-
-/**
- * Loads the extensions data from the cache file. If it is empty
- * or doesn't exist, try fetching from remote instead.
- *
- * @return string
- */
-
-/**
-private function grabCachedJson() {
-     $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this-   >getRepositoryUrl());
-     $json = NULL;
-     if (file_exists($filename)) {
-       $json = file_get_contents($filename);
-     }
-     if (empty($json)) {
-       $json = $this->grabRemoteJson();
-     }
-     return $json;
-   }
- */
-public function grabCachedJson() {
-  $isChanged = FALSE;
-  $extension = $this->cache->get('Extension_Browser');
-  if (empty($extension) || !is_array($extension)) {
-    $extension = array(
-      'expires' => 0, // ASAP
-      'ttl' => self::DEFAULT_RETRY,
-      'retry' => self::DEFAULT_RETRY,
-    );
-    $isChanged = TRUE;
-  }
-  if ($extension['expires'] <= CRM_Utils_Time::getTimeRaw()) {
-    $newExtension = $this->grabRemoteJson();
-    $extension = $newExtension;
-    $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['ttl'];
+  /**
+   * Get a description of a particular extension.
+   *
+   * @param string $key
+   *   Fully-qualified extension name.
+   *
+   * @return CRM_Extension_Info|NULL
+   */
+  public function getExtension($key) {
+    // TODO optimize performance -- we don't need to fetch/cache the entire repo
+    $exts = $this->getExtensions();
+    if (array_key_exists($key, $exts)) {
+      return $exts[$key];
+    }
     else {
-      // keep the old extensions for now, try again later
-      // $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
-      // }
+      return NULL;
+    }
+  }
+
+  /**
+   * @return array
+   * @throws CRM_Extension_Exception_ParseException
+   */
+  private function _discoverRemote() {
+    $tsPath = $this->getTsPath();
+    $timestamp = FALSE;
+
+    if (file_exists($tsPath)) {
+      $timestamp = file_get_contents($tsPath);
+    }
+
+    // 3 minutes ago for now
+    $outdated = (int) $timestamp < (time() - 180) ? TRUE : FALSE;
+
+    if (!$timestamp || $outdated) {
+      $remotes = json_decode($this->grabRemoteJson(), TRUE);
+    }
+    else {
+      $remotes = json_decode($this->grabCachedJson(), TRUE);
+    }
+
+    $this->_remotesDiscovered = array();
+    foreach ((array) $remotes as $id => $xml) {
+      $ext = CRM_Extension_Info::loadFromString($xml);
+      $this->_remotesDiscovered[] = $ext;
+    }
+
+    if (file_exists(dirname($tsPath))) {
+      file_put_contents($tsPath, (string) time());
+    }
+
+    return $this->_remotesDiscovered;
+  }
+
+  /**
+   * Loads the extensions data from the cache file. If it is empty
+   * or doesn't exist, try fetching from remote instead.
+   *
+   * @return string
+   */
+
+  /**
+  private function grabCachedJson() {
+     $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this-   >getRepositoryUrl());
+       $json = NULL;
+       if (file_exists($filename)) {
+         $json = file_get_contents($filename);
+        }
+       if (empty($json)) {
+       $json = $this->grabRemoteJson();
+       }
+       return $json;
+     }
+   */
+  public function grabCachedJson() {
+    $isChanged = FALSE;
+    $extension = $this->cache->get('Extension_Browser');
+    if (empty($extension) || !is_array($extension)) {
+      $extension = array(
+        'expires' => 0, // ASAP
+        'ttl' => self::DEFAULT_RETRY,
+        'retry' => self::DEFAULT_RETRY,
+      );
       $isChanged = TRUE;
     }
-    if ($isChanged) {
-      $this->cache->set('Extension_Browser', $extension);
+    if ($extension['expires'] <= CRM_Utils_Time::getTimeRaw()) {
+      $newExtension = $this->grabRemoteJson();
+      $extension = $newExtension;
+      $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['ttl'];
+      else {
+        // keep the old extensions for now, try again later
+        // $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
+        // }
+        $isChanged = TRUE;
+      }
+      if ($isChanged) {
+        $this->cache->set('Extension_Browser', $extension);
+      }
+      return $extension;
     }
-    return $extension;
-  }
 
   /**
    * Connects to public server and grabs the list of publicly available

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -266,12 +266,12 @@ public function grabCachedJson() {
     $newExtension = $this->grabRemoteJson();
     $extension = $newExtension;
     $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['ttl'];
-   else {
-    // keep the old extensions for now, try again later
-    // $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
-    // }
-    $isChanged = TRUE;
-   }
+    else {
+      // keep the old extensions for now, try again later
+      // $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
+      // }
+      $isChanged = TRUE;
+    }
     if ($isChanged) {
       $this->cache->set('Extension_Browser', $extension);
     }

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -66,26 +66,23 @@ class CRM_Extension_Browser {
 
   /**
    * Create default instance.
-   *
    * @return CRM_Extension_Browser
    */
 
    public static function create() {
-     return new CRM_Extension_Browser(
-       Civi::cache('extension_browser'),
-       CRM_Utils_HttpClient::singleton()
+    return new CRM_Extension_Browser(
+      Civi::cache('extension_browser'),
+      CRM_Utils_HttpClient::singleton()
      );
    }
 
    /**
     * @param string $repoUrl
-    *   URL of the remote repository.
+    *  URL of the remote repository.
     * @param string $indexPath
-    *   Relative path of the 'index' file within the repository.
-    * @param string $cacheDir
-    *   Local path in which to cache files.
+    *  Relative path of the 'index' file within the repository.
+    *  Local path in which to cache files.
     * @param CRM_Utils_Cache_Interface $cache
-    * @param CRM_Utils_HttpClient $client
     */
 
   public function __construct($cache, $client, $repoUrl, $indexPath) {
@@ -95,18 +92,16 @@ class CRM_Extension_Browser {
     // $this->client = $client;
     $this->indexPath = empty($indexPath) ? self::SINGLE_FILE_PATH : $indexPath;
     // if ($cacheDir && !file_exists($cacheDir) && is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
-    //   CRM_Utils_File::createDir($cacheDir, FALSE);
+    // CRM_Utils_File::createDir($cacheDir, FALSE);
     // }
   }
 
-  /**
-   * Determine whether the system policy allows downloading new extensions.
-   *
-   * This is reflection of *policy* and *intent*; it does not indicate whether
-   * the browser will actually *work*. For that, see checkRequirements().
-   *
-   * @return bool
-   */
+ /**
+  * Determine whether the system policy allows downloading new extensions.
+  * This is reflection of *policy* and *intent*; it does not indicate whether
+  * the browser will actually *work*. For that, see checkRequirements().
+  * @return bool
+  */
   public function isEnabled() {
     return (FALSE !== $this->getRepositoryUrl());
   }
@@ -241,17 +236,20 @@ class CRM_Extension_Browser {
    *
    * @return string
    */
-  // private function grabCachedJson() {
-  //   $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
-  //   $json = NULL;
-  //   if (file_exists($filename)) {
-  //     $json = file_get_contents($filename);
-  //   }
-  //   if (empty($json)) {
-  //     $json = $this->grabRemoteJson();
-  //   }
-  //   return $json;
-  // }
+
+/**   
+private function grabCachedJson() {
+     $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this-   >getRepositoryUrl());
+     $json = NULL;
+     if (file_exists($filename)) {
+       $json = file_get_contents($filename);
+     }
+     if (empty($json)) {
+       $json = $this->grabRemoteJson();
+     }
+     return $json;
+   }
+*/
 
   public function grabCachedJson() {
     $isChanged = FALSE;
@@ -268,10 +266,9 @@ class CRM_Extension_Browser {
       $newExtension = $this->grabRemoteJson();
         $extension = $newExtension;
         $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['ttl'];
-
-      // else {
-      //   // keep the old extensions for now, try again later
-      //   $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
+     else {
+      // keep the old extensions for now, try again later
+      // $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
       // }
       $isChanged = TRUE;
     }

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -58,7 +58,7 @@ class CRM_Extension_Browser {
   /**
    * @var CRM_Utils_HttpClient
    */
-  protected $client;
+  // protected $client;
   /**
    * @var CRM_Utils_Cache_Interface
    */
@@ -92,7 +92,7 @@ class CRM_Extension_Browser {
     $this->repoUrl = $repoUrl;
     // $this->cacheDir = $cacheDir;
     $this->cache = $cache;
-    $this->client = $client;
+    // $this->client = $client;
     $this->indexPath = empty($indexPath) ? self::SINGLE_FILE_PATH : $indexPath;
     // if ($cacheDir && !file_exists($cacheDir) && is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
     //   CRM_Utils_File::createDir($cacheDir, FALSE);
@@ -134,29 +134,29 @@ class CRM_Extension_Browser {
    * @return array
    *   List of error messages; empty if OK.
    */
-  // public function checkRequirements() {
-  //   if (!$this->isEnabled()) {
-  //     return array();
-  //   }
-  //
-  //   $errors = array();
-  //
-  //   if (!$this->cacheDir || !is_dir($this->cacheDir) || !is_writable($this->cacheDir)) {
-  //     $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
-  //     $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
-  //     $errors[] = array(
-  //       'title' => ts('Directory Unwritable'),
-  //       'message' => ts('Your extensions cache directory (%1) is not web server writable. Please go to the <a href="%2">path setting page</a> and correct it.<br/>',
-  //         array(
-  //           1 => $this->cacheDir,
-  //           2 => $url,
-  //         )
-  //       ),
-  //     );
-  //   }
-  //
-  //   return $errors;
-  // }
+  public function checkRequirements() {
+    if (!$this->isEnabled()) {
+      return array();
+    }
+
+    $errors = array();
+
+    // if (!$this->cacheDir || !is_dir($this->cacheDir) || !is_writable($this->cacheDir)) {
+    //   $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
+    //   $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
+    //   $errors[] = array(
+    //     'title' => ts('Directory Unwritable'),
+    //     'message' => ts('Your extensions cache directory (%1) is not web server writable. Please go to the <a href="%2">path setting page</a> and correct it.<br/>',
+    //       array(
+    //         1 => $this->cacheDir,
+    //         2 => $url,
+    //       )
+    //     ),
+    //   );
+    // }
+
+    return $errors;
+  }
 
   /**
    * Get a list of all available extensions.
@@ -253,7 +253,7 @@ class CRM_Extension_Browser {
   //   return $json;
   // }
 
-  public function grabExtCache() {
+  public function grabCachedJson() {
     $isChanged = FALSE;
     $extension = $this->cache->get('Extension_Browser');
     if (empty($extension) || !is_array($extension)) {
@@ -269,10 +269,10 @@ class CRM_Extension_Browser {
         $extension = $newExtension;
         $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['ttl'];
 
-      else {
-        // keep the old extensions for now, try again later
-        $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
-      }
+      // else {
+      //   // keep the old extensions for now, try again later
+      //   $extension['expires'] = CRM_Utils_Time::getTimeRaw() + $extension['retry'];
+      // }
       $isChanged = TRUE;
     }
     if ($isChanged) {

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -34,67 +34,67 @@
  */
 class CRM_Extension_Browser {
 
-  /**
-   * An URL for public extensions repository.
-   *
-   * Note: This default is now handled through setting/*.php.
-   *
-   * @deprecated
-   */
-  const DEFAULT_EXTENSIONS_REPOSITORY = 'https://civicrm.org/extdir/ver={ver}|cms={uf}';
+/**
+ * An URL for public extensions repository.
+ *
+ * Note: This default is now handled through setting/*.php.
+ *
+ * @deprecated
+ */
+const DEFAULT_EXTENSIONS_REPOSITORY = 'https://civicrm.org/extdir/ver={ver}|cms={uf}';
 
-  /**
-   * Relative path below remote repository URL for single extensions file.
-   */
-  const SINGLE_FILE_PATH = '/single';
+/**
+ * Relative path below remote repository URL for single extensions file.
+ */
+const SINGLE_FILE_PATH = '/single';
 
-  /**
-   * The name of the single JSON extension cache file.
-   */
-  const CACHE_JSON_FILE = 'extensions.json';
+/**
+ * The name of the single JSON extension cache file.
+ */
+const CACHE_JSON_FILE = 'extensions.json';
 
-  // timeout for when the connection or the server is slow
-  const CHECK_TIMEOUT = 5;
-  /**
-   * @var CRM_Utils_HttpClient
-   */
-  // protected $client;
-  /**
-   * @var CRM_Utils_Cache_Interface
-   */
-  protected $cache;
+// timeout for when the connection or the server is slow
+const CHECK_TIMEOUT = 5;
+/**
+ * @var CRM_Utils_HttpClient
+ */
+// protected $client;
+/**
+ * @var CRM_Utils_Cache_Interface
+ */
+protected $cache;
 
-  /**
-   * Create default instance.
-   * @return CRM_Extension_Browser
-   */
+/**
+ * Create default instance.
+ * @return CRM_Extension_Browser
+ */
 
-   public static function create() {
-    return new CRM_Extension_Browser(
-      Civi::cache('extension_browser'),
-      CRM_Utils_HttpClient::singleton()
-     );
-   }
+public static function create() {
+  return new CRM_Extension_Browser(
+    Civi::cache('extension_browser'),
+    CRM_Utils_HttpClient::singleton()
+  );
+}
 
-   /**
-    * @param string $repoUrl
-    *  URL of the remote repository.
-    * @param string $indexPath
-    *  Relative path of the 'index' file within the repository.
-    *  Local path in which to cache files.
-    * @param CRM_Utils_Cache_Interface $cache
-    */
+    /**
+     * @param string $repoUrl
+     *  URL of the remote repository.
+     * @param string $indexPath
+     *  Relative path of the 'index' file within the repository.
+     *  Local path in which to cache files.
+     * @param CRM_Utils_Cache_Interface $cache
+     */
 
-  public function __construct($cache, $client, $repoUrl, $indexPath) {
-    $this->repoUrl = $repoUrl;
-    // $this->cacheDir = $cacheDir;
-    $this->cache = $cache;
-    // $this->client = $client;
-    $this->indexPath = empty($indexPath) ? self::SINGLE_FILE_PATH : $indexPath;
-    // if ($cacheDir && !file_exists($cacheDir) && is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
-    // CRM_Utils_File::createDir($cacheDir, FALSE);
-    // }
-  }
+    public function __construct($cache, $client, $repoUrl, $indexPath) {
+      $this->repoUrl = $repoUrl;
+      // $this->cacheDir = $cacheDir;
+      $this->cache = $cache;
+      // $this->client = $client;
+      $this->indexPath = empty($indexPath) ? self::SINGLE_FILE_PATH : $indexPath;
+      // if ($cacheDir && !file_exists($cacheDir) && is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
+      // CRM_Utils_File::createDir($cacheDir, FALSE);
+      // }
+    }
 
  /**
   * Determine whether the system policy allows downloading new extensions.

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -296,29 +296,29 @@ class CRM_Extension_Browser {
         return array();
       }
 
-    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
-    $url = $this->getRepositoryUrl() . $this->indexPath;
-    $status = CRM_Utils_HttpClient::singleton()->fetch($url, $filename);
+      $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
+      $url = $this->getRepositoryUrl() . $this->indexPath;
+      $status = CRM_Utils_HttpClient::singleton()->fetch($url, $filename);
 
-    ini_restore('allow_url_fopen');
-    ini_restore('default_socket_timeout');
+      ini_restore('allow_url_fopen');
+      ini_restore('default_socket_timeout');
 
-    restore_error_handler();
+      restore_error_handler();
 
-    if ($status !== CRM_Utils_HttpClient::STATUS_OK) {
-      throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests or contact CiviCRM team on <a href="http://forum.civicrm.org/">CiviCRM forum</a>.', array(1 => $this->getRepositoryUrl())), 'connection_error');
+      if ($status !== CRM_Utils_HttpClient::STATUS_OK) {
+        throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests or contact CiviCRM team on <a href="http://forum.civicrm.org/">CiviCRM forum</a>.', array(1 => $this->getRepositoryUrl())), 'connection_error');
+      }
+
+      // Don't call grabCachedJson here, that would risk infinite recursion
+      return file_get_contents($filename);
     }
 
-    // Don't call grabCachedJson here, that would risk infinite recursion
-    return file_get_contents($filename);
-  }
-
-  /**
-   * @return string
-   */
-  private function getTsPath() {
-    return $this->cacheDir . DIRECTORY_SEPARATOR . 'timestamp.txt';
-  }
+    /**
+     * @return string
+     */
+    private function getTsPath() {
+      return $this->cacheDir . DIRECTORY_SEPARATOR . 'timestamp.txt';
+    }
 
   /**
    * A dummy function required for suppressing download errors.

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -154,7 +154,7 @@ class CRM_Extension_Browser {
    * Get a list of all available extensions.
    *
    * @return array
-   * ($key => CRM_Extension_Info)
+   *   ($key => CRM_Extension_Info)
    */
   public function getExtensions() {
     if (!$this->isEnabled() || count($this->checkRequirements())) {

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -320,14 +320,14 @@ class CRM_Extension_Browser {
       return $this->cacheDir . DIRECTORY_SEPARATOR . 'timestamp.txt';
     }
 
-  /**
-   * A dummy function required for suppressing download errors.
-   *
-   * @param $errorNumber
-   * @param $errorString
-   */
-  public static function downloadError($errorNumber, $errorString) {
-  }
+    /**
+     * A dummy function required for suppressing download errors.
+     *
+     * @param $errorNumber
+     * @param $errorString
+     */
+    public static function downloadError($errorNumber, $errorString) {
+    }
 
   }
 }

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -34,45 +34,45 @@
  */
 class CRM_Extension_Browser {
 
-/**
- * An URL for public extensions repository.
- *
- * Note: This default is now handled through setting/*.php.
- *
- * @deprecated
- */
-const DEFAULT_EXTENSIONS_REPOSITORY = 'https://civicrm.org/extdir/ver={ver}|cms={uf}';
+  /**
+   * An URL for public extensions repository.
+   *
+   * Note: This default is now handled through setting/*.php.
+   *
+   * @deprecated
+   */
+  const DEFAULT_EXTENSIONS_REPOSITORY = 'https://civicrm.org/extdir/ver={ver}|cms={uf}';
 
-/**
- * Relative path below remote repository URL for single extensions file.
- */
-const SINGLE_FILE_PATH = '/single';
+  /**
+   * Relative path below remote repository URL for single extensions file.
+   */
+  const SINGLE_FILE_PATH = '/single';
 
-/**
- * The name of the single JSON extension cache file.
- */
-const CACHE_JSON_FILE = 'extensions.json';
+  /**
+   * The name of the single JSON extension cache file.
+   */
+  const CACHE_JSON_FILE = 'extensions.json';
 
-// timeout for when the connection or the server is slow
-const CHECK_TIMEOUT = 5;
-/**
- * @var CRM_Utils_HttpClient
- */
-// protected $client;
-/**
- * @var CRM_Utils_Cache_Interface
- */
-protected $cache;
-/**
- * Create default instance.
- * @return CRM_Extension_Browser
- */
-public static function create() {
-  return new CRM_Extension_Browser(
-    Civi::cache('extension_browser'),
-    CRM_Utils_HttpClient::singleton()
-  );
-}
+  // timeout for when the connection or the server is slow
+  const CHECK_TIMEOUT = 5;
+  /**
+   * @var CRM_Utils_HttpClient
+   */
+  // protected $client;
+  /**
+   * @var CRM_Utils_Cache_Interface
+   */
+  protected $cache;
+  /**
+   * Create default instance.
+   * @return CRM_Extension_Browser
+   */
+  public static function create() {
+    return new CRM_Extension_Browser(
+      Civi::cache('extension_browser'),
+      CRM_Utils_HttpClient::singleton()
+    );
+  }
 
 /**
  * @param string $repoUrl
@@ -329,5 +329,5 @@ public function grabCachedJson() {
   public static function downloadError($errorNumber, $errorString) {
   }
 
- }
+}
 }

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -223,11 +223,11 @@ class CRM_Extension_System {
    */
   public function getBrowser() {
     if ($this->browser === NULL) {
-      $cacheDir = NULL;
+      $cache = NULL;
       if (!empty($this->parameters['uploadDir'])) {
-        $cacheDir = CRM_Utils_File::addTrailingSlash($this->parameters['uploadDir']) . 'cache';
+        $cache = CRM_Utils_File::addTrailingSlash($this->parameters['uploadDir']) . 'cache';
       }
-      $this->browser = new CRM_Extension_Browser($this->getRepositoryUrl(), '', $cacheDir);
+      $this->browser = new CRM_Extension_Browser($this->getRepositoryUrl(), '', $cache);
     }
     return $this->browser;
   }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -163,7 +163,7 @@ class Container {
     $basicCaches = array(
       'js_strings' => 'js_strings',
       'community_messages' => 'community_messages',
-      'extension_browser' =>  'extension_browser',
+      'extension_browser' => 'extension_browser',
       'checks' => 'checks',
       'session' => 'CiviCRM Session',
     );

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -163,6 +163,7 @@ class Container {
     $basicCaches = array(
       'js_strings' => 'js_strings',
       'community_messages' => 'community_messages',
+      'extension_browser' =>  'extension_browser',
       'checks' => 'checks',
       'session' => 'CiviCRM Session',
     );


### PR DESCRIPTION
Before
----------------------------------------
The current code in CRM_Extension_Browser is coded specifically for an adhoc, file-based caching logic

After
----------------------------------------
Change the backing/storage from a JSON file to the civicrm_cache table (at least, for the typical usage). 


Comments
----------------------------------------
see [comments](https://lab.civicrm.org/dev/cloud-native/issues/2#note_4790) in gitlab
