### PR TITLE
do not strtolower() string values while building where clause for cus…

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -295,8 +295,6 @@ SELECT f.id, f.label, f.data_type,
         continue;
       }
 
-      $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
-
       foreach ($values as $tuple) {
         list($name, $op, $value, $grouping, $wildcard) = $tuple;
 
@@ -335,7 +333,7 @@ SELECT f.id, f.label, f.data_type,
               // fix $value here to escape sql injection attacks
               if (!is_array($value)) {
                 if ($field['data_type'] == 'String') {
-                  $value = CRM_Utils_Type::escape($strtolower($value), 'String');
+                  $value = CRM_Utils_Type::escape($value, 'String');
                 }
                 elseif ($value) {
                   $value = CRM_Utils_Type::escape($value, 'Integer');


### PR DESCRIPTION
…tom field queries

Overview
----------------------------------------
Querying the database via API by custom field values that contain uppercase strings returns no results when it should. Found for Alphanumeric fields with multi-select widgets, but could affect other types/widgets

For https://lab.civicrm.org/dev/core/issues/436

Before
----------------------------------------
Create a custom field, Alphanumeric, multi-select widget, setup at least one option value with an uppercase character. Hypothetical field has id of custom_21 .  Update one contact that uses that custom field and set the option to the one that has an uppercase character.

$apiParams = [
    'sequential' => 1,
   'custom_21' => 'Alabama',
];

$result = civicrm_api3('Contact', 'get', $apiParams);

Returns no results

After
----------------------------------------
API call returns results correctly

Technical Details
----------------------------------------
Fixes for REGEX searches included adding a BINARY option to the RLIKE operator in 
https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/Query.php#L5687
This makes the query case sensitve, so we can no longer strtolower() string values in where clauses.

