### PR TITLE
Display message template title on deletion form

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -139,6 +139,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
     }
 
     if ($this->_action & CRM_Core_Action::DELETE) {
+      $this->assign('msg_title', $this->_values['msg_title']);
       return;
     }
 

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -39,7 +39,7 @@
 {if $action eq 8}
    <div class="messages status no-popup">
        <div class="icon inform-icon"></div>
-       {ts}Do you want to delete this message template?{/ts}
+       {ts 1=$msg_title}Do you want to delete the message template '%1'?{/ts}
    </div>
 {else}
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -39,7 +39,7 @@
 {if $action eq 8}
    <div class="messages status no-popup">
        <div class="icon inform-icon"></div>
-       {ts 1=$msg_title}Do you want to delete the message template '%1'?{/ts}
+       {ts 1=$msg_title|escape}Do you want to delete the message template '%1'?{/ts}
    </div>
 {else}
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>


### PR DESCRIPTION
Overview
----------------------------------------
On the deletion confirmation page for a message template it doesn't display the name of the template being deleted. It would be better UX to confirm the name of the template being deleted, otherwise it rather defeats the object of the confirmation page! ;]

Steps to recreate:
- Mailingg > Message templates > Choose one to delete

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/5212601/47923199-a776ef00-deb0-11e8-88b9-5366a5822d5d.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/5212601/47923142-8dd5a780-deb0-11e8-823b-d5c67b58be94.png)

Technical Details
----------------------------------------
-  Assign the message title to a template variable for the delete action
- Add the message title into the text on the page, in a translatable string

