### PR TITLE
Dedupe ignores Phone-Work-Mobile field

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -276,7 +276,7 @@ class CRM_Dedupe_Finder {
     // the -digit to civicrm_address.location_type_id and -Primary to civicrm_address.is_primary
     foreach ($flat as $key => $value) {
       $matches = array();
-      if (preg_match('/(.*)-(Primary-[\d+])$|(.*)-(\d+|Primary)$/', $key, $matches)) {
+      if (preg_match('/(.*)-((\d+|Primary)-[\d+])$|(.*)-(\d+|Primary)$/', $key, $matches)) {
         $return = array_values(array_filter($matches));
         $flat[$return[1]] = $value;
         unset($flat[$key]);


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Dedupe_Finder uses a dedupe rule to find contacts who match the supplied fields (eg, when registering participants). This failed in the case when one of the supplied fields was a Phone.

Before
----------------------------------------
Register for an event where ...

- The dedupe rule includes a Phone to get a match

- The fields on the register page include a Phone that is not Primary (eg Work Mobile)

- The registration data should match an existing contact if the phone number is used in the dedupe rule

A new contact is created.

After
----------------------------------------
The participation is registered for the existing contact.

Technical Details
----------------------------------------
Modified CRM_Dedupe_Finder::formatParams() to use rules that include 'phone' fields. This was being blocked because profile fields named 'phone-N-N' were not being recognised as 'phone' fields. The regex that parses the field name recognised 'phone-Primary' and 'phone-Primary-2' and 'phone-2' as 'phone' fields. I extended the regex to recognise 'phone-6-2' as a 'phone' field.

Comments
----------------------------------------
This change may have side-effects for other fields such as address fields.


https://lab.civicrm.org/dev/core/issues/429