### PR TITLE
Use cached function for financialAccount retrieval.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3208,14 +3208,14 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $partialAmtPay = CRM_Utils_Rule::cleanMoney($params['partial_amount_to_pay']);
       $partialAmtTotal = CRM_Utils_Rule::cleanMoney($params['partial_payment_total']);
 
-      $fromFinancialAccountId = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['financial_type_id'], 'Accounts Receivable Account is');
+      $fromFinancialAccountId = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($params['financial_type_id'], 'Accounts Receivable Account is');
       $statusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
       $params['total_amount'] = $partialAmtPay;
 
       $balanceTrxnInfo = CRM_Core_BAO_FinancialTrxn::getBalanceTrxnAmt($params['contribution']->id, $params['financial_type_id']);
       if (empty($balanceTrxnInfo['trxn_id'])) {
         // create new balance transaction record
-        $toFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['financial_type_id'], 'Accounts Receivable Account is');
+        $toFinancialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($params['financial_type_id'], 'Accounts Receivable Account is');
 
         $balanceTrxnParams['total_amount'] = $partialAmtTotal;
         $balanceTrxnParams['to_financial_account_id'] = $toFinancialAccount;
@@ -3356,12 +3356,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           if (!empty($params['revenue_recognition_date']) || $params['prevContribution']->revenue_recognition_date) {
             $accountRelationship = 'Deferred Revenue Account is';
           }
-          $oldFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['prevContribution']->financial_type_id, $accountRelationship);
-          $newFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['financial_type_id'], $accountRelationship);
+          $oldFinancialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($params['prevContribution']->financial_type_id, $accountRelationship);
+          $newFinancialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($params['financial_type_id'], $accountRelationship);
           if ($oldFinancialAccount != $newFinancialAccount) {
             $params['total_amount'] = 0;
             if (in_array($params['contribution']->contribution_status_id, $pendingStatus)) {
-              $params['trxnParams']['to_financial_account_id'] = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount(
+              $params['trxnParams']['to_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
                 $params['prevContribution']->financial_type_id, $accountRelationship);
             }
             else {

--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -380,6 +380,8 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
   /**
    * Get financial account for a Financial type.
    *
+   * @deprecated use the alternative with caching
+   * CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship
    *
    * @param int $entityId
    * @param string $accountRelationType

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -405,7 +405,7 @@ WHERE ceft.entity_id = %1";
     else {
       $financialTypeId = $params['financial_type_id'];
     }
-    $financialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($financialTypeId, 'Expense Account is');
+    $financialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($financialTypeId, 'Expense Account is');
 
     $params['trxnParams']['from_financial_account_id'] = $params['to_financial_account_id'];
     $params['trxnParams']['to_financial_account_id'] = $financialAccount;

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -263,7 +263,9 @@ WHERE cft.id = %1
           Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$accountRelationshipID] = $incomeAccountFinancialAccountID;
         }
       }
-
+      if (!isset(Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$relationTypeId])) {
+        Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$relationTypeId] = NULL;
+      }
     }
     return Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$relationTypeId];
   }

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -114,7 +114,7 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
       }
     }
     if ($lineItem->financial_type_id) {
-      $params['financial_account_id'] = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount(
+      $params['financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
         $lineItem->financial_type_id,
         $accountRelName
       );

--- a/tests/phpunit/CRM/Contribute/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Contribute/PseudoConstantTest.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info'AT'civicrm'DOT'org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * CRM_Contribute_PseudoConstantTest
+ * @group headless
+ */
+class CRM_Contribute_PseudoConstantTest extends CiviUnitTestCase {
+
+  /**
+   * Clean up after tests.
+   */
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  /**
+   * Test that getRelationalFinancialAccount works and returns the same as the performant alternative.
+   *
+   * Note this is to be changed to be a deprecated wrapper function.
+   *
+   * Future is CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship
+   */
+  public function testGetRelationalFinancialAccount() {
+    $financialTypes = $this->callAPISuccess('FinancialType', 'get', [])['values'];
+    $financialAccounts = $this->callAPISuccess('FinancialAccount', 'get', [])['values'];
+    foreach ($financialTypes as $financialType) {
+      $accountID = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($financialType['id'], 'Accounts Receivable Account is');
+      $this->assertEquals('Accounts Receivable', $financialAccounts[$accountID]['name']);
+      $accountIDFromBetterFunction = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+        $financialType['id'],
+        'Accounts Receivable Account is'
+      );
+      $this->assertEquals($accountIDFromBetterFunction, $accountID);
+
+      $accountID = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($financialType['id'], 'Income Account is');
+      $this->assertEquals($financialType['name'], $financialAccounts[$accountID]['name']);
+      $accountIDFromBetterFunction = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+        $financialType['id'],
+        'Income Account is'
+      );
+      $this->assertEquals($accountIDFromBetterFunction, $accountID);
+    }
+
+  }
+  
+  /**
+   * Test that getRelationalFinancialAccount works and returns the same as the performant alternative.
+   *
+   * Note this is to be changed to be a deprecated wrapper function.
+   *
+   * Future is CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship
+   */
+  public function testGetRelationalFinancialAccountForPaymentInstrument() {
+    $paymentInstruments = $this->callAPISuccess('Contribution', 'getoptions', ['field' => 'payment_instrument_id'])['values'];
+    $financialAccounts = $this->callAPISuccess('FinancialAccount', 'get', [])['values'];
+    foreach ($paymentInstruments as $paymentInstrumentID => $paymentInstrumentName) {
+      $financialAccountID = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($paymentInstrumentID);
+      if (in_array($paymentInstrumentName, ['Credit Card', 'Debit Card'])) {
+        $this->assertEquals('Payment Processor Account', $financialAccounts[$financialAccountID]['name']);
+      }
+      else {
+        $this->assertEquals('Deposit Bank Account', $financialAccounts[$financialAccountID]['name']);
+      }
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/Contribute/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Contribute/PseudoConstantTest.php
@@ -66,9 +66,8 @@ class CRM_Contribute_PseudoConstantTest extends CiviUnitTestCase {
       );
       $this->assertEquals($accountIDFromBetterFunction, $accountID);
     }
-
   }
-  
+
   /**
    * Test that getRelationalFinancialAccount works and returns the same as the performant alternative.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Performance improvement - reduce repetitive queries

Before
----------------------------------------
When inserting 100 contributions of the same financial type there are 200 queries to determine the appropriate financial accounts

After
----------------------------------------
only 2 queries

Technical Details
----------------------------------------
Since there is already an existing function that does a better job I added tests to confirm equivalence & switched over the key places, adding deprecation. The deprecated function has a couple of extra params that were not used in the places I touched but they deterred me from a larger change

Comments
----------------------------------------

