### PR TITLE
make addButtons accept the param crm-icon so developers can choose icons for buttons

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -680,6 +680,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           $attrs['accesskey'] = 'S';
         }
         $icon = CRM_Utils_Array::value('icon', $button, $defaultIcon);
+        // If someone sends the param crm-icon use that instead of the default
+        if (!empty($button['crm-icon'])) {
+          $icon = CRM_Utils_Array::value('icon', $button, $button['crm-icon']);
+        }
         if ($icon) {
           $attrs['crm-icon'] = $icon;
         }


### PR DESCRIPTION
Overview
----------------------------------------
This change makes it so that CRM_Core_Form->addButtons($params); accepts the param 'crm-icon' so that developers can choose what icon to use for buttons created using this function.

```php

    $this->addButtons(array(
      array(
        'type' => 'submit',
        'name' => E::ts('Switch'),
        'isDefault' => TRUE,
        // Change the icon for the button
        'crm-icon' => 'fa-random',
      ),
    ));
```

Before
----------------------------------------
the icon for buttons created using CRM_Core_Form->addButtons($params) would be set to be a default based on what type of button it is (a check for submit etc.)

After
----------------------------------------
developers can send the parameter 'crm-icon' to choose what icon to use for buttons created using  CRM_Core_Form->addButtons($params) 

