### PR TITLE
dev/core#423 MySQL 5.7 complains about 4.7.19 upgrade script

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.19.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.19.mysql.tpl
@@ -44,8 +44,9 @@ VALUES
 -- Some legacy sites have `0000-00-00 00:00:00` values in
 -- `civicrm_financial_trxn.trxn_date` which correspond to the same value in
 -- `civicrm_contribution.receive_date`
-UPDATE civicrm_financial_trxn SET trxn_date = NULL WHERE trxn_date = '0000-00-00 00:00:00';
-UPDATE civicrm_contribution SET receive_date = NULL WHERE receive_date = '0000-00-00 00:00:00';
+-- MySQL 5.7 may bork when comparing datetime columns to '0000-00-00 00:00:00' so cast the column to a CHAR(20) when comparing
+UPDATE civicrm_financial_trxn SET trxn_date = NULL WHERE CAST(trxn_date AS CHAR(20)) = '0000-00-00 00:00:00';
+UPDATE civicrm_contribution SET receive_date = NULL WHERE CAST(receive_date AS CHAR(20)) = '0000-00-00 00:00:00';
 
 -- CRM-20439 rename card_type to card_type_id of civicrm_financial_trxn table (IIDA-126)
 ALTER TABLE `civicrm_financial_trxn` CHANGE `card_type` `card_type_id` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'FK to accept_creditcard option group values';


### PR DESCRIPTION
MySQL 5.7 may bork when comparing datetime columns to '0000-00-00 00:00:00' so cast the column to a CHAR(20) when comparing

Overview
----------------------------------------
MySQL 5.7 complains "Incorrect datetime value: '0000-00-00 00:00:00' for column 'trxn_date'"

The error is raised by 2 lines of SQL in civicrm/CRM/Upgrade/Incremental/sql/4.7.19.mysql.tpl ...

UPDATE civicrm_financial_trxn SET trxn_date = NULL WHERE trxn_date = '0000-00-00 00:00:00';
UPDATE civicrm_contribution SET receive_date = NULL WHERE receive_date = '0000-00-00 00:00:00';

Before
----------------------------------------
MySQL 5.7 complains during the upgrade

After
----------------------------------------
Upgrade successful

Technical Details
----------------------------------------
See https://stackoverflow.com/questions/35565128/mysql-incorrect-datetime-value-0000-00-00-000000/37780259#37780259

Comments
----------------------------------------
I haven't tested this change on other versions of MySQL
