### PR TITLE
WIP dev/core#542 - case manager not displayed for closed cases

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -149,8 +149,14 @@ class CRM_Activity_Page_AJAX {
     $contactID = CRM_Utils_Type::escape($_GET['cid'], 'Integer');
 
     $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
+    $groupingValues = CRM_Core_OptionGroup::values('case_status', FALSE, TRUE, FALSE, NULL, 'value');
 
-    $caseRelationships = CRM_Case_BAO_Case::getCaseRoles($contactID, $caseID);
+    $onlyActive = TRUE;
+    $statusId = CRM_Core_DAO::getFieldValue('CRM_Case_BAO_Case', $caseID, 'status_id');
+    if (CRM_Utils_Array::value($statusId, $groupingValues) == 'Closed') {
+      $onlyActive = FALSE;
+    }
+    $caseRelationships = CRM_Case_BAO_Case::getCaseRoles($contactID, $caseID, NULL, $onlyActive);
     $caseTypeName = CRM_Case_BAO_Case::getCaseType($caseID, 'name');
     $xmlProcessor = new CRM_Case_XMLProcessor_Process();
     $caseRoles = $xmlProcessor->get($caseTypeName, 'CaseRoles');


### PR DESCRIPTION
Overview
----------------------------------------
Fix case manager to be displayed for closed cases.

Before
----------------------------------------
Closed Cases do not display case manager in `Manage Case` screen. More Details on the SE post - https://civicrm.stackexchange.com/questions/27215/case-roles-on-closed-cases

After
----------------------------------------
Case Manager is displayed on Manage Case Screen.

Technical Details
---------------------------------------
4.7 included the refactoring of case roles via https://github.com/civicrm/civicrm-core/pull/6806 which added a query to only load active relationship from getCaseRole function. This was made flexible by adding an extra param `$activeOnly` in https://github.com/civicrm/civicrm-core/pull/11736. The changes made here uses that variable and load case manager for closed cases.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/542