### PR TITLE
dev/core#410 Ensure that Email related fields in Scheduled Reminders …

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -319,15 +319,22 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $errors['entity'] = ts('Please select appropriate value');
     }
 
+    $mode = CRM_Utils_Array::value('mode', $fields, FALSE);
     if (!empty($fields['is_active']) &&
-      CRM_Utils_System::isNull($fields['subject'])
+      CRM_Utils_System::isNull($fields['subject']) && (!$mode || $mode != 'SMS')
     ) {
       $errors['subject'] = ts('Subject is a required field.');
     }
     if (!empty($fields['is_active']) &&
-      CRM_Utils_System::isNull(trim(strip_tags($fields['html_message'])))
+      CRM_Utils_System::isNull(trim(strip_tags($fields['html_message']))) && (!$mode || $mode != 'SMS')
     ) {
       $errors['html_message'] = ts('The HTML message is a required field.');
+    }
+
+    if (!empty($mode) && ($mode == 'SMS' || $mode == 'User_Preference') && !empty($fields['is_active']) &&
+     CRM_Utils_System::isNull(trim(strip_tags($fields['sms_text_message'])))
+    ) {
+      $errors['sms_text_message'] = ts('The SMS message is a required field.');
     }
 
     if (empty($self->getContext()) && CRM_Utils_System::isNull(CRM_Utils_Array::value(1, $fields['entity']))) {
@@ -339,7 +346,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
         $errors['absolute_date'] = ts('Absolute date cannot be earlier than the current time.');
       }
     }
-    if (!CRM_Utils_Rule::email($fields['from_email'])) {
+    if (!CRM_Utils_Rule::email($fields['from_email']) && (!$mode || $mode != 'SMS')) {
       $errors['from_email'] = ts('Please enter a valid email address.');
     }
     $recipientKind = array(


### PR DESCRIPTION
…are not required when creating an SMS reminder and ensure that SMS Text Message field is required when creating an SMS reminder

Overview
----------------------------------------
Fields are wrongly marked as required when generating an SMS reminder and some fields not marked as required

Before
----------------------------------------
Difficulty creating SMS reminder

After
----------------------------------------
Straight forward creating of SMS reminder
