### PR TITLE
Flatten fix

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -125,6 +125,8 @@ class CRM_Dedupe_Finder {
     if (!$params) {
       return array();
     }
+    // This may no longer be required - see https://github.com/civicrm/civicrm-core/pull/13176
+    $params = array_filter($params);
 
     $foundByID = FALSE;
     if ($ruleGroupID) {

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -238,9 +238,7 @@ class CRM_Utils_Array {
         self::flatten($value, $flat, $newPrefix, $seperator);
       }
       else {
-        if (!empty($value)) {
-          $flat[$newPrefix] = $value;
-        }
+        $flat[$newPrefix] = $value;
       }
     }
   }

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -328,4 +328,43 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     $this->assertEquals($expected, $source);
   }
 
+  /**
+   * Test the flatten function
+   */
+  public function testFlatten() {
+    $data = [
+      'my_array' => [
+        '0' => 'bar',
+        '1' => 'baz',
+        '2' => 'boz',
+      ],
+      'my_complex' => [
+         'dog' => 'woof',
+         'asdf' => [
+           'my_zero' => 0,
+           'my_int' => 1,
+           'my_null' => NULL,
+           'my_empty' => '',
+         ],
+      ],
+      'my_simple' => 999,
+    ];
+
+    $expected = [
+      'my_array.0' => 'bar',
+      'my_array.1' => 'baz',
+      'my_array.2' => 'boz',
+      'my_complex.dog' => 'woof',
+      'my_complex.asdf.my_zero' => 0,
+      'my_complex.asdf.my_int' => 1,
+      'my_complex.asdf.my_null' => NULL,
+      'my_complex.asdf.my_empty' => '',
+      'my_simple' => 999,
+    ];
+
+    $flat = [];
+    CRM_Utils_Array::flatten($data, $flat);
+    $this->assertEquals($flat, $expected);
+  }
+
 }

--- a/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
@@ -156,6 +156,7 @@ class WhitelistSubscriberTest extends \CiviUnitTestCase {
           'id' => 2,
           'title' => 'second widget',
           'api.Sprocket.get' => array(
+            'is_error' => 0,
             'count' => 2,
             'version' => 3,
             'values' => array(


### PR DESCRIPTION
Overview
----------------------------------------
Bug fix for `CRM_Utils_Array::flatten()` extracted from #12012  Flatten should restructure the array and return all original keys, not filter based on value.

Includes a test

Before
----------------------------------------
Keys with empty values are not in the flattened array

After
----------------------------------------
Keys with empty values are included in the flattened array

Comments
----------------------------------------
There are only a few uses of this function in the codebase.  So far as I can see, none of them assume empty values will be filtered out.
