### PR TITLE
Fix "crmURL" parameters in various templates

### DIFF
--- a/templates/CRM/Contact/Page/View/Print.tpl
+++ b/templates/CRM/Contact/Page/View/Print.tpl
@@ -33,7 +33,7 @@
 -->
 </style>
 {/literal}
-<form action="{crmURL p='civicrm/contact/view' q="&cid=`$contactId`&reset=1"}" method="post" id="Print1" >
+<form action="{crmURL p='civicrm/contact/view' q="cid=`$contactId`&reset=1"}" method="post" id="Print1" >
   <div class="form-item">
        <span class="element-right"><input onclick="window.print(); return false" class="crm-form-submit default" name="_qf_Print_next" value="{ts}Print{/ts}" type="submit" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input class="crm-form-submit" name="_qf_Print_back" value="{ts}Done{/ts}" type="submit" /></span>
   </div>
@@ -41,7 +41,7 @@
 <br />
 <div class="solid-border-top"><br />
     {include file="CRM/Contact/Page/View/Summary.tpl"}
-    <form action="{crmURL p='civicrm/contact/view' q="&cid=`$contactId`&reset=1"}" method="post" id="Print2" >
+    <form action="{crmURL p='civicrm/contact/view' q="cid=`$contactId`&reset=1"}" method="post" id="Print2" >
       <div class="form-item">
            <span class="element-right"><input onclick="window.print(); return false" class="crm-form-submit default" name="_qf_Print_next" value="{ts}Print{/ts}" type="submit" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input class="crm-form-submit" name="_qf_Print_back" value="{ts}Done{/ts}" type="submit" /></span>
       </div>

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -80,7 +80,7 @@
 
         {elseif call_user_func(array('CRM_Core_Permission','check'), 'delete contacts')}
           <li class="crm-delete-action crm-contact-delete">
-            {crmButton p='civicrm/contact/view/delete' q="&reset=1&delete=1&cid=$contactId" class="delete" icon="trash"}
+            {crmButton p='civicrm/contact/view/delete' q="reset=1&delete=1&cid=$contactId" class="delete" icon="trash"}
               {ts}Delete Contact{/ts}
             {/crmButton}
           </li>

--- a/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
+++ b/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
@@ -2,7 +2,7 @@
 
 {if $contact}
 <div class="messages status no-popup">
-    {ts 1=$contact.display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/event/cart_checkout' q="&cid=0&reset=1"}" title="{ts}Click here to register a different person for this event.{/ts}">{ts 1=$contact.display_name}Not %1, or want to register a different person{/ts}</a>?)</div>
+    {ts 1=$contact.display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/event/cart_checkout' q="cid=0&reset=1"}" title="{ts}Click here to register a different person for this event.{/ts}">{ts 1=$contact.display_name}Not %1, or want to register a different person{/ts}</a>?)</div>
 {/if}
 
 {foreach from=$events_in_carts key=index item=event_in_cart}

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -111,7 +111,7 @@
 
       var payment_instrument_id = $('#payment_instrument_id').val();
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="&formName=`$form.formName`&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName`&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {


### PR DESCRIPTION
Overview
----------------------------------------
As described on [CiviCRM Lab](https://lab.civicrm.org/dev/core/issues/459), in Smarty templates, when the `q` parameter is prefixed with an ampersand, for example:

```smarty
{crmButton p='civicrm/contact/view/delete' q="&reset=1&delete=1&cid=$contactId" class="delete" icon="trash"}
```

the resulting URL contains `&&` like this:

```
http://civicrm.local/wp-admin/admin.php?page=CiviCRM&q=civicrm/contact/view/delete&&reset=1&delete=1&cid=202
```

Before
----------------------------------------
URLs have double ampersands (`&&`) e.g.
```
http://civicrm.local/wp-admin/admin.php?page=CiviCRM&q=civicrm/contact/view/delete&&reset=1&delete=1&cid=202
```

After
----------------------------------------
URLs do not have double ampersands, e.g.
```
http://civicrm.local/wp-admin/admin.php?page=CiviCRM&q=civicrm/contact/view/delete&reset=1&delete=1&cid=202
```
