### PR TITLE
dev/core/544 Add report support for filter on multiple contact subtypes

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2055,6 +2055,10 @@ class CRM_Report_Form extends CRM_Core_Form {
         break;
     }
 
+    //dev/core/544 Add report support for multiple contact subTypes
+    if ($field['name'] == 'contact_sub_type' && $clause) {
+      $clause = $this->whereSubtypeClause($field, $value, $op);
+    }
     if (!empty($field['group']) && $clause) {
       $clause = $this->whereGroupClause($field, $value, $op);
     }
@@ -2070,6 +2074,27 @@ class CRM_Report_Form extends CRM_Core_Form {
     elseif (!empty($field['membership_type']) && $clause) {
       $clause = $this->whereMembershipTypeClause($value, $op);
     }
+    return $clause;
+  }
+
+  /**
+   * Get SQL where clause for contact subtypes
+   * @param string $field
+   * @param mixed $value
+   * @param string $op SQL Operator
+   *
+   * @return string
+   */
+  public function whereSubtypeClause($field, $value, $op) {
+    $clause = '( ';
+    $subtypeFilters = count($value);
+    for ($i = 0; $i < $subtypeFilters; $i++) {
+      $clause .= "{$field['dbAlias']} LIKE '%$value[$i]%'";
+      if ($i !== ($subtypeFilters - 1)) {
+        $clause .= " OR ";
+      }
+    }
+    $clause .= ' )';
     return $clause;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Issue is described at https://lab.civicrm.org/dev/core/issues/544

Before
----------------------------------------
Reports do not support filtering on multiple contact subtypes. Examples:

In the Contact Summary report, filtering on contact subtype 'is one of' 'Student' will bring up contacts with subtype 'Student', but not contacts with multiple subtypes including 'Student'.

Similarly, filtering on contact subtype 'is one of' 'Student', 'Volunteer' will bring up contacts with subtype 'Student', but not with multiple subtypes including 'Student', and not with the exact subtypes 'Student', 'Volunteer'.

After
----------------------------------------
Filtering on contact subtype 'is one of' with contacts that have multiple subtypes, or using multiple filters works as expected e.g. 'Student', 'Volunteer' will bring up contacts with subtypes 'Student', 'Volunteer', and 'StudentVolunteer' etc.

Technical Details
----------------------------------------
This is kind of a bandaid PR for this functionality rather than changing how it's stored. I've added whereSubtypeClause() to the report form and called it if we've got the contact_subtype field to get the desired results.