### PR TITLE
dev/core#498 Update Mailing Report to fix undefined property error

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1813,6 +1813,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $report['mailing'] = array();
     foreach (array_keys(self::fields()) as $field) {
+      if ($field == 'mailing_modified_date') {
+        $field = 'modified_date';
+      }
       $report['mailing'][$field] = $mailing->$field;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This doesn't aim to optimise the SQL just get pass the notice error. To repoduce load up any Mailing Report and see notice, apply fix no notice. The issue is there is a unique name which is used in the DAO fields array but not in the PHP vars for the DAO. 

Before
----------------------------------------
Notice shows

![screenshot 2018-12-02 15 23 15](https://user-images.githubusercontent.com/336308/49334918-56d8ea00-f646-11e8-8ddc-3e6725dcf141.png)


After
----------------------------------------
No Notice

ping @eileenmcnaughton @JKingsnorth 
