### PR TITLE
send action links on any page that extends CRM_Core_Page_basic thru hook_civicrm_links

### DIFF
--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -319,11 +319,12 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
       }
     }
 
+    $object_type = get_class($object);
+
     if (!$forceAction) {
       if (array_key_exists('is_reserved', $object) && $object->is_reserved) {
         $values['class'] = 'reserved';
         // check if object is relationship type
-        $object_type = get_class($object);
 
         $exceptions = array(
           'CRM_Contact_BAO_RelationshipType',
@@ -365,7 +366,16 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
     // make sure we only allow those actions that the user is permissioned for
     $newAction = $newAction & CRM_Core_Action::mask($permissions);
 
-    $values['action'] = CRM_Core_Action::formLink($links, $newAction, array('id' => $object->id));
+    $values['action'] = CRM_Core_Action::formLink(
+      $links,
+      $newAction,
+      ['id' => $object->id],
+      'more',
+      FALSE,
+      "basic.$object_type.page",
+      $object_type,
+      $object->id
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Makes it so extension developers can use [hook_civicrm_links](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/) to add or remove links from the Relationship Types Administration Page (CiviCRM Navigation Menu->Administer->Customize Data and Screens->Relationship Types) and any other page that extends CRM_Core_Page_Basic

Before
----------------------------------------
Pages that extend CRM_Core_Page_Basic never added sent links thru  hook_civicrm_links

After
----------------------------------------
Pages that extend CRM_Core_Page_Basic send links thru  hook_civicrm_links
