### PR TITLE
Convert RecurringEntity form to datepicker

### DIFF
--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -138,7 +138,7 @@ class CRM_Core_Form_RecurringEntity {
       if (self::$_scheduleReminderDetails->start_action_offset) {
         $defaults['ends'] = 1;
       }
-      list($defaults['repeat_absolute_date']) = CRM_Utils_Date::setDateDefaults(self::$_scheduleReminderDetails->absolute_date);
+      $defaults['repeat_absolute_date'] = self::$_scheduleReminderDetails->absolute_date;
       if (self::$_scheduleReminderDetails->absolute_date) {
         $defaults['ends'] = 2;
       }
@@ -184,7 +184,7 @@ class CRM_Core_Form_RecurringEntity {
     $form->add('select', 'repetition_frequency_unit', ts('Repeats every'), CRM_Core_SelectValues::getRecurringFrequencyUnits(), FALSE, array('class' => 'required'));
     $numericOptions = CRM_Core_SelectValues::getNumericOptions(1, 30);
     $form->add('select', 'repetition_frequency_interval', NULL, $numericOptions, FALSE, array('class' => 'required'));
-    $form->addDateTime('repetition_start_date', ts('Repetition Start Date'), FALSE, array('formatType' => 'activityDateTime'));
+    $form->add('datepicker', 'repetition_start_date', ts('Start Date'), array(), FALSE, array('time' => TRUE));
     foreach ($dayOfTheWeek as $key => $val) {
       $startActionCondition[] = $form->createElement('checkbox', $key, NULL, $val);
     }
@@ -193,7 +193,7 @@ class CRM_Core_Form_RecurringEntity {
       '1' => ts('day of the month'),
       '2' => ts('day of the week'),
     );
-    $form->addRadio('repeats_by', ts("Repeats by"), $roptionTypes, array('required' => TRUE), NULL);
+    $form->addRadio('repeats_by', ts("Repeats on"), $roptionTypes, array('required' => TRUE), NULL);
     $form->add('select', 'limit_to', '', CRM_Core_SelectValues::getNumericOptions(1, 31));
     $dayOfTheWeekNo = array(
       'first' => ts('First'),
@@ -215,10 +215,8 @@ class CRM_Core_Form_RecurringEntity {
     unset($offsetOptions[0]);
     $form->add('select', 'start_action_offset', NULL, $offsetOptions, FALSE);
     $form->addFormRule(array('CRM_Core_Form_RecurringEntity', 'formRule'));
-    $form->addDate('repeat_absolute_date', ts('On'), FALSE, array('formatType' => 'mailing'));
-    $form->add('text', 'exclude_date_list', ts('Exclude Dates'), array(
-        'class' => 'twenty',
-      ));
+    $form->add('datepicker', 'repeat_absolute_date', ts('On'), array(), FALSE, array('time' => FALSE));
+    $form->add('text', 'exclude_date_list', ts('Exclude Dates'), array('class' => 'twenty'));
     $form->addElement('hidden', 'allowRepeatConfigToSubmit', '', array('id' => 'allowRepeatConfigToSubmit'));
     $form->addButtons(array(
         array(
@@ -334,7 +332,7 @@ class CRM_Core_Form_RecurringEntity {
    * @throws \CiviCRM_API3_Exception
    */
   public static function postProcess($params = array(), $type, $linkedEntities = array()) {
-    //Check entity_id not present in params take it from class variable
+    // Check entity_id not present in params take it from class variable
     if (empty($params['entity_id'])) {
       $params['entity_id'] = self::$_entityId;
     }

--- a/templates/CRM/Core/Form/RecurringEntity.tpl
+++ b/templates/CRM/Core/Form/RecurringEntity.tpl
@@ -35,10 +35,6 @@
       </div>
     {/if}
     <table class="form-layout-compressed">
-      <tr class="crm-core-form-recurringentity-block-repetition_start_date" id="tr-repetition_start_date">
-        <td class="label">{$form.repetition_start_date.label}</td>
-        <td>{include file="CRM/common/jcalendar.tpl" elementName=repetition_start_date}</td>
-      </tr>
       <tr class="crm-core-form-recurringentity-block-repetition_frequency">
         <td class="label">{$form.repetition_frequency_unit.label}&nbsp;<span class="crm-marker">*</span>  {help id="id-repeats" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
         <td>{$form.repetition_frequency_interval.html} {$form.repetition_frequency_unit.html}</td>
@@ -52,23 +48,27 @@
         </td>
       </tr>
       <tr class="crm-core-form-recurringentity-block-repeats_by">
-        <td class="label">{$form.repeats_by.label} {help id="id-repeats-by-month" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
-        <td>{$form.repeats_by.1.html}&nbsp;&nbsp;{$form.limit_to.html}
+        <td class="label">{$form.repeats_by.label}&nbsp;<span class="crm-marker">*</span></td>
+        <td>{help id="id-repeats-by-month" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"} {$form.repeats_by.1.html} {$form.limit_to.html}
         </td>
       </tr>
       <tr class="crm-core-form-recurringentity-block-repeats_by">
-        <td class="label">{help id="id-repeats-by-week" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
-        <td>{$form.repeats_by.2.html}&nbsp;&nbsp;{$form.entity_status_1.html}&nbsp;&nbsp;{$form.entity_status_2.html}
+        <td class="label"></td>
+        <td>{help id="id-repeats-by-week" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"} {$form.repeats_by.2.html} {$form.entity_status_1.html} {$form.entity_status_2.html}
         </td>
+      </tr>
+      <tr><td>&nbsp;</td><td>&nbsp;</td></tr>
+      <tr class="crm-core-form-recurringentity-block-repetition_start_date" id="tr-repetition_start_date">
+        <td class="label">{$form.repetition_start_date.label}</td>
+        <td>{$form.repetition_start_date.html}</td>
       </tr>
       <tr class="crm-core-form-recurringentity-block-ends">
-        <td class="label">{$form.ends.label}&nbsp;<span class="crm-marker">*</span> {help id="id-ends-after" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
-        <td>{$form.ends.1.html}&nbsp;{$form.start_action_offset.html} {ts}occurrences{/ts}</td>
+        <td class="label">{$form.ends.label}&nbsp;<span class="crm-marker">*</span></td>
+        <td>{help id="id-ends-after" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"} {$form.ends.1.html} {$form.start_action_offset.html} {ts}occurrences{/ts}</td>
       </tr>
       <tr class="crm-core-form-recurringentity-block-absolute_date">
-        <td class="label"> {help id="id-ends-on" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
-        <td>{$form.ends.2.html}&nbsp;{include file="CRM/common/jcalendar.tpl" elementName=repeat_absolute_date}
-        </td>
+        <td class="label"> </td>
+        <td>{help id="id-ends-on" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"} {$form.ends.2.html} {$form.repeat_absolute_date.html}</td>
       </tr>
       <tr class="crm-core-form-recurringentity-block-exclude_date">
         <td class="label">{$form.exclude_date_list.label} {help id="id-exclude-date" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
@@ -111,19 +111,21 @@
     }
     $('#repetition_frequency_unit', $form).each(changeFrequencyUnit).change(changeFrequencyUnit);
 
-    function disableUnselected() {
-      $('input:radio[name=ends], input[name=repeats_by]', $form).not(':checked').siblings(':input').prop('disabled', true).removeClass('required');
+    function disableEnds() {
+      $("#repeat_absolute_date, #start_action_offset").prop('disabled', true).removeClass('required');
+
+      if ($('input[name=ends][value=2]').prop('checked')) {
+        $("#repeat_absolute_date").prop('disabled', false).addClass('required').focus();
+      }
+      else if ($('input[name=ends][value=1]').prop('checked')) {
+        $('#start_action_offset').prop('disabled', false).addClass('required').focus();
+      }
     }
-    disableUnselected();
 
-    $('input:radio[name=ends], input[name=repeats_by]', $form).click(function() {
-      $(this).siblings(':input').prop('disabled', false).filter(':visible').addClass('required').focus();
-      disableUnselected();
+    $('input[name=ends]').click(function() {
+      disableEnds();
     });
-
-    $('input:radio[name=ends]').siblings('.crm-clear-link').click(function() {
-      $('input:radio[name=ends][value=1]').prop('checked', true).trigger('click');
-    });
+    disableEnds();
 
     function validate() {
       var valid = $(':input', '#recurring-entity-block').valid(),


### PR DESCRIPTION
Overview
----------------------------------------
Convert "Repeating entity" form to datepicker.  This form is used by the create/edit activity dialog and the repeating events dialog.

Before
----------------------------------------
Form elements not using datepicker.
![repeat_predatepicker](https://user-images.githubusercontent.com/2052161/44792861-c1d4d980-ab9c-11e8-931f-190366609bf2.png)

After
----------------------------------------
Form elements using datepicker.  Cleaned up form slightly so elements are slightly better aligned, help icons are shown in the right places.
Start date moves down specifically because the first element will automatically receive focus and trigger the datepicker to popup when the form is loaded which is not desirable.  I think it also makes sense to be further down.
It was also possible to upset the disable/enable elements code previously so that has also been modified so that it now works correctly.

![repeat_postdatepicker](https://user-images.githubusercontent.com/2052161/44792865-c6998d80-ab9c-11e8-97c2-204ccb4c19cc.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
