### PR TITLE
[dev/core#457] Add $ids to hook_civicrm_export

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -600,7 +600,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       }
 
       // call export hook
-      CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode);
+      CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode, $componentTable, $ids);
 
       // In order to be able to write a unit test against this function we need to suppress
       // the csv writing. In future hopefully the csv writing & the main processing will be in separate functions.

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1263,12 +1263,17 @@ abstract class CRM_Utils_Hook {
    *   SQL columns.
    * @param int $exportMode
    *   Export mode ( contact, contribution, etc...).
+   * @param string $componentTable
+   *   Name of temporary table
+   * @param array $ids
+   *   Array of object's ids
    *
    * @return mixed
    */
-  public static function export(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode) {
-    return self::singleton()->invoke(array('exportTempTable', 'headerRows', 'sqlColumns', 'exportMode'), $exportTempTable, $headerRows, $sqlColumns, $exportMode,
-      self::$_nullObject, self::$_nullObject,
+  public static function export(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode, &$componentTable, &$ids) {
+    return self::singleton()->invoke(array('exportTempTable', 'headerRows', 'sqlColumns', 'exportMode', 'componentTable', 'ids'),
+      $exportTempTable, $headerRows, $sqlColumns,
+      $exportMode, $componentTable, $ids,
       'civicrm_export'
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
Because of GDPR rules we have to save information that some data were exported.

Before
----------------------------------------
Current hook https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_export/ is not enough because it returns data without id columns. It's hard to implement any sophisticated feature without id of objects.

After
----------------------------------------
Existing export hook is extended

```php
CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode, $componentTable, $ids);
```

Technical Details
----------------------------------------
You can find example here https://github.com/veda-consulting/uk.co.vedaconsulting.gdpr/issues/157


Comments
----------------------------------------
no comments