### PR TITLE
Unit test set up tweak - Set trxn_id & invoice_id in tests as needed rather than by default.

### DIFF
--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -38,7 +38,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
    */
   public function testGetFinancialTransactionsList() {
     $individualID = $this->individualCreate();
-    $this->contributionCreate(array('contact_id' => $individualID));
+    $this->contributionCreate(array('contact_id' => $individualID, 'trxn_id' => 12345));
     $batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open'));
     CRM_Core_DAO::executeQuery("
      INSERT INTO civicrm_entity_batch (entity_table, entity_id, batch_id)

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -135,6 +135,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
         'civicrm_membership_type',
         'civicrm_membership',
         'civicrm_uf_match',
+        'civicrm_email',
       )
     );
     foreach (array(17, 18, 23, 32) as $contactID) {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1302,8 +1302,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'financial_type_id' => 1,
       'payment_instrument_id' => 1,
       'non_deductible_amount' => 10.00,
-      'trxn_id' => 12345,
-      'invoice_id' => 67890,
       'source' => 'SSF',
       'contribution_status_id' => 1,
     ), $params);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -267,6 +267,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $params = array_merge($params, array(
       'id' => $contributionID,
       'invoice_number' => CRM_Utils_Array::value('invoice_prefix', Civi::settings()->get('contribution_invoice_settings')) . "" . $contributionID,
+      'trxn_id' => 12345,
+      'invoice_id' => 6789,
     ));
     $contributionID = $this->contributionCreate($params);
 


### PR DESCRIPTION
Overview
----------------------------------------
Do not set invoice_id & trxn_id in unit test shared create contribution function

Before
----------------------------------------
Tests calling createContribution cannot call it twice without overriding trxn_id & invoice_id

After
----------------------------------------
trxn_id & invoice_id need to be set by tests that want them set.

Technical Details
----------------------------------------
This causes work-arounds & flakiness by tests using this fn.
Better to add as required.

Comments
----------------------------------------
I expect this to fail on the first round as I will tweak the tests for it
