### PR TITLE
Drop custom CSS for Joomla CiviCRM menu so it works with shoreditch theme

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -295,14 +295,7 @@ br.clear {
 /* Moved from civicrm.css in v3.2 */
 
 ul#civicrm-menu {
-  z-index: 1;
   position:relative;
-  border: none;
-  left:0px;
-  height:0px;
-  padding: 2px 0px 25px 2px !important;
-  padding-bottom:25px !important; /*moz bottom */
-  padding-bottom:2px; /*ie bottom */
 }
 
 div#toolbar-box div.m {


### PR DESCRIPTION
Overview
----------------------------------------
The Joomla CiviCRM menu has some CSS customisation that dates back to CiviCRM 3.2 and I think is unnecessary.  It also breaks the menu when using the Shoreditch theme.

See https://github.com/civicrm/org.civicrm.shoreditch/issues/147

Before
----------------------------------------
Non shoreditch theme:
![bec-cave org uk_administrator__option com_civicrm task civicrm_admin reset 1](https://user-images.githubusercontent.com/2052161/43789008-c7dc24d8-9a66-11e8-86f3-066a9c4679ff.png)

Shoreditch theme:
![bec-cave org uk_administrator__option com_civicrm task civicrm_contribute reset 1](https://user-images.githubusercontent.com/2052161/43789029-d853dd24-9a66-11e8-99ce-ab409d454330.png)

After
----------------------------------------
Non shoreditch theme: 
![bec-cave org uk_administrator__option com_civicrm task civicrm_admin reset 1 1](https://user-images.githubusercontent.com/2052161/43789016-ce67226c-9a66-11e8-8308-d21f79a06a4d.png)

Shoreditch theme:
![bec-cave org uk_administrator__option com_civicrm task civicrm_contribute reset 1 1](https://user-images.githubusercontent.com/2052161/43789033-dbee177e-9a66-11e8-9b1f-2139923597c9.png)


Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
