### PR TITLE
dev/joomla#2 Joomla on Windows cli.php & cron.php fail due to incorrect path

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -529,7 +529,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    */
   public function getBasePath() {
     global $civicrm_root;
-    $joomlaPath = explode('/administrator', $civicrm_root);
+    $joomlaPath = explode(DIRECTORY_SEPARATOR . 'administrator', $civicrm_root);
     $joomlaBase = $joomlaPath[0];
     return $joomlaBase;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Ref: https://civicrm.stackexchange.com/questions/24867/compatibility-problem-with-joomla-3-8-7-and-civicrm-5-0-1-that-affects-cron

A hard-coded forward slash resulted in incorrect path on Windows, affecting cli.php and cron.php, with this error:
```
require(C:\Apache24\htdocs\joomla\administrator\components\com_civicrm\civicrm\administrator\includes\defines.php): failed to open stream: No such file or directory in C:\Apache24\htdocs\joomla\administrator\components\com_civicrm\civicrm\CRM\Utils\System\Joomla.php on line 559
```
This patch changes the ```/``` to ```DIRECTORY_SEPARATOR```

Before
----------------------------------------
The above error will be produced and cron jobs fail.

After
----------------------------------------
cron jobs run successfully.
