### PR TITLE
Status page: hush menu should be on top of other headers

### DIFF
--- a/ang/crmStatusPage.css
+++ b/ang/crmStatusPage.css
@@ -67,12 +67,13 @@
   width: auto;
   margin: 0;
   padding: 0;
+  z-index: 99;
 }
 
 #crm-status-list .hush-menu li {
   padding: 0.2em 0.5em;
   background-color: rgba(255, 255, 255, 0.9);
-  z-index: 99999;
+  z-index: 99;
   font-weight: normal;
 }
 


### PR DESCRIPTION
Also tempered a bit of z-index overkill on the `<li>` elements in the menu

Overview
----------------------------------------
On statuses with short messages, the menu to hush the status for a week/month/forever overlaps the next status header.  The menu should be on top of the header both for legibility and in order to click the last option.

Before
----------------------------------------
The next header is on top of the bottom of the menu.  You cannot select the last option.
![overlapping menu](https://user-images.githubusercontent.com/1682375/46966070-9fc6e600-d07a-11e8-8050-34b5f59b5a59.png)

After
----------------------------------------
The menu is on top of the next header.
![overlapping menu fixed](https://user-images.githubusercontent.com/1682375/46966211-09df8b00-d07b-11e8-9f11-bc02999cd915.png)

Technical Details
----------------------------------------
I set the z-index on the `<ul>` element.  The constituent `<li>` elements had a z-index of `99999`, which was excessive (it would appear on top of a modal, for example), so I dropped that down to `99` to allow some room for other things to go above it if necessary.  These numbers aren't magical; I just want to avoid a z-index arms race.
