### PR TITLE
dev/core#518 Fix lybunt performance

### DIFF
--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -364,9 +364,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
       $this->_from .= " ON {$this->_aliases['civicrm_contribution']}.contact_id = {$this->_aliases['civicrm_contact']}.id
          AND {$this->_aliases['civicrm_contribution']}.is_test = 0
          AND " . $this->whereClauseLastYear("{$this->_aliases['civicrm_contribution']}.receive_date") . "
-       {$this->_aclFrom}
-       LEFT JOIN civicrm_contribution cont_exclude ON cont_exclude.contact_id = {$this->_aliases['civicrm_contact']}.id
-         AND " . $this->whereClauseThisYear('cont_exclude.receive_date');
+       {$this->_aclFrom} ";
       $this->selectivelyAddLocationTablesJoinsToFilterQuery();
     }
 
@@ -399,7 +397,11 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
     if ($field['name'] == 'receive_date') {
       $clause = 1;
       if (empty($this->contactTempTable)) {
-        $this->_whereClauses[] = "cont_exclude.id IS NULL";
+        $clause = "{$this->_aliases['civicrm_contact']}.id NOT IN (
+          SELECT cont_exclude.contact_id
+          FROM civicrm_contribution cont_exclude
+          WHERE " . $this->whereClauseThisYear('cont_exclude.receive_date')
+        . ")";
       }
     }
     // Group filtering is already done so skip.


### PR DESCRIPTION
Overview
----------------------------------------

Per analysis on the issue this gave me a substantial performance
increase (from nearly 7 minutes down to less than a quarter of a second)
when performing a lybunt report on a small group wihtin a large database.

Before
----------------------------------------
SLoooooow - in our case WSOD

After
----------------------------------------
Fast

Technical Details
----------------------------------------
This changes the query from doing a LEFT JOIN on the contribution table with id NOT NULL to doing a 
```
 "civicrm_contact'.id NOT IN (
          SELECT cont_exclude.contact_id
          FROM civicrm_contribution cont_exclude
          WHERE ....
        . ")";
```
It's faster

Comments
----------------------------------------
I tried the query unfiltered (ie. against our whole DB) and it performed well
although not well enough I would want our users to run it on prod (~12 minutes) - so I feel comfortable this doesn't regress performance when a group filter is
NOT in play
