### PR TITLE
dev/core#349 correct default sort for scheduled reminders list

### DIFF
--- a/templates/CRM/Admin/Page/Reminders.tpl
+++ b/templates/CRM/Admin/Page/Reminders.tpl
@@ -32,7 +32,7 @@
   <table id="scheduleReminders" class="display">
     <thead>
     <tr id="options" class="columnheader">
-      <th class="sortable">{ts}Title{/ts}</th>
+      <th id="sortable">{ts}Title{/ts}</th>
       <th >{ts}Reminder For{/ts}</th>
       <th >{ts}When{/ts}</th>
       <th >{ts}While{/ts}</th>


### PR DESCRIPTION
Overview
----------------------------------------
The Scheduled Reminder list default sort does not work because of a small typo.
This PR corrects that.

Before
----------------------------------------
The Scheduled Reminder list default sort does not work

After
----------------------------------------
The Scheduled Reminder list default sort works for the title collumn

Technical Details
----------------------------------------
class="sortable" was used. But id="sortable" should have been used

https://lab.civicrm.org/dev/core/issues/349