### PR TITLE
NFC: fix grammar/punctuation in help

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Display.hlp
+++ b/templates/CRM/Admin/Form/Preferences/Display.hlp
@@ -42,5 +42,5 @@
 {/htxt}
 {htxt id="id-invoices_id"}
   {capture assign=invoiceURL}{crmURL p='civicrm/admin/setting/preferences/contribute' q="reset=1"}{/capture} 
-  {ts 1=$invoiceURL}In order to enable logged in users to download invoices and credit notes from the dashboard. Please first enable CiviCRM invoicing functionality <a href='%1'>Administer > CiviContribute > CiviContribute Component Settings</a>{/ts}
+  {ts 1=$invoiceURL}In order to enable logged in users to download invoices and credit notes from the dashboard, please first enable CiviCRM invoicing functionality <a href='%1'>Administer > CiviContribute > CiviContribute Component Settings</a>{/ts}
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
_Small grammar / punctuation change in settings help._

Before
----------------------------------------
_In order to enable logged in users to download invoices and credit notes from the dashboard. Please first enable CiviCRM invoicing functionality _

After
----------------------------------------
_In order to enable logged in users to download invoices and credit notes from the dashboard, please first enable CiviCRM invoicing functionality _

Technical Details
----------------------------------------
_NFC_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
