### PR TITLE
Fix warning error on php 7.2

### DIFF
--- a/templates/CRM/Core/I18n/Dialog.tpl
+++ b/templates/CRM/Core/I18n/Dialog.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $config->languageLimit|@count >= 2 and $translatePermission }
+{if $config->languageLimit && $config->languageLimit|@count >= 2 and $translatePermission }
   <a href="{crmURL p='civicrm/i18n' q="reset=1&table=$table&field=$field&id=$id"}" data-field="{$field}" class="crm-hover-button crm-multilingual-edit-button" title="{ts}Languages{/ts}">
     <i class="crm-i fa-language fa-lg"></i>
   </a>


### PR DESCRIPTION
Overview
----------------------------------------
Fix warnings that display on php 7.2 sites (that are configured to show warnings

Before
----------------------------------------
![screenshot 2018-11-16 09 13 22](https://user-images.githubusercontent.com/336308/48578932-e6607680-e97f-11e8-80bc-e9dd61e0ab26.png)

After
----------------------------------------
no red messages

Technical Details
----------------------------------------
Php 7.2 gives this error where we try to count NULL - there are a few places where this pattern exists & IMHO it requires pretty minimal review for these changes

Comments
----------------------------------------

