### PR TITLE
Replicate fix on PR #12643 for pledge report

### DIFF
--- a/CRM/Report/Form/Pledge/Pbnp.php
+++ b/CRM/Report/Form/Pledge/Pbnp.php
@@ -181,20 +181,6 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
         'fields' => array('email' => NULL),
         'grouping' => 'contact-fields',
       ),
-      'civicrm_group' => array(
-        'dao' => 'CRM_Contact_DAO_Group',
-        'alias' => 'cgroup',
-        'filters' => array(
-          'gid' => array(
-            'name' => 'group_id',
-            'title' => ts('Group'),
-            'type' => CRM_Utils_Type::T_INT,
-            'group' => TRUE,
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::staticGroup(),
-          ),
-        ),
-      ),
     );
 
     // If we have a campaign, build out the relevant elements
@@ -211,6 +197,7 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
       );
     }
 
+    $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
     $this->_currencyColumn = 'civicrm_pledge_currency';
     parent::__construct();


### PR DESCRIPTION
Overview
----------------------------------------
I saw the fix @jmcclelland applied in PR #12643.  On a hunch, I grepped for that code and found it copy/pasted to another report.  This PR cleans that up.

Before
----------------------------------------
"Pledged but not Paid" report only lets you filter by static groups.

After
----------------------------------------
"Pledged but not Paid" report can filter on smart groups; less code duplication.

Comments
----------------------------------------
This fix is identical to #12643.
