### PR TITLE
Add span to amount label in Confirm.tpl

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -70,7 +70,7 @@
                     <strong> -------------------------------------------</strong><br />
                     {ts}Total{/ts}: <strong>{$amount+$minimum_fee|crmMoney}</strong><br />
                 {elseif $amount }
-                    {ts}Amount{/ts}: <strong>{$amount|crmMoney} {if $amount_level } &ndash; {$amount_level} {/if}</strong>
+                    {ts}Amount{/ts}: <strong>{$amount|crmMoney} {if $amount_level }<span class='crm-price-amount-label'> &ndash; {$amount_level}</span>{/if}</strong>
                 {else}
                     {$membership_name} {ts}Membership{/ts}: <strong>{$minimum_fee|crmMoney}</strong>
                 {/if}
@@ -79,7 +79,7 @@
                   {ts 1=$taxTerm}Total %1 Amount{/ts}: <strong>{$totalTaxAmount|crmMoney} </strong><br />
                 {/if}
 		{if $amount}
-                    {if $installments}{ts}Installment Amount{/ts}{else}{ts}Total Amount{/ts}{/if}: <strong>{$amount|crmMoney}{if $amount_level } &ndash; {$amount_level}{/if}</strong>
+                    {if $installments}{ts}Installment Amount{/ts}{else}{ts}Total Amount{/ts}{/if}: <strong>{$amount|crmMoney}{if $amount_level }<span class='crm-price-amount-label'> &ndash; {$amount_level}</span>{/if}</strong>
                 {else}
                     {$membership_name} {ts}Membership{/ts}: <strong>{$minimum_fee|crmMoney}</strong>
                 {/if}


### PR DESCRIPTION
Add span to amount label.

Overview
----------------------------------------
Add span tag to amount label.

Before
----------------------------------------
Amount and label are in same div which doesn't allow manipulating label e.g. hiding.

After
----------------------------------------
Label has its own span within the div.

Technical Details
----------------------------------------


Comments
----------------------------------------

