### PR TITLE
dev/core/482 standardize contact edit form delete block behavior

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Website.tpl
+++ b/templates/CRM/Contact/Form/Edit/Website.tpl
@@ -41,7 +41,9 @@
 <tr id="Website_Block_{$blockId}">
     <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
     <td>{$form.website.$blockId.website_type_id.html}</td>
-    <td colspan="3"><a href="#" title="{ts}Delete Website Block{/ts}" onClick="removeBlock('Website','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
+    {if $blockId gt 1}
+      <td colspan="3"><a href="#" title="{ts}Delete Website Block{/ts}" onClick="removeBlock('Website','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
+    {/if}
 </tr>
 {if !$addBlock}
 <tr>
@@ -50,4 +52,3 @@
 </td>
 </tr>
 {/if}
-

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -50,7 +50,9 @@
     <tr id="Website_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
       <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
       <td>{$form.website.$blockId.website_type_id.html}</td>
-      <td><a class="crm-delete-inline crm-hover-button action-item" href="#" title="{ts}Delete Website{/ts}"><span class="icon delete-icon"></span></a></td>
+      {if $blockId gt 1}
+        <td><a class="crm-delete-inline crm-hover-button action-item" href="#" title="{ts}Delete Website{/ts}"><span class="icon delete-icon"></span></a></td>
+      {/if}
     </tr>
     {/section}
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
When adding a new contact via the "New Individual", "New Organization" etc forms, or editing a contact, the website blocks allow a user to delete a block even if it's the only one left. Afterwards, the user is not able to re-create a website block. This is non-standard for this form i.e. Phone Number, Email, IM do not let a user delete a block if it's the only one left.

Relevant issue: https://lab.civicrm.org/dev/core/issues/482

Before
----------------------------------------
Users can delete the last website block, breaking their ability to add a website.
![image](https://user-images.githubusercontent.com/12917373/49190106-d2285c00-f325-11e8-8642-71adb8258dbc.png)

After
----------------------------------------
Users are not given the option to delete the last website block, which is the standard behavior for this form.
![image](https://user-images.githubusercontent.com/12917373/49190088-bcb33200-f325-11e8-83d3-2d4a9689cd25.png)

Technical Details
----------------------------------------
The js to create a new block relies on an existing block of that type to copy. If statement added is present in the templates for phone, IM, email blocks but was missing in the website block template.
