### PR TITLE
dev/core#442 Fix Style issues on word replacements, credit card expir…

### DIFF
--- a/CRM/Admin/Form/WordReplacements.php
+++ b/CRM/Admin/Form/WordReplacements.php
@@ -127,8 +127,8 @@ class CRM_Admin_Form_WordReplacements extends CRM_Core_Form {
     }
     foreach ($soInstances as $instance) {
       $this->addElement('checkbox', "enabled[$instance]");
-      $this->add('textarea', "old[$instance]", NULL, array('rows' => 1, 'cols' => 40));
-      $this->add('textarea', "new[$instance]", NULL, array('rows' => 1, 'cols' => 40));
+      $this->add('text', "old[$instance]", NULL);
+      $this->add('text', "new[$instance]", NULL);
       $this->addElement('checkbox', "cb[$instance]");
     }
     $this->assign('numStrings', $this->_numStrings);

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -734,6 +734,7 @@ abstract class CRM_Core_Payment {
             'rule_parameters' => TRUE,
           ),
         ),
+        'extra' => ['class' => 'crm-form-select'],
       ),
       'credit_card_type' => array(
         'htmlType' => 'select',

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -115,6 +115,7 @@ class CRM_Core_Payment_Form {
   protected static function addCommonFields(&$form, $paymentFields) {
     $requiredPaymentFields = $paymentFieldsMetadata = [];
     foreach ($paymentFields as $name => $field) {
+      $field['extra'] = isset($field['extra']) ? $field['extra'] : NULL;
       if ($field['htmlType'] == 'chainSelect') {
         $form->addChainSelect($field['name'], array('required' => FALSE));
       }
@@ -123,7 +124,8 @@ class CRM_Core_Payment_Form {
           $field['name'],
           $field['title'],
           $field['attributes'],
-          FALSE
+          FALSE,
+          $field['extra']
         );
       }
       // This will cause the fields to be marked as required - but it is up to the payment processor to

--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -33,7 +33,7 @@
         {if !$type || $type eq 'tag'}
           <td>
             <div class="crm-section tag-section">
-              {if $title}{$form.tag.label}{/if}
+              {if $title}{$form.tag.label}<br>{/if}
               {$form.tag.html}
             </div>
             {if $context NEQ 'profile'}

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -31,11 +31,11 @@
     <tr>
       <td class="crm-contact-form-block-contact1">
         <label for="contact1">{ts}Contact 1{/ts}</label><br />
-        <input type="text" placeholder="Search Contact1" search-column="0" />
+        <input class="crm-form-text" type="text" placeholder="Search Contact1" search-column="0" />
       </td>
       <td class="crm-contact-form-block-contact2">
         <label for="contact2">{ts}Contact 2{/ts}</label><br />
-        <input type="text" placeholder="Search Contact2" search-column="1" />
+        <input class="crm-form-text" type="text" placeholder="Search Contact2" search-column="1" />
       </td>
     </tr>
   </table>


### PR DESCRIPTION
…y date section, dedupe execptions and tags and groups section

Overview
----------------------------------------
_This makes the following changes, 

* switches the fields to be text not text area on word replacements
* switches the class from crm-form-date to crm-form-select for the Credit Card Date fields
* Fixes a missing line break error in the Tags and Groups Form on edit contacts
* Adds in crm-form-text class to the Dedupe Exceptions input fields

Before
----------------------------------------
Strange styling

After
----------------------------------------
Better styling

ping @AkA84 @MikeyMJCO @colemanw 