### PR TITLE
Fix compatibility problem with CRM_Extendedreport_Form_Report_ExtendedReport

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4911,7 +4911,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * @param array $field
    * @param string $table
    */
-  private function setEntityRefDefaults(&$field, $table) {
+  public function setEntityRefDefaults(&$field, $table) {
     $field['attributes'] = $field['attributes'] ? $field['attributes'] : array();
     $field['attributes'] += array(
       'entity' => CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($table)),


### PR DESCRIPTION
@eileenmcnaughton my IDE flagged this problem where `CRM_Extendedreport_Form_Report_ExtendedReport` was calling this function but it had private access. Really no reason for that, so let's change it.