### PR TITLE
dev/core#352 Ensure that contacts that are to be exluded are not adde…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -282,8 +282,10 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     // Get recipients selected in prior mailings
     if (!empty($priorMailingIDs['Include'])) {
       CRM_Utils_SQL_Select::from('civicrm_mailing_recipients')
-        ->select("contact_id, $entityColumn")
+        ->select("DISTINCT civicrm_mailing_recipients.contact_id, $entityColumn")
+        ->join('temp', " LEFT JOIN $excludeTempTablename temp ON civicrm_mailing_recipients.contact_id = temp.contact_id ")
         ->where('mailing_id IN (#mailings)')
+        ->where('temp.contact_id IS NULL')
         ->param('#mailings', $priorMailingIDs['Include'])
         ->insertIgnoreInto($includedTempTablename, array('contact_id', $entityColumn))
         ->execute();


### PR DESCRIPTION
…d incorrectly when adding recipients of past mailings

Overview
----------------------------------------
When using recipients from a previous mailing as the recipients of a mailing. If any exclusion groups / mailings. The contacts in these are groups / mailings are not properly removed when adding the recipients of the mailing for inclusion. 

Before
----------------------------------------
Contacts wrongly included in emails when previous mailing used as the inclusion

After
----------------------------------------
Contacts not wrongly included and unit test added

ping @eileenmcnaughton @monishdeb @totten @andrew-cormick-dockery @jtwyman
