### PR TITLE
Fix typo in hook that enables links to be added to a block

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -417,8 +417,15 @@ class CRM_Core_Block {
       $values[$key] = self::setShortCutValues($short);
     }
 
-    // call links hook to add user defined links
+    // Deprecated hook with typo.  Please don't use this!
     CRM_Utils_Hook::links('create.new.shorcuts',
+      NULL,
+      CRM_Core_DAO::$_nullObject,
+      $values
+    );
+
+    // Hook that enables extensions to add user-defined links
+    CRM_Utils_Hook::links('create.new.shortcuts',
       NULL,
       CRM_Core_DAO::$_nullObject,
       $values


### PR DESCRIPTION
Overview
----------------------------------------
The code that adds a hook to enable a link to be added to a block has a typo.  It says 'shorcuts' rather than 'shortcuts'.

Before
----------------------------------------
The hook option is 'create.new.shorcuts'.

After
----------------------------------------
The old hook 'create.new.shorcuts' is still present but deprecated.  A new hook 'create.new.shortcuts' has been added.

Technical Details
----------------------------------------
None.  If any extensions use the old option they will still work.

Comments
----------------------------------------
The documentation refers to the incorrect spelling and needs to be updated.  I will do this now.

https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/
