### PR TITLE
Ensure relative dates are preserved for custom fields in smart group

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -429,7 +429,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     $relativeDates = array('relative_dates' => array());
     $specialDateFields = array('event_relative', 'case_from_relative', 'case_to_relative', 'participant_relative');
     foreach ($formValues as $id => $value) {
-      if ((preg_match('/_date_relative$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
+      if ((preg_match('/(_date|custom_[0-9]+)_relative$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
         $entityName = strstr($id, '_date', TRUE);
         if (empty($entityName)) {
           $entityName = strstr($id, '_relative', TRUE);
@@ -480,7 +480,12 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
 
     // select date range as default
     if ($isCustomDateField) {
-      $formValues[$fieldName . '_relative'] = 0;
+      if (array_key_exists('relative_dates', $formValues) && array_key_exists($fieldName, $formValues['relative_dates'])) {
+        $formValues[$fieldName . '_relative'] = $formValues['relative_dates'][$fieldName];
+      }
+      else {
+        $formValues[$fieldName . '_relative'] = 0;
+      }
     }
     switch ($op) {
       case 'BETWEEN':

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -135,27 +135,46 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
    * index so it is properly detects when executed.
    */
   public function testCustomFieldRelativeDates() {
+    // Create a custom field.
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual', 'title' => 'relative_date_test_group'));
+    $params = array(
+      'custom_group_id' => $customGroup['id'],
+      'name' => 'test_datefield',
+      'label' => 'Date Field for Testing',
+      'html_type' => 'Select Date',
+      'data_type' => 'Date',
+      'default_value' => NULL,
+      'weight' => 4,
+      'is_required' => 1,
+      'is_searchable' => 1,
+      'date_format' => 'mm/dd/yyyy',
+      'is_active' => 1,
+    );
+    $customField = $this->callAPIAndDocument('custom_field', 'create', $params, __FUNCTION__, __FILE__);
+    $id = $customField['id'];
+
     $queryParams = array(
       0 => array(
-        0 => 'custom_13_low',
+        0 => "custom_${id}_low",
         1 => '=',
         2 => '20170425000000',
       ),
       1 => array(
-        0 => 'custom_13_high',
+        0 => "custom_${id}_high",
         1 => '=',
         2 => '20170501235959',
       ),
     );
     $formValues = array(
-      'custom_13_relative' => 'ending.week',
+      "custom_${id}_relative" => 'ending.week',
     );
     CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
     // Since custom_13 doesn't have the word 'date' in it, the key is
     // set to 0, rather than the field name.
     $err = 'Relative date in custom field smart group creation failed.';
     $this->assertArrayHasKey('relative_dates', $queryParams, $err);
-
+    $dropCustomValueTables = TRUE;
+    $this->quickCleanup(array('civicrm_saved_search'), $dropCustomValueTables);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -127,6 +127,36 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     $this->checkArrayEquals($result['relative_dates'], $expectedResult);
   }
 
+  /**
+   * Test relative dates
+   *
+   * The function saveRelativeDates should detect whether a field is using
+   * a relative date range and include in the fromValues a relative_date
+   * index so it is properly detects when executed.
+   */
+  public function testCustomFieldRelativeDates() {
+    $queryParams = array(
+      0 => array(
+        0 => 'custom_13_low',
+        1 => '=',
+        2 => '20170425000000',
+      ),
+      1 => array(
+        0 => 'custom_13_high',
+        1 => '=',
+        2 => '20170501235959',
+      ),
+    );
+    $formValues = array(
+      'custom_13_relative' => 'ending.week',
+    );
+    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
+    // Since custom_13 doesn't have the word 'date' in it, the key is
+    // set to 0, rather than the field name.
+    $err = 'Relative date in custom field smart group creation failed.';
+    $this->assertArrayHasKey('relative_dates', $queryParams, $err);
+
+  }
 
   /**
    * Get variants of the fields we want to test.


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/issues/389

Overview
----------------------------------------

Saving smart groups with custom fields in which a relative date is specified does not work as expected. The date range is hard coded and does not updated when re-run on a different day.

Before
----------------------------------------
When you create a smart group using a custom date field and you choose a relative date option (e.g. This calendar year), the field is saved with the hard-coded dates for the current time, rather than the relative date range specified.

After
----------------------------------------
With this patch in place, relative dates are properly saved and displayed to the user.



