### PR TITLE
Replace deprecated event function

### DIFF
--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -336,7 +336,7 @@ ORDER BY start_date desc
    LIMIT $offset, $rowCount";
 
     $dao = CRM_Core_DAO::executeQuery($query, $params, TRUE, 'CRM_Event_DAO_Event');
-    $permissions = CRM_Event_BAO_Event::checkPermission();
+    $permittedEventsByAction = CRM_Event_BAO_Event::getAllPermissions();
 
     //get all campaigns.
     $allCampaigns = CRM_Campaign_BAO_Campaign::getCampaigns(NULL, NULL, FALSE, FALSE, FALSE, TRUE);
@@ -359,7 +359,7 @@ ORDER BY start_date desc
     )));
     $eventType = CRM_Core_OptionGroup::values('event_type');
     while ($dao->fetch()) {
-      if (in_array($dao->id, $permissions[CRM_Core_Permission::VIEW])) {
+      if (in_array($dao->id, $permittedEventsByAction[CRM_Core_Permission::VIEW])) {
         $manageEvent[$dao->id] = array();
         $repeat = CRM_Core_BAO_RecurringEntity::getPositionAndCount($dao->id, 'civicrm_event');
         $manageEvent[$dao->id]['repeat'] = '';
@@ -378,10 +378,10 @@ ORDER BY start_date desc
           $action -= CRM_Core_Action::DISABLE;
         }
 
-        if (!in_array($dao->id, $permissions[CRM_Core_Permission::DELETE])) {
+        if (!in_array($dao->id, $permittedEventsByAction[CRM_Core_Permission::DELETE])) {
           $action -= CRM_Core_Action::DELETE;
         }
-        if (!in_array($dao->id, $permissions[CRM_Core_Permission::EDIT])) {
+        if (!in_array($dao->id, $permittedEventsByAction[CRM_Core_Permission::EDIT])) {
           $action -= CRM_Core_Action::UPDATE;
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes use of a (newly deprecated) function

Before
----------------------------------------
![screenshot 2018-11-15 20 23 50](https://user-images.githubusercontent.com/336308/48536766-6a7d1480-e914-11e8-8052-46fa87849985.png)
![screenshot 2018-11-15 20 23 53](https://user-images.githubusercontent.com/336308/48536768-6a7d1480-e914-11e8-81ae-60dd26eeec5c.png)
![screenshot 2018-11-15 20 23 58](https://user-images.githubusercontent.com/336308/48536769-6b15ab00-e914-11e8-9faf-e41cca61fe89.png)

After
----------------------------------------
![screenshot 2018-11-15 20 22 42](https://user-images.githubusercontent.com/336308/48536705-3bff3980-e914-11e8-8da9-43ec01846bf6.png)

![screenshot 2018-11-15 20 23 08](https://user-images.githubusercontent.com/336308/48536782-72d54f80-e914-11e8-8637-a636f34e004a.png)
![screenshot 2018-11-15 20 23 14](https://user-images.githubusercontent.com/336308/48536783-736de600-e914-11e8-87b8-76316e10fe7a.png)


Technical Details
----------------------------------------
This function use (calling the single event permission function for all events) was deprecated in 5.8 by @mattwire who fixed a bug in it.

Comments
----------------------------------------
@mattwire @seamuslee001 @kcristiano should I put this against the rc. I would except that I know @kcristiano has been busy testing & I don't want to invalidate that. The notice only shows with debugging etc enabled
