### PR TITLE
Skip html encoding rich-text fields

### DIFF
--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -111,6 +111,10 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         'operator',
         'content', // CRM-20468
       );
+      $custom = CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_custom_field WHERE html_type = "RichTextEditor"');
+      while ($custom->fetch()) {
+        $this->skipFields[] = 'custom_' . $custom->id;
+      }
     }
     return $this->skipFields;
   }


### PR DESCRIPTION
Overview
-----
Fixes https://github.com/civicrm/org.civicrm.contactlayout/issues/21

Before
-----
Rich text custom fields saved with api were being escaped

After
------
Html is preserved as-is

Comments
-----
Ugh.