### PR TITLE
dev/core#379 Activity View: only nl2br Inbound Email.

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -156,9 +156,13 @@
       <td class="view-value">
       {$form.details.html}
       </td>
-      {else}
+    {elseif $activityTypeName eq "Inbound Email"}
       <td class="view-value">
        {$form.details.html|crmStripAlternatives|nl2br}
+      </td>
+    {else}
+      <td class="view-value">
+       {$form.details.html|crmStripAlternatives}
       </td>
     {/if}
   </tr>


### PR DESCRIPTION
Overview
----------------------------------------

When creating regular activities with multiple paragraphs, the resulting activity would be displayed with extra spaces between paragraphs (because of nl2br).

https://lab.civicrm.org/dev/core/issues/379

How to reproduce on http://dcase.demo.civicrm.org :

- Go to a contact record
- Create an activity
- In the details field, add 3 separate lines (by hitting 'enter' once, to create a new paragraph).

Before
----------------------------------------

See on the right side of the screen, activity details, where it says "line 1, line 2":

![44817615-028c1d00-abb4-11e8-9eba-07b9eb96c029](https://user-images.githubusercontent.com/254741/45102223-3f4b9d00-b0fb-11e8-923f-cdcd831074bf.png)

After
----------------------------------------

Works as expected.

Technical Details
----------------------------------------

Regression caused by: https://lab.civicrm.org/dev/core/issues/2 (February/March 2018, CiviCRM 5.0?)

The aim of that fix was to fix the display of inbound emails, but the fix was too broad.

Comments
----------------------------------------

