### PR TITLE
Allow descriptions for payment fields

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -689,6 +689,7 @@ abstract class CRM_Core_Payment {
           'class' => 'creditcard',
         ),
         'is_required' => TRUE,
+        // 'description' => '16 digit card number', // If you enable a description field it will be shown below the field on the form
       ),
       'cvv2' => array(
         'htmlType' => 'text',

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -113,7 +113,7 @@ class CRM_Core_Payment_Form {
    *   Fields that are to be shown on the payment form.
    */
   protected static function addCommonFields(&$form, $paymentFields) {
-    $requiredPaymentFields = array();
+    $requiredPaymentFields = $paymentFieldsMetadata = [];
     foreach ($paymentFields as $name => $field) {
       if ($field['htmlType'] == 'chainSelect') {
         $form->addChainSelect($field['name'], array('required' => FALSE));
@@ -129,8 +129,10 @@ class CRM_Core_Payment_Form {
       // This will cause the fields to be marked as required - but it is up to the payment processor to
       // validate it.
       $requiredPaymentFields[$field['name']] = $field['is_required'];
+      $paymentFieldsMetadata[$field['name']] = $field;
     }
 
+    $form->assign('paymentFieldsMetadata', $paymentFieldsMetadata);
     $form->assign('requiredPaymentFields', $requiredPaymentFields);
   }
 

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -41,7 +41,9 @@
             </div>
             <div class="content">
                 {$form.$paymentField.html}
-              {if $paymentField == 'cvv2'}{* @todo move to form assignment*}
+              {if $paymentFieldsMetadata.$name.description}
+                <div class="description">{$paymentFieldsMetadata.$name.description}</div>
+              {elseif $paymentField == 'cvv2'}{* @todo move to form assignment*}
                 <span class="cvv2-icon" title="{ts}Usually the last 3-4 digits in the signature area on the back of the card.{/ts}"> </span>
               {/if}
               {if $paymentField == 'credit_card_type'}


### PR DESCRIPTION
Overview
----------------------------------------
Allow a description to be specified for payment form fields.

Before
----------------------------------------
It is not possible to add a description for any of the payment fields.

After
----------------------------------------
A description can be added for any field added by `getPaymentFormFieldsMetadata()`
![payment_descriptions](https://user-images.githubusercontent.com/2052161/44519782-f987e100-a6c5-11e8-87cc-7372a963c227.png)


Technical Details
----------------------------------------
This adds an array of descriptions that is assigned to the template and can be used to display descriptions for each form element.  If the description is not specified there is no change.

Comments
----------------------------------------
Example usage in org.civicrm.smartdebit here: https://github.com/mattwire/org.civicrm.smartdebit/commit/931fbafde49d6b25c7e797e57aba8c1023d31235
