### PR TITLE
Use description from schema if available when using entityForm

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -44,6 +44,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
    * Fields may have keys
    *  - name (required to show in tpl from the array)
    *  - description (optional, will appear below the field)
+   *     Auto-added by setEntityFieldsMetadata unless specified here (use description => '' to hide)
    *  - not-auto-addable - this class will not attempt to add the field using addField.
    *    (this will be automatically set if the field does not have html in it's metadata
    *    or is not a core field on the form's entity).
@@ -70,11 +71,16 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
         'name' => 'label_b_a',
         'description' => ts("Label for the relationship from Contact B to Contact A. EXAMPLE: Contact B is 'Child of' Contact A. You may leave this blank for relationships where the name is the same in both directions (e.g. Spouse).")
       ],
-      'description' => ['name' => 'description'],
+      'description' => [
+        'name' => 'description',
+        'description' => ''
+      ],
       'contact_types_a' => ['name' => 'contact_types_a', 'not-auto-addable' => TRUE],
       'contact_types_b' => ['name' => 'contact_types_b', 'not-auto-addable' => TRUE],
       'is_active' => ['name' => 'is_active'],
     ];
+
+    self::setEntityFieldsMetadata();
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1292,7 +1292,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * Return string
    */
-  private function getApiAction() {
+  protected function getApiAction() {
     $action = $this->getAction();
     if ($action & (CRM_Core_Action::UPDATE + CRM_Core_Action::ADD)) {
       return 'create';

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -32,10 +32,11 @@
  */
 
 trait CRM_Core_Form_EntityFormTrait {
+
   /**
    * Get entity fields for the entity to be added to the form.
    *
-   * @var array
+   * @return array
    */
   public function getEntityFields() {
     return $this->entityFields;
@@ -51,7 +52,7 @@ trait CRM_Core_Form_EntityFormTrait {
   /**
    * Get entity fields for the entity to be added to the form.
    *
-   * @var array
+   * @return string
    */
   public function getDeleteMessage() {
     return $this->deleteMessage;
@@ -219,6 +220,24 @@ trait CRM_Core_Form_EntityFormTrait {
    */
   protected function isDeleteContext() {
     return ($this->_action & CRM_Core_Action::DELETE);
+  }
+
+  protected function setEntityFieldsMetadata() {
+    foreach ($this->entityFields as $field => &$props) {
+      if (!empty($props['not-auto-addable'])) {
+        // We can't load this field using metadata
+        continue;
+      }
+      // Resolve action.
+      if (empty($props['action'])) {
+        $props['action'] = $this->getApiAction();
+      }
+      $fieldSpec = civicrm_api3($this->getDefaultEntity(), 'getfield', $props);
+      $fieldSpec = $fieldSpec['values'];
+      if (!isset($props['description']) && isset($fieldSpec['description'])) {
+        $props['description'] = $fieldSpec['description'];
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Further development of entityForm.

This adds the (default) ability to automatically show the description from the entity schema instead of hardcoding in the entityFields property on the class.

Before
----------------------------------------
Converting to entityForm requires moving description from tpl to setEntityFields() in form class.

After
----------------------------------------
Converting to entityForm requires verifying metadata description in xml schema and updating if necessary. Description does not need to be hardcoded in class.

Technical Details
----------------------------------------
We get the metadata using API.getfield.  Technically this means we are now calling this twice (as it is also called by addField later on).

Comments
----------------------------------------
@mlutfy Please could you comment from a translation perspective.. ie. do the schema elements get translated?
@eileenmcnaughton Next stage of entityForm...
