### PR TITLE
CRM-21677 - report clean up

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -360,20 +360,6 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
-      if (array_key_exists('civicrm_address_state_province_id', $row)) {
-        if ($value = $row['civicrm_address_state_province_id']) {
-          $rows[$rowNum]['civicrm_address_state_province_id'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
-        }
-        $entryFound = TRUE;
-      }
-
-      if (array_key_exists('civicrm_address_country_id', $row)) {
-        if ($value = $row['civicrm_address_country_id']) {
-          $rows[$rowNum]['civicrm_address_country_id'] = CRM_Core_PseudoConstant::country($value, FALSE);
-        }
-        $entryFound = TRUE;
-      }
-
       if (array_key_exists('civicrm_contact_sort_name', $row) &&
         $rows[$rowNum]['civicrm_contact_sort_name'] &&
         array_key_exists('civicrm_contact_id', $row)


### PR DESCRIPTION
Overview
----------------------------------------
remove redundant piece of code as address display is handled later in https://github.com/civicrm/civicrm-core/blob/master/CRM/Report/Form/Member/Detail.php#L410
Visually no difference between before and after.

Before
----------------------------------------
![b](https://user-images.githubusercontent.com/3455173/44329806-0e286700-a483-11e8-9dd2-57e62a4cc89f.png)


After
----------------------------------------
![a](https://user-images.githubusercontent.com/3455173/44329822-17b1cf00-a483-11e8-99c6-8fc787f319de.png)

---

 * [CRM-21677: Report improvements](https://issues.civicrm.org/jira/browse/CRM-21677)