### PR TITLE
Navigation - Don't reprocess fully-formed urls

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -493,8 +493,9 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
     $config = CRM_Core_Config::singleton();
 
     $makeLink = FALSE;
-    if (isset($url) && $url) {
-      if (substr($url, 0, 4) !== 'http') {
+    if (!empty($url)) {
+      // Skip processing fully-formed urls
+      if (substr($url, 0, 4) !== 'http' && $url[0] !== '/') {
         //CRM-7656 --make sure to separate out url path from url params,
         //as we'r going to validate url path across cross-site scripting.
         $parsedUrl = parse_url($url);


### PR DESCRIPTION
Overview
-----

Fixes an edge-case bug where fully-formed *relative* urls were being reprocessed and messed up in the menubar.

Before
-----

Urls starting with a forward slash would end up with two slashes in front and garbled params.

After
------

Relative urls, absolute urls, and local urls all processed correctly.

Technical Details
--------

CRM_Core_BAO_Navigation can handle both internal and external urls, however it was incorrectly handling urls that started with a forward slash as it didn't correctly identify them as already processed and tried to run them through CRM_Utils_System::url() again.