### PR TITLE
(NFC) Make datatables in Activities Relationship tab adjust to screen size

### DIFF
--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -45,7 +45,7 @@
       </table>
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
-  <table class="contact-activity-selector-{$context} crm-ajax-table">
+  <table class="contact-activity-selector-{$context} crm-ajax-table" style="width: 100%;">
     <thead>
     <tr>
       <th data-data="activity_type" class="crm-contact-activity-activity_type">{ts}Type{/ts}</th>

--- a/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
@@ -29,7 +29,7 @@
 <div class="crm-contact-relationship-{$context}">
   <table
     class="crm-contact-relationship-selector-{$context} crm-ajax-table"
-    data-ajax="{crmURL p="civicrm/ajax/contactrelationships" q="context=$context&cid=$contactId"}">
+    data-ajax="{crmURL p="civicrm/ajax/contactrelationships" q="context=$context&cid=$contactId"}" style="width: 100%;">
     <thead>
     <tr>
       <th data-data="relation" class='crm-contact-relationship-type'>{ts}Relationship{/ts}</th>


### PR DESCRIPTION
Overview
----------------------------------------
Cosmetic changes to make datatables in Activities and Relationship tab behave like the membership tab, i.e. the table adjust as much as possible to the size of the screen.

Before
----------------------------------------
In Activities tab, the size is properly initialized but when resizing the window, it keeps the original size:
![activity-before](https://user-images.githubusercontent.com/372004/46423106-c9d7ea00-c703-11e8-9391-0dd04da2ebd5.png)

In Relationship tab, it doesn't initialize properly and doesn't follow the window size:
![relationship-before](https://user-images.githubusercontent.com/372004/46423105-c9d7ea00-c703-11e8-940d-c935c067aa02.png)

After
----------------------------------------
In Activities tab:
![activity-after](https://user-images.githubusercontent.com/372004/46423256-2e934480-c704-11e8-8dcd-6ad9ababb04e.png)

In Relationships tab:
![relationship-after](https://user-images.githubusercontent.com/372004/46423255-2e934480-c704-11e8-9933-0e28c6277c64.png)


Technical Details
----------------------------------------
Added style="width: 100%; " as suggested in https://datatables.net/examples/basic_init/flexible_width.html

