### PR TITLE
Freeze custom data elements when viewing an entity

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1639,6 +1639,9 @@ ORDER BY civicrm_custom_group.weight,
         $fieldId = $field['id'];
         $elementName = $field['element_name'];
         CRM_Core_BAO_CustomField::addQuickFormElement($form, $elementName, $fieldId, $required);
+        if ($form->getAction() == CRM_Core_Action::VIEW) {
+          $form->getElement($elementName)->freeze();
+        }
       }
     }
   }

--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -48,6 +48,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     $this->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive');
     $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive');
     $this->_onlySubtype = CRM_Utils_Request::retrieve('onlySubtype', 'Boolean');
+    $this->_action = CRM_Utils_Request::retrieve('action', 'Alphanumeric');
     $this->assign('cdType', FALSE);
     $this->assign('cgCount', $this->_groupCount);
 

--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -126,8 +126,10 @@ class CRM_Utils_Request {
     }
 
     // minor hack for action
-    if ($name == 'action' && is_string($value)) {
-      $value = CRM_Core_Action::resolve($value);
+    if ($name == 'action') {
+      if (!is_numeric($value) && is_string($value)) {
+        $value = CRM_Core_Action::resolve($value);
+      }
     }
 
     if (isset($value) && $store) {

--- a/templates/CRM/common/customData.tpl
+++ b/templates/CRM/common/customData.tpl
@@ -61,6 +61,9 @@
       {if $qfKey}
         dataUrl += '&qf=' + '{$qfKey}';
       {/if}
+      {if $action}
+      dataUrl += '&action=' + '{$action}';
+      {/if}
       {literal}
 
       if (!cgCount) {


### PR DESCRIPTION
Overview
----------------------------------------
When viewing an entity which has custom data (and loads it via AJAX) it should not be editable.

Before
----------------------------------------
Custom data is editable (but not saved) when viewing:
![localhost_8000_civicrm_admin_reltype_action view id 1 reset 1 1](https://user-images.githubusercontent.com/2052161/46009666-2d389b00-c0b8-11e8-869f-e2b034ebfce1.png)


After
----------------------------------------
Custom data is not editable when viewing:
![localhost_8000_civicrm_admin_reltype_action view id 1 reset 1](https://user-images.githubusercontent.com/2052161/46009635-15f9ad80-c0b8-11e8-899d-f86ced233b47.png)

Technical Details
----------------------------------------
Custom data is loaded via AJAX, but the AJAX form does not know what action is being performed.  We add the action via the URL on the template and then use that action to freeze the elements if appropriate.

Comments
----------------------------------------
In this case we are seeing the issue when using the "RelationshipType" form and have the nz.co.fuzion.relatedpermissions extension enabled (which adds custom data to the "RelationshipType" entity.
@eileenmcnaughton This relates to entityform code that we've recently added.  It's not a regression I don't think as it's around new "functionality" to view/edit custom data for any entity but it isn't currently working as it should, and I think this fix sorts that.