### PR TITLE
Export Remove redundant translate functionality

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1306,12 +1306,6 @@ WHERE  {$whereClause}";
             self::sqlColumnDefn($processor, $sqlColumns, $outputFieldName);
             $processor->addOutputSpecification($outputFieldName, NULL, $locationType, CRM_Utils_Array::value(1, $type));
             self::sqlColumnDefn($processor, $sqlColumns, $outputFieldName);
-            if ($actualDBFieldName == 'country' || $actualDBFieldName == 'world_region') {
-              $metadata[$daoFieldName] = array('context' => 'country');
-            }
-            if ($actualDBFieldName == 'state_province') {
-              $metadata[$daoFieldName] = array('context' => 'province');
-            }
             $outputColumns[$daoFieldName] = TRUE;
           }
         }
@@ -1388,19 +1382,6 @@ WHERE  {$whereClause}";
                 $row[$field . '_' . $fldValue] = '';
                 break;
 
-              case in_array('country', $type):
-              case in_array('world_region', $type):
-                $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
-                  array('context' => 'country')
-                );
-                break;
-
-              case in_array('state_province', $type):
-                $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
-                  array('context' => 'province')
-                );
-                break;
-
               default:
                 $row[$field . '_' . $fldValue] = $relDAO->$fldValue;
                 break;
@@ -1414,22 +1395,7 @@ WHERE  {$whereClause}";
           $row[$relPrefix] = CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
         }
         else {
-          //normal relationship fields
-          // CRM-3157: localise country, region (both have ‘country’ context) and state_province (‘province’ context)
-          switch ($relationField) {
-            case 'country':
-            case 'world_region':
-              $row[$relPrefix] = $i18n->crm_translate($fieldValue, array('context' => 'country'));
-              break;
-
-            case 'state_province':
-              $row[$relPrefix] = $i18n->crm_translate($fieldValue, array('context' => 'province'));
-              break;
-
-            default:
-              $row[$relPrefix] = $fieldValue;
-              break;
-          }
+          $row[$relPrefix] = $fieldValue;
         }
       }
       else {

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -637,47 +637,25 @@ class CRM_Export_BAO_ExportProcessor {
         return $iterationDAO->$fldValue;
       }
       else {
-        //normal fields with a touch of CRM-3157
-        switch ($field) {
-          case 'country':
-          case 'world_region':
-            return $i18n->crm_translate($fieldValue, array('context' => 'country'));
-
-          case 'state_province':
-            return $i18n->crm_translate($fieldValue, array('context' => 'province'));
-
-          case 'gender':
-          case 'preferred_communication_method':
-          case 'preferred_mail_format':
-          case 'communication_style':
-            return $i18n->crm_translate($fieldValue);
-
-          default:
-            if (isset($metadata[$field])) {
-              // No I don't know why we do it this way & whether we could
-              // make better use of pseudoConstants.
-              if (!empty($metadata[$field]['context'])) {
-                return $i18n->crm_translate($fieldValue, $metadata[$field]);
-              }
-              if (!empty($metadata[$field]['pseudoconstant'])) {
-                // This is not our normal syntax for pseudoconstants but I am a bit loath to
-                // call an external function until sure it is not increasing php processing given this
-                // may be iterated 100,000 times & we already have the $imProvider var loaded.
-                // That can be next refactor...
-                // Yes - definitely feeling hatred for this bit of code - I know you will beat me up over it's awfulness
-                // but I have to reach a stable point....
-                $varName = $metadata[$field]['pseudoconstant']['var'];
-                if ($varName === 'imProviders') {
-                  return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_IM', 'provider_id', $fieldValue);
-                }
-                if ($varName === 'phoneTypes') {
-                  return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_Phone', 'phone_type_id', $fieldValue);
-                }
-              }
-
+        if (isset($metadata[$field])) {
+          if (!empty($metadata[$field]['pseudoconstant'])) {
+            // This is not our normal syntax for pseudoconstants but I am a bit loath to
+            // call an external function until sure it is not increasing php processing given this
+            // may be iterated 100,000 times & we already have the $imProvider var loaded.
+            // That can be next refactor...
+            // Yes - definitely feeling hatred for this bit of code - I know you will beat me up over it's awfulness
+            // but I have to reach a stable point....
+            $varName = $metadata[$field]['pseudoconstant']['var'];
+            if ($varName === 'imProviders') {
+              return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_IM', 'provider_id', $fieldValue);
             }
-            return $fieldValue;
+            if ($varName === 'phoneTypes') {
+              return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_Phone', 'phone_type_id', $fieldValue);
+            }
+          }
+
         }
+        return $fieldValue;
       }
     }
     elseif ($this->isExportSpecifiedPaymentFields() && array_key_exists($field, $this->getcomponentPaymentFields())) {


### PR DESCRIPTION
Overview
----------------------------------------
Removes translate functionality from export class that is not actually doing anything

Before
----------------------------------------
More confusing code

After
----------------------------------------
Less code, less confusing.

Technical Details
----------------------------------------
From my testing the convertToPseudoNames function has already done this translation and this code is redundant. There is more cleanup that can be done with this code gone but I want to get some more confirmation first

Comments
----------------------------------------
@mlutfy @ErikHommel @samuelsov looking to get someone to test & verify this for me....

Note the test style fails will go when I remove the rest of the redundant code - jenkins has correctly picked up that some constructs are now obsolete
