### PR TITLE
dev/core#314 Event self-service Transfer picks up the deleted contact ID basically transferring to the wrong contact

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -337,10 +337,22 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     }
     else {
       //cancel 'from' participant row
-      $query = "select contact_id from civicrm_email where email = '" . $params['email'] . "'";
-      $dao = CRM_Core_DAO::executeQuery($query);
-      while ($dao->fetch()) {
-        $contact_id  = $dao->contact_id;
+      try{
+        $contact_id_result = civicrm_api3('Contact', 'get', array(
+          'sequential' => 1,
+          'return' => array("id"),
+          'email' => $params['email'],
+          'options' => array('limit' => 1),
+        ));
+        $contact_id_result = $contact_id_result['values'][0];
+        $contact_id = $contact_id_result['contact_id'];
+        $contact_is_deleted = $contact_id_result['contact_is_deleted'];
+        if ($contact_is_deleted || !is_numeric($contact_id)) {
+          CRM_Core_Error::statusBounce(ts('Contact does not exist.'));
+        }
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        CRM_Core_Error::statusBounce(ts('Contact does not exist.'));
       }
     }
     $from_participant = $params = array();

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -337,21 +337,16 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     }
     else {
       //cancel 'from' participant row
-      try{
-        $contact_id_result = civicrm_api3('Contact', 'get', array(
-          'sequential' => 1,
-          'return' => array("id"),
-          'email' => $params['email'],
-          'options' => array('limit' => 1),
-        ));
-        $contact_id_result = $contact_id_result['values'][0];
-        $contact_id = $contact_id_result['contact_id'];
-        $contact_is_deleted = $contact_id_result['contact_is_deleted'];
-        if ($contact_is_deleted || !is_numeric($contact_id)) {
-          CRM_Core_Error::statusBounce(ts('Contact does not exist.'));
-        }
-      }
-      catch (CiviCRM_API3_Exception $e) {
+      $contact_id_result = civicrm_api3('Contact', 'get', array(
+        'sequential' => 1,
+        'return' => array("id"),
+        'email' => $params['email'],
+        'options' => array('limit' => 1),
+      ));
+      $contact_id_result = $contact_id_result['values'][0];
+      $contact_id = $contact_id_result['contact_id'];
+      $contact_is_deleted = $contact_id_result['contact_is_deleted'];
+      if ($contact_is_deleted || !is_numeric($contact_id)) {
         CRM_Core_Error::statusBounce(ts('Contact does not exist.'));
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When transferring a event registration, it picks up the first email id in the email table and get the corresponding contact id, which in some cases can be the deleted contact. 

Before
----------------------------------------
It's picking up the wrong contact to attach the registration to. 

After
----------------------------------------
It's now picking up the correct contact to attach the registration to. 

Technical Details
----------------------------------------
Just a simple Join and checking for deleted records. 

Comments
----------------------------------------

---

https://lab.civicrm.org/dev/core/issues/314