### PR TITLE
Remove duplicate payment processor select on Membership Renewal form

### DIFF
--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -58,10 +58,6 @@
     </div>
     <div>{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout">
-      <tr class="crm-member-membershiprenew-form-block-payment_processor_id">
-        <td class="label">{$form.payment_processor_id.label}</td>
-        <td class="html-adjust">{$form.payment_processor_id.html}</td>
-      </tr>
       <tr class="crm-member-membershiprenew-form-block-org_name">
         <td class="label">{ts}Membership Organization and Type{/ts}</td>
         <td class="html-adjust">{$orgName}&nbsp;&nbsp;-&nbsp;&nbsp;{$memType}


### PR DESCRIPTION
Overview
----------------------------------------
Payment processor selection field should not appear twice on "Renew-Credit Card" form (accessed via contact membership tab->"Renew-Credit Card" button.

Before
----------------------------------------
![localhost_8000_civicrm_contact_view_reset 1 cid 205 2](https://user-images.githubusercontent.com/2052161/44719442-3d5e5a00-aabb-11e8-8f59-86919de82d0a.png)

After
----------------------------------------
![localhost_8000_civicrm_contact_view_reset 1 cid 205](https://user-images.githubusercontent.com/2052161/44719418-26b80300-aabb-11e8-9a91-9205e091fd96.png)


Technical Details
----------------------------------------
Template only change
