### PR TITLE
distmaker - Add APIv4 to standard tarball

### DIFF
--- a/distmaker/dists/backdrop_php5.sh
+++ b/distmaker/dists/backdrop_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/backdrop" "$TRG/backdrop"
+dm_install_cvext org.civicrm.api4 "$TRG/ext/api4"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
+dm_install_cvext org.civicrm.api4 "$TRG/ext/api4"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball

--- a/distmaker/dists/drupal7_dir_php5.sh
+++ b/distmaker/dists/drupal7_dir_php5.sh
@@ -30,6 +30,7 @@ dm_install_packages $DM_PACKAGESDIR "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$DM_DRUPALDIR" "$TRG/drupal"
+dm_install_cvext org.civicrm.api4 "$TRG/ext/api4"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
+dm_install_cvext org.civicrm.api4 "$TRG/ext/api4"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
+dm_install_cvext org.civicrm.api4 "$TRG/ext/api4"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # delete packages that distributions on Drupal.org repalce if present

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -22,6 +22,7 @@ dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
+dm_install_cvext org.civicrm.api4 "$TRG/ext/api4"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 ## WTF: It's so good we'll install it twice!

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/civicrm/civicrm/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/civicrm/civicrm/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/civicrm/civicrm/bower_components"
 dm_install_wordpress "$SRC/WordPress" "$TRG/civicrm"
+dm_install_cvext org.civicrm.api4 "$TRG/civicrm/civicrm/ext/api4"
 dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/civicrm/ext/iatspayments"
 
 # gen tarball


### PR DESCRIPTION
Overview
----------------------------------------
This patch adds the latest release of `org.civicrm.api4` to the standard tarball, per @colemanw's request and previous discussions.

Before
----------------------------------------
The tarballs do not include `org.civicrm.api4`.

After
----------------------------------------
The tarballs do include `org.civicrm.api4`. However, the extension is not activated.

Comments
----------------------------------------
This shouldn't have any particular runtime impact on existing systems/codeflows -- but it removes some download/upgrade steps when someone installs an extension that uses APIv4. (**Update**)  ... Except for people who previously installed APIv4 as a pre-release/alpha/beta. Their systems should continue to work, but it'd be prudent to delete the old copy and flush the caches so that the system can be maintained more intuitively. (Unless they're actually doing development of APIv4.)

For testing, I ran `distmaker` and `civihydra` locally. The extension appeared correctly on Backdorp, Drupal 7, and WordPress.