### PR TITLE
dev/core/287 Disable child groups if all parents are disabled

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -203,6 +203,7 @@ class CRM_Admin_Page_AJAX {
 
         case 'CRM_Contact_BAO_Group':
           $ret['content'] = ts('Are you sure you want to disable this Group?');
+          $ret['content'] .= '<br /><br /><strong>' . ts('WARNING - Disabling this group will disable all the child groups associated if any.') . '</strong>';
           break;
 
         case 'CRM_Core_BAO_OptionGroup':

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -350,7 +350,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       CRM_Utils_Hook::pre('create', 'Group', NULL, $params);
     }
 
-    //  CRM-287 Disable child groups if all parents are disabled.
+    // dev/core#287 Disable child groups if all parents are disabled.
     if(!empty($params['id'])) {
       $allChildGroupIds = self::getChildGroupIds($params['id']);
       foreach ($allChildGroupIds as $childKey => $childValue) {
@@ -359,10 +359,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
           'id' => ['IN' => $parentIds],
           'is_active' => 1,
         ]);
-        if (count($parentIds) == 1) {
-          $setDisable = self::setIsActive($childValue, $params['is_active']);
-        }
-        if (count($parentIds) > 1 && $activeParentsCount <= 1) {
+        if (count($parentIds) == 1 || count($parentIds) > 1 && $activeParentsCount <= 1) {
           $setDisable = self::setIsActive($childValue, $params['is_active']);
         }
       }

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -351,7 +351,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     }
 
     // dev/core#287 Disable child groups if all parents are disabled.
-    if(!empty($params['id'])) {
+    if (!empty($params['id'])) {
       $allChildGroupIds = self::getChildGroupIds($params['id']);
       foreach ($allChildGroupIds as $childKey => $childValue) {
         $parentIds = CRM_Contact_BAO_GroupNesting::getParentGroupIds($childValue);
@@ -359,7 +359,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
           'id' => ['IN' => $parentIds],
           'is_active' => 1,
         ]);
-        if (count($parentIds) == 1 || count($parentIds) > 1 && $activeParentsCount <= 1) {
+        if (count($parentIds) >= 1 && $activeParentsCount <= 1) {
           $setDisable = self::setIsActive($childValue, $params['is_active']);
         }
       }

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -350,6 +350,23 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       CRM_Utils_Hook::pre('create', 'Group', NULL, $params);
     }
 
+    //  CRM-287 Disable child groups if all parents are disabled.
+    if(!empty($params['id'])) {
+      $allChildGroupIds = self::getChildGroupIds($params['id']);
+      foreach ($allChildGroupIds as $childKey => $childValue) {
+        $parentIds = CRM_Contact_BAO_GroupNesting::getParentGroupIds($childValue);
+        $activeParentsCount = civicrm_api3('Group', 'getcount', [
+          'id' => ['IN' => $parentIds],
+          'is_active' => 1,
+        ]);
+        if (count($parentIds) == 1) {
+          $setDisable = self::setIsActive($childValue, $params['is_active']);
+        }
+        if (count($parentIds) > 1 && $activeParentsCount <= 1) {
+          $setDisable = self::setIsActive($childValue, $params['is_active']);
+        }
+      }
+    }
     // form the name only if missing: CRM-627
     $nameParam = CRM_Utils_Array::value('name', $params, NULL);
     if (!$nameParam && empty($params['id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Child groups with all parents disabled shows in group list

Before
----------------------------------------
**How it works currently:** If a child group has multiple parent groups and one of them is disabled, the child group should to show up on group selector lists. This has been fixed here https://issues.civicrm.org/jira/browse/CRM-20934.

If all parent group(s) are disabled the child group still shows up in search mode.

You can see the child group with title as Child group Child of: With null value for parent.
image
![image](https://user-images.githubusercontent.com/30790755/45221788-2b0cc900-b2d0-11e8-99a4-6b99c4fdf9ef.png)

After
----------------------------------------
If a child group has multiple or single parent group and all of them are disabled, then the child group be
disabled and removed from the selector lists.

Technical Details
----------------------------------------
Added warning before disabling any group. Checked for groups with both single and multiple parent groups.

https://lab.civicrm.org/dev/core/issues/287