### PR TITLE
Fix spelling error ("sript" vs "script")

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -265,7 +265,6 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
     return TRUE;
   }
 
-  
   /**
    * @inheritDoc
    */
@@ -608,7 +607,7 @@ AND    u.status = 1
     //need to get back for windows.
     $firstVar = array_shift($pathVars);
 
-    //lets remove script name to reduce one iteration.
+    // Remove the script name to remove an necessary iteration of the loop.
     array_pop($pathVars);
 
     // CRM-7429 -- do check for uppermost 'includes' dir, which would

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -265,6 +265,7 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
     return TRUE;
   }
 
+  
   /**
    * @inheritDoc
    */
@@ -607,7 +608,7 @@ AND    u.status = 1
     //need to get back for windows.
     $firstVar = array_shift($pathVars);
 
-    //lets remove sript name to reduce one iteration.
+    //lets remove script name to reduce one iteration.
     array_pop($pathVars);
 
     // CRM-7429 -- do check for uppermost 'includes' dir, which would


### PR DESCRIPTION
Overview
----------------------------------------
Fix spelling error in code comment

Before
----------------------------------------
Code comment spelled 'script' incorrectly

After
----------------------------------------
Code comment spells 'script' correctly

Technical Details
----------------------------------------
Code comment only

Comments
----------------------------------------
It has a 'c'
