### PR TITLE
core#539: Add a new hook to create custom relative date filters

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -873,8 +873,11 @@ class CRM_Utils_Date {
    */
   public static function getFromTo($relative, $from, $to, $fromTime = NULL, $toTime = '235959') {
     if ($relative) {
-      list($term, $unit) = explode('.', $relative, 2);
-      $dateRange = self::relativeToAbsolute($term, $unit);
+      $dateRange = CRM_Utils_Hook::relativeDate($relative);
+      if (!is_array($dateRange) || (empty($dateRange['from']) && empty($dateRange['to']))) {
+        list($term, $unit) = explode('.', $relative, 2);
+        $dateRange = self::relativeToAbsolute($term, $unit);
+      }
       $from = substr($dateRange['from'], 0, 8);
       $to = substr($dateRange['to'], 0, 8);
       // @todo fix relativeToAbsolute & add tests

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2491,4 +2491,15 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+
+  /**
+   * Extensions can define new formats for relative date filter "tokens".
+   * @param string $filter - the filter token, stored in civicrm_option_value
+   * @return mixed $dates - Should return an array with two elements, $dates['from']
+   *   and $dates['to'].  Or FALSE if hook isn't in use.
+   */
+  public static function relativeDate($filter) {
+    return self::singleton()->invoke(array('filter'), $filter, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_relativeDate');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a new hook to create custom relative date filters.

Before
----------------------------------------
No hook.

After
----------------------------------------
Hook.

Technical Details
----------------------------------------
The test should show how this hook works - but you can also download a [test extension](https://github.com/MegaphoneJon/com.megaphonetech.relativedatetest) I wrote if that's more familiar.

Comments
----------------------------------------
My test isn't working!  I get `Error: Call to a member function setHook() on null`.  I guess I'm not using the `setHook` callback properly, but I haven't had time to figure out what's up.  If someone else who's tested hooks before has seen this, I'd love a pointer.  If not I'll try to take another look next week.
