### PR TITLE
Show contact name on recurring contribution view and improve consistency with Contribution/Membership view

### DIFF
--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -83,6 +83,17 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $contributionRecur['id']);
 
     $this->assign('recur', $contributionRecur);
+
+    $displayName = CRM_Contact_BAO_Contact::displayName($contributionRecur['contact_id']);
+    $this->assign('displayName', $displayName);
+
+    // Check if this is default domain contact CRM-10482
+    if (CRM_Contact_BAO_Contact::checkDomainContact($contributionRecur['contact_id'])) {
+      $displayName .= ' (' . ts('default organization') . ')';
+    }
+
+    // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container
+    CRM_Utils_System::setTitle(ts('View Recurring Contribution from') . ' ' . $displayName);
   }
 
   public function preProcess() {

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -33,9 +33,12 @@
           <strong>{ts}This is a TEST transaction{/ts}</strong>
         </div>
         {/if}
-        <h3>{ts}View Recurring Payment{/ts}</h3>
         <div class="crm-block crm-content-block crm-recurcontrib-view-block">
           <table class="crm-info-panel">
+            <tr>
+              <td class="label">{ts}From{/ts}</td>
+              <td class="bold"><a href="{crmURL p='civicrm/contact/view' q="cid=`$recur.contact_id`"}">{$displayName}</a></td>
+            </tr>
             <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
             <tr><td class="label">{ts}Frequency{/ts}</td><td>every {$recur.frequency_interval} {$recur.frequency_unit}</td></tr>
             <tr><td class="label">{ts}Installments{/ts}</td><td>{$recur.installments}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
Show contact name on recurring contribution view.

Before
----------------------------------------
Recurring contribution view does not show contact name anywhere and has redundant "title" "View recurring Payment"
![localhost_8000_civicrm_contact_view_cid 134 3](https://user-images.githubusercontent.com/2052161/45544310-e07ad780-b80e-11e8-8a15-463e96715275.png)
But contribution is much clearer showing contact name:
![localhost_8000_civicrm_contact_view_cid 134 1](https://user-images.githubusercontent.com/2052161/45544324-e7094f00-b80e-11e8-840d-ea0c79c23731.png)


After
----------------------------------------
Recurring contribution view shows contact name and is consistent with both contribution and membership views:
![localhost_8000_civicrm_contact_view_cid 134](https://user-images.githubusercontent.com/2052161/45544333-ebce0300-b80e-11e8-8204-82ce123ecaaf.png)


Technical Details
----------------------------------------
Form only change.  Adds a new assign to the class and adjustments to the template for display.
