### PR TITLE
Fix custom Home URL parsing

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -48,7 +48,7 @@ class CRM_Admin_Page_AJAX {
       $smarty = CRM_Core_Smarty::singleton();
       $smarty->assign('includeEmail', civicrm_api3('setting', 'getvalue', array('name' => 'includeEmailInName', 'group' => 'Search Preferences')));
       print $smarty->fetchWith('CRM/common/navigation.js.tpl', array(
-        'navigation' => CRM_Core_BAO_Navigation::createNavigation($contactID),
+        'navigation' => CRM_Core_BAO_Navigation::createNavigation(),
       ));
     }
     CRM_Utils_System::civiExit();

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -598,7 +598,9 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       $homeIcon = '<span class="crm-logo-sm" ></span>';
       self::retrieve($homeParams, $homeNav);
       if ($homeNav) {
-        list($path, $q) = explode('?', $homeNav['url']);
+        $path = parse_url($homeNav['url'], PHP_URL_PATH);
+        $q = parse_url($homeNav['url'], PHP_URL_QUERY);
+
         $homeURL = CRM_Utils_System::url($path, $q);
         $homeLabel = $homeNav['label'];
         // CRM-6804 (we need to special-case this as we don’t ts()-tag variables)

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -600,8 +600,10 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       if ($homeNav) {
         $path = parse_url($homeNav['url'], PHP_URL_PATH);
         $q = parse_url($homeNav['url'], PHP_URL_QUERY);
+        $fragment = parse_url($homeNav['url'], PHP_URL_FRAGMENT);
 
-        $homeURL = CRM_Utils_System::url($path, $q);
+        $homeURL = CRM_Utils_System::url($path, $q, FALSE, $fragment);
+
         $homeLabel = $homeNav['label'];
         // CRM-6804 (we need to special-case this as we don’t ts()-tag variables)
         if ($homeLabel == 'Home') {

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -581,15 +581,10 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
   /**
    * Create navigation for CiviCRM Admin Menu.
    *
-   * @param int $contactID
-   *   Contact id.
-   *
    * @return string
    *   returns navigation html
    */
-  public static function createNavigation($contactID) {
-    $config = CRM_Core_Config::singleton();
-
+  public static function createNavigation() {
     $navigation = self::buildNavigation();
 
     if ($navigation) {

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -493,22 +493,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
 
     $makeLink = FALSE;
     if (!empty($url)) {
-      // Skip processing fully-formed urls
-      if (substr($url, 0, 4) !== 'http' && $url[0] !== '/' && $url[0] !== '#') {
-        //CRM-7656 --make sure to separate out url path from url params,
-        //as we'r going to validate url path across cross-site scripting.
-        $parsedUrl = parse_url($url);
-        if (empty($parsedUrl['query'])) {
-          $parsedUrl['query'] = NULL;
-        }
-        if (empty($parsedUrl['fragment'])) {
-          $parsedUrl['fragment'] = NULL;
-        }
-        $url = CRM_Utils_System::url($parsedUrl['path'], $parsedUrl['query'], FALSE, $parsedUrl['fragment'], TRUE);
-      }
-      elseif (strpos($url, '&amp;') === FALSE) {
-        $url = htmlspecialchars($url);
-      }
+      $url = self::makeFullyFormedUrl($url);
       $makeLink = TRUE;
     }
 
@@ -598,12 +583,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       $homeIcon = '<span class="crm-logo-sm" ></span>';
       self::retrieve($homeParams, $homeNav);
       if ($homeNav) {
-        $path = parse_url($homeNav['url'], PHP_URL_PATH);
-        $q = parse_url($homeNav['url'], PHP_URL_QUERY);
-        $fragment = parse_url($homeNav['url'], PHP_URL_FRAGMENT);
-
-        $homeURL = CRM_Utils_System::url($path, $q, FALSE, $fragment);
-
+        $homeURL = self::makeFullyFormedUrl($homeNav['url']);
         $homeLabel = $homeNav['label'];
         // CRM-6804 (we need to special-case this as we don’t ts()-tag variables)
         if ($homeLabel == 'Home') {
@@ -627,6 +607,44 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       // <li> tag doesn't need to be closed
     }
     return $prepandString . $navigation;
+  }
+
+  /**
+   * Turns relative URLs (like civicrm/foo/bar) into fully-formed
+   * ones (i.e. example.com/wp-admin?q=civicrm/dashboard).
+   *
+   * If the URL is already fully-formed, nothing will be done.
+   *
+   * @param string $url
+   *
+   * @return string
+   */
+  private static function makeFullyFormedUrl($url) {
+    if (self::isNotFullyFormedUrl($url)) {
+      //CRM-7656 --make sure to separate out url path from url params,
+      //as we'r going to validate url path across cross-site scripting.
+      $path = parse_url($url, PHP_URL_PATH);
+      $q = parse_url($url, PHP_URL_QUERY);
+      $fragment = parse_url($url, PHP_URL_FRAGMENT);
+      return CRM_Utils_System::url($path, $q, FALSE, $fragment);
+    }
+
+    if (strpos($url, '&amp;') === FALSE) {
+      return htmlspecialchars($url);
+    }
+
+    return $url;
+  }
+
+  /**
+   * Checks if the given URL is not fully-formed
+   *
+   * @param string $url
+   *
+   * @return bool
+   */
+  private static function isNotFullyFormedUrl($url) {
+    return substr($url, 0, 4) !== 'http' && $url[0] !== '/' && $url[0] !== '#';
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

The code used to parse a custom Home URL in the `CRM_Core_BAO_Navigation::createNavigation()` would throw an `E_NOTICE` if the URL did not contain a query string.

Also, URL fragments would be removed from the parsed URL.

Before
----------------------------------------

Custom Home URLs without a query string would result in an `E_NOTICE`. 

Fragments in a custom URL would be removed.

After
----------------------------------------

No `E_NOTICE` is thrown when parsing a custom Home URL without a query string.

Fragments are not removed from the custom URL.


Technical Details
----------------------------------------

The reason for the `E_NOTICE` was the usage of `explode()` to extract the parts of the URL and then using `list()` to assign the parts to variables. When the query string is not present, `explode()` will return an array with one single element and the assignment will fail. This was fixed by using the `parse_url()` function to query for the relevant parts of the URL.

There was also a problem where the previous code would end up removing fragments from the URL. This has also been fixed using `parse_url()` to get the fragment.

Finally, some minor cleanup was done in https://github.com/civicrm/civicrm-core/commit/2e42cb189eb3183165b5ea0dee1e61f950f61a9c. The `$contactId` param and the `$config` variable were not used anywhere inside the method, so I removed them.

Comments
--------------------------------

Since this a quite simple fix, I thought it would be ok to not create a Gitlab ticket first. If the ticket is necessary, please let me know and I'll create it.
