### PR TITLE
Add support for an encryption provider in an extension

### DIFF
--- a/CRM/Core/Encrypt/Interface.php
+++ b/CRM/Core/Encrypt/Interface.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Interface CRM_Core_Encrypt_Interface
+ *
+ * Provide encryption.
+ */
+interface CRM_Core_Encrypt_Interface {
+  /**
+   * Encrypts a string.
+   *
+   * @param string $string
+   *   Plaintext to be encrypted.
+   * @return string
+   *   ciphertext
+   */
+  public function encrypt($string);
+
+  /**
+   * Decrypts ciphertext.
+   *
+   * @param string $string
+   *   Ciphertext to be decrypted.
+   * @return string
+   *   Plaintext
+   */
+  public function decrypt($string);
+
+}

--- a/CRM/Utils/Crypt.php
+++ b/CRM/Utils/Crypt.php
@@ -51,7 +51,11 @@ class CRM_Utils_Crypt {
     if (empty($string)) {
       return $string;
     }
-
+    $encryptionProvider = Civi::settings()->get('encryption_provider');
+    if ($encryptionProvider) {
+      $encryptionClass = new $encryptionProvider();
+      return base64_encode($encryptionClass->encrypt($string));
+    }
     if (function_exists('mcrypt_module_open') &&
       defined('CIVICRM_SITE_KEY')
     ) {
@@ -89,6 +93,12 @@ class CRM_Utils_Crypt {
     $string = base64_decode($string);
     if (empty($string)) {
       return $string;
+    }
+
+    $encryptionProvider = Civi::settings()->get('encryption_provider');
+    if ($encryptionProvider) {
+      $encryptionClass = new $encryptionProvider();
+      return $encryptionClass->decrypt($string);
     }
 
     if (function_exists('mcrypt_module_open') &&

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1003,4 +1003,18 @@ return array(
     ),
     'quick_form_type' => 'Select',
   ),
+  'encryption_provider' => array(
+    'add' => '5.6',
+    'help_text' => ts('Provider of encryption services'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'encryption_provider',
+    'type' => 'String',
+    'default' => NULL,
+    'title' => ts('Encryption Provider'),
+    'description' => ts('Care must be used when changing providers as encrypted variables may need to be re-entered.'),
+  ),
+
 );


### PR DESCRIPTION
Overview
----------------------------------------
This is a proposal for https://lab.civicrm.org/dev/core/issues/236 - it doesn't seek to answer the question of how to provide encryption - only how to move that decision out of core.

I threw together https://github.com/eileenmcnaughton/org.civicrm.mcrypt and ran through the functions in a unit test.

Note that we ONLY ACTUALLY ENCRYPT ONE FIELD in core! That field is smtp_provider & if an imap account is set up it won't be encrypted there - so this feels kinda optional. I am guessing from @adixon interest there might be some usage outside of core & hence this has been written to provide no breakage & with the expecation that we would later deprecate & remove the lines that still handled mcrypt for people without the extension. We'd also need to consider shipping the extension until such time as we have a preferred extension for new builds.

This also punts any upgrade / migration related issues.


Before
----------------------------------------
Only Mcrypt possible

After
----------------------------------------
Extensions could add other providers. Only mcrypt exists as an extension provided encrypter :-)

Technical Details
----------------------------------------
The approach is simply to add a setting - which can be [set by an extension](https://github.com/eileenmcnaughton/org.civicrm.mcrypt/blob/master/CRM/Mcrypt/Upgrader.php#L16) and an interface.

Not sure if any inputs / outputs other than string make sense

Comments
----------------------------------------
I'm not actually vested in this - it just seemed like 40 minutes spent demonstrating in code would be easier than 40 mins spent explaining in a comment https://lab.civicrm.org/dev/core/issues/236 & it seems merging this would unblock stuff.

This looks like a good plugin https://github.com/defuse/php-encryption/blob/master/docs/Tutorial.md
