### PR TITLE
Export - small cleanup

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -605,7 +605,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       // In order to be able to write a unit test against this function we need to suppress
       // the csv writing. In future hopefully the csv writing & the main processing will be in separate functions.
       if (empty($exportParams['suppress_csv_for_testing'])) {
-        self::writeCSVFromTable($exportTempTable, $headerRows, $sqlColumns, $exportMode);
+        self::writeCSVFromTable($exportTempTable, $headerRows, $sqlColumns, $processor);
       }
       else {
         // return tableName sqlColumns headerRows in test context
@@ -1220,11 +1220,10 @@ GROUP BY civicrm_primary_id ";
    * @param $exportTempTable
    * @param $headerRows
    * @param $sqlColumns
-   * @param $exportMode
-   * @param null $saveFile
-   * @param string $batchItems
+   * @param \CRM_Export_BAO_ExportProcessor $processor
    */
-  public static function writeCSVFromTable($exportTempTable, $headerRows, $sqlColumns, $exportMode, $saveFile = NULL, $batchItems = '') {
+  public static function writeCSVFromTable($exportTempTable, $headerRows, $sqlColumns, $processor) {
+    $exportMode = $processor->getExportMode();
     $writeHeader = TRUE;
     $offset = 0;
     $limit = self::EXPORT_ROW_COUNT;
@@ -1256,16 +1255,12 @@ LIMIT $offset, $limit
       else {
         $getExportFileName = self::getExportFileName('csv', $exportMode);
       }
-      $csvRows = CRM_Core_Report_Excel::writeCSVFile($getExportFileName,
+      CRM_Core_Report_Excel::writeCSVFile($getExportFileName,
         $headerRows,
         $componentDetails,
         NULL,
-        $writeHeader,
-        $saveFile);
-
-      if ($saveFile && !empty($csvRows)) {
-        $batchItems .= $csvRows;
-      }
+        $writeHeader
+      );
 
       $writeHeader = FALSE;
       $offset += $limit;

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -625,45 +625,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
   }
 
   /**
-   * Name of the export file based on mode.
-   *
-   * @param string $output
-   *   Type of output.
-   * @param int $mode
-   *   Export mode.
-   *
-   * @return string
-   *   name of the file
-   */
-  public static function getExportFileName($output = 'csv', $mode = CRM_Export_Form_Select::CONTACT_EXPORT) {
-    switch ($mode) {
-      case CRM_Export_Form_Select::CONTACT_EXPORT:
-        return ts('CiviCRM Contact Search');
-
-      case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
-        return ts('CiviCRM Contribution Search');
-
-      case CRM_Export_Form_Select::MEMBER_EXPORT:
-        return ts('CiviCRM Member Search');
-
-      case CRM_Export_Form_Select::EVENT_EXPORT:
-        return ts('CiviCRM Participant Search');
-
-      case CRM_Export_Form_Select::PLEDGE_EXPORT:
-        return ts('CiviCRM Pledge Search');
-
-      case CRM_Export_Form_Select::CASE_EXPORT:
-        return ts('CiviCRM Case Search');
-
-      case CRM_Export_Form_Select::GRANT_EXPORT:
-        return ts('CiviCRM Grant Search');
-
-      case CRM_Export_Form_Select::ACTIVITY_EXPORT:
-        return ts('CiviCRM Activity Search');
-    }
-  }
-
-  /**
    * Handle import error file creation.
    */
   public static function invoke() {
@@ -1249,13 +1210,7 @@ LIMIT $offset, $limit
         }
         $componentDetails[] = $row;
       }
-      if ($exportMode == 'financial') {
-        $getExportFileName = 'CiviCRM Contribution Search';
-      }
-      else {
-        $getExportFileName = self::getExportFileName('csv', $exportMode);
-      }
-      CRM_Core_Report_Excel::writeCSVFile($getExportFileName,
+      CRM_Core_Report_Excel::writeCSVFile($processor->getExportFileName(),
         $headerRows,
         $componentDetails,
         NULL,

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -749,7 +749,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       $rows[] = $row;
     }
 
-    CRM_Core_Report_Excel::writeCSVFile(self::getExportFileName(), $header, $rows);
+    CRM_Core_Report_Excel::writeCSVFile(ts('CiviCRM Contact Search'), $header, $rows);
     CRM_Utils_System::civiExit();
   }
 

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -302,6 +302,45 @@ class CRM_Export_BAO_ExportProcessor {
   }
 
   /**
+   * Get the name for the export file.
+   *
+   * @return string
+   */
+  public function getExportFileName() {
+    switch ($this->getExportMode()) {
+      case CRM_Export_Form_Select::CONTACT_EXPORT:
+        return ts('CiviCRM Contact Search');
+
+      case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
+        return ts('CiviCRM Contribution Search');
+
+      case CRM_Export_Form_Select::MEMBER_EXPORT:
+        return ts('CiviCRM Member Search');
+
+      case CRM_Export_Form_Select::EVENT_EXPORT:
+        return ts('CiviCRM Participant Search');
+
+      case CRM_Export_Form_Select::PLEDGE_EXPORT:
+        return ts('CiviCRM Pledge Search');
+
+      case CRM_Export_Form_Select::CASE_EXPORT:
+        return ts('CiviCRM Case Search');
+
+      case CRM_Export_Form_Select::GRANT_EXPORT:
+        return ts('CiviCRM Grant Search');
+
+      case CRM_Export_Form_Select::ACTIVITY_EXPORT:
+        return ts('CiviCRM Activity Search');
+
+      default:
+        // Legacy code suggests the value could be 'financial' - ie. something
+        // other than what should be accepted. However, I suspect that this line is
+        // never hit.
+        return ts('CiviCRM Search');
+    }
+  }
+
+  /**
    * @param $params
    * @param $order
    * @param $returnProperties


### PR DESCRIPTION
Overview
----------------------------------------
Minor tidy up on export

Before
----------------------------------------
parameters $saveFile  & $batchItems are passed in but never set in calling functions. Export mode passed in

After
----------------------------------------
unneeded params not passed in. processor object passed in instead of exportMode. This is part of a bigger picture effort to move processing off to that object rather than passing around parameters

Technical Details
----------------------------------------
getExportFileName appears to be called from 2 places. One is on the file where it always passed no params & gets the same result so this is now hard-coded. The second is moved to the ExportProcessor class, with some handling for the possibility that mode might be invalid - but I think that is never true.

Comments
----------------------------------------
Follow up on https://github.com/civicrm/civicrm-core/pull/12586
