### PR TITLE
(dev/core#217) Search.setting.php - Fix mismatched metadata

### DIFF
--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -208,7 +208,7 @@ return array(
       //'class' => 'crm-select2',
     ),
     'default' => 'default',
-    'add' => '5.6',
+    'add' => '5.9',
     'title' => 'PrevNext Cache',
     'is_domain' => 1,
     'is_contact' => 0,


### PR DESCRIPTION
Overview
----------------------------------------
The setting `prevNextBackend` was introduced in PR #12665.  The PR was originally written for an earlier version (circa 5.6) and eventually merged in a later version (circa 5.9). The metadata should match the version-number of the actual release.

Before
----------------------------------------
* Specification for `prevNextBackend`  says it was added in 5.6, which is wrong.

After
----------------------------------------
* Specification for `prevNextBackend`  says it was added in 5.9, which is right.
