### PR TITLE
Added a path to the drupal8 path candidates to find civicrm.config.php

### DIFF
--- a/CRM/Core/CodeGen/Config.php
+++ b/CRM/Core/CodeGen/Config.php
@@ -56,6 +56,7 @@ class CRM_Core_CodeGen_Config extends CRM_Core_CodeGen_BaseTask {
       case 'drupal8':
         $candidates[] = "../../modules/civicrm/civicrm.config.php.drupal";
         $candidates[] = "../../../modules/civicrm/civicrm.config.php.drupal";
+        $candidates[] = "../../../modules/civicrm-drupal/civicrm.config.php.drupal";
         break;
 
       case 'wordpress':


### PR DESCRIPTION
Overview
----------------------------------------
Change is a fix for a civibuild error. When civibuild is run with the type drupal8-clean it fails on the sql install script generation. The reason is that it cannot find civicrm.config.php file. This patch adds another location to search for this file.

Before
----------------------------------------
Civibuild create drup8 --type=drupal8-clean throws the following error:

    PHP Fatal error:  Uncaught Exception: Failed to locate template for civicrm.config.php in /home/klaas/buildkit/build/etuc/libraries/civicrm/CRM/Core/CodeGen/Config.php:29
    Stack trace:
    #0 /home/klaas/buildkit/build/drup8/libraries/civicrm/CRM/Core/CodeGen/Config.php(8): CRM_Core_CodeGen_Config->setupCms()
    #1 /home/klaas/buildkit/build/drup8/libraries/civicrm/CRM/Core/CodeGen/Main.php(98): CRM_Core_CodeGen_Config->run()
    #2 /home/klaas/buildkit/build/drup8/libraries/civicrm/xml/GenCode.php(45): CRM_Core_CodeGen_Main->main()
    #3 {main}
  thrown in /home/klaas/buildkit/build/drup8/libraries/civicrm/CRM/Core/CodeGen/Config.php on line 29

After
----------------------------------------
Civibuild generates to installation files and goes to the next step.

Technical Details
----------------------------------------
The search locations are extended not replaced.