### PR TITLE
Fix Undefined index: params in CRM_Event_BAO_Event::buildCustomProfile()

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1826,7 +1826,10 @@ WHERE  id = $cfID
         $title = $groupTitles = array();
         foreach ($additionalIDs as $pId => $cId) {
           //get the params submitted by participant.
-          $participantParams = CRM_Utils_Array::value($pId, $values['params'], array());
+          $participantParams = NULL;
+          if(isset($values['params'])) {
+            $participantParams = CRM_Utils_Array::value($pId, $values['params'], array());
+          }
 
           list($profilePre, $groupTitles) = self::buildCustomDisplay($preProfileID,
             'additionalCustomPre',

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1827,7 +1827,7 @@ WHERE  id = $cfID
         foreach ($additionalIDs as $pId => $cId) {
           //get the params submitted by participant.
           $participantParams = NULL;
-          if(isset($values['params'])) {
+          if (isset($values['params'])) {
             $participantParams = CRM_Utils_Array::value($pId, $values['params'], array());
           }
 


### PR DESCRIPTION
Added check to suppress notice: Undefined index: params in CRM_Event_BAO_Event::buildCustomProfile() which comes after returning to site from an online payment provider.
