### PR TITLE
(NFC) Fix misleading comment for dupesInGroup()

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -170,7 +170,7 @@ class CRM_Dedupe_Finder {
    * @param int $rgid
    *   Rule group id.
    * @param int $gid
-   *   Contact group id (currently, works only with non-smart groups).
+   *   Contact group id.
    *
    * @param int $searchLimit
    *  Limit for the number of contacts to be used for comparison.


### PR DESCRIPTION
The function does also work with smart groups, so remove the comment that says otherwise.

I tested this on dmaster by creating two pairs of duplicates. I created a smart group which included one pair. I then ran the dedupe rule and filtered by the group. Only the pair of duplicates that was in the smart group appeared in the list of duplicates.

No functional change - just tidying up comments.