### PR TITLE
Refine upgrade message for `save Report Criteria`

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveFive.php
@@ -42,7 +42,7 @@ class CRM_Upgrade_Incremental_php_FiveFive extends CRM_Upgrade_Incremental_Base 
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     // Example: Generate a pre-upgrade message.
     // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFour.php
@@ -56,7 +56,7 @@ class CRM_Upgrade_Incremental_php_FiveFour extends CRM_Upgrade_Incremental_Base 
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
     if ($rev == '5.4.alpha1') {
-      $postUpgradeMessage .= '<p>' . ts('A new %1 permission has been added. It is not granted by default. If your users create reports, you may wish to review your permissions.', array(1 => 'save Report Criteria')) . '</p>';
+      $postUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. It is not granted by default. If your users create reports, you may wish to review their permissions.', array(1 => ts('save Report Criteria'))) . '</p>';
     }
     // Example: Generate a post-upgrade message.
     // if ($rev == '5.12.34') {

--- a/CRM/Upgrade/Incremental/php/FiveFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFour.php
@@ -42,7 +42,7 @@ class CRM_Upgrade_Incremental_php_FiveFour extends CRM_Upgrade_Incremental_Base 
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     // Example: Generate a pre-upgrade message.
     // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFour.php
@@ -55,7 +55,9 @@ class CRM_Upgrade_Incremental_php_FiveFour extends CRM_Upgrade_Incremental_Base 
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
-    $postUpgradeMessage .= '<p>' . ts('A new %1 permission has been added. It is not granted by default. If your users create reports, you may wish to review your permissions.', array(1 => 'save Report Criteria')) . '</p>';
+    if ($rev == '5.4.alpha1') {
+      $postUpgradeMessage .= '<p>' . ts('A new %1 permission has been added. It is not granted by default. If your users create reports, you may wish to review your permissions.', array(1 => 'save Report Criteria')) . '</p>';
+    }
     // Example: Generate a post-upgrade message.
     // if ($rev == '5.12.34') {
     //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");

--- a/CRM/Upgrade/Incremental/php/FiveOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveOne.php
@@ -42,7 +42,7 @@ class CRM_Upgrade_Incremental_php_FiveOne extends CRM_Upgrade_Incremental_Base {
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     // Example: Generate a pre-upgrade message.
     // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveThree.php
@@ -50,7 +50,7 @@ class CRM_Upgrade_Incremental_php_FiveThree extends CRM_Upgrade_Incremental_Base
     }
     // Example: Generate a pre-upgrade message.
     // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveZero.php
+++ b/CRM/Upgrade/Incremental/php/FiveZero.php
@@ -43,7 +43,7 @@ class CRM_Upgrade_Incremental_php_FiveZero extends CRM_Upgrade_Incremental_Base 
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     // Example: Generate a pre-upgrade message.
     //if ($rev == '5.12.34') {
-    //  $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     //}
   }
 

--- a/CRM/Upgrade/Incremental/php/Template.php
+++ b/CRM/Upgrade/Incremental/php/Template.php
@@ -48,7 +48,7 @@ class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrad
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     // Example: Generate a pre-upgrade message.
     // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
   }
 


### PR DESCRIPTION
Before
----------------------------------------
If an upgrade passed through 5.4.x, the post-upgrade message would display the same notice three times:

```
A new save Report Criteria permission has been added. It is not granted by default. If your users create reports, you may wish to review your permissions.
A new save Report Criteria permission has been added. It is not granted by default. If your users create reports, you may wish to review your permissions.
A new save Report Criteria permission has been added. It is not granted by default. If your users create reports, you may wish to review your permissions.
```

After
----------------------------------------
If an upgrade passed through 5.4.x, the post-upgrade message displays one (slightly more readable) message:

```
A new permission, "save Report Criteria", has been added. It is not granted by default. If your users create reports, you may wish to review their permissions.
```

Comments
----------------------------------------
Permission names have some weird capitalization, but normalizing that seems like a bigger/riskier enterprise.

There's also some similar example code in the autogenerated boilerplate. I've updated that as well to be more readable.