### PR TITLE
ensure search on survey results works properly

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -325,7 +325,7 @@ class CRM_Activity_BAO_Query {
       case 'activity_result':
         if (is_array($value)) {
           $safe = [];
-          foreach ($values as $id => $k) {
+          foreach ($value as $id => $k) {
             $safe[] = "'" . CRM_Utils_Type::escape($k, 'String') . "'";
           }
           $query->_where[$grouping][] = "civicrm_activity.result IN (" . implode(',', $safe) . ")";


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/422

Overview
----------------------------------------
When CiviCampaign is enabled, you can create a phone bank and ask a group of participants a series of questions.

As part of the Phone Bank configuration, you can specify a Result field, that indicates the over all result of the given interview (you can put results like: completed, no answer, left message, call back later, etc).

After completing a survey, you may want to use advanced search to find all contacts who have a given result (like finding everyone coded as call back later).

However, a search on "activity result" never turns up any records.

Before
----------------------------------------

When searching for activity result, you get no results and the following quill:

![survey-search-before](https://user-images.githubusercontent.com/4511942/46560064-516a5800-c8c0-11e8-8ea3-90acf267d581.png)

The description ('activity_result' or 'IN' or '' or '0' or '0') suggests that something is wrong.

After
----------------------------------------

The cause seems to be due to a simple typo. When fixed, the search description looks more reasonable and it shows up the right results:

![survey-search-after](https://user-images.githubusercontent.com/4511942/46560110-7c54ac00-c8c0-11e8-897a-c573948f5482.png)

Comments
----------------------------------------

This is such a simple and obvious typo that I'm hoping we can get this through without a unit test!