### PR TITLE
Fix links for tabs on manage event

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -45,6 +45,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
    */
   public function preProcess() {
     parent::preProcess();
+    $this->assign('selectedChild', 'settings');
 
     if ($this->_id) {
       $this->assign('entityID', $this->_id);

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -60,6 +60,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
    */
   public function preProcess() {
     parent::preProcess();
+    $this->assign('selectedChild', 'fee');
   }
 
   /**

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -72,6 +72,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
    */
   public function preProcess() {
     parent::preProcess();
+    $this->assign('selectedChild', 'location');
 
     $this->_values = $this->get('values');
     if ($this->_id && empty($this->_values)) {

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -55,6 +55,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $this->_profileBottomNumAdd = CRM_Utils_Array::value('addProfileNumAdd', $_GET, 0);
 
     parent::preProcess();
+    $this->assign('selectedChild', 'registration');
 
     $this->assign('addProfileBottom', $this->_addProfileBottom);
     $this->assign('profileBottomNum', $this->_profileBottomNum);

--- a/CRM/Event/Form/ManageEvent/Repeat.php
+++ b/CRM/Event/Form/ManageEvent/Repeat.php
@@ -25,6 +25,7 @@ class CRM_Event_Form_ManageEvent_Repeat extends CRM_Event_Form_ManageEvent {
 
   public function preProcess() {
     parent::preProcess();
+    $this->assign('selectedChild', 'repeat');
     $this->assign('currentEventId', $this->_id);
 
     $checkParentExistsForThisId = CRM_Core_BAO_RecurringEntity::getParentFor($this->_id, 'civicrm_event');

--- a/CRM/Event/Form/ManageEvent/ScheduleReminders.php
+++ b/CRM/Event/Form/ManageEvent/ScheduleReminders.php
@@ -47,6 +47,7 @@ class CRM_Event_Form_ManageEvent_ScheduleReminders extends CRM_Event_Form_Manage
    */
   public function preProcess() {
     parent::preProcess();
+    $this->assign('selectedChild', 'reminder');
     $setTab = CRM_Utils_Request::retrieve('setTab', 'Int', $this, FALSE, 0);
 
     $mapping = CRM_Utils_Array::first(CRM_Core_BAO_ActionSchedule::getMappings(array(

--- a/CRM/Friend/Form/Event.php
+++ b/CRM/Friend/Form/Event.php
@@ -48,6 +48,7 @@ class CRM_Friend_Form_Event extends CRM_Event_Form_ManageEvent {
 
   public function preProcess() {
     parent::preProcess();
+    $this->assign('selectedChild', 'friend');
   }
 
   /**

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -49,6 +49,7 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
 
   public function preProcess() {
     parent::preProcess();
+    $this->assign('selectedChild', 'pcp');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/12747#discussion_r236948035

Before
----------------------------------------
Links to manage event tabs broken following work on "selected tab" functionality.

After
----------------------------------------
Links to manage event tabs working.

Technical Details
----------------------------------------
Events are "unique" in that each tab has it's own full URL, whereas all other "tabheader" pages in CiviCRM use a single link and a "selectedChild" parameter to specify which tab to load.

Comments
----------------------------------------
@jitendrapurohit Please review.
