### PR TITLE
(dev/core#394) : Wildcards are ignored in some smart group criteria, when the smart group is directly generated for a mailing

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -681,7 +681,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     //create/update saved search record.
     $savedSearch = new CRM_Contact_BAO_SavedSearch();
     $savedSearch->id = $ssId;
-    $savedSearch->form_values = serialize($params['form_values']);
+    $savedSearch->form_values = serialize(CRM_Contact_BAO_Query::convertFormValues($params['form_values']));
     $savedSearch->mapping_id = $mappingId;
     $savedSearch->search_custom_id = CRM_Utils_Array::value('search_custom_id', $params);
     $savedSearch->save();

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -160,7 +160,9 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         ->param('#groupIDs', $groupIDs)
         ->execute();
       while ($groupDAO->fetch()) {
-        if ($groupDAO->cache_date == NULL) {
+        // hidden smart groups always have a cache date and there is no other way
+        //  we can rebuilt the contact list from UI so consider such smart group
+        if ($groupDAO->cache_date == NULL || $groupDAO->is_hidden) {
           CRM_Contact_BAO_GroupContactCache::load($groupDAO);
         }
         if ($groupType == 'Include') {

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -237,4 +237,41 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
     $testUpdate = CRM_Contact_BAO_Group::create($params2);
   }
 
+  /**
+   * Ensure that when hidden smart group is created, wildcard string value is not ignored
+   */
+  public function testHiddenSmartGroup() {
+    $customGroup = $this->customGroupCreate();
+    $fields = array(
+      'label' => 'testFld',
+      'data_type' => 'String',
+      'html_type' => 'Text',
+      'custom_group_id' => $customGroup['id'],
+    );
+    $customFieldID = CRM_Core_BAO_CustomField::create($fields)->id;
+
+    $contactID = $this->individualCreate(['custom_' . $customFieldID => 'abc']);
+
+    $hiddenSmartParams = [
+      'group_type' => ['2' => 1],
+      'form_values' => ['custom_' . $customFieldID => ['LIKE' => '%a%']],
+      'saved_search_id' => NULL,
+      'search_custom_id' => NULL,
+      'search_context' => 'advanced',
+    ];
+    list($smartGroupID, $savedSearchID) = CRM_Contact_BAO_Group::createHiddenSmartGroup($hiddenSmartParams);
+
+    $mailingID = $this->callAPISuccess('Mailing', 'create', [])['id'];
+    $this->callAPISuccess('MailingGroup', 'create', array(
+      'mailing_id' => $mailingID,
+      'group_type' => 'Include',
+      'entity_table' => 'civicrm_group',
+      'entity_id' => $smartGroupID,
+    ));
+
+    CRM_Mailing_BAO_Mailing::getRecipients($mailingID);
+    $recipients = $this->callAPISuccess('MailingRecipients', 'get', ['mailing_id' => $mailingID]);
+    $this->assertEquals(1, $recipients['count'], 'Check recipient count');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Create a text custom field used for Individual
2. Choose any contact and add custom field value say 'abc'
3. Go to Advance Search and search contact with criteria "custom field = '%a%'"
4. Select the contact and choose task 'Email - schedule/send via CiviMail'
5. Redirected to 'New Mailing' but with no recipient count 

Before
----------------------------------------
![screencast-before](https://user-images.githubusercontent.com/3735621/46668861-57777600-cbeb-11e8-9fc8-2898285711a1.gif)


After
----------------------------------------
![screencast-after](https://user-images.githubusercontent.com/3735621/46668921-7ece4300-cbeb-11e8-9ef3-676cbe49e312.gif)


Technical Details
----------------------------------------
As per the fix, we should first translate the formvalues in query format before saving the criteria for saved search which restores the operator and doesn't strip the wildcard which is essential, especially when such saved criteria are used by smart group. In addition, did a minor change to getRecipients() to ignore the cache_date of hidden smart groups for rebuilding its contact, as from UI there is no way we can rebuild recipients for such hidden smart group in other word cache_date is not updated.