### PR TITLE
Fix Activity api to cope with renamed record type labels (e.g renaming 'Target' to 'Directed At')

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -368,13 +368,11 @@ function civicrm_api3_activity_get($params) {
  */
 function _civicrm_api3_activity_get_extraFilters(&$params, &$sql) {
   // Filter by activity contacts
-  $recordTypes = civicrm_api3('ActivityContact', 'getoptions', array('field' => 'record_type_id'));
-  $recordTypes = $recordTypes['values'];
   $activityContactOptions = array(
     'contact_id' => NULL,
-    'target_contact_id' => array_search('Activity Targets', $recordTypes),
-    'source_contact_id' => array_search('Activity Source', $recordTypes),
-    'assignee_contact_id' => array_search('Activity Assignees', $recordTypes),
+    'target_contact_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets'),
+    'source_contact_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Source'),
+    'assignee_contact_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Assignees'),
   );
   foreach ($activityContactOptions as $activityContactName => $activityContactValue) {
     if (!empty($params[$activityContactName])) {

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -684,25 +684,27 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
 
     $contact2 = $this->individualCreate($contact2Params);
 
+    $this->callAPISuccess('OptionValue', 'get', ['name' => 'Activity Targets', 'api.OptionValue.create' => ['label' => 'oh so creative']]);
+
     $params['assignee_contact_id'] = array($contact1, $contact2);
     $params['target_contact_id'] = array($contact2 => $contact2);
     $activity = $this->callAPISuccess('Activity', 'Create', $params);
 
-    $activityget = $this->callAPISuccess('Activity', 'get', array(
+    $activityGet = $this->callAPISuccess('Activity', 'get', array(
       'id' => $activity['id'],
       'target_contact_id' => $contact2,
       'return.target_contact_id' => 1,
     ));
-    $this->assertEquals($activity['id'], $activityget['id']);
-    $this->assertEquals($contact2, $activityget['values'][$activityget['id']]['target_contact_id'][0]);
+    $this->assertEquals($activity['id'], $activityGet['id']);
+    $this->assertEquals($contact2, $activityGet['values'][$activityGet['id']]['target_contact_id'][0]);
 
-    $activityget = $this->callAPISuccess('activity', 'get', array(
+    $activityGet = $this->callAPISuccess('activity', 'get', array(
       'target_contact_id' => $this->_contactID,
       'return.target_contact_id' => 1,
       'id' => $activity['id'],
     ));
-    if ($activityget['count'] > 0) {
-      $this->assertNotEquals($contact2, $activityget['values'][$activityget['id']]['target_contact_id'][0]);
+    if ($activityGet['count'] > 0) {
+      $this->assertNotEquals($contact2, $activityGet['values'][$activityGet['id']]['target_contact_id'][0]);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Replaces https://github.com/civicrm/civicrm-core/pull/12413

The CiviCRM is matching activity contacts options by _option label_ instead of _option name_ when you are trying to use Activity API and filter them by _source_contact_id_ or _target_contact_id_ or _assignee_contact_id_.

Before
----------------------------------------
If a user changes the label of option (in admin panel), the filter on Activity API doesn’t work properly. The system can't filter Activities by _source_contact_id_ or _target_contact_id_ or _assignee_contact_id_.

After
----------------------------------------
The activity contacts options is matching by _option name_ instead of _option label_. So, a user can modify label of options and doesn't brake the API.

Technical Details
----------------------------------------
The Activity API (_get_ action) is using "OptionValue"(get action) instead of "ActivityContact"(_getoptions_ action).