### PR TITLE
only set custom field to null if it is really null, not string 'null'

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -219,7 +219,7 @@ class CRM_Core_BAO_CustomValueTable {
             default:
               break;
           }
-          if (strtolower($value) === "null") {
+          if (is_null($value)) {
             // when unsetting a value to null, we don't need to validate the type
             // https://projectllr.atlassian.net/browse/VGQBMP-20
             $set[$field['column_name']] = $value;

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -219,7 +219,7 @@ class CRM_Core_BAO_CustomValueTable {
             default:
               break;
           }
-          if (is_null($value)) {
+          if ($value === 'null') {
             // when unsetting a value to null, we don't need to validate the type
             // https://projectllr.atlassian.net/browse/VGQBMP-20
             $set[$field['column_name']] = $value;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1986,6 +1986,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'defaultValue' => 'Default Value',
       'lowercasevalue' => 'Lowercase Value',
       1 => 'Integer Value',
+      'NULL' => 'NULL',
     ];
     $custom_field_params = ['sequential' => 1, 'id' => $customField['id']];
     $custom_field_api_result = $this->callAPISuccess('custom_field', 'get', $custom_field_params);


### PR DESCRIPTION
Overview
----------------------------------------
The string 'null' (any case) is converted to actual NULLs. Is this a feature or a bug? It's a bug for one of my clients, as they have a multi-select custom field with one of the option values being 'NULL'

Before
----------------------------------------
Custom fields cannot be inserted or updated if the value is the string 'NULL'

After
----------------------------------------
Null strings as values for custom fields are saved.

Technical Details
----------------------------------------
This may break other stuff? 
Comments
----------------------------------------
Conversation about overall issue here: https://lab.civicrm.org/dev/core/issues/475
