### PR TITLE
Allow to specify template_id on URL when creating a new event

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -117,6 +117,8 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     if (!empty($defaults['end_date'])) {
       list($defaults['end_date'], $defaults['end_date_time']) = CRM_Utils_Date::setDateDefaults($defaults['end_date'], 'activityDateTime');
     }
+
+    $defaults['template_id'] = $this->_templateId;
     return $defaults;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a one-line change to allow a template ID to be specified on the URL when creating a new event.

Before
----------------------------------------
Can't specify template via URL parameter.

After
----------------------------------------
Can specify template via URL parameter.
Example: http://localhost:8000/civicrm/event/add?reset=1&action=add&template_id=99

Technical Details
----------------------------------------


