### PR TITLE
dev/core#507 - Fix wrong version of jstree in search popop

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -388,8 +388,8 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     parent::buildQuickForm();
     CRM_Core_Resources::singleton()
       // jsTree is needed for tags popup
-      ->addScriptFile('civicrm', 'packages/jquery/plugins/jstree/jquery.jstree.js', 0, 'html-header', FALSE)
-      ->addStyleFile('civicrm', 'packages/jquery/plugins/jstree/themes/default/style.css', 0, 'html-header');
+      ->addScriptFile('civicrm', 'bower_components/jstree/dist/jquery.jstree.min.js', 0, 'html-header', FALSE)
+      ->addStyleFile('civicrm', 'bower_components/jstree/dist/themes/default/style.min.css', 0, 'html-header');
 
     // some tasks.. what do we want to do with the selected contacts ?
     $this->_taskList = $this->buildTaskList();


### PR DESCRIPTION
Summary
------
Fixes https://lab.civicrm.org/dev/core/issues/507

Before
----
Tag popup doesn't work on search forms
 
After
----
Tag popup works on search forms

Technical details
--------
The jstree library was upgraded a few versions back for tag screens. In this case we need to include the upgraded version on the search form as it is used for tags.