### PR TITLE
dev/core#372 Remove notice on activity update due to trying to proces…

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -523,7 +523,9 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       // We filter out alternatives, in case this is a stored e-mail, before sending to front-end
-      $this->_values['details'] = CRM_Utils_String::stripAlternatives($this->_values['details']) ?: '';
+      if (isset($this->_values['details'])) {
+        $this->_values['details'] = CRM_Utils_String::stripAlternatives($this->_values['details']) ?: '';
+      }
 
       if ($this->_activityTypeName === 'Inbound Email' &&
         !CRM_Core_Permission::check('edit inbound email basic information and content')


### PR DESCRIPTION
…s details key when non existant

Overview
----------------------------------------
When updating an activity that has no details set there is a notice error

To reproduce
1. Login and create an activity but make sure you leave the details section blank
2. View the activity
3. Click to edit the activity and observe the undefined index error

Before
----------------------------------------
Notice error exists

After
----------------------------------------
No Notice error

ping @eileenmcnaughton @JoeMurray @colemanw 


https://lab.civicrm.org/dev/core/issues/372