### PR TITLE
dev/core#513: Using payment_instrument_id instead of payment_type to determine the payment instrument when using the Transact API

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -434,7 +434,8 @@ function civicrm_api3_contribution_transact($params) {
   $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($params['payment_processor'], $params['payment_processor_mode']);
   $paymentProcessor['object']->doPayment($params);
 
-  $params['payment_instrument_id'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType', $paymentProcessor['payment_processor_type_id'], 'payment_type') == 1 ? 'Credit Card' : 'Debit Card';
+  $params['payment_instrument_id'] = $paymentProcessor['object']->getPaymentInstrumentID();
+
   return civicrm_api('Contribution', 'create', $params);
 }
 


### PR DESCRIPTION

Before
----------------------------------------
When using the Contribution.Transact API, CiviCRM will either change the payment instrument to "Credit Card" or "Debit Card" based on the the value of payment_type field.

After
----------------------------------------
This is wrong and the payment instrument type should be taken form the used payment processor payment_instrument_id field which is what I fixed below.