### PR TITLE
Set default financial_type_id for creating new payment processors (form & api)

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -327,6 +327,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       if ($this->_paymentProcessorType) {
         $defaults['payment_processor_type_id'] = $this->_paymentProcessorType;
       }
+      $defaults['financial_account_id'] = CRM_Financial_BAO_PaymentProcessor::getDefaultFinancialAccountID();
       return $defaults;
     }
     $domainID = CRM_Core_Config::domainID();

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -597,4 +597,16 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
     }
   }
 
+  /**
+   * Get the default financial account id for payment processor accounts.
+   *
+   * Note that there is only a 'name' field & no label field. If people customise
+   * name then this won't work. This is new best-effort functionality so that's non-regressive.
+   *
+   * The fix for that is to add a label value to the financial account table.
+   */
+  public static function getDefaultFinancialAccountID() {
+    return CRM_Core_PseudoConstant::getKey('CRM_Financial_DAO_EntityFinancialAccount', 'financial_account_id', 'Payment Processor Account');
+  }
+
 }

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -62,6 +62,9 @@ function _civicrm_api3_payment_processor_create_spec(&$params) {
   $params['is_default']['api.default'] = 0;
   $params['is_test']['api.default'] = 0;
   $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
+  $params['financial_account_id']['api.default'] = CRM_Financial_BAO_PaymentProcessor::getDefaultFinancialAccountID();
+  $params['financial_account_id']['api.required'] = TRUE;
+  $params['financial_account_id']['title'] = ts('Financial Account for Processor');
 }
 
 /**

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -73,9 +73,8 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
   public function testPaymentProcessorCreate() {
     $params = $this->_params;
     $result = $this->callAPIAndDocument('payment_processor', 'create', $params, __FUNCTION__, __FILE__);
-    $this->assertNotNull($result['id']);
-    $this->assertDBState('CRM_Financial_DAO_PaymentProcessor', $result['id'], $params);
-    return $result['id'];
+    $this->callAPISuccessGetSingle('EntityFinancialAccount', ['entity_table' => 'civicrm_payment_processor', 'entity_id' => $result['id']]);
+    $this->getAndCheck($params, $result['id'], 'PaymentProcessor');
   }
 
   /**
@@ -124,9 +123,9 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
    * Check payment processor delete.
    */
   public function testPaymentProcessorDelete() {
-    $id = $this->testPaymentProcessorCreate();
+    $result = $this->callAPISuccess('payment_processor', 'create', $this->_params);
     $params = array(
-      'id' => $id,
+      'id' => $result['id'],
     );
 
     $this->callAPIAndDocument('payment_processor', 'delete', $params, __FUNCTION__, __FILE__);


### PR DESCRIPTION
Overview
----------------------------------------
When adding a payment processor financial_account_id is a required field. This adds a sensible default for this value 'Payment Processor Account'

Before
----------------------------------------
Api allows payment processors to be created without this required field being filled in.

When creating new processors you need to select the field in the UI
![screenshot 2018-11-30 13 58 05](https://user-images.githubusercontent.com/336308/49261805-894ce080-f4a8-11e8-9d02-36e1d5ccd172.png)


After
----------------------------------------
Api will use the default account if none is specified in the api call. If it cannot be loaded (e.g because the account doesn't exist or has been renamed) a mandatory required error will result

![screenshot 2018-11-30 13 58 18](https://user-images.githubusercontent.com/336308/49261852-b4cfcb00-f4a8-11e8-982b-ad6d7692eb96.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
@monishdeb @mattwire what's the bet this has been annoying you guys forever but like me haven't wanted to spend the time on fixing it (until now :-)
