### PR TITLE
Export class cleanup - remove some unnecessary code

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1330,10 +1330,6 @@ WHERE  {$whereClause}";
     elseif (isset($queryFields[$field]['title'])) {
       $headerRows[] = $queryFields[$field]['title'];
     }
-    elseif ($field == 'provider_id') {
-      // @todo - set this correctly in the xml rather than here.
-      $headerRows[] = ts('IM Service Provider');
-    }
     elseif ($processor->isExportPaymentFields() && array_key_exists($field, $processor->getcomponentPaymentFields())) {
       $headerRows[] = CRM_Utils_Array::value($field, $processor->getcomponentPaymentFields());
     }
@@ -1400,11 +1396,6 @@ WHERE  {$whereClause}";
           }
           elseif ($relationField == 'phone_type_id') {
             $headerName = $field . '-' . 'Phone Type';
-            $headerRows[] = $headerName;
-            self::sqlColumnDefn($processor, $sqlColumns, $headerName);
-          }
-          elseif ($relationField == 'provider_id') {
-            $headerName = $field . '-' . 'Im Service Provider';
             $headerRows[] = $headerName;
             self::sqlColumnDefn($processor, $sqlColumns, $headerName);
           }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -419,14 +419,6 @@ class CRM_Export_BAO_ExportProcessor {
    *   Array of fields to return in the format ['field_name' => 1,...]
    */
   public function getAdditionalReturnProperties() {
-
-    $missing = [
-      'location_type',
-      'im_provider',
-      'phone_type_id',
-      'provider_id',
-      'current_employer',
-    ];
     if ($this->getQueryMode() === CRM_Contact_BAO_Query::MODE_CONTACTS) {
       $componentSpecificFields = [];
     }
@@ -446,7 +438,7 @@ class CRM_Export_BAO_ExportProcessor {
       $componentSpecificFields = array_merge($componentSpecificFields, CRM_Contribute_BAO_Query::softCreditReturnProperties(TRUE));
       unset($componentSpecificFields['contribution_status_id']);
     }
-    return array_merge(array_fill_keys($missing, 1), $componentSpecificFields);
+    return $componentSpecificFields;
   }
 
   /**

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1182,13 +1182,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * Get return properties manually added in.
    */
   public function getExtraReturnProperties() {
-    return [
-      'location_type' => 1,
-      'im_provider' => 1,
-      'phone_type_id' => 1,
-      'provider_id' => 1,
-      'current_employer' => 1,
-    ];
+    return [];
   }
 
   /**
@@ -1284,7 +1278,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'tags' => 1,
       'notes' => 1,
       'phone_type_id' => 1,
-      'provider_id' => 1,
     ];
     if (!$isContactMode) {
       unset($returnProperties['groups']);
@@ -1339,11 +1332,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   public function getMembershipReturnProperties() {
     return [
-      'location_type' => 1,
-      'im_provider' => 1,
-      'phone_type_id' => 1,
-      'provider_id' => 1,
-      'current_employer' => 1,
       'contact_type' => 1,
       'contact_sub_type' => 1,
       'sort_name' => 1,
@@ -1975,7 +1963,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
         80 => 'Group(s)',
         81 => 'Tag(s)',
         82 => 'Note(s)',
-        83 => 'IM Service Provider',
       ];
     if (!$isContactExport) {
       unset($headers[80]);
@@ -2273,7 +2260,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'groups' => 'groups text',
       'tags' => 'tags text',
       'notes' => 'notes text',
-      'provider_id' => 'provider_id varchar(255)',
     ];
     if (!$isContactExport) {
       unset($columns['groups']);
@@ -2457,7 +2443,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'world_region' => 'world_region varchar(128)',
       'url' => 'url varchar(128)',
       'phone_type_id' => 'phone_type_id varchar(16)',
-      'provider_id' => 'provider_id varchar(255)',
       'financial_type' => 'financial_type varchar(64)',
       'contribution_source' => 'contribution_source varchar(255)',
       'receive_date' => 'receive_date varchar(32)',


### PR DESCRIPTION
Overview
----------------------------------------
Remove hard-coded add ons to 'primary' (AKA all) fields - these are already present & tested. The provider_id is actually a duplicate of im_provider and by removing it we get rid of some other hacks

Before
----------------------------------------
Unnecessary code present

After
----------------------------------------
Unnecessary code removed


Technical Details
----------------------------------------
These are being merged into an array that already contains them. The only one not already present is provider_id - but this exports the same data as im_provider

Comments
----------------------------------------
CRM_Export_BAO_ExportTest::testGetSQLColumnsAndHeaders covers this pretty thoroughly