### PR TITLE
Convert event search to datepicker and cleanup template

### DIFF
--- a/CRM/Event/Form/SearchEvent.php
+++ b/CRM/Event/Form/SearchEvent.php
@@ -60,8 +60,7 @@ class CRM_Event_Form_SearchEvent extends CRM_Core_Form {
   /**
    * Build the form object.
    *
-   *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     $this->add('text', 'title', ts('Event Name'),
@@ -72,10 +71,10 @@ class CRM_Event_Form_SearchEvent extends CRM_Core_Form {
 
     $eventsByDates = array();
     $searchOption = array(ts('Show Current and Upcoming Events'), ts('Search All or by Date Range'));
-    $this->addRadio('eventsByDates', ts('Events by Dates'), $searchOption, array('onclick' => "return showHideByValue('eventsByDates','1','id_fromToDates','block','radio',true);"), "<br />");
+    $this->addRadio('eventsByDates', ts('Events by Dates'), $searchOption, array('onclick' => "return showHideByValue('eventsByDates','1','id_fromToDates','block','radio',true);"), '&nbsp;');
 
-    $this->addDate('start_date', ts('From'), FALSE, array('formatType' => 'searchDate'));
-    $this->addDate('end_date', ts('To'), FALSE, array('formatType' => 'searchDate'));
+    $this->add('datepicker', 'start_date', ts('From'), [], FALSE, ['time' => FALSE]);
+    $this->add('datepicker', 'end_date', ts('To'), [], FALSE, ['time' => FALSE]);
 
     CRM_Campaign_BAO_Campaign::addCampaignInComponentSearch($this);
 
@@ -98,9 +97,8 @@ class CRM_Event_Form_SearchEvent extends CRM_Core_Form {
         if (isset($params[$field]) &&
           !CRM_Utils_System::isNull($params[$field])
         ) {
-          if (substr($field, -4) == 'date') {
-            $time = ($field == 'end_date') ? '235959' : NULL;
-            $parent->set($field, CRM_Utils_Date::processDate($params[$field], $time));
+          if ($field === 'end_date') {
+            $parent->set($field, $params[$field] . ' 23:59:59');
           }
           else {
             $parent->set($field, $params[$field]);

--- a/templates/CRM/Campaign/Form/addCampaignToComponent.tpl
+++ b/templates/CRM/Campaign/Form/addCampaignToComponent.tpl
@@ -5,9 +5,8 @@
 {* add campaign in component search *}
 <tr class="{$campaignTrClass}">
     {assign var=elementName value=$campaignInfo.elementName}
-
-    <td class="{$campaignTdClass}">{$form.$elementName.label}<br />
-    <div class="crm-select-container">{$form.$elementName.html}</div>
+    <td class="{$campaignTdClass}">
+      {$form.$elementName.label} {$form.$elementName.html}
     </td>
 </tr>
 

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -23,8 +23,11 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-event-searchevent-form-block">
- <h3>{ts}Find Events{/ts}</h3>
+  <div class="crm-accordion-wrapper crm-block crm-form-block crm-event-searchevent-form-block collapsed">
+    <div class="crm-accordion-header">
+      {ts}Find Events{/ts}
+    </div>
+    <div class="crm-accordion-body">
   <table class="form-layout">
     <tr class="crm-event-searchevent-form-block-title">
         <td>
@@ -33,24 +36,26 @@
           <div class="description font-italic">
                  {ts}Complete OR partial Event name.{/ts}
           </div>
-          <div style="height: auto; vertical-align: bottom">{$form.eventsByDates.html}</div>
         </td>
-        <td rowspan="2"><label>{ts}Event Type{/ts}</label>
+        <td><label>{ts}Event Type{/ts}</label>
           {$form.event_type_id.html}
         </td>
-        <td class="right" rowspan="2">&nbsp;{include file="CRM/common/formButtons.tpl"}</td>
     </tr>
-
+    <tr>
+    <td colspan="2"><div style="height: auto; vertical-align: bottom">{$form.eventsByDates.html}</div></td>
+    </tr>
     <tr>
        <td colspan="2">
        <table class="form-layout-compressed" id="id_fromToDates">
-        <tr class="crm-event-searchevent-form-block-start_date">
-            <td class="label">{$form.start_date.label}</td>
-            <td>{include file="CRM/common/jcalendar.tpl" elementName=start_date}</td>
-        </tr>
-        <tr class="crm-event-searchevent-form-block-end_date" >
-            <td class="label">{$form.end_date.label}</td>
-            <td>{include file="CRM/common/jcalendar.tpl" elementName=end_date}</td>
+        <tr class="">
+          <td class="crm-event-searchevent-form-block-start_date">
+            <label>{$form.start_date.label}</label>
+            {$form.start_date.html}
+          </td>
+          <td class="crm-event-searchevent-form-block-end_date">
+            <label>{$form.end_date.label}</label>
+            {$form.end_date.html}
+          </td>
         </tr>
       </table>
     </td></tr>
@@ -58,16 +63,17 @@
     {* campaign in event search *}
     {include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignContext="componentSearch"
     campaignTrClass='crm-event-searchevent-form-block-campaign_id' campaignTdClass=''}
-
+    <td class="right">{include file="CRM/common/formButtons.tpl"}</td>
   </table>
-</div>
+    </div>
+  </div>
 
 {include file="CRM/common/showHide.tpl"}
 
 {literal}
 <script type="text/javascript">
 if ( document.getElementsByName('eventsByDates')[1].checked ) {
-  cj('#id_fromToDates').show();
+  CRM.$('#id_fromToDates').show();
 }
 </script>
 {/literal}

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -28,6 +28,8 @@
 {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&list=1" fe=1}{/capture}
 {capture assign=rssFeed}{crmURL p='civicrm/event/ical' q="reset=1&list=1&rss=1" fe=1}{/capture}
 {capture assign=htmlFeed}{crmURL p='civicrm/event/ical' q="reset=1&list=1&html=1" fe=1}{/capture}
+
+<div class="crm-block crm-content-block">
 <div class="float-right">
   <a href="{$htmlFeed}"  target="_blank" title="{ts}HTML listing of current and future public events.{/ts}" class="crm-event-feed-link"><i class="crm-i fa-lg fa-calendar"></i></a>
   <a href="{$rssFeed}"  target="_blank" title="{ts}Get RSS 2.0 feed for current and future public events.{/ts}" class="crm-event-feed-link"><i class="crm-i fa-lg fa-rss"></i></a>
@@ -35,7 +37,6 @@
   <a href="{$icalFeed}"  target="_blank" title="{ts}Get iCalendar feed for current and future public events.{/ts}" class="crm-event-feed-link"><i class="crm-i fa-lg fa-calendar-o"></i></a>
   {help id='icalendar'}
 </div>
-{include file="CRM/Event/Form/SearchEvent.tpl"}
 
 <div class="action-link">
   <a accesskey="N" href="{$newEventURL}" id="newManageEvent" class="button crm-popup">
@@ -43,6 +44,9 @@
   </a>
   <div class="clear"></div>
 </div>
+
+{include file="CRM/Event/Form/SearchEvent.tpl"}
+
 {if $rows}
 <div id="event_status_id" class="crm-block crm-manage-events">
   {strip}
@@ -153,9 +157,6 @@
     </table>
   {include file="CRM/common/pager.tpl" location="bottom"}
   {/strip}
-  {if $isSearch eq 0}
-    <div class="status messages no-popup">{ts}Don't see your event listed? Try "Search All or by Date Range" above.{/ts}</div>
-  {/if}
 </div>
 {else}
   {if $isSearch eq 1}
@@ -179,3 +180,4 @@
   </div>
   {/if}
 {/if}
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Convert form to use datepicker:
* Event Search (On ManageEvent page - also cleaned up layout) - Before/After screenshot below.

Partial from #12973

Before
----------------------------------------
Using old jcalendar.
![localhost_8000_civicrm_event_manage_reset 1 2](https://user-images.githubusercontent.com/2052161/47265216-5b28c800-d51c-11e8-8aae-380bcaff45fc.png)


After
----------------------------------------
Using "new" datepicker.
![localhost_8000_civicrm_event_manage_reset 1 3](https://user-images.githubusercontent.com/2052161/47556495-58f0b000-d906-11e8-8c90-b6717f486e4a.png)

