### PR TITLE
Fixed Joomla menu z-index regression

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -296,6 +296,7 @@ br.clear {
 
 ul#civicrm-menu {
   position:relative;
+  z-index:1;
 }
 
 div#toolbar-box div.m {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes z-index ordering originally described https://civicrm.stackexchange.com/questions/26858/anyone-else-seeing-an-overlapping-admin-civi-menu-bug-with-joomla-3-8-13-and-civ

Before
----------------------------------------
![joomla-2-before](https://user-images.githubusercontent.com/1175967/47103872-1826d600-d238-11e8-95df-937b83e95e11.png)

Technical Details
----------------------------------------
Works with and without Shoreditch

Comments
----------------------------------------
For more details see https://github.com/civicrm/civicrm-core/pull/12947
