### PR TITLE
Don't show 'Register Participant' on the manage events page if the logged in user does not have 'Edit Event Participants' permission

### DIFF
--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -45,6 +45,12 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
    */
   static $_actionLinks = NULL;
 
+  /**
+   * The event links to display for the browse screen.
+   * @var array
+   */
+  static $_eventLinks = NULL;
+
   static $_links = NULL;
 
   static $_tabLinks = NULL;
@@ -95,6 +101,41 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
       );
     }
     return self::$_actionLinks;
+  }
+
+  public function eventLinks() {
+    if (!(self::$_eventLinks)) {
+      self::$_eventLinks = [
+        'register_participant' => [
+          'name' => ts('Register Participant'),
+          'title' => ts('Register Participant'),
+          'url' => 'civicrm/participant/add',
+          'qs' => 'reset=1&action=add&context=standalone&eid=%%id%%',
+        ],
+        'event_info' => [
+          'name' => ts('Event Info'),
+          'title' => ts('Event Info'),
+          'url' => 'civicrm/event/info',
+          'qs' => 'reset=1&id=%%id%%',
+          'fe' => TRUE,
+        ],
+        'online_registration_test' => [
+          'name' => ts('Registration (Test-drive)'),
+          'title' => ts('Online Registration (Test-drive)'),
+          'url' => 'civicrm/event/register',
+          'qs' => 'reset=1&action=preview&id=%%id%%',
+          'fe' => TRUE,
+        ],
+        'online_registration_live' => [
+          'name' => ts('Registration (Live)'),
+          'title' => ts('Online Registration (Live)'),
+          'url' => 'civicrm/event/register',
+          'qs' => 'reset=1&id=%%id%%',
+          'fe' => TRUE,
+        ],
+      ];
+    }
+    return self::$_eventLinks;
   }
 
   /**
@@ -344,6 +385,20 @@ ORDER BY start_date desc
           $action -= CRM_Core_Action::UPDATE;
         }
 
+        $eventLinks = self::eventLinks();
+        if (!CRM_Core_Permission::check('edit event participants')) {
+          unset($eventLinks['register_participant']);
+        }
+
+        $manageEvent[$dao->id]['eventlinks'] = CRM_Core_Action::formLink($eventLinks,
+          NULL,
+          array('id' => $dao->id),
+          ts('Event Links'),
+          TRUE,
+          'event.manage.eventlinks',
+          'Event',
+          $dao->id
+        );
         $manageEvent[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(),
           $action,
           array('id' => $dao->id),

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -138,34 +138,8 @@
                 </ul>
               </span>
             </div>
-
             <div class="crm-event-links">
-              <span id="event-links-{$row.id}" class="btn-slide crm-hover-button">{ts}Event Links{/ts}
-                <ul class="panel" id="panel_links_{$row.id}">
-                  <li>
-                    <a title="Register Participant" class="action-item crm-hover-button" href="{crmURL p='civicrm/participant/add'
-                    q="reset=1&action=add&context=standalone&eid=`$row.id`"}">{ts}Register Participant{/ts}</a>
-                  </li>
-                  <li>
-                    <a title="Event Info" class="action-item crm-hover-button" href="{crmURL p='civicrm/event/info'
-                    q="reset=1&id=`$row.id`" fe='true'}" target="_blank">{ts}Event Info{/ts}
-                    </a>
-                  </li>
-                  {if $row.is_online_registration}
-                    <li>
-                      <a title="Online Registration (Test-drive)" class="action-item crm-hover-button"
-                         href="{crmURL p='civicrm/event/register'
-                         q="reset=1&action=preview&id=`$row.id`"}">{ts}Registration (Test-drive){/ts}
-                      </a>
-                    </li>
-                    <li>
-                      <a title="Online Registration (Live)" class="action-item crm-hover-button" href="{crmURL p='civicrm/event/register'
-                      q="reset=1&id=`$row.id`" fe='true'}" target="_blank">{ts}Registration (Live){/ts}
-                      </a>
-                    </li>
-                  {/if}
-                </ul>
-              </span>
+              {$row.eventlinks|replace:'xx':$row.id}
             </div>
             <div class="crm-event-more">
               {$row.action|replace:'xx':$row.id}


### PR DESCRIPTION
Overview
----------------------------------------
Follow up for #12424.  Make sure we don't allow logged in user to follow an action link for "Register Participant" if they do not have permission to do so.

Before
----------------------------------------
"Register Participant" is displayed and can be clicked regardless of "Edit Event Participants" permission.  The actual page is inaccessible if they do not have permission.

After
----------------------------------------
"Register Participant" is only displayed and can be clicked if the logged in user has "Edit Event Participants" permission.

Technical Details
----------------------------------------
This PR converts the hardcoded "Event Links" on the manage events template to use an "action links" style function generated in the page class.  This means they can be manipulated before display and will also now be passed through `hook_civicrm_links` for modification by extensions if desired.
An additional check is then added to unset the "Register Participant" link if the necessary permission is not set.

Comments
----------------------------------------
@alifrumin Could you review this for me please?
