### PR TITLE
Prevent viewport jump when toggling help on "Administer CiviCRM" screen

### DIFF
--- a/CRM/Core/ShowHideBlocks.php
+++ b/CRM/Core/ShowHideBlocks.php
@@ -178,8 +178,8 @@ class CRM_Core_ShowHideBlocks {
    * @return array
    */
   public static function links(&$form, $prefix, $showLinkText, $hideLinkText, $assign = TRUE) {
-    $showCode = "cj('#id_{$prefix}').show(); cj('#id_{$prefix}_show').hide();";
-    $hideCode = "cj('#id_{$prefix}').hide(); cj('#id_{$prefix}_show').show(); return false;";
+    $showCode = "if(event.preventDefault) event.preventDefault(); else event.returnValue = false; cj('#id_{$prefix}').show(); cj('#id_{$prefix}_show').hide();";
+    $hideCode = "if(event.preventDefault) event.preventDefault(); else event.returnValue = false; cj('#id_{$prefix}').hide(); cj('#id_{$prefix}_show').show();";
 
     self::setIcons();
     $values = array();


### PR DESCRIPTION
Overview
----------------------------------------
Prevents the page jumping to the anchor when clicking the discovery tab on an item on the "Administer CiviCRM" screen. Fixes https://lab.civicrm.org/dev/core/issues/557

Before
----------------------------------------
The page jumps to the anchor when clicking a discovery tab.

After
----------------------------------------
Prevents the page jumping to the anchor when clicking a discovery tab.