### PR TITLE
dev/translation#14 Fix InnoDB Advanced Logging

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -331,7 +331,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
         $updateLogConn = TRUE;
       }
       if (!empty($alterSql)) {
-        CRM_Core_DAO::executeQuery("ALTER TABLE {$this->db}.{$logTable} " . implode(', ', $alterSql));
+        CRM_Core_DAO::executeQuery("ALTER TABLE {$this->db}.{$logTable} " . implode(', ', $alterSql), [], TRUE, NULL, FALSE, FALSE);
       }
     }
     if ($updateLogConn) {


### PR DESCRIPTION
Overview
----------------------------------------

InnoDB Advanced Logging cannot be enabled on multi-lingual sites, when using: https://github.com/eileenmcnaughton/nz.co.fuzion.innodbtriggers

Technical Details
----------------------------------------

Updating logging tables failed, because the SQL query gets localized (i.e. it tries to add an index to a SQL View).

Disable i18n process on the SQL query.

Comments
----------------------------------------

This will not have any impact on non-multi-lingual sites.

https://lab.civicrm.org/dev/translation/issues/14