### PR TITLE
Event Participant Source field is too short to store values for Events which have an Event Title over 128 characters in length

### DIFF
--- a/xml/schema/Event/Participant.xml
+++ b/xml/schema/Event/Participant.xml
@@ -133,7 +133,7 @@
     <headerPattern>/(participant.)?(source)$/i</headerPattern>
     <import>true</import>
     <type>varchar</type>
-    <length>128</length>
+    <length>512</length>
     <comment>Source of this event registration.</comment>
     <html>
       <type>Text</type>


### PR DESCRIPTION
Overview
----------------------------------------
Event Participant Source field is too short to store values for Events which have an Event Title over 128 characters in length. An Event Title can be up to 255 characters.

As a result, Event Registrations fail with a CiviCRM database error: **Data too long for column 'source' at row 1**

The problem is further exasperated because CiviCRM will also pre-pend additional characters to the source field, so potentially an Event with a 255 character Title will attempt to be recorded in the as a 282 string with text like: "Online Event Registration: [255 character Event title]"

Before
----------------------------------------
Event Registrations fail to be created if the Event Title is 101 or more characters in length.

After
----------------------------------------
Event Registrations can be created if the Event Title is up to the maximum size, 255 characters.

Technical Details
----------------------------------------
Database schema update and database upgrade will need to be performed as part of this change.

Comments
----------------------------------------
This same problem can occur for Contributions, Contribution Source; Membership, Membership Source fields.

The Source field also has inconsistent sizes for Group, Group Source and Contact, Contact Source.

Agileware Ref: CIVICRM-998