### PR TITLE
Drupal#9 - Make CKeditor location less hard-coded

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -735,7 +735,7 @@ class CRM_Core_Resources {
       CRM_Admin_Page_CKEditorConfig::setConfigDefault();
       $items[] = array(
         'config' => array(
-          'wysisygScriptLocation' => Civi::paths()->getUrl("[civicrm.root]/js/wysiwyg/crm.ckeditor.js"),
+          'wysisygScriptLocation' => $config->userFrameworkResourceURL . "/js/wysiwyg/crm.ckeditor.js",
           'CKEditorCustomConfig' => CRM_Admin_Page_CKEditorConfig::getConfigUrl(),
         ),
       );


### PR DESCRIPTION
Overview
----------------------------------------
Currently, the "wysisygScriptLocation" [sic] is hardcoded relative to the `[civicrm.root]` URL.  This uses the `userFrameworkResourceURL`.  This is a) more correct, b) necessary when using D8 with your assets in the webroot but your civiroot outside the webroot (as in [Drupal#9](https://lab.civicrm.org/dev/drupal/issues/9).  This is a patch @dsnopek wrote and referenced on that issue, I'm just submitting it upstream.

Before
----------------------------------------
CKEditor doesn't load when your civiroot is outside the webroot.

After
----------------------------------------
CKEditor can load from a user-defined location.