### PR TITLE
Add merge link to duplicate contact popup

### DIFF
--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -301,7 +301,8 @@
           var params = {
             title: data.count == 1 ? {/literal}"{ts escape='js'}Similar Contact Found{/ts}" : "{ts escape='js'}Similar Contacts Found{/ts}"{literal},
             info: "{/literal}{ts escape='js'}If the contact you were trying to add is listed below, click their name to view or edit their record{/ts}{literal}:",
-            contacts: data.values
+            contacts: data.values,
+            cid: cid
           };
           if (data.count) {
             openDupeAlert(params);
@@ -389,7 +390,8 @@
           info: data.count ?
             "{/literal}{ts escape='js'}If the contact you were trying to add is listed below, click their name to view or edit their record{/ts}{literal}:" :
             "{/literal}{ts escape='js'}No matches found using the default Supervised deduping rule.{/ts}{literal}",
-          contacts: data.values
+          contacts: data.values,
+          cid: cid
         };
         updateDupeAlert(params, data.count ? 'alert' : 'success');
       });
@@ -408,6 +410,10 @@
           <%- contact.display_name %>
         </a>
         <%- contact.email %>
+        <% if (cid) { %>
+          <% var params = {reset: 1, action: 'update', oid: contact.id > cid ? contact.id : cid, cid: contact.id > cid ? cid : contact.id }; %>
+          (<a href="<%= CRM.url('civicrm/contact/merge', params) %>">{/literal}{ts}Merge{/ts}{literal}</a>)
+        <% } %>
       </li>
     <% }); %>
   </ul>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a merge button to the duplicate contact popup which was inadvertently removed in a7ba493ce752fee7b05daa103bc1c956b7d05b0f

Before
----------------------------------------

![screenshot from 2018-11-11 11-57-18](https://user-images.githubusercontent.com/2874912/48315815-fb688e80-e5a8-11e8-9a70-53db69039f01.png)


After
----------------------------------------

![screenshot from 2018-11-11 11-54-17](https://user-images.githubusercontent.com/2874912/48315796-c1978800-e5a8-11e8-9d63-66da0f4d546f.png)


