### PR TITLE
Fix notices on Membership Settings form.

### DIFF
--- a/CRM/Admin/Form/Preferences.php
+++ b/CRM/Admin/Form/Preferences.php
@@ -44,7 +44,7 @@ class CRM_Admin_Form_Preferences extends CRM_Core_Form {
 
   protected $_checkbox = NULL;
 
-  protected $_varNames = NULL;
+  protected $_varNames = [];
 
   protected $_config = NULL;
 

--- a/CRM/Admin/Form/Preferences/Member.php
+++ b/CRM/Admin/Form/Preferences/Member.php
@@ -35,28 +35,9 @@
  * This class generates form components for component preferences.
  */
 class CRM_Admin_Form_Preferences_Member extends CRM_Admin_Form_Preferences {
-  public function preProcess() {
-    CRM_Utils_System::setTitle(ts('CiviMember Component Settings'));
-    $this->_varNames = array(
-      CRM_Core_BAO_Setting::MEMBER_PREFERENCES_NAME => array(
-        'default_renewal_contribution_page' => array(
-          'html_type' => 'select',
-          'title' => ts('Default online membership renewal page'),
-          'option_values' => array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::contributionPage(),
-          'weight' => 1,
-          'description' => ts('If you select a default online contribution page for self-service membership renewals, a "renew" link pointing to that page will be displayed on the Contact Dashboard for memberships which were entered offline. You will need to ensure that the membership block for the selected online contribution page includes any currently available memberships.'),
-        ),
-      ),
-    );
 
-    parent::preProcess();
-  }
-
-  /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    parent::buildQuickForm();
-  }
+  protected $_settings = [
+    'default_renewal_contribution_page' => CRM_Core_BAO_Setting::MEMBER_PREFERENCES_NAME,
+  ];
 
 }

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -191,6 +191,7 @@ trait CRM_Admin_Form_SettingTrait {
     // setting_description should be deprecated - see Mail.tpl for metadata based tpl.
     $this->assign('setting_descriptions', $descriptions);
     $this->assign('settings_fields', $settingMetaData);
+    $this->assign('fields', $settingMetaData);
   }
 
   /**
@@ -208,6 +209,7 @@ trait CRM_Admin_Form_SettingTrait {
       'checkboxes' => 'CheckBoxes',
       'checkbox' => 'CheckBox',
       'radio' => 'Radio',
+      'select' => 'Select',
     ];
     return $mapping[$spec['html_type']];
   }

--- a/settings/Member.setting.php
+++ b/settings/Member.setting.php
@@ -42,16 +42,17 @@ return array(
     'group' => 'member',
     'name' => 'default_renewal_contribution_page',
     'type' => 'Integer',
-    'html_type' => 'Select',
+    'html_type' => 'select',
     'default' => NULL,
     'pseudoconstant' => array(
-      'name' => 'contributionPage',
+      // @todo - handle table style pseudoconstants for settings & avoid deprecated function.
+      'callback' => 'CRM_Contribute_PseudoConstant::contributionPage',
     ),
     'add' => '4.1',
     'title' => 'Default online membership renewal page',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'If you select a default online contribution page for self-service membership renewals, a "renew" link pointing to that page will be displayed on the Contact Dashboard for memberships which were entered offline. You will need to ensure that the membership block for the selected online contribution page includes any currently available memberships.',
+    'description' => ts('If you select a default online contribution page for self-service membership renewals, a "renew" link pointing to that page will be displayed on the Contact Dashboard for memberships which were entered offline. You will need to ensure that the membership block for the selected online contribution page includes any currently available memberships.'),
     'help_text' => NULL,
   ),
 );


### PR DESCRIPTION
Overview
----------------------------------------
Fix some e-notices appearing on membership settings form (in master only, not in released versions), simplify code

Before
----------------------------------------
![screenshot 2018-10-19 09 11 24](https://user-images.githubusercontent.com/336308/47181252-fdab4480-d37e-11e8-83b4-b22f4ea99131.png)


After
----------------------------------------
![screenshot 2018-10-19 09 05 10](https://user-images.githubusercontent.com/336308/47180899-19621b00-d37e-11e8-82c6-caca5134bdc4.png)


Technical Details
----------------------------------------
There has been work done to sync up the 'settings' forms & 'preferences' forms which differ for historical reasons only & now have a shared settingstrait to migrate to. His has caused some warnings & notices which I am fixing

Comments
----------------------------------------
@mattwire 
