### PR TITLE
dev/core/issues/322 - fix JS error on contribution page, completing form…

### DIFF
--- a/js/AlternateContactSelector.js
+++ b/js/AlternateContactSelector.js
@@ -9,7 +9,7 @@ CRM.$(function($) {
           $.each(result.values, function (id, value) {
             $.each(value, function (fieldname, fieldvalue) {
               $('#' + fieldname).val(fieldvalue).change();
-              $("[name=" + fieldname + "]").val([fieldvalue]);
+              $('[name="' + fieldname + '"]').val([fieldvalue]);
               if ($.isArray(fieldvalue)) {
                 $.each(fieldvalue, function (index, val) {
                   $("#" + fieldname + "_" + val).prop('checked', true);


### PR DESCRIPTION
…on behalf of someone else, when profile includes checkbox field.

See https://lab.civicrm.org/dev/core/issues/322 .

Overview
----------------------------------------
On a contribution page, when "completing this form on behalf of someone else", a JavaScript syntax error occurs when the page includes a profile with a checkbox field and the contact has this field checked. This PR fixes that.

Replicated on demo site. Steps to replicate:

1. Create a custom field, Test Checkbox: Alphanumeric, CheckBox with 1 option: label "I agree", value 1.
2. Create a profile including this field.
3. Include this profile on a contribution page.
4. Edit Contact A and check the "I agree" checkbox.
5. On the contribution page, click "Not demo test, or want to do this for a different person?"
6. Choose Contact A.

Before
----------------------------------------
JavaScript error: "Syntax error, unrecognized expression: [name=custom_13[1]]".
Form does not populate with Contact A's data.

After
----------------------------------------
Form populates with Contact A's data.

Technical Details
----------------------------------------
Simple JS fix: ensure `name` attribute is properly quoted.
