### PR TITLE
dev/core#474 - Show missing log table warning only if logging is enabled

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -82,7 +82,7 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
     $logging = new CRM_Logging_Schema();
     $missingLogTables = $logging->getMissingLogTables();
 
-    if ($missingLogTables) {
+    if (Civi::settings()->get('logging') && $missingLogTables) {
       $msg = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts("You don't have logging enabled on some tables. This may cause errors on performing insert/update operation on them."),


### PR DESCRIPTION
Overview
----------------------------------------
Fix missing log table warning on the status page.

Before
----------------------------------------
Missing Log table warning is shown even if logging is disabled in the following scenario -

- Logging is enabled on the site which generates a list of log tables in the database.
- User now disables the logging functionality on the site which now stops generating any more log tables.
- User create a custom set on the site which creates a new table in the database.
- The system status page notices a missing log table for the above and displays a warning.

The last step should also check if the logging is enabled on the site even if it is able to find some core log tables already present in the db.

After
----------------------------------------
Missing log table warning only shown if logging is enabled.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/474