### PR TITLE
Add span and classes around navigation menu labels/icons

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -345,8 +345,10 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
   }
 
   /**
-   * buildNavigationTree retreives items in order. We call this function to
+   * buildNavigationTree retrieves items in order. We call this function to
    * ensure that any items added by the hook are also in the correct order.
+   *
+   * @param array $navigations
    */
   private static function orderByWeight(&$navigations) {
     // sort each item in navigations by weight
@@ -463,7 +465,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
   }
 
   /**
-   * Get Menu name.
+   * Get Menu name. This also checks permissions for menu items
    *
    * @param $value
    * @param array $skipMenuItems
@@ -561,8 +563,8 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
     }
 
     if (!empty($value['attributes']['icon'])) {
-      $menuIcon = sprintf('<i class="%s"></i>', $value['attributes']['icon']);
-      $name = $menuIcon . $name;
+      $menuIcon = sprintf('<i class="%s menumain-icon"></i>', $value['attributes']['icon']);
+      $name = $menuIcon . '<span class="menumain-label">' . $name . '</span>';
     }
 
     if ($makeLink) {


### PR DESCRIPTION
Overview
----------------------------------------
This allows the navigation menu to be themed more easily and should have no visible impact on the existing menu.
* Shoreditch is doing something similar, but inserting the classes/span via javascript after load.
* The changes in this PR make the icons appear in the accessible menu https://github.com/aydun/uk.squiffle.kam (Note: when testing use https://github.com/aydun/uk.squiffle.kam/pull/11 to display the icons with a space between the label).

Before
----------------------------------------
Difficult to apply theming to navigation menu items.

After
----------------------------------------
Easier to apply theming to navigation menu items without messing around with javascript after page load.

Technical Details
----------------------------------------
Change should be NFC. We are adding css classes and selectors where previously there were none.

Comments
----------------------------------------
@jamienovick can anyone from your team review this? @vingle this makes it easier to theme the nav menu, and show icons in kam.