### PR TITLE
Deduplicate setting of mailSent message

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -92,6 +92,29 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   }
 
   /**
+   * @var array
+   */
+  protected $statusMessage = [];
+
+  /**
+   * Add to the status message.
+   *
+   * @param $message
+   */
+  protected function addStatusMessage($message) {
+    $this->statusMessage[] = $message;
+  }
+
+  /**
+   * Get the status message.
+   *
+   * @return string
+   */
+  protected function getStatusMessage() {
+    return implode(' ', $this->statusMessage);
+  }
+
+  /**
    * Values submitted to the form, processed along the way.
    *
    * @var array

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -464,6 +464,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    * @dataProvider getThousandSeparators
    */
   public function testSubmit($thousandSeparator) {
+    CRM_Core_Session::singleton()->getStatus(TRUE);
     $this->setCurrencySeparators($thousandSeparator);
     $form = $this->getForm();
     $form->preProcess();
@@ -472,7 +473,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $this->createLoggedInUser();
     $params = array(
       'cid' => $this->_individualId,
-      'join_date' => date('m/d/Y', time()),
+      'join_date' => date('2/d/Y', time()),
       'start_date' => '',
       'end_date' => '',
       // This format reflects the 23 being the organisation & the 25 being the type.
@@ -545,6 +546,14 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'Receipt text',
     ));
     $this->mut->stop();
+    $this->assertEquals([
+      [
+        'text' => 'AnnualFixed membership for Mr. Anthony Anderson II has been added. The new membership End Date is December 31st, ' . date('Y') . '. A membership confirmation and receipt has been sent to anthony_anderson@civicrm.org.',
+        'title' => 'Complete',
+        'type' => 'success',
+        'options' => NULL,
+      ],
+    ], CRM_Core_Session::singleton()->getStatus());
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor refactor of code around setting submit status message, adds a test

Before
----------------------------------------
Code less logically grouped

After
----------------------------------------
Code more logically grouped.

Technical Details
----------------------------------------
This is a small refactor aimed at bringing code that is logically related together. There is a loop that iterates through    
```
   foreach ($this->_memTypeSelected as $memType) {
```
and creates memberships. It is an obvious candidate for extraction but it also turns out that loop builds up the $createdMemberships array for the sole purpose of setting the message for the form user. It seems fairly clear to me that every time we see 

```
        $createdMemberships[$memType] = $membership;
```

What we should really see is some variant of 
```
$this->addStatusMessage(
```


Comments
----------------------------------------
#12693 contains the a superset of this change but this is intended to be legible amount