### PR TITLE
Remove use of LOWER from mailing_name searches

### DIFF
--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -237,9 +237,6 @@ class CRM_Mailing_BAO_Query {
   public static function whereClauseSingle(&$values, &$query) {
     list($name, $op, $value, $grouping, $wildcard) = $values;
 
-    $fields = array();
-    $fields = self::getFields();
-
     switch ($name) {
       case 'mailing_id':
         $selectedMailings = array_flip($value);
@@ -259,14 +256,13 @@ class CRM_Mailing_BAO_Query {
         return;
 
       case 'mailing_name':
-        $value = strtolower(addslashes($value));
+        $value = addslashes($value);
         if ($wildcard) {
           $value = "%$value%";
           $op = 'LIKE';
         }
 
-        // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
-        $query->_where[$grouping][] = "LOWER(civicrm_mailing.name) $op '$value'";
+        $query->_where[$grouping][] = "civicrm_mailing.name $op '$value'";
         $query->_qill[$grouping][] = "Mailing Namename $op \"$value\"";
         $query->_tables['civicrm_mailing'] = $query->_whereTables['civicrm_mailing'] = 1;
         $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Improve performance and reliability of searches involving mailing name  (under some circumstances) by relying on mysql to handle case.

Before
----------------------------------------
We actively convert the string to use lower case in php and then use mysql LOWER for the comparison

After
----------------------------------------
We let mysql do what it does well. 

Technical Details
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/12494 mysql handles lcase.

Adding LOWER to mysql queries makes them slower. lowercasing php strings
breaks under some character sets with some server configs. Less is more


Comments
----------------------------------------
@seamuslee001 @monishdeb @colemanw I think we should push through on these since we have been chipping away for a few months after this discussion https://github.com/civicrm/civicrm-core/pull/12494 with no fallout