### PR TITLE
Only reset CiviCRM key instead of whole array in CRM_Core_Session::reset()

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -155,7 +155,7 @@ class CRM_Core_Session {
       unset($this->_session[$this->_key]);
     }
     else {
-      $this->_session = array();
+      $this->_session['CiviCRM'] = array();
     }
 
   }


### PR DESCRIPTION
Only reset CiviCRM key instead of whole $_SESSION array in CRM_Core_Session::reset()

Overview
----------------------------------------
When CiviCRM logs the current user out, it resets the whole contents of the $_SESSION superglobal array in CRM/Core/Session.php in the reset method. Here, I've just set it to reset the contents of the $_SESSION['CiviCRM'] array.

