### PR TITLE
Retrieve tab key from form attributes even when action is urlencoded

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -391,7 +391,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       switch ($className) {
         case 'Contribute':
           $attributes = $this->getVar('_attributes');
-          $subPage = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+          $subPage = CRM_Utils_Request::retrieveComponent($attributes);
           $subPageName = ucfirst($subPage);
           if ($subPage == 'friend') {
             $nextPage = 'custom';

--- a/CRM/Contribute/Form/ContributionPage/TabHeader.php
+++ b/CRM/Contribute/Form/ContributionPage/TabHeader.php
@@ -142,7 +142,7 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
     switch ($className) {
       case 'Contribute':
         $attributes = $form->getVar('_attributes');
-        $class = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+        $class = CRM_Utils_Request::retrieveComponent($attributes);
         break;
 
       case 'MembershipBlock':

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -357,7 +357,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       switch ($className) {
         case 'Event':
           $attributes = $this->getVar('_attributes');
-          $subPage = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+          $subPage = CRM_Utils_Request::retrieveComponent($attributes);
           break;
 
         case 'EventInfo':

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -168,7 +168,7 @@ WHERE      e.id = %1
     switch ($className) {
       case 'Event':
         $attributes = $form->getVar('_attributes');
-        $class = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
+        $class = CRM_Utils_Request::retrieveComponent($attributes);
         break;
 
       case 'EventInfo':

--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -221,4 +221,35 @@ class CRM_Utils_Request {
     return CRM_Utils_Request::retrieve((string) $name, (string) $type, $null, (bool) $isRequired, $defaultValue, $method, TRUE);
   }
 
+  /**
+   * Retrieve the component from the action attribute of a form.
+   *
+   * Contribution Page forms and Event Management forms detect the value of a
+   * component (and therefore the desired tab key) by reaching into the "action"
+   * attribute of a form and reading the final item of the path. In WordPress,
+   * however, the URL may be urlencoded, and so the URL may need to be decoded
+   * before parsing it.
+   *
+   * @see https://lab.civicrm.org/dev/wordpress/issues/12#note_10699
+   *
+   * @param array $attributes
+   *   The form attributes array.
+   *
+   * @return string $value
+   *   The desired value.
+   */
+  public static function retrieveComponent($attributes) {
+    $url = CRM_Utils_Array::value('action', $attributes);
+    // Whilst the following is a fallible universal test for urlencoded URLs,
+    // thankfully the "action" URL has a limited and predictable form and
+    // therefore this comparison is sufficient for our purposes.
+    if (rawurlencode(rawurldecode($url)) !== $url) {
+      $value = strtolower(basename(rawurldecode($url)));
+    }
+    else {
+      $value = strtolower(basename($url));
+    }
+    return $value;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes problems associated with Contribution Page forms and Event Management forms as described in [this comment](https://lab.civicrm.org/dev/wordpress/issues/12#note_10699) by @kcristiano.

The issue has appeared since #13043 because the existing code relied on URLs *not* being URL-endcoded to tease out the component for the active tab. Please see the discussion on the linked issue for further details.

This PR replaces #13090  and #13089.

Before
----------------------------------------
The component is misidentified by parsing the `action` attribute of the `form` object using `basename()`, but fails because the `q` variable is (properly) URL-encoded since #13043.

After
----------------------------------------
The component is correctly identified by parsing the `action` attribute of the  `form` object using `basename()` by not assuming that the URL is in its raw state. The new code URL-decodes the `action` URL when needed before teasing out the component name.

Comments
----------------------------------------
This only fails in WordPress because Drupal uses clean URLs by default and WordPress can _never_ use clean URLs in `wp-admin` because everything is routed through `wp-admin/admin.php`.