### PR TITLE
dev/core#421 Fix issue where creating user driven message templates w…

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1486,8 +1486,8 @@ class CRM_Core_Permission {
 
     $permissions['message_template'] = array(
       'get' => array('access CiviCRM'),
-      'create' => array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates'),
-      'update' => array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates'),
+      'create' => array(array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates')),
+      'update' => array(array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates')),
     );
 
     $permissions['report_template']['update'] = 'save Report Criteria';

--- a/tests/phpunit/api/v3/MessageTemplateTest.php
+++ b/tests/phpunit/api/v3/MessageTemplateTest.php
@@ -55,6 +55,11 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
     );
   }
 
+  public function tearDown() {
+    parent::tearDown();
+    unset(CRM_Core_Config::singleton()->userPermissionClass->permissions);
+  }
+
   /**
    * Test create function succeeds.
    */
@@ -87,6 +92,32 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
       'id' => $entity['id'],
     ));
     $this->assertEquals(0, $checkDeleted['count']);
+  }
+
+  public function testPermissionChecks() {
+    $entity = $this->createTestEntity();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit user-driven message templates');
+    // Ensure that it cannot create a system message or update a system message tempalte given current permissions.
+    $this->callAPIFailure('MessageTemplate', 'create', ['id' => $entity['id'], 'msg_subject' => 'test msg permission subject', 'check_permissions' => TRUE]);
+    $testUserEntity = $entity['values'][$entity['id']];
+    unset($testUserEntity['id']);
+    $testUserEntity['msg_subject'] = 'Test user message template';
+    unset($testUserEntity['workflow_id']);
+    $testuserEntity['check_permissions'] = TRUE;
+    // ensure that it can create user templates;
+    $userEntity = $this->callAPISuccess('MessageTemplate', 'create', $testUserEntity);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit system workflow message templates');
+    // Now check that when its swapped around permissions that the correct reponses are detected.
+    $this->callAPIFailure('MessageTemplate', 'create', ['id' => $userEntity['id'], 'msg_subject' => 'User template updated by system message permission', 'check_permissions' => TRUE]);
+    $this->callAPISuccess('MessageTemplate', 'create', ['id' => $entity['id'], 'msg_subject' => 'test msg permission subject', 'check_permissions' => TRUE]);
+    // verify with all 3 permissions someone can do everything.
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit system workflow message templates', 'edit user-driven message templates');
+    $this->callAPISuccess('MessageTemplate', 'create', ['id' => $userEntity['id'], 'msg_subject' => 'User template updated by system message permission', 'check_permissions' => TRUE]);
+    $this->callAPISuccess('MessageTemplate', 'create', ['id' => $entity['id'], 'msg_subject' => 'test msg permission subject', 'check_permissions' => TRUE]);
+    // Verify that the backwards compatabiltiy still works i.e. having edit message templates allows for editing of both kinds of message templates
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit message templates');
+    $this->callAPISuccess('MessageTemplate', 'create', ['id' => $userEntity['id'], 'msg_subject' => 'User template updated by edit message permission', 'check_permissions' => TRUE]);
+    $this->callAPISuccess('MessageTemplate', 'create', ['id' => $entity['id'], 'msg_subject' => 'test msg permission subject backwards compatabilty', 'check_permissions' => TRUE]);
   }
 
 }


### PR DESCRIPTION
…as requireing the ssystem workflow message template permission as well

Overview
----------------------------------------
This fixes a regression from https://github.com/civicrm/civicrm-core/pull/11974 which mean that creating any message template including a user driven message template required all 3 permissions when the intent was clearly they should be split up

Before
----------------------------------------
Creating a user driven message template requires all 3 permissions to work

After
----------------------------------------
Now only requires the 2 specifically related permissions as per the quickform

Technical Details
----------------------------------------
This changes the permissions on the entity.action but adds in specific checks in the create action to do the targeted permissions checks needed

ping @eileenmcnaughton @mickadoo @johntwyman @ajesamson 