### PR TITLE
fix for issue-525: Extraneous br-tags in rendered note-fields

### DIFF
--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -48,8 +48,6 @@
             <div class="crm-content crm-custom-data crm-contact-reference">
               <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$element.contact_ref_id`"}" title="view contact">{$element.field_value}</a>
             </div>
-          {elseif $element.field_data_type EQ 'Memo'}
-            <div class="crm-content crm-custom-data">{$element.field_value|nl2br}</div>
           {elseif $element.field_data_type EQ 'Money'}
             <div class="crm-content crm-custom-data">{$element.field_value|crmMoney}</div>
           {else}


### PR DESCRIPTION
Overview
----------------------------------------
This is a fix for [issue-525](https://lab.civicrm.org/dev/core/issues/525) "Extraneous br-tags in rendered note-fields"

Before
----------------------------------------
Note-Fields were rendered with extraneous br-tags. Newlines are displayed doubly.

![screenshot 2018-11-16 13 38 37](https://user-images.githubusercontent.com/336308/48590594-00608000-e9a5-11e8-85f5-483e852e131b.png)


After
----------------------------------------
Note-Fields were not rendered with extraneous br-tags. Newlines are displayed once.
![screenshot 2018-11-16 13 38 48](https://user-images.githubusercontent.com/336308/48590599-05bdca80-e9a5-11e8-87e7-09b2b20b45f3.png)



Technical Details
----------------------------------------
I simply removed the elseif-clause where memo-field-values were passed through the nl2br-filter within templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
