### PR TITLE
Regression: Fix delete event participant fatal error and display name if no email

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -753,6 +753,9 @@ WHERE  contribution_id = {$id}
   protected function assignContactEmailDetails() {
     if ($this->_contactID) {
       list($this->userDisplayName, $this->userEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
+      if (empty($this->userDisplayName)) {
+        $this->userDisplayName = civicrm_api3('contact', 'getvalue', ['id' => $this->_contactID, 'return' => 'display_name']);
+      }
       $this->assign('displayName', $this->userDisplayName);
     }
   }

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -118,6 +118,19 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     return $controller->run();
   }
 
+  public function delete() {
+    $controller = new CRM_Core_Controller_Simple(
+      'CRM_Event_Form_Participant',
+      ts('Delete Participant'),
+      $this->_action
+    );
+
+    $controller->setEmbedded(TRUE);
+    $controller->set('id', $this->_id);
+    $controller->set('cid', $this->_contactId);
+    $controller->run();
+  }
+
   public function preProcess() {
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
@@ -167,12 +180,11 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->view();
     }
-    elseif ($this->_action & (CRM_Core_Action::UPDATE |
-        CRM_Core_Action::ADD |
-        CRM_Core_Action::DELETE
-      )
-    ) {
+    elseif ($this->_action & (CRM_Core_Action::UPDATE | CRM_Core_Action::ADD)) {
       $this->edit();
+    }
+    elseif ($this->_action & (CRM_Core_Action::DELETE | CRM_Core_Action::DETACH)) {
+      $this->delete();
     }
     else {
       $this->browse();


### PR DESCRIPTION
Overview
----------------------------------------
Bizarrely, this https://github.com/civicrm/civicrm-core/pull/12775 seems to cause delete participant to fail because it tries to build the contribution search form before deleting and it can't create the cancel_reason field in "delete" context!

To reproduce search for an event participant (with no email address) and select the "delete" option.

Before
----------------------------------------
- The delete "popup" doesn't load and there is a fatal error.
- If the contact has no email address the name of the contact is not displayed in the title!

After
----------------------------------------
- The delete "popup" loads and allows you to continue and delete the participant.
- If the contact has no email address the contact name is still displayed in the title!

Technical Details
----------------------------------------
The event participant delete function was shared with the "edit" function on the core controller.  When editing, the contribution form needs to be built and displayed - we don't need to do this for delete participant!  Fix is to add a new delete action that only calls the required actions - should be a performance improvement too as we're not building a form we don't need.

Failure to display name is a slight aside, but found whilst debugging, if the contactID is set but has no email address the function `assignContactEmailDetails()` returns nothing.  We add an additional call to call the contact API and get the display_name if it was not found in the email call.

Comments
----------------------------------------
Regression in master. But this should also improve code.

@alifrumin Is this something you could test for me? @eileenmcnaughton ping as it was your PR that introduced this regression I think! Though there's no way I'd have expected this side-effect.
