### PR TITLE
Support contact_id param in api.settings.create

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -207,7 +207,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     }
 
     foreach ($domains as $domainID) {
-      Civi::settings($domainID)->add($fieldsToSet);
+      $settings = empty($params['contact_id']) ? Civi::settings($domainID) : Civi::contactSettings($params['contact_id'], $domainID);
+      $settings->add($fieldsToSet);
       $result[$domainID] = $fieldsToSet;
     }
 

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -300,6 +300,10 @@ function _civicrm_api3_setting_create_spec(&$params) {
     'title' => 'Setting Group',
     'description' => 'if you know the group defining it will make the api more efficient',
   );
+  $params['contact_id'] = array(
+    'title' => 'Contact ID',
+    'description' => 'Optional - if this setting applies to a specific contact',
+  );
 }
 
 /**


### PR DESCRIPTION
Followup to #12879 - support contact_id in `api3 create`. It is already supported by `get`.

