### PR TITLE
Disable ONLY_FULL_GROUP_BY sql mode when doing add2group function on …

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -697,7 +697,9 @@ FROM {$this->temporaryTables['activity_temp_table']} tar
 GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     $select = 'AS addtogroup_contact_id';
     $query = str_ireplace('AS civicrm_contact_contact_target_id', $select, $query);
+    CRM_Core_DAO::disableFullGroupByMode();
     $dao = $this->executeReportQuery($query);
+    CRM_Core_DAO::reenableFullGroupByMode();
 
     $contactIDs = array();
     // Add resulting contacts to group


### PR DESCRIPTION
…the Activity Detail report to avoid fatal error

Overview
----------------------------------------
When adding contacts to a group from the Activity Details report a fatal error is generated on MySQL instances that enable ONLY_FULL_GROUP_BY. 

Before
----------------------------------------
Fatal Error generated

After
----------------------------------------
No Fatal Error

ping @eileenmcnaughton 