### PR TITLE
CRM-21427 - Add form validation to make it clear we only allow a single website of each type

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -615,6 +615,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $blocks['Address'] = $otherEditOptions['Address'];
     }
 
+    $website_types = array();
     $openIds = array();
     $primaryID = FALSE;
     foreach ($blocks as $name => $label) {
@@ -629,8 +630,17 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           }
 
           if ($dataExists) {
-            // skip remaining checks for website
             if ($name == 'website') {
+              if (!empty($blockValues['website_type_id'])) {
+                if (empty($website_types[$blockValues['website_type_id']])) {
+                  $website_types[$blockValues['website_type_id']] = $blockValues['website_type_id'];
+                }
+                else {
+                  $errors["{$name}[1][website_type_id]"] = ts('Contacts may only have one website of each type at most.');
+                }
+              }
+
+              // skip remaining checks for website
               continue;
             }
 

--- a/CRM/Contact/Form/Inline/Website.php
+++ b/CRM/Contact/Form/Inline/Website.php
@@ -87,6 +87,8 @@ class CRM_Contact_Form_Inline_Website extends CRM_Contact_Form_Inline {
       CRM_Contact_Form_Edit_Website::buildQuickForm($this, $blockId, TRUE);
     }
 
+    $this->addFormRule(array('CRM_Contact_Form_Inline_Website', 'formRule'), $this);
+
   }
 
   /**
@@ -126,6 +128,40 @@ class CRM_Contact_Form_Inline_Website extends CRM_Contact_Form_Inline {
 
     $this->log();
     $this->response();
+  }
+
+  /**
+   * Global validation rules for the form.
+   *
+   * @param array $fields
+   *   Posted values of the form.
+   * @param array $errors
+   *   List of errors to be posted back to the form.
+   * @param CRM_Contact_Form_Inline_Website $form
+   *
+   * @return array
+   */
+  public static function formRule($fields, $errors, $form) {
+    $hasData = $errors = array();
+    if (!empty($fields['website']) && is_array($fields['website'])) {
+      $types = array();
+      foreach ($fields['website'] as $instance => $blockValues) {
+        $dataExists = CRM_Contact_Form_Contact::blockDataExists($blockValues);
+
+        if ($dataExists) {
+          $hasData[] = $instance;
+          if (!empty($blockValues['website_type_id'])) {
+            if (empty($types[$blockValues['website_type_id']])) {
+              $types[$blockValues['website_type_id']] = $blockValues['website_type_id'];
+            }
+            else {
+              $errors["website[" . $instance . "][website_type_id]"] = ts('Contacts may only have one website of each type at most.');
+            }
+          }
+        }
+      }
+    }
+    return $errors;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The contact edit & inline contact edit silently don't save multiple websites of the same type - this triggers a validation error

Original = https://github.com/civicrm/civicrm-core/pull/12582
Before
----------------------------------------
On saving a contact with 2 'Work' websites only one will be retained 

After
----------------------------------------
On saving a contact with 2 'Work' websites a validation error will be triggered

Technical Details
----------------------------------------
Adds form validation. The original PR made a slight tweak to the BAO which I left out as it felt like a separate thing. Discussion here is best place to find more https://github.com/civicrm/civicrm-core/pull/12582

Comments
----------------------------------------
Am treating this as a reviewer's PR & giving merge on pass. Original by @gboudrias had a style error