### PR TITLE
Minor Contact BAO code cleanup

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4234,14 +4234,8 @@ civicrm_relationship.start_date > {$today}
       $where[$grouping][] = "(civicrm_relationship.is_permission_a_b IN (" . implode(",", $relPermission[2]) . "))";
 
       $allRelationshipPermissions = CRM_Contact_BAO_Relationship::buildOptions('is_permission_a_b');
-      $relQill = '';
-      foreach ($relPermission[2] as $rel) {
-        if (!empty($relQill)) {
-          $relQill .= ' OR ';
-        }
-        $relQill .= ts($allRelationshipPermissions[$rel]);
-      }
-      $this->_qill[$grouping][] = ts('Permissioned Relationships') . ' - ' . $relQill;
+      $relPermNames = array_intersect_key($allRelationshipPermissions, array_flip($relPermission[2]));
+      $this->_qill[$grouping][] = ts('Permissioned Relationships') . ' - ' . join(' OR ', $relPermNames);
     }
   }
 

--- a/CRM/Upgrade/Incremental/sql/5.5.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.5.0.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.5.0 during upgrade *}

--- a/release-notes/5.5.0.md
+++ b/release-notes/5.5.0.md
@@ -1,6 +1,6 @@
 # CiviCRM 5.5.0
 
-Released September 5, 2018
+Released September 11, 2018
 
 - **[Synopsis](#synopsis)**
 - **[Features](#features)**
@@ -773,6 +773,9 @@ of Contribution Detail report
 
 - **Fix potential undefined array index
   ([12443](https://github.com/civicrm/civicrm-core/pull/12443))**
+
+- **CRM_Utils_StringTest - Fix false-negative on systems with non-standard HTTP port
+  ([12786](https://github.com/civicrm/civicrm-core/pull/12786))**
 
 ## <a name="credits"></a>Credits
 

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.5.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.5.0',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.5.beta1</version_no>
+  <version_no>5.5.0</version_no>
 </version>


### PR DESCRIPTION
In CRM/Contact/BAO/Query.php: addRelationshipPermissionClauses(), use native PHP functions and clearer variable name to reduce 8 lines of code to 2 and make the code more readable