### PR TITLE
Pass path through rawurlencode when not using CIVICRM_CLEANURL

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -208,6 +208,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $fragment = isset($fragment) ? ('#' . $fragment) : '';
 
     $path = CRM_Utils_String::stripPathChars($path);
+    $basepage = FALSE;
 
     //this means wp function we are trying to use is not available,
     //so load bootStrap
@@ -215,16 +216,20 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     if (!function_exists('get_option')) {
       $this->loadBootStrap();
     }
+
     if ($config->userFrameworkFrontend) {
+      global $post;
       if (get_option('permalink_structure') != '') {
-        global $post;
         $script = get_permalink($post->ID);
       }
-
+      if ($config->wpBasePage == $post->post_name) {
+        $basepage = TRUE;
+      }
       // when shortcode is included in page
       // also make sure we have valid query object
+      // FIXME: $wpPageParam has no effect and is only set on the *basepage*
       global $wp_query;
-      if (method_exists($wp_query, 'get')) {
+      if (get_option('permalink_structure') == '' && method_exists($wp_query, 'get')) {
         if (get_query_var('page_id')) {
           $wpPageParam = "page_id=" . get_query_var('page_id');
         }
@@ -251,18 +256,61 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     }
 
     $queryParts = array();
-    if (isset($path)) {
-      $queryParts[] = 'page=CiviCRM';
-      $queryParts[] = "q={$path}";
-    }
-    if ($wpPageParam) {
-      $queryParts[] = $wpPageParam;
-    }
-    if (isset($query)) {
-      $queryParts[] = $query;
+
+    // CRM_Core_Payment::getReturnSuccessUrl() passes $query as an array
+    if (isset($query) && is_array($query)) {
+      $query = implode($separator, $query);
     }
 
-    return $base . '?' . implode($separator, $queryParts) . $fragment;
+    if (
+      // not using clean URLs
+      !$config->cleanURL
+      // requesting an admin URL
+      || ((is_admin() && !$frontend) || $forceBackend)
+      // is shortcode
+      || (!$basepage && $script != '')
+    ) {
+
+      // pre-existing logic
+      if (isset($path)) {
+        $queryParts[] = 'page=CiviCRM';
+        // Encode all but the *path* placeholder
+        if ($path !== '*path*') {
+          $path = rawurlencode($path);
+        }
+        $queryParts[] = "q={$path}";
+      }
+      if ($wpPageParam) {
+        $queryParts[] = $wpPageParam;
+      }
+      if (isset($query)) {
+        $queryParts[] = $query;
+      }
+
+      $final = $base . '?' . implode($separator, $queryParts) . $fragment;
+
+    }
+    else {
+
+      // clean URLs
+      if (isset($path)) {
+        $base = trailingslashit($base) . str_replace('civicrm/', '', $path) . '/';
+      }
+      if (isset($query)) {
+        $query = ltrim($query, '=?&');
+        $queryParts[] = $query;
+      }
+
+      if (!empty($queryParts)) {
+        $final = $base . '?' . implode($separator, $queryParts) . $fragment;
+      }
+      else {
+        $final = $base . $fragment;
+      }
+
+    }
+
+    return $final;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/wordpress/issues/12

Before
----------------------------------------
CiviCRM does not generate valid URLs when `CIVICRM_CLEANURL` is off. This means URLs of the form: 

```
http://civicrm.local/?page=CiviCRM&q=civicrm/contribute/transact&_qf_ThankYou_display=true&qfKey=KEY
```

that CiviCRM uses on the front-end.

What happens when a shortcode is used on the home page is that this URL is caught by `redirect_canonical` on the `template_redirect` hook and redirected to a rebuilt URL (where where `q` is urlencoded) that looks like this:
 
```
http://civicrm.local/?page=CiviCRM&q=civicrm%2Fcontribute%2Ftransact&_qf_ThankYou_display=true&qfKey=KEY
```

but, crucially, not before CiviCRM has sent the confirmation email and cleared the session. This causes the next page load to trigger `invalidKeyRedirect` and thus causes an infinite redirect. This does not happen on other pages because of [the logic](https://developer.wordpress.org/reference/functions/redirect_canonical/) in `redirect_canonical`.

After
----------------------------------------
All relevant URLs are appropriately urlencoded in the form:

```
http://civicrm.local/?page=CiviCRM&q=civicrm%2Fcontribute%2Ftransact&_qf_ThankYou_display=true&qfKey=KEY
```

No redirection is made by `redirect_canonical`.

Technical Details
----------------------------------------
N/A

Comments
----------------------------------------
You may notice that this PR makes provision for a future where it is possible to allow Clean URLs in WordPress. The code to enable this is forthcoming in the CiviCRM WordPress repo - but since that code is dependent on #12969 and these changes to `url()`, it makes sense for this PR to include those changes here.