### PR TITLE
Update name of icon from pencil to wrench in EventInfo help

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
@@ -77,7 +77,7 @@
 <p>{if $params.waitlist}
   {ts}You may allow users to join a waitlist when the event is full (by checking the box below).{/ts}
 {else}
-  {ts}You may allow users to join a waitlist when the event is full. To enable this feature you must first enable the Participant Statuses used by the waitlist work-flow (click the pencil icon, or navigate to Administer » CiviEvent » Participant Statuses). Then reload this form and check 'Offer a Waitlist?'.{/ts}
+  {ts}You may allow users to join a waitlist when the event is full. To enable this feature you must first enable the Participant Statuses used by the waitlist work-flow (click the wrench icon, or navigate to Administer » CiviEvent » Participant Statuses). Then reload this form and check 'Offer a Waitlist?'.{/ts}
 {/if}</p>
 <p>{ts}Otherwise, the registration link is hidden and the &quot;Event Full Message&quot' is displayed when the maximum number of registrations is reached. Only participants with status types marked as 'counted' are included when checking if the event is full.{/ts}</p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
_Update help text to reflect name of current icon._

Before
----------------------------------------
_Wrench icon on screen is called pencil icon in help._

After
----------------------------------------
_Wrench icon referred to acurately in help._

Technical Details
----------------------------------------
_change in help text_

Comments
----------------------------------------
_Missed during icon replacement. Are there similar doc issues elsewhere?_
