### PR TITLE
dev/core/485 Website type should be required as other type values are

### DIFF
--- a/CRM/Contact/Form/Edit/Website.php
+++ b/CRM/Contact/Form/Edit/Website.php
@@ -55,7 +55,7 @@ class CRM_Contact_Form_Edit_Website {
     $form->applyFilter('__ALL__', 'trim');
 
     //Website type select
-    $form->addField("website[$blockId][website_type_id]", array('entity' => 'website', 'class' => 'eight'));
+    $form->addField("website[$blockId][website_type_id]", array('entity' => 'website', 'class' => 'eight', 'placeholder' => NULL));
 
     //Website box
     $form->addField("website[$blockId][url]", array('entity' => 'website', 'aria-label' => ts('Website URL %1', [1 => $blockId])));


### PR DESCRIPTION
Overview
----------------------------------------
Strange behavior possible as described in https://lab.civicrm.org/dev/core/issues/485.

A user could save a website record without a 'website type' (applies to any contact type, not just organization as in the ticket). Storing this value without a type, which should be required, causes data to be seemingly mysteriously deleted.

Before
----------------------------------------
User is able to click the (x) and save a website record with no type
![image](https://user-images.githubusercontent.com/12917373/49192916-086bd880-f332-11e8-9412-f9418eab12c9.png)

After
----------------------------------------
User can no longer click an (x) and must instead choose a website type, even if they create their own option value labelled "none", they must choose a type.
![image](https://user-images.githubusercontent.com/12917373/49192965-34875980-f332-11e8-8516-d0e3a725d413.png)

Technical Details
----------------------------------------
Adding the 'placeholder' => NULL option here is what looks standard when looking at the code for IM, Phone, Email, etc. They all require a type to be saved, so website should, too... or we'll run into trouble.
