### PR TITLE
dev/core#326: Fix for fatal error in section headers.

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -823,6 +823,12 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       // pull section aliases out of $this->_sections
       $sectionAliases = array_keys($this->_sections);
 
+      // hack alert - but it's tested so go forth & make pretty, or whack the new mole that popped up with gay abandon.
+      if (in_array('civicrm_contribution_total_amount', $this->_selectAliases)) {
+        $keyToHack = array_search('civicrm_contribution_total_amount', $this->_selectAliases);
+        $this->_selectAliases[$keyToHack] = 'civicrm_contribution_total_amount_sum';
+      }
+
       $ifnulls = array();
       foreach (array_merge($sectionAliases, $this->_selectAliases) as $alias) {
         $ifnulls[] = "ifnull($alias, '') as $alias";
@@ -837,10 +843,10 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
 
       $addtotals = '';
 
-      if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !==
+      if (array_search("civicrm_contribution_total_amount_sum", $this->_selectAliases) !==
         FALSE
       ) {
-        $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
+        $addtotals = ", sum(civicrm_contribution_total_amount_sum) as sumcontribs";
         $showsumcontribs = TRUE;
       }
 

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -906,4 +906,29 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     ]);
   }
 
+  /**
+   * Test the group filter works on the contribution summary.
+   */
+  public function testContributionDetailTotalHeader() {
+    $contactID = $this->individualCreate();
+    $contactID2 = $this->individualCreate();
+    $this->contributionCreate(['contact_id' => $contactID, 'api.ContributionSoft.create' => ['amount' => 5, 'contact_id' => $contactID2]]);
+    $template = 'contribute/detail';
+    $rows = $this->callAPISuccess('report_template', 'getrows', array(
+      'report_id' => $template,
+      'contribution_or_soft_value' => 'contributions_only',
+      'fields' => [
+        'sort_name' => '1',
+        'age' => '1',
+        'email' => '1',
+        'phone' => '1',
+        'financial_type_id' => '1',
+        'receive_date' => '1',
+        'total_amount' => '1',
+       ],
+      'order_bys' => [['column' => 'sort_name', 'order' => 'ASC', 'section' => '1']],
+      'options' => array('metadata' => array('sql')),
+    ));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on contribution detail report when section header selected
![screenshot 2018-09-04 12 34 56](https://user-images.githubusercontent.com/336308/45004222-f46c4f80-b03e-11e8-8c92-ba347213ef12.png)


Before
----------------------------------------
Fatal error
![screenshot 2018-09-04 12 34 25](https://user-images.githubusercontent.com/336308/45004212-e9192400-b03e-11e8-81a2-15851ce3331e.png)


After
----------------------------------------
report renders
![screenshot 2018-09-04 12 32 56](https://user-images.githubusercontent.com/336308/45004198-be2ed000-b03e-11e8-939f-78aeb303dac2.png)


Technical Details
----------------------------------------
Test added

Comments
----------------------------------------
@twomice I think this is not the full fix per your comments but as it gets us past the fatal error in a tested way I think we should merge this part to 5.5 if the tests do pass