### PR TITLE
Quote fee levels for regular expression in Participant search.

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -340,11 +340,13 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         return;
 
       case 'participant_fee_id':
+        $val_regexp = [];
         foreach ($value as $k => &$val) {
           $val = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $val, 'label');
+          $val_regexp[$k] = CRM_Core_DAO::escapeString(preg_quote(trim($val)));
           $val = CRM_Core_DAO::escapeString(trim($val));
         }
-        $feeLabel = implode('|', $value);
+        $feeLabel = implode('|', $val_regexp);
         $query->_where[$grouping][] = "civicrm_participant.fee_level REGEXP '{$feeLabel}'";
         $query->_qill[$grouping][] = ts("Fee level") . " IN " . implode(', ', $value);
         $query->_tables['civicrm_participant'] = $query->_whereTables['civicrm_participant'] = 1;

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -295,36 +295,19 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
-   * The post processing of the form gets done here.
-   *
-   * Key things done during post processing are
-   *      - check for reset or next request. if present, skip post procesing.
-   *      - now check if user requested running a saved search, if so, then
-   *        the form values associated with the saved search are used for searching.
-   *      - if user has done a submit with new values the regular post submissing is
-   *        done.
-   * The processing consists of using a Selector / Controller framework for getting the
-   * search results.
-   *
-   * @param
-   *
-   * @return void
+   * Test submit the form.
+   * @param $formValues
    */
-  public function postProcess() {
-    if ($this->_done) {
-      return;
-    }
+  public function testSubmit($formValues) {
+    $this->submit($formValues);
+  }
 
-    $this->_done = TRUE;
-
-    if (!empty($_POST)) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-      CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, array('participant_status_id'));
-    }
-
-    if (empty($this->_formValues)) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
+  /**
+   * Submit the search form with given values.
+   * @param $formValues
+   */
+  private function submit($formValues) {
+    $this->_formValues = $formValues;
 
     $this->fixFormValues();
 
@@ -398,6 +381,42 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $query->setSkipPermission(TRUE);
     }
     $controller->run();
+  }
+
+  /**
+   * The post processing of the form gets done here.
+   *
+   * Key things done during post processing are
+   *      - check for reset or next request. if present, skip post procesing.
+   *      - now check if user requested running a saved search, if so, then
+   *        the form values associated with the saved search are used for searching.
+   *      - if user has done a submit with new values the regular post submissing is
+   *        done.
+   * The processing consists of using a Selector / Controller framework for getting the
+   * search results.
+   *
+   * @param
+   *
+   * @return void
+   */
+  public function postProcess() {
+    if ($this->_done) {
+      return;
+    }
+
+    $this->_done = TRUE;
+    $formValues = array();
+
+    if (!empty($_POST)) {
+      $formValues = $this->controller->exportValues($this->_name);
+      CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, array('participant_status_id'));
+    }
+
+    if (empty($this->_formValues)) {
+      $formValues = $this->controller->exportValues($this->_name);
+    }
+
+    $this->submit($formValues);
   }
 
   /**

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -209,11 +209,13 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
         // CRM-15379
         if (!empty($this->_formValues['participant_fee_id'])) {
           $participant_fee_id = $this->_formValues['participant_fee_id'];
+          $val_regexp = [];
           foreach ($participant_fee_id as $k => &$val) {
             $val = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $val, 'label');
+            $val_regexp[$k] = CRM_Core_DAO::escapeString(preg_quote(trim($val)));
             $val = CRM_Core_DAO::escapeString(trim($val));
           }
-          $feeLabel = implode('|', $participant_fee_id);
+          $feeLabel = implode('|', $val_regexp);
           $seatClause[] = "( participant.fee_level REGEXP '{$feeLabel}' )";
         }
 

--- a/tests/phpunit/CRM/Event/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Event/Form/SearchTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Event_Form_SearchTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+    $this->individualID = $this->individualCreate();
+  }
+
+  /**
+   *  Test that search form returns correct number of rows for complex regex filters.
+   */
+  public function testSearch() {
+    $priceFieldValues = $this->createPriceSet('event', NULL, array(
+      'html_type'    => 'Radio',
+      'option_label' => array('1' => 'Radio Label A (inc. GST)', '2' => 'Radio Label B (inc. GST)'),
+      'option_name'  => array('1' => 'Radio Label A', '2' => 'Radio Label B'),
+    ));
+
+    $priceFieldValues = $priceFieldValues['values'];
+    $participantPrice = NULL;
+    foreach ($priceFieldValues as $priceFieldValue) {
+      $participantPrice = $priceFieldValue;
+      break;
+    }
+
+    $event = $this->eventCreate();
+    $individualID = $this->individualCreate();
+    $today = new DateTime();
+    $this->participantCreate(array(
+      'event_id'      => $event['id'],
+      'contact_id'    => $individualID,
+      'status_id'     => 1,
+      'fee_level'     => $participantPrice['label'],
+      'fee_amount'    => $participantPrice['amount'],
+      'fee_currency'  => 'USD',
+      'register_date' => $today->format('YmdHis'),
+    ));
+
+    $form = new CRM_Event_Form_Search();
+    $form->controller = new CRM_Event_Controller_Search();
+    $form->preProcess();
+    $form->testSubmit(array(
+      'participant_test' => 0,
+      'participant_fee_id' => array(
+        $participantPrice['id'],
+      ),
+      'radio_ts'         => 'ts_all',
+    ));
+    $rows = $form->controller->get('rows');
+    $this->assertEquals(1, count($rows), 'Exactly one row should be returned for given price field value.');
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes [core/433](https://lab.civicrm.org/dev/core/issues/433) for Search / Query for Participants registering for a fee level that includes regex metacharacters.
Common metacharacters that you might expect to find in a fee level include

- `$` – end of match (very problematic as it's normally followed by a number when present, which will never match anything)
- `(` and `)` – sub-expression grouping
- `[` and `]` – character class matching
- `.` – matches any single character (this one is less problematic as it will still match a literal '.')

Before
----------------------------------------
Querying for fee levels that contain regex metacharacters will not match, and return no match. Example fee level:
> Premium Gala Dinner ticket (adds $20.00)

![Screenshot 2019-04-04 13 06 40](https://user-images.githubusercontent.com/336308/55520850-b6b9cd00-56da-11e9-853d-aad42fd47423.png)


After
----------------------------------------
The fee level input is quoted for regex metacharacters before being combined with `|` and used with MySQL `REGEX` / `RLIKE` operator, so the metacharacters become literal characters and the search parameter now matches.  Example results of transform:
> Premium Gala Dinner ticket \\(adds \\$20\\.00\\)


![Screenshot 2019-04-04 13 07 41](https://user-images.githubusercontent.com/336308/55520851-bc171780-56da-11e9-9e65-51c378b4bfd1.png)


Comments
----------------------------------------
A copy of the fee level is made before quoting is applied, so the extra `\` do not appear in the search criteria output.
No other user-input queries were discovered which used the combining `|` and `REGEX` method.