### PR TITLE
dev/core#505 Allow Extensions to specify crmType and phpType when dea…

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -336,12 +336,13 @@ class CRM_Core_CodeGen_Specification {
         break;
 
       default:
-        $field['sqlType'] = $field['phpType'] = $type;
+        $field['phpType'] = $this->value('phpType', $fieldXML, $type);
+        $field['sqlType'] = $type;
         if ($type == 'int unsigned') {
           $field['crmType'] = 'CRM_Utils_Type::T_INT';
         }
         else {
-          $field['crmType'] = 'CRM_Utils_Type::T_' . strtoupper($type);
+          $field['crmType'] = $this->value('crmType', $fieldXML, 'CRM_Utils_Type::T_' . strtoupper($type));
         }
         break;
     }


### PR DESCRIPTION
…ling with unusual MySQL columns

Overview
----------------------------------------
When Extension authors create their XMLs they can at the moment only specify a Type of the column, this can sometimes create random DAO types which don't exist e.g. a column of type Geometry there is no CRM_Utils_Type::T_GEOMETRY

Before
----------------------------------------
Extension authors cannot specify phpType or crmType 

After
----------------------------------------
Can specify phpType and crmType which allows simpler usage of random mysql column types

ping @eileenmcnaughton @totten 