### PR TITLE
WIP send the links on the Relationship Types admin page (and any page that extends CRM_Core_Page_Basic) thru hook_civicrm_links 

### DIFF
--- a/CRM/Admin/Page/RelationshipType.php
+++ b/CRM/Admin/Page/RelationshipType.php
@@ -94,15 +94,6 @@ class CRM_Admin_Page_RelationshipType extends CRM_Core_Page_Basic {
         ),
       );
     }
-
-    // See if other modules want to add links to the Relationship Type row
-    CRM_Utils_Hook::links(
-      'relationshipType.selector.row',
-      'RelationshipType',
-      CRM_Core_DAO::$_nullObject,
-      self::$_links
-    );
-
     return self::$_links;
   }
 

--- a/CRM/Admin/Page/RelationshipType.php
+++ b/CRM/Admin/Page/RelationshipType.php
@@ -94,6 +94,15 @@ class CRM_Admin_Page_RelationshipType extends CRM_Core_Page_Basic {
         ),
       );
     }
+
+    // See if other modules want to add links to the Relationship Type row
+    CRM_Utils_Hook::links(
+      'relationshipType.selector.row',
+      'RelationshipType',
+      CRM_Core_DAO::$_nullObject,
+      self::$_links
+    );
+
     return self::$_links;
   }
 

--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -365,7 +365,16 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
     // make sure we only allow those actions that the user is permissioned for
     $newAction = $newAction & CRM_Core_Action::mask($permissions);
 
-    $values['action'] = CRM_Core_Action::formLink($links, $newAction, array('id' => $object->id));
+    $values['action'] = CRM_Core_Action::formLink(
+      $links,
+      $newAction,
+      ['id' => $object->id],
+      // the default
+      'more',
+      // the default
+      FALSE,
+      'basic.' . CRM_Utils_String::munge(__CLASS__) . '.page'
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Makes it so extension developers can use [hook_civicrm_links](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/) to add or remove links from the Relationship Types Administration Page (CiviCRM Navigation Menu->Administer->Customize Data and Screens->Relationship Types)

![relationshiptypespage](https://user-images.githubusercontent.com/11323624/48157458-a58ca180-e29d-11e8-83bc-435b82631ba9.png)


Before
----------------------------------------
no hook

After
----------------------------------------
hook