### PR TITLE
dev/core#524 Lybunt Clarify Row count reporting on calculated rows

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3154,7 +3154,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
 
     if ($this->_rowsFound && ($this->_rowsFound > $count)) {
       $statistics['counts']['rowsFound'] = array(
-        'title' => ts('Total Row(s)'),
+        'title' => ts('Total Row(s)') . $this->getCalculatedRowWarning(),
         'value' => $this->_rowsFound,
       );
     }
@@ -5820,6 +5820,34 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       }
     }
     return '';
+  }
+
+  /**
+   * Get a string to indicate the presence of calculated rows in the row count.
+   *
+   * We have 3 possible scenarios here:
+   *  - no rollup is used so no row calculations are included in the rows
+   *  - rollup is used with one level of group by. There will be a single calculated row
+   *  - rollup is used with more than one level of group by. There will be an
+   *    unknown number of calculated rows.
+   *
+   * Where there is only one calculated row we could remove it from the total
+   * but then the total would not match the pager which could be more confusing.
+   * If we remove if from the page it could be rendered unreachable.
+   *
+   * @return string
+   */
+  protected function getCalculatedRowWarning() {
+    $calculatedRowWarning = '';
+    if ($this->_rollup) {
+      if (count($this->_groupByArray) === 1) {
+        $calculatedRowWarning = ' ' . ts('Including 1 calculated row');
+      }
+      if (count($this->_groupByArray) > 1) {
+        $calculatedRowWarning = ' ' . ts('Including calculation rows');
+      }
+    }
+    return $calculatedRowWarning;
   }
 
 }

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -501,9 +501,21 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
     return date('YmdHis', strtotime('+ 1 year - 1 second', strtotime($this->getFirstDateOfPriorRange())));
   }
 
+  /**
+   * Store group bys into array - so we can check elsewhere what is grouped.
+   */
+  protected function storeGroupByArray() {
+    $this->_groupByArray['contact_id'] = "{$this->_aliases['civicrm_contribution']}.contact_id ";
+  }
 
+  /**
+   * Group by clause.
+   *
+   * Override the parent because it does bad stuff in it's attempt to handle full group by.
+   */
   public function groupBy() {
-    $this->_groupBy = "GROUP BY  {$this->_aliases['civicrm_contribution']}.contact_id ";
+    $this->storeGroupByArray();
+    $this->_groupBy = "GROUP BY " . implode(',', $this->_groupByArray);
     $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, "{$this->_aliases['civicrm_contribution']}.contact_id");
     $this->assign('chartSupported', TRUE);
   }
@@ -516,9 +528,6 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
   public function statistics(&$rows) {
 
     $statistics = parent::statistics($rows);
-    // The parent class does something odd where it adds an extra row to the count for the grand total.
-    // Perhaps that works on some other report? But here it just seems odd.
-    $this->countStat($statistics, count($rows));
     if (!empty($rows)) {
       if (!empty($this->rollupRow) && !empty($this->rollupRow['civicrm_contribution_last_year_total_amount'])) {
         $statistics['counts']['civicrm_contribution_last_year_total_amount'] = array(


### PR DESCRIPTION
Overview
----------------------------------------
Reduces ambiguity for row totals on report

Before
----------------------------------------
Rows Found includes calculated rows & the reason it does not equal rows listed is unclear
![screenshot 2018-11-15 14 20 45](https://user-images.githubusercontent.com/336308/48525311-92568300-e8e8-11e8-999b-a61737cada03.png)


After
----------------------------------------
In the above example Rows Found would be left off as that row is normally only shown when paging is in play. However, for a report WITH paging a note is added to show that not all rows are actual result rows
![screenshot 2018-11-15 14 11 37](https://user-images.githubusercontent.com/336308/48525374-cdf14d00-e8e8-11e8-9481-5bc011a7e4ff.png)


Technical Details
----------------------------------------
When there are multiple pages we have both the pager & the totals to deal with. If we remove the row from the totals count but not the pager it creates a confusing mismatch. If we remove from both the last row may become unreachable.

On the Lybunt report a maximum of one level of group by is in play. However, where reports support multiple levels of group by it's unknowable how many rows are rollup rows. In this case the message above would say 'Including calculation rows' - which at least points to the lack of clarity

This might all be an argument against the use of Rollup - but not going there at this stage I think my best proposal is to add text to indicate the possible presence of calc rows in the Total Rows

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/524
