### PR TITLE
[dev/core#412] Avoid truncated UTF-8 strings when using substr()

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -997,9 +997,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
       $customGroupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $customFieldId, 'custom_group_id');
       $customGroupName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupId, 'title');
 
-      if (strlen($customGroupName) > 13) {
-        $customGroupName = substr($customGroupName, 0, 10) . '...';
-      }
+      $customGroupName = CRM_Utils_String::ellipsify($customGroupName, 13);
 
       return $customGroupName;
     }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes broken export forms when a custom group name contains a UTF-8 character at the 10th character position.

See [dev/core#412](https://lab.civicrm.org/dev/core/issues/412).

Before
----------------------------------------
The export form can not be used due to a JavaScript error "Uncaught syntax error: Unexpected token ,".

The next column of options does not pop up.

![screenshot 2018-10-18 20 53 22](https://user-images.githubusercontent.com/336308/47139323-01f04700-d318-11e8-9314-4162115356e7.png)


After
----------------------------------------
The export form works correctly.

![screenshot 2018-10-18 20 54 05](https://user-images.githubusercontent.com/336308/47139346-103e6300-d318-11e8-8a97-5baf21b46201.png)


Technical Details
----------------------------------------
`CRM_Core_BAO_Mapping::getCustomGroupName()` truncates custom group names when longer than 10 characters using `substr()`, which causes multibyte characters being cut in half when at the truncating position.

This should use `CRM_Utils_String::ellipsify()` instead, which utilises `mb_substr()`.

Comments
----------------------------------------
Maybe someone with more core code insight should inspect a `grep substr(` result for more places where that happens.
