### PR TITLE
Fix check for financial acls to look for setting rather than sub-key of non-standard civicontribute_settings' setting

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -455,9 +455,12 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
   public static function isACLFinancialTypeStatus() {
     if (!isset(\Civi::$statics[__CLASS__]['is_acl_enabled'])) {
       \Civi::$statics[__CLASS__]['is_acl_enabled'] = FALSE;
-      $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
-      if (CRM_Utils_Array::value('acl_financial_type', $contributeSettings)) {
-        \Civi::$statics[__CLASS__]['is_acl_enabled'] = TRUE;
+      $realSetting = \Civi::$statics[__CLASS__]['is_acl_enabled'] = Civi::settings()->get('acl_financial_type');
+      if (!$realSetting) {
+        $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
+        if (CRM_Utils_Array::value('acl_financial_type', $contributeSettings)) {
+          \Civi::$statics[__CLASS__]['is_acl_enabled'] = TRUE;
+        }
       }
     }
     return \Civi::$statics[__CLASS__]['is_acl_enabled'];

--- a/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
@@ -38,7 +38,8 @@ trait CRMTraits_Financial_FinancialACLTrait {
   protected function enableFinancialACLs() {
     $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
     $this->callAPISuccess('Setting', 'create', [
-      'contribution_invoice_settings' => array_merge($contributeSettings, ['acl_financial_type' => TRUE])
+      'contribution_invoice_settings' => array_merge($contributeSettings, ['acl_financial_type' => TRUE]),
+      'acl_financial_type' => TRUE,
     ]);
     unset(\Civi::$statics['CRM_Financial_BAO_FinancialType']);
   }
@@ -49,7 +50,8 @@ trait CRMTraits_Financial_FinancialACLTrait {
   protected function disableFinancialACLs() {
     $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
     $this->callAPISuccess('Setting', 'create', [
-      'contribution_invoice_settings' => array_merge($contributeSettings, ['acl_financial_type' => FALSE])
+      'contribution_invoice_settings' => array_merge($contributeSettings, ['acl_financial_type' => FALSE]),
+      'acl_financial_type' => FALSE,
     ]);
     unset(\Civi::$statics['CRM_Financial_BAO_FinancialType']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an intra-rc regression where setting for financial acl was not being picked up

Before
----------------------------------------
Newly enabled financial acls ignored

After
----------------------------------------
Acls picked up

Technical Details
----------------------------------------
Some true awfulness was introduced in contribution settings a while ago. Some settings were declared as settings and settable via the api - but only worked when saved to 'the wrong place' via the preferences form munging them into a non-standard setting key. This now picks up either place.

As @mattwire commented - perhaps we would be better to update all the saved settings on upgrade....

Comments
----------------------------------------
@monishdeb can you test this with your financial acls stuff - I picked it up trying out something on them