### PR TITLE
Displayvalue fixes

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1217,7 +1217,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       case 'Multi-Select State/Province':
       case 'Multi-Select Country':
         if ($field['data_type'] == 'ContactReference' && $value) {
-          $display = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $value, 'display_name');
+          if (is_numeric($value)) {
+            $display = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $value, 'display_name');
+          }
+          else {
+            $display = $value;
+          }
         }
         elseif (is_array($value)) {
           $v = array();

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -179,6 +179,26 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $this->customGroupDelete($customGroup['id']);
   }
 
+  public function testGetDisplayedValuesContactRef() {
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $params = [
+      'data_type' => 'ContactReference',
+      'html_type' => 'Autocomplete-Select',
+      'label' => 'test ref',
+      'custom_group_id' => $customGroup['id'],
+    ];
+    $createdField = $this->callAPISuccess('customField', 'create', $params);
+    $contact1 = $this->individualCreate();
+    $contact2 = $this->individualCreate(['custom_' . $createdField['id'] => $contact1['id']]);
+
+    $this->assertEquals($contact1['display_name'], CRM_Core_BAO_CustomField::displayValue($contact2['id'], $createdField['id']));
+    $this->assertEquals("Bob", CRM_Core_BAO_CustomField::displayValue("Bob", $createdField['id']));
+
+    $this->contactDelete($contact2['id']);
+    $this->contactDelete($contact1['id']);
+    $this->customGroupDelete($customGroup['id']);
+  }
+
   public function testDeleteCustomField() {
     $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
     $fields = array(


### PR DESCRIPTION
Overview
----------------------------------------
A small bugfix for `CRM_Core_BAO_CustomField::displayValue()` for contact refs extracted from PR #12012 

Custom values are passed to this function for formatting.  Contact refs are handled differently by the API and return the display name instead of the contact id.

Test added.

No user changes.

Before
----------------------------------------
If the display name string is passed to this function, it fails since it is expecting an id.

After
----------------------------------------
If the display name string (any string) is passed to this function, the string is returned unchanged.
