### PR TITLE
Remove limit when choosing fields for quick search

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1151,7 +1151,7 @@ class CRM_Core_SelectValues {
       'custom_group_id.is_active' => 1,
       'is_active' => 1,
       'is_searchable' => 1,
-      'options' => ['sort' => ['custom_group_id.weight', 'weight']],
+      'options' => ['sort' => ['custom_group_id.weight', 'weight'], 'limit' => 0],
     ]);
     foreach ($custom['values'] as $field) {
       $options['custom_' . $field['name']] = $field['custom_group_id.title'] . ': ' . $field['label'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue with https://github.com/civicrm/civicrm-core/pull/13039 identified during review where custom fields were being inappropriately restricted

Before
----------------------------------------
Only first 25 custom fields available for quicksearch

After
----------------------------------------
All custom fields available

Technical Details
----------------------------------------
@colemanw - pre my comments on your PR

Comments
----------------------------------------
