### PR TITLE
dev/core#540 - Civicrm Contact Dashboard returns fatal error

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -173,10 +173,12 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
    * Build the form object.
    */
   public function buildQuickForm() {
-    parent::buildQuickForm();
-    $this->addContactSearchFields();
+    if ($this->isFormInViewOrEditMode()) {
+      parent::buildQuickForm();
+      $this->addContactSearchFields();
 
-    CRM_Contribute_BAO_Query::buildSearchForm($this);
+      CRM_Contribute_BAO_Query::buildSearchForm($this);
+    }
 
     $rows = $this->get('rows');
     if (is_array($rows)) {

--- a/CRM/Contribute/Page/DashBoard.php
+++ b/CRM/Contribute/Page/DashBoard.php
@@ -108,7 +108,7 @@ class CRM_Contribute_Page_DashBoard extends CRM_Core_Page {
     $this->preProcess();
 
     $controller = new CRM_Core_Controller_Simple('CRM_Contribute_Form_Search',
-      ts('Contributions'), CRM_Core_Action::BROWSE
+      ts('Contributions'), NULL
     );
     $controller->setEmbedded(TRUE);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on contact dashboard.

Before
----------------------------------------
Similar to https://github.com/civicrm/civicrm-core/pull/13112

Visiting the contact dashboard at https://dmaster.demo.civicrm.org/civicrm/user?reset=1 results in the following error:

>Sorry, due to an error, we are unable to fulfill your request at the moment. You may want to contact your administrator or service provider with more details about what action you were performing when this occurred.
Cannot determine api action for CRM_Contribute_Form_Search.CRM_Core_Action "NO DESCRIPTION SET

![image](https://user-images.githubusercontent.com/5929648/48818106-99114a00-ed6f-11e8-8f6d-dcd3a8ca6b77.png)


After
----------------------------------------
Fixed.

Comments
----------------------------------------
Gitlab Issue - https://lab.civicrm.org/dev/core/issues/540