### PR TITLE
Fix for dev/core#428: Fatal error in Activity Details report when Sorting uses Section Header

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -1080,7 +1080,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
       $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($ifnulls, $sectionAliases);
 
       $query = $this->_select .
-        ", count(DISTINCT civicrm_activity_id) as ct from {$this->temporaryTables['activity_temp_table']} group by " .
+        ", count(DISTINCT civicrm_activity_id) as ct from {$this->temporaryTables['activity_temp_table']['name']} group by " .
         implode(", ", $sectionAliases);
 
       // initialize array of total counts


### PR DESCRIPTION
Overview
----------------------------------------
This PR corrects a bug in the Activity Details report, in which a fatal error is caused by setting "Section header" for a column under the "Sort" tab.

Before
----------------------------------------
In the Activity Details report, a fatal error is caused by setting "Section header" for a column under the "Sort" tab.

After
----------------------------------------
No more fatal error.

Technical Details
----------------------------------------
Currently, the activity Details report assumes the name of a temporary table is stored in $this->temporaryTables['activity_temp_table'], but that's really an array. The table name is actually stored in $this->temporaryTables['activity_temp_table']['name']. This PR fixes that.

Comments
----------------------------------------
(none)
