### PR TITLE
Show recurring contribution links based on payment processor capabilities

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -81,19 +81,28 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     if ($recurID) {
       $links = self::$_links;
       $paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($recurID, 'recur', 'obj');
-      if (is_object($paymentProcessorObj) && $paymentProcessorObj->supports('cancelRecurring')) {
+      if (!is_object($paymentProcessorObj)) {
+        unset($links[CRM_Core_Action::DISABLE]);
+        unset($links[CRM_Core_Action::UPDATE]);
+        return $links;
+      }
+      if ($paymentProcessorObj->supports('cancelRecurring')) {
         unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
         $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
         $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
       }
 
-      if (is_object($paymentProcessorObj) && $paymentProcessorObj->isSupported('updateSubscriptionBillingInfo')) {
+      if ($paymentProcessorObj->supports('UpdateSubscriptionBillingInfo')) {
         $links[CRM_Core_Action::RENEW] = array(
           'name' => ts('Change Billing Details'),
           'title' => ts('Change Billing Details'),
           'url' => 'civicrm/contribute/updatebilling',
           'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
         );
+      }
+
+      if (!$paymentProcessorObj->supports('ChangeSubscriptionAmount') && !$paymentProcessorObj->supports('EditRecurringContribution')) {
+        unset($links[CRM_Core_Action::UPDATE]);
       }
       return $links;
     }
@@ -251,13 +260,6 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
       }
 
       if ($recurContributions[$recurId]['is_active']) {
-        $details = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurContributions[$recurId]['id'], 'recur');
-        $hideUpdate = $details->membership_id & $details->auto_renew;
-
-        if ($hideUpdate) {
-          $action -= CRM_Core_Action::UPDATE;
-        }
-
         $recurContributions[$recurId]['action'] = CRM_Core_Action::formLink(self::recurLinks($recurId), $action,
           array(
             'cid' => $this->_contactId,

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -28,7 +28,7 @@
     <div class="help">
       {$changeHelpText}
       {if $recurMembership}
-        <br/><strong> {ts}'WARNING: This recurring contribution is linked to membership:{/ts}
+        <br/><strong> {ts}WARNING: This recurring contribution is linked to membership:{/ts}
         <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$recurMembership.membership_id`&context=membership&selectedChild=member"}'>{$recurMembership.membership_name}</a>
         </strong>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
In [CRM-21512](https://issues.civicrm.org/jira/browse/CRM-21512) / https://github.com/civicrm/civicrm-core/pull/11366 we removed the restriction on editing recurring contributions based on whether they were linked to a membership.  However, the "edit" link was still being shown/hidden based on that criteria.

What we should be doing is showing/hiding links based on whether the payment processor actually supports those functions and this PR makes that happen.

Before
----------------------------------------
- Edit link does not respect payment processor supports ChangeSubscriptionAmount/EditRecurringContribution.
- If a payment processor is used but later the extension is disabled the edit/cancel links will still be shown but they will not work because the relevant classes don't exist.

After
----------------------------------------
- Edit link is shown/hidden based on result of ChangeSubscriptionAmount/EditRecurringContribution alone.
- If a payment processor is used but later the extension is disabled the edit/cancel links will not be shown as they will not work.  View is still shown as this does not require the payment processor class to exist.

Technical Details
----------------------------------------
Recent changes to payment processor supportsX methods have made this cleaner and easier to implement.

Comments
----------------------------------------
@KarinG @eileenmcnaughton @bhahumanists I think you're likely to have an interest


