### PR TITLE
dev/core#536 Remove duplicate call to contribution summary

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -387,9 +387,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if ($this->_context == 'user') {
       $query->setSkipPermission(TRUE);
     }
-    $summary = &$query->summaryContribution($this->_context);
-    $this->set('summary', $summary);
-    $this->assign('contributionSummary', $summary);
+
     $controller->run();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
As part of addressing performance issues on the contribution summary tab this first step simply reduces the number of expensive but redundant queries that run

Before
----------------------------------------
Time spent on running some sql queries twice

After
----------------------------------------
The 6 queries in question only run once. At volume these are slow queries so this saves around 20
seconds to load a contact with a lot of contributions on a very large database. Even very small databases will get some gain as there are just less queries 

We still see the summary 
![screenshot 2018-11-22 14 56 27](https://user-images.githubusercontent.com/336308/48877156-d573a180-ee66-11e8-8933-1ffe20ae20b3.png)

And here

![screenshot 2018-11-22 14 57 27](https://user-images.githubusercontent.com/336308/48877176-f1774300-ee66-11e8-8cb2-456698784a1c.png)


Technical Details
----------------------------------------
This is an expensive call (we get it at over 10 seconds for high
giving contacts in a large database) and it is quite simply called twice.

Removing these few lines knock out several expensive queries but I have checked
contribution tab, user dashboard, contribution search and advanced search displayed
as contributions and can find no instances where less info is shown.

(in the case of advanced search displayed as contributions it doesn't show before or
after)

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
