### PR TITLE
dev/core#463 Add in ability for Extensions to use their Extension Utils class to s…

### DIFF
--- a/CRM/Core/CodeGen/DAO.php
+++ b/CRM/Core/CodeGen/DAO.php
@@ -21,14 +21,22 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
   private $raw;
 
   /**
+   * @var string
+   * translate function name
+   */
+  private $tsFunctionName;
+
+  /**
    * CRM_Core_CodeGen_DAO constructor.
    *
    * @param \CRM_Core_CodeGen_Main $config
    * @param string $name
+   * @param string $tsFunctionName
    */
-  public function __construct($config, $name) {
+  public function __construct($config, $name, $tsFunctionName = 'ts') {
     parent::__construct($config);
     $this->name = $name;
+    $this->tsFunctionName = $tsFunctionName;
   }
 
   /**
@@ -69,6 +77,7 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
       $template->assign('indicesPhp', var_export($this->tables[$this->name]['index'], 1));
     }
     $template->assign('genCodeChecksum', $this->getTableChecksum());
+    $template->assign('tsFunctionName', $this->tsFunctionName);
     $template->run('dao.tpl', $this->getAbsFileName());
   }
 
@@ -88,6 +97,7 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
         $template->assign('indicesPhp', var_export($this->tables[$this->name]['index'], 1));
       }
       $template->assign('genCodeChecksum', 'NEW');
+      $template->assign('tsFunctionName', $this->tsFunctionName);
       $this->raw = $template->fetch('dao.tpl');
     }
     return $this->raw;

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -90,10 +90,10 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
                  'name'      => '{$field.name}',
                                                                       'type'      => {$field.crmType},
 {if $field.title}
-                                                                      'title'     => ts('{$field.title}'),
+                                                                      'title'     => {$tsFunctionName}('{$field.title}'),
 {/if}
 {if $field.comment}
-                                                                      'description'     => ts('{$field.comment|replace:"'":"\'"}'),
+                                                                      'description'     => {$tsFunctionName}('{$field.comment|replace:"'":"\'"}'),
 {/if}
 {if $field.required}
                                         'required'  => {$field.required|strtoupper},
@@ -148,7 +148,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
 {if $field.html}
   'html' => array(
   {foreach from=$field.html item=val key=key}
-    '{$key}' => {if $key eq 'label'}ts("{$val}"){else}'{$val}'{/if},
+    '{$key}' => {if $key eq 'label'}{$tsFunctionName}("{$val}"){else}'{$val}'{/if},
   {/foreach}
   ),
 {/if}


### PR DESCRIPTION
…upply ts Functions in DAOs

Overview
----------------------------------------
This allows for Civix or similar to ensure that when the DAO is generated that it uses instead of ts E::ts and that civix can insert the relevant use statement to use the Extensions' utils class

Before
----------------------------------------
No extension utils in DAO

After
----------------------------------------
Extension utils exists

Technical details
----------------------------------------
When creating a new entity (e.g DiscountItem) via an extension the new entity will need a DAO class. Our Civix code currently supports this - at least somewhat - but will not wrap any translatables with ```ts``` rather than the (correct for extensions) ```E::ts``` . Adding this to core will allow civix to leverage it to better create extension DAO objects
