### PR TITLE
dev/core#462 Exclude tmp tables from Advanced Logging missing table check

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -144,6 +144,8 @@ AND    TABLE_NAME LIKE 'civicrm_%'
     // CRM-18178
     $this->tables = preg_grep('/_bak$/', $this->tables, PREG_GREP_INVERT);
     $this->tables = preg_grep('/_backup$/', $this->tables, PREG_GREP_INVERT);
+    // dev/core#462
+    $this->tables = preg_grep('/^civicrm_tmp_/', $this->tables, PREG_GREP_INVERT);
 
     // do not log civicrm_mailing_event* tables, CRM-12300
     $this->tables = preg_grep('/^civicrm_mailing_event_/', $this->tables, PREG_GREP_INVERT);


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/issues/462

Export temporary tables cause Advanced Logging warning of missing log tables

`CRM/Utils/SQL/TempTable.php` was introduced around CiviCRM 5.3. It creates temp tables such as:

- `civicrm_tmp_d_{12}_{32}` (temporary tables, but created as ordinary tables)
- `civicrm_tmp_e_{12}_{32}` (ephemeral temp tables, automatically deleted by mysql)

After a while, depending on cleanup, users of CiviCRM using Advanced Logging will see warnings that there are missing log tables.

To reproduce:

- enable advanced logging
- run a few exports
- go to the System Check

Before
----------------------------------------

System.check warning warns about missing log tables.

After
----------------------------------------

No more warning.

Technical Details
----------------------------------------

Exclude tmp tables from the check.

Comments
----------------------------------------

SymbioTIC has been running this in production for a few months.