### PR TITLE
dev/core/497 Remove extraneous api params from entityref renderer

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -244,10 +244,7 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
     }
     if ($val) {
       $entity = $field->getAttribute('data-api-entity');
-      // Get api params, ensure it is an array
-      $params = $field->getAttribute('data-api-params');
-      $params = $params ? json_decode($params, TRUE) : array();
-      $result = civicrm_api3($entity, 'getlist', array('id' => $val) + $params);
+      $result = civicrm_api3($entity, 'getlist', array('id' => $val));
       if ($field->isFrozen()) {
         // Prevent js from treating frozen entityRef as a "live" field
         $field->removeAttribute('class');


### PR DESCRIPTION
Overview
----------------------------------------
Described in full at https://lab.civicrm.org/dev/core/issues/497

Issue begins with adding an entityRef field to a form with $form->addEntityRef(), and a field which uses api params to filter available values using an 'IN' clause.

Before
----------------------------------------
IF there are any default values (i.e. a value was set before), all valid values appear in the field on form load. For example if I save ID 1 out of choices 1,2, & 3... the form reloads and displays IDs 1,2,3 in the form (if I save again with no changes it will set all 3 IDs that it displays).

After
----------------------------------------
IF there are any default values, only the previously saved values appear in the field on form load. For example if I save ID 1 out of choice 1,2, & 3... the form reloads and displays only ID 1, so if you re-save the form without changes.. no changes will be made.

Technical Details
----------------------------------------
Does anyone know why these params were here? Conceptually, I can't seem to grok why we needed to re-grab the parameters from the field attribute, and then pass them in here... and it works fine without it. That said I am very unfamiliar with this bit of code. Is this seriously breaking something I don't know about?

On a semi-side note: I would be super willing to write a test here but would need some serious hand-holding to be able to write a test for something like this as I have very minimal test-writing experience. Any relevant examples welcomed.
