### PR TITLE
Issue273

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1830,8 +1830,10 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     $toPhoneNumber = NULL;
 
     if ($smsProviderParams['To']) {
-      // If phone number is specified use it
+      // If phone number is specified use it. We assume this contact has
+      // been checked to ensure Do Not SMS is not selected.
       $toPhoneNumber = trim($smsProviderParams['To']);
+      $doNotSms = FALSE;
     }
     elseif ($toID) {
       // No phone number specified, so find a suitable one for the contact

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -229,7 +229,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
 
     if ($isSMSmode) {
       $criteria = array(
-        'is_opt_out' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_opt_out = 0"),
+        'do_not_sms' => CRM_Utils_SQL_Select::fragment()->where("$contact.do_not_sms = 0"),
         'is_deceased' => CRM_Utils_SQL_Select::fragment()->where("$contact.is_deceased <> 1"),
         'location_filter' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone_type_id = " . CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_Phone', 'phone_type_id', 'Mobile')),
         'phone_not_null' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone IS NOT NULL"),


### PR DESCRIPTION
Overview
----------------------------------------
SMS sending features do not properly respect the do not sms flag.

See https://lab.civicrm.org/dev/core/issues/273

Before
----------------------------------------
When sending a single SMS message via an Outbound SMS activity, CiviCRM rejects the message with an error suggesting that the phone number is not correct or the contact does not wish to receive SMS messages (even though "Do not SMS" is not selected for the contact and the phone number is a valid mobile phone number).

In addition, if a contact has "Do not SMS" checked, they are included in mass CiviSMS mailings.

After
----------------------------------------
You can send an SMS message via Outbound SMS activity if do not SMS is unchecked. If it is checked, the contact is properly ommitted from mass SMS messages.

Comments
----------------------------------------

The first problem seems to be a regression from:
https://github.com/civicrm/civicrm-core/pull/10946

The second seems to have been an oversight when this commit was introduced:

https://github.com/civicrm/civicrm-core/pull/11558
