### PR TITLE
dev/core#357 Fix issue where user email addresses were keyed on email…

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -396,6 +396,16 @@ class CRM_Contact_Form_Task_EmailCommon {
     self::saveMessageTemplate($formValues);
 
     $from = CRM_Utils_Array::value('from_email_address', $formValues);
+    // dev/core#357 User Emails are keyed by their id so that the Signature is able to be added
+    // If we have had a contact email used here the value returned from the line above will be the
+    // numerical key where as $from for use in the sendEmail in Activity needs to be of format of "To Name" <toemailaddress>
+    if (is_numeric($from)) {
+      $result = civicrm_api3('Email', 'get', [
+        'id' => $from,
+        'return' => ['contact_id.display_name', 'email'],
+      ]);
+      $from = '"' . $result['values'][$from]['contact_id.display_name'] . '" <' . $result['values'][$from]['email'] . '>';
+    }
     $subject = $formValues['subject'];
 
     // CRM-13378: Append CC and BCC information at the end of Activity Details and format cc and bcc fields

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -333,7 +333,7 @@ AND    reset_date IS NULL
         if (!empty($emailVal['is_primary'])) {
           $fromEmailHtml .= ' ' . ts('(preferred)');
         }
-        $contactFromEmails[$fromEmail] = $fromEmailHtml;
+        $contactFromEmails[$emailId] = $fromEmailHtml;
       }
     }
     return CRM_Utils_Array::crmArrayMerge($contactFromEmails, $fromEmailValues);


### PR DESCRIPTION
… not id therefore breaking the usage of the signature option on email addresses and ensure that emails still get passed through correctly

Overview
----------------------------------------
User record supplied email addresses were keyed on the email not id breaking the signature element this fixes it and ensures we are still returning sensible format to the relevant function. 

Before
----------------------------------------
Email Signature broken

After
----------------------------------------
Email Signature Fixed

ping @pradpnayak @mattwire would one of you be able to test this? 
