### PR TITLE
Fixed fatal error 'DB Error: no such field' on Contribution detail re…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5387,7 +5387,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       ),
       'age' => array(
         'title' => $options['prefix_label'] . ts('Age'),
-        'dbAlias' => 'TIMESTAMPDIFF(YEAR, ' . $tableAlias . '.birth_date, CURDATE())',
+        'dbAlias' => 'TIMESTAMPDIFF(YEAR, ' . $tableAlias . '_civireport.birth_date, CURDATE())',
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
       ),


### PR DESCRIPTION
…port

Overview
----------------------------------------
Contribution Details report throw 'DB Error: no such field' error when 'Age' field under columns is selected.

https://lab.civicrm.org/dev/core/issues/325

Before
----------------------------------------
![before-patch](https://user-images.githubusercontent.com/2053075/44098459-2be18a7e-9fd8-11e8-8c89-d2815ef52faa.gif)


After
----------------------------------------
![afterpatch](https://user-images.githubusercontent.com/2053075/44098451-28ce07e0-9fd8-11e8-8fb5-5ce405b646f4.gif)

