### PR TITLE
 'Network Error' when creating membership type from contact membership tab

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -617,7 +617,7 @@
         var fname = '#priceset';
         if ( !priceSetId ) {
         cj('#membership_type_id_1').val(0);
-        CRM.buildCustomData(customDataType, 'null' );
+        CRM.buildCustomData(customDataType, null );
 
         // hide price set fields.
         cj( fname ).hide( );
@@ -797,7 +797,7 @@
 
       subTypeNames = currentMembershipType.join(',');
       if ( subTypeNames.length < 1 ) {
-        subTypeNames = 'null';
+        subTypeNames = null;
       }
 
       CRM.buildCustomData( customDataType, subTypeNames );


### PR DESCRIPTION
Overview
----------------------------------------
'Network Error' when creating membership type from contact membership tab.

To replicate:
Create a contact -> go to membership tab -> new membership
Select membership organisation and type -> choose priceset
Then select manual membership and price from Membership Organisation and Type
At this point the network error and invalid entity filter warning appears

Technical Details
----------------------------------------
In the above form null is used as 'null' (with quotes) which is not actually null because it is treated as a string with value 'null'. 