### PR TITLE
dev/core#503 - More accurate custom field checking before htmlEncode

### DIFF
--- a/CRM/Utils/API/AbstractFieldCoder.php
+++ b/CRM/Utils/API/AbstractFieldCoder.php
@@ -63,6 +63,11 @@ abstract class CRM_Utils_API_AbstractFieldCoder implements API_Wrapper {
     if ($skipFields === NULL) {
       return FALSE;
     }
+    // Strip extra numbers from custom fields e.g. custom_32_1 should be custom_32
+    if (strpos($fldName, 'custom_') === 0) {
+      list($fldName, $customId) = explode('_', $fldName);
+      $fldName .= '_' . $customId;
+    }
 
     // Field should be skipped
     if (in_array($fldName, $skipFields)) {


### PR DESCRIPTION
Overview
----------
Ensures rich text custom fields do not get html encoded. Fixes https://lab.civicrm.org/dev/core/issues/503