### PR TITLE
Intelligently adjust menubar for D7 toolbar toggle

### DIFF
--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -11,5 +11,7 @@ CRM.$(function($) {
         $('#toolbar').css('z-index', '');
       }
     });
-    $('#civicrm-menu').css({'width': '97%'});
+  if ($('#toolbar a.toggle').length) {
+    $('#civicrm-menu').css({width: 'calc(100% - 40px)'});
+  }
 });


### PR DESCRIPTION
Overview
-----
Civi menubar was being set to width 97% to make room for the Drupal Toolbar toggle. The 2 problems with that are:
- 97% is imprecise - what we really wanted was 100% minus the width of the toolbar toggle.
- Some Drupal sites do not use the toolbar module.

Before
------
Civi menubar set to width 97% unconditionally.

After
------
Civi menubar set to 100% minus the width of the toolbar toggle, but only if the toolbar toggle is actually present on the screen.