### PR TITLE
Convert "Info and Settings" tab on ManageEvent to use datepicker

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -112,12 +112,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $defaults['event_full_text'] = CRM_Utils_Array::value('event_full_text', $defaults, ts('This event is currently full.'));
 
     $defaults['waitlist_text'] = CRM_Utils_Array::value('waitlist_text', $defaults, ts('This event is currently full. However you can register now and get added to a waiting list. You will be notified if spaces become available.'));
-    list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults(CRM_Utils_Array::value('start_date', $defaults), 'activityDateTime');
-
-    if (!empty($defaults['end_date'])) {
-      list($defaults['end_date'], $defaults['end_date_time']) = CRM_Utils_Date::setDateDefaults($defaults['end_date'], 'activityDateTime');
-    }
-
     $defaults['template_id'] = $this->_templateId;
     return $defaults;
   }
@@ -179,8 +173,8 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->addElement('checkbox', 'is_share', ts('Allow sharing through social media?'));
     $this->addElement('checkbox', 'is_map', ts('Include Map to Event Location'));
 
-    $this->addDateTime('start_date', ts('Start Date'), FALSE, array('formatType' => 'activityDateTime'));
-    $this->addDateTime('end_date', ts('End Date / Time'), FALSE, array('formatType' => 'activityDateTime'));
+    $this->add('datepicker', 'start_date', ts('Start Date'), [], FALSE, ['time' => TRUE]);
+    $this->add('datepicker', 'end_date', ts('End Date / Time'), [], FALSE, ['time' => TRUE]);
 
     $this->add('text', 'max_participants', ts('Max Number of Participants'),
       array('onchange' => "if (this.value != '') {cj('#id-waitlist').show(); showHideByValue('has_waitlist','0','id-waitlist-text','table-row','radio',false); showHideByValue('has_waitlist','0','id-event_full','table-row','radio',true); return;} else {cj('#id-event_full, #id-waitlist, #id-waitlist-text').hide(); return;}")
@@ -217,13 +211,11 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $errors = array();
 
     if (!$values['is_template']) {
-      if (CRM_Utils_System::isNull($values['start_date'])) {
+      if (empty($values['start_date'])) {
         $errors['start_date'] = ts('Start Date and Time are required fields');
       }
       else {
-        $start = CRM_Utils_Date::processDate($values['start_date']);
-        $end = CRM_Utils_Date::processDate($values['end_date']);
-        if (($end < $start) && ($end != 0)) {
+        if (($values['end_date'] < $values['start_date']) && !empty($values['end_date'])) {
           $errors['end_date'] = ts('End date should be after Start date.');
         }
       }
@@ -244,11 +236,8 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $params = $this->controller->exportValues($this->_name);
 
     //format params
-    $params['start_date'] = CRM_Utils_Date::processDate($params['start_date'], $params['start_date_time']);
-    $params['end_date'] = CRM_Utils_Date::processDate(CRM_Utils_Array::value('end_date', $params),
-      CRM_Utils_Array::value('end_date_time', $params),
-      TRUE
-    );
+    $params['start_date'] = CRM_Utils_Array::value('start_date', $params);
+    $params['end_date'] = CRM_Utils_Array::value('end_date', $params);
     $params['has_waitlist'] = CRM_Utils_Array::value('has_waitlist', $params, FALSE);
     $params['is_map'] = CRM_Utils_Array::value('is_map', $params, FALSE);
     $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -173,8 +173,8 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->addElement('checkbox', 'is_share', ts('Allow sharing through social media?'));
     $this->addElement('checkbox', 'is_map', ts('Include Map to Event Location'));
 
-    $this->add('datepicker', 'start_date', ts('Start Date'), [], FALSE, ['time' => TRUE]);
-    $this->add('datepicker', 'end_date', ts('End Date / Time'), [], FALSE, ['time' => TRUE]);
+    $this->add('datepicker', 'start_date', ts('Start'), [], FALSE, ['time' => TRUE]);
+    $this->add('datepicker', 'end_date', ts('End'), [], FALSE, ['time' => TRUE]);
 
     $this->add('text', 'max_participants', ts('Max Number of Participants'),
       array('onchange' => "if (this.value != '') {cj('#id-waitlist').show(); showHideByValue('has_waitlist','0','id-waitlist-text','table-row','radio',false); showHideByValue('has_waitlist','0','id-event_full','table-row','radio',true); return;} else {cj('#id-event_full, #id-waitlist, #id-waitlist-text').hide(); return;}")

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -27,16 +27,16 @@
 
 <div class="crm-block crm-form-block crm-event-manage-eventinfo-form-block">
   {assign var=eventID value=$id}
-        <div class="crm-submit-buttons">
-        {include file="CRM/common/formButtons.tpl" location="top"}
-        </div>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="top"}
+  </div>
   <table class="form-layout-compressed">
-             {if $form.template_id}
+    {if $form.template_id}
       <tr class="crm-event-manage-eventinfo-form-block-template_id">
         <td class="label">{$form.template_id.label} {help id="id-select-template" isTemplate=$isTemplate}</td>
-            <td>{$form.template_id.html}</td>
-          </tr>
-        {/if}
+        <td>{$form.template_id.html}</td>
+      </tr>
+    {/if}
     {if $form.template_title}
       <tr class="crm-event-manage-eventinfo-form-block-template_title">
         <td class="label">{$form.template_title.label} {help id="id-template-title"}{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='template_title' id=$eventID}{/if}</td>
@@ -48,9 +48,9 @@
       <td>{$form.event_type_id.html}</td>
     </tr>
 
-          {* CRM-7362 --add campaign *}
-          {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
-          campaignTrClass="crm-event-manage-eventinfo-form-block-campaign_id"}
+    {* CRM-7362 --add campaign *}
+    {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
+    campaignTrClass="crm-event-manage-eventinfo-form-block-campaign_id"}
 
     <tr class="crm-event-manage-eventinfo-form-block-default_role_id">
       <td class="label">{$form.default_role_id.label} {help id="id-participant-role"}</td>
@@ -64,7 +64,7 @@
     <tr class="crm-event-manage-eventinfo-form-block-title">
       <td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='title' id=$eventID}{/if}</td>
       <td>{$form.title.html}<br />
-      <span class="description"> {ts}Please use only alphanumeric, spaces, hyphens and dashes for event names.{/ts}
+        <span class="description"> {ts}Please use only alphanumeric, spaces, hyphens and dashes for event names.{/ts}
       </span></td>
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-summary">
@@ -102,7 +102,7 @@
     </tr>
     <tr id="id-event_full" class="crm-event-manage-eventinfo-form-block-event_full_text">
       <td class="label">{$form.event_full_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='event_full_text' id=$eventID}{/if}
-      <br />{help id="id-event_full_text"}&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <br />{help id="id-event_full_text"}&nbsp;&nbsp;&nbsp;&nbsp;</td>
       <td>{$form.event_full_text.html}</td>
     </tr>
     <tr id="id-waitlist-text" class="crm-event-manage-eventinfo-form-block-waitlist_text">
@@ -129,17 +129,17 @@
     </tr>
 
     {if $eventID}
-    <tr>
-      <td>&nbsp;</td>
-      <td class="description">
-      {if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}
-        {ts}When this Event is active, create links to the Event Information page by copying and pasting the following URL:{/ts}<br />
-        <strong>{crmURL a=1 fe=1 p='civicrm/event/info' q="reset=1&id=`$eventID`"}</strong>
-      {elseif $config->userFramework EQ 'Joomla'}
-        {ts 1=$eventID}When this Event is active, create front-end links to the Event Information page using the Menu Manager. Select <strong>Event Info Page</strong> and enter <strong>%1</strong> for the Event ID.{/ts}
-      {/if}
-      </td>
-    </tr>
+      <tr>
+        <td>&nbsp;</td>
+        <td class="description">
+          {if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}
+            {ts}When this Event is active, create links to the Event Information page by copying and pasting the following URL:{/ts}<br />
+            <strong>{crmURL a=1 fe=1 p='civicrm/event/info' q="reset=1&id=`$eventID`"}</strong>
+          {elseif $config->userFramework EQ 'Joomla'}
+            {ts 1=$eventID}When this Event is active, create front-end links to the Event Information page using the Menu Manager. Select <strong>Event Info Page</strong> and enter <strong>%1</strong> for the Event ID.{/ts}
+          {/if}
+        </td>
+      </tr>
     {/if}
     <tr>
       <td>&nbsp;</td>
@@ -150,24 +150,24 @@
   {*include custom data js file*}
   {include file="CRM/common/customData.tpl"}
   {literal}
-    <script type="text/javascript">
-      CRM.$(function($) {
-        {/literal}
-        {if $customDataSubType}
-          CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
-        {else}
-          CRM.buildCustomData( '{$customDataType}' );
-        {/if}
-        {literal}
-      });
-    </script>
+  <script type="text/javascript">
+    CRM.$(function($) {
+      {/literal}
+      {if $customDataSubType}
+      CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
+      {else}
+      CRM.buildCustomData( '{$customDataType}' );
+      {/if}
+      {literal}
+    });
+  </script>
   {/literal}
-        <div class="crm-submit-buttons">
-           {include file="CRM/common/formButtons.tpl" location="bottom"}
-        </div>
-    {include file="CRM/common/showHide.tpl" elemType="table-row"}
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+  {include file="CRM/common/showHide.tpl" elemType="table-row"}
 
-    {include file="CRM/Form/validate.tpl"}
+  {include file="CRM/Form/validate.tpl"}
 </div>
 {literal}
 <script type="text/javascript">

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -78,11 +78,11 @@
     {if !$isTemplate}
       <tr class="crm-event-manage-eventinfo-form-block-start_date">
         <td class="label">{$form.start_date.label}</td>
-        <td>{include file="CRM/common/jcalendar.tpl" elementName=start_date}</td>
+        <td>{$form.start_date.html}</td>
       </tr>
       <tr class="crm-event-manage-eventinfo-form-block-end_date">
         <td class="label">{$form.end_date.label}</td>
-        <td>{include file="CRM/common/jcalendar.tpl" elementName=end_date}</td>
+        <td>{$form.end_date.html}</td>
       </tr>
     {/if}
     <tr class="crm-event-manage-eventinfo-form-block-max_participants">
@@ -146,22 +146,7 @@
       <td>&nbsp;</td>
     </tr>
   </table>
-  <div id="customData"></div>
-  {*include custom data js file*}
-  {include file="CRM/common/customData.tpl"}
-  {literal}
-  <script type="text/javascript">
-    CRM.$(function($) {
-      {/literal}
-      {if $customDataSubType}
-      CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
-      {else}
-      CRM.buildCustomData( '{$customDataType}' );
-      {/if}
-      {literal}
-    });
-  </script>
-  {/literal}
+  {include file="CRM/common/customDataBlock.tpl"}
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Convert "Info and Settings" tab on ManageEvent to use datepicker.

Before
----------------------------------------
Used old jcalendar widget

After
----------------------------------------
Uses datepicker widget

Technical Details
----------------------------------------
The first commit is formatting cleanup only for the template.  The second commit contains the functional changes.

Comments
----------------------------------------
