### PR TITLE
Fix invalid markup on extension page - remove dots from ids & classes

### DIFF
--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -20,7 +20,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         {if $localExtensionRows[$extKey]}
           {continue}
         {/if}
-        <tr id="addnew-row_{$row.id}" class="crm-extensions crm-extensions_{$row.id}">
+        <tr id="addnew-row_{$row.file}" class="crm-extensions crm-extensions_{$row.file}">
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>({$row.key})
           </td>
@@ -28,7 +28,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           <td class="crm-extensions-description">{$row.type|capitalize}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>
-        <tr class="hiddenElement" id="crm-extensions-details-addnew-{$row.id}">
+        <tr class="hiddenElement" id="crm-extensions-details-addnew-{$row.file}">
             <td>
                 {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row}
             </td>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -19,7 +19,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
       </thead>
       <tbody>
         {foreach from=$localExtensionRows key=extKey item=row}
-        <tr id="extension-{$row.id}" class="crm-entity crm-extension_{$row.id}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.upgradable} extension-upgradable{elseif $row.status eq 'installed'} extension-installed{/if}">
+        <tr id="extension-{$row.file}" class="crm-entity crm-extension-{$row.file}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.upgradable} extension-upgradable{elseif $row.status eq 'installed'} extension-installed{/if}">
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>({$row.key})
               {if $extAddNewEnabled && $remoteExtensionRows[$extKey] && $remoteExtensionRows[$extKey].is_upgradeable}
@@ -32,7 +32,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           <td class="crm-extensions-description">{$row.type|capitalize}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>
-        <tr class="hiddenElement" id="crm-extensions-details-{$row.id}">
+        <tr class="hiddenElement" id="crm-extensions-details-{$row.file}">
             <td>
                 {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row localExtensionRows=$localExtensionRows remoteExtensionRows=$remoteExtensionRows}
             </td>


### PR DESCRIPTION
Overview
-----
Fixes invalid html in the tpl.

Before
----
Rows in the table would have an id like "extension-org.civicrm.cividiscount" and a class like "crm-extension-org.civicrm.cividiscount"

After
-----
Rows have an id like "extension-cividiscount" and a class like "crm-extension-cividiscount".