### PR TITLE
Remove redundant jstree script from search form

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -386,10 +386,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    CRM_Core_Resources::singleton()
-      // jsTree is needed for tags popup
-      ->addScriptFile('civicrm', 'bower_components/jstree/dist/jquery.jstree.min.js', 0, 'html-header', FALSE)
-      ->addStyleFile('civicrm', 'bower_components/jstree/dist/themes/default/style.min.css', 0, 'html-header');
 
     // some tasks.. what do we want to do with the selected contacts ?
     $this->_taskList = $this->buildTaskList();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a 404 on an unnecessary script.

Before
----------------------------------------
Tag popup works on search forms because the unneeded script could not be found.

After
----------------------------------------
Tag popup works on search forms because the unneeded script is removed.

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/13128 fixed the old script interfering with the tag popup; turns out the correct script was loading from within the popup and doesn't need to be added to search forms at all.