### PR TITLE
(DX) Civi::contactSettings - Add a facade for working with the logged-in user's settings

### DIFF
--- a/CRM/Activity/Form/ActivityFilter.php
+++ b/CRM/Activity/Form/ActivityFilter.php
@@ -67,10 +67,8 @@ class CRM_Activity_Form_ActivityFilter extends CRM_Core_Form {
   public function setDefaultValues() {
     // CRM-11761 retrieve user's activity filter preferences
     $defaults = array();
-    if (Civi::settings()->get('preserve_activity_tab_filter') && ($userID = CRM_Core_Session::getLoggedInContactID())) {
-      $defaults = Civi::service('settings_manager')
-        ->getBagByContact(NULL, $userID)
-        ->get('activity_tab_filter');
+    if (Civi::settings()->get('preserve_activity_tab_filter') && (CRM_Core_Session::getLoggedInContactID())) {
+      $defaults = Civi::contactSettings()->get('activity_tab_filter');
     }
     // set Activity status 'Scheduled' by default only for dashlet
     elseif (strstr(CRM_Utils_Array::value('q', $_GET), 'dashlet')) {

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -453,11 +453,7 @@ class CRM_Activity_Page_AJAX {
         }
       }
 
-      /**
-       * @var \Civi\Core\SettingsBag $cSettings
-       */
-      $cSettings = Civi::service('settings_manager')->getBagByContact(CRM_Core_Config::domainID(), $userID);
-      $cSettings->set('activity_tab_filter', $activityFilter);
+      Civi::contactSettings()->set('activity_tab_filter', $activityFilter);
     }
     if (!empty($_GET['is_unit_test'])) {
       return array($activities, $activityFilter);

--- a/Civi.php
+++ b/Civi.php
@@ -109,6 +109,22 @@ class Civi {
   }
 
   /**
+   * Obtain the contact's personal settings.
+   *
+   * @param NULL|int $contactID
+   *   For the default/active user's contact, leave $domainID as NULL.
+   * @param NULL|int $domainID
+   *   For the default domain, leave $domainID as NULL.
+   * @return \Civi\Core\SettingsBag
+   * @throws CRM_Core_Exception
+   *   If there is no contact, then there's no SettingsBag, and we'll throw
+   *   an exception.
+   */
+  public static function contactSettings($contactID = NULL, $domainID = NULL) {
+    return \Civi\Core\Container::getBootService('settings_manager')->getBagByContact($domainID, $contactID);
+  }
+
+  /**
    * Obtain the domain settings.
    *
    * @param int|null $domainID

--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -171,12 +171,23 @@ class SettingsManager {
 
   /**
    * @param int|NULL $domainId
+   *   For the default domain, leave $domainID as NULL.
    * @param int|NULL $contactId
+   *   For the default/active user's contact, leave $domainID as NULL.
    * @return SettingsBag
+   * @throws \CRM_Core_Exception
+   *   If there is no contact, then there's no SettingsBag, and we'll throw
+   *   an exception.
    */
   public function getBagByContact($domainId, $contactId) {
     if ($domainId === NULL) {
       $domainId = \CRM_Core_Config::domainID();
+    }
+    if ($contactId === NULL) {
+      $contactId = \CRM_Core_Session::getLoggedInContactID();
+      if (!$contactId) {
+        throw new \CRM_Core_Exception("Cannot access settings subsystem - user or domain is unavailable");
+      }
     }
 
     $key = "$domainId:$contactId";

--- a/tests/phpunit/Civi/Core/CiviFacadeTest.php
+++ b/tests/phpunit/Civi/Core/CiviFacadeTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Civi\Core;
+
+class CiviFacadeTest extends \CiviUnitTestCase {
+
+  protected $origSetting;
+
+  protected function setUp() {
+    $this->origSetting = $GLOBALS['civicrm_setting'];
+
+    parent::setUp();
+    $this->useTransaction(TRUE);
+
+    $this->mandates = array();
+  }
+
+  public function tearDown() {
+    $GLOBALS['civicrm_setting'] = $this->origSetting;
+    parent::tearDown();
+  }
+
+  /**
+   * Get the the settingsbag for a logged-in user.
+   */
+  public function testContactSettings_loggedIn() {
+    $this->createLoggedInUser();
+    $settingsBag = \Civi::contactSettings();
+    $settingsBag->set('foo', 'bar');
+    $this->assertEquals('bar', $settingsBag->get('foo'));
+  }
+
+  /**
+   * Anonymous users don't have a SettingsBag.
+   * @expectedException \CRM_Core_Exception
+   */
+  public function testContactSettings_anonFail() {
+    \Civi::contactSettings();
+  }
+
+  /**
+   * Get the SettingsBag for a specific user.
+   */
+  public function testContactSettings_byId() {
+    $cid = \CRM_Core_DAO::singleValueQuery('SELECT MIN(id) FROM civicrm_contact');
+    $settingsBag = \Civi::contactSettings($cid);
+    $settingsBag->set('foo', 'bar');
+    $this->assertEquals('bar', $settingsBag->get('foo'));
+  }
+
+}


### PR DESCRIPTION
Before
------

To read/write a setting for the logged-in user, you need a snippet like this:

```php
$cid = CRM_Core_Session::getLoggedInContactID();
$myFilter = Civi::service('settings_manager')
  ->getBagByContact(NULL, $cid)
  ->get('activity_tab_filter');
```

After
-----

To read/write a setting for the logged-in user, you can use a snippet like this:

```php
$myFilter = Civi::contactSettings()->get('activity_tab_filter');
```

Technical Details
-----------------

* A convenience function like this is liable to be used in lazy circumstances where
  the developer is unlikely to check their conditions carefully. Therefore, the
  errors are reported as exceptions so that mistakes are easiliy revealed.
* This is technically a small contract change to `SettingsManager::getBagByContact()`
  because it now interprets `$contactId===NULL` as meaning "the logged-in user".
  However, I don't think NULL was a sensible value before, and this interface
  isn't widely known/used.
