### PR TITLE
dev/core/#299 Fix mishandling of non decimal currency on additional payment form.

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -174,7 +174,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $defaults['total_amount'] = CRM_Utils_Money::format(abs($this->_refund), NULL, NULL, TRUE);
     }
     elseif ($this->_owed) {
-      $defaults['total_amount'] = number_format($this->_owed, 2);
+      $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($this->_owed);
     }
 
     // Set $newCredit variable in template to control whether link to credit card mode is included


### PR DESCRIPTION
Overview
----------------------------------------
Fixes mis-loading of default for amount on record payment form when non decimal thousand separators used

Before
----------------------------------------
Currency loads with a decimal point even when a comma decimal separator is configured

After
----------------------------------------
Currency loads with a comma when a comma decimal separator is configured


Technical Details
----------------------------------------
I tried to use as much of @mattwire work as relevant to solve this 
https://github.com/civicrm/civicrm-core/pull/12055/files

What I found in there was that the code assumed that the code extracted to formatNumericByFormat fixed thousand separators but it in fact didn't. What I found is it converted '70' to '70.00' but in fact it didn't & required the self::replaceCurrencySeparators($amount); sequence to do that work. As a result I made formatNumeric protected & exposed 2 wrappers 

- formatLocaleNumericRoundedByCurrency
- formatLocaleNumericRoundedForDefaultCurrency

@mattwire what do you think - this brings across some but not all of your work in a specific context - which could go broader.  My big concern with the existing money format function is that it tries to do something for everyone & handle too many things.

We could shorten the function names - ie. 
 formatLocaleNumericByCurrency
formatLocaleNumericRoundedDefaultCurrency
Although if we later thought 'we only sometimes want to round' we'd find someone adding a magic param & we would start rebuilding 'format'

We could actually solve this bug with the existing format function except we would lose the rounding that is in the current function.


Comments
----------------------------------------

