### PR TITLE
Alter Test to ensure that order of city is output doesn't mater in th…

### DIFF
--- a/tests/phpunit/CRM/Report/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Report/Form/ActivityTest.php
@@ -154,7 +154,7 @@ class CRM_Report_Form_ActivityTest extends CiviReportTestCase {
     // ensure that country values of respective target contacts are only shown
     $this->assertTrue(in_array($rows[0]['civicrm_address_country_id'], ['India;United States', 'United States;India']));
     // ensure that city values of respective target contacts are only shown
-    $this->assertEquals('ABC;DEF', $rows[0]['civicrm_address_city']);
+    $this->assertTrue(in_array($rows[0]['civicrm_address_city'], ['ABC;DEF', 'DEF;ABC']));
   }
 
 }


### PR DESCRIPTION
…e same format as country

Overview
----------------------------------------
We have seen lately that this test fails every now and then because the order of the items returned changes this alters the test to not care about the order, only that only those 2 items are returned https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=min,CIVIVER=5.6,label=test-bknix/lastCompletedBuild/testReport/(root)/CRM_Report_Form_ActivityTest/testTargetAddressFields/

Before
----------------------------------------
Test unstable

After
----------------------------------------
Test stable