### PR TITLE
Use tab title in feedback message

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -392,7 +392,6 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
         case 'Contribute':
           $attributes = $this->getVar('_attributes');
           $subPage = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
-          $subPageName = ucfirst($subPage);
           if ($subPage == 'friend') {
             $nextPage = 'custom';
           }
@@ -403,13 +402,11 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
 
         case 'MembershipBlock':
           $subPage = 'membership';
-          $subPageName = 'MembershipBlock';
           $nextPage = 'thankyou';
           break;
 
         default:
           $subPage = strtolower($className);
-          $subPageName = $className;
           $nextPage = strtolower($nextPage);
 
           if ($subPage == 'amount') {
@@ -422,7 +419,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       }
 
       CRM_Core_Session::setStatus(ts("'%1' information has been saved.",
-        array(1 => $subPageName)
+        array(1 => CRM_Utils_Array::value('title', CRM_Utils_Array::value($subPage, $this->get('tabHeader')), $className))
       ), ts('Saved'), 'success');
 
       $this->postProcessHook();


### PR DESCRIPTION
Overview
----------------------------------------
When saving forms to configure a Contribution Page in languages other than English, the feedback given is not translated or translatable. Fixes [Issue 526 on GitLab](https://lab.civicrm.org/dev/core/issues/526).

Before
----------------------------------------
<img width="1263" alt="screen shot 2018-11-15 at 12 37 55" src="https://user-images.githubusercontent.com/726936/48554098-654ca500-e8d5-11e8-8bc6-62f48a1926e4.png">

After
----------------------------------------
<img width="1273" alt="screen shot 2018-11-15 at 12 41 08" src="https://user-images.githubusercontent.com/726936/48554121-71d0fd80-e8d5-11e8-8cd3-d1dcd4292e67.png">

Comments
----------------------------------------
Clones the logic used by [Event Management forms](https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/ManageEvent.php#L376-L378).
