### PR TITLE
dev/core#752 [WIP] Add cid parameter in custom group form url & set it for Activity  form

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -663,10 +663,13 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     // Enable form element (ActivityLinks sets this true).
     $this->assign('suppressForm', FALSE);
 
+    // Send cid parameter to custom group url if _currentlyViewedContactId exists
+    $cid = ($this->_currentlyViewedContactId) ?: "null";
+
     $element = &$this->add('select', 'activity_type_id', ts('Activity Type'),
       array('' => '- ' . ts('select') . ' -') + $this->_fields['followup_activity_type_id']['attributes'],
       FALSE, array(
-        'onchange' => "CRM.buildCustomData( 'Activity', this.value );",
+        'onchange' => "CRM.buildCustomData( 'Activity', this.value, {$cid} );",
         'class' => 'crm-select2 required',
       )
     );

--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -37,12 +37,20 @@
 class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
 
   /**
+   * Contact ID of the parent entity.
+   *
+   * @var int
+   */
+  public $_contactID = NULL;
+
+  /**
    * Preprocess function.
    */
   public function preProcess() {
 
     $this->_type = $this->_cdType = CRM_Utils_Request::retrieve('type', 'String', CRM_Core_DAO::$_nullObject, TRUE);
     $this->_subType = CRM_Utils_Request::retrieve('subType', 'String');
+    $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive');
     $this->_subName = CRM_Utils_Request::retrieve('subName', 'String');
     $this->_groupCount = CRM_Utils_Request::retrieve('cgcount', 'Positive');
     $this->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive');

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -297,9 +297,9 @@
 
       {/literal}
       {if $customDataSubType}
-        CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
+        CRM.buildCustomData( '{$customDataType}', {$customDataSubType} {if $contactId}, {$contactId}{/if});
         {else}
-        CRM.buildCustomData( '{$customDataType}' );
+        CRM.buildCustomData( '{$customDataType}' {if $contactId}, null, {$contactId}{/if});
       {/if}
       {literal}
     });

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -209,7 +209,7 @@
       }
       function loadNextRecord(i, groupValue, groupCount) {
         if (i < groupCount) {
-          CRM.buildCustomData({/literal}"{$contactType}"{literal}, subTypeValues, null, i, groupValue, true).one('crmLoad', function() {
+          CRM.buildCustomData({/literal}"{$contactType}"{literal}, subTypeValues, null, null, i, groupValue, true).one('crmLoad', function() {
             highlightTabs(this);
             loadNextRecord(i+1, groupValue, groupCount);
           });

--- a/templates/CRM/Contact/Form/CustomData.tpl
+++ b/templates/CRM/Contact/Form/CustomData.tpl
@@ -51,7 +51,7 @@
         // Building the complete form in php with no ajax would be way more efficient.
         function loadNextRecord() {
           if (i < customValueCount) {
-            CRM.buildCustomData(contact_type, contact_subtype, null, i++, groupID, true).one('crmLoad', loadNextRecord);
+            CRM.buildCustomData(contact_type, contact_subtype, null, null, i++, groupID, true).one('crmLoad', loadNextRecord);
           }
         }
         CRM.buildCustomData(contact_type, contact_subtype).one('crmLoad', loadNextRecord);

--- a/templates/CRM/Custom/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomData.tpl
@@ -33,7 +33,7 @@
     </div>
   {else}
     <div id="add-more-link-{$cgCount}" class="add-more-link-{$group_id} add-more-link-{$group_id}-{$cgCount}">
-      <a href="#" class="crm-hover-button" onclick="CRM.buildCustomData('{$cd_edit.extends}',{if $cd_edit.subtype}'{$cd_edit.subtype}'{else}'{$cd_edit.extends_entity_column_id}'{/if}, '', {$cgCount}, {$group_id}, true ); return false;">
+      <a href="#" class="crm-hover-button" onclick="CRM.buildCustomData('{$cd_edit.extends}',{if $cd_edit.subtype}'{$cd_edit.subtype}'{else}'{$cd_edit.extends_entity_column_id}'{/if}, null, '', {$cgCount}, {$group_id}, true ); return false;">
         <i class="crm-i fa-plus-circle"></i>
         {ts 1=$cd_edit.title}Another %1 record{/ts}
       </a>

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -351,8 +351,8 @@
           $('#campaign_id', $form).select2('val', info.campaign_id);
 
           // Event and event-type custom data
-          CRM.buildCustomData('Participant', eventId, {/literal}{$eventNameCustomDataTypeID}{literal}, null, null, null, true);
-          CRM.buildCustomData('Participant', info.event_type_id, {/literal}{$eventTypeCustomDataTypeID}{literal}, null, null, null, true);
+          CRM.buildCustomData('Participant', eventId, {/literal}{$eventNameCustomDataTypeID}{literal}, null, null, null, null, true);
+          CRM.buildCustomData('Participant', info.event_type_id, {/literal}{$eventTypeCustomDataTypeID}{literal}, null, null, null, null, true);
 
           buildFeeBlock();
         });
@@ -375,7 +375,7 @@
 
         function buildRoleCustomData() {
           var roleId = $('select[name^=role_id]', $form).val() || [];
-          CRM.buildCustomData('Participant', roleId.join(), {/literal}{$roleCustomDataTypeID}{literal});
+          CRM.buildCustomData('Participant', roleId.join(), null, {/literal}{$roleCustomDataTypeID}{literal});
         }
 
         //build fee block
@@ -424,12 +424,12 @@
         }
 
         {/literal}
-        CRM.buildCustomData( '{$customDataType}', null, null );
+        CRM.buildCustomData( '{$customDataType}', null, null, null );
         {if $eventID}
-          CRM.buildCustomData( '{$customDataType}', {$eventID}, {$eventNameCustomDataTypeID} );
+          CRM.buildCustomData( '{$customDataType}', {$eventID}, null, {$eventNameCustomDataTypeID} );
         {/if}
         {if $eventTypeID}
-          CRM.buildCustomData( '{$customDataType}', {$eventTypeID}, {$eventTypeCustomDataTypeID} );
+          CRM.buildCustomData( '{$customDataType}', {$eventTypeID}, null, {$eventTypeCustomDataTypeID} );
         {/if}
         {literal}
 

--- a/templates/CRM/common/customData.tpl
+++ b/templates/CRM/common/customData.tpl
@@ -26,7 +26,7 @@
 {literal}
 <script type="text/javascript">
   (function($) {
-    CRM.buildCustomData = function (type, subType, subName, cgCount, groupID, isMultiple, onlySubtype) {
+    CRM.buildCustomData = function (type, subType, cid, subName, cgCount, groupID, isMultiple, onlySubtype) {
       var dataUrl = CRM.url('civicrm/custom', {type: type}),
         prevCount = 1,
         fname = '#customData',
@@ -34,6 +34,10 @@
 
       if (subType) {
         dataUrl += '&subType=' + subType;
+      }
+
+      if (cid) {
+        dataUrl += '&cid=' + cid;
       }
 
       if (onlySubtype) {


### PR DESCRIPTION
Overview
----------------------------------------
Custom group forms are usually loaded by AJAX, in the parent entities forms they extend from. 
The class `CRM_Custom_Form_CustomDataByType` is the one that manages custom group form, but doesn't contain the **contact_id** attribute which is essential for performing tasks such as set a default value based on Contact's data, validate values against Contact's data, etc.
Now a days, theses tasks are hard to code, and most of them must rely on JQuery scripts or too complex workarounds to be achieved 

https://lab.civicrm.org/dev/core/issues/752

Before
----------------------------------------
class `CRM_Custom_Form_CustomDataByType` doesn't store **contact_id** value

After
----------------------------------------
class `CRM_Custom_Form_CustomDataByType`  stores **contact_id** value, which is sent by the parent Entity through url parameter **cid** (when is available)

Technical Details
----------------------------------------
The url is called from this function:

https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/common/customData.tpl#L29

```js
CRM.buildCustomData = function (type, subType, subName, cgCount, groupID, isMultiple, onlySubtype) {
      var dataUrl = CRM.url('civicrm/custom', {type: type}),
        prevCount = 1,
        fname = '#customData',
        storage = {};
      . . . .
```
then there are **42 php/tpls** files that use this function and must be adapted to send the **cid** when is available
List of 42 files [here](https://gist.github.com/sluc23/a83cb45c05c784747b4d8b0c16a19af7)

Comments
----------------------------------------
This is the first iteration of an incremental change that must be performed to adapt every Entity in CiviCRM.

MM discussion [here](https://chat.civicrm.org/civicrm/pl/gcfhwf9g77fstcbupq3ynwhgce)
