### PR TITLE
Convert membership date fields to datepicker & form to entity form

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -79,7 +79,7 @@ trait CRM_Core_Form_EntityFormTrait {
    * Build the form object.
    */
   public function buildQuickEntityForm() {
-    if ($this->_action & CRM_Core_Action::DELETE) {
+    if ($this->isDeleteContext()) {
       $this->buildDeleteForm();
       return;
     }
@@ -202,12 +202,23 @@ trait CRM_Core_Form_EntityFormTrait {
   protected function addEntityFieldsToTemplate() {
     foreach ($this->getEntityFields() as $fieldSpec) {
       if (empty($fieldSpec['not-auto-addable'])) {
-        $element = $this->addField($fieldSpec['name'], [], CRM_Utils_Array::value('required', $fieldSpec));
+        $element = $this->addField($fieldSpec['name'], [], CRM_Utils_Array::value('required', $fieldSpec), FALSE);
         if (!empty($fieldSpec['is_freeze'])) {
           $element->freeze();
         }
       }
     }
+  }
+
+  /**
+   * Is the form being used in the context of a deletion.
+   *
+   * (For some reason rather than having separate forms Civi overloads one form).
+   *
+   * @return bool
+   */
+  protected function isDeleteContext() {
+    return ($this->_action & CRM_Core_Action::DELETE);
   }
 
 }

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -37,6 +37,7 @@
  */
 class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
+  use CRM_Core_Form_EntityFormTrait;
   /**
    * The id of the object being edited / created
    *
@@ -97,6 +98,24 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @var array
    */
   protected $_params = array();
+
+  /**
+   * Fields for the entity to be assigned to the template.
+   *
+   * Fields may have keys
+   *  - name (required to show in tpl from the array)
+   *  - description (optional, will appear below the field)
+   *  - not-auto-addable - this class will not attempt to add the field using addField.
+   *    (this will be automatically set if the field does not have html in it's metadata
+   *    or is not a core field on the form's entity).
+   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
+   *  - template - use a field specific template to render this field
+   *  - required
+   *  - is_freeze (field should be frozen).
+   *
+   * @var array
+   */
+  protected $entityFields = [];
 
   public function preProcess() {
     // Check for edit permission.

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -112,13 +112,53 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   );
 
   /**
-   * Get the entity id being edited.
-   *
-   * @return int|null
+   * Set entity fields to be assigned to the form.
    */
-  public function getEntityId() {
-    return $this->_id;
+  protected function setEntityFields() {
+    $this->entityFields = [
+      'join_date' => [
+        'name' => 'join_date',
+        'description' => ts('Member Since'),
+      ],
+      'start_date' => [
+        'name' => 'start_date',
+        'description' => ts('Start Date'),
+      ],
+      'end_date' => [
+        'name' => 'end_date',
+        'description' => ts('End Date'),
+      ],
+    ];
   }
+
+  /**
+   * Set the delete message.
+   *
+   * We do this from the constructor in order to do a translation.
+   */
+  public function setDeleteMessage() {
+    $this->deleteMessage = '<span class="font-red bold">'
+      . ts("WARNING: Deleting this membership will also delete any related payment (contribution) records." .  ts("This action cannot be undone.")
+        . '</span><p>'
+        . ts("Consider modifying the membership status instead if you want to maintain an audit trail and avoid losing payment data. You can set the status to Cancelled by editing the membership and clicking the Status Override checkbox.")
+          . '</p><p>'
+        . ts("Click 'Delete' if you want to continue.") . '</p>');
+  }
+
+  /**
+   * Overriding this entity trait function as not yet tested.
+   *
+   * We continue to rely on legacy handling.
+   */
+  public function addCustomDataToForm() {}
+
+
+  /**
+   * Overriding this entity trait function as not yet tested.
+   *
+   * We continue to rely on legacy handling.
+   */
+  public function addFormButtons() {}
 
   /**
    * Get selected membership type from the form values.
@@ -182,6 +222,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     // This string makes up part of the class names, differentiating them (not sure why) from the membership fields.
     $this->assign('formClass', 'membership');
     parent::preProcess();
+    if ($this->isUpdateToExistingRecurringMembership()) {
+      $this->entityFields['end_date']['is_freeze'] = TRUE;
+    }
     // get price set id.
     $this->_priceSetId = CRM_Utils_Array::value('priceSetId', $_GET);
     $this->set('priceSetId', $this->_priceSetId);
@@ -372,16 +415,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       // $defaults['credit_card_exp_date'] = array( 'Y' => '2012', 'M' => '05' );
     }
 
-    $dates = array('join_date', 'start_date', 'end_date');
-    foreach ($dates as $key) {
-      if (!empty($defaults[$key])) {
-        list($defaults[$key]) = CRM_Utils_Date::setDateDefaults(CRM_Utils_Array::value($key, $defaults));
-      }
-    }
-
     //setting default join date if there is no join date
     if (empty($defaults['join_date'])) {
-      $defaults['join_date'] = $now;
+      $defaults['join_date'] = date('Y-m-d H:i:s');
     }
 
     if (!empty($defaults['membership_end_date'])) {
@@ -396,6 +432,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    */
   public function buildQuickForm() {
 
+    $this->buildQuickEntityForm();
     $this->assign('currency', CRM_Core_Config::singleton()->defaultCurrencySymbol);
     $isUpdateToExistingRecurringMembership = $this->isUpdateToExistingRecurringMembership();
     // build price set form.
@@ -562,17 +599,8 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $sel->freeze();
     }
 
-    $this->applyFilter('__ALL__', 'trim');
-
     if ($this->_action & CRM_Core_Action::ADD) {
       $this->add('text', 'num_terms', ts('Number of Terms'), array('size' => 6));
-    }
-
-    $this->addDate('join_date', ts('Member Since'), FALSE, array('formatType' => 'activityDate'));
-    $this->addDate('start_date', ts('Start Date'), FALSE, array('formatType' => 'activityDate'));
-    $endDate = $this->addDate('end_date', ts('End Date'), FALSE, array('formatType' => 'activityDate'));
-    if ($endDate && $isUpdateToExistingRecurringMembership) {
-      $endDate->freeze();
     }
 
     $this->add('text', 'source', ts('Source'),
@@ -1934,9 +1962,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   protected function isUpdateToExistingRecurringMembership() {
     $isRecur = FALSE;
     if ($this->_action & CRM_Core_Action::UPDATE
-      && CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_id,
+      && CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->getEntityId(),
         'contribution_recur_id')
-      && !CRM_Member_BAO_Membership::isSubscriptionCancelled($this->_id)) {
+      && !CRM_Member_BAO_Membership::isSubscriptionCancelled($this->getEntityId())) {
 
       $isRecur = TRUE;
     }

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -120,6 +120,18 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
   );
 
   /**
+   * Set entity fields to be assigned to the form.
+   */
+  protected function setEntityFields() {}
+
+  /**
+   * Set the delete message.
+   *
+   * We do this from the constructor in order to do a translation.
+   */
+  public function setDeleteMessage() {}
+
+  /**
    * Pre-process form.
    *
    * @throws \Exception

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -79,9 +79,7 @@
     {if $action eq 8}
     <div class="messages status no-popup">
       <div class="icon inform-icon"></div>&nbsp;
-      <span class="font-red bold">{ts}WARNING: Deleting this membership will also delete any related payment (contribution) records.{/ts} {ts}This action cannot be undone.{/ts}</span>
-      <p>{ts}Consider modifying the membership status instead if you want to maintain an audit trail and avoid losing payment data. You can set the status to Cancelled by editing the membership and clicking the Status Override checkbox.{/ts}</p>
-      <p>{ts}Click 'Delete' if you want to continue.{/ts}</p>
+      {$deleteMessage}
     </div>
     {else}
       <table class="form-layout-compressed">
@@ -133,10 +131,10 @@
         {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
         campaignTrClass="crm-membership-form-block-campaign_id"}
 
-        <tr class="crm-membership-form-block-join_date"><td class="label">{$form.join_date.label}</td><td>{include file="CRM/common/jcalendar.tpl" elementName=join_date}
+        <tr class="crm-membership-form-block-join_date"><td class="label">{$form.join_date.label}</td><td>{$form.join_date.html}
           <br />
           <span class="description">{ts}When did this contact first become a member?{/ts}</span></td></tr>
-        <tr class="crm-membership-form-block-start_date"><td class="label">{$form.start_date.label}</td><td>{include file="CRM/common/jcalendar.tpl" elementName=start_date}
+        <tr class="crm-membership-form-block-start_date"><td class="label">{$form.start_date.label}</td><td>{$form.start_date.html}
           <br />
           <span class="description">{ts}First day of current continuous membership period. Start Date will be automatically set based on Membership Type if you don't select a date.{/ts}</span></td></tr>
         <tr class="crm-membership-form-block-end_date"><td class="label">{$form.end_date.label}</td>
@@ -148,7 +146,7 @@
               {help id="override_end_date"}
           </td>
           <td id="end-date-editable">
-            {include file="CRM/common/jcalendar.tpl" elementName=end_date}
+            {$form.end_date.html}
             <br />
             <span class="description">{ts}Latest membership period expiration date. End Date will be automatically set based on Membership Type if you don't select a date.{/ts}</span>
           </td>


### PR DESCRIPTION
Overview
----------------------------------------
As part of our ongoing effort to convert all date fields to datepicker field & a newer interest in cleaning up the membership form this converts 3 date fields on the Membership form. It uses the new & preferred entityFormTrait to add the fields

Before
----------------------------------------
Old style date fields

After
----------------------------------------
New style date fields

Technical Details
----------------------------------------
Removing jcalendar has been a pretty long-running initiative - although we still have 68 instances even after this :-( The new datepicker format requires less date wrangling & hence is more robust & allows simplification. Ditto the EntityFormTrait allows us to move to a more metadata oriented approach

Comments
----------------------------------------
@mattwire @seamuslee001 @colemanw 