### PR TITLE
Corrected tag_id parameter description to refer cases

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -202,7 +202,7 @@ function _civicrm_api3_case_get_spec(&$params) {
   );
   $params['tag_id'] = array(
     'title' => 'Tags',
-    'description' => 'Find activities with specified tags.',
+    'description' => 'Find cases with specified tags.',
     'type' => 1,
     'FKClassName' => 'CRM_Core_DAO_Tag',
     'FKApiName' => 'Tag',


### PR DESCRIPTION
The description for the tag_id parameter should be
"Find cases with specified tags."
instead of
"Find activities with specified tags."

(See https://lab.civicrm.org/dev/core/issues/361)
