### PR TITLE
Extract getContributionBalance function, use that rather than wrapper…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4169,6 +4169,39 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
   }
 
   /**
+   * Get the outstanding balance on a contribution.
+   *
+   * @param int $contributionId
+   * @param float $contributionTotal
+   *   Optional amount to override the saved amount paid (e.g if calculating what it WILL be).
+   *
+   * @return float
+   */
+  public static function getContributionBalance($contributionId, $contributionTotal = NULL) {
+
+    if ($contributionTotal === NULL) {
+      $contributionTotal = CRM_Price_BAO_LineItem::getLineTotal($contributionId);
+    }
+    $statusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+    $refundStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded');
+
+    $sqlFtTotalAmt = "
+SELECT SUM(ft.total_amount)
+FROM civicrm_financial_trxn ft
+  INNER JOIN civicrm_entity_financial_trxn eft ON (ft.id = eft.financial_trxn_id AND eft.entity_table = 'civicrm_contribution' AND eft.entity_id = {$contributionId})
+WHERE ft.is_payment = 1
+  AND ft.status_id IN ({$statusId}, {$refundStatusId})
+";
+
+    $ftTotalAmt = CRM_Core_DAO::singleValueQuery($sqlFtTotalAmt);
+    if (!$ftTotalAmt) {
+      $ftTotalAmt = 0;
+    }
+    $currency = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency');
+    return CRM_Utils_Money::subtractCurrencies($contributionTotal, $ftTotalAmt, $currency);
+  }
+
+  /**
    * Get the tax amount (misnamed function).
    *
    * @param array $params

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1313,13 +1313,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       CRM_Core_Error::statusBounce(ts("Returning since there is no contact attached to this contribution id."));
     }
 
-    $payment = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_ccid, 'contribution');
+    $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_ccid);
     //bounce if the contribution is not pending.
-    if (empty($payment['balance'])) {
+    if ((int) $paymentBalance <= 0) {
       CRM_Core_Error::statusBounce(ts("Returning since contribution has already been handled."));
     }
-    if (!empty($payment['total'])) {
-      $this->_pendingAmount = $payment['total'];
+    if (!empty($paymentBalance)) {
+      $this->_pendingAmount = $paymentBalance;
       $this->assign('pendingAmount', $this->_pendingAmount);
     }
 

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -466,26 +466,10 @@ WHERE ceft.entity_id = %1";
     $financialTypeId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'financial_type_id');
 
     if ($contributionId && $financialTypeId) {
-      $statusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-      $refundStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded');
 
-      if (empty($lineItemTotal)) {
-        $lineItemTotal = CRM_Price_BAO_LineItem::getLineTotal($contributionId);
-      }
-      $sqlFtTotalAmt = "
-SELECT SUM(ft.total_amount)
-FROM civicrm_financial_trxn ft
-  INNER JOIN civicrm_entity_financial_trxn eft ON (ft.id = eft.financial_trxn_id AND eft.entity_table = 'civicrm_contribution' AND eft.entity_id = {$contributionId})
-WHERE ft.is_payment = 1
-  AND ft.status_id IN ({$statusId}, {$refundStatusId})
-";
+      $value = CRM_Contribute_BAO_Contribution::getContributionBalance($contributionId, $lineItemTotal);
 
-      $ftTotalAmt = CRM_Core_DAO::singleValueQuery($sqlFtTotalAmt);
-      if (!$ftTotalAmt) {
-        $ftTotalAmt = 0;
-      }
-      $currency = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency');
-      $value = $paymentVal = CRM_Utils_Money::subtractCurrencies($lineItemTotal, $ftTotalAmt, $currency);
+      $paymentVal = $value;
       if ($returnType) {
         $value = array();
         if ($paymentVal < 0) {
@@ -493,9 +477,6 @@ WHERE ft.is_payment = 1
         }
         elseif ($paymentVal > 0) {
           $value['amount_owed'] = $paymentVal;
-        }
-        elseif ($lineItemTotal == $ftTotalAmt) {
-          $value['full_paid'] = $ftTotalAmt;
         }
       }
     }

--- a/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
@@ -207,8 +207,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
     $amtPaid = 60;
     $balance = $feeAmt - $amtPaid;
     $result = $this->addParticipantWithPayment($feeAmt, $amtPaid);
-    extract($result);
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($participant['id'], 'event');
+    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($result['participant']['id'], 'event');
 
     // amount checking
     $this->assertEquals(round($paymentInfo['total']), $feeAmt, 'Total amount recorded is not proper');
@@ -216,7 +215,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->assertEquals(round($paymentInfo['balance']), $balance, 'Balance amount is not proper');
 
     // status checking
-    $this->assertEquals($participant['participant_status_id'], 14, 'Status record is not proper for participant');
+    $this->assertEquals($result['participant']['participant_status_id'], 14, 'Status record is not proper for participant');
     $this->assertEquals($result['contribution']['contribution_status_id'], 8, 'Status record is not proper for contribution');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup to extract the guts of an overloaded function so just the relevant part can be called. These are internal functions only.

Before
----------------------------------------
Complex function ``function getPartialPaymentWithType`` doing multiple things

After
----------------------------------------
Get balance part callable by itself

Technical Details
----------------------------------------
@monishdeb @pradpnayak this function is only called from a few places and I couldn't find any evidence that the 'full_paid' parameter is ever used so I dropped that. I feel like this 'getByType' stuff is a bit silly & we should determine that before calling it but for now I haven't touched that.

I also updated the payment only bit from the contribution form to call this function - this came off trying to understand https://github.com/civicrm/civicrm-core/pull/12319/files#diff-e59ea24da123edeec35a0c498d02874fR1322 & feeling that we just need to know the amount owing whatever the status

Comments
----------------------------------------

