### PR TITLE
Fix accidental scroll when saving/deleting CiviMail draft

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -876,7 +876,7 @@
         link: function (scope, element, attrs) {
           scope.ts = CRM.ts(null);
 
-          element.find('.crm-wizard-buttons button').click(function () {
+          element.find('.crm-wizard-buttons button[ng-click^=crmUiWizardCtrl]').click(function () {
             // These values are captured inside the click handler to ensure the
             // positions/sizes of the elements are captured at the time of the
             // click vs. at the time this directive is initialized.


### PR DESCRIPTION
Overview
-------
Fixes a weird UI problem.

Before
------
Clicking a save draft or delete draft button scrolls the page to the top.
![before](https://user-images.githubusercontent.com/2874912/48441042-83d96180-e758-11e8-8929-3376c99ac735.gif)

After
------
No funny business.