### PR TITLE
filter current employer report by all groups

### DIFF
--- a/CRM/Report/Form/Contact/CurrentEmployer.php
+++ b/CRM/Report/Form/Contact/CurrentEmployer.php
@@ -189,22 +189,9 @@ class CRM_Report_Form_Contact_CurrentEmployer extends CRM_Report_Form {
           ),
         ),
       ),
-      'civicrm_group' => array(
-        'dao' => 'CRM_Contact_DAO_Group',
-        'alias' => 'cgroup',
-        'filters' => array(
-          'gid' => array(
-            'name' => 'group_id',
-            'title' => ts('Group'),
-            'type' => CRM_Utils_Type::T_INT,
-            'group' => TRUE,
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::staticGroup(),
-          ),
-        ),
-      ),
     );
 
+    $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
     parent::__construct();
   }


### PR DESCRIPTION
Code only filtered by static groups before.

https://lab.civicrm.org/dev/core/issues/320

Overview
----------------------------------------
Update the current Employer report so you can filter by all groups, not just static groups. 

Before
----------------------------------------
Previously, the only groups listed in the Filter tab, Group field are static groups. You can't filter the report by smart groups.

After
----------------------------------------
You can filter by all groups.

Technical Details
----------------------------------------
The old code included a stanza for the group filter which specified the options using `CRM_Core_PseudoConstant::staticGroup()`. The new code eliminates the stanza and sets _groupFilter = TRUE;

