### PR TITLE
dev/core#334 Fix Contribution Page with Checksum and multiple Payment Processors

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2069,7 +2069,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $validUser = CRM_Contact_BAO_Contact_Utils::validChecksum($tempID, $userChecksum);
       if ($validUser) {
         CRM_Core_Resources::singleton()->addVars('coreForm', array('contact_id' => (int) $tempID));
-        CRM_Core_Resources::singleton()->addVars('coreForm', array('checksum' => (int) $tempID));
+        CRM_Core_Resources::singleton()->addVars('coreForm', array('checksum' => $userChecksum));
         return $tempID;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

Public contribution form and Checksums: billing information not loaded if using multiple processors

How to reproduce:

- Create a Contribution Page
- Associate multiple payment processors
- Create a contact
- Fill in a billing address for the contact
- Generate a contribution page link that includes the checksum (cs) and cid.

What happens:

- The payment block does not pre-populate the Billing Address
- Note that this only happens when there are multiple processors, because of the ajax request that loads the payment block. This request does not happen when there is only one PP.

Before
----------------------------------------

![core-334-billing-block-empty](https://user-images.githubusercontent.com/254741/44215398-65a39b80-a140-11e8-9494-be97528bf120.gif)

After
----------------------------------------

![core-334-billing-block-works](https://user-images.githubusercontent.com/254741/44215407-6c321300-a140-11e8-86a9-56c94d2c9e49.gif)


Technical Details
----------------------------------------

Seems like a copy-paste error in the code. According to the git blame, goes back to 2015.
