### PR TITLE
Allow extensions to add core resources to the list

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -591,13 +591,21 @@ class CRM_Core_Resources {
         if (is_array($item)) {
           $this->addSetting($item);
         }
-        elseif (substr($item, -2) == 'js') {
-          // Don't bother  looking for ts() calls in packages, there aren't any
-          $translate = (substr($item, 0, 3) == 'js/');
-          $this->addScriptFile('civicrm', $item, $jsWeight++, $region, $translate);
-        }
         else {
-          $this->addStyleFile('civicrm', $item, -100, $region);
+          $ext = 'civicrm';
+          // Parse extension name in square brackets e.g. '[org.civicrm.api4]/js/api4.js'
+          if ($item[0] === '[') {
+            list($ext, $item) = explode(']', substr($item, 1));
+          }
+          $item = trim($item, '/\\');
+          if (substr($item, -2) == 'js') {
+            // Don't bother  looking for ts() calls in packages or bower_components
+            $translate = (substr($item, 0, 8) != 'packages' && substr($item, 0, 5) != 'bower');
+            $this->addScriptFile($ext, $item, $jsWeight++, $region, $translate);
+          }
+          else {
+            $this->addStyleFile($ext, $item, -100, $region);
+          }
         }
       }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2341,6 +2341,8 @@ abstract class CRM_Utils_Hook {
   /**
    * This hook is called when core resources are being loaded
    *
+   * For adding resources from an extension, place the extension name in square brackets like '[org.civicrm.api4]/js/api4.js'
+   *
    * @see CRM_Core_Resources::coreResourceList
    *
    * @param array $list


### PR DESCRIPTION
Overview
------
Now extensions can add resources directly to the list using `hook_core_resourceList`

Before
------
Only paths relative to the civicrm directory were supported.

After
----
One can specify a path relative to an extension, e.g. '[org.civicrm.api4]/js/api4.js'