### PR TITLE
dev/financial#33 Add in Hook postIPNProcess to allow Extensions to do c…

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1393,6 +1393,9 @@ abstract class CRM_Core_Payment {
       $extension_instance_found = TRUE;
     }
 
+    // Call IPN alterIPNData hook to allow for custom processing of IPN data.
+    $IPNParams = array_merge($_GET, $_REQUEST);
+    CRM_Utils_Hook::postIPNProcess($IPNParams);
     if (!$extension_instance_found) {
       $message = "No extension instances of the '%1' payment processor were found.<br />" .
         "%2 method is unsupported in legacy payment processors.";

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2473,4 +2473,17 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * ALlow Extensions to custom process IPN hook data such as sending Google Analyitcs information based on the IPN
+   * @param array $IPNData - Array of IPN Data
+   * @return mixed
+   */
+  public static function postIPNProcess(&$IPNData) {
+    return self::singleton()->invoke(array('IPNData'),
+      $IPNData, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_postIPNProcess'
+    );
+  }
+
 }


### PR DESCRIPTION
…ustom processing of the IPN Data

Overview
----------------------------------------
This adds in a hook alterIPNData which would allow extension authors the ability to do custom processing on IPNs as they come in

Before
----------------------------------------
No Hook on the IPN data

After
----------------------------------------
Hook exists, meaning custom processing such as sending google analytics information based on the IPN data can occur

ping @eileenmcnaughton @monishdeb @johntwyman
