### PR TITLE
dev/core#434: Check If 'absolute_date' Is Used In 'prepareRepetitionEndFilter' To Prevent SQL Error

### DIFF
--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -157,6 +157,9 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
     $query['casEntityIdField'] = 'e.id';
     $query['casContactTableAlias'] = NULL;
     $query['casDateField'] = str_replace('event_', 'r.', $schedule->start_action_date);
+    if (empty($query['casDateField']) && $schedule->absolute_date) {
+      $query['casDateField'] = $schedule->absolute_date;
+    }
 
     $query->join('r', 'INNER JOIN civicrm_event r ON e.event_id = r.id');
     if ($schedule->recipient_listing && $schedule->limit_to) {


### PR DESCRIPTION
Overview
----------------------------------------
When adding a scheduled reminder with an 'absolute_date' initially and then enabling 'Repeat'and adding conditions results in an SQL error when executed.

Before
----------------------------------------
SQL systax error because of empty datefield
Produces SQL with condition something like the following (notice empty value in DATE_ADD)
...AND ("20181219180831" <= DATE_ADD(, INTERVAL 9 day))

After
----------------------------------------
SQL is fixed by checking if datefield is empty and replacing it with absolute_date

Technical Details
----------------------------------------
A function in Civi\ActionSchedule\RecipientBuilder.php, 'prepareRepetitionEndFilter' expects a date field which would be empty when using an 'absolute_date'. This causes the SQL query to be constructed with an empty string inside thus creating a syntax error.
Edit:
Its more appropriate to handle this in CRM/Event/ActionMapping.php createQuery() method and make sure 'casDateField' param is not empty. PR updated.