### PR TITLE
dev/core#406 fix warnings under php 7.2 when importing

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -37,8 +37,8 @@ require_once 'api/v3/utils.php';
  * class to parse contact csv files
  */
 class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
-  protected $_mapperKeys;
-  protected $_mapperLocType;
+  protected $_mapperKeys = [];
+  protected $_mapperLocType = [];
   protected $_mapperPhoneType;
   protected $_mapperImProvider;
   protected $_mapperWebsiteType;
@@ -109,21 +109,21 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
    * Class constructor.
    *
    * @param array $mapperKeys
-   * @param int $mapperLocType
-   * @param int $mapperPhoneType
-   * @param int $mapperImProvider
-   * @param int $mapperRelated
-   * @param int $mapperRelatedContactType
+   * @param array $mapperLocType
+   * @param array $mapperPhoneType
+   * @param array $mapperImProvider
+   * @param array $mapperRelated
+   * @param array $mapperRelatedContactType
    * @param array $mapperRelatedContactDetails
-   * @param int $mapperRelatedContactLocType
-   * @param int $mapperRelatedContactPhoneType
-   * @param int $mapperRelatedContactImProvider
-   * @param int $mapperWebsiteType
-   * @param int $mapperRelatedContactWebsiteType
+   * @param array $mapperRelatedContactLocType
+   * @param array $mapperRelatedContactPhoneType
+   * @param array $mapperRelatedContactImProvider
+   * @param array $mapperWebsiteType
+   * @param array $mapperRelatedContactWebsiteType
    */
   public function __construct(
-    &$mapperKeys, $mapperLocType = NULL, $mapperPhoneType = NULL, $mapperImProvider = NULL, $mapperRelated = NULL, $mapperRelatedContactType = NULL, $mapperRelatedContactDetails = NULL, $mapperRelatedContactLocType = NULL, $mapperRelatedContactPhoneType = NULL, $mapperRelatedContactImProvider = NULL,
-    $mapperWebsiteType = NULL, $mapperRelatedContactWebsiteType = NULL
+    &$mapperKeys, $mapperLocType = [], $mapperPhoneType = [], $mapperImProvider = [], $mapperRelated = [], $mapperRelatedContactType = [], $mapperRelatedContactDetails = [], $mapperRelatedContactLocType = [], $mapperRelatedContactPhoneType = [], $mapperRelatedContactImProvider = [],
+    $mapperWebsiteType = [], $mapperRelatedContactWebsiteType = []
   ) {
     parent::__construct();
     $this->_mapperKeys = &$mapperKeys;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes import warnings under php 7.2 on import

Before
----------------------------------------
```
2018/09/25 18:15:04 [error] 33#33: *451 FastCGI sent in stderr: "PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 375
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 387
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 396
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 408
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 417
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 426
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 435
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 444
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 455
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 464
PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /usr/share/civicrm/CRM/Contact/Import/Parser.php on line 476" while reading response header from upstream, client: 192.168.0.2, server: civicrm.local, request: "POST /wp-admin/admin.php?page=CiviCRM&q=civicrm/impor
```

After
----------------------------------------
No red messages

Technical Details
----------------------------------------
php 7.2 won't accept counting NULL. I have chosen to set the variables to empty arrays instead of NULL - which seems to work fine

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/406