### PR TITLE
php 7.3 support - Fix misplaced hyphens in regex

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -108,7 +108,7 @@ class CRM_Utils_Rule {
     //   * Composed of alphanumeric chars, underscore and hyphens.
     //   * Maximum length of 64 chars.
     //   * Optionally surrounded by backticks, in which case spaces also OK.
-    if (!preg_match('/^((`[\w- ]{1,64}`|[\w-]{1,64})\.)?(`[\w- ]{1,64}`|[\w-]{1,64})$/i', $str)) {
+    if (!preg_match('/^((`[-\w ]{1,64}`|[-\w]{1,64})\.)?(`[-\w ]{1,64}`|[-\w]{1,64})$/i', $str)) {
       return FALSE;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Inside a character range surrounded by [], the hyphen is interpreted
as defining a range, unless it's the first character. Move the
hyphens to the first character in the square brackets where it's
supposed to be interpreted as a hyphen.

Before
----------------------------------------
Under PHP 7.3, the previous code failed with error message
preg_match(): Compilation failed: invalid range in character class at offset 7
when creating a new contribution with custom field values

After
----------------------------------------
No problem importing a new contribution with custom field values under PHP 7.3

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
