### PR TITLE
dev/core#535 fix: do not allow editing of recurring contribution amount when one or more related lineitems exist

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -191,10 +191,10 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
    * Actually build the components of the form.
    */
   public function buildQuickForm() {
-    // CRM-16398: If current recurring contribution got > 1 lineitems then make amount field readonly
+    // dev/core#535 Update: If current recurring contribution got >= 1 lineitems then make amount field readonly
     $amtAttr = array('size' => 20);
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($this->_coid);
-    if (count($lineItems) > 1) {
+    if (count($lineItems) >= 1) {
       $amtAttr += array('readonly' => TRUE);
     }
     $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,


### PR DESCRIPTION
Overview
----------------------------------------
This is an improvement in https://issues.civicrm.org/jira/browse/CRM-16398

Before
----------------------------------------
Currently CiviCRM allows to edit recurring contribution amount if one related contribution exists.
The Recurring contribution edit UI should not allow to edit the total amount for transactions with one line item.


Technical Details
----------------------------------------
The code needs to refactor so it will not allow edit when 1 recur is done.
In /Contribute/Form/UpdateSubscription.php updated the check to >= 1 (Greater than or equal to 1)

