### PR TITLE
Trigger post hook on Event Copy

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1670,7 +1670,9 @@ FROM   civicrm_domain
         }
       }
       $newObject->save();
+      CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getBriefName($daoName), $newObject->id, $newObject);
     }
+
     return $newObject;
   }
 

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -259,11 +259,12 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
       $params = array_merge(CRM_Event_BAO_Event::getTemplateDefaultValues($params['template_id']), $params);
     }
 
-    $event = CRM_Event_BAO_Event::create($params);
-
     // now that we have the event’s id, do some more template-based stuff
     if (!empty($params['template_id'])) {
-      CRM_Event_BAO_Event::copy($params['template_id'], $event, TRUE);
+      $event = CRM_Event_BAO_Event::copy($params['template_id']);
+    }
+    else {
+      $event = CRM_Event_BAO_Event::create($params);
     }
 
     $this->set('id', $event->id);

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -452,6 +452,7 @@ ORDER BY start_date desc
    * all the fields in the event wizard
    *
    * @return void
+   * @throws \CRM_Core_Exception
    */
   public function copy() {
     $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE, 0, 'GET');

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -98,6 +98,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
     $components = array('Contact', 'Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity');
 
     // FIXME: This should use a modified version of CRM_Contact_Form_Search::getModeValue but it doesn't have all the contexts
+    // FIXME: Or better still, use CRM_Core_DAO_AllCoreTables::getBriefName($daoName) to get the $entityShortName
     switch ($this->getQueryMode()) {
       case CRM_Contact_BAO_Query::MODE_CONTRIBUTE:
         $entityShortname = 'Contribute';


### PR DESCRIPTION
Overview
----------------------------------------
When creating a copy of an event via API Event.create (with a template ID) (or directly using the CRM_Event_BAO_Event::copy function - as called from ManageEvents-"Copy" in the UI) a "copy" hook is called but the expected Event.create hook is not called, despite a new event being created.

In addition the copy function (which is only called in two places) has complexities to support passing in an already copied event.  This seems unnecessarily complex and this PR simplifies that so it is always responsible for creating the copied event.

Note: Copying events via the "Repeat Events" (RecurringEntity) functionality doesn't use this function... It hardcodes it's own version which should be replaced with this copy function in a future PR.

Before
----------------------------------------
`CRM_Event_BAO_Event::copy()` doesn't call the "create" hook when an event is created and adds unnecessary complexity by allowing an already created event to be passed in.

After
----------------------------------------
`CRM_Event_BAO_Event::copy()` calls the "create" (post) hook when an event is created and simplifies the function so it is easier to maintain and simpler.

Technical Details
----------------------------------------
The "pre" hook is still not implemented because this would require conversion from an object to a params array and changes can be made via the "post" hook if required.

Comments
----------------------------------------
This change should be NFC.  The API remains the same, if extensions are calling `CRM_Event_BAO_Event::copy()` directly (which is unsupported) they will need to switch to use the API. However I'm not aware of any extensions that do call that function.