### PR TITLE
[NFC] Minor cleanup, return preferred parameter

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -96,7 +96,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $config = CRM_Core_Config::singleton();
       $recurring->currency = $config->defaultCurrency;
     }
-    $result = $recurring->save();
+    $recurring->save();
 
     if (!empty($params['id'])) {
       CRM_Utils_Hook::post('edit', 'ContributionRecur', $recurring->id, $recurring);
@@ -111,7 +111,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_contribution_recur', $recurring->id);
     }
 
-    return $result;
+    return $recurring;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor code clean up - no actual impact

Before
----------------------------------------
$result returned from Contribute_BAO_ContributionRecur::create

After
----------------------------------------
$recurring returned from Contribute_BAO_ContributionRecur::create

Technical Details
----------------------------------------
The result parameter is the same as $recurring (save()) returns $this. But
it's more correct to return $recurring than result as
a) it's defined as a Contribute_BAO_ContributionRecur object which is correct.
b) it's the object passed through hooks

Comments
----------------------------------------

