### PR TITLE
Fix help for financial acls.

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -143,11 +143,6 @@ trait CRM_Admin_Form_SettingTrait {
           $this->includesReadOnlyFields = TRUE;
         }
 
-        if (isset($props['help_link'])) {
-          // Set both the value in this loop & the outer value as we assign both to the template while we deprecate the $descriptions assignment.
-          $settingMetaData[$setting]['description'] = $props['description'] .= ' ' . CRM_Utils_System::docURL2($props['help_link']['page'], NULL, NULL, NULL, NULL, $props['help_link']['resource']);
-
-        }
         $add = 'add' . $quickFormType;
         if ($add == 'addElement') {
           $this->$add(
@@ -162,7 +157,7 @@ trait CRM_Admin_Form_SettingTrait {
           $this->addElement('select', $setting, ts($props['title']), $options, CRM_Utils_Array::value('html_attributes', $props));
         }
         elseif ($add == 'addCheckBox') {
-          $this->addCheckBox($setting, ts($props['title']), $options, NULL, CRM_Utils_Array::value('html_attributes', $props), NULL, NULL, ['&nbsp;&nbsp;']);
+          $this->addCheckBox($setting, '', $options, NULL, CRM_Utils_Array::value('html_attributes', $props), NULL, NULL, ['&nbsp;&nbsp;']);
         }
         elseif ($add == 'addCheckBoxes') {
           $options = array_flip($options);

--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -101,6 +101,7 @@ return array(
     'is_contact' => 0,
     'description' => NULL,
     'help_text' => NULL,
+    'help' => ['id' => 'acl_financial_type'],
   ),
   'deferred_revenue_enabled' => array(
     'group_name' => 'Contribute Preferences',

--- a/settings/Event.setting.php
+++ b/settings/Event.setting.php
@@ -48,7 +48,7 @@ return array(
     'is_contact' => 0,
     'description' => ts('This feature allows users to register for more than one event at a time. When enabled, users will add event(s) to a "cart" and then pay for them all at once. Enabling this setting will affect online registration for all active events. The code is an alpha state, and you will potentially need to have developer resources to debug and fix sections of the codebase while testing and deploying it'),
     'help_text' => '',
-    'help_link' => ['page' => 'CiviEvent Cart Checkout', 'resource' => 'wiki'],
+    'documentation_link' => ['page' => 'CiviEvent Cart Checkout', 'resource' => 'wiki'],
   ),
   'show_events' => array(
     'name' => 'show_events',

--- a/settings/Multisite.setting.php
+++ b/settings/Multisite.setting.php
@@ -48,7 +48,7 @@ return array(
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Make CiviCRM aware of multiple domains. You should configure a domain group if enabled'),
-    'help_link' => ['page' => 'Multi Site Installation', 'resource' => 'wiki'],
+    'documentation_link' => ['page' => 'Multi Site Installation', 'resource' => 'wiki'],
     'help_text' => NULL,
   ),
   'domain_group_id' => array(

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -35,6 +35,6 @@
   </td>
   <td>{if $form.$fieldName.html}{if $fieldSpec.formatter === 'crmMoney'}{$form.$fieldName.html|crmMoney}{else}{$form.$fieldName.html}{/if}{else}{$fieldSpec.place_holder}{/if}<br />
     {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
-    {if $fieldSpec.documentation_link}{docURL page=$fieldSpec.documentation_link.page}{/if}
+    {if $fieldSpec.documentation_link}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>
 {/if}

--- a/templates/CRM/Form/basicFormFields.tpl
+++ b/templates/CRM/Form/basicFormFields.tpl
@@ -25,28 +25,11 @@
 *}
 {* @todo with a small amount of tinkering most of this can be replaced by re-using the foreach loop in CRM_Core_EntityForm.tpl *}
 <table class="form-layout">
-  {foreach from=$fields item=field key=fieldName}
-    {assign var=n value=$fieldName}
-    {if $form.$n}
-      <tr class="crm-preferences-form-block-{$fieldName}">
-        {if $field.html_type EQ 'checkbox'|| $field.html_type EQ 'checkboxes'}
-          <td class="label"></td>
-          <td>
-            {$form.$n.html}
-            {if $field.description}
-              <br /><span class="description">{$field.description}</span>
-            {/if}
-          </td>
-        {else}
-          <td class="label">{$form.$n.label}</td>
-          <td>
-            {$form.$n.html}
-            {if $field.description}
-              <br /><span class="description">{$field.description}</span>
-            {/if}
-          </td>
-        {/if}
-      </tr>
-    {/if}
+
+  {foreach from=$fields item=fieldSpec}
+    {assign var=fieldName value=$fieldSpec.name}
+    <tr class="crm-{$entityInClassFormat}-form-block-{$fieldName}">
+      {include file="CRM/Core/Form/Field.tpl"}
+    </tr>
   {/foreach}
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
Follow up fix on https://github.com/civicrm/civicrm-core/pull/13047 to get help text on financial acls working on contribution settings page (addresses temporary regression in master / unreleased code)

Before
----------------------------------------
![screenshot 2018-11-05 09 37 12](https://user-images.githubusercontent.com/336308/47969624-42eda700-e0df-11e8-895e-0f60341fe4cb.png)



After
----------------------------------------
![screenshot 2018-11-05 09 40 56](https://user-images.githubusercontent.com/336308/47969617-10dc4500-e0df-11e8-950d-8f5d5a9625a9.png)


Technical Details
----------------------------------------
**To test this make sure you do a cv flush or similar since setting metadata is cached** - also the help text is slow to load locally - not sure why but don't give up :-) (this is not a new slowness)

@mattwire @pradpnayak this is kind of exciting

I've done this by using the field template that is used by entity forms & adding
help to the setting spec (which I'll document).

I noted in this that entityTrait used a different field key for the
documentation link - literally documentation_link whereas I had used field_link
so I fixed settings to match

Comments
----------------------------------------
Remaining todo list

- ~~address the help text issue~~
- see if I can create the generic form per https://lab.civicrm.org/dev/core/issues/495 -UPDATE - see https://github.com/civicrm/civicrm-core/pull/13054
- update docs
- look at handling casing in a noisy but non-fail-y way
- if you want to put your PR up as an improvement I'll review & merge that
- audit settings / preferences forms to check for any failures
- email dev & request people specifically test settings forms in the rc