### PR TITLE
Partial revert of pull/12559

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2880,7 +2880,7 @@ INNER JOIN  civicrm_option_group grp ON ( grp.id = val.option_group_id AND grp.n
     }
 
     // Get contact activities.
-    $activities = CRM_Activity_BAO_Activity::getActivities($params);
+    $activities = CRM_Activity_BAO_Activity::deprecatedGetActivities($params);
 
     // Add total.
     $params['total'] = CRM_Activity_BAO_Activity::deprecatedGetActivitiesCount($params);

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -393,7 +393,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
       'sort' => $sort,
     );
     $config = CRM_Core_Config::singleton();
-    $rows = CRM_Activity_BAO_Activity::getActivities($params);
+    $rows = CRM_Activity_BAO_Activity::deprecatedGetActivities($params);
 
     if (empty($rows)) {
       return $rows;


### PR DESCRIPTION
Overview
----------------------------------------
Revert a change currently in the rc in order to give more time to work through potential issues

Before
----------------------------------------
5.6 rc switches from deprecatedGetActivities to getActivities function. This is more performant in most places but is specifically slow in one scenario

After
----------------------------------------
Previous performance highs & lows restored.

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/12559/files is currently in RC.

While we have deployed the 5.6 rc to production &  find that the merged change improves performance
we have identified that performance is very poor in the specific scenario where one
activity is linked to 39000 assignees - in our case it was an old experimental civimail
activity. In the interests of prudence I am reverting the parts that switch function
in the rc in order to re-introduce later.

Comments
----------------------------------------
@seamuslee001 @mattwire 
