### PR TITLE
Add cancel_reason field in contribute query whereClauseSingle

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -258,6 +258,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       case (strpos($name, '_amount') !== FALSE):
       case (strpos($name, '_date') !== FALSE && $name != 'contribution_fulfilled_date'):
       case 'contribution_campaign_id':
+      case 'contribution_cancel_reason':
 
         $fieldNamesNotToStripContributionFrom = array(
           'contribution_currency_type',


### PR DESCRIPTION
Overview
----------------------------------------
Contribution's **Cancel Reason** is not working when used in Search Builder using *IN* operator

Before
----------------------------------------
![civicrm_bug1](https://user-images.githubusercontent.com/2589799/44975270-4ee3ae00-af62-11e8-900b-ef664e7cf277.gif)

Query produced is wrong
```sql
SELECT 
  DISTINCT UPPER(LEFT(contact_a.sort_name, 1)) AS sort_name
FROM 
  civicrm_contact contact_a
LEFT JOIN 
  civicrm_contribution ON civicrm_contribution.contact_id = contact_a.id
WHERE 
  ((civicrm_contribution.financial_type_id IN ("3", "1",  "4","2")
        AND civicrm_contribution.cancel_reason IN ''))
  AND (contact_a.is_deleted = 0)
ORDER BY UPPER(LEFT(contact_a.sort_name, 1)) ASC 
```

```
[nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''' )  )  AND (contact_a.is_deleted = 0)    ORDER BY UPPER(LEFT(contact_a.sort_na' at line 1]
```


After
----------------------------------------
![civicrm_bug2](https://user-images.githubusercontent.com/2589799/44975277-55722580-af62-11e8-94b1-71885f17a3a1.gif)


Technical Details
----------------------------------------
**cancel_reason** field is not treated as rest of contribution's fields in *whereClauseSingle()*.
This PR just add this field to be treated as the rest of common contribution's fields

