### PR TITLE
Fix recent item deduping & call hooks

### DIFF
--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -116,7 +116,7 @@ class CRM_Utils_Recent {
 
     // make sure item is not already present in list
     for ($i = 0; $i < count(self::$_recent); $i++) {
-      if (self::$_recent[$i]['type'] === $type && self::$_recent[$i]['id'] === $id) {
+      if (self::$_recent[$i]['type'] === $type && self::$_recent[$i]['id'] == $id) {
         // delete item from array
         array_splice(self::$_recent, $i, 1);
         break;

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -174,6 +174,7 @@ class CRM_Utils_Recent {
       }
     }
 
+    CRM_Utils_Hook::recent(self::$_recent);
     $session = CRM_Core_Session::singleton();
     $session->set(self::STORE_NAME, self::$_recent);
   }
@@ -200,15 +201,17 @@ class CRM_Utils_Recent {
       self::$_recent[] = $tempRecent[$i];
     }
 
+    CRM_Utils_Hook::recent(self::$_recent);
     $session = CRM_Core_Session::singleton();
     $session->set(self::STORE_NAME, self::$_recent);
   }
 
   /**
    * Check if a provider is allowed to add stuff.
-   * If correspondig setting is empty, all are allowed
+   * If corresponding setting is empty, all are allowed
    *
    * @param string $providerName
+   * @return bool
    */
   public static function isProviderEnabled($providerName) {
 
@@ -230,6 +233,8 @@ class CRM_Utils_Recent {
 
   /**
    * Gets the list of available providers to civi's recent items stack
+   *
+   * @return array
    */
   public static function getProviders() {
     $providers = array(


### PR DESCRIPTION
Overview
--------

Fixes a bug when adding to the "recent items" list, where the same item would sometimes be added twice.
Also adds a fix to call hooks when deleting items, for consistency with `add`.

To reproduce
-----

1. Go to the contact menu and click on "new activity".
2. Save the new activity. Note that it is now in the recent items list.
3. Click on the activity in the recent items list.
4. Note that it is now in the list twice.

Technical details
-----

Strict type checking using `===` was overkill, as CiviCRM uses string and int values interchangeably. E.g. activity id `123` was being compared to the string `"123"`.