### PR TITLE
Add validate api action for ContributionPage.submit

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -626,7 +626,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    *   The input form values.
    * @param array $files
    *   The uploaded files if any.
-   * @param CRM_Core_Form $self
+   * @param \CRM_Contribute_Form_Contribution_Main $self
    *
    * @return bool|array
    *   true if no errors, else array of errors
@@ -670,7 +670,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $previousId = $otherAmount = FALSE;
       while ($priceField->fetch()) {
 
-        if ($self->_quickConfig && ($priceField->name == 'contribution_amount' || $priceField->name == 'membership_amount')) {
+        if ($self->isQuickConfig() && ($priceField->name == 'contribution_amount' || $priceField->name == 'membership_amount')) {
           $previousId = $priceField->id;
           if ($priceField->name == 'membership_amount' && !$priceField->is_active) {
             $membershipIsActive = FALSE;
@@ -951,7 +951,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       return $errors;
     }
 
-    if (CRM_Utils_Array::value('payment_processor_id', $fields) == NULL) {
+    if (CRM_Utils_Array::value('payment_processor_id', $fields) === NULL) {
       $errors['payment_processor_id'] = ts('Payment Method is a required field.');
     }
     else {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -212,6 +212,14 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public $paymentInstrumentID;
 
   /**
+   * Is the price set quick config.
+   * @return bool
+   */
+  public function isQuickConfig() {
+    return isset(self::$_quickConfig) ? self::$_quickConfig : FALSE;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Contribute_Exception_InactiveContributionPageException

--- a/api/v3/ContributionPage.php
+++ b/api/v3/ContributionPage.php
@@ -104,6 +104,26 @@ function civicrm_api3_contribution_page_submit($params) {
   return civicrm_api3_create_success($result, $params, 'ContributionPage', 'submit');
 }
 
+/**
+ * Validate ContributionPage submission parameters.
+ *
+ * @param array $params
+ *   Array per getfields metadata.
+ *
+ * @return array
+ *   API result array
+ */
+function civicrm_api3_contribution_page_validate($params) {
+  $form = new CRM_Contribute_Form_Contribution_Main();
+  $form->controller = new CRM_Core_Controller();
+  $form->set('id', $params['id']);
+  $form->preProcess();
+  $errors = CRM_Contribute_Form_Contribution_Main::formRule($params, [], $form);
+  if ($errors === TRUE) {
+    $errors = [];
+  }
+  return civicrm_api3_create_success($errors, $params, 'ContributionPage', 'validate');
+}
 
 /**
  * Set default getlist parameters.


### PR DESCRIPTION
Overview
----------------------------------------
Extends existing validate action to provide specific support for the ContributionPage.submit action

Before
----------------------------------------
calling
```
civicrm_api3('ContributionPage', 'validate', array_merge($params, ['action' => 'submit']))
```

does not check if the parameters are valid for the form

After
----------------------------------------
The above checks the parameters are valid for the form

Technical Details
----------------------------------------
@colemanw @mattwire the intent of this is to be able to support a flow like the new paypal method where the user is redirected offsite to authorise the order before the form is submitted. It's important to check the data is valid first - e.g they haven't entered as amount below the minimum and if they have entered yes to recurring they have also entered other details.

This is a first step. It seems to me that in order to be able to validate at the js level we need to be able to test the input against the formRule function. I can see quite a lot of appropriate extension & tidy up work but have kept this to the minimum 

Comments
----------------------------------------
I am open to doing this on the api v4 rather than v3 if it makes sense.
