### PR TITLE
Fix notices on Campaign preferences form

### DIFF
--- a/CRM/Admin/Form/Preferences/Campaign.php
+++ b/CRM/Admin/Form/Preferences/Campaign.php
@@ -29,35 +29,16 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id: Display.php 36505 2011-10-03 14:19:56Z lobo $
- *
  */
 
 /**
- * This class generates form components for the display preferences
- *
+ * This class displays campaign preferences.
  */
 class CRM_Admin_Form_Preferences_Campaign extends CRM_Admin_Form_Preferences {
-  public function preProcess() {
-    CRM_Utils_System::setTitle(ts('CiviCampaign Component Settings'));
-    $this->_varNames = array(
-      CRM_Core_BAO_Setting::CAMPAIGN_PREFERENCES_NAME => array(
-        'tag_unconfirmed' => array(
-          'html_type' => 'text',
-          'title' => ts('Tag for Unconfirmed Petition Signers'),
-          'weight' => 1,
-          'description' => ts('If set, new contacts that are created when signing a petition are assigned a tag of this name.'),
-        ),
-        'petition_contacts' => array(
-          'html_type' => 'text',
-          'title' => ts('Petition Signers Group'),
-          'weight' => 2,
-          'description' => ts('All contacts that have signed a CiviCampaign petition will be added to this group. The group will be created if it does not exist (it is required for email verification).'),
-        ),
-      ),
-    );
 
-    parent::preProcess();
-  }
+  protected $_settings = [
+    'tag_unconfirmed' => CRM_Core_BAO_Setting::CAMPAIGN_PREFERENCES_NAME,
+    'petition_contacts' => CRM_Core_BAO_Setting::CAMPAIGN_PREFERENCES_NAME,
+  ];
 
 }

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -229,6 +229,7 @@ trait CRM_Admin_Form_SettingTrait {
       'radio' => 'Radio',
       'select' => 'Select',
       'textarea' => 'Element',
+      'text' => 'Element',
       'entity_reference' => 'EntityRef',
     ];
     return $mapping[$spec['html_type']];

--- a/settings/Campaign.setting.php
+++ b/settings/Campaign.setting.php
@@ -29,10 +29,9 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
-/*
+
+/**
  * Settings metadata file
  */
 
@@ -42,28 +41,28 @@ return array(
     'group' => 'campaign',
     'name' => 'tag_unconfirmed',
     'type' => 'String',
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'default' => 'Unconfirmed',
     'add' => '4.1',
-    'title' => 'Tag for Unconfirmed Petition Signers',
+    'title' => ts('Tag for Unconfirmed Petition Signers'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => NULL,
-    'help_text' => 'If set, new contacts that are created when signing a petition are assigned a tag of this name.',
+    'description' => ts('If set, new contacts that are created when signing a petition are assigned a tag of this name.'),
+    'help_text' => '',
   ),
   'petition_contacts' => array(
     'group_name' => 'Campaign Preferences',
     'group' => 'campaign',
     'name' => 'petition_contacts',
     'type' => 'String',
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'default' => 'Petition Contacts',
     'add' => '4.1',
-    'title' => 'Petition Signers Group',
+    'title' => ts('Petition Signers Group'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => NULL,
-    'help_text' => 'If set, new contacts that are created when signing a petition are assigned a tag of this name.',
+    'description' => ts('All contacts that have signed a CiviCampaign petition will be added to this group. The group will be created if it does not exist (it is required for email verification).'),
+    'help_text' => '',
   ),
 
 );


### PR DESCRIPTION
Overview
----------------------------------------
Update campaign prefs form in line with related PR -   https://github.com/civicrm/civicrm-core/pull/13022 & releated

Before
----------------------------------------
![screenshot 2018-10-30 00 03 23](https://user-images.githubusercontent.com/336308/47645946-4b257e00-dbd7-11e8-9884-5a014a9c7023.png)

After
----------------------------------------
notices fixed

Technical Details
----------------------------------------
Uses metadata & shared code after the change

Comments
----------------------------------------

