### PR TITLE
dev/drupal#36 Unfork zetacomponents/mail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
     "symfony/finder": "^2.8.44 || ~3.0",
     "tecnickcom/tcpdf" : "6.2.*",
     "totten/ca-config": "~17.05",
-    "zetacomponents/base": "1.7.*",
-    "zetacomponents/mail": "dev-1.7-civi",
+    "zetacomponents/base": "1.9.*",
+    "zetacomponents/mail": "1.8.*",
     "marcj/topsort": "~1.1",
     "phpoffice/phpword": "^0.14.0",
     "pear/Validate_Finance_CreditCard": "dev-master",
@@ -59,12 +59,6 @@
     "guzzlehttp/guzzle": "^6.3",
     "psr/simple-cache": "~1.0.1"
   },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/civicrm/zetacomponents-mail.git"
-    }
-  ],
   "scripts": {
     "post-install-cmd": [
       "bash tools/scripts/composer/dompdf-cleanup.sh",


### PR DESCRIPTION
Overview
----------------------------------------

* Helps with simplifying Drupal8 composer setups
* Unforks a library that is somewhat maintained upstream.

See: https://lab.civicrm.org/dev/drupal/issues/36

And also: https://github.com/civicrm/zetacomponents-mail/pull/2