### PR TITLE
Remove mcrypt warning except for affected sites.

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -125,13 +125,21 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    */
   public function checkPhpEcrypt() {
     $messages = array();
+    $mailingBackend = Civi::settings()->get('mailing_backend');
+    if (!is_array($mailingBackend)
+      || !isset($mailingBackend['outBound_option'])
+      || $mailingBackend['outBound_option'] != CRM_Mailing_Config::OUTBOUND_OPTION_SMTP
+      || !CRM_Utils_Array::value('smtpAuth', $mailingBackend)
+    ) {
+      return $messages;
+    }
+
     $test_pass = 'iAmARandomString';
     $encrypted_test_pass = CRM_Utils_Crypt::encrypt($test_pass);
     if ($encrypted_test_pass == base64_encode($test_pass)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Your PHP does not include the recommended encryption functions. Some passwords will not be stored encrypted, and if you have recently upgraded from a PHP that does include these functions, your encrypted passwords will not be decrypted correctly. If you are using PHP 7.0 or earlier, you probably want to include the "%1" extension.',
-          array('1' => 'mcrypt')
+        ts('Your PHP does not include the mcrypt encryption functions. Your SMTP password will not be stored encrypted, and if you have recently upgraded from a PHP that stored it with encryption, it will not be decrypted correctly.'
         ),
         ts('PHP Missing Extension "mcrypt"'),
         \Psr\Log\LogLevel::WARNING,


### PR DESCRIPTION
Overview
----------------------------------------
We have a system check that warns people if mcrypt is not available. This refines that to only warn affected sites - ie. ones that have their smtp password stored in the database. There are no other places that core uses encryption so it's not appropriate for people to get messages if they are unaffected.

Before
----------------------------------------
Site on php 7.2 gets encryption warning, regardless of whether they have stored smtp passwords

After
----------------------------------------
Site on php 7.2 (or other site without mcrypt) only gets warning if they have stored smtp passwords

Technical Details
----------------------------------------
Extensions that wish to have a version of this should implement it themselves as
it is basically pretty trivial & it doesn't make sense to spam non-affected people

Comments
----------------------------------------
I also altered the wording as our php version recommendations have changed we no longer actively recommend mcrypt
