### PR TITLE
CRM_Core_Resources - Allow container to swap the implementation

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -115,13 +115,7 @@ class CRM_Core_Resources {
       self::$_singleton = $instance;
     }
     if (self::$_singleton === NULL) {
-      $sys = CRM_Extension_System::singleton();
-      $cache = Civi::cache('js_strings');
-      self::$_singleton = new CRM_Core_Resources(
-        $sys->getMapper(),
-        $cache,
-        CRM_Core_Config::isUpgradeMode() ? NULL : 'resCacheCode'
-      );
+      self::$_singleton = Civi::service('resources');
     }
     return self::$_singleton;
   }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -201,7 +201,6 @@ class Container {
 
     // Expose legacy singletons as services in the container.
     $singletons = array(
-      'resources' => 'CRM_Core_Resources',
       'httpClient' => 'CRM_Utils_HttpClient',
       'cache.default' => 'CRM_Utils_Cache',
       'i18n' => 'CRM_Core_I18n',
@@ -215,6 +214,11 @@ class Container {
         ->setFactory(array($class, 'singleton'));
     }
     $container->setAlias('cache.short', 'cache.default');
+
+    $container->setDefinition('resources', new Definition(
+      'CRM_Core_Resources',
+      [new Reference('service_container')]
+    ))->setFactory(array(new Reference(self::SELF), 'createResources'));
 
     $container->setDefinition('prevnext', new Definition(
       'CRM_Core_PrevNextCache_Interface',
@@ -409,6 +413,19 @@ class Container {
     ));
 
     return $kernel;
+  }
+
+  /**
+   * @param ContainerInterface $container
+   * @return \CRM_Core_Resources
+   */
+  public static function createResources($container) {
+    $sys = \CRM_Extension_System::singleton();
+    return new \CRM_Core_Resources(
+      $sys->getMapper(),
+      $container->get('cache.js_strings'),
+      \CRM_Core_Config::isUpgradeMode() ? NULL : 'resCacheCode'
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_Resources` manages the registration of page-level resources, such as JS and CSS files. This changes the construction logic so that it becomes possible for an extension to modify the definition of `CRM_Core_Resources`. 

This is intended to allow experimentation with theme-management in extensions.

Before and After (Unchanged)
----------------------------------------
`CRM_Core_Resources::singleton()`, `Civi::resources()`, and `Civi::container()->get('resources')` all return the same object.

Before
----------------------------------------
The object construction is handled in the `singleton()` function.

After
----------------------------------------
The object construction is handled in the `Container`. Container defintions can be modified via `hook_civicrm_container`.

Technical Details
----------------------------------------
A possible critique: "*You can't move everything in the container; is this one safe?.*" The main limitation of the container is that it cannot initialize boot-critical services (i.e. it's not available during pre/early-bootstrap). However, the resource manager is not boot-critical. You can tell this because the old logic (from `CRM_Core_Resources::singleton()`) already relied on having a working container (to lookup `js_strings`). If it was boot-critical, then the old call to `Civi::cache('js_strings')` would have been crash-y.
