### PR TITLE
Fix default for repetition_start_date

### DIFF
--- a/CRM/Event/Form/ManageEvent/Repeat.php
+++ b/CRM/Event/Form/ManageEvent/Repeat.php
@@ -81,8 +81,7 @@ class CRM_Event_Form_ManageEvent_Repeat extends CRM_Event_Form_ManageEvent {
     $defaults = array();
 
     //Always pass current event's start date by default
-    $currentEventStartDate = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_id, 'start_date', 'id');
-    list($defaults['repetition_start_date'], $defaults['repetition_start_date_time']) = CRM_Utils_Date::setDateDefaults($currentEventStartDate, 'activityDateTime');
+    $defaults['repetition_start_date'] = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_id, 'start_date', 'id');
     $recurringEntityDefaults = CRM_Core_Form_RecurringEntity::setDefaultValues();
     return array_merge($defaults, $recurringEntityDefaults);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix default not loading for start date on event repeat pane. It should default to the current event start date but due to date mishandling this is not happening

Before
----------------------------------------
![screenshot 2018-10-24 17 22 47](https://user-images.githubusercontent.com/336308/47406324-2a61c080-d7b2-11e8-9818-dd04ab287e7c.png)

After
----------------------------------------
![screenshot 2018-10-24 17 31 24](https://user-images.githubusercontent.com/336308/47406418-a9ef8f80-d7b2-11e8-8244-b11314237847.png)



Technical Details
----------------------------------------
I think this is a regression from https://github.com/civicrm/civicrm-core/pull/12746 hence I put it against the rc which contains that fix. It's pretty trivial so should be rc-safe

Comments
----------------------------------------
@colemanw @mattwire you were both involved in the earlier one. Note there might be other affected places because the original PR focussed on recurring entities from the activity screen but I'm not sure what other screens support it. Also, possibly CiviVolunteer?