### PR TITLE
[NFC] Preferences form template cleanup

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Contribute.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Contribute.tpl
@@ -25,7 +25,6 @@
 *}
 <div class="crm-block crm-form-block crm-{$formName}-block">
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-  {if $formName == "Contribute_Preferences"}
     <table class = "form-layout">
       {foreach from=$htmlFields item=desc key=htmlField}
         {if $form.$htmlField}
@@ -52,12 +51,10 @@
         {/if}
       {/foreach}
     </table>
-  {/if}
-
   {include file="CRM/Form/basicFormFields.tpl"}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
-{if $formName == "Contribute_Preferences"}
+
 {literal}
   <script type="text/javascript">
     cj(document).ready(function() {
@@ -80,4 +77,3 @@
     });
   </script>
 {/literal}
-{/if}

--- a/templates/CRM/Admin/Form/Preferences/Contribute.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Contribute.tpl
@@ -25,32 +25,32 @@
 *}
 <div class="crm-block crm-form-block crm-{$formName}-block">
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-    <table class = "form-layout">
-      {foreach from=$htmlFields item=desc key=htmlField}
-        {if $form.$htmlField}
-          {assign var=n value=$htmlField|cat:'_description'}
-          <tr class="crm-preferences-form-block-{$htmlField}">
-            {if $form.$htmlField.html_type EQ 'checkbox'|| $form.$htmlField.html_type EQ 'checkboxes'}
-              <td class="label"></td>
-              <td>
-                {$form.$htmlField.html} {$form.$htmlField.label}
-                {if $desc}
-                  <br /><span class="description">{$desc}</span>
-                {/if}
-              </td>
-            {else}
-              <td class="label">{$form.$htmlField.label}&nbsp;{if $htmlField eq 'acl_financial_type'}{help id="$htmlField"}{/if}</td>
-              <td>
-                {$form.$htmlField.html}
-                {if $desc}
-                  <br /><span class="description">{$desc}</span>
-                {/if}
-              </td>
-            {/if}
-          </tr>
-        {/if}
-      {/foreach}
-    </table>
+  <table class = "form-layout">
+    {foreach from=$htmlFields item=desc key=htmlField}
+      {if $form.$htmlField}
+        {assign var=n value=$htmlField|cat:'_description'}
+        <tr class="crm-preferences-form-block-{$htmlField}">
+          {if $form.$htmlField.html_type EQ 'checkbox'|| $form.$htmlField.html_type EQ 'checkboxes'}
+            <td class="label"></td>
+            <td>
+              {$form.$htmlField.html} {$form.$htmlField.label}
+              {if $desc}
+                <br /><span class="description">{$desc}</span>
+              {/if}
+            </td>
+          {else}
+            <td class="label">{$form.$htmlField.label}&nbsp;{if $htmlField eq 'acl_financial_type'}{help id="$htmlField"}{/if}</td>
+            <td>
+              {$form.$htmlField.html}
+              {if $desc}
+                <br /><span class="description">{$desc}</span>
+              {/if}
+            </td>
+          {/if}
+        </tr>
+      {/if}
+    {/foreach}
+  </table>
   {include file="CRM/Form/basicFormFields.tpl"}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Admin/Form/Preferences/Contribute.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Contribute.tpl
@@ -23,4 +23,61 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{include file="CRM/Form/basicForm.tpl"}
+<div class="crm-block crm-form-block crm-{$formName}-block">
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+  {if $formName == "Contribute_Preferences"}
+    <table class = "form-layout">
+      {foreach from=$htmlFields item=desc key=htmlField}
+        {if $form.$htmlField}
+          {assign var=n value=$htmlField|cat:'_description'}
+          <tr class="crm-preferences-form-block-{$htmlField}">
+            {if $form.$htmlField.html_type EQ 'checkbox'|| $form.$htmlField.html_type EQ 'checkboxes'}
+              <td class="label"></td>
+              <td>
+                {$form.$htmlField.html} {$form.$htmlField.label}
+                {if $desc}
+                  <br /><span class="description">{$desc}</span>
+                {/if}
+              </td>
+            {else}
+              <td class="label">{$form.$htmlField.label}&nbsp;{if $htmlField eq 'acl_financial_type'}{help id="$htmlField"}{/if}</td>
+              <td>
+                {$form.$htmlField.html}
+                {if $desc}
+                  <br /><span class="description">{$desc}</span>
+                {/if}
+              </td>
+            {/if}
+          </tr>
+        {/if}
+      {/foreach}
+    </table>
+  {/if}
+
+  {include file="CRM/Form/basicFormFields.tpl"}
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>
+{if $formName == "Contribute_Preferences"}
+{literal}
+  <script type="text/javascript">
+    cj(document).ready(function() {
+      if (document.getElementById("invoicing").checked) {
+        cj("#invoicing_blocks").show();
+      }
+      else {
+        cj("#invoicing_blocks").hide();
+      }
+    });
+    cj(function () {
+      cj("input[type=checkbox]").click(function() {
+        if (cj("#invoicing").is(":checked")) {
+          cj("#invoicing_blocks").show();
+        }
+        else {
+          cj("#invoicing_blocks").hide();
+        }
+      });
+    });
+  </script>
+{/literal}
+{/if}

--- a/templates/CRM/Form/basicForm.tpl
+++ b/templates/CRM/Form/basicForm.tpl
@@ -25,59 +25,6 @@
 *}
 <div class="crm-block crm-form-block crm-{$formName}-block">
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-    {if $formName == "Contribute_Preferences"}
-      <table class = "form-layout">
-        {foreach from=$htmlFields item=desc key=htmlField}
-          {if $form.$htmlField}
-	    {assign var=n value=$htmlField|cat:'_description'}
-            <tr class="crm-preferences-form-block-{$htmlField}">
-              {if $form.$htmlField.html_type EQ 'checkbox'|| $form.$htmlField.html_type EQ 'checkboxes'}
-                <td class="label"></td>
-                <td>
-                  {$form.$htmlField.html} {$form.$htmlField.label}
-                  {if $desc}
-                    <br /><span class="description">{$desc}</span>
-                  {/if}
-                </td>
-              {else}
-                <td class="label">{$form.$htmlField.label}&nbsp;{if $htmlField eq 'acl_financial_type'}{help id="$htmlField"}{/if}</td>
-                <td>
-                  {$form.$htmlField.html}
-                  {if $desc}
-                    <br /><span class="description">{$desc}</span>
-                  {/if}
-                </td>
-              {/if}
-            </tr>
-          {/if}
-        {/foreach}
-      </table>
-    {/if}
-
     {include file="CRM/Form/basicFormFields.tpl"}
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
-{if $formName == "Contribute_Preferences"}
-  {literal}
-    <script type="text/javascript">
-      cj(document).ready(function() {
-        if (document.getElementById("invoicing").checked) {
-          cj("#invoicing_blocks").show();
-        }
-        else {
-          cj("#invoicing_blocks").hide();
-        }
-      });
-      cj(function () {
-        cj("input[type=checkbox]").click(function() {
-          if (cj("#invoicing").is(":checked")) {
-            cj("#invoicing_blocks").show();
-          }
-          else {
-            cj("#invoicing_blocks").hide();
-          }
-        });
-      });
-    </script>
-  {/literal}
-{/if}

--- a/templates/CRM/Form/basicForm.tpl
+++ b/templates/CRM/Form/basicForm.tpl
@@ -53,33 +53,8 @@
         {/foreach}
       </table>
     {/if}
-    <table class="form-layout" id="invoicing_blocks">
-        {foreach from=$fields item=field key=fieldName}
-            {assign var=n value=$fieldName}
-            {if $form.$n}
-              <tr class="crm-preferences-form-block-{$fieldName}">
-                    {if $field.html_type EQ 'checkbox'|| $field.html_type EQ 'checkboxes'}
-                        <td class="label"></td>
-                        <td>
-                            {$form.$n.html}
-                            {if $field.description}
-                                <br /><span class="description">{$field.description}</span>
-                            {/if}
-                        </td>
-                    {else}
-                        <td class="label">{$form.$n.label}</td>
-                        <td>
-                            {$form.$n.html}
-                            {if $field.description}
-                                <br /><span class="description">{$field.description}</span>
-                            {/if}
-                        </td>
-                    {/if}
-              </tr>
-          {/if}
-        {/foreach}
-  </table>
 
+    {include file="CRM/Form/basicFormFields.tpl"}
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 {if $formName == "Contribute_Preferences"}

--- a/templates/CRM/Form/basicFormFields.tpl
+++ b/templates/CRM/Form/basicFormFields.tpl
@@ -1,0 +1,53 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{* @todo the invoicing_blocks id is used by contribution preferences - get that out of the shared code & back to where it belongs *}
+{* @todo with a small amount of tinkering most of this can be replaced by re-using the foreach loop in CRM_Core_EntityForm.tpl *}
+<table class="form-layout" id="invoicing_blocks">
+  {foreach from=$fields item=field key=fieldName}
+    {assign var=n value=$fieldName}
+    {if $form.$n}
+      <tr class="crm-preferences-form-block-{$fieldName}">
+        {if $field.html_type EQ 'checkbox'|| $field.html_type EQ 'checkboxes'}
+          <td class="label"></td>
+          <td>
+            {$form.$n.html}
+            {if $field.description}
+              <br /><span class="description">{$field.description}</span>
+            {/if}
+          </td>
+        {else}
+          <td class="label">{$form.$n.label}</td>
+          <td>
+            {$form.$n.html}
+            {if $field.description}
+              <br /><span class="description">{$field.description}</span>
+            {/if}
+          </td>
+        {/if}
+      </tr>
+    {/if}
+  {/foreach}
+</table>


### PR DESCRIPTION
Overview
----------------------------------------
Moves code around to a more logical place.

Before
----------------------------------------
When the invoicing code was added it was added to the preferences template...badly. Instead of adding code related to invoicing to the relevant preferences template  it was added to a shared template, wrapped in 'ifs'. 

After
----------------------------------------
Code specific to only one preference form moved back to it's own template & shared code simplified.

Technical Details
----------------------------------------
Just moves code around - no change. Note each commit is  a distinct small step in this process

Comments
----------------------------------------
There are still a couple of things to fix on the php side on this form - but this neither creates or fixes those issues.