### PR TITLE
closes reporting#6 - can't sort by Street Name

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5514,12 +5514,6 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'is_filters' => TRUE,
         'is_fields' => TRUE,
       ),
-      $options['prefix'] . 'street_name' => array(
-        'name' => 'street_name',
-        'title' => ts($options['prefix_label'] . 'Street Name'),
-        'type' => 1,
-        'is_fields' => TRUE,
-      ),
       $options['prefix'] . 'street_unit' => array(
         'name' => 'street_unit',
         'title' => ts($options['prefix_label'] . 'Street Unit'),


### PR DESCRIPTION
Overview
----------------------------------------
You can't sort by street name on reports that use the common function to get address fields.

Before
----------------------------------------
See screenshots from Constituent Summary Report:
![selection_598](https://user-images.githubusercontent.com/1796012/45401066-f45ee780-b61c-11e8-840d-e189ebece808.png)


After
----------------------------------------
![selection_599](https://user-images.githubusercontent.com/1796012/45401076-f9239b80-b61c-11e8-8c8a-b2bd7f8859b9.png)


Technical Details
----------------------------------------
The `street_name` is defined twice in this array - once correctly, once incorrectly.  I'm removing the second instance.  The first instance is at line 5487.