### PR TITLE
dev/core#511 Fix wrong current month showing on Membership Dashboard

### DIFF
--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -428,7 +428,7 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
 
     $this->assign('membershipSummary', $membershipSummary);
     $this->assign('totalCount', $totalCount);
-    $this->assign('month', CRM_Utils_Date::customFormat($monthStartTs, '%B'));
+    $this->assign('month', CRM_Utils_Date::customFormatTs($monthStartTs, '%B'));
     $this->assign('year', date('Y', $monthStartTs));
     $this->assign('premonth', CRM_Utils_Date::customFormat($preMonth, '%B'));
     $this->assign('currentMonth', date('F'));

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -439,6 +439,23 @@ class CRM_Utils_Date {
   }
 
   /**
+   * Wrapper for customFormat that takes a timestamp
+   *
+   * @param int $timestamp
+   *   Date and time in timestamp format.
+   * @param string $format
+   *   The output format.
+   * @param array $dateParts
+   *   An array with the desired date parts.
+   *
+   * @return string
+   *   the $format-formatted $date
+   */
+  public static function customFormatTs($timestamp, $format = NULL, $dateParts = NULL) {
+    return CRM_Utils_Date::customFormat(date("Y-m-d H:i:s", $timestamp), $format, $dateParts);
+  }
+
+  /**
    * Converts the date/datetime from MySQL format to ISO format
    *
    * @param string $mysql

--- a/templates/CRM/Member/Page/DashBoard.tpl
+++ b/templates/CRM/Member/Page/DashBoard.tpl
@@ -30,7 +30,7 @@
     <tr class="columnheader-dark">
       <th scope="col" rowspan="2">{ts}Members by Type{/ts}</th>
         {if $preMonth}
-      <th scope="col" colspan="3">{$premonth} &ndash; {ts}(Last Month){/ts}</th>
+      <th scope="col" colspan="3">{$premonth} {ts}(Last Month){/ts}</th>
         {/if}
         <th scope="col" colspan="3">{$month}{if $isCurrent}{ts} (MTD){/ts}{/if}</th>
         <th scope="col" colspan="3">

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -173,4 +173,48 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test customFormat() function
+   */
+  public function testCustomFormat() {
+    $dateTime = "2018-11-08 21:46:44";
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%b"), "Nov");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%B"), "November");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%d"), "08");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%e"), " 8");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%E"), "8");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%f"), "th");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%H"), "21");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%I"), "09");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%k"), "21");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%l"), " 9");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%m"), "11");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%M"), "46");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%p"), "pm");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%P"), "PM");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%Y"), "2018");
+  }
+
+  /**
+   * Test customFormat() function
+   */
+  public function testCustomFormatTs() {
+    $ts = mktime(21, 46, 44, 11, 8, 2018);
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%b"), "Nov");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%B"), "November");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%d"), "08");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%e"), " 8");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%E"), "8");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%f"), "th");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%H"), "21");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%I"), "09");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%k"), "21");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%l"), " 9");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%m"), "11");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%M"), "46");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%p"), "pm");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%P"), "PM");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%Y"), "2018");
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Correct the current month on the Membership Dashboard summary.

Before
----------------------------------------
![screenshot from 2018-11-08 12-48-54](https://user-images.githubusercontent.com/2730045/48199685-cc59df00-e354-11e8-93e1-67d0f8a60fb0.png)

Current month is wrong

After
----------------------------------------
![screenshot from 2018-11-08 12-48-22](https://user-images.githubusercontent.com/2730045/48199697-d976ce00-e354-11e8-949c-fed9bdfb9a2f.png)

Current month is right

Technical Details
----------------------------------------
Nothing much

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/511