### PR TITLE
Fix capitalisation for 'Republic of' countries (Iran, Macedonia)

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.6.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.6.alpha1.mysql.tpl
@@ -2,3 +2,9 @@
 
 ALTER TABLE civicrm_prevnext_cache
   CHANGE `entity_id2` `entity_id2` int unsigned NULL   COMMENT 'FK to entity table specified in entity_table column.';
+
+UPDATE civicrm_country
+SET name = 'Iran, Islamic Republic of' where name = 'Iran, Islamic Republic Of';
+
+UPDATE civicrm_country
+SET name = 'Macedonia, Republic of' where name = 'Macedonia, Republic Of';

--- a/xml/templates/civicrm_country.tpl
+++ b/xml/templates/civicrm_country.tpl
@@ -144,7 +144,7 @@ INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1100", "Iceland", "IS", "1", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1101", "India", "IN", "4", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1102", "Indonesia", "ID", "4", "0");
-INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1103", "Iran, Islamic Republic Of", "IR", "3", "0");
+INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1103", "Iran, Islamic Republic of", "IR", "3", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1104", "Iraq", "IQ", "3", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1105", "Ireland", "IE", "1", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1106", "Israel", "IL", "3", "0");
@@ -169,7 +169,7 @@ INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1125", "Lithuania", "LT", "1", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1126", "Luxembourg", "LU", "1", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1127", "Macao", "MO", "4", "0");
-INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1128", "Macedonia, Republic Of", "MK", "1", "0");
+INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1128", "Macedonia, Republic of", "MK", "1", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1129", "Madagascar", "MG", "5", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1130", "Malawi", "MW", "5", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1131", "Malaysia", "MY", "4", "0");


### PR DESCRIPTION
Overview
----------------------------------------

Some time ago, in early 4.7, country names were converted to uppercase. This change was later reverted. However, some names were incorrectly normalized, such as:

* Iran, Republic of (was 'Republic Of')
* Macedonia, Republic of (same).

This commit reverts that change.

Caught this while updating Transifex strings. I want to avoid sending incorrect strings to translators.

Comments
----------------------------------------

Includes changes for the initial install, as well as for sites to upgrade (country names are saved in the database, and then later send through gettext at runtime).