### PR TITLE
Fix continue / break PHP 7.3 warnings

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1564,7 +1564,7 @@ ORDER BY civicrm_custom_group.weight,
 
           case 'File':
             if ($skipFile) {
-              continue;
+              break;
             }
 
             //store the file in d/b

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -737,7 +737,7 @@ WHERE  id = %1";
         case 'Radio':
           //special case if user select -none-
           if ($params["price_{$id}"] <= 0) {
-            continue;
+            break;
           }
           $params["price_{$id}"] = array($params["price_{$id}"] => 1);
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);


### PR DESCRIPTION
Overview
----------------------------------------
PHP 7.3 emits warnings on ambiguous use of 'continue' where it
serves as a 'break' statement.

In all of these cases it looked like 'break' would have also worked
since there was nothing after the end of the switch statement but
before the end of the loop. But I used continue 2 to be a bit safer
about it, in case people add more code there.

Before
----------------------------------------
PHP 7.3 emits warnings, causing tests to fail under strict conditions

After
----------------------------------------
Fewer warnings

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
Note that in the contact Query there seems to be a fallthrough bug
with campaign, where a comment says things not matching the tested
cases should fall through to default, but 'website' has been added
in between.