### PR TITLE
Lookup path-variable for the private filepath

### DIFF
--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -106,7 +106,7 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
       CRM_Utils_File::restrictAccess($this->templateCompileDir);
     }
 
-    $civicrm_private = $GLOBALS['civicrm_paths']['civicrm.private'];
+    $civicrm_private = $GLOBALS['civicrm_paths']['civicrm.private']['path'];
     if (!empty($civicrm_private)) {
       $this->configAndLogDir = rtrim($civicrm_private, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
     }

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -101,13 +101,17 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
 
     if (defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
       $this->configAndLogDir = CRM_Utils_File::baseFilePath() . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
-      CRM_Utils_File::createDir($this->configAndLogDir);
-      CRM_Utils_File::restrictAccess($this->configAndLogDir);
-
       $this->templateCompileDir = defined('CIVICRM_TEMPLATE_COMPILEDIR') ? CRM_Utils_File::addTrailingSlash(CIVICRM_TEMPLATE_COMPILEDIR) : NULL;
       CRM_Utils_File::createDir($this->templateCompileDir);
       CRM_Utils_File::restrictAccess($this->templateCompileDir);
     }
+
+    $civicrm_private = Civi::paths()->getPath('[civicrm.private]');
+    if (!empty($civicrm_private)) {
+      $this->configAndLogDir = rtrim($civicrm_private, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
+    }
+    CRM_Utils_File::createDir($this->configAndLogDir);
+    CRM_Utils_File::restrictAccess($this->configAndLogDir);
 
     if (!defined('CIVICRM_UF')) {
       $this->fatal('You need to define CIVICRM_UF in civicrm.settings.php');

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -106,7 +106,7 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
       CRM_Utils_File::restrictAccess($this->templateCompileDir);
     }
 
-    $civicrm_private = Civi::paths()->getPath('[civicrm.private]');
+    $civicrm_private = $GLOBALS['civicrm_paths']['civicrm.private'];
     if (!empty($civicrm_private)) {
       $this->configAndLogDir = rtrim($civicrm_private, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -487,10 +487,10 @@ class Container {
     $bootServices = [];
     \Civi::$statics[__CLASS__]['boot'] = &$bootServices;
 
+    $bootServices['paths'] = new \Civi\Core\Paths();
+
     $bootServices['runtime'] = $runtime = new \CRM_Core_Config_Runtime();
     $runtime->initialize($loadFromDB);
-
-    $bootServices['paths'] = new \Civi\Core\Paths();
 
     $class = $runtime->userFrameworkClass;
     $bootServices['userSystem'] = $userSystem = new $class();

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -487,10 +487,10 @@ class Container {
     $bootServices = [];
     \Civi::$statics[__CLASS__]['boot'] = &$bootServices;
 
-    $bootServices['paths'] = new \Civi\Core\Paths();
-
     $bootServices['runtime'] = $runtime = new \CRM_Core_Config_Runtime();
     $runtime->initialize($loadFromDB);
+
+    $bootServices['paths'] = new \Civi\Core\Paths();
 
     $class = $runtime->userFrameworkClass;
     $bootServices['userSystem'] = $userSystem = new $class();

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -56,6 +56,9 @@ class Paths {
       ->register('civicrm.files', function () {
         return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
       })
+      ->register('civicrm.private', function () {
+        return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
+      })
       ->register('wp.frontend.base', function () {
         return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
       })


### PR DESCRIPTION
Overview
----------------------------------------
Addresses https://lab.civicrm.org/dev/cloud-native/issues/3. It attempts to allow uses to set a private filesystem separately from the public filesystem for webhosts where the private and public paths are not customizable (such as with Pantheon).

Before
----------------------------------------
The ConfigAndLog directory is set to be the same location as the templates directory.

After
----------------------------------------
The ConfigAndLog directory is set by `[civicrm.private]` in civicrm.settings.

Comments
----------------------------------------
This PR takes the approach suggested by @totten:

> The reference to baseFilePath() in CRM_Core_Config_Runtime is more effort. I don't know if it'd work, but my first try would be (a) lookup a path-variable like Civi::paths()->getVariable('civicrm.log', 'path'), (b) declare the variable in Civi\Core\Paths, (c) change the relative boot order of Civi\Core\Paths and CRM_Core_Config_Runtime.

I decided to make the PR to get some guidance on how to resolve an error. The attempt to switch the boot order didn't work and I'm not sure what else to do that would be proper (I assume just referencing `$GLOBALS['civicrm.settings']['civicrm.private']['path']` wouldn't be proper).

Here's the error I get:

`Notice: Undefined index: userSystem in Civi\Core\Container::getBootService() (line 475 of /app/sites/all/modules/civicrm/Civi/Core/Container.php).`
`Error: Call to a member function getDefaultFileStorage() on null in Civi\Core\Paths->Civi\Core\{closure}() (line 57 of /app/sites/all/modules/civicrm/Civi/Core/Paths.php).`

