### PR TITLE
(dev/core#217) PrevNext - More conservative transition (5.7=>5.8=>5.9)

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -56,6 +56,7 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     'dedupe_default_limit' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'remote_profile_submissions' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'allow_alert_autodismissal' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    'prevNextBackend' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   );
 
   public $_uploadMaxSize;
@@ -77,6 +78,7 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
       'recentItemsMaxCount',
       'recentItemsProviders',
       'dedupe_default_limit',
+      'prevNextBackend',
     ));
   }
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4949,27 +4949,45 @@ civicrm_relationship.start_date > {$today}
   }
 
   /**
-   * Fetch a list of contacts from the prev/next cache for displaying a search results page
+   * Fetch a list of contacts for displaying a search results page
    *
-   * @param string $cacheKey
-   * @param int $offset
-   * @param int $rowCount
+   * @param array $cids
+   *   List of contact IDs
    * @param bool $includeContactIds
    * @return CRM_Core_DAO
    */
-  public function getCachedContacts($cacheKey, $offset, $rowCount, $includeContactIds) {
+  public function getCachedContacts($cids, $includeContactIds) {
+    CRM_Utils_Type::validateAll($cids, 'Positive');
     $this->_includeContactIds = $includeContactIds;
     $onlyDeleted = in_array(array('deleted_contacts', '=', '1', '0', '0'), $this->_params);
     list($select, $from, $where) = $this->query(FALSE, FALSE, FALSE, $onlyDeleted);
-    $from = " FROM civicrm_prevnext_cache pnc INNER JOIN civicrm_contact contact_a ON contact_a.id = pnc.entity_id1 AND pnc.cacheKey = '$cacheKey' " . substr($from, 31);
-    $order = " ORDER BY pnc.id";
-    $groupByCol = array('contact_a.id', 'pnc.id');
-    $select = self::appendAnyValueToSelect($this->_select, $groupByCol, 'GROUP_CONCAT');
-    $groupBy = " GROUP BY " . implode(', ', $groupByCol);
-    $limit = " LIMIT $offset, $rowCount";
+    $select .= sprintf(", (%s) AS _wgt", $this->createSqlCase('contact_a.id', $cids));
+    $where .= sprintf(' AND contact_a.id IN (%s)', implode(',', $cids));
+    $order = 'ORDER BY _wgt';
+    $groupBy = '';
+    $limit = '';
     $query = "$select $from $where $groupBy $order $limit";
 
     return CRM_Core_DAO::executeQuery($query);
+  }
+
+  /**
+   * Construct a SQL CASE expression.
+   *
+   * @param string $idCol
+   *   The name of a column with ID's (eg 'contact_a.id').
+   * @param array $cids
+   *   Array(int $weight => int $id).
+   * @return string
+   *   CASE WHEN id=123 THEN 1 WHEN id=456 THEN 2 END
+   */
+  private function createSqlCase($idCol, $cids) {
+    $buf = "CASE\n";
+    foreach ($cids as $weight => $cid) {
+      $buf .= " WHEN $idCol = $cid THEN $weight \n";
+    }
+    $buf .= "END\n";
+    return $buf;
   }
 
   /**

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -578,8 +578,11 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // and contain the search criteria (parameters)
     // note that the default action is basic
     if ($rowCount) {
+      /** @var CRM_Core_PrevNextCache_Interface $prevNext */
+      $prevNext = Civi::service('prevnext');
       $cacheKey = $this->buildPrevNextCache($sort);
-      $resultSet = $this->_query->getCachedContacts($cacheKey, $offset, $rowCount, $includeContactIds)->fetchGenerator();
+      $cids = $prevNext->fetch($cacheKey, $offset, $rowCount);
+      $resultSet = empty($cids) ? [] : $this->_query->getCachedContacts($cids, $includeContactIds)->fetchGenerator();
     }
     else {
       $resultSet = $this->_query->searchQuery($offset, $rowCount, $sort, FALSE, $includeContactIds)->fetchGenerator();

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -483,4 +483,18 @@ AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
     }
   }
 
+  /**
+   * Get a list of available backend services.
+   *
+   * @return array
+   *   Array(string $id => string $label).
+   */
+  public static function getPrevNextBackends() {
+    return [
+      'default' => ts('Default (Auto-detect)'),
+      'sql' => ts('SQL'),
+      'redis' => ts('Redis'),
+    ];
+  }
+
 }

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -114,4 +114,15 @@ interface CRM_Core_PrevNextCache_Interface {
    */
   public function getCount($cacheKey);
 
+  /**
+   * Fetch a list of contacts from the prev/next cache for displaying a search results page
+   *
+   * @param string $cacheKey
+   * @param int $offset
+   * @param int $rowCount
+   * @return array
+   *   List of contact IDs (entity_id1).
+   */
+  public function fetch($cacheKey, $offset, $rowCount);
+
 }

--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -1,0 +1,256 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Core_PrevNextCache_Memory
+ *
+ * Store the previous/next cache in a Redis set.
+ *
+ * Each logical prev-next cache corresponds to three distinct items in Redis:
+ *   - "{prefix}/{qfKey}/list" - Sorted set of `entity_id`, with all entities
+ *   - "{prefix}/{qfkey}/sel" - Sorted set of `entity_id`, with only entities marked by user
+ *   - "{prefix}/{qfkey}/data" - Hash mapping from `entity_id` to `data`
+ *
+ * @link https://github.com/phpredis/phpredis
+ */
+class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
+
+  const TTL = 21600;
+
+  /**
+   * @var Redis
+   */
+  protected $redis;
+
+  /**
+   * @var string
+   */
+  protected $prefix;
+
+  /**
+   * CRM_Core_PrevNextCache_Redis constructor.
+   * @param array $settings
+   */
+  public function __construct($settings) {
+    $this->redis = CRM_Utils_Cache_Redis::connect($settings);
+    $this->prefix = isset($settings['prefix']) ? $settings['prefix'] : '';
+    $this->prefix .= \CRM_Utils_Cache::DELIMITER . 'prevnext' . \CRM_Utils_Cache::DELIMITER;
+  }
+
+  public function fillWithSql($cacheKey, $sql) {
+    $dao = CRM_Core_DAO::executeQuery($sql, [], FALSE, NULL, FALSE, TRUE, TRUE);
+    if (is_a($dao, 'DB_Error')) {
+      throw new CRM_Core_Exception($dao->message);
+    }
+
+    list($allKey, $dataKey, , $maxScore) = $this->initCacheKey($cacheKey);
+
+    while ($dao->fetch()) {
+      list (, $entity_id, $data) = array_values($dao->toArray());
+      $maxScore++;
+      $this->redis->zAdd($allKey, $maxScore, $entity_id);
+      $this->redis->hSet($dataKey, $entity_id, $data);
+    }
+
+    $dao->free();
+    return TRUE;
+  }
+
+  public function fillWithArray($cacheKey, $rows) {
+    list($allKey, $dataKey, , $maxScore) = $this->initCacheKey($cacheKey);
+
+    foreach ($rows as $row) {
+      $maxScore++;
+      $this->redis->zAdd($allKey, $maxScore, $row['entity_id1']);
+      $this->redis->hSet($dataKey, $row['entity_id1'], $row['data']);
+    }
+
+    return TRUE;
+  }
+
+  public function fetch($cacheKey, $offset, $rowCount) {
+    $allKey = $this->key($cacheKey, 'all');
+    return $this->redis->zRange($allKey, $offset, $offset + $rowCount - 1);
+  }
+
+  public function markSelection($cacheKey, $action, $ids = NULL) {
+    $allKey = $this->key($cacheKey, 'all');
+    $selKey = $this->key($cacheKey, 'sel');
+
+    if ($action === 'select') {
+      foreach ((array) $ids as $id) {
+        $score = $this->redis->zScore($allKey, $id);
+        $this->redis->zAdd($selKey, $score, $id);
+      }
+    }
+    elseif ($action === 'unselect' && $ids === NULL) {
+      $this->redis->delete($selKey);
+      $this->redis->setTimeout($selKey, self::TTL);
+    }
+    elseif ($action === 'unselect' && $ids !== NULL) {
+      foreach ((array) $ids as $id) {
+        $this->redis->zDelete($selKey, $id);
+      }
+    }
+  }
+
+  public function getSelection($cacheKey, $action = 'get') {
+    $allKey = $this->key($cacheKey, 'all');
+    $selKey = $this->key($cacheKey, 'sel');
+
+    if ($action === 'get') {
+      $result = [];
+      foreach ($this->redis->zRange($selKey, 0, -1) as $entity_id) {
+        $result[$entity_id] = 1;
+      }
+      return [$cacheKey => $result];
+    }
+    elseif ($action === 'getall') {
+      $result = [];
+      foreach ($this->redis->zRange($allKey, 0, -1) as $entity_id) {
+        $result[$entity_id] = 1;
+      }
+      return [$cacheKey => $result];
+    }
+    else {
+      throw new \CRM_Core_Exception("Unrecognized action: $action");
+    }
+  }
+
+  public function getPositions($cacheKey, $id1) {
+    $allKey = $this->key($cacheKey, 'all');
+    $dataKey = $this->key($cacheKey, 'data');
+
+    $rank = $this->redis->zRank($allKey, $id1);
+    if (!is_int($rank) || $rank < 0) {
+      return ['foundEntry' => 0];
+    }
+
+    $pos = ['foundEntry' => 1];
+
+    if ($rank > 0) {
+      $pos['prev'] = [];
+      foreach ($this->redis->zRange($allKey, $rank - 1, $rank - 1) as $value) {
+        $pos['prev']['id1'] = $value;
+      }
+      $pos['prev']['data'] = $this->redis->hGet($dataKey, $pos['prev']['id1']);
+    }
+
+    $count = $this->getCount($cacheKey);
+    if ($count > $rank + 1) {
+      $pos['next'] = [];
+      foreach ($this->redis->zRange($allKey, $rank + 1, $rank + 1) as $value) {
+        $pos['next']['id1'] = $value;
+      }
+      $pos['next']['data'] = $this->redis->hGet($dataKey, $pos['next']['id1']);
+    }
+
+    return $pos;
+  }
+
+  public function deleteItem($id = NULL, $cacheKey = NULL) {
+    if ($id === NULL && $cacheKey !== NULL) {
+      // Delete by cacheKey.
+      $allKey = $this->key($cacheKey, 'all');
+      $selKey = $this->key($cacheKey, 'sel');
+      $dataKey = $this->key($cacheKey, 'data');
+      $this->redis->delete($allKey, $selKey, $dataKey);
+    }
+    elseif ($id === NULL && $cacheKey === NULL) {
+      // Delete everything.
+      $keys = $this->redis->keys($this->prefix . '*');
+      $this->redis->del($keys);
+    }
+    elseif ($id !== NULL && $cacheKey !== NULL) {
+      // Delete a specific contact, within a specific cache.
+      $this->redis->zDelete($this->key($cacheKey, 'all'), $id);
+      $this->redis->zDelete($this->key($cacheKey, 'sel'), $id);
+      $this->redis->hDel($this->key($cacheKey, 'data'), $id);
+    }
+    elseif ($id !== NULL && $cacheKey === NULL) {
+      // Delete a specific contact, across all prevnext caches.
+      $allKeys = $this->redis->keys($this->key('*', 'all'));
+      foreach ($allKeys as $allKey) {
+        $parts = explode(\CRM_Utils_Cache::DELIMITER, $allKey);
+        array_pop($parts);
+        $tmpCacheKey = array_pop($parts);
+        $this->deleteItem($id, $tmpCacheKey);
+      }
+    }
+    else {
+      throw new CRM_Core_Exception("Not implemented: Redis::deleteItem");
+    }
+  }
+
+  public function getCount($cacheKey) {
+    $allKey = $this->key($cacheKey, 'all');
+    return $this->redis->zSize($allKey);
+  }
+
+  /**
+   * Construct the full path to a cache item.
+   *
+   * @param string $cacheKey
+   *   Identifier for this saved search.
+   *   Ex: 'abcd1234abcd1234'.
+   * @param string $item
+   *   Ex: 'list', 'rel', 'data'.
+   * @return string
+   *   Ex: 'dmaster/prevnext/abcd1234abcd1234/list'
+   */
+  private function key($cacheKey, $item) {
+    return $this->prefix . $cacheKey . \CRM_Utils_Cache::DELIMITER . $item;
+  }
+
+  /**
+   * Initialize any data-structures or timeouts for the cache-key.
+   *
+   * This is non-destructive -- if data already exists, it's preserved.
+   *
+   * @return array
+   *   0 => string $allItemsCacheKey,
+   *   1 => string $dataItemsCacheKey,
+   *   2 => string $selectedItemsCacheKey,
+   *   3 => int $maxExistingScore
+   */
+  private function initCacheKey($cacheKey) {
+    $allKey = $this->key($cacheKey, 'all');
+    $selKey = $this->key($cacheKey, 'sel');
+    $dataKey = $this->key($cacheKey, 'data');
+
+    $this->redis->setTimeout($allKey, self::TTL);
+    $this->redis->setTimeout($dataKey, self::TTL);
+    $this->redis->setTimeout($selKey, self::TTL);
+
+    $maxScore = 0;
+    foreach ($this->redis->zRange($allKey, -1, -1, TRUE) as $lastElem => $lastScore) {
+      $maxScore = $lastScore;
+    }
+    return array($allKey, $dataKey, $selKey, $maxScore);
+  }
+
+}

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -244,4 +244,27 @@ ORDER BY id
     return (int) CRM_Core_DAO::singleValueQuery($query, $params, TRUE, FALSE);
   }
 
+  /**
+   * Fetch a list of contacts from the prev/next cache for displaying a search results page
+   *
+   * @param string $cacheKey
+   * @param int $offset
+   * @param int $rowCount
+   * @return array
+   *   List of contact IDs.
+   */
+  public function fetch($cacheKey, $offset, $rowCount) {
+    $cids = array();
+    $dao = CRM_Utils_SQL_Select::from('civicrm_prevnext_cache pnc')
+      ->where('pnc.cacheKey = @cacheKey', ['cacheKey' => $cacheKey])
+      ->select('pnc.entity_id1 as cid')
+      ->orderBy('pnc.id')
+      ->limit($rowCount, $offset)
+      ->execute();
+    while ($dao->fetch()) {
+      $cids[] = $dao->cid;
+    }
+    return $cids;
+  }
+
 }

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -78,19 +78,19 @@ INSERT INTO civicrm_prevnext_cache (cacheKey, entity_id1, data)
    * @param string $cacheKey
    * @param string $action
    *   Ex: 'select', 'unselect'.
-   * @param array|int|NULL $cIds
+   * @param array|int|NULL $ids
    *   A list of contact IDs to (un)select.
    *   To unselect all contact IDs, use NULL.
    */
-  public function markSelection($cacheKey, $action, $cIds = NULL) {
+  public function markSelection($cacheKey, $action, $ids = NULL) {
     if (!$cacheKey) {
       return;
     }
     $params = array();
 
-    if ($cIds && $cacheKey && $action) {
-      if (is_array($cIds)) {
-        $cIdFilter = "(" . implode(',', $cIds) . ")";
+    if ($ids && $cacheKey && $action) {
+      if (is_array($ids)) {
+        $cIdFilter = "(" . implode(',', $ids) . ")";
         $whereClause = "
 WHERE cacheKey = %1
 AND (entity_id1 IN {$cIdFilter} OR entity_id2 IN {$cIdFilter})
@@ -101,7 +101,7 @@ AND (entity_id1 IN {$cIdFilter} OR entity_id2 IN {$cIdFilter})
 WHERE cacheKey = %1
 AND (entity_id1 = %2 OR entity_id2 = %2)
 ";
-        $params[2] = array("{$cIds}", 'Integer');
+        $params[2] = array("{$ids}", 'Integer');
       }
       if ($action == 'select') {
         $whereClause .= "AND is_selected = 0";
@@ -115,7 +115,7 @@ AND (entity_id1 = %2 OR entity_id2 = %2)
       }
       // default action is reseting
     }
-    elseif (!$cIds && $cacheKey && $action == 'unselect') {
+    elseif (!$ids && $cacheKey && $action == 'unselect') {
       $sql = "
 UPDATE civicrm_prevnext_cache
 SET    is_selected = 0

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -230,6 +230,14 @@ class Container {
       []
     ));
 
+    $container->setDefinition('prevnext.driver.redis', new Definition(
+      'CRM_Core_PrevNextCache_Redis',
+      [new Reference('cache_config')]
+    ));
+
+    $container->setDefinition('cache_config', new Definition('ArrayObject'))
+      ->setFactory(array(new Reference(self::SELF), 'createCacheConfig'));
+
     $container->setDefinition('civi.mailing.triggers', new Definition(
       'Civi\Core\SqlTrigger\TimestampTriggers',
       array('civicrm_mailing', 'Mailing')
@@ -438,6 +446,13 @@ class Container {
     return $container->has($service)
       ? $container->get($service)
       : $container->get('prevnext.driver.sql');
+  }
+
+  public static function createCacheConfig() {
+    $driver = \CRM_Utils_Cache::getCacheDriver();
+    $settings = \CRM_Utils_Cache::getCacheSettings($driver);
+    $settings['driver'] = $driver;
+    return new \ArrayObject($settings);
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -441,11 +441,17 @@ class Container {
    * @return \CRM_Core_PrevNextCache_Interface
    */
   public static function createPrevNextCache($container) {
-    $cacheDriver = \CRM_Utils_Cache::getCacheDriver();
-    $service = 'prevnext.driver.' . strtolower($cacheDriver);
-    return $container->has($service)
-      ? $container->get($service)
-      : $container->get('prevnext.driver.sql');
+    $setting = \Civi::settings()->get('prevNextBackend');
+    if ($setting === 'default') {
+      $cacheDriver = \CRM_Utils_Cache::getCacheDriver();
+      $service = 'prevnext.driver.' . strtolower($cacheDriver);
+      return $container->has($service)
+        ? $container->get($service)
+        : $container->get('prevnext.driver.sql');
+    }
+    else {
+      return $container->get('prevnext.driver.' . $setting);
+    }
   }
 
   public static function createCacheConfig() {

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -443,9 +443,11 @@ class Container {
   public static function createPrevNextCache($container) {
     $setting = \Civi::settings()->get('prevNextBackend');
     if ($setting === 'default') {
+      // For initial release (5.8.x), continue defaulting to SQL.
+      $isTransitional = version_compare(\CRM_Utils_System::version(), '5.9.alpha1', '<');
       $cacheDriver = \CRM_Utils_Cache::getCacheDriver();
       $service = 'prevnext.driver.' . strtolower($cacheDriver);
-      return $container->has($service)
+      return $container->has($service) && !$isTransitional
         ? $container->get($service)
         : $container->get('prevnext.driver.sql');
     }

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -197,6 +197,27 @@ return array(
     'description' => 'If set, this will be the default profile used for contact search.',
     'help_text' => NULL,
   ),
+  'prevNextBackend' => array(
+    'group_name' => 'Search Preferences',
+    'group' => 'Search Preferences',
+    'name' => 'prevNextBackend',
+    'type' => 'String',
+    'quick_form_type' => 'Select',
+    'html_type' => 'Select',
+    'html_attributes' => array(
+      //'class' => 'crm-select2',
+    ),
+    'default' => 'default',
+    'add' => '5.6',
+    'title' => 'PrevNext Cache',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'pseudoconstant' => array(
+      'callback' => 'CRM_Core_BAO_PrevNextCache::getPrevNextBackends',
+    ),
+    'description' => 'When performing a search, how should the search-results be cached?',
+    'help_text' => '',
+  ),
   'searchPrimaryDetailsOnly' => array(
     'group_name' => 'Search Preferences',
     'group' => 'Search Preferences',

--- a/tests/phpunit/E2E/Core/PrevNextTest.php
+++ b/tests/phpunit/E2E/Core/PrevNextTest.php
@@ -93,6 +93,19 @@ class PrevNextTest extends \CiviEndToEndTestCase {
     $this->assertSelections([]);
   }
 
+  public function testFetch() {
+    $this->testFillArray();
+
+    $cids = $this->prevNext->fetch($this->cacheKey, 0, 2);
+    $this->assertEquals([100, 400], $cids);
+
+    $cids = $this->prevNext->fetch($this->cacheKey, 0, 4);
+    $this->assertEquals([100, 400, 200, 300], $cids);
+
+    $cids = $this->prevNext->fetch($this->cacheKey, 2, 2);
+    $this->assertEquals([200, 300], $cids);
+  }
+
   public function getFillFunctions() {
     return [
       ['testFillSql'],


### PR DESCRIPTION
Overview
-------------
This revision sets up more conservative transition process for adopting new PrevNext drivers.

Before
------

* 5.7.x - Hard-coded to SQL driver.
* 5.8.x - Allow admin use a setting to pick a driver. If left as `default`, then auto-detect best-available (based on configured services).

After
------

* 5.7.x - Hard-coded to SQL driver.
* 5.8.x - Allow admin use a setting to pick a driver. If left as `default`, then use SQL driver.
* 5.9.x - Allow admin use a setting to pick a driver. If left as `default`, then auto-detect best-available (based on configured services).

This essentially mitigates the risk that bugs in the new Redis driver cause regreessions for sites already running Redis.

Comments
---------------

This extends/depends on #12665. The new change here is only one commit - the last one, 318583d.

An alternative way to achieve the same goal (*more conservative transition*) would be to default to SQL under all circumstances -- and (if Redis is available, then...) show a status message suggesting that the admin change the settings. OTOH, 6 months from now, we'll probably be happier to just have it auto-detect the best driver. I'm OK to close and do a different PR if folks really want that process instead, but either approach seems fair enough IMHO.