### PR TITLE
Accept id as well as contact_id in bao

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -159,7 +159,9 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
 
     $allNull = $contact->copyValues($params);
 
-    $contact->id = CRM_Utils_Array::value('contact_id', $params);
+    if (!empty($params['contact_id'])) {
+      $contact->id = $params['contact_id'];
+    }
 
     if ($contact->contact_type == 'Individual') {
       $allNull = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
I ran into some weird bugs with profile blocks in the contact summary extension where the 'id' field would sometimes get ignored and the update would be treated as if it were creating a new contact. This fixes it.

Before
----------------------------------------
The contact BAO does not accept an "id" param. This is nonstandard.

After
----------------------------------------
"id" param works as well as "contact_id"
