### PR TITLE
enable CRM.alert() on public CiviCRM pages

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -721,6 +721,7 @@ class CRM_Core_Resources {
       "packages/jquery/plugins/jquery.form.min.js",
       "packages/jquery/plugins/jquery.timeentry.min.js",
       "packages/jquery/plugins/jquery.blockUI.min.js",
+      "packages/jquery/plugins/jquery.notify.min.js",
       "bower_components/datatables/media/js/jquery.dataTables.min.js",
       "bower_components/datatables/media/css/jquery.dataTables.min.css",
       "bower_components/jquery-validation/dist/jquery.validate.min.js",
@@ -747,7 +748,6 @@ class CRM_Core_Resources {
       $items[] = "packages/jquery/plugins/jquery.tableHeader.js";
       $items[] = "packages/jquery/plugins/jquery.menu.min.js";
       $items[] = "css/civicrmNavigation.css";
-      $items[] = "packages/jquery/plugins/jquery.notify.min.js";
     }
 
     // JS for multilingual installations

--- a/templates/CRM/common/publicFooter.tpl
+++ b/templates/CRM/common/publicFooter.tpl
@@ -30,3 +30,4 @@
     {ts 1=$civilogo}empowered by %1{/ts}
   </div>
 {/if}
+{include file="CRM/common/notifications.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Make form validation messages consistent for logged-in or not logged-in users.
Changes the logic that results in the inclusion of jquery.notify, as well as the necessary hidden elements in the footer used by CRM.alert().

Before
----------------------------------------
If a contact is logged-in and has the Access CiviCRM permission, then the jquery.notify plugin is included and used (via CRM.alert()) by Event Registration pages for things like form validation errors. If the user is not logged-in or doesn't have Access CiviCRM, then the validation messages are displayed in-line.

After
----------------------------------------
No matter whether a user is logged-in or has Access CiviCRM, form validation messages are displayed consistently to all users.

Comments
----------------------------------------
I've only tested this on an Event Registration page. I don't know if there is other sleeping functionality that will be awoken by this change. I included the tpl and jquery plugin for a custom feature and discovered the hidden/inconsitent core functionality for form validation.

Someone had a vague recollection that @colemanw may have been working on providing CRM.alert() on public pages... maybe this is relevant??
