### PR TITLE
Fix isAjaxMode to also recognize angular ajax

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -794,7 +794,8 @@ class CRM_Core_Resources {
     ) {
       return TRUE;
     }
-    return strpos(CRM_Utils_System::getUrlPath(), 'civicrm/ajax') === 0;
+    $url = CRM_Utils_System::getUrlPath();
+    return (strpos($url, 'civicrm/ajax') === 0) || (strpos($url, 'civicrm/angular') === 0);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -339,6 +339,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
   public function ajaxModeData() {
     return array(
       array(array('q' => 'civicrm/ajax/foo'), TRUE),
+      array(array('q' => 'civicrm/angularprofiles/template'), TRUE),
       array(array('q' => 'civicrm/test/page'), FALSE),
       array(array('q' => 'civicrm/test/page', 'snippet' => 'json'), TRUE),
       array(array('q' => 'civicrm/test/page', 'snippet' => 'foo'), FALSE),


### PR DESCRIPTION
Overview
----
CRM_Core_Resources was not recognizing the angular template callback as ajax. 

Before
-----
Some scripts load twice

After
------
Scripts not meant to load during ajax, don't.
