### PR TITLE
Add Financial Account permissions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1115,6 +1115,7 @@ class CRM_Core_Permission {
       ),
     );
     $permissions['line_item'] = $permissions['contribution'];
+    $permissions['financial_account'] = $permissions['contribution'];
 
     // Payment permissions
     $permissions['payment'] = array(


### PR DESCRIPTION
Overview
----------------------------------------
see related issue [Bookkeeping Transactions Report insufficient permissions
When](https://lab.civicrm.org/dev/core/issues/551)

Before
----------------------------------------
Users with contribution permissions can't visualize the Bookeeping Transactions Report

After
----------------------------------------
Users with contribution permissions can visualize the Bookeeping Transactions Report

Technical Details
----------------------------------------
This patch applies same permissions for Financial Account for the Contributions.

Comments
----------------------------------------
It should be checked that there are no security implications derived from adding permissions in this way.
