### PR TITLE
dev/translation#15 Fix backend CC contributions left pending if statuses are localised

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1156,7 +1156,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       // NOTE - I expect this is obsolete.
       $payment = Civi\Payment\System::singleton()->getByProcessor($this->_paymentProcessor);
       try {
-        $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id');
+        $completeStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
         $result = $payment->doPayment($paymentParams, 'contribute');
         $this->assign('trxn_id', $result['trxn_id']);
         $contribution->trxn_id = $result['trxn_id'];
@@ -1170,7 +1170,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
          * as historically we have had to guess from the context - ie doDirectPayment
          * = error or success, unless it is a recurring contribution in which case it is pending.
          */
-        if ($result['payment_status_id'] == array_search('Completed', $statuses)) {
+        if ($result['payment_status_id'] == $completeStatusId) {
           try {
             civicrm_api3('contribution', 'completetransaction', array(
               'id' => $contribution->id,


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

- Modify the Contribution Statuses, so that the label for Complete is 'Terminé' (https://dmaster.demo.civicrm.org/civicrm/admin/options?gid=11&reset=1) - this changes the label, not the name, so that we can localize the contribution statuses.
- Go to a contact record and record a new credit card contribution (you can use the dummy processor)

Details & animated GIF: https://lab.civicrm.org/dev/translation/issues/15

Before
----------------------------------------

The contribution is left as pending.

After
----------------------------------------

The contribution is completed.

Technical Details
----------------------------------------

The usual "option values had obscure function names and programmers did lots of errors".

Comments
----------------------------------------

The fix was suggested by @mattwire

[Symbiotic](https://symbiotic.coop/en) has been running this patch for the past month.