### PR TITLE
Fix edit form of custom field not linked to og

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -322,7 +322,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       'return' => ['title'],
     ];
 
-    if ($this->_action == CRM_Core_Action::UPDATE) {
+    if ($this->_action == CRM_Core_Action::UPDATE && !empty($this->_values['option_group_id'])) {
       $this->freeze('data_type');
       // Before dev/core#155 we didn't set the is_reserved flag properly, which should be handled by the upgrade script...
       //  but it is still possible that existing installs may have optiongroups linked to custom fields that are marked reserved.


### PR DESCRIPTION
Overview
----------------------------------------
Fix edit form of custom field not linked to og

Before
----------------------------------------
Error on custom field edit form not linked to an option group

![image](https://user-images.githubusercontent.com/5929648/45137421-31af1980-b1c6-11e8-93c1-ef749be43564.png)


After
----------------------------------------
Fixed.

Comments
----------------------------------------
seems related to the work done on https://github.com/civicrm/civicrm-core/pull/12729 and https://github.com/civicrm/civicrm-core/pull/12718

------------------------------

Gitlab - https://lab.civicrm.org/dev/core/issues/383