### PR TITLE
dev/core#499 Fix CustomField Checkbox display when values are non-sorted

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1199,8 +1199,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $value = CRM_Utils_Array::explodePadded($value);
     }
     // CRM-12989 fix
-    if ($field['html_type'] == 'CheckBox') {
-      CRM_Utils_Array::formatArrayKeys($value);
+    if ($field['html_type'] == 'CheckBox' && $value) {
+      $value = CRM_Utils_Array::convertCheckboxFormatToArray($value);
     }
 
     $display = is_array($value) ? implode(', ', $value) : (string) $value;


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/issues/499

How to reproduce:

* Create a new Alphanumeric/Checkbox custom field
* Create new options with this specific order:

![capture d ecran de 2018-11-01 14-36-36](https://user-images.githubusercontent.com/254741/47872200-62858680-dde4-11e8-839b-9bafd0bda0b6.png)


(Values are prefixed with '0' because back in the day, the advanced search would consider that, for example, "9" also matches "99", because of the sql query `custom_field like '%9%'`, but that's another topic.)

Result: the custom field renders empty.

![custom-fields-rendering-empty](https://user-images.githubusercontent.com/254741/47916163-9cee3280-de7b-11e8-88ec-e6bac068a781.gif)


Technical Details
----------------------------------------

`CRM_Utils_Array::formatArrayKeys()` is flagged as deprecated, and replaced with `CRM_Utils_Array::convertCheckboxFormatToArray()`, which happens to fix the issue.



Comments
----------------------------------------

Also tested with CiviCase (Case View).