### PR TITLE
Allow contribution search by recurring payment processor ID / Transaction ID

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -783,6 +783,15 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     $form->addElement('text', 'contribution_recur_processor_id', ts('Processor ID'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_ContributionRecur', 'processor_id'));
     $form->addElement('text', 'contribution_recur_trxn_id', ts('Transaction ID'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_ContributionRecur', 'trxn_id'));
 
+    $paymentProcessorParams = [
+      'return' => ["id", "name", 'is_test'],
+    ];
+    $paymentProcessors = civicrm_api3('PaymentProcessor', 'get', $paymentProcessorParams);
+    foreach ($paymentProcessors['values'] as $key => $value) {
+      $paymentProcessorOpts[$key] = $value['name'] . ($value['is_test'] ? ' (Test)' : '');
+    }
+    $form->add('select', 'contribution_recur_payment_processor_id', ts('Payment Processor ID'), $paymentProcessorOpts, FALSE, ['class' => 'crm-select2', 'multiple' => 'multiple']);
+
     CRM_Core_BAO_Query::addCustomFormFields($form, array('ContributionRecur'));
 
   }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -762,6 +762,14 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       }
     }
 
+    // If values have been supplied for recurring contribution fields, open the recurring contributions pane.
+    foreach (array('contribution_status_id', 'payment_processor_id', 'processor_id', 'trxn_id') as $fieldName) {
+      if (!empty($form->_formValues['contribution_recur_' . $fieldName])) {
+        $form->assign('contribution_recur_pane_open', TRUE);
+        break;
+      }
+    }
+
     // Add field to check if payment is made for recurring contribution
     $recurringPaymentOptions = array(
       1 => ts('All recurring contributions'),

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -376,6 +376,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         return;
 
       case 'contribution_recur_processor_id':
+      case 'contribution_recur_payment_processor_id':
       case 'contribution_recur_trxn_id':
         $fieldName = str_replace('contribution_recur_', '', $name);
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_recur.{$fieldName}",

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -375,13 +375,25 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
         return;
 
-      case 'contribution_recur_processor_id':
       case 'contribution_recur_payment_processor_id':
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_recur.payment_processor_id", $op, $value, "String");
+        $paymentProcessors = civicrm_api3('PaymentProcessor', 'get', array());
+        $paymentProcessorNames = array();
+        foreach ($value as $paymentProcessorId) {
+          $paymentProcessorNames[] = $paymentProcessors['values'][$paymentProcessorId]['name'];
+        }
+        $query->_qill[$grouping][] = ts("Recurring Contribution Payment Processor %1 %2", array(1 => $op, 2 => implode(', ', $paymentProcessorNames)));
+        $query->_tables['civicrm_contribution_recur'] = $query->_whereTables['civicrm_contribution_recur'] = 1;
+        return;
+
+      case 'contribution_recur_processor_id':
       case 'contribution_recur_trxn_id':
         $fieldName = str_replace('contribution_recur_', '', $name);
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_recur.{$fieldName}",
           $op, $value, "String"
         );
+        $recurFields = CRM_Contribute_DAO_ContributionRecur::fields();
+        $query->_qill[$grouping][] = ts("Recurring Contribution %1 %2 '%3'", array(1 => $recurFields[$fieldName]['title'], 2 => $op, 3 => $value));
         $query->_tables['civicrm_contribution_recur'] = $query->_whereTables['civicrm_contribution_recur'] = 1;
         return;
 

--- a/templates/CRM/Contact/Form/Search/Advanced.hlp
+++ b/templates/CRM/Contact/Form/Search/Advanced.hlp
@@ -111,3 +111,17 @@
     <p>{ts}In the process of setting up CiviCRM components or configuring pages and profiles, you might have created test contributions, activities, participants, pledges, etc.{/ts}</p>
     <p>{ts}Once you have finished your testing, it is a good idea to clean up by finding your test records and deleting them.{/ts}</p>
 {/htxt}
+
+{htxt id="processor-id-title"}
+{ts}Processor ID{/ts}
+{/htxt}
+{htxt id="processor-id"}
+    <p>{ts}This is the payment processor's own ID for the recurring contribution. Ideally it should be unique, but in practice may not be.{/ts}</p>
+{/htxt}
+
+{htxt id="transaction-id-title"}
+{ts}Transaction ID{/ts}
+{/htxt}
+{htxt id="transaction-id"}
+    <p>{ts}Unique reference for the recurring contribution. May be made up of other fields, e.g. bank ID, account number, etc.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
@@ -71,10 +71,31 @@
         </td>
       </tr>
       <tr>
-        <td>{ts}Recurring Contribution Status{/ts}</td>
+        <td>{ts}Status{/ts}</td>
         <td></td>
         <td col='span2'>
           {$form.contribution_recur_contribution_status_id.html|crmAddClass:twenty}
+        </td>
+      </tr>
+      <tr>
+        <td>{ts}Payment Processor{/ts}</td>
+        <td></td>
+        <td col='span2'>
+          {$form.contribution_recur_payment_processor_id.html}
+        </td>
+      </tr>
+      <tr>
+        <td>{ts}Transaction ID{/ts}</td>
+        <td></td>
+        <td col='span2'>
+          {$form.contribution_recur_trxn_id.html}
+        </td>
+      </tr>
+      <tr>
+        <td>{ts}Processor ID{/ts}</td>
+        <td></td>
+        <td col='span2'>
+          {$form.contribution_recur_processor_id.html}
         </td>
       </tr>
       {if $contributionRecurGroupTree}

--- a/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
@@ -85,17 +85,17 @@
         </td>
       </tr>
       <tr>
-        <td>{ts}Transaction ID{/ts}</td>
-        <td></td>
-        <td col='span2'>
-          {$form.contribution_recur_trxn_id.html}
-        </td>
-      </tr>
-      <tr>
-        <td>{ts}Processor ID{/ts}</td>
+        <td>{ts}Processor ID{/ts} {help id="processor-id" file="CRM/Contact/Form/Search/Advanced"}</td>
         <td></td>
         <td col='span2'>
           {$form.contribution_recur_processor_id.html}
+        </td>
+      </tr>
+      <tr>
+        <td>{ts}Transaction ID{/ts} {help id="transaction-id" file="CRM/Contact/Form/Search/Advanced"}</td>
+        <td></td>
+        <td col='span2'>
+          {$form.contribution_recur_trxn_id.html}
         </td>
       </tr>
       {if $contributionRecurGroupTree}


### PR DESCRIPTION
Overview
----------------------------------------
Allow to search by recurring contribution transaction ID / payment processor ID / processor ID

Before
----------------------------------------
Cannot search by recurring contribution transaction ID / payment processor ID / processor ID

After
----------------------------------------
Can search by recurring contribution transaction ID / payment processor ID / processor ID

![recur_search](https://user-images.githubusercontent.com/2052161/46581038-682bbe80-ca28-11e8-9d01-d179ab82fe91.png)


Technical Details
----------------------------------------
Just exposes three extra fields for searching.

