### PR TITLE
GL-425: Log a message if CiviCRM thinks SSL is not enabled

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1191,6 +1191,8 @@ class CRM_Utils_System {
     ) {
       // ensure that SSL is enabled on a civicrm url (for cookie reasons etc)
       $url = "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+      // @see https://lab.civicrm.org/dev/core/issues/425 if you're seeing this message.
+      Civi::log()->warning('CiviCRM thinks site is not SSL, redirecting to {url}', ['url' => $url]);
       if (!self::checkURL($url, TRUE)) {
         if ($abort) {
           CRM_Core_Error::fatal('HTTPS is not set up on this machine');


### PR DESCRIPTION
Overview
----------------------------------------
The enableSSL setting doesn't reliably detect the presence of SSL (especially when behind SSL terminating proxies). This log message will allow people affected by this behaviour to more readily debug it, because CiviCRM will give them a clue to work with.

See https://lab.civicrm.org/dev/core/issues/425

Before
----------------------------------------
CiviCRM behind an SSL-terminating proxy may misdetect SSL and generate circular 302s to the current URL for any path below `civicrm/admin`.

After
----------------------------------------
CiviCRM will still do that until you disable "Force Secure URLs", but at least it'll put a clue in the debug log.

Technical Details
----------------------------------------
Only behaviour change should be addition of the warning message to log.

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/425 :grin: 