### PR TITLE
dev/core#193: Ensure that tax amount is calculated when checking for order API line item

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4939,7 +4939,8 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
   }
 
   /**
-   * Function to check line items.
+   * Checks if line items total amounts
+   * match the contribution total amount.
    *
    * @param array $params
    *  array of order params.
@@ -4955,7 +4956,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
         if (empty($item['financial_type_id'])) {
           $item['financial_type_id'] = $params['financial_type_id'];
         }
-        $lineItemAmount += $item['line_total'];
+        $lineItemAmount += $item['line_total'] + CRM_Utils_Array::value('tax_amount', $item, 0.00);
       }
     }
 

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -532,4 +532,104 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     ));
   }
 
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Line item total doesn't match with total amount.
+   */
+  public function testCreateOrderIfTotalAmountDoesNotMatchLineItemsAmountsIfNoTaxSupplied() {
+    $params = [
+      'contact_id' => $this->_individualId,
+      'receive_date' => '2018-01-01',
+      'total_amount' => 50,
+      'financial_type_id' => $this->_financialTypeId,
+      'contribution_status_id' => 1,
+      'line_items' => [
+        0 => [
+          'line_item' => [
+            '0' => [
+              'price_field_id' => 1,
+              'price_field_value_id' => 1,
+              'label' => 'Test 1',
+              'field_title' => 'Test 1',
+              'qty' => 1,
+              'unit_price' => 40,
+              'line_total' => 40,
+              'financial_type_id' => 1,
+              'entity_table' => 'civicrm_contribution',
+            ],
+          ]
+        ],
+      ],
+    ];
+
+    civicrm_api3('Order', 'create', $params);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Line item total doesn't match with total amount.
+   */
+  public function testCreateOrderIfTotalAmountDoesNotMatchLineItemsAmountsIfTaxSupplied() {
+    $params = [
+      'contact_id' => $this->_individualId,
+      'receive_date' => '2018-01-01',
+      'total_amount' => 50,
+      'financial_type_id' => $this->_financialTypeId,
+      'contribution_status_id' => 1,
+      'tax_amount' => 15,
+      'line_items' => [
+        0 => [
+          'line_item' => [
+            '0' => [
+              'price_field_id' => 1,
+              'price_field_value_id' => 1,
+              'label' => 'Test 1',
+              'field_title' => 'Test 1',
+              'qty' => 1,
+              'unit_price' => 30,
+              'line_total' => 30,
+              'financial_type_id' => 1,
+              'entity_table' => 'civicrm_contribution',
+              'tax_amount' => 15,
+            ],
+          ]
+        ],
+      ],
+    ];
+
+    civicrm_api3('Order', 'create', $params);
+  }
+
+  public function testCreateOrderIfTotalAmountDoesMatchLineItemsAmountsAndTaxSupplied() {
+    $params = [
+      'contact_id' => $this->_individualId,
+      'receive_date' => '2018-01-01',
+      'total_amount' => 50,
+      'financial_type_id' => $this->_financialTypeId,
+      'contribution_status_id' => 1,
+      'tax_amount' => 15,
+      'line_items' => [
+        0 => [
+          'line_item' => [
+            '0' => [
+              'price_field_id' => 1,
+              'price_field_value_id' => 1,
+              'label' => 'Test 1',
+              'field_title' => 'Test 1',
+              'qty' => 1,
+              'unit_price' => 35,
+              'line_total' => 35,
+              'financial_type_id' => 1,
+              'entity_table' => 'civicrm_contribution',
+              'tax_amount' => 15,
+            ],
+          ]
+        ],
+      ],
+    ];
+
+    $order = civicrm_api3('Order', 'create', $params);
+    $this->assertEquals(1, $order['count']);
+  }
+
 }


### PR DESCRIPTION
The PR Replaces the following  :
-  https://github.com/civicrm/civicrm-core/pull/12372
- https://github.com/civicrm/civicrm-core/pull/12584

Overview
----------------------------------------
When creating an Order using Order API a check is done to compare Contribution's total_amount against the sum of line item's line_total's. If Contribution total amount and Line Items' total are not equal, Order creation will fail.

Before
----------------------------------------
As we know:

The line item line_total do not include any tax. Tax will be recorded separately in line item tax_amount field.
The contribution total_amount do include tax. A separate contribution tax_amount field also records the amount of tax.


Since the validation only compares the sum of line_totals with contribution total_amount, whenever there is tax, the validation will fail.

For illustration consider following data set that should create 1 contribution with 2 line items for memberships.

```
order_data =
{
    'is_pay_later': True,
    'contact_id': 240L,
    'payment_instrument_id': 6,
    'line_items': [{
                       'line_item': {
                           '42': {
                               'price_field_value_id': 60L,
                               'price_field_id': 36L,
                               'entity_id': 1249L,
                               'tax_amount': 2.0,
                               'line_total': 10.0,
                               'financial_type_id': 2,
                               'label': 'General',
                               'entity_table': 'civicrm_membership',
                               'unit_price': 10,
                               'qty': '1'}}}, {
                       'line_item': {
                           '43': {
                               'price_field_value_id': 61L,
                               'price_field_id': 37L,
                               'entity_id': 1248L,
                               'tax_amount': 1.67,
                               'line_total': 8.33,
                               'financial_type_id': 2,
                               'label': 'Concession',
                               'entity_table': 'civicrm_membership',
                               'unit_price': '8.33',
                               'qty': '1'}}}],
    'tax_amount': 3.67,
    'total_amount': 22.0,
    'contribution_recur_id': 605L,
    'financial_type_id': 2,
    'fee_amount': 0,
    'payment_processor_id': 5L,
    'receive_date': u'2019-08-01',
    'contribution_status_id': 2}
```

Currently Calling the Order API to create Order with the above data results with  "Line item total doesn't match with total amount". This is because total_amount (22.0) <> sum of line_totals (18.33)

After
----------------------------------------
The Line Items check now consider tax_amounts of line_items and order API works fine with the parameters above.



