### PR TITLE
Extract selectedChild tabheader functionality and enable for Manage Events

### DIFF
--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -187,22 +187,13 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
    * @throws Exception
    */
   public function run($args = NULL, $pageArgs = NULL, $sort = NULL) {
+    $id = $this->getIdAndAction();
     // handle the revert action and offload the rest to parent
-    if (CRM_Utils_Request::retrieve('action', 'String', $this) & CRM_Core_Action::REVERT) {
-
-      $id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-      if (!$this->checkPermission($id, NULL)) {
-        CRM_Core_Error::fatal(ts('You do not have permission to revert this template.'));
-      }
-
+    if ($this->_action & CRM_Core_Action::REVERT) {
       $this->_revertedId = $id;
-
       CRM_Core_BAO_MessageTemplate::revert($id);
     }
-    $selectedChild = CRM_Utils_Request::retrieve('selectedChild', 'String', $this);
-    if (in_array($selectedChild, array('user', 'workflow'))) {
-      $this->assign('selectedChild', $selectedChild);
-    }
+
     return parent::run($args, $pageArgs, $sort);
   }
 

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -122,7 +122,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
       ->addSetting(array(
         'summaryPrint' => array('mode' => $this->_print),
-        'tabSettings' => array('active' => CRM_Utils_Request::retrieve('selectedChild', 'String', $this, FALSE, 'summary')),
+        'tabSettings' => array('active' => CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $this, FALSE, 'summary')),
       ));
     $this->assign('summaryPrint', $this->_print);
     $session = CRM_Core_Session::singleton();

--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -171,10 +171,13 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
    *
    * @return int
    *   The ID if present, or 0.
+   * @throws \CRM_Core_Exception
    */
   public function getIdAndAction() {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->assign('action', $this->_action);
+
+    $this->assign('selectedChild', CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $this));
 
     // get 'id' if present
     $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);

--- a/CRM/Event/Form/ManageEvent/Repeat.php
+++ b/CRM/Event/Form/ManageEvent/Repeat.php
@@ -110,7 +110,7 @@ class CRM_Event_Form_ManageEvent_Repeat extends CRM_Event_Form_ManageEvent {
       unset($params['id']);
 
       $url = 'civicrm/event/manage/repeat';
-      $urlParams = "action=update&reset=1&id={$this->_id}";
+      $urlParams = "action=update&reset=1&id={$this->_id}&selectedChild=repeat";
 
       $linkedEntities = array(
         array(

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -42,8 +42,11 @@ class CRM_Event_Form_ManageEvent_TabHeader {
    * @param CRM_Event_Form_ManageEvent $form
    *
    * @return array
+   * @throws \CRM_Core_Exception
    */
   public static function build(&$form) {
+    $form->assign('selectedChild', CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $form));
+
     $tabs = $form->get('tabHeader');
     if (!$tabs || empty($_GET['reset'])) {
       $tabs = self::process($form);
@@ -235,7 +238,7 @@ WHERE      e.id = %1
 
     if (is_array($tabs)) {
       foreach ($tabs as $subPage => $pageVal) {
-        if ($pageVal['current'] === TRUE) {
+        if (CRM_Utils_Array::value('current', $pageVal) === TRUE) {
           $current = $subPage;
           break;
         }

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -145,10 +145,6 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
    * This method is called after the page is created. It checks for the
    * type of action and executes that action.
    * Finally it calls the parent's run method.
-   *
-   * @param
-   *
-   * @return void
    */
   public function run() {
     // get the requested action
@@ -160,7 +156,7 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
 
     // assign vars to templates
     $this->assign('action', $action);
-    $this->assign('selectedChild', CRM_Utils_Request::retrieve('selectedChild', 'String', $this));
+    $this->assign('selectedChild', CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $this));
     $id = CRM_Utils_Request::retrieve('id', 'Positive',
       $this, FALSE, 0
     );

--- a/templates/CRM/Admin/Page/Extensions.tpl
+++ b/templates/CRM/Admin/Page/Extensions.tpl
@@ -101,20 +101,7 @@
     </script>
     {/literal}
 
-    {* Tab management *}
-    <script type="text/javascript">
-    var selectedTab  = 'summary';
-    {if $selectedChild}selectedTab = "{$selectedChild}";{/if}
-
-    {literal}
-
-    CRM.$(function($) {
-      var tabIndex = $('#tab_' + selectedTab).prevAll().length;
-      $("#mainTabContainer").tabs({active: tabIndex});
-      $(".crm-tab-button").addClass("ui-corner-bottom");
-    });
-    {/literal}
-    </script>
+    {include file="CRM/common/TabSelected.tpl" defaultTab="summary"}
 
     {* Refresh buttons *}
     {literal}

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -173,16 +173,7 @@
     {/foreach}
   </div>
 </div>
-  <script type='text/javascript'>
-    var selectedTab = 'user';
-    {if $selectedChild}selectedTab = '{$selectedChild}';{/if}
-    {literal}
-      CRM.$(function($) {
-        var tabIndex = $('#tab_' + selectedTab).prevAll().length
-        $("#mainTabContainer").tabs( {active: tabIndex} );
-      });
-    {/literal}
-  </script>
+{include file="CRM/common/TabSelected.tpl" defaultTab="user"}
 
 {elseif $action ne 1 and $action ne 2 and $action ne 4 and $action ne 8}
   <div class="messages status no-popup">

--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -31,18 +31,8 @@
     <div class="contact-summary-contribute-tab view-content">
 
       <div id="secondaryTabContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
-        {* Tab management *}
-        <script type="text/javascript">
-          var selectedTab  = 'contributions';
+        {include file="CRM/common/TabSelected.tpl" defaultTab="contributions" tabContainer="#secondaryTabContainer"}
 
-          {literal}
-          CRM.$(function($) {
-            var tabIndex = $('#tab_' + selectedTab).prevAll().length;
-            $("#secondaryTabContainer").tabs({active: tabIndex});
-            $(".crm-tab-button").addClass("ui-corner-bottom");
-          });
-          {/literal}
-        </script>
         <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
           <li id="tab_contributions" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
             <a href="#contributions-subtab" title="{ts}Contributions{/ts}">

--- a/templates/CRM/Event/Form/ManageEvent/Tab.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Tab.tpl
@@ -107,3 +107,4 @@ CRM.$(function($) {
 </script>
 {/literal}
 {include file="CRM/Event/Form/ManageEvent/ConfirmRepeatMode.tpl" entityID=$id entityTable="civicrm_event"}
+{include file="CRM/common/TabSelected.tpl" defaultTab="settings"}

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -157,17 +157,8 @@
             </div>
         </div>{* reserved profile*}
 
-  </div> {* maincontainer*}
-  <script type='text/javascript'>
-    var selectedTab = 'user-profiles';
-    {if $selectedChild}selectedTab = '{$selectedChild}';{/if}
-    {literal}
-      CRM.$(function($) {
-        var tabIndex = $('#tab_' + selectedTab).prevAll().length
-        $("#mainTabContainer").tabs( {active: tabIndex} );
-      });
-    {/literal}
-  </script>
+  </div>
+{include file="CRM/common/TabSelected.tpl" defaultTab="user-profiles"}
 
     {else}
     {if $action ne 1} {* When we are adding an item, we should not display this message *}

--- a/templates/CRM/common/TabSelected.tpl
+++ b/templates/CRM/common/TabSelected.tpl
@@ -1,0 +1,12 @@
+<script type='text/javascript'>
+  var selectedTab = '{$defaultTab}';
+  var tabContainer = '#mainTabContainer';
+  {if $tabContainer}tabContainer = '{$tabContainer}';{/if}
+  {if $selectedChild}selectedTab = '{$selectedChild}';{/if}
+  {literal}
+  CRM.$(function($) {
+    var tabIndex = $('#tab_' + selectedTab).prevAll().length;
+    $(tabContainer).tabs( {active: tabIndex} );
+  });
+  {/literal}
+</script>


### PR DESCRIPTION
Overview
----------------------------------------
Some pages with tabs in CiviCRM allow you to link directly to a specific tab using the URL parameter `&selectedChild=tabname` (eg. for the contact summary to link directly to the contributions tab `tabname="contribute"`

This is currently supported for:
* Contact tabs
* Contribution page tabs
* Messagetemplates tabs
* Extensions tabs
* Profiles tabs

... But the code is duplicated in each template.

This PR extracts the duplicate code to a common shared template and adds support to the event page tabs.

Before
----------------------------------------
* Duplicated code in template for each instance.
* No support in event tabs.

After
----------------------------------------
* Shared code which can be included anywhere tabs are implemented.
* Support for `selectedChild` in event tabs.

Technical Details
----------------------------------------
For the events tab we have to retrieve the `selectedChild` parameter.  Other than that this is just template extraction.

Comments
----------------------------------------
