### PR TITLE
dev/core#528 - Advanced Search -> Contribution Tab and Contribution D…

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -931,7 +931,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     $form->add('text', 'contribution_amount_high', ts('To'), array('size' => 8, 'maxlength' => 8));
     $form->addRule('contribution_amount_high', ts('Please enter a valid money value (e.g. %1).', array(1 => CRM_Utils_Money::format('99.99', ' '))), 'money');
 
-    $form->addField('cancel_reason');
+    $form->addField('cancel_reason', array('entity' => 'Contribution'));
     CRM_Core_Form_Date::buildDateRange($form, 'contribution_cancel_date', 1, '_low', '_high', ts('From:'), FALSE);
     $form->addElement('hidden', 'contribution_cancel_date_range_error');
 

--- a/CRM/Contribute/Page/DashBoard.php
+++ b/CRM/Contribute/Page/DashBoard.php
@@ -108,7 +108,7 @@ class CRM_Contribute_Page_DashBoard extends CRM_Core_Page {
     $this->preProcess();
 
     $controller = new CRM_Core_Controller_Simple('CRM_Contribute_Form_Search',
-      ts('Contributions'), NULL
+      ts('Contributions'), CRM_Core_Action::BROWSE
     );
     $controller->setEmbedded(TRUE);
 


### PR DESCRIPTION
…ashboard returns a fatal error

Overview
----------------------------------------
Fix network error on advanced search and fatal error on civicontribute dashboard.

Before
----------------------------------------
On Dmaster
https://dmaster.demo.civicrm.org/civicrm/contact/search/advanced?reset=1 -> Expanding the contribution div section displays a network error

![image](https://user-images.githubusercontent.com/5929648/48603434-6d234c80-e99c-11e8-8d4f-275335de52b7.png)

Similarly, Contribution Dashboard returns a fatal error - https://dmaster.demo.civicrm.org/civicrm/contribute?reset=1

![image](https://user-images.githubusercontent.com/5929648/48603759-8d074000-e99d-11e8-9e07-912def5c7cee.png)


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
`cancel_reason ` input field was replaced with the latest [`addField` function](https://github.com/civicrm/civicrm-core/commit/927898c59a56afcd73d9842e1628946c5d91e960) which expects an `_action` to be loaded on the page. We can fix this by simply ignoring to load the search form on dashboard page by inserting an if check [at this point](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Search.php#L179). But as we load the [browse action](https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/Page/DashBoard.php#L99) on civicase, this PR follows the same rule.

Comments
----------------------------------------
This error is not present in 5.8rc released version.

Gitlab - https://lab.civicrm.org/dev/core/issues/528