### PR TITLE
Upgrader - When updating message templates, identify them by name

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -131,9 +131,13 @@ class CRM_Upgrade_Incremental_General {
     if (empty($messages)) {
       return;
     }
+    $messagesHtml = array_map(function($k, $v) {
+      return sprintf("<li><em>%s</em> - %s</li>", htmlentities($k), htmlentities($v));
+    }, array_keys($messages), $messages);
+
     $message .= '<br />' . ts("The default copies of the message templates listed below will be updated to handle new features or correct a problem. Your installation has customized versions of these message templates, and you will need to apply the updates manually after running this upgrade. <a href='%1' style='color:white; text-decoration:underline; font-weight:bold;' target='_blank'>Click here</a> for detailed instructions. %2", array(
         1 => 'http://wiki.civicrm.org/confluence/display/CRMDOC/Message+Templates#MessageTemplates-UpgradesandCustomizedSystemWorkflowTemplates',
-        2 => '<ul><l>' . implode('</li><li>', $messages) . '</li></ul>',
+        2 => '<ul>' . implode('', $messagesHtml) . '</ul>',
       ));
 
     $messageObj->updateTemplates();


### PR DESCRIPTION
Overview
----------------------------------------
When updating message templates, identify them by name. This resolves confusion in the upgrade UI for sites passing through/to v5.4.

Also: Fix a layout issue caused by a typo in the `<li>` tag.

Before
----------------------------------------
![rtl_before](https://user-images.githubusercontent.com/1336047/44189722-df07a380-a0d8-11e8-8498-51a5eb21199f.png)

(*Screenshot from @Stoob's original report.*)

After
----------------------------------------
![screen shot 2018-08-15 at 10 12 38 pm](https://user-images.githubusercontent.com/1336047/44189726-e75fde80-a0d8-11e8-83de-4d1dfcdab4bf.png)

(*Screenshot from a local upgrade prepared for 5.3.x=>5.5.beta1*)

Comments
----------------------------------------
This doesn't make any change to the substantive upgrade logic -- it's just addresses a presentational issue.