### PR TITLE
[NFC] Add unit test to cover component ACLs.

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2696,19 +2696,19 @@ AND cl.modified_id  = c.id
    * @return bool
    */
   public static function checkPermission($activityId, $action) {
-    $allow = FALSE;
+
     if (!$activityId ||
       !in_array($action, array(CRM_Core_Action::UPDATE, CRM_Core_Action::VIEW))
     ) {
-      return $allow;
+      return FALSE;
     }
 
     $activity = new CRM_Activity_DAO_Activity();
     $activity->id = $activityId;
     if (!$activity->find(TRUE)) {
-      return $allow;
+      return FALSE;
     }
-
+    $allow = FALSE;
     // Component related permissions.
     $compPermissions = array(
       'CiviCase' => array(

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1796,7 +1796,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'location' => 'Baker Street',
       'details' => 'Lets schedule a meeting',
       'status_id' => 1,
-      'activity_name' => 'Meeting',
+      'activity_type_id' => 'Meeting',
     ), $params);
     if (!isset($params['source_contact_id'])) {
       $params['source_contact_id'] = $this->individualCreate();

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -134,7 +134,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'subject' => 'this case should fail',
       'scheduled_date_time' => date('Ymd'),
     );
-    $result = $this->callAPIFailure('activity', 'create', $params);
+    $this->callAPIFailure('activity', 'create', $params);
   }
 
   /**
@@ -155,7 +155,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'scheduled_date_time' => date('Ymd'),
     );
 
-    $result = $this->callAPIFailure('activity', 'create', $params);
+    $this->callAPIFailure('activity', 'create', $params);
   }
 
   /**
@@ -231,7 +231,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'activity_type_id' => 'Invalid Test activity type',
     );
 
-    $result = $this->callAPIFailure('activity', 'create', $params);
+    $this->callAPIFailure('activity', 'create', $params);
   }
 
   /**
@@ -556,7 +556,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'activity_name' => 'Test activity type',
     );
 
-    $result = $this->callAPIFailure('activity', 'create', $params,
+    $this->callAPIFailure('activity', 'create', $params,
       "'Invalid' is not a valid option for field status_id");
   }
 
@@ -589,7 +589,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    * Test civicrm_activity_get() with no params
    */
   public function testActivityGetEmpty() {
-    $result = $this->callAPISuccess('activity', 'get', array());
+    $this->callAPISuccess('activity', 'get', array());
   }
 
   /**
@@ -713,11 +713,11 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $subject = 'test activity ' . __FUNCTION__ . mt_rand();
     $params = $this->_params;
     $params['subject'] = $subject;
-    $activity = $this->callAPISuccess('Activity', 'Create', $params);
-    $activityget = $this->callAPISuccess('activity', 'getsingle', array(
+    $this->callAPISuccess('Activity', 'Create', $params);
+    $activityGet = $this->callAPISuccess('activity', 'getsingle', array(
       'subject' => $subject,
     ));
-    $this->assertEquals($activityget['subject'], $subject);
+    $this->assertEquals($activityGet['subject'], $subject);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This adds a unit test and does a very minor cleanup making the return a little clearer

Before
----------------------------------------
No test

After
---------------------------------------
test

Technical Details
----------------------------------------
This is preliminary to sorting out performance issues of activity.get api calls in some circumstances. We have some activities that take over 60 seconds to load using the api.

Comments
----------------------------------------
I have a pretty good idea what I need to do to sort out the performance issue but given the state of the PR queue I'm going to leave it at this very minor cleanup & removing the better in most cases worse in some change in https://github.com/civicrm/civicrm-core/pull/12845 - I suspect this PR might take a couple of rounds with Jenkins anyway given the change I made to the activityCreate helper in the test suite
