### PR TITLE
CRM-21417 Fix regression in participant count in summary report

### DIFF
--- a/CRM/Report/Form/Event/Summary.php
+++ b/CRM/Report/Form/Event/Summary.php
@@ -194,7 +194,7 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form_Event {
                  civicrm_participant.status_id   AS statusId,
                  COUNT( civicrm_participant.id ) AS participant,
                  SUM( civicrm_participant.fee_amount ) AS amount,
-                 civicrm_participant.fee_currency
+                 GROUP_CONCAT(DISTINCT(civicrm_participant.fee_currency)) as fee_currency
 
             FROM civicrm_participant
 
@@ -202,8 +202,7 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form_Event {
                   $this->_participantWhere
 
         GROUP BY civicrm_participant.event_id,
-                 civicrm_participant.status_id,
-                 civicrm_participant.fee_currency";
+                 civicrm_participant.status_id";
 
     $info = CRM_Core_DAO::executeQuery($sql);
     $participant_data = $participant_info = $currency = array();


### PR DESCRIPTION
Overview
----------------------------------------
See https://issues.civicrm.org/jira/browse/CRM-21417

The 'event summary' report doesn't display the correct number of attendees for free events.

When someone registers through the front end, they appear on the report (because a contribution is recorded).

When you then record someone through the back end they do not appear, because there is no contribution record for the free event.

Steps to recreate:

Create a free event with online registration
Register through the front end
Create another registration through the back end
View the 'Event Income Summary' report
Notice that only 1 participant is counted

Comments
----------------------------------------
This is based on https://gist.github.com/monishdeb/2e8c399510765da4539d9866dda88df1 by @monishdeb but with a change to how the field is being referred to, as documented in the JIRA issue

@michaeljanuszkiewicz tested this with full_group_by on and off.

https://lab.civicrm.org/dev/core/issues/804
