### PR TITLE
Fix html wrapper on basic summary block

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -1,4 +1,4 @@
-{*<div class="crm-clear crm-inline-block-content">*}
+<div class="crm-clear crm-inline-block-content">
   <div class="crm-summary-row">
     <div class="crm-label" id="tagLink">
       <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contactId&selectedChild=tag"}"
@@ -38,4 +38,4 @@
       {if isset($external_identifier)}{$external_identifier}{/if}
     </div>
   </div>
-{*</div>*}
+</div>

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -158,7 +158,7 @@
                 </div>
               {/if}
                 <div class="{if !empty($imageURL)} float-left{/if}">
-                  <div class="crm-clear crm-summary-block">
+                  <div class="crm-summary-basic-block crm-summary-block">
                     {include file="CRM/Contact/Page/Inline/Basic.tpl"}
                   </div>
                 </div>


### PR DESCRIPTION
Overview
-----
In 5.5 I extracted this tpl, but did so very cautiously. This is the followup to wrap the block in the standard `<div>`s that wrap every other block on the summary screen. I don't forsee any problems with this, but wanted to let it sit in the 5.6 RC for a little while just in case.

Before
----
Inconsistent markup

After
----
Consistent markup. No visible change on vanilla Civi. Fixes font-size problem when Layout Editor is installed.

Notes
-----
Fixes https://github.com/civicrm/org.civicrm.contactlayout/issues/32