### PR TITLE
Added relationship active filter in CiviCRM Case reports.

### DIFF
--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -180,6 +180,12 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => $this->rel_types,
           ),
+          'is_active' => array(
+            'title' => ts('Active Role?'),
+            'type' => CRM_Utils_Type::T_BOOLEAN,
+            'default' => TRUE,
+            'options' => CRM_Core_SelectValues::boolean(),
+          ),
         ),
       ),
       'civicrm_email' => array(
@@ -572,8 +578,9 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
   }
 
   public function checkEnabledFields() {
-    if (isset($this->_params['case_role_value'])
-      && !empty($this->_params['case_role_value'])
+    if ((isset($this->_params['case_role_value'])
+        && !empty($this->_params['case_role_value'])) ||
+        (isset($this->_params['is_active_value']))
     ) {
       $this->_relField = TRUE;
     }

--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -182,6 +182,12 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => $this->rel_types,
           ),
+          'is_active' => array(
+            'title' => ts('Active Relationship?'),
+            'type' => CRM_Utils_Type::T_BOOLEAN,
+            'default' => TRUE,
+            'options' => CRM_Core_SelectValues::boolean(),
+          ),
         ),
       ),
       'civicrm_relationship_type' => array(


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM's Case Reports are showing Cases in the report results even when a Contact has been removed from a Case Role. This is problem can be replicated on CiviCRM's Case Summary Report and Case Detail Report.

Investigation showed that there was no way to filter for the is_active flag on the role / relationship, and the reports do not currently check this field.

Solution is to add this field as a filter criteria to the reports in CiviCRM Core.

Before
----------------------------------------
Relationships which are inactive or active are included in the report results, which can cause confusion as previous Staff previously assigned Case Roles are still being listed. There is no filter available to remove inactive relationships to the Case.

This greatly reduces the usefulness of the report because it lists both Staff that are working on a Case and those that are no longer working on the Case in the same listing with no clear identification of each state.

After
----------------------------------------
An "Active Relationship?" filter has been added to the report which defaults to "Yes". Such that only relationships which are active are included in the report. Staff members assigned a Case Role will be listed. Staff members that are no longer assigned a Case Role will not be listed.
 
Technical Details
----------------------------------------
"Active Relationship?" filter has been added to the report which defaults to "Yes".

Comments
----------------------------------------
With the default being "Yes" to "Active Relationship?", previous report results for the Case Summary Report and Case Detail Report will change with this patch applied.

Ref: CIVICRM-965