### PR TITLE
Problem with Custom Field in Contact Reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3935,7 +3935,7 @@ ORDER BY cg.weight, cf.weight";
           $curFilters[$fieldName]['type'] = CRM_Utils_Type::T_STRING;
 
           $options = CRM_Core_PseudoConstant::get('CRM_Core_BAO_CustomField', 'custom_' . $customDAO->cf_id, array(), 'search');
-          if ($options !== FALSE) {
+          if ((is_array($options) && count($options)!=0) || (!is_array($options) && $options !== FALSE)) {
             $curFilters[$fieldName]['operatorType'] = CRM_Core_BAO_CustomField::isSerialized($customDAO) ? CRM_Report_Form::OP_MULTISELECT_SEPARATOR : CRM_Report_Form::OP_MULTISELECT;
             $curFilters[$fieldName]['options'] = $options;
           }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3935,7 +3935,7 @@ ORDER BY cg.weight, cf.weight";
           $curFilters[$fieldName]['type'] = CRM_Utils_Type::T_STRING;
 
           $options = CRM_Core_PseudoConstant::get('CRM_Core_BAO_CustomField', 'custom_' . $customDAO->cf_id, array(), 'search');
-          if ((is_array($options) && count($options)!=0) || (!is_array($options) && $options !== FALSE)) {
+          if ((is_array($options) && count($options) != 0) || (!is_array($options) && $options !== FALSE)) {
             $curFilters[$fieldName]['operatorType'] = CRM_Core_BAO_CustomField::isSerialized($customDAO) ? CRM_Report_Form::OP_MULTISELECT_SEPARATOR : CRM_Report_Form::OP_MULTISELECT;
             $curFilters[$fieldName]['options'] = $options;
           }


### PR DESCRIPTION
Custom fields with data type 'String' cannot be displayed in Reports->Contacts->Contituent Summary->Summery Fields->Filters Tab. This should be related to function addCustomDataToColumns(). Putting a different control for variable '$option' in case 'String' seems to solve the issue

Overview
----------------------------------------
Problems with displaying Custom fields in Reports->Contacts. The code modified should solve this issue

Before
----------------------------------------
Custom fields with data type 'String' cannot be displayed in Reports->Contacts->Contituent Summary->Summery Fields->Filters Tab

After
----------------------------------------
Custom fields with data type 'String' now are visible in Reports->Contacts->Contituent Summary->Summery Fields->Filters Tab

Technical Details
----------------------------------------
Putting a different control for variable '$options' seems to solve the issue.

Comments
----------------------------------------

