### PR TITLE
Fix order by on is_primary.

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -239,7 +239,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         'phone_not_empty' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone != ''"),
         'mailing_id' => CRM_Utils_SQL_Select::fragment()->where("mg.mailing_id = #mailingID"),
         'temp_contact_null' => CRM_Utils_SQL_Select::fragment()->where('temp.contact_id IS null'),
-        'order_by' => CRM_Utils_SQL_Select::fragment()->orderBy("$entityTable.is_primary = 1"),
+        'order_by' => CRM_Utils_SQL_Select::fragment()->orderBy("$entityTable.is_primary"),
       );
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
As pointed out in https://lab.civicrm.org/dev/mail/issues/26 the order by is not the
correct format for order_by and has no effect. I tested to make sure it was not
some magic.

Before
----------------------------------------
Order by ignored

After
----------------------------------------
Order by works

Technical Details
----------------------------------------
I opted for (implict) ASC as the order by for non sms is ASC and further down
processing seems to overwrite each row as it happens so primary later
would overwrite earlier.



Comments
----------------------------------------
@monishdeb @seamuslee001 @mattwire @totten ping (original commit by Tim but merged by Monish)
