### PR TITLE
Fix regression on activity detail report add to group

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -693,7 +693,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
     $new_having = ' addtogroup_contact_id';
     $having = str_ireplace(' civicrm_contact_contact_target_id', $new_having, $this->_having);
     $query = "$select
-FROM {$this->temporaryTables['activity_temp_table']} tar
+FROM {$this->temporaryTables['activity_temp_table']['name']} tar
 GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     $select = 'AS addtogroup_contact_id';
     $query = str_ireplace('AS civicrm_contact_contact_target_id', $select, $query);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes hard fail on using add to group function from activity detail report

Before
----------------------------------------
![screenshot 2018-10-19 09 56 00](https://user-images.githubusercontent.com/336308/47183828-8af19780-d385-11e8-941f-1278ccb1712b.png)

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
![screenshot 2018-10-19 10 02 05](https://user-images.githubusercontent.com/336308/47184027-0eab8400-d386-11e8-8082-c763bd6403f5.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
This hasn't been reported but I spotted it when reviewing a pr to fix another variant of this mistake in the same report