### PR TITLE
Cleanup contact summary tabs code

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -308,6 +308,54 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
 
   /**
    * @return array
+   */
+  public static function basicTabs() {
+    return [
+      [
+        'id' => 'summary',
+        'url' => '#contact-summary',
+        'title' => ts('Summary'),
+        'weight' => 0,
+      ],
+      [
+        'id' => 'activity',
+        'title' => ts('Activities'),
+        'class' => 'livePage',
+        'weight' => 70,
+      ],
+      [
+        'id' => 'rel',
+        'title' => ts('Relationships'),
+        'class' => 'livePage',
+        'weight' => 80,
+      ],
+      [
+        'id' => 'group',
+        'title' => ts('Groups'),
+        'class' => 'ajaxForm',
+        'weight' => 90,
+      ],
+      [
+        'id' => 'note',
+        'title' => ts('Notes'),
+        'class' => 'livePage',
+        'weight' => 100,
+      ],
+      [
+        'id' => 'tag',
+        'title' => ts('Tags'),
+        'weight' => 110,
+      ],
+      [
+        'id' => 'log',
+        'title' => ts('Change Log'),
+        'weight' => 120,
+      ],
+    ];
+  }
+
+  /**
+   * @return array
    * @throws \CRM_Core_Exception
    */
   public function getTabs() {
@@ -344,53 +392,24 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
           'count' => CRM_Contact_BAO_Contact::getCountComponent($u, $this->_contactId),
           'class' => 'livePage',
         ];
-        // make sure to get maximum weight, rest of tabs go after
-        // FIXME: not very elegant again
-        if ($weight < $elem['weight']) {
-          $weight = $elem['weight'];
-        }
       }
     }
 
-    $rest = [
-      'activity' => [
-        'title' => ts('Activities'),
-        'class' => 'livePage',
-      ],
-      'rel' => [
-        'title' => ts('Relationships'),
-        'class' => 'livePage',
-      ],
-      'group' => [
-        'title' => ts('Groups'),
-        'class' => 'ajaxForm',
-      ],
-      'note' => [
-        'title' => ts('Notes'),
-        'class' => 'livePage',
-      ],
-      'tag' => [
-        'title' => ts('Tags'),
-      ],
-      'log' => [
-        'title' => ts('Change Log'),
-      ],
-    ];
-
     // show the tabs only if user has generic access to CiviCRM
     $accessCiviCRM = CRM_Core_Permission::check('access CiviCRM');
-    foreach ($rest as $k => $v) {
-      if ($accessCiviCRM && !empty($this->_viewOptions[$k])) {
-        $allTabs[] = $v + [
-          'id' => $k,
+    foreach (self::basicTabs() as $tab) {
+      if ($tab['id'] == 'summary') {
+        $allTabs[] = $tab;
+      }
+      elseif ($accessCiviCRM && !empty($this->_viewOptions[$tab['id']])) {
+        $allTabs[] = $tab + [
           'url' => CRM_Utils_System::url(
-            "civicrm/contact/view/$k",
+            "civicrm/contact/view/{$tab['id']}",
             "reset=1&cid={$this->_contactId}"
           ),
-          'weight' => $weight,
-          'count' => CRM_Contact_BAO_Contact::getCountComponent($k, $this->_contactId),
+          'count' => CRM_Contact_BAO_Contact::getCountComponent($tab['id'], $this->_contactId),
         ];
-        $weight += 10;
+        $weight = $tab['weight'] + 10;
       }
     }
 
@@ -420,13 +439,6 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     // see if any other modules want to add any tabs
     CRM_Utils_Hook::tabs($allTabs, $this->_contactId);
     CRM_Utils_Hook::tabset('civicrm/contact/view', $allTabs, $context);
-
-    $allTabs[] = [
-      'id' => 'summary',
-      'url' => '#contact-summary',
-      'title' => ts('Summary'),
-      'weight' => 0,
-    ];
 
     // now sort the tabs based on weight
     usort($allTabs, ['CRM_Utils_Sort', 'cmpFunc']);

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -264,138 +264,16 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $lastModified = CRM_Core_BAO_Log::lastModified($this->_contactId, 'civicrm_contact');
     $this->assign_by_ref('lastModified', $lastModified);
 
-    $allTabs = array();
-    $weight = 10;
-
     $this->_viewOptions = CRM_Core_BAO_Setting::valueOptions(
       CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
       'contact_view_options',
       TRUE
     );
 
-    // show the tabs only if user has generic access to CiviCRM
-    $accessCiviCRM = CRM_Core_Permission::check('access CiviCRM');
-
     $changeLog = $this->_viewOptions['log'];
     $this->assign_by_ref('changeLog', $changeLog);
-    $components = CRM_Core_Component::getEnabledComponents();
 
-    foreach ($components as $name => $component) {
-      if (!empty($this->_viewOptions[$name]) &&
-        CRM_Core_Permission::access($component->name)
-      ) {
-        $elem = $component->registerTab();
-
-        // FIXME: not very elegant, probably needs better approach
-        // allow explicit id, if not defined, use keyword instead
-        if (array_key_exists('id', $elem)) {
-          $i = $elem['id'];
-        }
-        else {
-          $i = $component->getKeyword();
-        }
-        $u = $elem['url'];
-
-        //appending isTest to url for test soft credit CRM-3891.
-        //FIXME: hack ajax url.
-        $q = "reset=1&force=1&cid={$this->_contactId}";
-        if (CRM_Utils_Request::retrieve('isTest', 'Positive', $this)) {
-          $q .= "&isTest=1";
-        }
-        $allTabs[] = array(
-          'id' => $i,
-          'url' => CRM_Utils_System::url("civicrm/contact/view/$u", $q),
-          'title' => $elem['title'],
-          'weight' => $elem['weight'],
-          'count' => CRM_Contact_BAO_Contact::getCountComponent($u, $this->_contactId),
-          'class' => 'livePage',
-        );
-        // make sure to get maximum weight, rest of tabs go after
-        // FIXME: not very elegant again
-        if ($weight < $elem['weight']) {
-          $weight = $elem['weight'];
-        }
-      }
-    }
-
-    $rest = array(
-      'activity' => array(
-        'title' => ts('Activities'),
-        'class' => 'livePage',
-      ),
-      'rel' => array(
-        'title' => ts('Relationships'),
-        'class' => 'livePage',
-      ),
-      'group' => array(
-        'title' => ts('Groups'),
-        'class' => 'ajaxForm',
-      ),
-      'note' => array(
-        'title' => ts('Notes'),
-        'class' => 'livePage',
-      ),
-      'tag' => array(
-        'title' => ts('Tags'),
-      ),
-      'log' => array(
-        'title' => ts('Change Log'),
-      ),
-    );
-
-    foreach ($rest as $k => $v) {
-      if ($accessCiviCRM && !empty($this->_viewOptions[$k])) {
-        $allTabs[] = $v + array(
-          'id' => $k,
-          'url' => CRM_Utils_System::url(
-            "civicrm/contact/view/$k",
-            "reset=1&cid={$this->_contactId}"
-          ),
-          'weight' => $weight,
-          'count' => CRM_Contact_BAO_Contact::getCountComponent($k, $this->_contactId),
-        );
-        $weight += 10;
-      }
-    }
-
-    // now add all the custom tabs
-    $entityType = $this->get('contactType');
-    $activeGroups = CRM_Core_BAO_CustomGroup::getActiveGroups(
-      $entityType,
-      'civicrm/contact/view/cd',
-      $this->_contactId
-    );
-
-    foreach ($activeGroups as $group) {
-      $id = "custom_{$group['id']}";
-      $allTabs[] = array(
-        'id' => $id,
-        'url' => CRM_Utils_System::url($group['path'], $group['query'] . "&selectedChild=$id"),
-        'title' => $group['title'],
-        'weight' => $weight,
-        'count' => CRM_Contact_BAO_Contact::getCountComponent($id, $this->_contactId, $group['table_name']),
-        'hideCount' => !$group['is_multiple'],
-        'class' => 'livePage',
-      );
-      $weight += 10;
-    }
-
-    $context = array('contact_id' => $this->_contactId);
-    // see if any other modules want to add any tabs
-    CRM_Utils_Hook::tabs($allTabs, $this->_contactId);
-    CRM_Utils_Hook::tabset('civicrm/contact/view', $allTabs, $context);
-
-    $allTabs[] = array(
-      'id' => 'summary',
-      'url' => '#contact-summary',
-      'title' => ts('Summary'),
-      'weight' => 0,
-    );
-
-    // now sort the tabs based on weight
-    usort($allTabs, array('CRM_Utils_Sort', 'cmpFunc'));
-
-    $this->assign('allTabs', $allTabs);
+    $this->assign('allTabs', $this->getTabs());
 
     // hook for contact summary
     // ignored but needed to prevent warnings
@@ -426,6 +304,133 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       }
     }
     return parent::getTemplateFileName();
+  }
+
+  /**
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getTabs() {
+    $allTabs = [];
+    $weight = 10;
+
+    foreach (CRM_Core_Component::getEnabledComponents() as $name => $component) {
+      if (!empty($this->_viewOptions[$name]) &&
+        CRM_Core_Permission::access($component->name)
+      ) {
+        $elem = $component->registerTab();
+
+        // FIXME: not very elegant, probably needs better approach
+        // allow explicit id, if not defined, use keyword instead
+        if (array_key_exists('id', $elem)) {
+          $i = $elem['id'];
+        }
+        else {
+          $i = $component->getKeyword();
+        }
+        $u = $elem['url'];
+
+        //appending isTest to url for test soft credit CRM-3891.
+        //FIXME: hack ajax url.
+        $q = "reset=1&force=1&cid={$this->_contactId}";
+        if (CRM_Utils_Request::retrieve('isTest', 'Positive', $this)) {
+          $q .= "&isTest=1";
+        }
+        $allTabs[] = [
+          'id' => $i,
+          'url' => CRM_Utils_System::url("civicrm/contact/view/$u", $q),
+          'title' => $elem['title'],
+          'weight' => $elem['weight'],
+          'count' => CRM_Contact_BAO_Contact::getCountComponent($u, $this->_contactId),
+          'class' => 'livePage',
+        ];
+        // make sure to get maximum weight, rest of tabs go after
+        // FIXME: not very elegant again
+        if ($weight < $elem['weight']) {
+          $weight = $elem['weight'];
+        }
+      }
+    }
+
+    $rest = [
+      'activity' => [
+        'title' => ts('Activities'),
+        'class' => 'livePage',
+      ],
+      'rel' => [
+        'title' => ts('Relationships'),
+        'class' => 'livePage',
+      ],
+      'group' => [
+        'title' => ts('Groups'),
+        'class' => 'ajaxForm',
+      ],
+      'note' => [
+        'title' => ts('Notes'),
+        'class' => 'livePage',
+      ],
+      'tag' => [
+        'title' => ts('Tags'),
+      ],
+      'log' => [
+        'title' => ts('Change Log'),
+      ],
+    ];
+
+    // show the tabs only if user has generic access to CiviCRM
+    $accessCiviCRM = CRM_Core_Permission::check('access CiviCRM');
+    foreach ($rest as $k => $v) {
+      if ($accessCiviCRM && !empty($this->_viewOptions[$k])) {
+        $allTabs[] = $v + [
+          'id' => $k,
+          'url' => CRM_Utils_System::url(
+            "civicrm/contact/view/$k",
+            "reset=1&cid={$this->_contactId}"
+          ),
+          'weight' => $weight,
+          'count' => CRM_Contact_BAO_Contact::getCountComponent($k, $this->_contactId),
+        ];
+        $weight += 10;
+      }
+    }
+
+    // now add all the custom tabs
+    $entityType = $this->get('contactType');
+    $activeGroups = CRM_Core_BAO_CustomGroup::getActiveGroups(
+      $entityType,
+      'civicrm/contact/view/cd',
+      $this->_contactId
+    );
+
+    foreach ($activeGroups as $group) {
+      $id = "custom_{$group['id']}";
+      $allTabs[] = [
+        'id' => $id,
+        'url' => CRM_Utils_System::url($group['path'], $group['query'] . "&selectedChild=$id"),
+        'title' => $group['title'],
+        'weight' => $weight,
+        'count' => CRM_Contact_BAO_Contact::getCountComponent($id, $this->_contactId, $group['table_name']),
+        'hideCount' => !$group['is_multiple'],
+        'class' => 'livePage',
+      ];
+      $weight += 10;
+    }
+
+    $context = ['contact_id' => $this->_contactId];
+    // see if any other modules want to add any tabs
+    CRM_Utils_Hook::tabs($allTabs, $this->_contactId);
+    CRM_Utils_Hook::tabset('civicrm/contact/view', $allTabs, $context);
+
+    $allTabs[] = [
+      'id' => 'summary',
+      'url' => '#contact-summary',
+      'title' => ts('Summary'),
+      'weight' => 0,
+    ];
+
+    // now sort the tabs based on weight
+    usort($allTabs, ['CRM_Utils_Sort', 'cmpFunc']);
+    return $allTabs;
   }
 
 }

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -47,7 +47,7 @@ class CRM_Core_Component {
   /**
    * @param bool $force
    *
-   * @return array|null
+   * @return CRM_Core_Component_Info[]
    */
   private static function &_info($force = FALSE) {
     if (!isset(Civi::$statics[__CLASS__]['info'])|| $force) {
@@ -84,7 +84,7 @@ class CRM_Core_Component {
   /**
    * @param bool $force
    *
-   * @return array
+   * @return CRM_Core_Component_Info[]
    * @throws Exception
    */
   public static function &getComponents($force = FALSE) {
@@ -132,7 +132,7 @@ class CRM_Core_Component {
   /**
    * @param bool $force
    *
-   * @return array|null
+   * @return CRM_Core_Component_Info[]
    */
   static public function &getEnabledComponents($force = FALSE) {
     return self::_info($force);

--- a/CRM/Grant/Info.php
+++ b/CRM/Grant/Info.php
@@ -117,7 +117,7 @@ class CRM_Grant_Info extends CRM_Core_Component_Info {
     return array(
       'title' => ts('Grants'),
       'url' => 'grant',
-      'weight' => 50,
+      'weight' => 60,
     );
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is code cleanup and function extraction which should have no impact on end-users or hooks.

Before
----------------------------------------
Contact summary tabs in hard-coded order.

After
----------------------------------------
Contact summary tabs still in the same hard-coded order, but extracted a couple functions to make it possible for the LayoutEditor extension to modify them.

Technical Details
----------------------------------------
This preserves the current order of tabs, but does slightly change the numeric weights of some of them. They were somewhat unpredictable before, now they all have fixed values.

Comments
--------
Hoping to slip this into 5.7 to meet the Contact Layout Editor release schedule.
