### PR TITLE
Remove backslashes from a json parameter for REST API

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -334,7 +334,7 @@ class CRM_Utils_REST {
     );
 
     if (array_key_exists('json', $requestParams) && $requestParams['json'][0] == "{") {
-      $params = json_decode($requestParams['json'], TRUE);
+      $params = json_decode(stripslashes($requestParams['json']), TRUE);
       if ($params === NULL) {
         CRM_Utils_JSON::output(array('is_error' => 1, 'error_message', 'Unable to decode supplied JSON.'));
       }


### PR DESCRIPTION
Overview
----------------------------------------
_Json_ parameter doesn't work for API using WordPress and CiviCRM.

Before
----------------------------------------
How it works currently: If a user send any API request with json parameter the CiviCRM returns error. I've found this issue using _WordPress_ docker container https://hub.docker.com/_/wordpress/
The problem is not in _WordPress_, the problem is that _json_ string can be with slashes if the server has _magic_quotes_gpc_ enabled.

You may try to send a request:
http://localhost/wp-content/plugins/civicrm/civicrm/extern/rest.php?entity=Activity&action=get&api_key=userkey&key=sitekey&json={"sequential":1}


The result is:
```

{
    "0": "error_message",
    "1": "Unable to decode supplied JSON.",
    "is_error": 1
}
```

Screenshot:
<img width="1299" alt="before" src="https://user-images.githubusercontent.com/36959503/45436017-7bae6880-b6ba-11e8-8098-ad8281ea5cf5.png">


After
----------------------------------------
I've removed slashes from json parameters. Now the API and json parameter works correctly.
<img width="1263" alt="after" src="https://user-images.githubusercontent.com/36959503/45436054-8a951b00-b6ba-11e8-86a0-1cce2616f3fc.png">


Technical Details
----------------------------------------
I've added [stripslashes()](http://php.net/manual/en/function.stripslashes.php) before _json_decode_.