### PR TITLE
Wrap long labels onto multiple lines to prevent text being cut off

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -384,6 +384,10 @@ input.crm-form-entityref {
   text-align: right;
 }
 
+.crm-container .crm-section .label label{
+  white-space: normal;
+}
+
 .crm-container .label-left .label {
   text-align: left;
 }


### PR DESCRIPTION
Overview
----------------------------------------

In long labels, a width of 17% hides part of the content... Just changing whitespace wrapping back to normal allows them to show the whole label.

Before
---------
![captura_2018-08-22_22-50-52](https://user-images.githubusercontent.com/17086589/44490250-243e4f00-a65e-11e8-8c7a-0d8bee9c50c7.png)

After
--------
![captura_2018-08-25_10-48-48](https://user-images.githubusercontent.com/17086589/44616698-b90a9d80-a854-11e8-95af-3b08c51a4e18.png)