### PR TITLE
Retrieve "class" and "subPage" from form attributes even when urlencoded

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -391,7 +391,14 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       switch ($className) {
         case 'Contribute':
           $attributes = $this->getVar('_attributes');
-          $subPage = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+          $rawSubPage = CRM_Utils_Array::value('action', $attributes);
+          // WordPress may have urlencoded URLs
+          if (rawurlencode(rawurldecode($rawSubPage)) !== $rawSubPage) {
+            $subPage = strtolower(basename(rawurldecode($rawSubPage)));
+          }
+          else {
+            $subPage = strtolower(basename($rawSubPage));
+          }
           $subPageName = ucfirst($subPage);
           if ($subPage == 'friend') {
             $nextPage = 'custom';

--- a/CRM/Contribute/Form/ContributionPage/TabHeader.php
+++ b/CRM/Contribute/Form/ContributionPage/TabHeader.php
@@ -142,7 +142,14 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
     switch ($className) {
       case 'Contribute':
         $attributes = $form->getVar('_attributes');
-        $class = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+        $rawUrl = CRM_Utils_Array::value('action', $attributes);
+        // WordPress may have urlencoded URLs
+        if (rawurlencode(rawurldecode($rawUrl)) !== $rawUrl) {
+          $class = strtolower(basename(rawurldecode($rawUrl)));
+        }
+        else {
+          $class = strtolower(basename($rawUrl));
+        }
         break;
 
       case 'MembershipBlock':

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -357,7 +357,14 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       switch ($className) {
         case 'Event':
           $attributes = $this->getVar('_attributes');
-          $subPage = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+          $rawSubPage = CRM_Utils_Array::value('action', $attributes);
+          // WordPress may have urlencoded URLs
+          if (rawurlencode(rawurldecode($rawSubPage)) !== $rawSubPage) {
+            $subPage = strtolower(basename(rawurldecode($rawSubPage)));
+          }
+          else {
+            $subPage = strtolower(basename($rawSubPage));
+          }
           break;
 
         case 'EventInfo':

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -168,7 +168,14 @@ WHERE      e.id = %1
     switch ($className) {
       case 'Event':
         $attributes = $form->getVar('_attributes');
-        $class = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+        $rawUrl = CRM_Utils_Array::value('action', $attributes);
+        // WordPress may have urlencoded URLs
+        if (rawurlencode(rawurldecode($rawUrl)) !== $rawUrl) {
+          $class = strtolower(basename(rawurldecode($rawUrl)));
+        }
+        else {
+          $class = strtolower(basename($rawUrl));
+        }
         break;
 
       case 'EventInfo':


### PR DESCRIPTION
Overview
----------------------------------------
Fixes problems associated with Contribution Page forms and Event Management forms as described in [this comment](https://lab.civicrm.org/dev/wordpress/issues/12#note_10699) by @kcristiano.

The issue has appeared since #13043 because the existing code relied on URLs *not* being URL-endcoded to tease out the component for the active tab. Please see the discussion on the linked issue for further details.

Before
----------------------------------------
The component is misidentified by parsing the `action` attribute of the `form` object using `basename()`, but fails because the `q` variable is (properly) URL-encoded since #13043.

After
----------------------------------------
The component is correctly identified by parsing the `action` attribute of the  `form` object using `basename()` by not assuming that the URL is in its raw state. The new code URL-decodes the `action` URL when needed before teasing out the component name.

Comments
----------------------------------------
This only fails in WordPress because Drupal uses clean URLs by default and WordPress can _never_ use clean URLs in `wp-admin` because everything is routed through `wp-admin/admin.php`.