### PR TITLE
dev/core#563: Duplicate Case manager role fix

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -247,13 +247,22 @@ class CRM_Contact_Page_AJAX {
     // Loop through multiple case clients
     foreach ($clientList as $i => $sourceContactID) {
       try {
-        $result = civicrm_api3('relationship', 'create', array(
+        $params = [
           'case_id' => $caseID,
           'relationship_type_id' => $relTypeId,
           "contact_id_$a" => $relContactID,
           "contact_id_$b" => $sourceContactID,
+          'sequential' => TRUE,
+        ];
+        // first check if there is any existing relationship present with same parameters.
+        // If yes then update the relationship by setting active and start date to current time
+        $relationship = civicrm_api3('Relationship', 'get', $params)['values'];
+        $params = array_merge(CRM_Utils_Array::value(0, $relationship, $params), [
           'start_date' => 'now',
-        ));
+          'is_active' => TRUE,
+          'end_date' => '',
+        ]);
+        $result = civicrm_api3('relationship', 'create', $params);
       }
       catch (CiviCRM_API3_Exception $e) {
         $ret['is_error'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Create case
2. Go to 'Manage case' and change case manager to someone else
3. Change case manager back to original contact: error - duplicate relationship
4. From the contact's relationship tab, enable a relationship
-- note that the end date is preserved, which may mean that the newly re-enabled relationship is still considered inactive
-- note that in the manage case roles panel the newly re-enabled relationship is not listed as the case manager
5. From the manage case roles panel, add a new role with the same case manager type, to one of the existing contacts: error, duplicate relationship
-- so if you change the case manager, there's currently no way to go back and set the original contact as case manager again

Before
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/49284822-b8b91880-f4bb-11e8-82ee-80e86f4377c5.gif)

After
----------------------------------------
![screencast-12189-role](https://user-images.githubusercontent.com/3735621/49284913-02a1fe80-f4bc-11e8-8a30-86ef902a253f.gif)

Comments
----------------------------------------
ping @colemanw @lcdservices  
