### PR TITLE
Correct inconsistent fileID reference

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1666,7 +1666,7 @@ SELECT id
       $value = 0;
     }
 
-    $fileId = NULL;
+    $fileID = NULL;
 
     if ($customFields[$customFieldId]['data_type'] == 'File') {
       if (empty($value)) {
@@ -1705,20 +1705,20 @@ SELECT $columnName
   FROM $tableName
  WHERE id = %1";
         $params = array(1 => array($customValueId, 'Integer'));
-        $fileId = CRM_Core_DAO::singleValueQuery($query, $params);
+        $fileID = CRM_Core_DAO::singleValueQuery($query, $params);
       }
 
       $fileDAO = new CRM_Core_DAO_File();
 
-      if ($fileId) {
-        $fileDAO->id = $fileId;
+      if ($fileID) {
+        $fileDAO->id = $fileID;
       }
 
       $fileDAO->uri = $filename;
       $fileDAO->mime_type = $mimeType;
       $fileDAO->upload_date = date('YmdHis');
       $fileDAO->save();
-      $fileId = $fileDAO->id;
+      $fileID = $fileDAO->id;
       $value = $filename;
     }
 
@@ -1746,7 +1746,7 @@ SELECT $columnName
       'custom_group_id' => $groupID,
       'table_name' => $tableName,
       'column_name' => $columnName,
-      'file_id' => $fileId,
+      'file_id' => $fileID,
       'is_multiple' => $customFields[$customFieldId]['is_multiple'],
     );
 


### PR DESCRIPTION
Overview
----------------------------------------
Correct inconsistent `$fileID` reference causing new File entity creation when updating a Contact's custom field of type File.

Before
----------------------------------------
Steps to reproduce:
1. Create a custom field of type File for Contacts entity.
2. Create a file through the API:
```
$file = civicrm_api3('File', 'create', [
  'document' => "An attachment.",
  'mime_type' => "text/plain",
  'uri' => "some_attachment.txt",
]);

// result
    ...
    "values": {
        "id": "80",
        "mime_type": "text/plain",
        ...

```
3. Update a Conctact's custom File field ( ie Attachment, `custom_13`) through the API passing the created `file_id` in step 1:
```
$contact = civicrm_api3('Contact', 'create', [
  'contact_type' => "Individual",
  'id' => 203,
  'custom_13' => 80,
]);

// result
    ...
    "values": [
            "contact_id": "203",
            "custom_13": "81", // file id 81, a new file has been created
            ...
```

After
----------------------------------------
The custom File (`custom_13`) is updated with the passed `file_id` as expected.

Technical Details
----------------------------------------
N/A


Comments
----------------------------------------
N/A
