### PR TITLE
Optimize CRM_Core_BAO_FinancialTrxn::getTotalPayment

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4169,27 +4169,15 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
    * @return float
    */
   public static function getContributionBalance($contributionId, $contributionTotal = NULL) {
-
     if ($contributionTotal === NULL) {
       $contributionTotal = CRM_Price_BAO_LineItem::getLineTotal($contributionId);
     }
-    $statusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-    $refundStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded');
 
-    $sqlFtTotalAmt = "
-SELECT SUM(ft.total_amount)
-FROM civicrm_financial_trxn ft
-  INNER JOIN civicrm_entity_financial_trxn eft ON (ft.id = eft.financial_trxn_id AND eft.entity_table = 'civicrm_contribution' AND eft.entity_id = {$contributionId})
-WHERE ft.is_payment = 1
-  AND ft.status_id IN ({$statusId}, {$refundStatusId})
-";
-
-    $ftTotalAmt = CRM_Core_DAO::singleValueQuery($sqlFtTotalAmt);
-    if (!$ftTotalAmt) {
-      $ftTotalAmt = 0;
-    }
-    $currency = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency');
-    return CRM_Utils_Money::subtractCurrencies($contributionTotal, $ftTotalAmt, $currency);
+    return CRM_Utils_Money::subtractCurrencies(
+      $contributionTotal,
+      CRM_Core_BAO_FinancialTrxn::getTotalPayments($contributionId, TRUE) ?: 0,
+      CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency')
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This patch optimizes the ```getContributionBalance()``` function to use ```CRM_Core_BAO_FinancialTrxn::getTotalPayments``` to fetch the total paid amount. 


Before
----------------------------------------
getContributionBalance() uses codes already present in ```CRM_Core_BAO_FinancialTrxn::getTotalPayments```

After
----------------------------------------
1. Generalize ```CRM_Core_BAO_FinancialTrxn::getTotalPayments``` consider refund trxns
2. Cleaned up  ```getContributionBalance()```

Comments
----------------------------------------
This is a followup PR of https://github.com/civicrm/civicrm-core/pull/13151 

ping @eileenmcnaughton @jitendrapurohit @seamuslee001 
