### PR TITLE
Mark event start date as required and refactoring

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -173,7 +173,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->addElement('checkbox', 'is_share', ts('Allow sharing through social media?'));
     $this->addElement('checkbox', 'is_map', ts('Include Map to Event Location'));
 
-    $this->add('datepicker', 'start_date', ts('Start'), [], FALSE, ['time' => TRUE]);
+    $this->add('datepicker', 'start_date', ts('Start'), [], !$this->_isTemplate, ['time' => TRUE]);
     $this->add('datepicker', 'end_date', ts('End'), [], FALSE, ['time' => TRUE]);
 
     $this->add('text', 'max_participants', ts('Max Number of Participants'),
@@ -210,15 +210,8 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
   public static function formRule($values) {
     $errors = array();
 
-    if (!$values['is_template']) {
-      if (empty($values['start_date'])) {
-        $errors['start_date'] = ts('Start Date and Time are required fields');
-      }
-      else {
-        if (($values['end_date'] < $values['start_date']) && !empty($values['end_date'])) {
-          $errors['end_date'] = ts('End date should be after Start date.');
-        }
-      }
+    if (!empty($values['end_date']) && ($values['end_date'] < $values['start_date'])) {
+      $errors['end_date'] = ts('End date should be after Start date.');
     }
 
     //CRM-4286


### PR DESCRIPTION
Overview
----------------------------------------
The event start date is a required field, but is not marked as such.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/5212601/47850757-44149080-ddce-11e8-8dfc-1ac2558d9a26.png)


After
----------------------------------------

![image](https://user-images.githubusercontent.com/5212601/47850731-2e06d000-ddce-11e8-835e-9237495d1f3b.png)


Technical Details
----------------------------------------
The field is required if the event is not a template, so we use the 'isTemplate' property to determine whether the field is marked as required.

