### PR TITLE
Fix Job Log entries containing links so they will display properly

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -229,10 +229,21 @@ class CRM_Core_JobManager {
     $dao = new CRM_Core_DAO_JobLog();
 
     $dao->domain_id = $domainID;
-    $dao->description = substr($message, 0, 235);
-    if (strlen($message) > 235) {
-      $dao->description .= " (...)";
+
+    /*
+     * The description is a summary of the message.
+     * HTML tags are stripped from the message.
+     * The description is limited to 240 characters
+     * and has an ellipsis added if it is truncated.
+     */
+    $maxDescription = 240;
+    $ellipsis = " (...)";
+    $description = strip_tags($message);
+    if (strlen($description) > $maxDescription) {
+      $description = substr($description, 0, $maxDescription - strlen($ellipsis)) . $ellipsis;
     }
+    $dao->description = $description;
+
     if ($this->currentJob) {
       $dao->job_id = $this->currentJob->id;
       $dao->name = $this->currentJob->name;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the display of JobLog entries when they contains links

Before
----------------------------------------
The geocode job provides links in it's message to help users fix unparseable addresses. These appear in the description, but because the description is truncated, the links get broken and the entry doesn't display properly (in this image the whole of the message has become a link).

![Job entry before change](https://user-images.githubusercontent.com/4818337/44091076-a0689a40-a00f-11e8-8f01-cd80831916f6.png)

After
----------------------------------------
All HTML tags are stripped from the message before it is truncated to form the description

![Job entry after change](https://user-images.githubusercontent.com/4818337/44091120-c826b328-a00f-11e8-9996-0b274b371ab8.png)

Technical Details
----------------------------------------
Nil

Comments
----------------------------------------
The description is limited to 240 characters and has an ellipsis added if it is truncated. It does it in a better way than the original code ;-)