### PR TITLE
Api3 profile:submit - fix handling of greeting fields

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -188,6 +188,14 @@ function civicrm_api3_profile_submit($params) {
     }
   }
 
+  // Add custom greeting fields
+  $greetingFields = ['email_greeting', 'postal_greeting', 'addressee'];
+  foreach ($greetingFields as $greetingField) {
+    if (isset($profileFields[$greetingField]) && !isset($profileFields["{$greetingField}_custom"])) {
+      $profileFields["{$greetingField}_custom"] = ['name' => "{$greetingField}_custom"];
+    }
+  }
+
   foreach ($profileFields as $fieldName => $field) {
     if (!isset($params[$fieldName])) {
       continue;

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -770,6 +770,39 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
   }
 
   /**
+   * Check handling a custom greeting.
+   */
+  public function testSubmitGreetingFields() {
+    $profileFieldValues = $this->_createIndividualContact();
+    $params = reset($profileFieldValues);
+    $contactId = key($profileFieldValues);
+    $params['profile_id'] = $this->_profileID;
+    $params['contact_id'] = $contactId;
+
+    $this->callAPISuccess('ufField', 'create', array(
+      'uf_group_id' => $this->_profileID,
+      'field_name' => 'email_greeting',
+      'visibility' => 'Public Pages and Listings',
+      'field_type' => 'Contact',
+      'label' => 'Email Greeting',
+    ));
+
+    $emailGreetings = array_column(civicrm_api3('OptionValue', 'get', ['option_group_id' => "email_greeting"])['values'], NULL, 'name');
+
+    $params['email_greeting'] = $emailGreetings['Customized']['value'];
+    // Custom greeting should be required
+    $this->callAPIFailure('profile', 'submit', $params);
+
+    $params['email_greeting_custom'] = 'Hello fool!';
+    $this->callAPISuccess('profile', 'submit', $params);
+
+    // Api3 will not return custom greeting field so resorting to this
+    $greeting = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'email_greeting_custom');
+
+    $this->assertEquals("Hello fool!", $greeting);
+  }
+
+  /**
    * Helper function to create an Individual with address/email/phone info. Import UF Group and UF Fields
    * @param array $params
    *


### PR DESCRIPTION
Overview
-------
Fixes a bug in the LayoutEditor extension where profile forms could not be submitted with a custom greeting selected.

Before
--------
1. Add e.g. Email Greeting field to a profile block.
2. Edit the block for a contact; choose custom greeting and enter one when the box appears.
3. Form gives an error instead of saving.

After
---
Saves correctly.
