### PR TITLE
dev/core#367: Query optimization for A-Z pager by adding indices to t…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4208,6 +4208,12 @@ civicrm_relationship.start_date > {$today}
       }
       $sql = "
         CREATE TEMPORARY TABLE {$relationshipTempTable}
+          (
+            `contact_id` int(10) unsigned NOT NULL DEFAULT '0',
+            `contact_id_alt` int(10) unsigned NOT NULL DEFAULT '0',
+            KEY `contact_id` (`contact_id`),
+            KEY `contact_id_alt` (`contact_id_alt`)
+          )
           (SELECT contact_id_b as contact_id, contact_id_a as contact_id_alt, civicrm_relationship.id
             FROM civicrm_relationship
             INNER JOIN  civicrm_contact c ON civicrm_relationship.contact_id_a = c.id


### PR DESCRIPTION
…emp table.

Overview
----------------------------------------
As described at https://lab.civicrm.org/dev/core/issues/367, sites with large numbers of "spouse" relationships (or other reciprocally named relationship types) can encounter WSOD and/or minutes-long wait times when performing an Advanced Search on that relationship type with a "target contact is in group" criteria.

Before
----------------------------------------
As described in the ticket repro steps, a particular set of criteria for Advanced Search, performed on a sufficiently large contact base, results in either a minutes-long wait for search results, or a fatal error "Sorry, due to an error, we are unable to fulfill your request at the moment. You may want to contact your administrator or service provider with more details about what action you were performing when this occurred.
DB Error: unknown error"


After
----------------------------------------
On the same site with the same search criteria, wait time is reduced to mere seconds.

Technical Details
----------------------------------------
Just adding a couple of indices and matching column definitions (e,g, unsigned int 10) for columns that need them in the temporary table that's used to flatten relationships before searching.

Comments
----------------------------------------
Kinda hard to reproduce considering you need a fairly large contact base. Also not sure how we could test for this.
