### PR TITLE
CRM-21851 Current employer dissapears when disabling expired relationships

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -656,7 +656,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     $relationship->id = $id;
     $relationship->find(TRUE);
 
-    //to delete relationship between household and individual                                                                                          \
+    //to delete relationship between household and individual                                                                                          
     //or between individual and organization
     if (($action & CRM_Core_Action::DISABLE) || ($action & CRM_Core_Action::DELETE)) {
       $relTypes = CRM_Utils_Array::index(array('name_a_b'), CRM_Core_PseudoConstant::relationshipType('name'));
@@ -676,12 +676,12 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
 
         if ($relationship->relationship_type_id == $employerRelTypeId && $relationship->contact_id_b == $sharedContact->employer_id) {
           $currentEmployerRlationship = new CRM_Contact_DAO_Relationship();
-			$currentEmployerRlationship->contact_id_a = $relationship->contact_id_a;
-			$currentEmployerRlationship->end_date=NULL;
-			$currentEmployerRlationship->is_active=1;
-			if(!$currentEmployerRlationship->find(TRUE)){
-					 CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
-			}
+          $currentEmployerRlationship->contact_id_a = $relationship->contact_id_a;
+          $currentEmployerRlationship->end_date=NULL;
+          $currentEmployerRlationship->is_active=1;
+          if(!$currentEmployerRlationship->find(TRUE)){
+	     CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
+          }
         }
 
       }
@@ -2277,14 +2277,14 @@ AND cc.sort_name LIKE '%$name%'";
     if ($existingTypeName !== 'Employer of') {
       return FALSE;
     }
-	//check if there are another relationship which is not expired 
-	  $relationship = new CRM_Contact_DAO_Relationship();
-      $relationship->contact_id_a = $params['contactID'];
-      $relationship->relationship_type_id = $params['relationship_type_id'];
-	  $relationship->end_date = NULL;
-	  if ($relationship->find(TRUE)) {
-		return FALSE;
-      }
+    //check if there are another relationship which is not expired
+    $relationship = new CRM_Contact_DAO_Relationship();
+    $relationship->contact_id_a = $params['contactID'];
+    $relationship->relationship_type_id = $params['relationship_type_id'];
+    $relationship->end_date = NULL;
+    if ($relationship->find(TRUE)) {
+      return FALSE;
+    }
 	  
     //Clear employer if relationship is expired.
     if (!empty($params['end_date']) && strtotime($params['end_date']) < time()) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -675,7 +675,13 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
         $employerRelTypeId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', 'Employee of', 'id', 'name_a_b');
 
         if ($relationship->relationship_type_id == $employerRelTypeId && $relationship->contact_id_b == $sharedContact->employer_id) {
-          CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
+          $currentEmployerRlationship = new CRM_Contact_DAO_Relationship();
+			$currentEmployerRlationship->contact_id_a = $relationship->contact_id_a;
+			$currentEmployerRlationship->end_date=NULL;
+			$currentEmployerRlationship->is_active=1;
+			if(!$currentEmployerRlationship->find(TRUE)){
+					 CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
+			}
         }
 
       }
@@ -2271,6 +2277,15 @@ AND cc.sort_name LIKE '%$name%'";
     if ($existingTypeName !== 'Employer of') {
       return FALSE;
     }
+	//check if there are another relationship which is not expired 
+	  $relationship = new CRM_Contact_DAO_Relationship();
+      $relationship->contact_id_a = $params['contactID'];
+      $relationship->relationship_type_id = $params['relationship_type_id'];
+	  $relationship->end_date = NULL;
+	  if ($relationship->find(TRUE)) {
+		return FALSE;
+      }
+	  
     //Clear employer if relationship is expired.
     if (!empty($params['end_date']) && strtotime($params['end_date']) < time()) {
       return TRUE;


### PR DESCRIPTION
To fix this we have to check if there is no unexpired relation ship before remove current contact employer. 