### PR TITLE
Lybunt report - improve developer support for debugging this report

### DIFF
--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -567,13 +567,12 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
     // @todo this acl has no test coverage and is very hard to test manually so could be fragile.
     $this->resetFormSqlAndWhereHavingClauses();
 
-    $this->contactTempTable = CRM_Utils_SQL_TempTable::build()->setCategory('rptlybunt')->setId(date('Ymd_') . uniqid())->getName();
+    $this->contactTempTable = $this->createTemporaryTable('rptlybunt', "
+      SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from}
+      {$this->_where}
+      GROUP BY {$this->_aliases['civicrm_contact']}.id"
+    );
     $this->limit();
-    $getContacts = "
-      CREATE TEMPORARY TABLE $this->contactTempTable {$this->_databaseAttributes}
-      SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where}
-      GROUP BY {$this->_aliases['civicrm_contact']}.id";
-    $this->executeReportQuery($getContacts);
     if (empty($this->_params['charts'])) {
       $this->setPager();
     }

--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -233,6 +233,7 @@ class CRM_Utils_SQL_TempTable {
 
   /**
    * @param string|NULL $category
+   *
    * @return CRM_Utils_SQL_TempTable
    */
   public function setCategory($category) {
@@ -244,7 +245,12 @@ class CRM_Utils_SQL_TempTable {
   }
 
   /**
-   * @parma bool $value
+   * Set whether the table should be durable.
+   *
+   * Durable tables are not TEMPORARY in the mysql sense.
+   *
+   * @param bool $durable
+   *
    * @return CRM_Utils_SQL_TempTable
    */
   public function setDurable($durable = TRUE) {
@@ -253,7 +259,10 @@ class CRM_Utils_SQL_TempTable {
   }
 
   /**
+   * Setter for id
+   *
    * @param mixed $id
+   *
    * @return CRM_Utils_SQL_TempTable
    */
   public function setId($id) {
@@ -264,6 +273,15 @@ class CRM_Utils_SQL_TempTable {
     return $this;
   }
 
+  /**
+   * Set table collation to UTF8.
+   *
+   * This would make sense as a default but cautiousness during phasing in has made it opt-in.
+   *
+   * @param bool $value
+   *
+   * @return $this
+   */
   public function setUtf8($value = TRUE) {
     $this->utf8 = $value;
     return $this;


### PR DESCRIPTION
Overview
----------------------------------------
Minor update affecting Lybunt & other (tested) reports to make query diagnosis easier for developers

Before
----------------------------------------
Group queries not output to developer tab. Group temp table not retained when CIVICRM_TEMP_FORCE_DURABLE is defined

After
----------------------------------------
Group queries output to developer tab. Group temp table retained when CIVICRM_TEMP_FORCE_DURABLE is defined

Technical Details
----------------------------------------
By using the createTemporaryTable to create our temporaray table we
help developers out by
a) adding the query to the developer tab
b) supporting CIVICRM_TEMP_FORCE_DURABLE
(see debugging section in dev docs)

This fix updates a function used by reports that have been marked with

groupFilterNotOptimised = FALSE

The reports with optimised group filtering construct a temp table
of contacts in the groups & use those to inner join / limit
the contacts in the report.

They are tested via a bunch of tests in api_v3_ReportTemplateTest such as

testReportsWithNonSmartGroupFilter

Comments
----------------------------------------
This is preliminary to some performance improvements on the lybunt report https://lab.civicrm.org/dev/core/issues/518
