### PR TITLE
Include the recur_id value in parameters to updateSubscriptionBillingInfo

### DIFF
--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -241,6 +241,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
     $processorParams['month'] = $processorParams['credit_card_exp_date']['M'];
     $processorParams['year'] = $processorParams['credit_card_exp_date']['Y'];
     $processorParams['subscriptionId'] = $this->_subscriptionDetails->subscription_id;
+    $processorParams['recur_id'] = $this->_subscriptionDetails->recur_id;
     $processorParams['amount'] = $this->_subscriptionDetails->amount;
     $updateSubscription = $this->_paymentProcessor['object']->updateSubscriptionBillingInfo($message, $processorParams);
     if (is_a($updateSubscription, 'CRM_Core_Error')) {


### PR DESCRIPTION
Overview
----------------------------------------
Payment processor objects can implement the method updateSubscriptionBillingInfo to implement payment-processor specific code to update card-on-file type information with the payment processor service, for recurring payments. The second parameter passed to the method "processorParams" does not include the id of the corresponding recurring contribution, making it hard/unreliable to identify the card to be updated when the payment processor doesn't use/implement the processor_id field.

Before
----------------------------------------
iATS Payments recurring contributions are unavailable for self-service updates.

After
----------------------------------------
iATS Payments recurring contributions are available for self-service updates.

Technical Details
----------------------------------------
Really minor ...

Comments
----------------------------------------
1. Self-service billing info updates could use some documentation and tests. 
2. See: https://github.com/iATSPayments/com.iatspayments.civicrm/issues/252 for the origin of this issue.
