### PR TITLE
dev/core#552 Fix missaving of net_amount

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -115,13 +115,6 @@ class CRM_Contribute_Form_AdditionalInfo {
       $feeAmount->freeze();
     }
 
-    $netAmount = &$form->add('text', 'net_amount', ts('Net Amount'),
-      $attributes['net_amount']
-    );
-    $form->addRule('net_amount', ts('Please enter a valid monetary value for Net Amount.'), 'money');
-    if ($form->_online) {
-      $netAmount->freeze();
-    }
     $element = &$form->add('text', 'invoice_id', ts('Invoice ID'),
       $attributes['invoice_id']
     );
@@ -285,7 +278,6 @@ class CRM_Contribute_Form_AdditionalInfo {
       'non_deductible_amount',
       'total_amount',
       'fee_amount',
-      'net_amount',
       'trxn_id',
       'invoice_id',
       'creditnote_id',


### PR DESCRIPTION
Overview
----------------------------------------
Fix failure to update net_amount when editing other amounts on back office contribution form

Before
----------------------------------------
Go to a contact summary
Contributions > Record Contribution
Choose a financial type
Enter amount as 100
Save
View the Contribution just created and note Total amount = $100, Fee amount $0, Net amount $100 -> Correct
Now edit the contribution
Expand Additional Details section
Enter Fee Amount as 1.23
Save
View the Contribution just created a note Total amount = $100, Fee amount $1.23, Net amount $100 -> Total and Fee amounts are correct, but the Net amount is not recalculated.

After
----------------------------------------
Net amount correctly recalculated

Technical Details
----------------------------------------
dev/core#552 it seems net_amount was removed incompletely
from the additional info form - causing it to block updating of the value when it should have been updated

Comments
----------------------------------------
5.6 regression
