### PR TITLE
Fix notices on Multisite settings form

### DIFF
--- a/CRM/Admin/Form/Preferences/Multisite.php
+++ b/CRM/Admin/Form/Preferences/Multisite.php
@@ -29,53 +29,16 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id: Display.php 36505 2011-10-03 14:19:56Z lobo $
- *
  */
 
 /**
- * This class generates form components for multi site preferences
- *
+ * This class generates form components for multi site preferences.
  */
 class CRM_Admin_Form_Preferences_Multisite extends CRM_Admin_Form_Preferences {
-  public function preProcess() {
-    $msDoc = CRM_Utils_System::docURL2('Multi Site Installation', NULL, NULL, NULL, NULL, "wiki");
-    CRM_Utils_System::setTitle(ts('Multi Site Settings'));
-    $this->_varNames = array(
-      CRM_Core_BAO_Setting::MULTISITE_PREFERENCES_NAME => array(
-        'is_enabled' => array(
-          'html_type' => 'checkbox',
-          'title' => ts('Enable Multi Site Configuration'),
-          'weight' => 1,
-          'description' => ts('Make CiviCRM aware of multiple domains. You should configure a domain group if enabled') . ' ' . $msDoc,
-        ),
-        /** Remove this checkbox until some one knows what this setting does
-         * 'uniq_email_per_site' => array(
-         * 'html_type' => 'checkbox',
-         * 'title' => ts('Ensure multi sites have a unique email per site'),
-         * 'weight' => 2,
-         * 'description' => NULL,
-         * ),
-         */
-        'domain_group_id' => array(
-          'html_type' => 'entity_reference',
-          'title' => ts('Domain Group'),
-          'weight' => 3,
-          'options' => array('entity' => 'group', 'select' => array('minimumInputLength' => 0)),
-          'description' => ts('Contacts created on this site are added to this group'),
-        ),
-        /** Remove this checkbox until some one knows what this setting does
-         * 'event_price_set_domain_id' => array(
-         * 'html_type' => 'text',
-         * 'title' => ts('Domain for event price sets'),
-         * 'weight' => 4,
-         * 'description' => NULL,
-         * ),
-         */
-      ),
-    );
 
-    parent::preProcess();
-  }
+  protected $_settings = [
+    'is_enabled' => CRM_Core_BAO_Setting::MULTISITE_PREFERENCES_NAME,
+    'domain_group_id' => CRM_Core_BAO_Setting::MULTISITE_PREFERENCES_NAME,
+  ];
 
 }

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -143,6 +143,11 @@ trait CRM_Admin_Form_SettingTrait {
           $this->includesReadOnlyFields = TRUE;
         }
 
+        if (isset($props['help_link'])) {
+          // Set both the value in this loop & the outer value as we assign both to the template while we deprecate the $descriptions assignment.
+          $settingMetaData[$setting]['description'] = $props['description'] .= ' ' . CRM_Utils_System::docURL2($props['help_link']['page'], NULL, NULL, NULL, NULL, $props['help_link']['resource']);
+
+        }
         $add = 'add' . $quickFormType;
         if ($add == 'addElement') {
           $this->$add(
@@ -179,6 +184,9 @@ trait CRM_Admin_Form_SettingTrait {
         }
         elseif ($add == 'addMonthDay') {
           $this->add('date', $setting, ts($props['title']), CRM_Core_SelectValues::date(NULL, 'M d'));
+        }
+        elseif ($add === 'addEntityRef') {
+          $this->$add($setting, ts($props['title']), $props['entity_reference_options']);
         }
         else {
           $this->$add($setting, ts($props['title']), $options);
@@ -221,6 +229,7 @@ trait CRM_Admin_Form_SettingTrait {
       'radio' => 'Radio',
       'select' => 'Select',
       'textarea' => 'Element',
+      'entity_reference' => 'EntityRef',
     ];
     return $mapping[$spec['html_type']];
   }

--- a/settings/Multisite.setting.php
+++ b/settings/Multisite.setting.php
@@ -29,10 +29,9 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
-/*
+
+/**
  * Settings metadata file
  */
 
@@ -41,26 +40,30 @@ return array(
     'group_name' => 'Multi Site Preferences',
     'group' => 'multisite',
     'name' => 'is_enabled',
-    'title' => 'Multisite Is enabled',
-    'type' => 'Integer',
+    'title' => ts('Enable Multi Site Configuration'),
+    'html_type' => 'checkbox',
+    'type' => 'Boolean',
     'default' => '0',
     'add' => '4.1',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'Multisite is enabled',
+    'description' => ts('Make CiviCRM aware of multiple domains. You should configure a domain group if enabled'),
+    'help_link' => ['page' => 'Multi Site Installation', 'resource' => 'wiki'],
     'help_text' => NULL,
   ),
   'domain_group_id' => array(
     'group_name' => 'Multi Site Preferences',
     'group' => 'multisite',
     'name' => 'domain_group_id',
-    'title' => 'Multisite Domain Group',
+    'title' => ts('Multisite Domain Group'),
     'type' => 'Integer',
+    'html_type' => 'entity_reference',
+    'entity_reference_options' => ['entity' => 'group', 'select' => array('minimumInputLength' => 0)],
     'default' => '0',
     'add' => '4.1',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => NULL,
+    'description' => ts('Contacts created on this site are added to this group'),
     'help_text' => NULL,
   ),
   'event_price_set_domain_id' => array(


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices (unreleased version) on multisite settings form. 

Before
----------------------------------------
e-notices
![screenshot 2018-10-29 19 07 46](https://user-images.githubusercontent.com/336308/47632190-f588ab80-dbad-11e8-9124-f3f52149245f.png)


After
----------------------------------------
![screenshot 2018-10-29 19 01 40](https://user-images.githubusercontent.com/336308/47632008-2b796000-dbad-11e8-9f86-38475b187cf1.png)

Technical Details
----------------------------------------
Includes  https://github.com/civicrm/civicrm-core/pull/13023 & I will rebase when merged - that PR also gives more back ground.

the key thing to note here is that it proposes new things in the setting spec for html rendering

For the 'learn more' url is rendered by this in the html

```
    'help_link' => [
      'page' => 'Multi Site Installation',
      'resource' => 'wiki',
    ],
```
I also added 

```
'entity_reference_options' => ['entity' => 'group', 'select' => array('minimumInputLength' => 0)],
```

Which holds the options for the entity reference field. I didn't want to use 'options' as we pretty consistently use that as an array of option values

Comments
----------------------------------------
@mattwire @seamuslee001 @colemanw 