### PR TITLE
Minor cleanup to CancelSubscription

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -217,14 +217,9 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
       CRM_Core_Error::displaySessionError($cancelSubscription);
     }
     elseif ($cancelSubscription) {
-      $activityParams
-        = array(
-          'subject' => $this->_mid ? ts('Auto-renewal membership cancelled') : ts('Recurring contribution cancelled'),
-          'details' => $message,
-        );
       $cancelStatus = CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(
         $this->_subscriptionDetails->recur_id,
-        $activityParams
+        ['details' => $message]
       );
 
       if ($cancelStatus) {


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution() is called in 3 places: here, tests and via API.  This is the only place that activity "subject" is specified outside of the function and leads to messages such as:
_Auto-renewal membership cancelled `<br />`Automatic renewal of %1 membership cancelled."_

Before
----------------------------------------
Activity "subject" basically duplicated.

After
----------------------------------------
Activity "subject" not duplicated.

Technical Details
----------------------------------------
Almost an NFC change. The `$details` string is appended with a slightly more verbose one in the function leading to duplicated information in the message.

Comments
----------------------------------------
Any willing victims? @kirk-jackson @seamuslee001 