### PR TITLE
Drupal#38 - allow creating absolute URLs from CLI in D8

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -300,11 +300,13 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   ) {
     $query = html_entity_decode($query);
 
+    $config = CRM_Core_Config::singleton();
+    $base = $absolute ? $config->userFrameworkBaseURL : 'base:';
     $url = \Drupal\civicrm\CivicrmHelper::parseURL("{$path}?{$query}");
 
     // Not all links that CiviCRM generates are Drupal routes, so we use the weaker ::fromUri method.
     try {
-      $url = \Drupal\Core\Url::fromUri("base:{$url['path']}", array(
+      $url = \Drupal\Core\Url::fromUri("{$base}{$url['path']}", array(
         'query' => $url['query'],
         'fragment' => $fragment,
         'absolute' => $absolute,


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Utils_System::url()` doesn't create absolute URLs in D8 when run from the CLI.

Before
----------------------------------------
Running `cv ev 'return CRM_Utils_System::url("civicrm", NULL, TRUE)'` returns:
`"http://:/civicrm"`

After
----------------------------------------
Running `cv ev 'return CRM_Utils_System::url("civicrm", NULL, TRUE)'` returns:
`"http://dmaster.localhost/civicrm"`

Technical Details
----------------------------------------
The current code passes the string `base:` to D8, which tells D8 to auto-detect the base URL.  However, this fails when run from the CLI because D8 relies on superglobals only set via web SAPIs.
