### PR TITLE
dev-core#564: Differentiate case relationships in Contact Summary page

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1434,6 +1434,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
               if ($values[$rid]['rtype'] == 'b_a') {
                 $replace['clientid'] = $values[$rid]['cid'];
               }
+              $values[$rid]['case'] = '<a href="' . CRM_Utils_System::url('civicrm/case/ajax/details', sprintf('caseId=%d&cid=%d&snippet=4', $values[$rid]['case_id'], $values[$rid]['cid'])) . '" class="action-item crm-hover-button crm-summary-link"><i class="crm-i fa-folder-open-o"></i></a>';
             }
           }
 
@@ -2120,7 +2121,7 @@ AND cc.sort_name LIKE '%$name%'";
             'civicrm/contact/view',
             "reset=1&cid={$values['cid']}");
 
-        $relationship['relation'] = CRM_Utils_System::href(
+        $relationship['relation'] = CRM_Utils_Array::value('case', $values, '') . CRM_Utils_System::href(
           $values['relation'],
           'civicrm/contact/view/rel',
           "action=view&reset=1&cid={$values['cid']}&id={$values['id']}&rtype={$values['rtype']}");


### PR DESCRIPTION
Overview
----------------------------------------
The relationships tab doesn't do much to communicate that a given relationship is tied to a specific case. if you click "more" you can click to manage the case, but from the listing, there is no visual queue to connect it to a case, which makes the relationships look like duplicates.


Before
----------------------------------------
<img width="854" alt="screen shot 2018-11-30 at 5 18 57 pm" src="https://user-images.githubusercontent.com/3735621/49289046-83ff8e00-f4c8-11e8-930b-e29a58540e8d.png">

After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/49289056-8cf05f80-f4c8-11e8-9ece-f60e3bc8a0e2.gif)

As per this improvement:
1. Adds a case icon against case-relationships.
2. On hover, it opens a modal to show the case relationships info
3. It has a 'Manage Case' link clicking which opens the Case management page in a medium dialog box


Comments
----------------------------------------
ping @colemanw @lcdservices 