### PR TITLE
fixing batch search by payment method

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -697,7 +697,7 @@ LEFT JOIN civicrm_contribution_soft ON civicrm_contribution_soft.contribution_id
       'sort_name',
       'financial_type_id',
       'contribution_page_id',
-      'payment_instrument_id',
+      'contribution_payment_instrument_id',
       'contribution_trxn_id',
       'contribution_source',
       'contribution_currency_type',

--- a/CRM/Financial/Form/BatchTransaction.php
+++ b/CRM/Financial/Form/BatchTransaction.php
@@ -185,7 +185,7 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form {
     }
     if (isset(self::$_entityID)) {
       $paymentInstrumentID = CRM_Core_DAO::getFieldValue('CRM_Batch_BAO_Batch', self::$_entityID, 'payment_instrument_id');
-      $defaults['payment_instrument_id'] = $paymentInstrumentID;
+      $defaults['contribution_payment_instrument_id'] = $paymentInstrumentID;
       $this->assign('paymentInstrumentID', $paymentInstrumentID);
     }
     return $defaults;

--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -48,39 +48,37 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
     // create two contributions: one check and one credit card
 
     $contactId = $this->individualCreate(array('first_name' => 'John', 'last_name' => 'Doe'));
-    $contribParams = 
-      array(
-        'contact_id' => $contactId,
-        'total_amount' => 1,
-        'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
-        'financial_type_id' => 1,
-        'contribution_status_id' => 1,
-        'receive_date' => '20080522000000',
-        'receipt_date' => '20080522000000',
-        'trxn_id' => '22ereerwww322323',
-        'id' => NULL,
-        'fee_amount' => 0,
-        'net_amount' => 1,
-        'currency' => 'USD',
-        'skipCleanMoney' => TRUE,
-      );
+    $contribParams = array(
+      'contact_id' => $contactId,
+      'total_amount' => 1,
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+      'financial_type_id' => 1,
+      'contribution_status_id' => 1,
+      'receive_date' => '20080522000000',
+      'receipt_date' => '20080522000000',
+      'trxn_id' => '22ereerwww322323',
+      'id' => NULL,
+      'fee_amount' => 0,
+      'net_amount' => 1,
+      'currency' => 'USD',
+      'skipCleanMoney' => TRUE,
+    );
     $contribCheck = CRM_Contribute_BAO_Contribution::create($contribParams);
-    $contribParams = 
-      array(
-        'contact_id' => $contactId,
-        'total_amount' => 1,
-        'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit Card'),
-        'financial_type_id' => 1,
-        'contribution_status_id' => 1,
-        'receive_date' => '20080523000000',
-        'receipt_date' => '20080523000000',
-        'trxn_id' => '22ereerwww323323',
-        'id' => NULL,
-        'fee_amount' => 0,
-        'net_amount' => 1,
-        'currency' => 'USD',
-        'skipCleanMoney' => TRUE,
-      );
+    $contribParams = array(
+      'contact_id' => $contactId,
+      'total_amount' => 1,
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit Card'),
+      'financial_type_id' => 1,
+      'contribution_status_id' => 1,
+      'receive_date' => '20080523000000',
+      'receipt_date' => '20080523000000',
+      'trxn_id' => '22ereerwww323323',
+      'id' => NULL,
+      'fee_amount' => 0,
+      'net_amount' => 1,
+      'currency' => 'USD',
+      'skipCleanMoney' => TRUE,
+    );
     $contribCC = CRM_Contribute_BAO_Contribution::create($contribParams);
 
     //create an empty batch to use for the search, and run the search
@@ -93,9 +91,9 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
       'civicrm_financial_trxn.payment_instrument_id as payment_method',
     );
     $notPresent = TRUE;
-    $params['contribution_payment_instrument_id'] = 
-      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
-    $resultChecksOnly = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId,$returnvalues,$notPresent,$params,TRUE);
+    $params['contribution_payment_instrument_id']
+      = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
+    $resultChecksOnly = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId, $returnvalues, $notPresent, $params, TRUE);
 
     //test that the search results make sense
 
@@ -104,15 +102,16 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
       $resultChecksOnlyCount[] = $resultChecksOnly->id;
       $key = 'payment_method';
       $paymentMethod = CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'payment_instrument_id', $resultChecksOnly->$key);
-      $this->assertEquals($paymentMethod,'Check');
+      $this->assertEquals($paymentMethod, 'Check');
     }
     if (isset($resultChecksOnlyCount)) {
       $totalChecksOnly = count($resultChecksOnlyCount);
-      $this->assertEquals($totalChecksOnly,1);
-    } else {
+      $this->assertEquals($totalChecksOnly, 1);
+    }
+    else {
       $this->fail("Search results expected.");
     }
 
   }
+
 }
-?>

--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ *  File for the BatchTest class
+ *
+ *  (PHP 5)
+ *
+ * @package   CiviCRM
+ *
+ *   This file is part of CiviCRM
+ *
+ *   CiviCRM is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Affero General Public License
+ *   as published by the Free Software Foundation; either version 3 of
+ *   the License, or (at your option) any later version.
+ *
+ *   CiviCRM is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public
+ *   License along with this program.  If not, see
+ *   <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *  Test CRM/Batch/BAO/Batch.php getBatchFinancialItems
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
+
+  /**
+   * This test checks that a batch search
+   * by payment method works.
+   * This function could later be expanded to include
+   * checks that other types of searches are also
+   * working.
+   *
+   * It creates two contributions, one with payment method credit
+   * card and one with payment method check.  After performing a
+   * search by payment method for checks, it makes sure that the
+   * results are only contributions made by check.
+   */
+  public function testGetBatchFinancialItems() {
+
+    // create two contributions: one check and one credit card
+
+    $contactId = $this->individualCreate(array('first_name' => 'John', 'last_name' => 'Doe'));
+    $contribParams = 
+      array(
+        'contact_id' => $contactId,
+        'total_amount' => 1,
+        'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+        'financial_type_id' => 1,
+        'contribution_status_id' => 1,
+        'receive_date' => '20080522000000',
+        'receipt_date' => '20080522000000',
+        'trxn_id' => '22ereerwww322323',
+        'id' => NULL,
+        'fee_amount' => 0,
+        'net_amount' => 1,
+        'currency' => 'USD',
+        'skipCleanMoney' => TRUE,
+      );
+    $contribCheck = CRM_Contribute_BAO_Contribution::create($contribParams);
+    $contribParams = 
+      array(
+        'contact_id' => $contactId,
+        'total_amount' => 1,
+        'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit Card'),
+        'financial_type_id' => 1,
+        'contribution_status_id' => 1,
+        'receive_date' => '20080523000000',
+        'receipt_date' => '20080523000000',
+        'trxn_id' => '22ereerwww323323',
+        'id' => NULL,
+        'fee_amount' => 0,
+        'net_amount' => 1,
+        'currency' => 'USD',
+        'skipCleanMoney' => TRUE,
+      );
+    $contribCC = CRM_Contribute_BAO_Contribution::create($contribParams);
+
+    //create an empty batch to use for the search, and run the search
+
+    $batchParams = array('title' => 'Test Batch');
+    $batchParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Open');
+    $batch = CRM_Batch_BAO_Batch::create($batchParams);
+    $entityId = $batch->id;
+    $returnvalues = array(
+      'civicrm_financial_trxn.payment_instrument_id as payment_method',
+    );
+    $notPresent = TRUE;
+    $params['contribution_payment_instrument_id'] = 
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
+    $resultChecksOnly = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId,$returnvalues,$notPresent,$params,TRUE);
+
+    //test that the search results make sense
+
+    while ($resultChecksOnly->fetch()) {
+      error_log("fetching");
+      $resultChecksOnlyCount[] = $resultChecksOnly->id;
+      $key = 'payment_method';
+      $paymentMethod = CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'payment_instrument_id', $resultChecksOnly->$key);
+      $this->assertEquals($paymentMethod,'Check');
+    }
+    if (isset($resultChecksOnlyCount)) {
+      $totalChecksOnly = count($resultChecksOnlyCount);
+      $this->assertEquals($totalChecksOnly,1);
+    } else {
+      $this->fail("Search results expected.");
+    }
+
+  }
+}
+?>

--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -91,12 +91,12 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
       'civicrm_financial_trxn.payment_instrument_id as payment_method',
     );
     $notPresent = TRUE;
-    $params['contribution_payment_instrument_id'] =
-      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
+    $params['contribution_payment_instrument_id']
+      = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
     $result = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId, $returnvalues, $notPresent, $params, TRUE)->fetchAll();
     $this->assertEquals(count($result), 1, 'In line' . __LINE__);
     $this->assertEquals($result[0]['payment_method'], CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'), 'In line' . __LINE__);
 
   }
+
 }
-?>

--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -48,7 +48,7 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
     // create two contributions: one check and one credit card
 
     $contactId = $this->individualCreate(array('first_name' => 'John', 'last_name' => 'Doe'));
-    $contribParams = array(
+    $this->contributionCreate([
       'contact_id' => $contactId,
       'total_amount' => 1,
       'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
@@ -61,12 +61,12 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
       'fee_amount' => 0,
       'net_amount' => 1,
       'currency' => 'USD',
+      'invoice_id' => '22ed39c9e9ee6ef6031621ce0eafe6da70',
       'skipCleanMoney' => TRUE,
-    );
-    $contribCheck = CRM_Contribute_BAO_Contribution::create($contribParams);
-    $contribParams = array(
+    ]);
+    $this->contributionCreate([
       'contact_id' => $contactId,
-      'total_amount' => 1,
+     'total_amount' => 1,
       'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit Card'),
       'financial_type_id' => 1,
       'contribution_status_id' => 1,
@@ -77,9 +77,9 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
       'fee_amount' => 0,
       'net_amount' => 1,
       'currency' => 'USD',
+      'invoice_id' => '22ed39c9e9ee6ef6031621ce0eafe6da71',
       'skipCleanMoney' => TRUE,
-    );
-    $contribCC = CRM_Contribute_BAO_Contribution::create($contribParams);
+    ]);
 
     //create an empty batch to use for the search, and run the search
 
@@ -91,27 +91,12 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
       'civicrm_financial_trxn.payment_instrument_id as payment_method',
     );
     $notPresent = TRUE;
-    $params['contribution_payment_instrument_id']
-      = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
-    $resultChecksOnly = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId, $returnvalues, $notPresent, $params, TRUE);
-
-    //test that the search results make sense
-
-    while ($resultChecksOnly->fetch()) {
-      error_log("fetching");
-      $resultChecksOnlyCount[] = $resultChecksOnly->id;
-      $key = 'payment_method';
-      $paymentMethod = CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'payment_instrument_id', $resultChecksOnly->$key);
-      $this->assertEquals($paymentMethod, 'Check');
-    }
-    if (isset($resultChecksOnlyCount)) {
-      $totalChecksOnly = count($resultChecksOnlyCount);
-      $this->assertEquals($totalChecksOnly, 1);
-    }
-    else {
-      $this->fail("Search results expected.");
-    }
+    $params['contribution_payment_instrument_id'] =
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
+    $result = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId, $returnvalues, $notPresent, $params, TRUE)->fetchAll();
+    $this->assertEquals(count($result), 1, 'In line' . __LINE__);
+    $this->assertEquals($result[0]['payment_method'], CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'), 'In line' . __LINE__);
 
   }
-
 }
+?>


### PR DESCRIPTION
Overview
----------------------------------------
This issue describes my problem, https://issues.civicrm.org/jira/browse/CRM-17090, except that I haven't seen any problems with the Transaction ID.  This issue was previously fixed by changing contribution_payment_instrument_id to payment_instrument_id (https://github.com/civicrm/civicrm-core/pull/6628/commits/30d46f2f4de13d7bb3007dda4dc374315716bc9b) and now it's fixed by changing it back to contribution_payment_instrument_id.



Before
----------------------------------------
A search by payment method in an accounting batch returns all of the contributions, regardless of the payment method.

After
----------------------------------------
A search by payment method in an accounting batch only returns the contributions matching the payment method.

Comments
----------------------------------------
I found the problem with Backdrop CMS 1.10.1 and CiviCRM 5.2.2