### PR TITLE
dev/core#487 Menu cleanup in preparation for switch to SmartMenus library

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -611,6 +611,10 @@ class CRM_Core_Resources {
           'isFrontend' => $config->userFrameworkFrontend,
         ),
       );
+      $contactID = CRM_Core_Session::getLoggedInContactID();
+      if ($contactID) {
+        $settings['config']['menuCacheCode'] = CRM_Core_BAO_Navigation::getCacheKey($contactID);
+      }
       // Disable profile creation if user lacks permission
       if (!CRM_Core_Permission::check('edit all contacts') && !CRM_Core_Permission::check('add contacts')) {
         $settings['config']['entityRef']['contactCreate'] = FALSE;
@@ -685,6 +689,7 @@ class CRM_Core_Resources {
       ),
       'ajaxPopupsEnabled' => self::singleton()->ajaxPopupsEnabled,
       'allowAlertAutodismissal' => (bool) Civi::settings()->get('allow_alert_autodismissal'),
+      'resourceCacheCode' => self::singleton()->getCacheCode(),
     );
     print CRM_Core_Smarty::singleton()->fetchWith('CRM/common/l10n.js.tpl', $vars);
     CRM_Utils_System::civiExit();

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -1,5 +1,5 @@
 // http://civicrm.org/licensing
-CRM.$(function($) {
+(function($) {
   $(document)
     .on('dialogopen', function(e) {
       // D7 hack to get the toolbar out of the way (CRM-15341)
@@ -10,8 +10,10 @@ CRM.$(function($) {
         // D7 hack, restore toolbar position (CRM-15341)
         $('#toolbar').css('z-index', '');
       }
+    })
+    .on('crmLoad', '#civicrm-menu', function(e) {
+      if ($('#toolbar a.toggle').length) {
+        $('#civicrm-menu').css({width: 'calc(100% - 40px)'});
+      }
     });
-  if ($('#toolbar a.toggle').length) {
-    $('#civicrm-menu').css({width: 'calc(100% - 40px)'});
-  }
-});
+})(CRM.$);

--- a/js/crm.drupal8.js
+++ b/js/crm.drupal8.js
@@ -8,7 +8,7 @@ CRM.$(function($) {
 
    $('#toolbar-bar').hide();
 
-   $('.crm-hidemenu').click(function(e) {
+   $('body').on('click', '.crm-hidemenu', function() {
      $('#toolbar-bar').slideDown();
    });
    $('#crm-notification-container').on('click', '#crm-restore-menu', function() {

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -34,6 +34,7 @@
   CRM.config.timeIs24Hr = {if $config->timeInputFormat eq 2}true{else}false{/if};
   CRM.config.ajaxPopupsEnabled = {$ajaxPopupsEnabled|@json_encode};
   CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal|@json_encode};
+  CRM.config.resourceCacheCode = {$resourceCacheCode|@json_encode};
 
   // Merge entityRef settings
   CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -195,6 +195,7 @@ $('#civicrm-menu').ready(function() {
   $('#root-menu-div').on('click', 'a', $.Menu.closeAll);
 });
 $('#civicrm-menu').menuBar({arrowClass: 'crm-i fa-caret-right'});
+$('#civicrm-menu').trigger('crmLoad');
 $(window).on("beforeunload", function() {
   $('.crm-logo-sm', '#civicrm-menu').addClass('crm-i fa-spin');
 });

--- a/tests/phpunit/CRM/Core/BAO/NavigationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/NavigationTest.php
@@ -284,4 +284,30 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     $this->assertEquals(100, $output[10]['child'][101]['child'][100]['attributes']['navID']);
   }
 
+  /**
+   * Tests that permissions and component status are checked with the correct operator.
+   */
+  public function testCheckPermissions() {
+    $menuItem = [
+      'permission' => 'access CiviCRM, access CiviContribute',
+      'operator' => 'AND'
+    ];
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviContribute');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'access CiviContribute'];
+    $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+
+    CRM_Core_BAO_ConfigSetting::disableComponent('CiviContribute');
+    $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviContribute');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviContribute'];
+    $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+
+    $menuItem['operator'] = 'OR';
+    $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+
+    CRM_Core_BAO_ConfigSetting::disableComponent('CiviContribute');
+    $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Code tweaks and cleanup to support the new [SmartMenus based extension](https://github.com/aydun/uk.squiffle.kam). Should have no impact otherwise.

Before
----------------------------------------
Messier code.

After
----------------------------------------
Cleaner code. No impact to existing sites.

Technical Details
----------------------------------------
- Add a couple client side variables
- Fix access to functions that were private for no reason
- Extract permissions check into its own function
- Fire crmLoad event when menu loads

See https://lab.civicrm.org/dev/core/issues/487