### PR TITLE
Fix missing amount in soft credit mode

### DIFF
--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -527,6 +527,31 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the amount column is populated on soft credit details.
+   */
+  public function testContributionDetailSoftCreditsOnly() {
+    $contactID = $this->individualCreate();
+    $contactID2 = $this->individualCreate();
+    $this->contributionCreate(['contact_id' => $contactID, 'api.ContributionSoft.create' => ['amount' => 5, 'contact_id' => $contactID2]]);
+    $template = 'contribute/detail';
+    $rows = $this->callAPISuccess('report_template', 'getrows', array(
+      'report_id' => $template,
+      'contribution_or_soft_value' => 'soft_credits_only',
+      'fields' => [
+        'sort_name' => '1',
+        'email' => '1',
+        'financial_type_id' => '1',
+        'receive_date' => '1',
+        'total_amount' => '1',
+      ],
+      'options' => array('metadata' => ['sql', 'labels']),
+    ));
+    foreach (array_keys($rows['metadata']['labels']) as $header) {
+      $this->assertTrue(!empty($rows['values'][0][$header]));
+    }
+  }
+
+  /**
    * Test the group filter works on the various reports.
    *
    * @dataProvider getMembershipAndContributionReportTemplatesForGroupTests


### PR DESCRIPTION
Overview
----------------------------------------
Fix missing non-display of soft credit amount in detail report

Before
----------------------------------------
Field empty, untested

After
----------------------------------------
Field populated, test added.

Technical Details
----------------------------------------
The contribution detail report is fundamentally badly designed in how it melds the soft credits with the contribution details & although we have now brought in under unit tests we are still dealing with whack-a-mole on it (& have been for many many many months). We are adding unit tests now as we fix these things.

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/386

@twomice @lcdservices can you test?
