### PR TITLE
Fix caching issues with Event permissions

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2059,34 +2059,127 @@ WHERE  ce.loc_block_id = $locBlockId";
 
   /**
    * Make sure that the user has permission to access this event.
+   * FIXME: We have separate caches for checkPermission('permission') and getAllPermissions['permissions'] so they don't interfere.
+   *    But it would be nice to clean this up some more.
    *
    * @param int $eventId
-   * @param int $type
+   * @param int $permissionType
    *
-   * @return string
-   *   the permission that the user has (or null)
+   * @return bool|array
+   *   Whether the user has permission for this event (or if eventId=NULL an array of permissions)
+   * @throws \CiviCRM_API3_Exception
    */
-  public static function checkPermission($eventId = NULL, $type = CRM_Core_Permission::VIEW) {
-    if (!isset(Civi::$statics[__CLASS__]['permissions'])) {
-      $params = array(
-        'check_permissions' => 1,
-        'return' => 'title',
-        'options' => array(
-          'limit' => 0,
-        ),
-      );
+  public static function checkPermission($eventId = NULL, $permissionType = CRM_Core_Permission::VIEW) {
+    if (empty($eventId)) {
+      CRM_Core_Error::deprecatedFunctionWarning('CRM_Event_BAO_Event::getAllPermissions');
+      return self::getAllPermissions();
+    }
 
-      if ($eventId) {
-        $params['id'] = $eventId;
+    switch ($permissionType) {
+      case CRM_Core_Permission::EDIT:
+        // We also set the cached "view" permission to TRUE if "edit" is TRUE
+        if (isset(Civi::$statics[__CLASS__]['permission']['edit'][$eventId])) {
+          return Civi::$statics[__CLASS__]['permission']['edit'][$eventId];
+        }
+        Civi::$statics[__CLASS__]['permission']['edit'][$eventId] = FALSE;
+
+        list($allEvents, $createdEvents) = self::checkPermissionGetInfo($eventId);
+        // Note: for a multisite setup, a user with edit all events, can edit all events
+        // including those from other sites
+        if (($permissionType == CRM_Core_Permission::EDIT) && CRM_Core_Permission::check('edit all events')) {
+          Civi::$statics[__CLASS__]['permission']['edit'][$eventId] = TRUE;
+          Civi::$statics[__CLASS__]['permission']['view'][$eventId] = TRUE;
+        }
+        elseif (in_array($eventId, CRM_ACL_API::group(CRM_Core_Permission::EDIT, NULL, 'civicrm_event', $allEvents, $createdEvents))) {
+          Civi::$statics[__CLASS__]['permission']['edit'][$eventId] = TRUE;
+          Civi::$statics[__CLASS__]['permission']['view'][$eventId] = TRUE;
+        }
+        return Civi::$statics[__CLASS__]['permission']['edit'][$eventId];
+
+      case CRM_Core_Permission::VIEW:
+        if (isset(Civi::$statics[__CLASS__]['permission']['view'][$eventId])) {
+          return Civi::$statics[__CLASS__]['permission']['view'][$eventId];
+        }
+        Civi::$statics[__CLASS__]['permission']['view'][$eventId] = FALSE;
+
+        list($allEvents, $createdEvents) = self::checkPermissionGetInfo($eventId);
+        if (CRM_Core_Permission::check('access CiviEvent')) {
+          if (in_array($eventId, CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_event', $allEvents, array_keys($createdEvents)))) {
+            // User created this event so has permission to view it
+            return Civi::$statics[__CLASS__]['permission']['view'][$eventId] = TRUE;
+          }
+          if (CRM_Core_Permission::check('view event participants')) {
+            // User has permission to view all events
+            // use case: allow "view all events" but NOT "edit all events"
+            // so for a normal site allow users with these two permissions to view all events AND
+            // at the same time also allow any hook to override if needed.
+            if (in_array($eventId, CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_event', $allEvents, array_keys($allEvents)))) {
+              Civi::$statics[__CLASS__]['permission']['view'][$eventId] = TRUE;
+            }
+          }
+        }
+        return Civi::$statics[__CLASS__]['permission']['view'][$eventId];
+
+      case CRM_Core_Permission::DELETE:
+        if (isset(Civi::$statics[__CLASS__]['permission']['delete'][$eventId])) {
+          return Civi::$statics[__CLASS__]['permission']['delete'][$eventId];
+        }
+        Civi::$statics[__CLASS__]['permission']['delete'][$eventId] = FALSE;
+        if (CRM_Core_Permission::check('delete in CiviEvent')) {
+          Civi::$statics[__CLASS__]['permission']['delete'][$eventId] = TRUE;
+        }
+        return Civi::$statics[__CLASS__]['permission']['delete'][$eventId];
+
+      default:
+        return FALSE;
+    }
+  }
+
+  /**
+   * This is a helper for refactoring checkPermission
+   * FIXME: We should be able to get rid of these arrays, but that would require understanding how CRM_ACL_API::group actually works!
+   *
+   * @param int $eventId
+   *
+   * @return array $allEvents, $createdEvents
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function checkPermissionGetInfo($eventId = NULL) {
+    $params = [
+      'check_permissions' => 1,
+      'return' => 'id, created_id',
+      'options' => ['limit' => 0],
+    ];
+    if ($eventId) {
+      $params['id'] = $eventId;
+    }
+
+    $allEvents = [];
+    $createdEvents = [];
+    $eventResult = civicrm_api3('Event', 'get', $params);
+    if ($eventResult['count'] > 0) {
+      $contactId = CRM_Core_Session::getLoggedInContactID();
+      foreach ($eventResult['values'] as $eventId => $eventDetail) {
+        $allEvents[$eventId] = $eventId;
+        if (isset($eventDetail['created_id']) && $contactId == $eventDetail['created_id']) {
+          $createdEvents[$eventId] = $eventId;
+        }
       }
+    }
+    return [$allEvents, $createdEvents];
+  }
 
-      $result = civicrm_api3('Event', 'get', $params);
-      $allEvents = CRM_Utils_Array::collect('title', $result['values']);
-
-      // Search again, but only events created by the user.
-      $params['created_id'] = 'user_contact_id';
-      $result = civicrm_api3('Event', 'get', $params);
-      $createdEvents = array_keys($result['values']);
+  /**
+   * Make sure that the user has permission to access this event.
+   * TODO: This function needs refactoring / cleaning up after being split from checkPermissions()
+   *
+   * @return array
+   *   Array of events with permissions (array_keys=permissions)
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getAllPermissions() {
+    if (!isset(Civi::$statics[__CLASS__]['permissions'])) {
+      list($allEvents, $createdEvents) = self::checkPermissionGetInfo();
 
       // Note: for a multisite setup, a user with edit all events, can edit all events
       // including those from other sites
@@ -2121,10 +2214,6 @@ WHERE  ce.loc_block_id = $locBlockId";
           Civi::$statics[__CLASS__]['permissions'][CRM_Core_Permission::VIEW]
         );
       }
-    }
-
-    if ($eventId) {
-      return in_array($eventId, Civi::$statics[__CLASS__]['permissions'][$type]) ? TRUE : FALSE;
     }
 
     return Civi::$statics[__CLASS__]['permissions'];

--- a/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
+++ b/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
@@ -34,17 +34,116 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
     $this->_contactId = $this->createLoggedInUser();
+    $this->createOwnEvent();
+    $this->createOtherEvent();
+  }
+
+  public function createOwnEvent() {
     $event = $this->eventCreate(array(
       'created_id' => $this->_contactId,
     ));
-    $this->_eventId = $event['id'];
+    $this->_ownEventId = $event['id'];
+  }
+
+  public function createOtherEvent() {
+    $this->_otherContactId = $this->_contactId + 1;
+    $event = $this->eventCreate(array(
+      'created_id' => $this->_otherContactId,
+    ));
+    $this->_otherEventId = $event['id'];
+  }
+
+  private function setViewOwnEventPermissions() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'access CiviEvent', 'view event info'];
+  }
+
+  private function setViewAllEventPermissions() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'access CiviEvent', 'view event info', 'view event participants'];
+  }
+
+  private function setEditAllEventPermissions() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'access CiviEvent', 'view event info', 'edit all events'];
+  }
+
+  private function setDeleteAllEventPermissions() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'access CiviEvent', 'view event info', 'delete in CiviEvent'];
+  }
+
+  public function testViewOwnEvent() {
+    self::setViewOwnEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_ownEventId, CRM_Core_Permission::VIEW);
+    $this->assertTrue($permissions);
+    // Now check that caching is actually working
+    \Civi::$statics['CRM_Event_BAO_Event']['permission']['view'][$this->_ownEventId] = FALSE;
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_ownEventId, CRM_Core_Permission::VIEW);
+    $this->assertFalse($permissions);
   }
 
   public function testEditOwnEvent() {
-    CRM_Core_Config::singleton()->userPermissionTemp = ['access civievent', 'access CiviCRM', 'view event info'];
+    self::setViewOwnEventPermissions();
     unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
-    $permissions = CRM_Event_BAO_Event::checkPermission($this->_eventId, CRM_Core_Permission::EDIT);
+    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_ownEventId, CRM_Core_Permission::EDIT);
     $this->assertTrue($permissions);
+  }
+
+  /**
+   * This requires the same permissions as testDeleteOtherEvent()
+   */
+  public function testDeleteOwnEvent() {
+    // Check that you can't delete your own event without "Delete in CiviEvent" permission
+    self::setViewOwnEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_ownEventId, CRM_Core_Permission::DELETE);
+    $this->assertFalse($permissions);
+  }
+
+  public function testViewOtherEventDenied() {
+    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    self::setViewOwnEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_otherEventId, CRM_Core_Permission::VIEW);
+    $this->assertFalse($permissions);
+  }
+
+  public function testViewOtherEventAllowed() {
+    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    self::setViewAllEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_otherEventId, CRM_Core_Permission::VIEW);
+    $this->assertTrue($permissions);
+  }
+
+  public function testEditOtherEventDenied() {
+    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    self::setViewAllEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_otherEventId, CRM_Core_Permission::EDIT);
+    $this->assertFalse($permissions);
+  }
+
+  public function testEditOtherEventAllowed() {
+    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    self::setEditAllEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_otherEventId, CRM_Core_Permission::EDIT);
+    $this->assertTrue($permissions);
+  }
+
+  public function testDeleteOtherEventAllowed() {
+    self::setDeleteAllEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_otherEventId, CRM_Core_Permission::DELETE);
+    $this->assertTrue($permissions);
+  }
+
+  public function testDeleteOtherEventDenied() {
+    // FIXME: This test could be improved, but for now it checks that we can't delete if we don't have "Delete in CiviEvent"
+    self::setEditAllEventPermissions();
+    unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
+    $permissions = CRM_Event_BAO_Event::checkPermission($this->_otherEventId, CRM_Core_Permission::DELETE);
+    $this->assertFalse($permissions);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/12424

Calling checkPermission() with an event ID and then with no ID (to get all permissions) only returns permission for the first event, meaning all subsequent events are returned as having no permission when they probably do.

Before
----------------------------------------
If `CRM_Event_BAO_Event::checkPermission()` is called with a single event ID the static cache is "populated" but actually only has a single event ID in.  If the same function is called again with no ID the cache is returned rather than building an array of all events with permissions.

After
----------------------------------------
Refactor `CRM_Event_BAO_Event::checkPermission()` into two separate functions as they return two different things - an array of permissions in the case of all events, and TRUE/FALSE in the case of a single event ID.
A separate cache is implemented for all event permissions and for a single event permission.
So if you:
1. Call `checkPermission()` with an event ID you will get a TRUE/FALSE response and that will be cached.
2. Call `checkPermission()` with no event ID you will be "redirected" to `getAllPermissions()` which will build it's own cache and return an array of all event permissions.

Technical Details
----------------------------------------
If `CRM_Event_BAO_Event::checkPermission()` is called with a single event ID the static cache is "populated" but actually only has a single event ID in.  If the same function is called again with no ID the cache is returned rather than building an array of all events with permissions.

Comments
----------------------------------------
@alifrumin Would you be able to review this one?  It may need some further work on the existing unit tests as well if you have chance to take a look?
