### PR TITLE
Get title for event tell a friend mail

### DIFF
--- a/CRM/Friend/Form.php
+++ b/CRM/Friend/Form.php
@@ -95,6 +95,7 @@ class CRM_Friend_Form extends CRM_Core_Form {
       if ($pcomponent == 'event') {
         $this->_entityTable = 'civicrm_event';
         $isShare = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_entityId, 'is_share');
+        $this->_title = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_entityId, 'title');
       }
       else {
         $isShare = CRM_Utils_Array::value('is_share', $values);


### PR DESCRIPTION
Overview
----------------------------------------
When using the Tell-a-Friend by mail option I found that the event title wasn't appearing in the mail subject.

See Issue https://lab.civicrm.org/dev/core/issues/344

Before
----------------------------------------
Sent mail has a title like: "Jo Bloggs wants you to know about"
ie without the event title appended

After
----------------------------------------
Sent mail has a title like: "Jo Bloggs wants you to know about Special Training Day"
ie with event title

Technical Details
----------------------------------------
The added code simply retrieves the title in the event case.

The code unnecessarily tries to get the contribution details first and then, if an event, gets the event info. Ideally the code would switch on $pcomponent. However my PR contains the simplest fix.

Comments
----------------------------------------
Tested on 5.4.0 in WordPress
