### PR TITLE
Case type management fixes

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -76,6 +76,7 @@
             }];
             reqs.relTypes = ['RelationshipType', 'get', {
               sequential: 1,
+              is_active: 1,
               options: {
                 sort: CRM.crmCaseType.REL_TYPE_CNAME,
                 limit: 0
@@ -315,7 +316,8 @@
       _.each($scope.caseType.definition.activitySets, function (set) {
         _.each(set.activityTypes, function (type, name) {
           var isDefaultAssigneeTypeUndefined = _.isUndefined(type.default_assignee_type);
-          type.label = $scope.activityTypes[type.name].label;
+          var typeDefinition = $scope.activityTypes[type.name];
+          type.label = (typeDefinition && typeDefinition.label) || type.name;
 
           if (isDefaultAssigneeTypeUndefined) {
             type.default_assignee_type = defaultAssigneeDefaultValue.value;


### PR DESCRIPTION
## Overview
This PR fixes the following issues with case type management:

* When selecting default assignees by relationships, it will only display active relationship types.
* It handles the absence of activity types that have been deleted. Without taking this into consideration, the screen would break if it encounters a missing activity type.

## Active relationship types

To reproduce the issue:

1. disable a relationship type
2. edit a case type and select a timeline
3. select any activity, change the default assignee option, and choose "By relationship to case client"
4. search for the relationship type that was disabled.

The relationship type is shown, but it should not.

### Before
![relationship-type-before](https://user-images.githubusercontent.com/1642119/44003932-cd515c06-9e28-11e8-91cf-c8bc9d5da8d1.png)

### After
![pr-relationship-types-before](https://user-images.githubusercontent.com/1642119/44003757-2902c7a4-9e26-11e8-8d2e-d89da0aff558.png)

### Technical details

The issue is present because when constructing the list of relationship types for default assignees, the list does not take into consideration the `is_active` field. To fix this, the request that brings relationship types was amended:

```js
reqs.relTypes = ['RelationshipType', 'get', {
  sequential: 1,
  is_active: 1,
  options: {
    sort: CRM.crmCaseType.REL_TYPE_CNAME,
    limit: 0
  }
}];
```

------------------

## Deleted activity types

How to reproduce the issue:

1. Find an activity type that is included in one of the case types's timelines.
2. Delete the activity type.
3. Try to edit the case type where the activity type was included.

A broken AngularJS screen is shown and it should not.

### Before
![missing-activity-before](https://user-images.githubusercontent.com/1642119/44003898-6e098db8-9e28-11e8-899f-cfe8a61d20c6.png)

### After
![missing-activity-after](https://user-images.githubusercontent.com/1642119/44004061-4eab99fa-9e2a-11e8-9445-9d82ee43dd1a.png)

### Technical details

The issue happens because the list of all activity types is stored in a `$scope.activityTypes` indexed by activity name, but when one of the activities defined in a timeline references a deleted activity type, it breaks:

```js
// before
type.label = $scope.activityTypes[type.name].label;

// after
var typeDefinition = $scope.activityTypes[type.name];
type.label = (typeDefinition && typeDefinition.label) || type.name;
```

The fix checks if the activity type exists, if not, it will use the type name as label as a fall back.

-----------------

Comments
----------------------------------------
Tests could not be added because running `karma start` yields the following error:

```
ERROR [config]: Invalid config file!
  TypeError: Cannot read property 'replace' of undefined
    at escape (/vagrant/hr17-9000/sites/all/modules/civicrm/node_modules/civicrm-cv/civicrm-cv.js:5:20)
    at serializeArgs (/vagrant/hr17-9000/sites/all/modules/civicrm/node_modules/civicrm-cv/civicrm-cv.js:11:22)
    at /vagrant/hr17-9000/sites/all/modules/civicrm/node_modules/civicrm-cv/civicrm-cv.js:42:20
    at Object.<anonymous> (/vagrant/hr17-9000/sites/all/modules/civicrm/karma.conf.js:17:23)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
```


I'm guessing this is an issue with the `civicrm-cv` package.