### PR TITLE
Upgrade changes for reminder entity dates

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.6.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.6.alpha1.mysql.tpl
@@ -2,3 +2,8 @@
 
 ALTER TABLE civicrm_prevnext_cache
   CHANGE `entity_id2` `entity_id2` int unsigned NULL   COMMENT 'FK to entity table specified in entity_table column.';
+
+UPDATE civicrm_action_schedule SET start_action_date = 'start_date' WHERE start_action_date = 'event_start_date';
+UPDATE civicrm_action_schedule SET start_action_date = 'end_date' WHERE start_action_date = 'event_end_date';
+UPDATE civicrm_action_schedule SET start_action_date = 'join_date' WHERE start_action_date = 'membership_join_date';
+UPDATE civicrm_action_schedule SET start_action_date = 'end_date' WHERE start_action_date = 'membership_end_date';


### PR DESCRIPTION
Overview
----------------------------------------
Fix action date for sched reminders in DB.

Before
----------------------------------------
Db values for reminders created before 5.3 have action date set as `membership_end_date`. It was changed recently in https://github.com/civicrm/civicrm-core/pull/12114 to end_date but the patch missed the upgrade changes. 

Due to this, membership form is loaded with incorrect default value for start action date and user accidentally saves the unintended values.

After
----------------------------------------
DB values fixed. Reminder form is loaded with correct defaults.

