### PR TITLE
dev/core#281 Fix invoice number in message template

### DIFF
--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -211,7 +211,7 @@
                 <tr>
                   <td colspan = "2"></td>
                   <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Invoice Number: {/ts}</font></td>
-                  <td><font size = "1" align = "right">{$invoice_id}</font></td>
+                  <td><font size = "1" align = "right">{$invoice_number}</font></td>
                 </tr>
                 <tr><td colspan = "5"style = "color:#F5F5F5;"><hr></hr></td></tr>
                 {if $is_pay_later == 1}


### PR DESCRIPTION
shift upgrade to 5.7.alpha1 and Get passing unit tests where template didn't exist before 4.6.alpha1

Overview
----------------------------------------
This is a reviewers' commit of https://github.com/civicrm/civicrm-core/pull/12572 to bring it up to 5.7.alpha1 and to get it passing unit tests

Before
----------------------------------------
Wrong invoice id used in template

After
----------------------------------------
Correct invoice id used in message template

ping @eileenmcnaughton @yashodha
