### PR TITLE
When submitting a standalone credit card contribution the contact email address should not be deleted

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -245,6 +245,9 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    */
   public function preProcess() {
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
+    if (empty($this->_contactID)) {
+      $this->_contactID = CRM_Utils_Request::retrieve('contact_id', 'Positive');
+    }
     if (empty($this->_contactID) && !empty($this->_id) && $this->entity) {
       $this->_contactID = civicrm_api3($this->entity, 'getvalue', array('id' => $this->_id, 'return' => 'contact_id'));
     }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1049,14 +1049,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $now = date('YmdHis');
 
-    // we need to retrieve email address
-    if ($this->_context == 'standalone' && !empty($submittedValues['is_email_receipt'])) {
-      list($this->userDisplayName,
-        $this->userEmail
-        ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
-      $this->assign('displayName', $this->userDisplayName);
-    }
-
     $this->_contributorEmail = $this->userEmail;
     $this->_contributorContactID = $contactID;
     $this->processBillingAddress();


### PR DESCRIPTION
Overview
----------------------------------------
When submitting a credit card contribution via the backend 

Process to reproduce (tested with Stripe payment processor):

1. Contributions -> New Contribution
1. Click "submit credit card contribution" link on right
1. Select a contact that you know for sure has an email address
1. Fill out the rest of the form
1. Click Save
1. Results in error message "No email address found. Please report this issue." (screenshot attached)
1. Go to contact record, see that email address is now blank

Before
----------------------------------------
Email address is deleted

After
----------------------------------------
Email address is not deleted

Technical Details
----------------------------------------
The submit credit card contribution form has a few issues... in this case when submitting via a standalone form there is no contact ID when the form is loaded and so various parameters on the form are not populated.  During submission the form checks if the form is standalone, and if email_receipt is checked it will try and load the users email address.  If not, createProfileContact will overwrite the billing/primary email with NULL.
This PR changes the form so that it uses the submitted contact ID when re-triggering preprocess so that the form object is correctly populated before the submission completes.

Comments
----------------------------------------
Identified here: https://github.com/mattwire/com.drastikbydesign.stripe/issues/21 but the issue itself has nothing to do with Stripe, other than it is a payment processor that can be used for live backend contributions.