### PR TITLE
Remove use of LOWER from city & street searches

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2294,8 +2294,7 @@ class CRM_Contact_BAO_Query {
 
         //get the location name
         list($tName, $fldName) = self::getLocationTableName($field['where'], $locType);
-        // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
-        $fieldName = "LOWER(`$tName`.$fldName)";
+        $fieldName = "`$tName`.$fldName";
 
         // we set both _tables & whereTables because whereTables doesn't seem to do what the name implies it should
         $this->_tables[$tName] = $this->_whereTables[$tName] = 1;
@@ -2307,8 +2306,7 @@ class CRM_Contact_BAO_Query {
         }
         else {
           if ($op != 'IN' && !is_numeric($value) && !is_array($value)) {
-            // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
-            $fieldName = "LOWER({$field['where']})";
+            $fieldName = "{$field['where']}";
           }
           else {
             $fieldName = "{$field['where']}";
@@ -3566,7 +3564,6 @@ WHERE  $smartGroupClause
         $value = "%{$value}%";
       }
       $op = 'LIKE';
-      // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
       $this->_where[$grouping][] = self::buildClause('civicrm_address.street_address', $op, $value, 'String');
       $this->_qill[$grouping][] = ts('Street') . " $op '$n'";
     }

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -223,8 +223,8 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->defaultSearchProfileID = 1;
     $this->callAPISuccess('address', 'create', array(
         'contact_id' => $contactID,
-        'city' => 'Cool City',
-        'street_address' => 'Long Street',
+        'city' => 'Cool CITY',
+        'street_address' => 'Long STREET',
         'location_type_id' => 1,
       ));
     $returnProperties = array(
@@ -257,7 +257,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   public function getSearchProfileData() {
     return [
       [
-        [['city', '=', 'Cool City', 1, 0]], "civicrm_address.city as `city`", "LOWER(civicrm_address.city) = 'cool city'",
+        [['city', '=', 'Cool City', 1, 0]], "civicrm_address.city as `city`", "civicrm_address.city = 'cool city'",
       ],
       [
         // Note that in the query 'long street' is lower cased. We eventually want to change that & not mess with the vars - it turns out


### PR DESCRIPTION
Overview
----------------------------------------
Improve performance and reliability of searches involving street address & city  (under some circumstances) by relying on mysql to handle case.

Before
----------------------------------------
We actively convert the string to use lower case in php and then use mysql LOWER for the comparison

After
----------------------------------------
We let mysql do what it does well. 

Technical Details
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/12494 mysql handles lcase.

Adding LOWER to mysql queries makes them slower. lowercasing php strings
breaks under some character sets with some server configs. Less is more


Comments
----------------------------------------
@seamuslee001 @monishdeb @colemanw I think we should push through on these since we have been chipping away for a few months after this discussion https://github.com/civicrm/civicrm-core/pull/12494 with no fallout