### PR TITLE
Export code cleanup - Use getComponentPaymentFields from processorClass

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -440,6 +440,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
       if (CRM_Core_Permission::access('CiviEvent')) {
         $fields['Participant'] = CRM_Event_BAO_Participant::exportableFields();
         //get the component payment fields
+        // @todo - review this - inconsistent with other entities & hacky.
         if ($exportMode == CRM_Export_Form_Select::EVENT_EXPORT) {
           $componentPaymentFields = array();
           foreach (CRM_Export_BAO_Export::componentPaymentFields() as $payField => $payTitle) {

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -439,7 +439,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       // If we haven't selected specific payment fields, load in all the
       // payment headers.
       if (!$processor->isExportSpecifiedPaymentFields()) {
-        $paymentHeaders = self::componentPaymentFields();
+        $paymentHeaders = $processor->getcomponentPaymentFields();
         if (!empty($paymentDetails)) {
           $addPaymentHeader = TRUE;
         }
@@ -1304,6 +1304,11 @@ WHERE  {$whereClause}";
 
   /**
    * Build componentPayment fields.
+   *
+   * This is no longer used by export but BAO_Mapping still calls it & we
+   * should find a generic way to handle this or move this to that class.
+   *
+   * @deprecated
    */
   public static function componentPaymentFields() {
     static $componentPaymentFields;
@@ -1345,8 +1350,8 @@ WHERE  {$whereClause}";
       // @todo - set this correctly in the xml rather than here.
       $headerRows[] = ts('IM Service Provider');
     }
-    elseif ($processor->isExportPaymentFields() && array_key_exists($field, self::componentPaymentFields())) {
-      $headerRows[] = CRM_Utils_Array::value($field, self::componentPaymentFields());
+    elseif ($processor->isExportPaymentFields() && array_key_exists($field, $processor->getcomponentPaymentFields())) {
+      $headerRows[] = CRM_Utils_Array::value($field, $processor->getcomponentPaymentFields());
     }
     else {
       $headerRows[] = $field;
@@ -1807,7 +1812,7 @@ WHERE  {$whereClause}";
         }
       }
     }
-    elseif ($processor->isExportSpecifiedPaymentFields() && array_key_exists($field, self::componentPaymentFields())) {
+    elseif ($processor->isExportSpecifiedPaymentFields() && array_key_exists($field, $processor->getcomponentPaymentFields())) {
       $paymentTableId = $processor->getPaymentTableID();
       $paymentData = CRM_Utils_Array::value($iterationDAO->$paymentTableId, $paymentDetails);
       $payFieldMapper = array(

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -235,8 +235,6 @@ class CRM_Export_BAO_Export {
     $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
     self::$relationshipTypes = $processor->getRelationshipTypes();
 
-    $queryMode = $processor->getQueryMode();
-
     if ($fields) {
       foreach ($fields as $key => $value) {
         $fieldName = CRM_Utils_Array::value(1, $value);
@@ -445,7 +443,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     }
 
     $componentDetails = array();
-    $setHeader = TRUE;
 
     $rowCount = self::EXPORT_ROW_COUNT;
     $offset = 0;
@@ -469,7 +466,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       }
     }
 
+    $exportTempTable = self::createTempTable($sqlColumns);
     $limitReached = FALSE;
+
     while (!$limitReached) {
       $limitQuery = "{$queryString} LIMIT {$offset}, {$rowCount}";
       $iterationDAO = CRM_Core_DAO::executeQuery($limitQuery);
@@ -532,13 +531,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
             $row[$field] = self::getTransformedFieldValue($field, $iterationDAO, $fieldValue, $i18n, $metadata, $paymentDetails, $processor);
           }
         }
-
-        if ($setHeader) {
-          $exportTempTable = self::createTempTable($sqlColumns);
-        }
-
-        //build header only once
-        $setHeader = FALSE;
 
         // If specific payment fields have been selected for export, payment
         // data will already be in $row. Otherwise, add payment related

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -459,6 +459,16 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
     list($outputColumns, $headerRows, $sqlColumns, $metadata) = self::getExportStructureArrays($returnProperties, $processor);
 
+    // add payment headers if required
+    if ($addPaymentHeader && $processor->isExportPaymentFields()) {
+      // @todo rather than do this for every single row do it before the loop starts.
+      // where other header definitions take place.
+      $headerRows = array_merge($headerRows, $processor->getPaymentHeaders());
+      foreach (array_keys($processor->getPaymentHeaders()) as $paymentHdr) {
+        self::sqlColumnDefn($processor, $sqlColumns, $paymentHdr);
+      }
+    }
+
     $limitReached = FALSE;
     while (!$limitReached) {
       $limitQuery = "{$queryString} LIMIT {$offset}, {$rowCount}";
@@ -520,16 +530,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           }
           else {
             $row[$field] = self::getTransformedFieldValue($field, $iterationDAO, $fieldValue, $i18n, $metadata, $paymentDetails, $processor);
-          }
-        }
-
-        // add payment headers if required
-        if ($addPaymentHeader && $processor->isExportPaymentFields()) {
-          // @todo rather than do this for every single row do it before the loop starts.
-          // where other header definitions take place.
-          $headerRows = array_merge($headerRows, $processor->getPaymentHeaders());
-          foreach (array_keys($processor->getPaymentHeaders()) as $paymentHdr) {
-            self::sqlColumnDefn($processor, $sqlColumns, $paymentHdr);
           }
         }
 

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -432,25 +432,16 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
     $paymentDetails = array();
     if ($processor->isExportPaymentFields()) {
-
       // get payment related in for event and members
       $paymentDetails = CRM_Contribute_BAO_Contribution::getContributionDetails($exportMode, $ids);
       //get all payment headers.
       // If we haven't selected specific payment fields, load in all the
       // payment headers.
       if (!$processor->isExportSpecifiedPaymentFields()) {
-        $paymentHeaders = $processor->getcomponentPaymentFields();
         if (!empty($paymentDetails)) {
           $addPaymentHeader = TRUE;
         }
       }
-      // If we have selected specific payment fields, leave the payment headers
-      // as an empty array; the headers for each selected field will be added
-      // elsewhere.
-      else {
-        $paymentHeaders = array();
-      }
-      $nullContributionDetails = array_fill_keys(array_keys($paymentHeaders), NULL);
     }
 
     $componentDetails = array();
@@ -536,8 +527,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         if ($addPaymentHeader && $processor->isExportPaymentFields()) {
           // @todo rather than do this for every single row do it before the loop starts.
           // where other header definitions take place.
-          $headerRows = array_merge($headerRows, $paymentHeaders);
-          foreach (array_keys($paymentHeaders) as $paymentHdr) {
+          $headerRows = array_merge($headerRows, $processor->getPaymentHeaders());
+          foreach (array_keys($processor->getPaymentHeaders()) as $paymentHdr) {
             self::sqlColumnDefn($processor, $sqlColumns, $paymentHdr);
           }
         }
@@ -554,6 +545,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         // information, if appropriate.
         if ($addPaymentHeader) {
           if (!$processor->isExportSpecifiedPaymentFields()) {
+            $nullContributionDetails = array_fill_keys(array_keys($processor->getPaymentHeaders()), NULL);
             if ($processor->isExportPaymentFields()) {
               $paymentData = CRM_Utils_Array::value($row[$paymentTableId], $paymentDetails);
               if (!is_array($paymentData) || empty($paymentData)) {

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -534,6 +534,19 @@ class CRM_Export_BAO_ExportProcessor {
   }
 
   /**
+   * Get headers for payment fields.
+   *
+   * Returns an array of contribution fields when the entity supports payment fields and specific fields
+   * are not specified. This is a transitional function for refactoring legacy code.
+   */
+  public function getPaymentHeaders() {
+    if ($this->isExportPaymentFields() && !$this->isExportSpecifiedPaymentFields()) {
+      return $this->getcomponentPaymentFields();
+    }
+    return [];
+  }
+
+  /**
    * Get the default properties when not specified.
    *
    * In the UI this appears as 'Primary fields only' but in practice it's

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -519,9 +519,11 @@ class CRM_Export_BAO_ExportProcessor {
   /**
    * Get fields that indicate payment fields have been requested for a component.
    *
+   * Ideally this should be protected but making it temporarily public helps refactoring..
+   *
    * @return array
    */
-  protected function getComponentPaymentFields() {
+  public function getComponentPaymentFields() {
     return [
       'componentPaymentField_total_amount' => ts('Total Amount'),
       'componentPaymentField_contribution_status' => ts('Contribution Status'),


### PR DESCRIPTION
Overview
----------------------------------------
Minor code refactor as part of ongoing cleanup on export processor

Before
----------------------------------------
Less functions on new processor class

After
----------------------------------------
More functions on new processor class

Technical Details
----------------------------------------
We have been cleaning up this class preliminary to address bugs, including moving code to use the new ExportProcessor class

Comments
----------------------------------------

@twomice I've added another small refactor - this affects the compilation of payment fields being exported (eg from a participant export or member export) - it seems they should be included in 'primary fields' for the entity or be selectable for export - but the way this functionality was added is pretty bad.

Next step is to move getTransformedFieldValue off to the ExportProcessor class & extracting a buildRow function. The goal would be to merge the household in that function (maybe via array merge) and completely eliminate the mergeSameHousehold function 