### PR TITLE
don't add query to developer tab if we are downloading the data

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1393,6 +1393,10 @@ class CRM_Report_Form extends CRM_Core_Form {
     if (!CRM_Core_Permission::check('view report sql')) {
       return;
     }
+    $ignored_output_modes = array('pdf', 'csv', 'print');
+    if (in_array($this->_outputMode, $ignored_output_modes)) {
+      return;
+    }
     $this->tabs['Developer'] = array(
       'title' => ts('Developer'),
       'tpl' => 'Developer',

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -747,7 +747,6 @@ UNION ALL
 SELECT civicrm_contact_id, civicrm_contact_sort_name, civicrm_contribution_total_amount, civicrm_contribution_currency
 FROM   civireport_contribution_detail_temp2
 WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribution_id']}";
-        $this->addToDeveloperTab($query);
         $dao = CRM_Core_DAO::executeQuery($query);
         $string = '';
         $separator = ($this->_outputMode !== 'csv') ? "<br/>" : ' ';
@@ -770,7 +769,6 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
 SELECT civicrm_contact_id, civicrm_contact_sort_name
 FROM   civireport_contribution_detail_temp1
 WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribution_id']}";
-        $this->addToDeveloperTab($query);
         $dao = CRM_Core_DAO::executeQuery($query);
         $string = '';
         while ($dao->fetch()) {


### PR DESCRIPTION
Overview
----------------------------------------
For developers only: Avoid long wait times when accessing reports that add a lot of queries to the developers tab

Before
----------------------------------------
When a user has permission to see the report sql statements (via the developers tab) and the user chooses to download some reports (specifically the Contribution Detail report) via CSV, printing or outputing as a PDF, and the report has a lot of rows (over 1,000), then... CiviCRM might hang for a long period.

After
----------------------------------------
Under the specified conditions, the CiviCRM responds at a reasonable speed.

Technical Details
----------------------------------------
Many reports take advantage of the addToDevelopersTab function from the CRM_Report_Form class. This function prints the given SQL query in the developers tab on the report itself, allowing for easier debugging

CRM_Report_Form_Contribution_Detail was recently changed to add more queries to the developers tab, including queries that ran against every row in the report. When viewing the report on screen, this was not a huge problem because the screen limits each query to 50 records by default. However, when choosing to download a report with over 1,000 rows via CSV, CiviCRM tried to add over 1,000 queries to the developers tab, causing a significant slow down.

Since the developers tab is not even displayed when a reports is printed, output as a PDF or downloaded via CSV, there is no reason to add these queries under these conditions.

In addition, the Contribution Detail report should not be adding queries to the developers tab that run on every row.

