### PR TITLE
dev/core#456 Improve UX of scheduling mass SMS

### DIFF
--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -53,7 +53,7 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
     $count = $this->get('count');
 
     $this->assign('count', $count);
-    $defaults['now'] = 1;
+    $defaults['send_option'] = 'send_immediate';
     return $defaults;
   }
 
@@ -61,9 +61,18 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
    * Build the form object for the last step of the sms wizard.
    */
   public function buildQuickform() {
-    $this->addDateTime('start_date', ts('Schedule SMS'), FALSE, array('formatType' => 'mailing'));
 
-    $this->addElement('checkbox', 'now', ts('Send Immediately'));
+    // Fix Firefox issue where the non-default field is displayed as checked
+    // on page refresh.
+    $this->setAttribute('autocomplete', 'off');
+
+    $sendOptions = [
+      $this->createElement('radio', NULL, NULL, 'Send immediately', 'send_immediate', ['id' => 'send_immediate', 'style' => 'margin-bottom: 10px;']),
+      $this->createElement('radio', NULL, NULL, 'Send at:', 'send_later', ['id' => 'send_later']),
+    ];
+    $this->addGroup($sendOptions, 'send_option', '', '<br>');
+
+    $this->add('datepicker', 'start_date', '', NULL, FALSE, ['minDate' => time()]);
 
     $this->addFormRule(array('CRM_SMS_Form_Schedule', 'formRule'), $this);
 
@@ -111,29 +120,28 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
    *   set.
    */
   public static function formRule($params, $files, $self) {
-    if (!empty($params['_qf_Schedule_submit'])) {
 
+    if (!empty($params['_qf_Schedule_submit'])) {
       CRM_Core_Session::setStatus(ts("Your Mass SMS has been saved. Click the 'Continue' action to resume working on it."), ts('Saved'), 'success');
       $url = CRM_Utils_System::url('civicrm/mailing/browse/unscheduled', 'scheduled=false&reset=1&sms=1');
       CRM_Utils_System::redirect($url);
     }
-    if (isset($params['now']) || CRM_Utils_Array::value('_qf_Schedule_back', $params) == ts('Previous')) {
+
+    if ((isset($params['send_option']) && $params['send_option'] == 'send_immediate') || CRM_Utils_Array::value('_qf_Schedule_back', $params) == ts('Previous')) {
       return TRUE;
     }
 
-    if (CRM_Utils_Date::format(CRM_Utils_Date::processDate($params['start_date'],
-        $params['start_date_time']
-      )) < CRM_Utils_Date::format(date('YmdHi00'))
-    ) {
+    if (strtotime($params['start_date']) < time()) {
       return array(
         'start_date' => ts('Start date cannot be earlier than the current time.'),
       );
     }
+
     return TRUE;
   }
 
   /**
-   * Process the posted form values.  Create and schedule a Mass SMS.
+   * Process the posted form values. Create and schedule a Mass SMS.
    */
   public function postProcess() {
     $params = array();
@@ -144,34 +152,23 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
       CRM_Core_Error::fatal(ts('Could not find a mailing id'));
     }
 
-    foreach (array('now', 'start_date', 'start_date_time') as $parameter) {
-      $params[$parameter] = $this->controller->exportValue($this->_name, $parameter);
-    }
-
-    if ($params['now']) {
+    $send_option = $this->controller->exportValue($this->_name, 'send_option');
+    if (isset($params['send_option']) && $params['send_option'] == 'send_immediate') {
       $params['scheduled_date'] = date('YmdHis');
     }
     else {
-      $params['scheduled_date'] = CRM_Utils_Date::processDate($params['start_date'] . ' ' . $params['start_date_time']);
+      $params['scheduled_date'] = $this->controller->exportValue($this->_name, 'start_date');
     }
 
     $session = CRM_Core_Session::singleton();
     // set the scheduled_id
     $params['scheduled_id'] = $session->get('userID');
-    $params['scheduled_date'] = date('YmdHis');
 
     // set approval details if workflow is not enabled
     if (!CRM_Mailing_Info::workflowEnabled()) {
       $params['approver_id'] = $session->get('userID');
       $params['approval_date'] = date('YmdHis');
       $params['approval_status_id'] = 1;
-    }
-
-    if ($params['now']) {
-      $params['scheduled_date'] = date('YmdHis');
-    }
-    else {
-      $params['scheduled_date'] = CRM_Utils_Date::processDate($params['start_date'] . ' ' . $params['start_date_time']);
     }
 
     // Build the mailing object.

--- a/templates/CRM/SMS/Form/Schedule.tpl
+++ b/templates/CRM/SMS/Form/Schedule.tpl
@@ -30,24 +30,16 @@
 </div>
 {include file="CRM/Mailing/Form/Count.tpl"}
 
-<table class="form-layout">
-  <tbody>
-    <tr class="crm-sms-schedule-form-block-now">
-        <td class="label">{$form.now.label}</td>
-        <td>{$form.now.html}</td>
-    </tr>
-    <tr>
-        <td class="label">{ts}OR{/ts}</td>
-        <td>&nbsp;</td>
-    </tr>
-    <tr class="crm-sms-schedule-form-block-start_date">
-        <td class="label">{$form.start_date.label}</td>
-        <td>{include file="CRM/common/jcalendar.tpl" elementName=start_date}
-            <div class="description">{ts}Set a date and time when you want CiviSMS to start sending this Mass SMS.{/ts}</div>
-        </td>
-    </tr>
-  </tbody>
-</table>
+<div>
+  <div>
+    <div>
+      {$form.send_option.html}
+      <span class="start_date_elements">{$form.start_date.html}</span>
+    </div>
+
+  </div>
+  <div class="description">{ts}Set a date and time when you want CiviSMS to start sending this Mass SMS.{/ts}</div>
+</div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
 
 {if $preview}
@@ -71,16 +63,21 @@
 <script type="text/javascript">
 {literal}
   CRM.$(function($) {
-    $('#start_date_display').change(function() {
-      $('#now').prop('checked', !$(this).val());
+
+    // If someone changes the schedule date, auto-select the 'send at' option
+    $(".start_date_elements input").change(function() {
+      $('#send_immediate').prop('checked', false);
+      $('#send_later').prop('checked', true);
     });
-    $('#now').change(function() {
+
+    // Clear scheduled date/time when send immediately is selected
+    $("#send_immediate").change(function() {
       if ($(this).prop('checked')) {
-        $('#start_date_display, #start_date, #start_date_time').val('');
-      } else {
-        $('#start_date_display').focus();
+        $(".start_date_elements input").val('');
+        $(".start_date_elements input").siblings("a.crm-clear-link").css('visibility', 'hidden');
       }
     });
+
   });
 {/literal}
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
As an electronic marketer I want to be able to schedule SMS mailings. However the interface can cause unexpected results.

If I leave 'send immediately' ticked, then the 'schedule sms' date is overridden, and 'now' is chosen instead. ie:

![sms-before-1](https://user-images.githubusercontent.com/5212601/47444806-3730e500-d7af-11e8-960a-9602999491f6.png)

![sms-before-2](https://user-images.githubusercontent.com/5212601/47444816-3d26c600-d7af-11e8-9663-dd4a2f581735.png)

This is very poor UX. As the options should be 'distinct'.

The desired solution would be to use a form the same as when scheduling an email in the, which makes this kind of error impossible. ie: usign radio buttons like the email scheduling tool does.

Before
----------------------------------------
Ambiguous UI.

After
----------------------------------------
Clear UI, better formatted code, improved UX:

- Options are now distinct
- Deprecated datetime element has been removed and replace with new datepicker
- Datepicker only displays dates in the future
- JS enhances user experience, ie: preselected 'schedule at' if someone enters a date / clears date when 'send immediately' is selected

![sms-after](https://user-images.githubusercontent.com/5212601/47444934-90007d80-d7af-11e8-83ac-62579edcbdbf.PNG)
