### PR TITLE
Activities can be linked to multiple cases. Handle caseIds being an array

### DIFF
--- a/Civi/CCase/Events.php
+++ b/Civi/CCase/Events.php
@@ -46,11 +46,12 @@ class Events {
    * @throws \CRM_Core_Exception
    */
   public static function fireCaseChange(\Civi\Core\Event\PostEvent $event) {
-    $caseId = NULL;
+    // Activities can be linked to multiple cases, so $caseIds might be an array or an int
+    $caseIds = NULL;
     switch ($event->entity) {
       case 'Activity':
         if (!empty($event->object->case_id)) {
-          $caseId = $event->object->case_id;
+          $caseIds = $event->object->case_id;
         }
         break;
 
@@ -58,7 +59,7 @@ class Events {
         // by the time we get the post-delete event, the record is gone, so
         // there's nothing to analyze
         if ($event->action != 'delete') {
-          $caseId = $event->id;
+          $caseIds = $event->id;
         }
         break;
 
@@ -66,15 +67,17 @@ class Events {
         throw new \CRM_Core_Exception("CRM_Case_Listener does not support entity {$event->entity}");
     }
 
-    if ($caseId) {
-      if (!isset(self::$isActive[$caseId])) {
-        $tx = new \CRM_Core_Transaction();
-        \CRM_Core_Transaction::addCallback(
-          \CRM_Core_Transaction::PHASE_POST_COMMIT,
-          array(__CLASS__, 'fireCaseChangeForRealz'),
-          array($caseId),
-          "Civi_CCase_Events::fire::{$caseId}"
-        );
+    if ($caseIds) {
+      foreach ((array) $caseIds as $caseId) {
+        if (!isset(self::$isActive[$caseId])) {
+          $tx = new \CRM_Core_Transaction();
+          \CRM_Core_Transaction::addCallback(
+            \CRM_Core_Transaction::PHASE_POST_COMMIT,
+            array(__CLASS__, 'fireCaseChangeForRealz'),
+            array($caseId),
+            "Civi_CCase_Events::fire::{$caseId}"
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
This was found when submitting a drupal webform with a case and an activity and some custom code on a post hook which does an activity.get API call and then an activity.create to update the activity.

Here is an example of an API call that will give you an array for case_id:
```
$result = civicrm_api3('Activity', 'get', [
  'sequential' => 1,
  'return' => ["case_id"],
  'case_id' => ['IS NOT NULL' => 1],
]);
```

The `\Civi\CCase\fireCaseChange function doesn't handle the case when `$caseIds` is an array, yet the callback function it calls does handle `$caseIds` being an array.  The result is that PHP throws some warnings about illegal offset type and the caseId is never added to the static cache and thus gets fired multiple times.

Before
----------------------------------------
CaseIds as array not handled properly, PHP warnings and case changed event fired multiple times (as not cached).

After
----------------------------------------
CaseIds as array handled properly. Cached properly and only fired once.

Technical Details
----------------------------------------

Comments
----------------------------------------
