### PR TITLE
Move towards allowing sending 500 http errors back by switching civiE…

### DIFF
--- a/CRM/Badge/BAO/Badge.php
+++ b/CRM/Badge/BAO/Badge.php
@@ -73,7 +73,7 @@ class CRM_Badge_BAO_Badge {
     }
 
     $this->pdf->Output(CRM_Utils_String::munge($layoutInfo['title'], '_', 64) . '.pdf', 'D');
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
   /**

--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -351,7 +351,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
 
     //call function to create labels
     self::createLabel($rows, $fv['label_name']);
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
   /**

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -465,7 +465,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
 
     $form->postProcessHook();
 
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
   /**

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -156,7 +156,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     }
     if (!empty($html)) {
       // ie. we have only sent emails - lets no show a white screen
-      CRM_Utils_System::civiExit(1);
+      CRM_Utils_System::civiExit();
     }
   }
 

--- a/CRM/Event/Badge.php
+++ b/CRM/Event/Badge.php
@@ -88,7 +88,7 @@ class CRM_Event_Badge {
     $this->event = self::retrieveEvent($eventID);
     //call function to create labels
     self::createLabels($participants);
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
   /**

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -142,7 +142,7 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
     }
     //call function to create labels
     CRM_Contact_Form_Task_LabelCommon::createLabel($labelRows, $labelName);
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
 }

--- a/CRM/Member/Form/Task/PDFLetterCommon.php
+++ b/CRM/Member/Form/Task/PDFLetterCommon.php
@@ -37,7 +37,7 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
 
     $form->postProcessHook();
 
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
   /**

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -189,7 +189,7 @@ class CRM_Utils_PDF_Utils {
     $pdf->Close();
     $pdf_file = 'CiviLetter' . '.pdf';
     $pdf->Output($pdf_file, 'D');
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
   /**


### PR DESCRIPTION
…xit(1) to be just civiExit()

Overview
----------------------------------------
This moves us towards the path being advocated by @michaelmcandrew in this PR https://github.com/civicrm/civicrm-core/pull/11821 where we should be sending 500 http errors on error. 

Before
----------------------------------------
Exit 1 where it should be exit 0

ping @eileenmcnaughton @michaelmcandrew @davejenx 