### PR TITLE
CRM_Utils_StringTest - Fix false-negative on systems with non-standard HTTP port

### DIFF
--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -251,8 +251,11 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
    */
   public function simplifyURLProvider() {
     $config = CRM_Core_Config::singleton();
-    $urlParts = parse_url($config->userFrameworkBaseURL);
-    $localDomain = $urlParts['host'];
+    $urlParts = CRM_Utils_String::simpleParseUrl($config->userFrameworkBaseURL);
+    $localDomain = $urlParts['host+port'];
+    if (empty($localDomain)) {
+      throw new \Exception("Failed to determine local base URL");
+    }
     $externalDomain = 'example.org';
 
     // Ensure that $externalDomain really is different from $localDomain
@@ -323,6 +326,13 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
         "https://example.com:8000/foo/bar/?id=1#fragment",
         array(
           'host+port' => "example.com:8000",
+          'path+query' => "/foo/bar/?id=1",
+        ),
+      ),
+      "default port example" => array(
+        "https://example.com/foo/bar/?id=1#fragment",
+        array(
+          'host+port' => "example.com",
           'path+query' => "/foo/bar/?id=1",
         ),
       ),


### PR DESCRIPTION
Before
------

On a local build with the base URL `http://dmaster.bknix:8001`, the test
`testSimplifyURL()` fails because the actual URL includes `:8001`.  The
actual URL is correct, but the test expectation is wrong.

After
-----

The test passes. The runtime behavior is unchanged.

Comments
--------

* In the continuous-integration server, we've traditionally tested with
  the default/blank port (`http://core-1234-1234.test-ubu1204-5.civicrm.org`), so
  this didn't come up.
* The formatt returned by `simpleParseUrl()`  in `host+port` is clever about colons.
  It has unit-test coverage to show this.
