### PR TITLE
Enable custom data display on MembershipType form

### DIFF
--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -125,6 +125,8 @@
       </div>
     </fieldset>
 
+    {include file="CRM/common/customDataBlock.tpl"}
+
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   {/if}
     <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Enable display of custom data on MembershipType form.

Before
----------------------------------------
Custom fields not displayed on MembershipType form

After
----------------------------------------
If MembershipType custom fields are configured it is displayed on MembershipType form:
![localhost_8000_civicrm_admin_member_membershiptype_reset 1](https://user-images.githubusercontent.com/2052161/44733610-da32ee80-aadf-11e8-9eb6-95cd42cdbc94.png)


Technical Details
----------------------------------------
Just a template change as all the other required changes have already been made.

Comments
----------------------------------------
@eileenmcnaughton Are we ok to merge this now?  I know you'd like to do some more work on the MembershipType form but I think both you and I have other priorities at the moment, we've made some quite significant improvements on this form and it's probably worth focussing efforts elsewhere for now?
