### PR TITLE
ensure all valid relationship types are available

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1469,7 +1469,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     $allRelationshipType = CRM_Core_PseudoConstant::relationshipType();
 
     foreach ($allRelationshipType as $key => $type) {
-      if ($type['contact_type_b'] == $targetContactType) {
+      if ($type['contact_type_b'] == $targetContactType || empty($type['contact_type_b'])) {
         $relationshipType[$key . '_a_b'] = $type['label_a_b'];
       }
     }

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
@@ -299,4 +299,22 @@ DELETE FROM civicrm_contact_type
     $this->relationshipTypeDelete($relType->id);
   }
 
+  public function testGetAnyToAnyRelTypes() {
+    // Create an any to any relationship.
+    $relTypeParams = array(
+      'name_a_b' => 'MookieIs',
+      'name_b_a' => 'MookieOf',
+      'contact_type_a' => '',
+      'contact_type_b' => '',
+    );
+    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
+    $indTypes = CRM_Contact_BAO_Relationship::getRelationType('Individual');
+    $orgTypes = CRM_Contact_BAO_Relationship::getRelationType('Organization');
+
+    $this->assertContains('MookieIs', $indTypes);
+    $this->assertContains('MookieIs', $orgTypes);
+    $this->relationshipTypeDelete($relType->id);
+
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
When adding relationships to search results, ensure all relationship types, including ones that apply to any contact, are available to choose.

https://lab.civicrm.org/dev/core/issues/418

Before
----------------------------------------
1. Create a relationship type in which Contact A is an individual and Contact B is any contact called Benefits Specialist.
![create-relationship](https://user-images.githubusercontent.com/4511942/46678889-ad302c00-cbb3-11e8-8c38-e6f83bae2dd5.png)
2. Conduct a search for individuals
3. Select a few individuals
4. From the actions drop down menu, select "Add relationship to Individual"
5. The resulting screen doesn't provide you with the option to choose the Benefits relationship.
![select-relationship-fails](https://user-images.githubusercontent.com/4511942/46678981-ecf71380-cbb3-11e8-980a-0e98cbd39590.png)

After
----------------------------------------
Now, relationship types that apply to any contact are always shown as an option when adding relationships to search results.

![relationship-after](https://user-images.githubusercontent.com/4511942/46679057-2039a280-cbb4-11e8-8dcf-ba71e21284fa.png)

