### PR TITLE
Fix typo in smarty help

### DIFF
--- a/templates/CRM/Custom/Page/Group.hlp
+++ b/templates/CRM/Custom/Page/Group.hlp
@@ -55,10 +55,10 @@
 {/htxt}
 
 {capture assign=importMultipleURL}{crmURL p="civicrm/import/custom" q="reset=1"}{/capture}
-{htxt id=id-is_multiple-title"}
+{htxt id="id-is_multiple-title"}
   {ts}Allow Multiple Records{/ts}
 {/htxt}
-{htxt id=id-is_multiple"}
+{htxt id="id-is_multiple"}
     <p>{ts}Checking this box allows you to enter multiple sets of values for a given contact.{/ts}</p>
     <p>{ts}<strong>EXAMPLE:</strong> When creating a set of custom fields used to collect <strong>Employment History</strong> - you might have fields for Job Title, Start Date, End Date, and Reason for Leaving. Checking the "multiple records" box allows you to collect information for multiple jobs.{/ts}</p>
     <p>{ts}You can also set the maximum number of records which can be recorded per contact. Using the previous example, you might only want data for the three most recent jobs.{/ts}</p>
@@ -72,10 +72,10 @@
     </p>
 {/htxt}
 
-{htxt id=id-max_multiple-title"}
+{htxt id="id-max_multiple-title"}
 {ts}Maximum Records{/ts}
 {/htxt}
-{htxt id=id-max_multiple"}
+{htxt id="id-max_multiple"}
  {ts}If you want to set a specific limit on the maximum number of records, enter that number. Otherwise leave this field blank.{/ts}
 {/htxt}
 

--- a/templates/CRM/Custom/Page/Group.hlp
+++ b/templates/CRM/Custom/Page/Group.hlp
@@ -104,7 +104,7 @@
   {ts}Is this Custom Group Public{/ts}
 {/htxt}
 {htxt id="id-is-public"}
-  {ts}Check this box if you want this custom group to be displayed on public forms e.g. Event Information page. Only public custom groups will be included in event receipts.{/ts}  {docURL page="user/organising-your-data/creating-custom-fields/#is-this-custom-field-set-public" title"Read More"}
+  {ts}Check this box if you want this custom group to be displayed on public forms e.g. Event Information page. Only public custom groups will be included in event receipts.{/ts}  {docURL page="user/organising-your-data/creating-custom-fields/#is-this-custom-field-set-public"}
 {/htxt}
 
 {htxt id="id-help_pre-title"}


### PR DESCRIPTION
Overview
-------
Fixes a Smarty compile error message due to the missing `=` in `title"Read More"` which should be `title="Read More"`. However, the default title supplied by the `{docURL}` function seemed perfectly adequate so I just removed it.

Additionally fixed some other missing quotation marks in the file. Not sure how that file was able to compile at all :/