### PR TITLE
dev/399 Fix saving of relationship permissions when relationship is b_a on form

### DIFF
--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -578,22 +578,23 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
   /**
    * Prepares parameters to be used for create/update actions
    *
-   * @param array $params
+   * @param array $values
    *
    * @return array
    */
-  private function preparePostProcessParameters($params) {
-    $relationshipTypeParts = explode('_', $params['relationship_type_id']);
+  private function preparePostProcessParameters($values) {
+    $params = $values;
+    list($relationshipTypeId, $relationshipContactA, $relationshipContactB) = explode('_', $params['relationship_type_id']);
 
-    $params['relationship_type_id'] = $relationshipTypeParts[0];
-    $params['contact_id_' . $relationshipTypeParts[1]] = $this->_contactId;
+    $params['relationship_type_id'] = $relationshipTypeId;
+    $params['contact_id_' . $relationshipContactA] = $this->_contactId;
 
     if (empty($this->_relationshipId)) {
-      $params['contact_id_' . $relationshipTypeParts[2]] = explode(',', $params['related_contact_id']);
+      $params['contact_id_' . $relationshipContactB] = explode(',', $params['related_contact_id']);
     }
     else {
       $params['id'] = $this->_relationshipId;
-      $params['contact_id_' . $relationshipTypeParts[2]] = $params['related_contact_id'];
+      $params['contact_id_' . $relationshipContactB] = $params['related_contact_id'];
 
       foreach (array('start_date', 'end_date') as $dateParam) {
         if (!empty($params[$dateParam])) {
@@ -602,11 +603,12 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       }
     }
 
-    // CRM-14612 - Don't use adv-checkbox as it interferes with the form js
-    $params['is_permission_a_b'] = CRM_Utils_Array::value('is_permission_a_b', $params, 0);
-    $params['is_permission_b_a'] = CRM_Utils_Array::value('is_permission_b_a', $params, 0);
+    // The javascript on the form will swap these fields if it is a b_a relationship, so we compensate here
+    $relationshipType = "${relationshipContactA}_${relationshipContactB}";
+    $params['is_permission_a_b'] = CRM_Utils_Array::value('is_permission_' . $relationshipType, $values, 0);
+    $params['is_permission_b_a'] = CRM_Utils_Array::value('is_permission_' . strrev($relationshipType), $values, 0);
 
-    return array($params, $relationshipTypeParts[1]);
+    return array($params, $relationshipContactA);
   }
 
   /**

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -227,7 +227,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
         $defaults['description'] = CRM_Utils_Array::value('description', $this->_values);
         $defaults['is_active'] = CRM_Utils_Array::value('is_active', $this->_values);
 
-        // The javascript on the form will swap these fields if it is a b_a relationship, so we compensate here
+        // The postprocess function will swap these fields if it is a b_a relationship, so we compensate here
         $defaults['is_permission_a_b'] = CRM_Utils_Array::value('is_permission_' . $this->_rtype, $this->_values);
         $defaults['is_permission_b_a'] = CRM_Utils_Array::value('is_permission_' . strrev($this->_rtype), $this->_values);
 
@@ -584,17 +584,17 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
    */
   private function preparePostProcessParameters($values) {
     $params = $values;
-    list($relationshipTypeId, $relationshipContactA, $relationshipContactB) = explode('_', $params['relationship_type_id']);
+    list($relationshipTypeId, $a, $b) = explode('_', $params['relationship_type_id']);
 
     $params['relationship_type_id'] = $relationshipTypeId;
-    $params['contact_id_' . $relationshipContactA] = $this->_contactId;
+    $params['contact_id_' . $a] = $this->_contactId;
 
     if (empty($this->_relationshipId)) {
-      $params['contact_id_' . $relationshipContactB] = explode(',', $params['related_contact_id']);
+      $params['contact_id_' . $b] = explode(',', $params['related_contact_id']);
     }
     else {
       $params['id'] = $this->_relationshipId;
-      $params['contact_id_' . $relationshipContactB] = $params['related_contact_id'];
+      $params['contact_id_' . $b] = $params['related_contact_id'];
 
       foreach (array('start_date', 'end_date') as $dateParam) {
         if (!empty($params[$dateParam])) {
@@ -603,12 +603,11 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       }
     }
 
-    // The javascript on the form will swap these fields if it is a b_a relationship, so we compensate here
-    $relationshipType = "${relationshipContactA}_${relationshipContactB}";
-    $params['is_permission_a_b'] = CRM_Utils_Array::value('is_permission_' . $relationshipType, $values, 0);
-    $params['is_permission_b_a'] = CRM_Utils_Array::value('is_permission_' . strrev($relationshipType), $values, 0);
+    // If this is a b_a relationship these form elements are flipped
+    $params['is_permission_a_b'] = CRM_Utils_Array::value("is_permission_{$a}_{$b}", $values, 0);
+    $params['is_permission_b_a'] = CRM_Utils_Array::value("is_permission_{$b}_{$a}", $values, 0);
 
-    return array($params, $relationshipContactA);
+    return array($params, $a);
   }
 
   /**

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -121,7 +121,7 @@
           </td>
         </tr>
         <tr class="crm-relationship-form-block-is_permission_b_a">
-          <td class="label"></td>
+          <td class="label"> </td>
           <td>
             {ts 1=$contact_b|ucfirst 2=$display_name_a}Permission for <strong>%1</strong> to access information about <strong>%2</strong>{/ts}<br />
             {$form.is_permission_b_a.html}

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -262,10 +262,6 @@
             // Show/hide employer field
             $('.crm-relationship-form-block-is_current_employer', $form).toggle(rType === {/literal}'{$employmentRelationship}'{literal});
 
-            // Swap the permission checkboxes to match selected relationship direction
-            $('#is_permission_a_b', $form).attr('name', 'is_permission_' + source + '_' + target);
-            $('#is_permission_b_a', $form).attr('name', 'is_permission_' + target + '_' + source);
-
             CRM.buildCustomData('Relationship', rType);
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Save relationship permissions correctly when submitting the relationship edit form if we are saving a b_a relationship.

Before
----------------------------------------
On the relationship edit form saving a relationship of type b_a gets saved with the relationship permissions reversed.

After
----------------------------------------
On the relationship edit form saving a relationship of type b_a gets saved with the relationship permissions as displayed on the form (ie. correctly).

Technical Details
----------------------------------------
In setDefaultValues() we already take into account the relationship direction before loading the form. But when saving the relationship we don't take into account the relationship direction and the permissions are always saved as submitted on the form (ie the first one is permission in the a_b direction, the second on is permission in the b_a direction).

Comments
----------------------------------------
@aydun @eileenmcnaughton Surprised if neither of you have run into this issue?

https://lab.civicrm.org/dev/core/issues/399