### PR TITLE
Fix (unreleased) fatal error on contribution preferences settings page

### DIFF
--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -29,10 +29,7 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
  *
- */
-/*
  * Settings metadata file
  */
 
@@ -125,7 +122,8 @@ return array(
     'quick_form_type' => 'Element',
     'default' => NULL,
     'pseudoconstant' => array(
-      'name' => 'contributionPage',
+      // @todo - handle table style pseudoconstants for settings & avoid deprecated function.
+      'callback' => 'CRM_Contribute_PseudoConstant::contributionPage',
     ),
     'html_type' => 'select',
     'add' => '4.7',


### PR DESCRIPTION
Overview
----------------------------------------
Recent changes to the display preferences page have caused an unreleased regression on the civicontribute preferences page. This fixes the regression but there are still some warnings for a follow up

Before
----------------------------------------
Page gives fatal rather than load

After
----------------------------------------
Page loads

Technical Details
----------------------------------------
Settings.getoptions supports a lesser format-set to CRM_Core_DAO::buildOptions does
in terms of pseudoconstant keys. Ideally we would fix that but for now
fix the fatal on the contribution page settings page by using
a format that is supported


Comments
----------------------------------------

