### PR TITLE
dev/core/#273 Fix issue where sending an SMS with the To Field in the…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -231,6 +231,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
       $criteria = array(
         'is_opt_out' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_opt_out = 0"),
         'is_deceased' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_deceased <> 1"),
+        'do_not_sms' => CRM_Utils_SQL_Select::fragment()->where("$contact.do_not_sms = 0"),
         'location_filter' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone_type_id = " . CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_Phone', 'phone_type_id', 'Mobile')),
         'phone_not_null' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone IS NOT NULL"),
         'phone_not_empty' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone != ''"),


### PR DESCRIPTION
… provider params set did not work and fix handling of do_not_sms

Overview
----------------------------------------
Picking up the work done in these 2 PRs https://github.com/civicrm/civicrm-core/pull/12614/files https://github.com/civicrm/civicrm-core/pull/12554/files it was obvious that when the phone number was set in the To param for the sms provider params that SMSes were failing. This was shown to be happening when you selected outbound sms from the list of actions on a contact screen. 

When investigating this i found that in that case where the phone number was set in the SMS provider Params, the do_not_sms flag was potentially not properly being respected  and would have been worsened under PR 12614. This now has tests that a) prove the original bug and b) lock in the handling on do not SMS

Before
----------------------------------------
SMS sending fails when phone number included in the To param of smsProviderParams

After
----------------------------------------
SMSes fail to send and potential mis handling in terms of do_not_sms

Technical Details
----------------------------------------
SMSes send correctly have better handling of do_not_sms and more tests

ping @mattwire @eileenmcnaughton @vinuvarshith @jyothi-shree21