### PR TITLE
5.7

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -227,7 +227,7 @@ br.clear {
   background-color: #ddd;
   width: 16em;
   /* padding in px not ex because IE messes up 100% width tables otherwise */
-  padding: 10px;
+  padding: 20px;
   vertical-align: top;
 }
 
@@ -296,6 +296,7 @@ br.clear {
 
 ul#civicrm-menu {
   position:relative;
+  z-index: 1;
 }
 
 div#toolbar-box div.m {
@@ -378,4 +379,36 @@ ul#civicrm-menu li#crm-qsearch {
   background-color: inherit;
   width: inherit;
   display: block;
+}
+
+/* Remove Joomla subhead toolbar & whitespace border */
+	
+body.admin.com_civicrm .subhead-collapse {
+	display:none;
+}
+body.admin.com_civicrm .container-fluid.container-main {
+	padding: 0;
+	border-top: 1px solid #787878;
+}
+body.admin.com_civicrm #crm-nav-menu-container {
+	padding-bottom: 0 !important;
+}
+body.admin.com_civicrm #content-right {
+	padding: 12px;
+}
+body.admin.com_civicrm #civicrm-menu #crm-qsearch {
+  padding-left: 20px;
+}
+body.admin.com_civicrm #root-menu-div div.outerbox:first-of-type {
+	margin-left: 20px;
+} 
+body.admin.com_civicrm div.outerbox {
+	z-index: 10;
+}
+
+/* Shoreditch-specific */
+
+body.admin.com_civicrm {
+	padding-top: 0px !important;
+	margin-top: 30px !important; 
 }

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -403,7 +403,7 @@ body.admin.com_civicrm #root-menu-div div.outerbox:first-of-type {
 	margin-left: 20px;
 } 
 body.admin.com_civicrm div.outerbox {
-	z-index: 10;
+	z-index: 1000;
 }
 
 /* Shoreditch-specific */


### PR DESCRIPTION
Overview
----------------------------------------
Rebase of https://github.com/civicrm/civicrm-core/pull/12947 with fixes for issues raised here https://github.com/civicrm/civicrm-core/pull/12947#issuecomment-430820759.

The first commit in the original pull request fixes a z-index regression, described [here](https://civicrm.stackexchange.com/questions/26858/anyone-else-seeing-an-overlapping-admin-civi-menu-bug-with-joomla-3-8-13-and-civ). The second & third commit makes some visual changes: 

- CiviCRM doesn't use the SubHead Toolbar in Joomla's 3.x admin theme, leaving an empty region so this is removed. 
- Hiding  removes the padding under the menu, so left and right whitespace is removed for balance, and padding added to preserve a readability at the screen-edge, and keep the left sidebar items aligned thru Civi into the Joomla interface.
- Shoreditch also has creates some empty space so these is removed (without breaking non-Shoreditch instances). 

Before
----------------------------------------

Without Shoreditch:

![joomla-2-before](https://user-images.githubusercontent.com/1175967/47103872-1826d600-d238-11e8-95df-937b83e95e11.png)

With:

![joomla-shore-before](https://user-images.githubusercontent.com/1175967/47103676-b1a1b800-d237-11e8-9c6c-508f0132f5d0.png)

After
----------------------------------------
Without Shoreditch:

![joomla-after](https://user-images.githubusercontent.com/1175967/47103894-2d9c0000-d238-11e8-8025-3657d8fe9470.png)

With:

![joomla-shore-after](https://user-images.githubusercontent.com/1175967/47103912-37256800-d238-11e8-9137-51e106045869.png)

Technical Details
----------------------------------------
This has been tested with and without Shoreditch. Changes should only target CiviCRM admin screens, not other Joomla pages or front-end CiviCRM markup.

Comments
----------------------------------------
A regrettable use of '!important' to override one hardcoded element and deal with the order of css file loading.
