### PR TITLE
dev/core#299 Fix mishandling of non decimal currency on update payment details form

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -81,7 +81,13 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
    * @return array
    */
   public function setDefaultValues() {
-    return $this->_values;
+    $defaults = $this->_values;
+    // Format money fields - localize for display
+    $moneyFields = ['total_amount', 'fee_amount', 'net_amount'];
+    foreach ($moneyFields as $field) {
+      $defaults[$field] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($this->_values[$field]);
+    }
+    return $defaults;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
**Follow up to https://github.com/civicrm/civicrm-core/pull/12626**

Fixes display of amount on UpdatePaymentDetails form

Before
----------------------------------------
![updatepaymentdetails_before](https://user-images.githubusercontent.com/2052161/44261898-fb0e6080-a210-11e8-8267-d0e565ef02c0.png)

After
----------------------------------------
![updatepaymentdetails_after](https://user-images.githubusercontent.com/2052161/44261900-fea1e780-a210-11e8-944d-958cc4d4a559.png)


Technical Details
----------------------------------------
Amount is read-only and only used for display - it is not used in postProcess at all so we don't need to worry about formatting to save it.

https://lab.civicrm.org/dev/core/issues/299