### PR TITLE
Fix default value of `civicrm_option_group.is_locked` in DB schema

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.5.3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.5.3.mysql.tpl
@@ -1,0 +1,2 @@
+#fix typo when setting default in https://github.com/civicrm/civicrm-core/pull/12410
+ALTER TABLE civicrm_option_group MODIFY COLUMN  is_locked TINYINT(4) NOT NULL DEFAULT 0 COMMENT 'A lock to remove the ability to add new options via the UI.';


### PR DESCRIPTION
Overview
----------------------------------------
The 5.5 update set civicrm_option_group.is_locked & is_reserved to have a db defaults but the upgrade script was incorrect on is_locked

Before
----------------------------------------
Newly created option groups (e.g for custom fields) are set to is_locked

After
----------------------------------------
Newly created option groups (e.g for custom fields) are not set to is_locked

Technical Details
----------------------------------------
The default for new instals was correct

Comments
----------------------------------------
@seamuslee001 
