### PR TITLE
Permit Checkbox price set options to be deselected if they are full

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -666,10 +666,12 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   public static function formatFieldsForOptionFull(&$form) {
     $priceSet = $form->get('priceSet');
     $priceSetId = $form->get('priceSetId');
-    $defaultPricefieldIds = array();
+    $selectedPricefieldIds = array();
     if (!empty($form->_values['line_items'])) {
       foreach ($form->_values['line_items'] as $lineItem) {
-        $defaultPricefieldIds[] = $lineItem['price_field_value_id'];
+        if ($lineItem['qty'] > 0) {
+          $selectedPricefieldIds[] = $lineItem['price_field_value_id'];
+        }
       }
     }
     if (!$priceSetId ||
@@ -723,14 +725,18 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           (empty($form->_lineItem[$currentParticipantNo][$optId]['price_field_id']) || $dbTotalCount >= $maxValue))
         ) {
           $isFull = TRUE;
+          // @todo this is a bit confusing - for CheckBox & Select we won't freeze
+          // already selected options that are full (so they can be
+          // deselected if need be)
+          // But what about Radio & Text? How do they fit in?
           $optionFullIds[$optId] = $optId;
-          if ($field['html_type'] != 'Select') {
-            if (in_array($optId, $defaultPricefieldIds)) {
+          if ($field['html_type'] != 'Select' && $field['html_type'] !== 'CheckBox') {
+            if (in_array($optId, $selectedPricefieldIds)) {
               $optionFullTotalAmount += CRM_Utils_Array::value('amount', $option);
             }
           }
           else {
-            if (!empty($defaultPricefieldIds) && in_array($optId, $defaultPricefieldIds)) {
+            if (in_array($optId, $selectedPricefieldIds)) {
               unset($optionFullIds[$optId]);
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------

Replaces https://github.com/civicrm/civicrm-core/pull/10804
 https://issues.civicrm.org/jira/browse/CRM-17267

Before
----------------------------------------
![screenshot 2018-04-04 20 33 50](https://user-images.githubusercontent.com/336308/38297122-8a9dc29c-3847-11e8-897c-d96cb22c8df3.png)

After
----------------------------------------
![screenshot 2018-04-04 20 34 53](https://user-images.githubusercontent.com/336308/38297162-a70764a6-3847-11e8-87be-9aa3ccdd00d1.png)

Technical Details
----------------------------------------
The functionality is already there for some types of fields (Select, Radio?) but doesn't work for Checkboxes - partly because the Checkboxes aren't handled, but also code that determines which are selected ignores the fact that qty could be 0 - that likely affects multiple field types

Comments
----------------------------------------
@JKingsnorth @monishdeb 
