### PR TITLE
dev/core#346 - Online Pay Now error when used from dashboard checksum…

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -74,6 +74,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     if (empty($userID) && $this->_contactId && $userChecksum) {
       $this->assign('userChecksum', $userChecksum);
       $validUser = CRM_Contact_BAO_Contact_Utils::validChecksum($this->_contactId, $userChecksum);
+      $this->_isChecksumUser = $validUser;
     }
 
     if (!$this->_contactId) {
@@ -169,7 +170,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
       $this->assign('pcpInfo', $pcpInfo);
     }
 
-    if (!empty($this->_userOptions['Assigned Activities'])) {
+    if (!empty($this->_userOptions['Assigned Activities']) && empty($this->_isChecksumUser)) {
       // Assigned Activities section
       $dashboardElements[] = array(
         'class' => 'crm-dashboard-assignedActivities',

--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -72,6 +72,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this);
     $validUser = FALSE;
     if (empty($userID) && $this->_contactId && $userChecksum) {
+      $this->assign('userChecksum', $userChecksum);
       $validUser = CRM_Contact_BAO_Contact_Utils::validChecksum($this->_contactId, $userChecksum);
     }
 

--- a/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
@@ -23,6 +23,9 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{if $userChecksum}
+  {assign var=edit value='0'}
+{/if}
 {crmRegion name="crm-contact-userdashboard-groupcontact-pre"}
 {/crmRegion}
 <div id="groupContact">

--- a/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
@@ -37,7 +37,7 @@
     <th>{ts}In Support of{/ts}</th>
     <th>{ts}Campaign Ends{/ts}</th>
     <th>{ts}Status{/ts}</th>
-    <th></th>
+    {if !$userChecksum} <th></th> {/if}
   </tr>
 
   {foreach from=$pcpInfo item=row}
@@ -46,7 +46,9 @@
         <td>{$row.pageTitle}</td>
         <td>{if $row.end_date}{$row.end_date|truncate:10:''|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
         <td>{$row.pcpStatus}</td>
-        <td>{$row.action|replace:'xx':$row.pcpId}</td>
+        {if !$userChecksum}
+          <td>{$row.action|replace:'xx':$row.pcpId}</td>
+        {/if}
   </tr>
   {/foreach}
 </table>
@@ -58,7 +60,6 @@
   {ts}You do not have any active Personal Campaign pages.{/ts}
 </div>
 {/if}
-
 
 {if $pcpBlock}
 {strip}

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -76,8 +76,12 @@
                         {/if}
                         {if $defaultInvoicePage && $row.contribution_status_name == 'Pending' }
                           <td>
+                            {assign var='checksum_url' value=""}
+                            {if $userChecksum}
+                              {assign var='checksum_url' value="&cid=$contactId&cs=$userChecksum"}
+                            {/if}
                             {assign var='id' value=$row.contribution_id}
-                            {capture assign=payNowLink}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$defaultInvoicePage`&ccid=`$id`"}{/capture}
+                            {capture assign=payNowLink}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$defaultInvoicePage`&ccid=`$id`$checksum_url"}{/capture}
                             <a class="button" href="{$payNowLink}"><span class='nowrap'>{ts}Pay Now{/ts}</span></a>
                           </td>
                         {/if}

--- a/templates/CRM/Pledge/Page/UserDashboard.tpl
+++ b/templates/CRM/Pledge/Page/UserDashboard.tpl
@@ -46,12 +46,14 @@
     <td class="crm-pledge-pledge_next_pay_date">{$row.pledge_next_pay_date|truncate:10:''|crmDate}</td>
     <td class="crm-pledge-pledge_next_pay_amount">{$row.pledge_next_pay_amount|crmMoney:$row.pledge_currency}</td>
     <td class="crm-pledge-pledge_status crm-pledge-pledge_status_{$row.pledge_status}">{$row.pledge_status}</td>
-    <td>
-      {if $row.pledge_contribution_page_id and ($row.pledge_status_name neq 'Completed') and ( $row.contact_id eq $loggedUserID ) }
-        <a href="{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$row.pledge_contribution_page_id`&pledgeId=`$row.pledge_id`"}">{ts}Make Payment{/ts}</a><br/>
-      {/if}
-      <a class="crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}">{ts}Payments{/ts}</a>
-    </td>
+    {if !$userChecksum}
+      <td>
+        {if $row.pledge_contribution_page_id and ($row.pledge_status_name neq 'Completed') and ( $row.contact_id eq $loggedUserID ) }
+          <a href="{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$row.pledge_contribution_page_id`&pledgeId=`$row.pledge_id`"}">{ts}Make Payment{/ts}</a><br/>
+        {/if}
+        <a class="crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}">{ts}Payments{/ts}</a>
+      </td>
+    {/if}
    </tr>
   {/foreach}
 </table>


### PR DESCRIPTION
… link

Overview
----------------------------------------
Fix checksum URL for paynow link when dashboard is accessed through checksum.

Before
----------------------------------------
PayNow button URL is not built with cs param when user dashboard is access with checksum. More details at https://lab.civicrm.org/dev/core/issues/346

After
----------------------------------------
PayNow button URL has cs param which enabled user to complete the payment.

Comments
----------------------------------------
@magnolia61 Can you pls test this change?

----------------------

Gitlab Issue - https://lab.civicrm.org/dev/core/issues/346