### PR TITLE
dev/core#393 Allow 0 as a valid option value when option group data_type is Integer

### DIFF
--- a/CRM/Utils/Check/Component/OptionGroups.php
+++ b/CRM/Utils/Check/Component/OptionGroups.php
@@ -49,7 +49,7 @@ class CRM_Utils_Check_Component_OptionGroups extends CRM_Utils_Check_Component {
         if (count($values) > 0) {
           foreach ($values as $value) {
             $validate = CRM_Utils_Type::validate($value['value'], $optionGroup['data_type'], FALSE);
-            if (!$validate) {
+            if (is_null($validate)) {
               $problemValues[] = array(
                 'group_name' => $optionGroup['title'],
                 'value_name' => $value['label'],

--- a/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
@@ -24,8 +24,9 @@ class CRM_Utils_Check_Component_OptionGroupsTest extends CiviUnitTestCase {
       'label' => 'zero',
       'value' => 0,
     ]);
-    $check = new \CRM_Utils_Check_Component_OptionGroups;
+    $check = new \CRM_Utils_Check_Component_OptionGroups();
     $result = $check->checkOptionGroupValues();
     $this->assertArrayNotHasKey(0, $result);
   }
+
 }

--- a/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Class CRM_Utils_TypeTest
+ * @package CiviCRM
+ * @subpackage CRM_Utils_Type
+ * @group headless
+ */
+class CRM_Utils_Check_Component_OptionGroupsTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function testCheckOptionGroupValues() {
+    $optionGroup = $this->callAPISuccess('OptionGroup', 'create', [
+      'name' => 'testGroup',
+      'title' => 'testGroup',
+      'data_type' => 'Integer',
+    ]);
+    // test that zero is a valid integer.
+    $this->callAPISuccess('OptionValue', 'create', [
+      'option_group_id' => $optionGroup['id'],
+      'label' => 'zero',
+      'value' => 0,
+    ]);
+    $check = new \CRM_Utils_Check_Component_OptionGroups;
+    $result = $check->checkOptionGroupValues();
+    $this->assertArrayNotHasKey(0, $result);
+  }
+}


### PR DESCRIPTION
…ata_type is Integer

Overview
----------------------------------------
The check for invalid option values gives a false positive when the option group's `data_type` is `Integer` and the value is `0`.  This is particularly noticeable when you have the "Related Permissions" extension version 1.5 installed.

Before
----------------------------------------
A notice appears in the System Status screen.

After
----------------------------------------
No notice appears.

Technical Details
----------------------------------------
This is a truthiness issue.

Comments
----------------------------------------
Steps to replicate manually are on [the Gitlab issue](https://lab.civicrm.org/dev/core/issues/393) but a phpunit test is included which you can run with/without the functional change.
