### PR TITLE
/dev/core/#303 print/merge html via PDF pathway, instead of PHPWord

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -431,7 +431,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
-    if ($type == 'pdf') {
+    if ($type == 'pdf' || $type == 'html') {
       $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -48,7 +48,7 @@ class CRM_Utils_PDF_Utils {
    *
    * @return string|void
    */
-  public static function html2pdf(&$text, $fileName = 'civicrm.pdf', $output = FALSE, $pdfFormat = NULL) {
+  public static function html2pdf(&$text, $fileName = 'civicrm.pdf', $output = FALSE, $pdfFormat = NULL, $type = 'pdf') {
     if (is_array($text)) {
       $pages = &$text;
     }
@@ -127,6 +127,14 @@ class CRM_Utils_PDF_Utils {
     </div>
   </body>
 </html>";
+
+    //output HTML if needed
+	  if($type == 'html') {
+		  header('Content-Disposition: attachment; filename="' . $fileName);
+		  echo $html;
+		  return;
+	  }
+
     if ($config->wkhtmltopdfPath) {
       return self::_html2pdf_wkhtmltopdf($paper_size, $orientation, $margins, $html, $output, $fileName);
     }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a problem where printing a document to HTML produced poor HTML. In 'Print/Merge Document' you can select to output to HTML. In practice, this processes the HTML via PHPWord. This seems to mangle it quite badly: div tags get converted into text (it literally says 'div'), styling gets removed, etc. 

Before
----------------------------------------
CRM_Contact_Form_Task_PDFLetterCommon sent HTML via CRM_Utils_PDF_Document::html2doc(), which processes it using PHPWord.

After
----------------------------------------
CRM_Contact_Form_Task_PDFLetterCommon sends HTML via CRM_Urils_PDF_Utils::html2pdf(). This is the pathway used to create PDFs, which creates an elegant HTML page en route.
