### PR TITLE
(dev/core#559) Declare crmUi's dependency on ui.utils.

### DIFF
--- a/ang/crmUi.ang.php
+++ b/ang/crmUi.ang.php
@@ -7,5 +7,8 @@ return array(
   'ext' => 'civicrm',
   'js' => array('ang/crmUi.js'),
   'partials' => array('ang/crmUi'),
-  'requires' => array('crmResource'),
+  'requires' => array(
+    'crmResource',
+    'ui.utils',
+  ),
 );


### PR DESCRIPTION
Overview
----------------------------------------
This pull request declares `crmUi`'s dependency on `ui.utils`.

Before
----------------------------------------
`crmUiTabSet` directive doesn't work in apps on a custom AngularJS base page unless developer figures out and includes its dependencies.

After
----------------------------------------
Developer's custom module declares `crmUi` as a dependency and can use the `crmUiTabSet` directive.

Comments
----------------------------------------
See [issue tracker](https://lab.civicrm.org/dev/core/issues/559) for more information.
