### PR TITLE
Trigger change event for financial type select list when page loads.

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -350,6 +350,8 @@
   {literal}
   <script type="text/javascript">
     CRM.$(function($) {
+      // trigger change event on financial type select list.
+      $('#financial_type_id').trigger('change');
     {/literal}
       {if $buildPriceSet}{literal}buildAmount();{/literal}{/if}
     {literal}


### PR DESCRIPTION
Overview
----------------------------------------
When there is a custom field set that is configured to appear only for a financial type (eg. Expenses, Donation, etc) then after trying to save a contribution where you didn't fill these required custom fields, the custom field set will disappear.

Reason for the issue:
----------------------------------------
This was happening because the custom field sets are fetched dynamically on "onchange" event on financial type select list. When the validation errors occured, the page reloaded and didn't fetch the custom field sets again because the "onchange" event didnot occur on select list.

Solution:
----------------------------------------
Trigger "change" event when the page loads which runs the code that fetches custom field sets as per the option chosen in financial type select list even in case of validation errors.
