### PR TITLE
dev/core#411 - Default currency shown on View participant and contrib…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4115,10 +4115,11 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     }
 
     $paymentBalance = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($id, $entity, FALSE, $total);
-    $contribution = civicrm_api3('Contribution', 'getsingle', array('id' => $contributionId, 'return' => array('is_pay_later', 'contribution_status_id', 'financial_type_id')));
+    $contribution = civicrm_api3('Contribution', 'getsingle', array('id' => $contributionId, 'return' => array('currency', 'is_pay_later', 'contribution_status_id', 'financial_type_id')));
 
     $info['payLater'] = $contribution['is_pay_later'];
     $info['contribution_status'] = $contribution['contribution_status'];
+    $info['currency'] = $contribution['currency'];
 
     $financialTypeId = $contribution['financial_type_id'];
     $feeFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($financialTypeId, 'Expense Account is');

--- a/templates/CRM/Contribute/Page/PaymentInfo.tpl
+++ b/templates/CRM/Contribute/Page/PaymentInfo.tpl
@@ -61,10 +61,10 @@ CRM.$(function($) {
     <th class="right">{ts}Balance{/ts}</th>
   </tr>
   <tr>
-    <td>{$paymentInfo.total|crmMoney}</td>
+    <td>{$paymentInfo.total|crmMoney:$paymentInfo.currency}</td>
     <td class='right'>
       {if $paymentInfo.paid > 0}
-        {$paymentInfo.paid|crmMoney}
+        {$paymentInfo.paid|crmMoney:$paymentInfo.currency}
         {if !$hideButtonLinks}
           <br/>
           <a class="crm-hover-button action-item crm-popup medium-popup" href='{crmURL p="civicrm/payment" q="view=transaction&cid=`$cid`&id=`$paymentInfo.id`&component=`$paymentInfo.component`&action=browse"}'>
@@ -74,7 +74,7 @@ CRM.$(function($) {
         {/if}
       {/if}
     </td>
-    <td class="right" id="payment-info-balance" data-balance="{$paymentInfo.balance}">{$paymentInfo.balance|crmMoney}</td>
+    <td class="right" id="payment-info-balance" data-balance="{$paymentInfo.balance}">{$paymentInfo.balance|crmMoney:$paymentInfo.currency}</td>
   </tr>
 </table>
 {if $paymentInfo.balance and !$paymentInfo.payLater && !$hideButtonLinks}

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -25,6 +25,10 @@
 *}
 
 {* Displays contribution/event fees when price set is used. *}
+{if !$currency && $fee_currency}
+  {assign var=currency value="$fee_currency"}
+{/if}
+
 {foreach from=$lineItem item=value key=priceset}
   {if $value neq 'skip'}
     {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
@@ -68,23 +72,23 @@
           {/if}
           {if $context NEQ "Membership"}
             <td class="right">{$line.qty}</td>
-            <td class="right">{$line.unit_price|crmMoney}</td>
+            <td class="right">{$line.unit_price|crmMoney:$currency}</td>
     {else}
-            <td class="right">{$line.line_total|crmMoney}</td>
+            <td class="right">{$line.line_total|crmMoney:$currency}</td>
           {/if}
     {if !$getTaxDetails && $context NEQ "Membership"}
-      <td class="right">{$line.line_total|crmMoney}</td>
+      <td class="right">{$line.line_total|crmMoney:$currency}</td>
     {/if}
     {if $getTaxDetails}
-      <td class="right">{$line.line_total|crmMoney}</td>
+      <td class="right">{$line.line_total|crmMoney:$currency}</td>
       {if $line.tax_rate != "" || $line.tax_amount != ""}
         <td class="right">{$taxTerm} ({$line.tax_rate}%)</td>
-        <td class="right">{$line.tax_amount|crmMoney}</td>
+        <td class="right">{$line.tax_amount|crmMoney:$currency}</td>
       {else}
         <td></td>
         <td></td>
       {/if}
-      <td class="right">{$line.line_total+$line.tax_amount|crmMoney}</td>
+      <td class="right">{$line.line_total+$line.tax_amount|crmMoney:$currency}</td>
     {/if}
           {if $pricesetFieldsCount}
             <td class="right">{$line.participant_count}</td>
@@ -98,13 +102,13 @@
 <div class="crm-section no-label total_amount-section">
   <div class="content bold">
     {if $getTaxDetails && $totalTaxAmount}
-      {ts 1=$taxTerm}Total %1 Amount{/ts}: {$totalTaxAmount|crmMoney}<br />
+      {ts 1=$taxTerm}Total %1 Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}<br />
     {/if}
     {if $context EQ "Contribution"}
       {ts}Contribution Total{/ts}:
     {elseif $context EQ "Event"}
       {if $totalTaxAmount}
-        {ts}Event SubTotal: {$totalAmount-$totalTaxAmount|crmMoney}{/ts}<br />
+        {ts}Event SubTotal: {$totalAmount-$totalTaxAmount|crmMoney:$currency}{/ts}<br />
       {/if}
       {ts}Event Total{/ts}:
     {elseif $context EQ "Membership"}
@@ -112,7 +116,7 @@
     {else}
       {ts}Total Amount{/ts}:
     {/if}
-    {$totalAmount|crmMoney}
+    {$totalAmount|crmMoney:$currency}
   </div>
   <div class="clear"></div>
   <div class="content bold">


### PR DESCRIPTION
…ution page if payment is made with different currency

Overview
----------------------------------------
Default currency shown on View participant and contribution page if payment is made with different currency

Before
----------------------------------------
If payment is made with a non-default currency, the view participant and the contribution page still lists the payment with USD amount.

![image](https://user-images.githubusercontent.com/5929648/46129465-7160a280-c254-11e8-952c-7edf36109169.png)

Event Participant -

![image](https://user-images.githubusercontent.com/5929648/46129556-bc7ab580-c254-11e8-80f8-6749c46cba08.png)


After
----------------------------------------
Fixed -

![image](https://user-images.githubusercontent.com/5929648/46129599-d1efdf80-c254-11e8-9345-24e3a5b8cbaa.png)


Technical Details
----------------------------------------
The payment is recorded in correct format. It is just the display that needs to be fixed.

Comments
----------------------------------------
Gitlab ref - https://lab.civicrm.org/dev/core/issues/411
