### PR TITLE
dev/core/329: Set Case XMLProcessor REL_TYPE_CNAME To Use 'name' Instead Of 'label'

### DIFF
--- a/CRM/Case/ManagedEntities.php
+++ b/CRM/Case/ManagedEntities.php
@@ -111,7 +111,7 @@ class CRM_Case_ManagedEntities {
     $result = array();
 
     if (!isset(Civi::$statics[__CLASS__]['reltypes'])) {
-      $relationshipInfo = CRM_Core_PseudoConstant::relationshipType('label', TRUE, NULL);
+      $relationshipInfo = CRM_Core_PseudoConstant::relationshipType('name', TRUE, NULL);
       Civi::$statics[__CLASS__]['reltypes'] = CRM_Utils_Array::collect(CRM_Case_XMLProcessor::REL_TYPE_CNAME, $relationshipInfo);
     }
     $validRelTypes = Civi::$statics[__CLASS__]['reltypes'];

--- a/CRM/Case/XMLProcessor.php
+++ b/CRM/Case/XMLProcessor.php
@@ -53,10 +53,8 @@ class CRM_Case_XMLProcessor {
    * label_b_a), but CiviCase XML refers to reltypes by a single name.
    * REL_TYPE_CNAME identifies the canonical name field as used by CiviCase XML.
    *
-   * This appears to be "label_b_a", but IMHO "name_b_a" would be more
-   * sensible.
    */
-  const REL_TYPE_CNAME = 'label_b_a';
+  const REL_TYPE_CNAME = 'name_b_a';
 
   /**
    * @param $caseType
@@ -111,7 +109,7 @@ class CRM_Case_XMLProcessor {
    */
   public function &allRelationshipTypes() {
     if (self::$relationshipTypes === NULL) {
-      $relationshipInfo = CRM_Core_PseudoConstant::relationshipType('label', TRUE);
+      $relationshipInfo = CRM_Core_PseudoConstant::relationshipType('name', TRUE);
 
       self::$relationshipTypes = array();
       foreach ($relationshipInfo as $id => $info) {


### PR DESCRIPTION
Overview
----------------------------------------
'Api error: DB Error: already exists' on drush cc civicrm and any extension enable/disable on a fairly new site.

Technical Details
----------------------------------------
On drush cc civicrm and any extension enable/disable.
CRM_Core_ManagedEntities::reconcile() is called and this method tries to re create a relationship-type that already exists.
On looking into more, it was an issue with core Case XMLProcessor.
Case ManagedEntities checks all Case types and their XML definition and then checks to see if all relationship types used within the case types needs to be created/updated.
Here on checking the relatoinship types between case type XML definition and all relationship types, there is a mismatch in the field used to compare them.
The "label_b_a" field is compared with "name_b_a" and so if these two are not the same (there is no need to be) it tries to re create it and results in this error.

In his PR I am changing REL_TYPE_CNAME in CRM_Case_XMLProcessor from 'label_b_a' to 'name_b_a'. This is because only the 'name' columns are unique in relationship type table ('name_a_b' and 'name_b_a')