### PR TITLE
Added missing field name in custom-field deletion dialog

### DIFF
--- a/CRM/Custom/Form/DeleteField.php
+++ b/CRM/Custom/Form/DeleteField.php
@@ -66,7 +66,7 @@ class CRM_Custom_Form_DeleteField extends CRM_Core_Form {
     CRM_Core_BAO_CustomField::retrieve($params, $defaults);
 
     $this->_title = CRM_Utils_Array::value('label', $defaults);
-
+    $this->assign('title', $this->_title);
     CRM_Utils_System::setTitle(ts('Delete %1', array(1 => $this->_title)));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The dialog that pops up when a custom field is deleted, does not show the name of the field to be deleted.

Before
----------------------------------------
_The name of the field in the deletion dialog box was missing._
![missing custom-field name in deletion dialog](https://user-images.githubusercontent.com/43573448/46013195-72ae9580-c0c3-11e8-822e-a69d184b9b8c.png)


After
----------------------------------------
_The name of the field in the deletion dialog box is now visible._
![present custom-field name in deletion dialog](https://user-images.githubusercontent.com/43573448/46013607-b950bf80-c0c4-11e8-963b-71faa3fb3e3d.PNG)
