### PR TITLE
Test fix for intermittant error

### DIFF
--- a/tests/phpunit/CRM/Report/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Report/Form/ActivityTest.php
@@ -152,7 +152,7 @@ class CRM_Report_Form_ActivityTest extends CiviReportTestCase {
     // ensure that only 1 activity is created
     $this->assertEquals(1, count($rows));
     // ensure that country values of respective target contacts are only shown
-    $this->assertEquals('India;United States', $rows[0]['civicrm_address_country_id']);
+    $this->assertTrue(in_array($rows[0]['civicrm_address_country_id'], ['India;United States', 'United States;India']));
     // ensure that city values of respective target contacts are only shown
     $this->assertEquals('ABC;DEF', $rows[0]['civicrm_address_city']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Test fix for intermittent error

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/333 CRM_Report_Form_ActivityTest::testTargetAddressFields() was added in 5.5. 5.5 is the current RC, and test is failing frequently -- about half the time. (Recent build history)

After
----------------------------------------
Test should cope with order variants & not fail

Technical Details
----------------------------------------
The order is not what is being measured by the test so we should make the test flexible about the order

Comments
----------------------------------------
@totten I'm happy just to loosen
