### PR TITLE
NFC: Rename variable in RecurringEntityPreview

### DIFF
--- a/CRM/Core/Page/RecurringEntityPreview.php
+++ b/CRM/Core/Page/RecurringEntityPreview.php
@@ -36,7 +36,7 @@ class CRM_Core_Page_RecurringEntityPreview extends CRM_Core_Page {
    * Run the basic page (run essentially starts execution for that page).
    */
   public function run() {
-    $parentEventId = $startDate = $endDate = NULL;
+    $parentEntityId = $startDate = $endDate = NULL;
     $dates = $original = array();
     $formValues = $_REQUEST;
     if (!empty($formValues['entity_table'])) {
@@ -56,15 +56,15 @@ class CRM_Core_Page_RecurringEntityPreview extends CRM_Core_Page {
       }
 
       if (!empty($formValues['entity_id'])) {
-        $parentEventId = CRM_Core_BAO_RecurringEntity::getParentFor($formValues['entity_id'], $formValues['entity_table']);
+        $parentEntityId = CRM_Core_BAO_RecurringEntity::getParentFor($formValues['entity_id'], $formValues['entity_table']);
       }
 
       // Get original entity
       $original[$startDateColumnName] = CRM_Utils_Date::processDate($formValues['repetition_start_date']);
       $daoName = CRM_Core_BAO_RecurringEntity::$_tableDAOMapper[$formValues['entity_table']];
-      if ($parentEventId) {
-        $startDate = $original[$startDateColumnName] = CRM_Core_DAO::getFieldValue($daoName, $parentEventId, $startDateColumnName);
-        $endDate = $original[$startDateColumnName] = $endDateColumnName ? CRM_Core_DAO::getFieldValue($daoName, $parentEventId, $endDateColumnName) : NULL;
+      if ($parentEntityId) {
+        $startDate = $original[$startDateColumnName] = CRM_Core_DAO::getFieldValue($daoName, $parentEntityId, $startDateColumnName);
+        $endDate = $original[$startDateColumnName] = $endDateColumnName ? CRM_Core_DAO::getFieldValue($daoName, $parentEntityId, $endDateColumnName) : NULL;
       }
 
       //Check if there is any enddate column defined to find out the interval between the two range
@@ -88,8 +88,8 @@ class CRM_Core_Page_RecurringEntityPreview extends CRM_Core_Page {
       }
 
       //Show the list of participants registered for the events if any
-      if ($formValues['entity_table'] == "civicrm_event" && !empty($parentEventId)) {
-        $getConnectedEntities = CRM_Core_BAO_RecurringEntity::getEntitiesForParent($parentEventId, 'civicrm_event', TRUE);
+      if ($formValues['entity_table'] == "civicrm_event" && !empty($parentEntityId)) {
+        $getConnectedEntities = CRM_Core_BAO_RecurringEntity::getEntitiesForParent($parentEntityId, 'civicrm_event', TRUE);
         if ($getConnectedEntities) {
           $participantDetails = CRM_Event_Form_ManageEvent_Repeat::getParticipantCountforEvent($getConnectedEntities);
           if (!empty($participantDetails['countByName'])) {


### PR DESCRIPTION
Overview
----------------------------------------
$parentEventId can be an event ID, an activity ID, or any other entity ID that implements recurringentity.
This is a simple rename to make the code easier to understand.

Before
----------------------------------------
$parentEventId is not necessarily an event ID

After
----------------------------------------
$parentEventId renamed to $parentEntityId

Technical Details
----------------------------------------
No functional changes.

Comments
----------------------------------------
RecurringEntity has some code that is specific to events and should probably be moved to a child class, but this variable is not!
