### PR TITLE
Set currency template variable from contribution pages

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -484,8 +484,13 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_defaults = array();
 
     $this->_amount = $this->get('amount');
+    // Assigning this to the template means it will be passed through to the payment form.
+    // This can, for example, by used by payment processors using client side encryption
+    $this->assign('currency', $this->getCurrency());
 
     //CRM-6907
+    // these lines exist to support a non-default currenty on the form but are probably
+    // obsolete & meddling wth the defaultCurrency is not the right approach....
     $config = CRM_Core_Config::singleton();
     $config->defaultCurrency = CRM_Utils_Array::value('currency',
       $this->_values,

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -72,8 +72,7 @@ class CRM_Core_Payment_ProcessorForm {
 
     $form->assign('suppressSubmitButton', $form->_paymentObject->isSuppressSubmitButtons());
 
-    $currency = $form->getCurrency();
-    $form->assign('currency', $currency);
+    $form->assign('currency', $form->getCurrency());
 
     // also set cancel subscription url
     if (!empty($form->_paymentProcessor['is_recur']) && !empty($form->_values['is_recur'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Assign $currency variable to the template for contribution pages more consistently

Before
----------------------------------------
Under some circumstances the smarty var currencyID is not populated

After
----------------------------------------
variable is more consistenty populated

Technical Details
----------------------------------------
When we load the PaymentForm the currency is set there and assigned to the template.

However, if the form doesn't load by default (ie because there is no payment processor selected by
default) the currency variable is not assigned to the template.

When the payment form is loaded by
      var dataUrl = '{crmURL p='civicrm/payment/form' h=0 q=formName=

Comments
----------------------------------------

