### PR TITLE
Remove instances of LOWER casing searches from 

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3490,7 +3490,7 @@ WHERE  $smartGroupClause
       return;
     }
 
-    $n = strtolower(trim($value));
+    $n = trim($value);
     if ($n) {
       if (substr($n, 0, 1) == '"' &&
         substr($n, -1, 1) == '"'

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -175,7 +175,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
         0 => array(
           0 => 'email',
           1 => 'LIKE',
-          2 => 'secondary@example.com',
+          2 => 'sEcondary@example.com',
           3 => 0,
           4 => 1,
         ),


### PR DESCRIPTION
Overview
----------------------------------------
Improve performance and reliability of searches involving email (under some circumstances) by relying on mysql to handle case.

Before
----------------------------------------
We actively convert the string to use lower case in php and then use mysql LOWER for the comparison

After
----------------------------------------
We let mysql do what it does well. Test added

Technical Details
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/12494 mysql handles lcase.

Adding LOWER to mysql queries makes them slower. lowercasing php strings
breaks under some character sets with some server configs. Less is more


Comments
----------------------------------------
@seamuslee001 @monishdeb @colemanw I think we should push through on these since we have been chipping away for a few months after this discussion https://github.com/civicrm/civicrm-core/pull/12494 with no fallout
