### PR TITLE
Add `ext/` folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.bak
 .use-civicrm-setup
+/ext/
 backdrop/
 bower_components
 CRM/Case/xml/configuration


### PR DESCRIPTION
This folder is populated in various build processes (civibuild's
`drupal-demo`, `wp-demo`, etc; as well as `distmaker`), and sometimes
I like to use it for personal things. Moreover, there is no committed
content inside here.