### PR TITLE
Fix for issue editing custom fields with option groups after #12423

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -319,15 +319,21 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $this->freeze('data_type');
     }
 
-    $optionGroupParams = [
-      'is_reserved' => 0,
-      'is_active' => 1,
-      'options' => ['limit' => 0, 'sort' => "title ASC"],
-      'return' => ['title'],
-    ];
     if ($this->_action == CRM_Core_Action::UPDATE) {
-      $optionGroupParams['id'] = $this->_values['id'];
+      $optionGroupParams = [
+        'id' => $this->_values['option_group_id'],
+        'return' => ['title'],
+      ];
     }
+    else {
+      $optionGroupParams = [
+        'is_reserved' => 0,
+        'is_active' => 1,
+        'options' => ['limit' => 0, 'sort' => "title ASC"],
+        'return' => ['title'],
+      ];
+    }
+
     // Get all custom (is_reserved=0) option groups
     $optionGroupMetadata = civicrm_api3('OptionGroup', 'get', $optionGroupParams);
 


### PR DESCRIPTION
Overview
----------------------------------------
Ref #12423 

To reproduce:

On a stock demo site, go to the custom fields screen.
Click on "View and Edit Fields" for Constituent Information
Click "Edit Field" next to "Most Important Issue"
The options will appear garbled, and you will be unable to save.
I think this is a critical regression and needs to be fixed immediately, but I'm hesitant to just revert this PR because it has an upgrade script. @mattwire - thoughts?

Before
----------------------------------------
Cannot edit/save custom fields with existing option groups.

After
----------------------------------------
Can edit/save custom fields with existing option groups.

Technical Details
----------------------------------------
API parameters were not being set correctly on UPDATE

