### PR TITLE
[phpunit test only] - Add one additional data integrity check to ensure that after Edit Fin…

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1357,6 +1357,13 @@ Expires: ',
     $this->assertEquals($contribution['total_amount'], $lineItem['line_total'] + $lineItem['tax_amount']);
     $this->assertEquals($contribution['tax_amount'], $lineItem['tax_amount']);
 
+    $financialItems = $this->callAPISuccess('FinancialItem', 'get', array());
+    $financialItems_sum = 0;
+    foreach ($financialItems['values'] as $financialItem) {
+      $financialItems_sum += $financialItem['amount'];
+    }
+    $this->assertEquals($contribution['total_amount'], $financialItems_sum);
+
     // reset the price options static variable so not leave any dummy data, that might hamper other unit tests
     \Civi::$statics['CRM_Price_BAO_PriceField']['priceOptions'] = NULL;
     $this->disableTaxAndInvoicing();


### PR DESCRIPTION
…ancial Items add up to total_amount at Contribution level.

Overview
----------------------------------------
This is a small follow up - add/on to: https://github.com/civicrm/civicrm-core/pull/12629 

Before
----------------------------------------
Test is checking line_items, tax_amount and total_amount all add up [after editing a Membership that has Line Items and Sales Tax associated with it].

After
----------------------------------------
In addition test is now also checking that the Financial Items add up to total_amount at the contribution level [after editing a Membership that has Line Items and Sales Tax associated with it].

Comments
----------------------------------------
Bigger picture: one of our clients has been hit with intermittent regressions on the Edit Contribution screen (if the Contribution involves Line Items and Sales Tax) - this will help ensure that what's working currently is locked in. 

All tests are passing on my local - over to Jenkins.