### PR TITLE
Fix notices on event settings form

### DIFF
--- a/CRM/Admin/Form/Preferences/Event.php
+++ b/CRM/Admin/Form/Preferences/Event.php
@@ -29,44 +29,17 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id: Display.php 36505 2011-10-03 14:19:56Z lobo $
- *
  */
 
 /**
- * This class generates form components for the display preferences
+ * This class generates the form for event preferences.
  *
  */
 class CRM_Admin_Form_Preferences_Event extends CRM_Admin_Form_Preferences {
-  public function preProcess() {
-    CRM_Utils_System::setTitle(ts('CiviEvent Component Settings'));
-    // pass "wiki" as 6th param to docURL2 if you are linking to a page in wiki.civicrm.org
-    $docLink = CRM_Utils_System::docURL2("CiviEvent Cart Checkout", NULL, NULL, NULL, NULL, "wiki");
-    // build an array containing all selectable option values for show_events
-    $optionValues = array();
-    for ($i = 10; $i <= 100; $i += 10) {
-      $optionValues[$i] = $i;
-    }
-    $this->_varNames = array(
-      CRM_Core_BAO_Setting::EVENT_PREFERENCES_NAME => array(
-        'enable_cart' => array(
-          'html_type' => 'checkbox',
-          'title' => ts('Use Shopping Cart Style Event Registration'),
-          'weight' => 1,
-          'description' => ts('This feature allows users to register for more than one event at a time. When enabled, users will add event(s) to a "cart" and then pay for them all at once. Enabling this setting will affect online registration for all active events. The code is an alpha state, and you will potentially need to have developer resources to debug and fix sections of the codebase while testing and deploying it. %1',
-            array(1 => $docLink)),
-        ),
-        'show_events' => array(
-          'html_type' => 'select',
-          'title' => ts('Dashboard entries'),
-          'weight' => 2,
-          'description' => ts('Configure how many events should be shown on the dashboard. This overrides the default value of 10 entries.'),
-          'option_values' => array('' => ts('- select -')) + $optionValues + array(-1 => ts('show all')),
-        ),
-      ),
-    );
 
-    parent::preProcess();
-  }
+  protected $_settings = [
+    'enable_cart' => CRM_Core_BAO_Setting::EVENT_PREFERENCES_NAME,
+    'show_events' => CRM_Core_BAO_Setting::EVENT_PREFERENCES_NAME,
+  ];
 
 }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1109,4 +1109,19 @@ class CRM_Core_SelectValues {
     );
   }
 
+  /**
+   * Get option values for dashboard entries (used for 'how many events to display on dashboard').
+   *
+   * @return array
+   *   Dashboard entries options - in practice [-1 => 'Show All', 10 => 10, 20 => 20, ... 100 => 100].
+   */
+  public static function getDashboardEntriesCount() {
+    $optionValues = [];
+    $optionValues[-1] = ts('show all');
+    for ($i = 10; $i <= 100; $i += 10) {
+      $optionValues[$i] = $i;
+    }
+    return $optionValues;
+  }
+
 }

--- a/settings/Event.setting.php
+++ b/settings/Event.setting.php
@@ -29,10 +29,9 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
-/*
+
+/**
  * Settings metadata file
  */
 return array(
@@ -41,28 +40,30 @@ return array(
     'group_name' => 'Event Preferences',
     'group' => 'event',
     'type' => 'Boolean',
-    'quick_form_type' => 'Element',
+    'quick_form_type' => 'CheckBox',
     'default' => '0',
     'add' => '4.1',
-    'title' => 'Enable Event Cart',
+    'title' => ts('Use Shopping Cart Style Event Registration'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => "WRITE ME",
-    'help_text' => 'WRITE ME',
+    'description' => ts('This feature allows users to register for more than one event at a time. When enabled, users will add event(s) to a "cart" and then pay for them all at once. Enabling this setting will affect online registration for all active events. The code is an alpha state, and you will potentially need to have developer resources to debug and fix sections of the codebase while testing and deploying it'),
+    'help_text' => '',
+    'help_link' => ['page' => 'CiviEvent Cart Checkout', 'resource' => 'wiki'],
   ),
   'show_events' => array(
     'name' => 'show_events',
     'group_name' => 'Event Preferences',
     'group' => 'event',
     'type' => 'Integer',
-    'quick_form_type' => 'Element',
+    'quick_form_type' => 'Select',
     'default' => 10,
     'add' => '4.5',
-    'title' => 'Dashboard entries',
+    'title' => ts('Dashboard entries'),
     'html_type' => 'select',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => "Configure how many events should be shown on the dashboard. This overrides the default value of 10 entries.",
+    'description' => ts('Configure how many events should be shown on the dashboard. This overrides the default value of 10 entries.'),
     'help_text' => NULL,
+    'pseudoconstant' => ['callback' => 'CRM_Core_SelectValues::getDashboardEntriesCount'],
   ),
 );


### PR DESCRIPTION
Overview
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/13023 fix recent spawning of e-notice on preferences forms by pushing through to cleaning them up fully

Before
----------------------------------------
![screenshot 2018-10-29 20 58 16](https://user-images.githubusercontent.com/336308/47636503-65526280-dbbd-11e8-9b41-d752ce8df78c.png)


After
----------------------------------------
![screenshot 2018-10-29 20 52 58](https://user-images.githubusercontent.com/336308/47636472-49e75780-dbbd-11e8-8ef9-54195ab11adc.png)


Technical Details
----------------------------------------
details in https://github.com/civicrm/civicrm-core/pull/13023 but note that I altered the handing of 'Dashboard entries' as it incorrectly made it seem optional. The setting is used to determine how many events to show on the events dashboard.

Comments
----------------------------------------

