### PR TITLE
Toward CRM-19751: conditionally change On-Hold criteria to select on …

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1635,8 +1635,9 @@ class CRM_Contact_BAO_Query {
         }
       }
       elseif ($id == 'email_on_hold') {
-        if ($formValues['email_on_hold']['on_hold']) {
-          $params[] = array('on_hold', '=', $formValues['email_on_hold']['on_hold'], 0, 0);
+        if ($onHoldValue = CRM_Utils_Array::value('email_on_hold', $formValues)) {
+          $onHoldValue = (array) $onHoldValue;
+          $params[] = array('on_hold', 'IN', $onHoldValue, 0, 0);
         }
       }
       elseif (substr($id, 0, 7) == 'custom_'

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -231,9 +231,13 @@ class CRM_Contact_Form_Search_Criteria {
     $form->addRadio('privacy_toggle', ts('Privacy Options'), $options, array('allowClear' => FALSE));
 
     // preferred communication method
-
-    $onHold[] = $form->createElement('advcheckbox', 'on_hold', NULL, '');
-    $form->addGroup($onHold, 'email_on_hold', ts('Email On Hold'));
+    if (Civi::settings()->get('civimail_multiple_bulk_emails')) {
+      $form->addSelect('email_on_hold',
+        array('entity' => 'email', 'multiple' => 'multiple', 'label' => ts('Email On Hold'), 'options' => CRM_Core_PseudoConstant::emailOnHoldOptions()));
+    }
+    else {
+      $form->add('advcheckbox', 'email_on_hold', ts('Email On Hold'));
+    }
 
     $form->addSelect('preferred_communication_method',
       array('entity' => 'contact', 'multiple' => 'multiple', 'label' => ts('Preferred Communication Method'), 'option_url' => NULL, 'placeholder' => ts('- any -')));

--- a/CRM/Upgrade/Incremental/php/FiveNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveNine.php
@@ -55,6 +55,14 @@ class CRM_Upgrade_Incremental_php_FiveNine extends CRM_Upgrade_Incremental_Base 
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
+    if ($rev == '5.9.0') {
+      $args = array(
+        1 => ts('Enable multiple bulk email address for a contact'),
+        2 => ts('Email on Hold'),
+      );
+      $postUpgradeMessage .= '<p>' . ts('If the setting "%1" is enabled, you should update any smart groups based on the "%2" field.', $args) . '</p>';
+    }
+
     // Example: Generate a post-upgrade message.
     // if ($rev == '5.12.34') {
     //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");

--- a/CRM/Upgrade/Incremental/sql/5.9.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.9.0.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.9.0 during upgrade *}

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -189,7 +189,7 @@ return array(
     'title' => ts('Enable multiple bulk email address for a contact.'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('CiviMail will deliver a copy of the email to each bulk email listed for the contact.'),
+    'description' => ts('CiviMail will deliver a copy of the email to each bulk email listed for the contact. Enabling this setting will also change the options for the "Email on Hold" field in Advanced Search.'),
     'help_text' => NULL,
   ),
   'include_message_id' => array(

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl
@@ -3,7 +3,13 @@
 {$form.preferred_communication_method.html}
 <br/>
 
-{if $form.email_on_hold}
+{if $form.email_on_hold.type == 'select'}
+  <br/>
+  {$form.email_on_hold.label}
+  <br/>
+  {$form.email_on_hold.html}
+  <br/>
+{elseif $form.email_on_hold.type == 'checkbox'}
   <div class="spacer"></div>
   {$form.email_on_hold.html}
   {$form.email_on_hold.label}

--- a/tests/phpunit/CRM/Contact/Form/Search/CriteriaTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/CriteriaTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 5                                                  |
+  +--------------------------------------------------------------------+
+  | Copyright CiviCRM LLC (c) 2004-2018                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for CRM_Contact_Form_Search_Criteria
+ *
+ * @package CiviCRM
+ * @group headless
+ */
+class CRM_Contact_Form_Search_CriteraTest extends CiviUnitTestCase {
+
+  /**
+   * Test that the 'multiple bulk email' setting correctly affects the type of
+   * field used for the 'email on hold' criteria in Advanced Search.
+   */
+  public function testAdvancedHSearchObservesMultipleBulkEmailSetting() {
+
+    // If setting is enabled, criteria should be a select element.
+    Civi::settings()->set('civimail_multiple_bulk_emails', 1);
+    $form = new CRM_Contact_Form_Search_Advanced();
+    $form->controller = new CRM_Contact_Controller_Search();
+    $form->preProcess();
+    $form->buildQuickForm();
+    $onHoldElemenClass = (get_class($form->_elements[$form->_elementIndex['email_on_hold']]));
+    $this->assertEquals('HTML_QuickForm_select', $onHoldElemenClass, 'civimail_multiple_bulk_emails setting = 1, so email_on_hold should be a select element.');
+
+    // If setting is disabled, criteria should be a checkbox.
+    Civi::settings()->set('civimail_multiple_bulk_emails', 0);
+    $form = new CRM_Contact_Form_Search_Advanced();
+    $form->controller = new CRM_Contact_Controller_Search();
+    $form->preProcess();
+    $form->buildQuickForm();
+    $onHoldElemenClass = (get_class($form->_elements[$form->_elementIndex['email_on_hold']]));
+    $this->assertEquals('HTML_QuickForm_advcheckbox', $onHoldElemenClass, 'civimail_multiple_bulk_emails setting = 0, so email_on_hold should be a checkbox.');
+  }
+
+}


### PR DESCRIPTION
…Advanced Search form.

Overview
----------------------------------------
The issue [CRM-19751](https://issues.civicrm.org/jira/browse/CRM-19751) notes that Advanced Search criteria "email on hold" doesn't find emails with the "on hold opt-out" setting (which is only available when the CiviMail component setting "Enable multiple bulk email address for a contact" is enabled. 

To fix this, we need the form to offer a set of options for this criteria, not just a checkbox. 

PR #12883 addressed an underlying issue in the XML/SQL schema. Following onto that, the PR provided here makes the actual changes to the form.

Before
----------------------------------------
The "Email On Hold" criteria is a checkbox.

![checkbox](https://user-images.githubusercontent.com/759449/47022922-24ba0a00-d124-11e8-9efa-e3501069e6fa.png)

This allows searching for contacts having an email address with `on_hold` = 1, which equates to "on hold" when the  "Enable multiple bulk email address for a contact"  setting is disabled, and equates to "on hold - bounce" when the setting is enabled. There's no way to search for contacts having emails set to "on hold - opt out" (which is only available when this setting is enabled).

After
----------------------------------------
The "Email On Hold" criteria is still a checkbox when the "Enable multiple bulk email address for a contact"  setting is disabled, so it still works as it did before in that state.

![setting-disabled](https://user-images.githubusercontent.com/759449/47023298-00aaf880-d125-11e8-8412-9c9660addd70.png)

This still allows searching for contacts having an email address with `on_hold` = 1, which equates to "on hold" when the "Enable multiple bulk email address for a contact" setting is disabled, and equates to "on hold - bounce" when the setting is enabled. 

On the other hand, when the "Enable multiple bulk email address for a contact"  setting is enabled, the "Email On Hold" criteria is a multi-select, allowing to search on any of the three possible values for an email "on hold" property.

![setting-enabled](https://user-images.githubusercontent.com/759449/47023541-78792300-d125-11e8-9c3c-a60346662ff6.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
Needs tests.