### PR TITLE
Remove net_amount from the Back office contribution form.

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -378,7 +378,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
     }
 
-    $amountFields = array('non_deductible_amount', 'fee_amount', 'net_amount');
+    $amountFields = array('non_deductible_amount', 'fee_amount');
     foreach ($amountFields as $amt) {
       if (isset($defaults[$amt])) {
         $defaults[$amt] = CRM_Utils_Money::format($defaults[$amt], NULL, '%a');
@@ -535,7 +535,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       'invoice_id',
       'non_deductible_amount',
       'fee_amount',
-      'net_amount',
     );
     foreach ($additionalDetailFields as $key) {
       if (!empty($defaults[$key])) {
@@ -882,13 +881,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     $softErrors = CRM_Contribute_Form_SoftCredit::formRule($fields, $errors, $self);
-
-    if (!empty($fields['total_amount']) && (!empty($fields['net_amount']) || !empty($fields['fee_amount']))) {
-      $sum = CRM_Utils_Rule::cleanMoney($fields['net_amount']) + CRM_Utils_Rule::cleanMoney($fields['fee_amount']);
-      if (CRM_Utils_Rule::cleanMoney($fields['total_amount']) != $sum) {
-        $errors['total_amount'] = ts('The sum of fee amount and net amount must be equal to total amount');
-      }
-    }
 
     //CRM-16285 - Function to handle validation errors on form, for recurring contribution field.
     CRM_Contribute_BAO_ContributionRecur::validateRecurContribution($fields, $files, $self, $errors);

--- a/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
@@ -33,8 +33,6 @@
             <span class="description">{ts}Non-deductible portion of this contribution.{/ts}</span></td></tr>
         <tr class="crm-contribution-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html|crmMoney:$currency:'XXX':'YYY'}<br />
             <span class="description">{ts}Processing fee for this transaction (if applicable).{/ts}</span></td></tr>
-
-        <tr class="crm-contribution-form-block-net_amount"><td class="label">{$form.net_amount.label}</td><td{$valueStyle}>{$form.net_amount.html|crmMoney:$currency:'':1}<br />
             <span class="description">{ts}Net value of the contribution (Total Amount minus Fee).{/ts}</span></td></tr>
         <tr class="crm-contribution-form-block-invoice_id"><td class="label">{$form.invoice_id.label}</td><td{$valueStyle}>{$form.invoice_id.html}<br />
             <span class="description">{ts}Unique internal reference ID for this contribution.{/ts}</span></td></tr>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -44,7 +44,7 @@
     {/if}
   </div>
   {/if}
-  
+
   <div class="crm-block crm-form-block crm-contribution-form-block">
 
   {if !$email and $action neq 8 and $context neq 'standalone'}
@@ -52,7 +52,7 @@
     <div class="icon inform-icon"></div>&nbsp;{ts}You will not be able to send an automatic email receipt for this contribution because there is no email address recorded for this contact. If you want a receipt to be sent when this contribution is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the contribution.{/ts}
   </div>
   {/if}
-  
+
   {if $action eq 8}
   <div class="messages status no-popup">
     <div class="icon inform-icon"></div>
@@ -589,15 +589,6 @@ function showStartDate( ) {
 {/literal}{/if}{literal}
 var thousandMarker = "{/literal}{$config->monetaryThousandSeparator}{literal}";
 var separator = "{/literal}{$config->monetaryDecimalPoint}{literal}";
-
-cj('#fee_amount').change( function() {
-  var totalAmount = cj('#total_amount').val().replace(thousandMarker,'').replace(separator,'.');
-  var feeAmount = cj('#fee_amount').val().replace(thousandMarker,'').replace(separator,'.');
-  var netAmount = totalAmount - feeAmount;
-  if (totalAmount) {
-    cj('#net_amount').val(CRM.formatMoney(netAmount, true));
-  }
-});
 
 cj("#financial_type_id").on("change",function(){
     cj('#total_amount').trigger("change");


### PR DESCRIPTION
Overview
----------------------------------------
Remove net_amount field from back office contribution form

Before
----------------------------------------
Field needs to be filled in & needs to match a form rule calculation

After
----------------------------------------
We just calculate it

Technical Details
----------------------------------------
Net amount is calculated in the BAO if not set so asking users to enter it does not gain us anything.

Currently we require them to calculate it & edit it if they change the fee_amount or total_amount
and we validate their data entry, and make them re-do it if they get it wrong.

Since the field is pretty hidden it's unintuitive to need to change it and
makes for a painful contribution update process.

The current behaviour dates back to svn days - however since 2015 the BAO has handled the possibilityof it not being set.

In addition we have had code issues with the comparison around currency & float comparison issues
eg. https://github.com/civicrm/civicrm-core/pull/11485
and https://lab.civicrm.org/dev/core/issues/260 ( in the latter case the data saves
correctly without net_amount and incorrectly if it is changed to meet the form validation rule.
(There was a proposal in Mar 2017 to address that https://github.com/civicrm/civicrm-core/pull/9948#issuecomment-285040403 by fixing the calculation but I believe just dropping the field is better).

Our unit tests test the form submissions but for some reason net_amoutn was removed from the tests
https://github.com/civicrm/civicrm-core/pull/9948/files#diff-40e2e0f106ba620465acf3a9a81f2498L1535
meaning our test coverage is more reliable without it being set.


Comments
----------------------------------------
@KarinG @JoeMurray was doing a cleanup of my local git branches & found this - we should probably merge 
