### PR TITLE
dev/core/501 Allow resize of images in sub directory to speedup page

### DIFF
--- a/CRM/Contact/Page/ImageFile.php
+++ b/CRM/Contact/Page/ImageFile.php
@@ -73,7 +73,8 @@ class CRM_Contact_Page_ImageFile extends CRM_Core_Page {
         $suffix = '_w' . $width . '_h' . $height;
         try {
           $thisFileName = CRM_Utils_File::resizeImage($thisFileName, $width, $height, $suffix, TRUE, 'cache', TRUE);
-        } catch (CRM_Core_Exception $e) {
+        }
+        catch (CRM_Core_Exception $e) {
           CRM_Core_Session::singleton()->setStatus($e->getMessage());
         }
       }

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -54,6 +54,18 @@ class CRM_Core_Page_File extends CRM_Core_Page {
 
       list($path, $mimeType) = CRM_Core_BAO_File::path($id, $eid, NULL, $quest);
     }
+    if ($mimeType && strpos($mimeType, 'image') == '0') {
+      $width  = CRM_Utils_Request::retrieve('width', 'Positive', CRM_Core_DAO::$_nullObject);
+      $height = CRM_Utils_Request::retrieve('height', 'Positive', CRM_Core_DAO::$_nullObject);
+      if ($width && $height) {
+        $suffix = '_w' . $width . '_h' . $height;
+        try {
+          $path = CRM_Utils_File::resizeImage($path, $width, $height, $suffix, TRUE, 'cache', TRUE);
+        } catch (CRM_Core_Exception $e) {
+          CRM_Core_Session::singleton()->setStatus($e->getMessage());
+        }
+      }
+    }
 
     if (!$path) {
       CRM_Core_Error::statusBounce('Could not retrieve the file');

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -61,7 +61,8 @@ class CRM_Core_Page_File extends CRM_Core_Page {
         $suffix = '_w' . $width . '_h' . $height;
         try {
           $path = CRM_Utils_File::resizeImage($path, $width, $height, $suffix, TRUE, 'cache', TRUE);
-        } catch (CRM_Core_Exception $e) {
+        }
+        catch (CRM_Core_Exception $e) {
           CRM_Core_Session::singleton()->setStatus($e->getMessage());
         }
       }

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1013,16 +1013,16 @@ HTACCESS;
       $transparent = imagecolortransparent($sourceData);
       if ($transparent >= 0) {
         // Find out the number of colors in the image palette. It will be 0 for truecolor images.
-        $palette_size = imagecolorstotal($sourceData);
-        if ($palette_size == 0 || $transparent < $palette_size) {
+        $paletteSize = imagecolorstotal($sourceData);
+        if ($paletteSize == 0 || $transparent < $paletteSize) {
           // Set the transparent color in the new resource, either if it is a
           // truecolor image or if the transparent color is part of the palette.
           // Since the index of the transparency color is a property of the
           // image rather than of the palette, it is possible that an image
           // could be created with this index set outside the palette size (see
           // http://stackoverflow.com/a/3898007).
-          $transparent_color = imagecolorsforindex($sourceData, $transparent);
-          $transparent = imagecolorallocate($targetData, $transparent_color['red'], $transparent_color['green'], $transparent_color['blue']);
+          $transparentColor = imagecolorsforindex($sourceData, $transparent);
+          $transparent = imagecolorallocate($targetData, $transparentColor['red'], $transparentColor['green'], $transparentColor['blue']);
 
           // Flood with our new transparent color.
           imagefill($targetData, 0, 0, $transparent);

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -951,9 +951,9 @@ HTACCESS;
    *   - When GD is not available.
    *   - When the source file is not an image.
    */
-  public static function resizeImage($sourceFile, $targetWidth, $targetHeight, $suffix = "", $preserveAspect = TRUE, $subDir = null, $returnPath = FALSE) {
+  public static function resizeImage($sourceFile, $targetWidth, $targetHeight, $suffix = "", $preserveAspect = TRUE, $subDir = NULL, $returnPath = FALSE) {
 
-    if ( !file_exists($sourceFile) && $returnPath) {
+    if (!file_exists($sourceFile) && $returnPath) {
       return $sourceFile;
     }
     // figure out the new filename
@@ -1007,7 +1007,6 @@ HTACCESS;
       }
     }
 
-
     $targetData = imagecreatetruecolor($targetWidth, $targetHeight);
     /* Check if this image is PNG or GIF, then set if Transparent*/
     if ($sourceMime == 'image/gif') {
@@ -1057,10 +1056,21 @@ HTACCESS;
     $fp = fopen($targetFile, 'w+');
     ob_start();
     switch ($sourceInfo[2]) {
-      case 1: imagegif($targetData); break;
-      case 2: imagejpeg($targetData); break;
-      case 3: imagepng($targetData); break;
-      default: imagejpeg($targetData); break;
+      case 1:
+        imagegif($targetData);
+        break;
+
+      case 2:
+        imagejpeg($targetData);
+        break;
+
+      case 3:
+        imagepng($targetData);
+        break;
+
+      default:
+        imagejpeg($targetData);
+        break;
     }
     $image_buffer = ob_get_contents();
     ob_end_clean();


### PR DESCRIPTION
Overview
----------------------------------------
Generate Resized image by passing image dimensions in url to speedup page, [ticket](https://lab.civicrm.org/dev/core/issues/501)

Before
----------------------------------------
Actual Images were loading

After
----------------------------------------
Resized images are loading if requested

Technical Details
----------------------------------------
When images are uploaded to civicrm (profile or custom field of image type), they are moved to civicrm/custom directory. And every time we requested that images same image are served.

In case we need these images in different dimensions, we load same images and then apply height and with attribute to img tag. if image size in MB and we are loading multiple contact images on certain pages then it take time load all images. To avoid this issue we can resize original image as per our requirement and keep these resized image in separate directory.

```
https://dmaster.demo.civicrm.org/civicrm/contact/imagefile?photo=BU_Stacked_Logo_980877eb4a5a814a017b582fb2439d8f.png&width=150&height=150
https://dmaster.demo.civicrm.org/civicrm/file?reset=1&filename=BU_Stacked_Logo_980877eb4a5a814a017b582fb2439d8f.png&mime-type=image/png&width=150&height=150
https://dmaster.demo.civicrm.org/civicrm/file?reset=1&id=1&eid=202&width=150&height=150
```
This will create sub directory 'cache' (civicrm/custom/cache) and new resize image placed in this sub directory ( BU_Stacked_Logo_980877eb4a5a814a017b582fb2439d8f_w150_h150.png )

Also image showing with Thumbnail size on Contact Summary Page / for custom Field  actual using img attribute  and on clicking thumbnail img, it shows Original images in pop up box. In this PR we also resize thumbnail image.

Comments
----------------------------------------
For Better results after resize image we using imagecopyresampled instead of imagecopyresized