### PR TITLE
dev/core#362 fix search functionality of contact reference fields in On Behalf Profiles

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1062,8 +1062,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $element = $qf->add('text', $elementName, $label, $attributes, $useRequired && !$search);
 
           $urlParams = "context=customfield&id={$field->id}";
-
-          $customUrls[$elementName] = CRM_Utils_System::url('civicrm/ajax/contactref',
+          $idOfelement = $elementName;
+          // dev/core#362 if in an onbehalf profile clean up the name to get rid of square brackets that break the select 2 js
+          if (strpos($elementName, '[') && strpos($elementName, ']')) {
+            $idOfelement = substr(substr($elementName, (strpos($elementName, '[') + 1)), 0, -1);
+          }
+          $customUrls[$idOfelement] = CRM_Utils_System::url('civicrm/ajax/contactref',
             $urlParams,
             FALSE, NULL, FALSE
           );

--- a/templates/CRM/Custom/Form/ContactReference.tpl
+++ b/templates/CRM/Custom/Form/ContactReference.tpl
@@ -28,7 +28,8 @@
 {literal}
 <script type="text/javascript">
   CRM.$(function($) {
-    var $field = $("{/literal}#{$element_name|replace:']':''|replace:'[':'_'}{literal}");
+    // dev/core#362 if in an onbehalf profile reformat the id
+    var $field = $("{/literal}#{if $prefix}{$prefix}_{/if}{$element_name|replace:']':''|replace:'[':'_'}{literal}");
 
     $field.crmSelect2({
       placeholder: {/literal}'{ts escape="js"}- select contact -{/ts}'{literal},


### PR DESCRIPTION
Overview
----------------------------------------
This pr addresses a bug where for contact reference fields in on behalf profiles, the search and select functionality was breaking because of some confusion around naming (onbehalf_custom_12 vs custom_12). More notes: https://lab.civicrm.org/dev/core/issues/362

Before
----------------------------------------
When a Contact Reference field is added to an On Behalf of profile on a Donation/Membership page it is displayed but the search and select function never populates on the page. No error is generated.

After
----------------------------------------
Contact Reference fields in On behalf profiles work as expected.


