### PR TITLE
Add icons to contact summary tabs

### DIFF
--- a/CRM/Campaign/Info.php
+++ b/CRM/Campaign/Info.php
@@ -132,6 +132,14 @@ class CRM_Campaign_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-star-o';
+  }
+
+  /**
+   * @inheritDoc
    * @return null
    */
   public function registerAdvancedSearchPane() {

--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -178,6 +178,14 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-folder-open-o';
+  }
+
+  /**
+   * @inheritDoc
    * @return array
    */
   public function registerAdvancedSearchPane() {

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -316,40 +316,47 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
         'url' => '#contact-summary',
         'title' => ts('Summary'),
         'weight' => 0,
+        'icon' => 'crm-i fa-address-card-o'
       ],
       [
         'id' => 'activity',
         'title' => ts('Activities'),
         'class' => 'livePage',
         'weight' => 70,
+        'icon' => 'crm-i fa-tasks',
       ],
       [
         'id' => 'rel',
         'title' => ts('Relationships'),
         'class' => 'livePage',
         'weight' => 80,
+        'icon' => 'crm-i fa-handshake-o',
       ],
       [
         'id' => 'group',
         'title' => ts('Groups'),
         'class' => 'ajaxForm',
         'weight' => 90,
+        'icon' => 'crm-i fa-users',
       ],
       [
         'id' => 'note',
         'title' => ts('Notes'),
         'class' => 'livePage',
         'weight' => 100,
+        'icon' => 'crm-i fa-sticky-note-o',
       ],
       [
         'id' => 'tag',
         'title' => ts('Tags'),
         'weight' => 110,
+        'icon' => 'crm-i fa-tags',
       ],
       [
         'id' => 'log',
         'title' => ts('Change Log'),
         'weight' => 120,
+        'icon' => 'crm-i fa-history',
       ],
     ];
   }
@@ -391,6 +398,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
           'weight' => $elem['weight'],
           'count' => CRM_Contact_BAO_Contact::getCountComponent($u, $this->_contactId),
           'class' => 'livePage',
+          'icon' => $component->getIcon(),
         ];
       }
     }
@@ -431,6 +439,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
         'count' => CRM_Contact_BAO_Contact::getCountComponent($id, $this->_contactId, $group['table_name']),
         'hideCount' => !$group['is_multiple'],
         'class' => 'livePage',
+        'icon' => 'crm-i fa-gear',
       ];
       $weight += 10;
     }

--- a/CRM/Contribute/Info.php
+++ b/CRM/Contribute/Info.php
@@ -166,6 +166,14 @@ class CRM_Contribute_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-credit-card';
+  }
+
+  /**
+   * @inheritDoc
    * Provides information about advanced search pane
    * offered by this component.
    *

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -199,6 +199,15 @@ abstract class CRM_Core_Component_Info {
   abstract public function registerTab();
 
   /**
+   * Get icon font class representing this component.
+   *
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-puzzle-piece';
+  }
+
+  /**
    * Provides information about advanced search pane
    * offered by this component.
    *

--- a/CRM/Event/Info.php
+++ b/CRM/Event/Info.php
@@ -145,6 +145,14 @@ class CRM_Event_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-calendar';
+  }
+
+  /**
+   * @inheritDoc
    * @return array
    */
   public function registerAdvancedSearchPane() {

--- a/CRM/Grant/Info.php
+++ b/CRM/Grant/Info.php
@@ -123,6 +123,14 @@ class CRM_Grant_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-money';
+  }
+
+  /**
+   * @inheritDoc
    * @return array
    */
   public function registerAdvancedSearchPane() {

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -278,6 +278,14 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-envelope-o';
+  }
+
+  /**
+   * @inheritDoc
    * @return array
    */
   public function registerAdvancedSearchPane() {

--- a/CRM/Member/Info.php
+++ b/CRM/Member/Info.php
@@ -152,6 +152,14 @@ class CRM_Member_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-id-badge';
+  }
+
+  /**
+   * @inheritDoc
    * Provides information about advanced search pane
    * offered by this component.
    *

--- a/CRM/Pledge/Info.php
+++ b/CRM/Pledge/Info.php
@@ -138,6 +138,14 @@ class CRM_Pledge_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-paper-plane';
+  }
+
+  /**
+   * @inheritDoc
    * Provides information about advanced search pane
    * offered by this component.
    *

--- a/CRM/Report/Info.php
+++ b/CRM/Report/Info.php
@@ -166,6 +166,14 @@ class CRM_Report_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
+   * @return string
+   */
+  public function getIcon() {
+    return 'crm-i fa-table';
+  }
+
+  /**
+   * @inheritDoc
    * Provides information about advanced search pane
    * offered by this component.
    *

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -127,7 +127,7 @@
           <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all crm-count-{$tabValue.count}{if isset($tabValue.class)} {$tabValue.class}{/if}">
             <a href="{$tabValue.url}" title="{$tabValue.title|escape}">
               <i class="{if $tabValue.icon}{$tabValue.icon}{else}crm-i fa-puzzle-piece{/if}"></i>
-              {$tabValue.title}
+              <span>{$tabValue.title}</span>
               {if empty($tabValue.hideCount)}<em>{$tabValue.count}</em>{/if}
             </a>
           </li>

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -126,6 +126,7 @@
         {foreach from=$allTabs key=tabName item=tabValue}
           <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all crm-count-{$tabValue.count}{if isset($tabValue.class)} {$tabValue.class}{/if}">
             <a href="{$tabValue.url}" title="{$tabValue.title|escape}">
+              <i class="{if $tabValue.icon}{$tabValue.icon}{else}crm-i fa-puzzle-piece{/if}"></i>
               {$tabValue.title}
               {if empty($tabValue.hideCount)}<em>{$tabValue.count}</em>{/if}
             </a>

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -31,7 +31,11 @@
        {foreach from=$tabHeader key=tabName item=tabValue}
           <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if}{if isset($tabValue.class)} {$tabValue.class}{/if}" {$tabValue.extra}>
           {if $tabValue.active}
-             <a href="{if !empty($tabValue.template)}#panel_{$tabName}{else}{$tabValue.link}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">{$tabValue.title}{if isset($tabValue.count)} <em>{$tabValue.count}</em>{/if}</a>
+             <a href="{if !empty($tabValue.template)}#panel_{$tabName}{else}{$tabValue.link}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
+               {if !empty($tabValue.icon)}<i class="{$tabValue.icon}"></i>{/if}
+               <span>{$tabValue.title}</span>
+               {if isset($tabValue.count)}<em>{$tabValue.count}</em>{/if}
+             </a>
           {else}
              <span {if !$tabValue.valid} title="{ts}disabled{/ts}"{/if}>{$tabValue.title}</span>
           {/if}


### PR DESCRIPTION
Before
-----
No icons in tabs

After
-----
![screenshot from 2018-10-26 10-09-35](https://user-images.githubusercontent.com/2874912/47571745-4e82e600-d907-11e8-99c3-18014393a54c.png)

Technical Details
-------
Any extension that adds a tab via `hook_civicrm_tabset` can specify the icon by adding that to the array (no change to the hook signature is needed, it just works). If they don't, they get `fa-puzzle-piece`.

Notes
-------
Shoreditch also adds these icons, but does it in a less robust way. Once this is merged, Shoreditch should be updated to remove those or there will be double-icons.