### PR TITLE
dev/core#391 - Fix saving tags in profile

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2032,8 +2032,10 @@ ORDER BY civicrm_email.is_primary DESC";
       CRM_Contact_BAO_GroupContact::create($params['group'], $contactID, $visibility, $method);
     }
 
-    if (!empty($fields['tag'])) {
-      CRM_Core_BAO_EntityTag::create($params['tag'], 'civicrm_contact', $contactID);
+    if (!empty($fields['tag']) && array_key_exists('tag', $params)) {
+      // Convert comma separated form values from select2 v3
+      $tags = is_array($params['tag']) ? $params['tag'] : array_fill_keys(array_filter(explode(',', $params['tag'])), 1);
+      CRM_Core_BAO_EntityTag::create($tags, 'civicrm_contact', $contactID);
     }
 
     //to add profile in default group


### PR DESCRIPTION
Overview
-----
There was a regression in profile forms which broke saving tags. I'm not sure exactly which version, probably the early 5.x series.

Before
----
Saving a profile in "edit mode" containing _Tag(s)_ field **deletes all tags from a contact**.

After
---
Tags save correctly.

Comments
----
Some form inputs submit values as an array. Select2 v3 is an oddball in that regard. To be safe I changed the function to accept either.