### PR TITLE
(REF) Allow subclasses of AbstractTokenSubscriber to override the determination of active tokens.

### DIFF
--- a/Civi/Token/AbstractTokenSubscriber.php
+++ b/Civi/Token/AbstractTokenSubscriber.php
@@ -45,6 +45,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *   3. Implement the evaluateToken() method.
  *   4. Optionally, override others:
  *      + checkActive()
+ *      + getActiveTokens()
  *      + prefetch()
  *      + alterActionScheduleMailing()
  *   5. Register the new class with the event-dispatcher.
@@ -142,13 +143,10 @@ abstract class AbstractTokenSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
-    if (!isset($messageTokens[$this->entity])) {
+    $activeTokens = $this->getActiveTokens($e);
+    if (!$activeTokens) {
       return;
     }
-
-    $activeTokens = array_intersect($messageTokens[$this->entity], array_keys($this->tokenNames));
-
     $prefetch = $this->prefetch($e);
 
     foreach ($e->getRows() as $row) {
@@ -156,6 +154,21 @@ abstract class AbstractTokenSubscriber implements EventSubscriberInterface {
         $this->evaluateToken($row, $this->entity, $field, $prefetch);
       }
     }
+  }
+
+  /**
+   * To handle variable tokens, override this function and return the active tokens.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *
+   * @return mixed
+   */
+  public function getActiveTokens(TokenValueEvent $e) {
+    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
+    if (!isset($messageTokens[$this->entity])) {
+      return FALSE;
+    }
+    return array_intersect($messageTokens[$this->entity], array_keys($this->tokenNames));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is extracted from PRs #13174 and #12012  By refactoring the determination of active tokens into a separate function `getActiveTokens()`, subclasses of `Civi\Token\AbstractTokenSubscriber` can override this definition if desired.  

No functional change.


