### PR TITLE
CIVICRM-947: Added activityTypeName in template params.

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1344,8 +1344,8 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
 
     $tplParams = $activityInfo = array();
     //if its a case activity
+    $activityTypeId = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $activityId, 'activity_type_id');
     if ($caseId) {
-      $activityTypeId = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $activityId, 'activity_type_id');
       $nonCaseActivityTypes = CRM_Core_PseudoConstant::activityType();
       if (!empty($nonCaseActivityTypes[$activityTypeId])) {
         $anyActivity = TRUE;
@@ -1369,6 +1369,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
     if ($caseId) {
       $activityInfo['fields'][] = array('label' => 'Case ID', 'type' => 'String', 'value' => $caseId);
     }
+    $tplParams['activityTypeName'] = $nonCaseActivityTypes[$activityTypeId];
     $tplParams['activity'] = $activityInfo;
     foreach ($tplParams['activity']['fields'] as $k => $val) {
       if (CRM_Utils_Array::value('label', $val) == ts('Subject')) {


### PR DESCRIPTION
Overview
----------------------------------------
This PR is for the Drupal issue #2990790
https://www.drupal.org/project/webform_civicrm/issues/2990790

Email sent from CiviCRM for a new Case and Activity does not evaluate the **$activityTypeName** or **$manageCaseURL** tokens and possibly other tokens as well.

**Steps to reproduce:**
1. Set up a fresh install of Drupal (7.59) and CiviCRM (5.40).
2. Installed latest versions of Webform and CiviCRM Webform Integration and supporting modules (Chaos tools, Views etc.)
3. Enabled CiviCase
4. Created a webform and enabled CiviCRM processing with three fields - first/last name, email
5. Enabled 1 activity ('Long-term housing plan' - out of the box 'sample' CiviCRM case activity) and assigned it to Contact 1
6. Enabled 1 case ('Housing Support' - out of the box 'sample' CiviCRM case type)
7. File the Activity enabled in 5. on Case 1.
8. Submit the webform
9. Case and Activity are created correctly
10. Error is that the email resulting from webform submission does not evaluate all Case related tokens (**$activityTypeName** or **$manageCaseURL**).

This PR added acitivtyTypeName in email copy, Case related details were not getting added because of a bug in **Webform CIviCRM** module.

Before
----------------------------------------
Email copy from webform submission does not evaluate all Case related tokens (**$activityTypeName** or **$manageCaseURL**).

After
----------------------------------------
It now works as expected and includes **activityTypeName**.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-947_
