### PR TITLE
dev/core#341 sybunt custom search date field fix

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -404,7 +404,7 @@ AND      c.receive_date < {$this->start_date_1}
    * @param array $formValues
    *
    */
-  public static function formatSavedSearchFields(&$formValues) {
+  public static function formatSavedSearchFields($formValues) {
     $dateFields = array(
       'start_date_1',
       'end_date_1',
@@ -418,6 +418,8 @@ AND      c.receive_date < {$this->start_date_1}
         $formValues[$element] = date('Y-m-d', strtotime($value));
       }
     }
+
+    return $formValues;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The "Contributions made in Year X and not Year Y" custom search ignores date field parameters. To reproduce, enter date fields and observe that the result set ignores them.

https://lab.civicrm.org/dev/core/issues/341

Before
----------------------------------------
Date parameters are ignored.

After
----------------------------------------
Date parameters are respected.

Technical Details
----------------------------------------
The formatSavedSearchFields() function assumed values passed/altered by reference, but the use of that function expected the modified formValues to be returned.
