### PR TITLE
Prototype for metadata based fields on search screens.

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -434,14 +434,25 @@ class CRM_Activity_BAO_Query {
   }
 
   /**
+   * Get the metadata for fields to be included on the activity search form.
+   *
+   * @todo ideally this would be a trait included on the activity search & advanced search
+   * rather than a static function.
+   */
+  public static function getSearchFieldMetadata() {
+    $fields = ['activity_type_id'];
+    $metadata = civicrm_api3('Activity', 'getfields', [])['values'];
+    return array_intersect_key($metadata, array_flip($fields));
+  }
+
+  /**
    * Add all the elements shared between case activity search and advanced search.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Core_Form_Search $form
    */
   public static function buildSearchForm(&$form) {
-    $form->addSelect('activity_type_id',
-      array('entity' => 'activity', 'label' => ts('Activity Type(s)'), 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
-    );
+    $form->addSearchFieldMetadata(['Activity' => self::getSearchFieldMetadata()]);
+    $form->addFormFieldsFromMetadata();
 
     CRM_Core_Form_Date::buildDateRange($form, 'activity_date', 1, '_low', '_high', ts('From'), FALSE, FALSE);
     $form->addElement('hidden', 'activity_date_range_error');

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -70,6 +70,13 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
   protected $_ssID;
 
   /**
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'Activity';
+  }
+
+  /**
    * Processing needed for buildForm and later.
    */
   public function preProcess() {
@@ -95,6 +102,8 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       if ($this->_force) {
         // If we force the search then merge form values with url values
         // and set submit values to form values.
+        // @todo this is not good security practice. Instead define the fields in metadata & use
+        // getEntityDefaults.
         $this->_formValues = array_merge((array) $this->_formValues, CRM_Utils_Request::exportValues());
         $this->_submitValues = $this->_formValues;
       }
@@ -203,7 +212,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
 
       CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);
     }
-
     $this->fixFormValues();
 
     if (isset($this->_ssID) && empty($_POST)) {
@@ -369,6 +377,8 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     }
 
     // Enable search activity by custom value
+    // @todo this is not good security practice. Instead define entity fields in metadata &
+    // use getEntity Defaults
     $requestParams = CRM_Utils_Request::exportValues();
     foreach (array_keys($requestParams) as $key) {
       if (substr($key, 0, 7) != 'custom_') {
@@ -397,12 +407,26 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
+   * This virtual function is used to set the default values of various form elements.
+   *
+   * @return array|NULL
+   *   reference to the array of default values
+   */
+  public function setDefaultValues() {
+    return array_merge($this->getEntityDefaults($this->getDefaultEntity()), $this->_formValues);
+  }
+
+  /**
    * Return a descriptive name for the page, used in wizard header
    *
    * @return string
    */
   public function getTitle() {
     return ts('Find Activities');
+  }
+
+  protected function getEntityMetadata() {
+    return CRM_Activity_BAO_Query::getSearchFieldMetadata();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Introduces methodology to clean up search forms.

Before
----------------------------------------
No clear plan for where to go with search forms

After
----------------------------------------
Entity-form type approach intiated. Also activity search can take activity_type_id (as the only converted field) in the url to set defaults :-)

Technical Details
----------------------------------------
This is a first step towards making search screens more metadata driven. It switches the activity_type_id field to being metadata-added and adds support for activity_type_id=1 via the url.

The setting of defaults is more like 'normal' forms where they are loaded & can be changed in the UI
rather than 'search methods' where they only work in conjunction with 'force'
(which also still works).

This comes out of my concern that
a) we already have url defaults added badly on this form &
b) we have had more than one PR to add more defaults - eg. https://github.com/civicrm/civicrm-core/pull/12455

So I think we should define how we really want entity data to be used with search forms & move towards it.

Note also that the tpls for Contribution Search and one of the contact search panes have been amended to
be metadata driven. I haven't tried to align with that in this step but it should be down the track

Comments
----------------------------------------
ping @mattwire @colemanw @jitendrapurohit @monishdeb @seamuslee001 
