### PR TITLE
Ensure hard-coded date ranges are preserved in smart groups

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -124,20 +124,30 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
             continue;
           }
         }
+        // Check for a date range field, which might be a standard date
+        // range or a relative date.
         if (strpos($id, '_date_low') !== FALSE || strpos($id, '_date_high') !== FALSE) {
           $entityName = strstr($id, '_date', TRUE);
-          if (!empty($result['relative_dates']) && array_key_exists($entityName, $result['relative_dates'])) {
-            $result[$id] = NULL;
-            $result["{$entityName}_date_relative"] = $result['relative_dates'][$entityName];
-          }
-          elseif (!empty($specialDateFields[$id])) {
-            $entityName = strstr($specialDateFields[$id], '_date', TRUE);
-            $result[$id] = NULL;
-            $result["{$entityName}_relative"] = $result['relative_dates'][$entityName];
-          }
-          else {
-            $result[$id] = $value;
-            $result["{$entityName}_date_relative"] = 0;
+
+          // This is the default, for non relative dates. We will overwrite
+          // it if we determine this is a relative date.
+          $result[$id] = $value;
+          $result["{$entityName}_date_relative"] = 0;
+
+          if (!empty($result['relative_dates'])) {
+            if (array_key_exists($entityName, $result['relative_dates'])) {
+              // We have a match from a regular field.
+              $result[$id] = NULL;
+              $result["{$entityName}_date_relative"] = $result['relative_dates'][$entityName];
+            }
+            elseif (!empty($specialDateFields[$id])) {
+              // We may have a match on a special date field.
+              $entityName = strstr($specialDateFields[$id], '_date', TRUE);
+              if (array_key_exists($entityName, $result['relative_dates'])) {
+                $result[$id] = NULL;
+                $result["{$entityName}_relative"] = $result['relative_dates'][$entityName];
+              }
+            }
           }
         }
         else {

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -98,6 +98,52 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test if dates ranges are stored correctly
+   * in civicrm_saved_search table and are
+   * extracted properly.
+   */
+  public function testDateRange() {
+    $savedSearch = new CRM_Contact_BAO_SavedSearch();
+    $formValues = array(
+      'hidden_basic' => 1,
+      'group_search_selected' => 'group',
+      'component_mode' => 1,
+      'operator' => 'AND',
+      'privacy_operator' => 'OR',
+      'privacy_toggle' => 1,
+      'participant_register_date_low' => '01/01/2009',
+      'participant_register_date_high' => '01/01/2018',
+      'radio_ts' => 'ts_all',
+      'title' => 'bah bah bah',
+    );
+
+    $queryParams = array(
+      0 => array(
+        0 => 'participant_register_date_low',
+        1 => '=',
+        2 => '01/01/2009',
+        3 => 0,
+        4 => 0,
+      ),
+      1 => array(
+        0 => 'participant_register_date_high',
+        1 => '=',
+        2 => '01/01/2018',
+        3 => 0,
+        4 => 0,
+      ),
+    );
+
+    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
+    CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
+    $savedSearch->form_values = serialize($queryParams);
+    $savedSearch->save();
+
+    $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
+    $this->assertEquals('01/01/2009', $result['participant_register_date_low']);
+    $this->assertEquals('01/01/2018', $result['participant_register_date_high']);
+  }
+  /**
    * Test if relative dates are stored correctly
    * in civicrm_saved_search table.
    */


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/issues/396

Overview
----------------------------------------
Due to a regression introduced by https://github.com/civicrm/civicrm-core/pull/11486, smart groups based on manually entered date ranges fail to properly filter by the date ranges when executed.

Before
----------------------------------------
If you create a smart group based on a search using one of several specially identified date fields (including event participant registration date) and you manually specify a date range instead of selecting a pre-chosen range, then your smart group will be properly saved, but the date range will be ignored when the saved search is executed.

After
----------------------------------------
Smart groups based on manually selected date ranges properly select the right contacts based on the date ranges entered.


Technical Details
----------------------------------------

Prior to the fix, CiviCRM issued an undefined index error.

Comments
------------------------------------------
This is a reviewer's commit. I reviewed @jmcclelland patch & decided 
1) it works
2) the issue is on save rather than on load so groups created while this is broken will be incorrect. I think we should consider a 5.6.1 drop @seamuslee001 @totten - getting this into the rc as a first step