### PR TITLE
Do not treat an empty array as not set in caches.

### DIFF
--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -75,7 +75,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
       $cache = CRM_Utils_Cache::singleton();
       $cleanKey = self::cleanKey($argString);
       self::$_cache[$argString] = $cache->get($cleanKey);
-      if (!self::$_cache[$argString]) {
+      if (self::$_cache[$argString] === NULL) {
         $table = self::getTableName();
         $where = self::whereCache($group, $path, $componentID);
         $rawData = CRM_Core_DAO::singleValueQuery("SELECT data FROM $table WHERE $where");

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -82,7 +82,10 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
         $data = $rawData ? self::decode($rawData) : NULL;
 
         self::$_cache[$argString] = $data;
-        $cache->set($cleanKey, self::$_cache[$argString]);
+        if ($data !== NULL) {
+          // Do not cache 'null' as that is most likely a cache miss & we shouldn't then cache it.
+          $cache->set($cleanKey, self::$_cache[$argString]);
+        }
       }
     }
     return self::$_cache[$argString];

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -129,9 +129,9 @@ class CRM_Core_OptionGroup {
         return self::$_cache[$cacheKey];
       }
       // Fetch from main cache
-      $var = $cache->get($cacheKey);
-      if ($var) {
-        return $var;
+      self::$_cache[$cacheKey] = $cache->get($cacheKey);
+      if (self::$_cache[$cacheKey] !== NULL) {
+        return self::$_cache[$cacheKey];
       }
     }
 

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -234,9 +234,9 @@ WHERE  v.option_group_id = g.id
 
     $cache = CRM_Utils_Cache::singleton();
     if (!$fresh) {
-      $var = $cache->get($cacheKey);
-      if ($var) {
-        return $var;
+      self::$_cache[$cacheKey] = $cache->get($cacheKey);
+      if (self::$_cache[$cacheKey] !== NULL) {
+        return self::$_cache[$cacheKey];
       }
     }
     $query = "

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -539,7 +539,7 @@ class CRM_Core_PseudoConstant {
     $cacheKey = CRM_Core_BAO_Cache::cleanKey("CRM_PC_{$name}_{$all}_{$key}_{$retrieve}_{$filter}_{$condition}_{$orderby}");
     $cache = CRM_Utils_Cache::singleton();
     $var = $cache->get($cacheKey);
-    if ($var && empty($force)) {
+    if ($var !== NULL && empty($force)) {
       return $var;
     }
 

--- a/CRM/Member/PseudoConstant.php
+++ b/CRM/Member/PseudoConstant.php
@@ -65,7 +65,7 @@ class CRM_Member_PseudoConstant extends CRM_Core_PseudoConstant {
     if (!self::$membershipType || $force) {
       CRM_Core_PseudoConstant::populate(self::$membershipType,
         'CRM_Member_DAO_MembershipType',
-        FALSE, 'name', 'is_active', NULL, 'weight', 'id', TRUE
+        FALSE, 'name', 'is_active', NULL, 'weight', 'id'
       );
     }
     if ($id) {


### PR DESCRIPTION
Overview
----------------------------------------
Reduce cache miss calls by respecting empty arrays as a cache hit

Before
----------------------------------------
Cache calls which return empty arrays are treated as misses

After
----------------------------------------
Cache calls which return empty arrays are treated as hits

Technical Details
----------------------------------------
On testing Redis we found that even after Redis cache had been
built the set function was still being called. It turned out the reason is that
when a value was set to an empty array that was being treated as FALSEY.

In fact the cache function returns NULL if nothing is set & no default is
specified & we should only treat NULL as a cache miss

Comments
----------------------------------------
As an aside Our testing is showing a speed decrease when we switch from Array Caching to Redis caching. My thinking is that array caching is in fact more efficient & ideally it would be array caching & fall back on Redis caching - so if not loaded this session that is where it loads from. That is how the BAO_Cache::getItem function works but the Civi::cache()->get does not.
