### PR TITLE
Remove lowercasing in relationship query

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4045,16 +4045,16 @@ WHERE  $smartGroupClause
         substr($name, -1, 1) == '"'
       ) {
         $name = substr($name, 1, -1);
-        $name = strtolower(CRM_Core_DAO::escapeString($name));
+        $name = CRM_Core_DAO::escapeString($name);
         $nameClause = "= '$name'";
       }
       else {
-        $name = strtolower(CRM_Core_DAO::escapeString($name));
+        $name = CRM_Core_DAO::escapeString($name);
         $nameClause = "LIKE '%{$name}%'";
       }
     }
 
-    $rTypeValues = $relTypes = $relTypesIds = array();
+    $relTypes = $relTypesIds = array();
     if (!empty($relationType)) {
       $relationType[2] = (array) $relationType[2];
       foreach ($relationType[2] as $relType) {
@@ -4064,21 +4064,16 @@ WHERE  $smartGroupClause
         $typeValues = array();
         $rTypeValue = CRM_Contact_BAO_RelationshipType::retrieve($params, $typeValues);
         if (!empty($rTypeValue)) {
-          $rTypeValues[] = $rTypeValue;
+          if ($rTypeValue->name_a_b == $rTypeValue->name_b_a) {
+            // if we don't know which end of the relationship we are dealing with we'll create a temp table
+            self::$_relType = 'reciprocal';
+          }
           $relTypesIds[] = $rel[0];
           $relTypes[] = $relType;
         }
       }
     }
-    if (!empty($rTypeValues)) {
-      foreach ($rTypeValues as $rTypeValue) {
-        $rTypeValue = (array) $rTypeValue;
-        if ($rTypeValue['name_a_b'] == $rTypeValue['name_b_a']) {
-          // if we don't know which end of the relationship we are dealing with we'll create a temp table
-          self::$_relType = 'reciprocal';
-        }
-      }
-    }
+
     // if we are creating a temp table we build our own where for the relationship table
     $relationshipTempTable = NULL;
     if (self::$_relType == 'reciprocal') {


### PR DESCRIPTION
Overview
----------------------------------------
Removes another instance of non-functional lower casing in searches - which cause some strings to be hishandled

Before
----------------------------------------
Relationship search passes strings through lower casing. This is not compared with a lower case string so mysql handles the comparison, but can fail on some charactersets. I acheives nothing & causes edge-case harm

After
----------------------------------------
strtolower removed

Technical Details
----------------------------------------
This was picked up as being tested through testCreateSavedSearchWithSmartGroup as part of https://github.com/civicrm/civicrm-core/pull/12494 - the test actually already uses a non-lower case string 'Default Organization' - I found the casting to an array broke my ability to step through the code line by line so I tidied that slightly.

Comments
----------------------------------------
