### PR TITLE
dev/core#370: No new tasks and documents get added to workflow

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -355,7 +355,8 @@
     }
 
     function addActivityToSet(activitySet, activityTypeName) {
-      var activity = {
+      activitySet.activityTypes = activitySet.activityTypes || [];
+	    var activity = {
           name: activityTypeName,
           label: $scope.activityTypes[activityTypeName].label,
           status: 'Scheduled',


### PR DESCRIPTION
Overview
----------------------------------------
In civi case types, when all built-in tasks and documents are deleted from the Standard Timeline of a workflow, no new tasks and documents get saved to that workflow. This PR fixes the issue, ensuring new task can be added.

Before
----------------------------------------
![case_type](https://user-images.githubusercontent.com/1507645/44798799-58f45e00-abaa-11e8-8d8b-972dced0e26a.gif)


After
----------------------------------------
![case_type_after](https://user-images.githubusercontent.com/1507645/44798813-5eea3f00-abaa-11e8-9b4d-96185c0e99cb.gif)


Technical Details
----------------------------------------
After deleting all existing tasks, `activityTypes` becomes undefined. To fix the issue, it was ensured the property `activityTypes` exists on `activitySet` by initializing it with existing value or empty array.

```
activitySet.activityTypes = activitySet.activityTypes || [];
```

