### PR TITLE
dev/core#231 Drupal8: Fix for user account creation via CiviCRM

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -65,7 +65,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     if ($user_register_conf != 'visitors' && !$user->hasPermission('administer users')) {
       $account->block();
     }
-    elseif (!$verify_mail_conf) {
+    elseif ($verify_mail_conf) {
       $account->activate();
     }
 
@@ -110,8 +110,9 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
         break;
     }
 
-    // If this is a user creating their own account, login them in!
-    if ($account->isActive() && $user->isAnonymous()) {
+    // If this is a user creating their own account, login them in.
+    // Except when mail confirmation is required
+    if (!$verify_mail_conf && $user->isAnonymous()) {
       \user_login_finalize($account);
     }
 


### PR DESCRIPTION
in https://lab.civicrm.org/dev/core/issues/231 I first mentioned a problem we had with user registration confirm in drupal 8.

Overview
----------------------------------------
In our Drupal8 & CiviCRM setup we allow visitors to create accounts, with email verification. These users are created by CiviCRM when they sign up for a membership.

We encountered some issues around the registration process: the user was denied permission to the password form. This is because Drupal 8 requires a user to be active for this link to work.

Before
----------------------------------------
When a new user account was created in Drupal for a new contact. A verification mail was send with a one time login mail in it. This link was always invalid/faulty. and we got permission denied on the form.

After
----------------------------------------
When receiving the one-time login mail and click on the link, the form is accessible for that user and he/she can fill in their password

Technical Details
----------------------------------------
In Drupal core you can see where the checks for this link happen in `core/modules/user/src/Controller/UserController.php` resetPassLogin(). 

```
    // Verify that the user exists and is active.
    if ($user === NULL || !$user->isActive()) {
      // Blocked or invalid user ID, so deny access. The parameters will be in
      // the watchdog's URL for the administrator to check.
      throw new AccessDeniedHttpException();
    }
```
