### PR TITLE
/dev/core/#303 print/merge html via PDF pathway, instead of PHPWord

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -432,8 +432,17 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
     if ($type == 'pdf') {
-      $fileName = "CiviLetter.$type";
-      CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
+      $fileName = "CiviLetter.pdf";
+      $format = CRM_Utils_PDF_Utils::getPDFformat($formValues);
+      $html = CRM_Utils_PDF_Utils::getProcessedHTML($html, $format);
+      CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $format);
+    }
+    elseif ($type == 'html') {
+      $fileName = "CiviLetter.html";
+      $format = CRM_Utils_PDF_Utils::getPDFformat($formValues);
+      $html = CRM_Utils_PDF_Utils::getProcessedHTML($html, $format);
+      CRM_Utils_System::setHttpHeader('Content-Disposition', 'attachment; filename="' . $fileName);
+      echo $html;
     }
     elseif (!empty($formValues['document_file_path'])) {
       $fileName = pathinfo($formValues['document_file_path'], PATHINFO_FILENAME) . '.' . $type;


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a problem where printing a document to HTML produced poor HTML. In 'Print/Merge Document' you can select to output to HTML. In practice, this processes the HTML via PHPWord. This seems to mangle it quite badly: div tags get converted into text (it literally says 'div'), styling gets removed, etc.

Before
----------------------------------------
CRM_Contact_Form_Task_PDFLetterCommon sent HTML via CRM_Utils_PDF_Document::html2doc(), which processes it using PHPWord.

After
----------------------------------------
CRM_Urils_PDF_Utils::html2pdf() has been split into three functions: one to generate the page formatting, one to generate the HTML, and one to generate the PDF. HTML documents use the first two, then output the HTML directly.
