### PR TITLE
dev/core#343 Fix long address lines overflowing label

### DIFF
--- a/CRM/Utils/PDF/Label.php
+++ b/CRM/Utils/PDF/Label.php
@@ -184,7 +184,7 @@ class CRM_Utils_PDF_Label extends TCPDF {
    * @param string $text
    */
   public function generateLabel($text) {
-    // paddingLeft is used for both left & right padding so needs to be 
+    // paddingLeft is used for both left & right padding so needs to be
     // subtracted twice from width to get the width that is available for text
     $args = array(
       'w' => $this->width - 2 * $this->paddingLeft,

--- a/CRM/Utils/PDF/Label.php
+++ b/CRM/Utils/PDF/Label.php
@@ -184,6 +184,8 @@ class CRM_Utils_PDF_Label extends TCPDF {
    * @param string $text
    */
   public function generateLabel($text) {
+    // paddingLeft is used for both left & right padding so needs to be 
+    // subtracted twice from width to get the width that is available for text
     $args = array(
       'w' => $this->width - 2 * $this->paddingLeft,
       'h' => 0,

--- a/CRM/Utils/PDF/Label.php
+++ b/CRM/Utils/PDF/Label.php
@@ -185,7 +185,7 @@ class CRM_Utils_PDF_Label extends TCPDF {
    */
   public function generateLabel($text) {
     $args = array(
-      'w' => $this->width,
+      'w' => $this->width - 2 * $this->paddingLeft,
       'h' => 0,
       'txt' => $text,
       'border' => 0,


### PR DESCRIPTION
Overview
----------------------------------------
When a name or address is very long (long enough for the text to wrap onto a new line) it overflows the label. This can be seen by comparing the PDF output by CiviCRM with an official Avery template. This fixes that by modifying ```CRM_Utils_PDF_Label::generateLabel()``` so that the width that it uses has the left & right padding subtracted from the label's width.

Before
----------------------------------------
Long lines can overflow the label boundary.

After
----------------------------------------
Long lines wrap within the label boundary with correct padding applied.

https://lab.civicrm.org/dev/core/issues/343
