### PR TITLE
Add SQL modes to developer tab

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1403,7 +1403,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     $this->sqlArray[] = $sql;
     foreach ($this->sqlArray as $sql) {
       foreach (array('LEFT JOIN') as $term) {
-        $sql = str_replace($term, '<br>&nbsp&nbsp' . $term, $sql);
+        $sql = str_replace($term, '<br>  ' . $term, $sql);
       }
       foreach (array('FROM', 'WHERE', 'GROUP BY', 'ORDER BY', 'LIMIT', ';') as $term) {
         $sql = str_replace($term, '<br><br>' . $term, $sql);

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1411,6 +1411,8 @@ class CRM_Report_Form extends CRM_Core_Form {
       $this->sqlFormattedArray[] = $sql;
       $this->assign('sql', implode(';<br><br><br><br>', $this->sqlFormattedArray));
     }
+    $this->assign('sqlModes', $sqlModes = CRM_Utils_SQL::getSqlModes());
+
   }
 
   /**

--- a/templates/CRM/Report/Form/Tabs/Developer.tpl
+++ b/templates/CRM/Report/Form/Tabs/Developer.tpl
@@ -1,4 +1,9 @@
 <div id="report-tab-set-developer" class="civireport-criteria">
-  <p><b>{ts}Class used{/ts}: {$report_class}</b></p>
+  <p><b>{ts}Class used{/ts}: {$report_class|escape}</b></p>
+  <p>{ts}SQL Modes{/ts}:
+  {foreach from=$sqlModes item=sqlMode}
+    {$sqlMode|escape}
+  {/foreach}
+  </p>
   <pre>{$sql|purify}</pre>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Developer tab shows information for debugging reports, this adds SQL Mode info and fixes a formatting issue

Before
----------------------------------------
![screenshot 2018-08-14 12 16 54](https://user-images.githubusercontent.com/336308/44064930-f60df836-9fbb-11e8-86b2-5a0ba95d80cb.png)


Also nbsp handling is broken since security release
![screenshot 2018-08-14 12 16 59](https://user-images.githubusercontent.com/336308/44064939-02c20f22-9fbc-11e8-85e3-d9a7c0a434ef.png)


After
----------------------------------------
![screenshot 2018-08-14 12 15 22](https://user-images.githubusercontent.com/336308/44064901-c7f63db4-9fbb-11e8-921b-2091efdf5f7e.png)

![screenshot 2018-08-14 12 18 46](https://user-images.githubusercontent.com/336308/44064975-3fdb1a70-9fbc-11e8-9f40-dd9f1d15a23d.png)


Technical Details
----------------------------------------
The escaping I added is not required but I think it's best practice. Our last round of fixing escaping resulted in spaces being shown as &nbsp - this also fixes that.

Comments
----------------------------------------
I hit issues because of the STRICT_TRANS_TABLES sql mode imposed on dev sites that was hurting my head. This would have helped me get there quicker
