### PR TITLE
Export code cleanup - only construct one metadata array with all types of metadata

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1243,7 +1243,7 @@ WHERE  {$whereClause}";
     foreach ($returnProperties as $key => $value) {
       if (($key != 'location' || !is_array($value)) && !$processor->isRelationshipTypeKey($key)) {
         $outputColumns[$key] = $value;
-        $processor->addOutputSpecification($key, $processor->getHeaderForRow($key));
+        $processor->addOutputSpecification($key);
         self::sqlColumnDefn($processor, $sqlColumns, $key);
       }
       elseif ($processor->isRelationshipTypeKey($key)) {
@@ -1254,7 +1254,7 @@ WHERE  {$whereClause}";
           if (isset($queryFields[$relationField]['title'])) {
             if (!$processor->isHouseholdMergeRelationshipTypeKey($field)) {
               // Do not add to header row if we are only generating for merge reasons.
-              $processor->addOutputSpecification($relationField, $processor->getHeaderForRow($relationField), $key);
+              $processor->addOutputSpecification($relationField, $key);
             }
             self::sqlColumnDefn($processor, $sqlColumns, $field . '-' . $relationField);
           }
@@ -1274,7 +1274,7 @@ WHERE  {$whereClause}";
                     $hdr .= "-" . CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_IM', 'provider_id', $type[1]);
                   }
                 }
-                $processor->addOutputSpecification($field, $hdr, $key);
+                $processor->addOutputSpecification($field, $key, $ltype, CRM_Utils_Array::value(1, $type));
                 self::sqlColumnDefn($processor, $sqlColumns, $field . '-' . $hdr);
               }
             }
@@ -1304,7 +1304,7 @@ WHERE  {$whereClause}";
               $metadata[$daoFieldName]['pseudoconstant']['var'] = 'imProviders';
             }
             self::sqlColumnDefn($processor, $sqlColumns, $outputFieldName);
-            $processor->addOutputSpecification($outputFieldName, $processor->getHeaderForRow($outputFieldName));
+            $processor->addOutputSpecification($outputFieldName, NULL, $locationType, CRM_Utils_Array::value(1, $type));
             self::sqlColumnDefn($processor, $sqlColumns, $outputFieldName);
             if ($actualDBFieldName == 'country' || $actualDBFieldName == 'world_region') {
               $metadata[$daoFieldName] = array('context' => 'country');

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1207,38 +1207,6 @@ WHERE  {$whereClause}";
   }
 
   /**
-   * Set the definition for the header rows and sql columns based on the field to output.
-   *
-   * @param string $field
-   * @param array $headerRows
-   * @param \CRM_Export_BAO_ExportProcessor $processor
-   *
-   * @return array
-   */
-  public static function setHeaderRows($field, $headerRows, $processor) {
-
-    $queryFields = $processor->getQueryFields();
-    if (substr($field, -11) == 'campaign_id') {
-      // @todo - set this correctly in the xml rather than here.
-      $headerRows[] = ts('Campaign ID');
-    }
-    elseif ($processor->isMergeSameHousehold() && $field === 'id') {
-      $headerRows[] = ts('Household ID');
-    }
-    elseif (isset($queryFields[$field]['title'])) {
-      $headerRows[] = $queryFields[$field]['title'];
-    }
-    elseif ($processor->isExportPaymentFields() && array_key_exists($field, $processor->getcomponentPaymentFields())) {
-      $headerRows[] = CRM_Utils_Array::value($field, $processor->getcomponentPaymentFields());
-    }
-    else {
-      $headerRows[] = $field;
-    }
-
-    return $headerRows;
-  }
-
-  /**
    * Get the various arrays that we use to structure our output.
    *
    * The extraction of these has been moved to a separate function for clarity and so that
@@ -1274,7 +1242,7 @@ WHERE  {$whereClause}";
     foreach ($returnProperties as $key => $value) {
       if (($key != 'location' || !is_array($value)) && !$processor->isRelationshipTypeKey($key)) {
         $outputColumns[$key] = $value;
-        $headerRows = self::setHeaderRows($key, $headerRows, $processor);
+        $headerRows[] = $processor->getHeaderForRow($key);
         self::sqlColumnDefn($processor, $sqlColumns, $key);
       }
       elseif ($processor->isRelationshipTypeKey($key)) {
@@ -1335,7 +1303,7 @@ WHERE  {$whereClause}";
               $metadata[$daoFieldName]['pseudoconstant']['var'] = 'imProviders';
             }
             self::sqlColumnDefn($processor, $sqlColumns, $outputFieldName);
-            $headerRows = self::setHeaderRows($outputFieldName, $headerRows, $processor);
+            $headerRows[] = $processor->getHeaderForRow($outputFieldName);
             self::sqlColumnDefn($processor, $sqlColumns, $outputFieldName);
             if ($actualDBFieldName == 'country' || $actualDBFieldName == 'world_region') {
               $metadata[$daoFieldName] = array('context' => 'country');

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -390,6 +390,33 @@ class CRM_Export_BAO_ExportProcessor {
   }
 
   /**
+   * Get the label for the header row based on the field to output.
+   *
+   * @param string $field
+   *
+   * @return string
+   */
+  public function getHeaderForRow($field) {
+    if (substr($field, -11) == 'campaign_id') {
+      // @todo - set this correctly in the xml rather than here.
+      // This will require a generalised handling cleanup
+      return ts('Campaign ID');
+    }
+    if ($this->isMergeSameHousehold() && $field === 'id') {
+      return ts('Household ID');
+    }
+    elseif (isset($this->getQueryFields()[$field]['title'])) {
+      return $this->getQueryFields()[$field]['title'];
+    }
+    elseif ($this->isExportPaymentFields() && array_key_exists($field, $this->getcomponentPaymentFields())) {
+      return CRM_Utils_Array::value($field, $this->getcomponentPaymentFields());
+    }
+    else {
+      return $field;
+    }
+  }
+
+  /**
    * @param $params
    * @param $order
    * @param $returnProperties

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -443,16 +443,33 @@ class CRM_Export_BAO_ExportProcessor {
 
   /**
    * Add a row to the specification for how to output data.
+   *
    * @param string $key
-   * @param string $label
    * @param string $relationshipType
+   * @param string $locationType
+   * @param int $entityTypeID phone_type_id or provider_id for phone or im fields.
    */
-  public function addOutputSpecification($key, $label, $relationshipType = NULL) {
-    $labelPrefix = '';
+  public function addOutputSpecification($key, $relationshipType = NULL, $locationType = NULL, $entityTypeID = NULL) {
+    $label = $this->getHeaderForRow($key);
+    $labelPrefix = $fieldPrefix = [];
     if ($relationshipType) {
-      $labelPrefix = $this->getRelationshipTypes()[$relationshipType] . '-';
+      $labelPrefix[] = $this->getRelationshipTypes()[$relationshipType];
+      $fieldPrefix[] = $relationshipType;
     }
-    $this->outputSpecification[$key]['header'] = $labelPrefix . $label;
+    if ($locationType) {
+      $labelPrefix[] = $fieldPrefix[] = $locationType;
+    }
+    if ($entityTypeID) {
+      if ($key === 'phone') {
+        $labelPrefix[] = $fieldPrefix[] = CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_Phone', 'phone_type_id', $entityTypeID);
+      }
+      if ($key === 'im') {
+        $labelPrefix[] = $fieldPrefix[] = CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_IM', 'provider_id', $entityTypeID);
+      }
+    }
+    $index = ($fieldPrefix ? (implode('-', $fieldPrefix)  . '-') : '') . $key;
+    $this->outputSpecification[$index]['header'] = ($labelPrefix ? (implode('-', $labelPrefix) . '-') : '') . $label;
+
   }
 
   /**

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -452,9 +452,18 @@ class CRM_Export_BAO_ExportProcessor {
     if ($relationshipType) {
       $labelPrefix = $this->getRelationshipTypes()[$relationshipType] . '-';
     }
-    $this->outputSpecification[$key] = [
-      'header' => $labelPrefix . $label
-    ];
+    $this->outputSpecification[$key]['header'] = $labelPrefix . $label;
+  }
+
+  /**
+   * Mark a column as only required for calculations.
+   *
+   * Do not include the row with headers.
+   *
+   * @param string $column
+   */
+  public function setColumnAsCalculationOnly($column) {
+    $this->outputSpecification[$column]['do_not_output_to_csv'] = TRUE;
   }
 
   /**
@@ -463,7 +472,9 @@ class CRM_Export_BAO_ExportProcessor {
   public function getHeaderRows() {
     $headerRows = [];
     foreach ($this->outputSpecification as $key => $spec) {
-      $headerRows[] = $spec['header'];
+      if (empty($spec['do_not_output_to_csv'])) {
+        $headerRows[] = $spec['header'];
+      }
     }
     return $headerRows;
   }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -116,6 +116,11 @@ class CRM_Export_BAO_ExportProcessor {
   protected $returnProperties = [];
 
   /**
+   * @var array
+   */
+  protected $outputSpecification = [];
+
+  /**
    * CRM_Export_BAO_ExportProcessor constructor.
    *
    * @param int $exportMode
@@ -434,6 +439,33 @@ class CRM_Export_BAO_ExportProcessor {
     list($select, $from, $where, $having) = $query->query();
     $this->setQueryFields($query->_fields);
     return array($query, $select, $from, $where, $having);
+  }
+
+  /**
+   * Add a row to the specification for how to output data.
+   * @param string $key
+   * @param string $label
+   * @param string $relationshipType
+   */
+  public function addOutputSpecification($key, $label, $relationshipType = NULL) {
+    $labelPrefix = '';
+    if ($relationshipType) {
+      $labelPrefix = $this->getRelationshipTypes()[$relationshipType] . '-';
+    }
+    $this->outputSpecification[$key] = [
+      'header' => $labelPrefix . $label
+    ];
+  }
+
+  /**
+   * @return array
+   */
+  public function getHeaderRows() {
+    $headerRows = [];
+    foreach ($this->outputSpecification as $key => $spec) {
+      $headerRows[] = $spec['header'];
+    }
+    return $headerRows;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Further export code cleanup 
Before
----------------------------------------
Code more brittle

After
----------------------------------------
Code more maintainable

Technical Details
----------------------------------------
This moves away from the construction of multiple related arrays that need to be kept in sync to a single array holding the data for the various arrays

Comments
----------------------------------------
@mattwire this is a little bit harder to read code-wise than some of the other chunks but it is very heavily tested

Follow on currently in https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:export_more_im?expand=1
