### PR TITLE
dev/core#500 Fix CiviCase Dashboard Summary Count to not include cases from inactive relationships

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -809,8 +809,8 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
  LEFT JOIN civicrm_option_group option_group_case_status ON ( option_group_case_status.name = 'case_status' )
  LEFT JOIN civicrm_option_value case_status ON ( civicrm_case.status_id = case_status.value
  AND option_group_case_status.id = case_status.option_group_id )
- LEFT JOIN civicrm_relationship case_relationship ON ( case_relationship.case_id  = civicrm_case.id
- AND case_relationship.contact_id_b = {$userID})
+ LEFT JOIN civicrm_relationship case_relationship
+   ON (case_relationship.case_id = civicrm_case.id AND case_relationship.contact_id_b = {$userID} AND case_relationship.is_active = 1)
  WHERE is_deleted = 0 AND cc.contact_id IN (SELECT id FROM civicrm_contact WHERE is_deleted <> 1)
 {$myCaseWhereClause} {$myGroupByClause}";
 


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/500

Overview
----------------------------------------

How to reproduce:

* Create a case
* Assign it to someone, view their dashboard, it will show X cases
* Then re-assign it to someone else, view their dashboard, it will still show X cases (instead of X-1).

Technical Details
----------------------------------------

The SQL query had forgotten to filter on `case_relationship.is_active = 1`.
