### PR TITLE
Improve styling of address block on summary screen

### DIFF
--- a/css/contactSummary.css
+++ b/css/contactSummary.css
@@ -21,10 +21,6 @@ div#crm-contact-thumbnail {
   border-bottom: 1px solid #FFF;
 }
 
-.crm-summary-block {
-  clear: both;
-}
-
 #crm-container div.crm-inline-edit {
   border: 2px dashed transparent;
   background: none;

--- a/css/contactSummary.css
+++ b/css/contactSummary.css
@@ -63,18 +63,22 @@ div#crm-contact-thumbnail {
   border-bottom-left-radius: 1em;
 }
 
-#crm-container .crm-inline-edit.add-new .crm-edit-help {
+#crm-container .crm-address-block+.crm-address-block .add-new .crm-edit-help {
   display: block;
   background-color: #EBEBEB;
 }
 
-#crm-container .crm-edit-ready .crm-inline-edit:hover .crm-edit-help {
+#crm-container .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help {
   display: block;
   background-color: #DFE1FF;
 }
 
 #crm-container div.crm-inline-edit.form .crm-edit-help {
   display: none !important;
+}
+
+#crm-container .crm-address-block+.crm-address-block .add-new .crm-summary-row {
+  display: none;
 }
 
 #crm-container span.crm-custom-greeting {

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -31,7 +31,12 @@
         <span class="crm-i fa-pencil"></span> {if $add}{ts}Edit address{/ts}{else}{ts}Add address{/ts}{/if}
       </div>
     {/if}
-    {if $add }
+    {if !$add}
+      <div class="crm-summary-row">
+        <div class="crm-label">{ts}Address{/ts}</div>
+        <div class="crm-content"></div>
+      </div>
+    {else}
       <div class="crm-summary-row {if $add.is_primary eq 1} primary{/if}">
         <div class="crm-label">
           {ts 1=$add.location_type}%1 Address{/ts}

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -268,7 +268,7 @@
             CRM.api3('address', 'delete', {id: $block.data('edit-params').aid}, true)
               .done(function(data) {
                 $('.crm-inline-edit-container').addClass('crm-edit-ready');
-                $block.remove();
+                $block.closest('.crm-address-block').remove();
                 reloadBlock('.crm-inline-edit.address:not(.add-new)');
               });
             });


### PR DESCRIPTION
Overview
-------
More consistent styling of the address block with other elements of the contact summary screen; makes the block easier to see when the contact does not have an address.

Before
----------
![screenshot from 2018-08-23 11-40-54](https://user-images.githubusercontent.com/2874912/44535998-77012080-a6c9-11e8-8938-17c229a6f03c.png)

After
------
![screenshot from 2018-08-23 11-37-52](https://user-images.githubusercontent.com/2874912/44536007-79fc1100-a6c9-11e8-8154-2ae4c10d12ae.png)

Before (w Shoreditch)
------
![screenshot from 2018-08-23 11-36-23](https://user-images.githubusercontent.com/2874912/44536024-84b6a600-a6c9-11e8-84ce-6d2a9f6f6757.png)

After (w Shoreditch)
--------
![screenshot from 2018-08-23 11-36-47](https://user-images.githubusercontent.com/2874912/44536047-913afe80-a6c9-11e8-9bca-eb13ee9be59f.png)

