### PR TITLE
Fix payment hangs when registering a user for a paid event without recording payment

### DIFF
--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -311,7 +311,7 @@ AND    co.id IN ( $contribIDs )";
    */
   public static function &getDetails($contributionIDs) {
     //Fix for empty param, avoiding payment hangs
-    $contributionIDs = (!empty($contributionIDs))? $contributionIDs : 'NULL' ;
+    $contributionIDs = (!empty($contributionIDs)) ? $contributionIDs : 'NULL';
     $query = "
 SELECT    c.id              as contribution_id,
           c.contact_id      as contact_id     ,

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -310,6 +310,8 @@ AND    co.id IN ( $contribIDs )";
    * @return array
    */
   public static function &getDetails($contributionIDs) {
+    //Fix for empty param, avoiding payment hangs
+    $contributionIDs = (!empty($contributionIDs))? $contributionIDs : 'NULL' ;
     $query = "
 SELECT    c.id              as contribution_id,
           c.contact_id      as contact_id     ,


### PR DESCRIPTION
Overview
----------------------------------------
Payment hangs when registering a user for a paid event without recording payment

Before
----------------------------------------

1.     Go to a contact record
2.     Click to the "Events" tab
3.     Click add event registration
4.     Select an event that takes payment, for example: "UKSG One-Day Conference: London"
5.     Set a participant role to anything
6.     Uncheck the "Record payment?" checkbox
7.     Save
8.     It'll hang forever, but actually create the registration. (To retest with the same contact and event, you'll have to refresh their contact page, go to the events tab, and delete the registration)


After
----------------------------------------

1.     Go to a contact record
2.     Click to the "Events" tab
3.     Click add event registration
4.     Select an event that takes payment, for example: "UKSG One-Day Conference: London"
5.     Set a participant role to anything
6.     Uncheck the "Record payment?" checkbox
7.     Save
8.     The event is saved and you can see your created event


Technical Details
----------------------------------------
The issue was due to a lack of validation in getDetails function when contributionIDs param is empty

Comments
----------------------------------------
https://mydropwizard.atlassian.net/browse/ROUND-696
