### PR TITLE
Fix malformed redirect URLs

### DIFF
--- a/CRM/Core/QuickForm/Action/Jump.php
+++ b/CRM/Core/QuickForm/Action/Jump.php
@@ -74,6 +74,9 @@ class CRM_Core_QuickForm_Action_Jump extends CRM_Core_QuickForm_Action {
     }
     // generate the URL for the page 'display' event and redirect to it
     $action = $current->getAttribute('action');
+    // prevent URLs that end in ? from causing redirects
+    $action = rtrim($action, '?');
+    // FIXME: this should be passed through CRM_Utils_System::url()
     $url = $action . (FALSE === strpos($action, '?') ? '?' : '&') . $current->getButtonName('display') . '=true' . '&qfKey=' . $page->get('qfKey');
 
     CRM_Utils_System::redirect($url);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [Issue 460](https://lab.civicrm.org/dev/core/issues/460). Please refer to that for details.

Prevents `CRM_Core_QuickForm_Action_Jump::perform()` from constructing invalid URLs.

Before
----------------------------------------
Can produce URLs like this:

```
https://civicrm.latest/civicrm/event/register/?&_qf_ThankYou_display=true&qfKey=<some-key>
```

After
----------------------------------------
Will build URL like this:

```
https://civicrm.latest/civicrm/event/register/?_qf_ThankYou_display=true&qfKey=<some-key>
```
