### PR TITLE
Remove contact tags when none selected on edit screen

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1004,11 +1004,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     if (array_key_exists('TagsAndGroups', $this->_editOptions)) {
       //add contact to tags
-      if (isset($params['tag']) && !empty($params['tag'])) {
+      if (isset($params['tag'])) {
         $params['tag'] = array_flip(explode(',', $params['tag']));
         CRM_Core_BAO_EntityTag::create($params['tag'], 'civicrm_contact', $params['contact_id']);
       }
-
       //save free tags
       if (isset($params['contact_taglist']) && !empty($params['contact_taglist'])) {
         CRM_Core_Form_Tag::postProcess($params['contact_taglist'], $params['contact_id'], 'civicrm_contact', $this);


### PR DESCRIPTION
Overview
----------------------------------------
Contact are not untagged when all the values from tag select drop down is unselected. 

merged to 5.7 in #12958

Steps to reproduce:

Log in to CRM
Go to Individual's profile
Click the button "Edit"
Open block "Tags and Groups"
Delete data from field "Tag(s)"
Click the button "Save"
Result: The information in the tag field is not updated (see below gif file)

Expected result: The field "Tag(s)" has been updated.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/47210852-f6d6fe80-d38b-11e8-8731-d983e6b36902.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/47210872-05bdb100-d38c-11e8-9fcf-824bdf3c9672.gif)


Technical Details
----------------------------------------
When Tags are unselected on Contact edit form $params['tags'] is empty and hence it doesn't call create entity tag function where it removes or adds tags depending upon $params['tags'] array passed. The create entity tag function first gets all the tags of the contact and then diff with $params['tags'] and untags the contact from result of diff.


