### PR TITLE
dev/core#382 Ensure that no db errors are generated when trying to up…

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -448,8 +448,11 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     }
 
     if (!empty($params['organization_id'])) {
-      $groupOrg = $params;
-      $groupOrg['group_id'] = $group->id;
+      // dev/core#382 Keeping the id here can cause db errors as it tries to update the wrong record in the Organization table
+      $groupOrg = [
+        'group_id' => $group->id,
+        'organization_id' => $params['organization_id'],
+      ];
       CRM_Contact_BAO_GroupOrganization::add($groupOrg);
     }
 

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -199,4 +199,42 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Ensure that when updating a group with a linked organisation record even tho that record's id doesn't match the group id no db error is produced
+   */
+  public function testGroupUpdateWithOrganization() {
+    $params = array(
+      'name' => uniqid(),
+      'title' => 'Group A',
+      'description' => 'Group One',
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+    );
+    $group1 = CRM_Contact_BAO_Group::create($params);
+
+    $domain1 = $this->callAPISuccess('Domain', 'get', ['id' => 1]);
+    $params2 = array(
+      'name' => uniqid(),
+      'title' => 'Group B',
+      'description' => 'Group Two',
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+      'organization_id' => $domain1['values'][1]['contact_id'],
+    );
+    $group2 = CRM_Contact_BAO_Group::create($params2);
+
+    $domain2 = $this->callAPISuccess('Domain', 'get', ['id' => 2]);
+    $params3 = array(
+      'name' => uniqid(),
+      'title' => 'Group C',
+      'description' => 'Group Three',
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+      'organization_id' => $domain2['values'][2]['contact_id'],
+    );
+    $group3 = CRM_Contact_BAO_Group::create($params3);
+    $params2['id'] = $group2->id;
+    $testUpdate = CRM_Contact_BAO_Group::create($params2);
+  }
+
 }


### PR DESCRIPTION
…date a civicrm group linked to an organization when the group id doesn't match the id of the relevant row in civicrm_group_organization

Overview
----------------------------------------
When updating a group linked to an organization. If the record id in the civicrm_group_organization table doesn't match that of the groupID there can be a db error generated because of the unique key on the civicrm_group_organization table

Before
----------------------------------------
DB error generated

After
----------------------------------------
No DB error

ping @mattwire @eileenmcnaughton @nganivet @monishdeb This is especially an issue in Multisite configurations