### PR TITLE
Fixed fatal error for function not found

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2449,8 +2449,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * @return mixed
    */
   protected function alterLocationTypeID($value, &$row, $selectedfield, $criteriaFieldName) {
-    $values = $this->getLocationTypeOptions();
-    return CRM_Utils_Array::value($value, $values);
+    return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_Address', 'location_type_id', $value);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
<img width="975" alt="screen shot 2018-10-18 at 10 22 09" src="https://user-images.githubusercontent.com/2053075/47144839-45b76200-d2c0-11e8-9946-26c47abcd5ce.png">


After
----------------------------------------
<img width="848" alt="screen shot 2018-10-18 at 10 22 27" src="https://user-images.githubusercontent.com/2053075/47144822-3c2dfa00-d2c0-11e8-954b-c734457fa86b.png">


Technical Details
----------------------------------------
Function $this->getLocationTypeOptions() not present in CRM_Core_Form(), so replaced with CRM_Core_PseudoConstant::getLabel() to retrieve labels for Location type.

