### PR TITLE
dev/core#561 Remove jcalendar from the Event Aggregate Custom Search

### DIFF
--- a/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -85,8 +85,8 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
     $events = CRM_Event_BAO_Event::getEvents(1);
     $form->add('select', 'event_id', ts('Event Name'), array('' => ts('- select -')) + $events);
 
-    $form->addDate('start_date', ts('Payments Date From'), FALSE, array('formatType' => 'custom'));
-    $form->addDate('end_date', ts('...through'), FALSE, array('formatType' => 'custom'));
+    $form->add('datepicker', 'start_date', ts('Payments Date From'), [], FALSE, ['time' => FALSE]);
+    $form->add('datepicker', 'end_date', ts('...through'), [], FALSE, ['time' => FALSE]);
 
     /**
      * If you are using the sample template, this array tells the template fields to render
@@ -237,14 +237,13 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
       $clauses[] = "civicrm_contribution.payment_instrument_id <> 0";
     }
 
-    $startDate = CRM_Utils_Date::processDate($this->_formValues['start_date']);
-    if ($startDate) {
-      $clauses[] = "civicrm_contribution.receive_date >= $startDate";
+    // As we only allow date to be submitted we need to set default times so midnight for start time and just before midnight for end time.
+    if ($this->_formValues['start_date']) {
+      $clauses[] = "civicrm_contribution.receive_date >= '{$this->_formValues['start_date']} 00:00:00'";
     }
 
-    $endDate = CRM_Utils_Date::processDate($this->_formValues['end_date']);
-    if ($endDate) {
-      $clauses[] = "civicrm_contribution.receive_date <= {$endDate}235959";
+    if ($this->_formValues['end_date']) {
+      $clauses[] = "civicrm_contribution.receive_date <= '{$this->_formValues['end_date']} 23:59:59'";
     }
 
     if (!empty($this->_formValues['event_id'])) {

--- a/templates/CRM/Contact/Form/Search/Custom/EventDetails.tpl
+++ b/templates/CRM/Contact/Form/Search/Custom/EventDetails.tpl
@@ -41,13 +41,7 @@
             {foreach from=$elements item=element}
                 <tr class="crm-contact-custom-search-eventDetails-form-block-{$element}">
                     <td class="label">{$form.$element.label}</td>
-                    {if $element eq 'start_date'}
-                        <td>{include file="CRM/common/jcalendar.tpl" elementName=start_date}</td>
-                    {elseif $element eq 'end_date'}
-                        <td>{include file="CRM/common/jcalendar.tpl" elementName=end_date}</td>
-                    {else}
-                        <td>{$form.$element.html}</td>
-                    {/if}
+                    <td>{$form.$element.html}</td>
                 </tr>
             {/foreach}
             <tr class="crm-contact-custom-search-eventDetails-form-block-event_type">


### PR DESCRIPTION
Overview
----------------------------------------
This removes the usage of jcalendar from the event aggregate custom search

Before
----------------------------------------
deprecated jcalendar used for the search

After
----------------------------------------
date picker used in stead

ping @eileenmcnaughton @mattwire 