### PR TITLE
Handle smart groups created in previous Civis which include relation_permission

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4231,6 +4231,10 @@ civicrm_relationship.start_date > {$today}
   public function addRelationshipPermissionClauses($grouping, &$where) {
     $relPermission = $this->getWhereValues('relation_permission', $grouping);
     if ($relPermission) {
+      if (!is_array($relPermission[2])) {
+        // this form value was scalar in previous versions of Civi
+        $relPermission[2] = array($relPermission[2]);
+      }
       $where[$grouping][] = "(civicrm_relationship.is_permission_a_b IN (" . implode(",", $relPermission[2]) . "))";
 
       $allRelationshipPermissions = CRM_Contact_BAO_Relationship::buildOptions('is_permission_a_b');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/issues/390: Smart groups created before 5.5.0 using "relation_permission" break on upgrade to 5.5.0

Before
----------------------------------------
* In Civi 5.4, create a smart group based on a relationship search.
* Upgrade to 5.5, clear cache and try to open the group.
* Error: DB Error: syntax error

After
----------------------------------------
* In Civi 5.4, create a smart group based on a relationship search.
* Upgrade to 5.5, clear cache and try to open the group.
* Group opens as expected.

Technical Details
----------------------------------------
When you create a Smart Group for a relationship search, the form values which are saved include `relation_permission`. Prior to 5.5.0, the operator was "=" and the value was scalar. As of 5.5.0, the operator is "IN" and the value is an array.