### PR TITLE
dev/core#383 Fix edit form of custom field not linked to optiongroup

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -324,10 +324,12 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
 
     if ($this->_action == CRM_Core_Action::UPDATE) {
       $this->freeze('data_type');
-      // Before dev/core#155 we didn't set the is_reserved flag properly, which should be handled by the upgrade script...
-      //  but it is still possible that existing installs may have optiongroups linked to custom fields that are marked reserved.
-      $optionGroupParams['id'] = $this->_values['option_group_id'];
-      $optionGroupParams['options']['or'] = [["is_reserved", "id"]];
+      if (!empty($this->_values['option_group_id'])) {
+        // Before dev/core#155 we didn't set the is_reserved flag properly, which should be handled by the upgrade script...
+        //  but it is still possible that existing installs may have optiongroups linked to custom fields that are marked reserved.
+        $optionGroupParams['id'] = $this->_values['option_group_id'];
+        $optionGroupParams['options']['or'] = [["is_reserved", "id"]];
+      }
     }
 
     // Retrieve optiongroups for selection list


### PR DESCRIPTION
Overview
----------------------------------------
Fix edit form of custom field not linked to option group

Alternative for #12787. Additionally against 5.5RC as this is a recent regression

Before
----------------------------------------
Error on custom field edit form not linked to an option group

After
----------------------------------------
Fixed.

ping @totten @jitendrapurohit 