### PR TITLE
(dev/core#491) Report results don't show inactive campaigns

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -90,7 +90,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
     $config = CRM_Core_Config::singleton();
     $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
     if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
+      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, FALSE, FALSE, TRUE);
       $this->activeCampaigns = $getCampaigns['campaigns'];
       asort($this->activeCampaigns);
     }

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -74,7 +74,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
     $config = CRM_Core_Config::singleton();
     $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
     if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
+      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, FALSE, FALSE, TRUE);
       $this->activeCampaigns = $getCampaigns['campaigns'];
       asort($this->activeCampaigns);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Report results don't show inactive campaigns. The results can be searched properly via _Find Contributions_.

Before
----------------------------------------
![find_camp](https://user-images.githubusercontent.com/3455173/47707294-81074880-dc51-11e8-9b01-88b00d940c90.png)
![camp_before](https://user-images.githubusercontent.com/3455173/47707347-9bd9bd00-dc51-11e8-9683-d9908c6d932a.png)

After
----------------------------------------
![camp_after](https://user-images.githubusercontent.com/3455173/47707365-a09e7100-dc51-11e8-973b-01a360f0cd98.png)


