### PR TITLE
PHP 7.1 bugfix: undeclared array subdimension with batch CSV export

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -160,7 +160,7 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
    */
   public function formatHeaders($values) {
     $arrayKeys = array_keys($values);
-    $headers = '';
+    $headers = array();
     if (!empty($arrayKeys)) {
       foreach ($values[$arrayKeys[0]] as $title => $value) {
         $headers[] = $title;


### PR DESCRIPTION
Overview
----------------------------------------
Exporting CSV batches on PHP 7.1 crashes and then makes the exported batches screen inaccessible.
https://civicrm.stackexchange.com/q/26895/26

This is due to an undeclared array subdimension. This PR fixes it.

https://lab.civicrm.org/dev/core/issues/452