### PR TITLE
dev/core#541 - Contact custom fields are not imported when basic type…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -462,7 +462,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $onlySubType = FALSE,
     $checkPermission = TRUE
   ) {
-    if (empty($customDataType)) {
+    if (empty($customDataType) || $customDataType == 'Contact') {
       $customDataType = array('Contact', 'Individual', 'Organization', 'Household');
     }
     if ($customDataType && !is_array($customDataType)) {


### PR DESCRIPTION
… custom field is included in import file

Overview
----------------------------------------
Fix contact import for custom fields.

Before
----------------------------------------
Contact custom fields are not imported when basic type custom field is included in import file

To replicate -

- Create a custom group which extends `Contact`. Add some fields to it.
- Create a custom group which extends `Individual`. Similarly, add some fields.
- Import contact with a csv file holding values of both the above custom fields.
- Only custom fields that extends `Contact` will be imported. The one created at step 2 will be ignored.


After
----------------------------------------
All custom fields are imported correctly.


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/541