### PR TITLE
Fix php7.2 notices on trying to count null

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -135,13 +135,13 @@
     </div>
     {/if}
 
-    {if $onbehalfProfile|@count}
+    {if $onbehalfProfile && $onbehalfProfile|@count}
       <div class="crm-group onBehalf_display-group label-left crm-profile-view">
          {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
       </div>
     {/if}
 
-    {if $honoreeProfileFields|@count}
+    {if $honoreeProfileFields && $honoreeProfileFields|@count}
         <div class="crm-group honor_block-group">
             <div class="header-dark">
                 {$soft_credit_type}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -204,7 +204,7 @@
       {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="makeContribution"}
     </div>
 
-    {if $honoreeProfileFields|@count}
+    {if $honoreeProfileFields && $honoreeProfileFields|@count}
       <fieldset class="crm-public-form-item crm-group honor_block-group">
         {crmRegion name="contribution-soft-credit-block"}
           <legend>{$honor_block_title}</legend>

--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -41,7 +41,7 @@
 
 <div class="crm-public-form-item" id="on-behalf-block">
   {crmRegion name="onbehalf-block"}
-    {if $onBehalfOfFields|@count}
+    {if $onBehalfOfFields && $onBehalfOfFields|@count}
       <fieldset>
       <legend>{$fieldSetTitle}</legend>
       {if $form.org_option}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -188,13 +188,13 @@
     </div>
   {/if}
 
-  {if $onbehalfProfile|@count}
+  {if $onbehalfProfile && $onbehalfProfile|@count}
     <div class="crm-group onBehalf_display-group label-left crm-profile-view">
       {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
      </div>
   {/if}
 
-  {if $honoreeProfileFields|@count}
+  {if $honoreeProfileFields && $honoreeProfileFields|@count}
     <div class="crm-group honor_block-group">
       <div class="header-dark">
         {$soft_credit_type}


### PR DESCRIPTION
Overview
----------------------------------------
Fix warning messages in php 7.2 when trying to count NULL

Before
----------------------------------------
![screenshot 2018-11-16 14 54 49](https://user-images.githubusercontent.com/336308/48592984-c2b52480-e9af-11e8-86a1-05cd7a72c085.png)


After
----------------------------------------
![screenshot 2018-11-16 14 55 24](https://user-images.githubusercontent.com/336308/48592992-c8ab0580-e9af-11e8-9ed2-5eac356ef140.png)


Technical Details
----------------------------------------
I just fixed all the places where these 2 smarty vars are counted as they are often NULL. There are a couple of other similar patterns but I don't know if they are potentially null so not addressing pro-actively

Comments
----------------------------------------
@seamuslee001 another one
