### PR TITLE
Use cached version of payment processor.

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -273,7 +273,7 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    */
   public static function getAllPaymentProcessors($mode = 'all', $reset = FALSE, $isCurrentDomainOnly = TRUE) {
 
-    $cacheKey = 'CRM_Financial_BAO_Payment_Processor_' . $mode . '_' . CRM_Core_Config::domainID();
+    $cacheKey = 'CRM_Financial_BAO_Payment_Processor_' . $mode . '_' . $isCurrentDomainOnly . '_' . CRM_Core_Config::domainID();
     if (!$reset) {
       $processors = CRM_Utils_Cache::singleton()->get($cacheKey);
       if (!empty($processors)) {
@@ -370,10 +370,10 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
   public static function getPaymentProcessors($capabilities = array(), $ids = FALSE) {
     $testProcessors = in_array('TestMode', $capabilities) ? self::getAllPaymentProcessors('test') : array();
     if (is_array($ids)) {
-      $processors = self::getAllPaymentProcessors('all', TRUE, FALSE);
+      $processors = self::getAllPaymentProcessors('all', FALSE, FALSE);
     }
     else {
-      $processors = self::getAllPaymentProcessors('all', TRUE);
+      $processors = self::getAllPaymentProcessors('all');
     }
 
     if (in_array('TestMode', $capabilities) && is_array($ids)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix issues with retrieving payment processors in Redis

Before
----------------------------------------
With some processors combined with Redis caching the call to completetransaction fails

After
----------------------------------------
Complete transaction works even when the gateway has been 'used'

Technical Details
----------------------------------------
I am hitting a slightly obscure bug in Redis that is solved by this change.

Per https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/55
we have an issue whereby Omnipay adds the gateway to a variable on class when processing payments.

In some cases this gateway will not serialize into a key under Redis causing a fatal.

However, we don't really need to be storing the payment processor in it's 'used' state. The 
getAllPaymentProcessor function is intended to retrieve 'fresh' copies - but in https://github.com/civicrm/civicrm-core/pull/9371/files#diff-de613d42f9ac91739e1d5df2d835af67R381 the caching was by-passed by @seamuslee001 to protect multidomain weirdness -however, I think we can get
past that by changing the cache key.


Comments
----------------------------------------
@seamuslee001 any chance you can test this? @mattwire ping

@totten ping - just an FYI that there is an issue with Redis that caching objects can crash it sometimes
