### PR TITLE
Closes core#477 - display employer/title/group info in print summary

### DIFF
--- a/templates/CRM/Contact/Page/View/Print.tpl
+++ b/templates/CRM/Contact/Page/View/Print.tpl
@@ -50,7 +50,6 @@
 {literal}
 <script type="text/javascript">
 cj('#mainTabContainer').children(':first').remove();
-cj('#contact-summary' ).children(':first').remove();
 
 </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
From Stack Exchange: https://civicrm.stackexchange.com/q/27063/12
To replicate:

* Open any individual's contact.
* From the "Actions" button, select "Print Summary".

Before
----------------------------------------
Employer/Job Title/Groups/Tags aren't present.

After
----------------------------------------
They're present.

Comments
----------------------------------------
I suspect that a different DOM element used to be targeted here.
