### PR TITLE
Fix payment hangs when registering a user for a paid event without recording payment

### DIFF
--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -305,11 +305,14 @@ AND    co.id IN ( $contribIDs )";
   }
 
   /**
-   * @param $contributionIDs
+   * @param string $contributionIDs
    *
    * @return array
    */
   public static function &getDetails($contributionIDs) {
+    if (empty($contributionIDs)) {
+      return [];
+    }
     $query = "
 SELECT    c.id              as contribution_id,
           c.contact_id      as contact_id     ,
@@ -326,7 +329,6 @@ WHERE     c.id IN ( $contributionIDs )";
     $dao = CRM_Core_DAO::executeQuery($query,
       CRM_Core_DAO::$_nullArray
     );
-    $rows = array();
 
     while ($dao->fetch()) {
       $rows[$dao->contribution_id]['component'] = $dao->participant_id ? 'event' : 'contribute';


### PR DESCRIPTION
Overview
----------------------------------------
Payment hangs when registering a user for a paid event without recording payment


Before
----------------------------------------

1.     Go to a contact record
2.     Click to the "Events" tab
3.     Click add event registration
4.     Select an event that takes payment, for example: "UKSG One-Day Conference: London"
5.     Set a participant role to anything
6.     Uncheck the "Record payment?" checkbox
7.     Save
8.     It'll hang forever, but actually create the registration. (To retest with the same contact and event, you'll have to refresh their contact page, go to the events tab, and delete the registration)


After
----------------------------------------

1.     Go to a contact record
2.     Click to the "Events" tab
3.     Click add event registration
4.     Select an event that takes payment, for example: "UKSG One-Day Conference: London"
5.     Set a participant role to anything
6.     Uncheck the "Record payment?" checkbox
7.     Save
8.     The event is saved and you can see your created event


Technical Details
----------------------------------------
The issue was due to a lack of validation in getDetails function when contributionIDs param is empty

Comments
------------------------------------------------
This is an alternative to https://github.com/civicrm/civicrm-core/pull/12888
I wasn't actually able to reproduce the issue but this solution, proposed by
Monish, seems safe & sensible