### PR TITLE
dev/core#11: Email - send now error screen should display earlier

### DIFF
--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -131,7 +131,6 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
     if (!$cid && $this->_context != 'standalone') {
       parent::preProcess();
     }
-    CRM_Contact_Form_Task_EmailCommon::bounceIfSimpleMailLimitExceeded(count($this->_contactIds));
 
     $this->assign('single', $this->_single);
     if (CRM_Core_Permission::check('administer CiviCRM')) {

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -124,6 +124,7 @@ class CRM_Contact_Form_Task_EmailCommon {
     if (count($form->_contactIds) > 1) {
       $form->_single = FALSE;
     }
+    CRM_Contact_Form_Task_EmailCommon::bounceIfSimpleMailLimitExceeded(count($form->_contactIds));
 
     $emailAttributes = array(
       'class' => 'huge',


### PR DESCRIPTION
Overview
----------------------------------------
In Advanced Search, if you are displaying results as contacts and then:

- select more than 50 of the results 
 - select Email - send now (to 50 or less) 
you see the Error message telling you that you can't email more than 50 contacts this way and the process stops

However, if you display the results as contributions or as memberships then, selecting more than 50 records doesn't result in this error message.

It would be a better user experience if the error message always appeared when Email - send now (to 50 or less) was selected.

Before
----------------------------------------
Here, for result displayed as contacts are properly showing the error message but not in case of contributions and other types:
![before](https://user-images.githubusercontent.com/3735621/49344280-ea3c0a80-f69a-11e8-8871-32cb40a299bc.gif)


After
----------------------------------------
Correctly throw the error message in case of result displayed as Contributions or other entities:
![after](https://user-images.githubusercontent.com/3735621/49344290-08096f80-f69b-11e8-873b-1f983a958d19.gif)


Comments
----------------------------------------
ping @colemanw @lcdservices 