### PR TITLE
dev/financial#34 : Incorrect allocation of payment on an edited multi-line item event registration 

### DIFF
--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -726,7 +726,7 @@ WHERE ceft.entity_id = %1";
       $trxnParams = [
         'total_amount' => $trxn->total_amount,
         'contribution_id' => $currentContribution->id,
-      );
+      ];
       CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $trxn->id, $prevContribution->total_amount, CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $prevContribution->contribution_status_id));
     }
 

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -726,8 +726,8 @@ WHERE ceft.entity_id = %1";
       $trxnParams = [
         'total_amount' => $trxn->total_amount,
         'contribution_id' => $currentContribution->id,
-      ];
-      CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $trxn->id, $prevContribution->total_amount);
+      );
+      CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $trxn->id, $prevContribution->total_amount, CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $prevContribution->contribution_status_id));
     }
 
     self::createDeferredTrxn(CRM_Utils_Array::value('line_item', $inputParams), $currentContribution, TRUE, 'changePaymentInstrument');

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -323,28 +323,7 @@ class CRM_Financial_BAO_Payment {
     if ($updateStatus) {
       CRM_Core_DAO::setFieldValue('CRM_Contribute_BAO_Contribution', $contributionId, 'contribution_status_id', $completedStatusId);
     }
-    // add financial item entry
-    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contributionDAO->id);
-    if (!empty($lineItems)) {
-      foreach ($lineItems as $lineItemId => $lineItemValue) {
-        // don't record financial item for cancelled line-item
-        if ($lineItemValue['qty'] == 0) {
-          continue;
-        }
-        $paid = $lineItemValue['line_total'] * ($financialTrxn->total_amount / $contributionDAO->total_amount);
-        $addFinancialEntry = [
-          'transaction_date' => $financialTrxn->trxn_date,
-          'contact_id' => $contributionDAO->contact_id,
-          'amount' => round($paid, 2),
-          'currency' => $contributionDAO->currency,
-          'status_id' => $paidStatus,
-          'entity_id' => $lineItemId,
-          'entity_table' => 'civicrm_line_item',
-        ];
-        $trxnIds = ['id' => $financialTrxn->id];
-        CRM_Financial_BAO_FinancialItem::create($addFinancialEntry, NULL, $trxnIds);
-      }
-    }
+
     return $financialTrxn;
   }
 

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -96,7 +96,7 @@ class CRM_Financial_BAO_Payment {
         }
       }
       elseif (!empty($trxn)) {
-        CRM_Contribute_BAO_Contribution::assignProportionalLineItems($params, $trxn->id, $contribution['total_amount']);
+        CRM_Contribute_BAO_Contribution::assignProportionalLineItems($params, $trxn->id, $contribution['total_amount'], $contributionStatus);
       }
     }
 

--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -214,7 +214,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
         $trxnParams = [
           'total_amount' => $financialTrxnParams['total_amount'],
           'contribution_id' => $this->_contributionID,
-        );
+        ];
         $contribution = civicrm_api3('Contribution', 'getsingle', ['id' => $this->_contributionID]);
         CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $financialTrxn['id'], $contribution['total_amount'], $contribution['contribution_status']);
       }

--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -214,9 +214,9 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
         $trxnParams = [
           'total_amount' => $financialTrxnParams['total_amount'],
           'contribution_id' => $this->_contributionID,
-        ];
-        $contributionTotalAmount = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $this->_contributionID, 'total_amount');
-        CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $financialTrxn['id'], $contributionTotalAmount);
+        );
+        $contribution = civicrm_api3('Contribution', 'getsingle', ['id' => $this->_contributionID]);
+        CRM_Contribute_BAO_Contribution::assignProportionalLineItems($trxnParams, $financialTrxn['id'], $contribution['total_amount'], $contribution['contribution_status']);
       }
     }
     else {

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -834,7 +834,8 @@ WHERE li.contribution_id = %1";
       // INSERT a financial item to record surplus/lesser amount when a text price fee is changed
       elseif (!empty($lineItemsToUpdate) &&
       $lineItemsToUpdate[$updateFinancialItemInfoValues['price_field_value_id']]['html_type'] == 'Text' &&
-      $updateFinancialItemInfoValues['amount'] > 0
+      $updateFinancialItemInfoValues['amount'] > 0 &&
+      ($lineItemsToUpdate[$updateFinancialItemInfoValues['price_field_value_id']]['line_total'] - $totalFinancialAmount) != 0
       ) {
         // calculate the amount difference, considered as financial item amount
         $updateFinancialItemInfoValues['amount'] = $lineItemsToUpdate[$updateFinancialItemInfoValues['price_field_value_id']]['line_total'] - $totalFinancialAmount;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1387,12 +1387,13 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
    * Create a paid event.
    *
    * @param array $params
+   * @param string $priceFieldType
    *
    * @return array
    */
-  protected function eventCreatePaid($params) {
+  protected function eventCreatePaid($params, $priceFieldType = 'Radio') {
     $event = $this->eventCreate($params);
-    $this->priceSetID = $this->eventPriceSetCreate(55, 0, 'Radio');
+    $this->priceSetID = $this->eventPriceSetCreate(55, 0, $priceFieldType);
     CRM_Price_BAO_PriceSet::addTo('civicrm_event', $event['id'], $this->priceSetID);
     $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($this->priceSetID, TRUE, FALSE);
     $priceSet = CRM_Utils_Array::value($this->priceSetID, $priceSet);

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -549,7 +549,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'financial_trxn_id' => $payment['id'],
     );
     $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params);
-    $amounts = array(66.67, 33.33);
+    $amounts = array(-33.33, -16.67);
     foreach ($eft['values'] as $value) {
       $this->assertEquals($value['amount'], array_pop($amounts));
     }
@@ -701,7 +701,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params);
     $this->assertEquals($eft['values'][$eft['id']]['amount'], 40);
     $params = array(
-      'entity_table' => 'civicrm_financial_item',
+      'entity_table' => 'civicrm_contribution',
       'financial_trxn_id' => $payment['id'],
     );
     $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params);

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -549,7 +549,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'financial_trxn_id' => $payment['id'],
     );
     $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params);
-    $amounts = array(-33.33, -16.67);
+    $amounts = array(66.66, 33.34);
     foreach ($eft['values'] as $value) {
       $this->assertEquals($value['amount'], array_pop($amounts));
     }
@@ -701,7 +701,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params);
     $this->assertEquals($eft['values'][$eft['id']]['amount'], 40);
     $params = array(
-      'entity_table' => 'civicrm_contribution',
+      'entity_table' => 'civicrm_financial_item',
       'financial_trxn_id' => $payment['id'],
     );
     $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params);


### PR DESCRIPTION
Overview
----------------------------------------

Edit of one line item previously led to changed allocations on more than one line item. This has been fixed so only the edited line item has new financial entries associated with it.

Steps to replicate:
1. Create new Financial Type Event Fees 2. 
2. At Administer > Financial Accounts, navigate to the Financial Account this creates also called Event Fees 2 and enter 4301 as the Accounting Code.
3. Create an event with priceset with two fields, first with financial Type Event fees, second with FT of Event Fees 2. 
4. Register in event with payment of say $25 for first ticket (Event Fees) and $10 for second ticket (Event fees 2), total $35.
5. Edit Event registration. Click Change selections. Change quantity for second field from 1 to 5, line item total of $50, contribution total of $75, total paid $35. Save. Balance is $40. 
6. Click Record Payment and pay the balance.

Before
----------------------------------------
At Contributions > Accounting Batches > Open Batches, select the batch just created and export as csv, open and view the resulting transactions: [Financial_Transactions_3_20180807210702](https://lab.civicrm.org/dev/financial/uploads/0cccae0ceba1707701f9cf699f52a3e3/Financial_Transactions_3_20180807210702.csv)

After
----------------------------------------
[Financial_Transactions_3_20181119192008.csv](https://lab.civicrm.org/dev/financial/uploads/d2d17944c0224b1bc3dff5a1880b3f21/Financial_Transactions_3_20181119192008.csv)

**RESULT**: If you compare both the CSV results, each file show same number of records in which first two records represent the financial entries for respective tickets ($25 and $10), third entry is the financial entry created to indicate the outstanding balance of $40 and is payable (i.e. is_payment = FALSE). For the last two entries the amount differ whereas now after the fix $40 is being assigned to Ticket2 (as qty is changed from 1 to 5, thus amount $10 is changed to $50) and $0 to Ticket 1 unlike earlier where amount is proportionally distributed to two tickets on basis of total contribution amount, instead of financial item's amount

Technical Details
----------------------------------------
I have changed the algorithm to do allocation on basis of financial_item.amount. Ensured that proportional allocation of financial items, in case of partial payment is not changed and we already have existing UTs for this.
    In addition I have made changes in various unit test which does not follow the standard approach to change amount of a existing contribution (in order to calculate proportional amount allocation to different line-items). 

Comments
----------------------------------------
ping @JoeMurray @kcristiano @pradpnayak @eileenmcnaughton @mattwire 
