### PR TITLE
Minor Contact BAO code cleanup

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4234,14 +4234,8 @@ civicrm_relationship.start_date > {$today}
       $where[$grouping][] = "(civicrm_relationship.is_permission_a_b IN (" . implode(",", $relPermission[2]) . "))";
 
       $allRelationshipPermissions = CRM_Contact_BAO_Relationship::buildOptions('is_permission_a_b');
-      $relQill = '';
-      foreach ($relPermission[2] as $rel) {
-        if (!empty($relQill)) {
-          $relQill .= ' OR ';
-        }
-        $relQill .= ts($allRelationshipPermissions[$rel]);
-      }
-      $this->_qill[$grouping][] = ts('Permissioned Relationships') . ' - ' . $relQill;
+      $relPermNames = array_intersect_key($allRelationshipPermissions, array_flip($relPermission[2]));
+      $this->_qill[$grouping][] = ts('Permissioned Relationships') . ' - ' . join(' OR ', $relPermNames);
     }
   }
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4235,7 +4235,7 @@ civicrm_relationship.start_date > {$today}
 
       $allRelationshipPermissions = CRM_Contact_BAO_Relationship::buildOptions('is_permission_a_b');
       $relPermNames = array_intersect_key($allRelationshipPermissions, array_flip($relPermission[2]));
-      $this->_qill[$grouping][] = ts('Permissioned Relationships') . ' - ' . join(' OR ', $relPermNames);
+      $this->_qill[$grouping][] = ts('Permissioned Relationships') . ' - ' . implode(' OR ', $relPermNames);
     }
   }
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4228,6 +4228,12 @@ civicrm_relationship.start_date > {$today}
     }
   }
 
+  /**
+   * Add relationship permission criteria to where clause.
+   * @param string $grouping
+   * @param array $where Array to add "where" criteria to, in case you are 
+   * generating a temp table. Not the main query.
+   */
   public function addRelationshipPermissionClauses($grouping, &$where) {
     $relPermission = $this->getWhereValues('relation_permission', $grouping);
     if ($relPermission) {


### PR DESCRIPTION
In CRM/Contact/BAO/Query.php: addRelationshipPermissionClauses(), use native PHP functions and clearer variable name to reduce 8 lines of code to 2 and make the code more readable