### PR TITLE
Further fix for updating custom fields linked to optiongroups.

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -315,26 +315,22 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $this->add('checkbox', 'in_selector', ts('Display in Table?'));
     }
 
+    $optionGroupParams = [
+      'is_reserved' => 0,
+      'is_active' => 1,
+      'options' => ['limit' => 0, 'sort' => "title ASC"],
+      'return' => ['title'],
+    ];
+
     if ($this->_action == CRM_Core_Action::UPDATE) {
       $this->freeze('data_type');
+      // Before dev/core#155 we didn't set the is_reserved flag properly, which should be handled by the upgrade script...
+      //  but it is still possible that existing installs may have optiongroups linked to custom fields that are marked reserved.
+      $optionGroupParams['id'] = $this->_values['option_group_id'];
+      $optionGroupParams['options']['or'] = [["is_reserved", "id"]];
     }
 
-    if ($this->_action == CRM_Core_Action::UPDATE) {
-      $optionGroupParams = [
-        'id' => $this->_values['option_group_id'],
-        'return' => ['title'],
-      ];
-    }
-    else {
-      $optionGroupParams = [
-        'is_reserved' => 0,
-        'is_active' => 1,
-        'options' => ['limit' => 0, 'sort' => "title ASC"],
-        'return' => ['title'],
-      ];
-    }
-
-    // Get all custom (is_reserved=0) option groups
+    // Retrieve optiongroups for selection list
     $optionGroupMetadata = civicrm_api3('OptionGroup', 'get', $optionGroupParams);
 
     // OptionGroup selection


### PR DESCRIPTION
Overview
----------------------------------------
Follow on from #12718 which resolved a problem with saving on update.  However, we should actually be displaying all non-reserved option groups so an alternative can be selected - this matches the previous behaviour on this form.

Before
----------------------------------------
Only the selected option group is displayed.

After
----------------------------------------
![customfieldoptiongroups](https://user-images.githubusercontent.com/2052161/44590827-fcf99600-a7b3-11e8-9852-961d20b135a8.png)
A list of all non-reserved option groups is displayed, with the selected one selected.

Technical Details
----------------------------------------
When we "fixed" the is_reserved flag for option groups in #12423 updating custom fields linked to option groups stopped working if the option group was still marked as reserved as it could not be found.  The fix in #12718 explicitly looks for the optiongroup by ID but we also need to present a list of alternative optiongroups for selection.

Comments
----------------------------------------
@colemanw @seamuslee001 Follow up