### PR TITLE
Add new paymentprocessor supportsX methods to replace remaining isSupported methods

### DIFF
--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -95,7 +95,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
       $this->_selfService = TRUE;
     }
 
-    if (!$this->_paymentProcessor['object']->isSupported('updateSubscriptionBillingInfo')) {
+    if (!$this->_paymentProcessor['object']->supports('updateSubscriptionBillingInfo')) {
       CRM_Core_Error::fatal(ts("%1 processor doesn't support updating subscription billing details.",
         array(1 => $this->_paymentProcessor['object']->_processorName)
       ));

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -257,7 +257,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
 
     $params['subscriptionId'] = $this->_subscriptionDetails->subscription_id;
     $updateSubscription = TRUE;
-    if ($this->_paymentProcessorObj->isSupported('changeSubscriptionAmount')) {
+    if ($this->_paymentProcessorObj->supports('changeSubscriptionAmount')) {
       $updateSubscription = $this->_paymentProcessorObj->changeSubscriptionAmount($message, $params);
     }
     if (is_a($updateSubscription, 'CRM_Core_Error')) {

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -376,6 +376,18 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Does this processor support updating billing info for recurring contributions through code.
+   *
+   * If the processor returns true then it must be possible to update billing info from within CiviCRM
+   * that will be updated at the payment processor.
+   *
+   * @return bool
+   */
+  protected function supportsUpdateSubscriptionBillingInfo() {
+    return method_exists(CRM_Utils_System::getClassName($this), 'updateSubscriptionBillingInfo');
+  }
+
+  /**
    * Can recurring contributions be set against pledges.
    *
    * In practice all processors that use the baseIPN function to finish transactions or
@@ -590,7 +602,7 @@ abstract class CRM_Core_Payment {
    * @return array
    */
   public function getEditableRecurringScheduleFields() {
-    if (method_exists($this, 'changeSubscriptionAmount')) {
+    if ($this->supports('changeSubscriptionAmount')) {
       return array('amount');
     }
   }
@@ -1453,7 +1465,7 @@ abstract class CRM_Core_Payment {
 
       case 'billing':
         //in notify mode don't return the update billing url
-        if (!$this->isSupported('updateSubscriptionBillingInfo')) {
+        if (!$this->supports('updateSubscriptionBillingInfo')) {
           return NULL;
         }
         $url = 'civicrm/contribute/updatebilling';
@@ -1504,7 +1516,7 @@ INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
     }
 
     // Else login URL
-    if ($this->isSupported('accountLoginURL')) {
+    if ($this->supports('accountLoginURL')) {
       return $this->accountLoginURL();
     }
 
@@ -1551,6 +1563,18 @@ INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
   }
 
   /**
+   * Does this processor support changing the amount for recurring contributions through code.
+   *
+   * If the processor returns true then it must be possible to update the amount from within CiviCRM
+   * that will be updated at the payment processor.
+   *
+   * @return bool
+   */
+  protected function supportsChangeSubscriptionAmount() {
+    return method_exists(CRM_Utils_System::getClassName($this), 'changeSubscriptionAmount');
+  }
+
+  /**
    * Checks if payment processor supports recurring contributions
    *
    * @return bool
@@ -1560,6 +1584,17 @@ INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Checks if payment processor supports an account login URL
+   * TODO: This is checked by self::subscriptionURL but is only used if no entityID is found.
+   * TODO: It is implemented by AuthorizeNET, any others?
+   *
+   * @return bool
+   */
+  protected function supportsAccountLoginURL() {
+    return method_exists(CRM_Utils_System::getClassName($this), 'accountLoginURL');
   }
 
   /**

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -108,9 +108,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
         $paymentObject = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity(
           $membership[$dao->id]['membership_id'], 'membership', 'obj');
         if (!empty($paymentObject)) {
-          // @todo - get this working with syntax style $paymentObject->supports(array
-          //('updateSubscriptionBillingInfo'));
-          $isUpdateBilling = $paymentObject->isSupported('updateSubscriptionBillingInfo');
+          $isUpdateBilling = $paymentObject->supports('updateSubscriptionBillingInfo');
         }
 
         // @todo - get this working with syntax style $paymentObject->supports(array


### PR DESCRIPTION
Overview
----------------------------------------
This replaces the old `isSupported('X')` methods for the following 3 capabilities with the newer style `supports('X')` methods for:

```
updateSubscriptionBillingInfo
changeSubscriptionAmount
accountLoginURL
```

Before
----------------------------------------
Using deprecated methods

After
----------------------------------------
Using non-deprecated methods

Comments
----------------------------------------
This should be a non-functional change as we are just replacing deprecated methods with new methods to do the same thing.