### PR TITLE
Fix for recurring entities being deleted when none are selected for deletion

### DIFF
--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -424,32 +424,29 @@ class CRM_Core_Form_RecurringEntity {
           if (CRM_Utils_Array::value('delete_func', CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]) &&
             CRM_Utils_Array::value('helper_class', CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']])
           ) {
-            //Check if pre delete function has some ids to be deleted
-            if (!empty(CRM_Core_BAO_RecurringEntity::$_entitiesToBeDeleted)) {
-              foreach (CRM_Core_BAO_RecurringEntity::$_entitiesToBeDeleted as $eid) {
-                $result = civicrm_api3(
-                  ucfirst(strtolower($apiType)),
-                  CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['delete_func'],
-                  array(
-                    'sequential' => 1,
-                    'id' => $eid,
-                  )
-                );
-                if ($result['error']) {
-                  CRM_Core_Error::statusBounce('Error creating recurring list');
+            if (CRM_Utils_Array::value('pre_delete_func', CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']])) {
+              // As we have a pre-delete function we delete any entities that were selected to be deleted
+              if (!empty(CRM_Core_BAO_RecurringEntity::$_entitiesToBeDeleted)) {
+                foreach (CRM_Core_BAO_RecurringEntity::$_entitiesToBeDeleted as $eid) {
+                  $result = civicrm_api3(
+                    ucfirst(strtolower($apiType)),
+                    CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['delete_func'],
+                    ['id' => $eid]
+                  );
+                  if ($result['error']) {
+                    CRM_Core_Error::statusBounce('Error creating recurring list');
+                  }
                 }
               }
             }
             else {
+              // If we have no pre-delete function we delete all existing recurring entities
               $getRelatedEntities = CRM_Core_BAO_RecurringEntity::getEntitiesFor($params['entity_id'], $params['entity_table'], FALSE);
               foreach ($getRelatedEntities as $key => $value) {
                 $result = civicrm_api3(
                   ucfirst(strtolower($apiType)),
                   CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['delete_func'],
-                  array(
-                    'sequential' => 1,
-                    'id' => $value['id'],
-                  )
+                  ['id' => $value['id']]
                 );
                 if ($result['error']) {
                   CRM_Core_Error::statusBounce('Error creating recurring list');


### PR DESCRIPTION
Overview
----------------------------------------
When editing recurring (event) series you are given the option to update/add/replace existing (event) entities in the series.

1. On submit the recurringEntity postProcess class calls a preDelete function which selects those entities which should be deleted.
2. In some cases this will return none for deletion, in some cases it will return a selected list of entity IDs based. 
3. If none are selected for deletion the code currently deletes all of them!  When it should actually be deleting none of them! This results in an unexpected loss of (event) entities.

Before
----------------------------------------
(Events) are unexpectedly deleted in some cases.

After
----------------------------------------
(Events) are not unexpectedly deleted when none have been marked for deletion.

Technical Details
----------------------------------------
The code was checking if an array contained values (`$_entitiesToBeDeleted`) and if not then it was deleting all entities.  However, the array will only be filled if there is a "pre delete" function AND the "pre delete function selects some entities for deletion.  This PR modifies the check so that we only execute the "delete all entities (`else`)" if there is no pre-delete function defined.

Comments
----------------------------------------
This was identified as part of some work I'm doing on a more advanced repeating events extension.  The recurring entity functionality is used by activities and events only but the deletion issue is not visible for the activities because there are no linked entities (such as participant records) to be lost when an activity is deleted/copied.