### PR TITLE
Add custom search handling for jcalendar converstion.

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ActivitySearch.php
+++ b/CRM/Contact/Form/Search/Custom/ActivitySearch.php
@@ -42,7 +42,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
    * @param array $formValues
    */
   public function __construct(&$formValues) {
-    $this->_formValues = $formValues;
+    $this->_formValues = self::formatSavedSearchFields($formValues);
 
     /**
      * Define the columns for search result rows
@@ -417,6 +417,30 @@ ORDER BY contact_a.sort_name';
    */
   public function buildACLClause($tableAlias = 'contact') {
     list($this->_aclFrom, $this->_aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause($tableAlias);
+  }
+
+  /**
+   * Format saved search fields for this custom group.
+   *
+   * Note this is a function to facilitate the transition to jcalendar for
+   * saved search groups. In time it can be stripped out again.
+   *
+   * @param array $formValues
+   *
+   * @return array
+   */
+  public static function formatSavedSearchFields($formValues) {
+    $dateFields = array(
+      'start_date',
+      'end_date',
+    );
+    foreach ($formValues as $element => $value) {
+      if (in_array($element, $dateFields) && !empty($value)) {
+        $formValues[$element] = date('Y-m-d', strtotime($value));
+      }
+    }
+
+    return $formValues;
   }
 
 }

--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -399,10 +399,14 @@ AND      c.receive_date < {$this->start_date_1}
   }
 
   /**
-   * Format saved search fields for this custom group
+   * Format saved search fields for this custom group.
+   *
+   * Note this is a function to facilitate the transition to jcalendar for
+   * saved search groups. In time it can be stripped out again.
    *
    * @param array $formValues
    *
+   * @return array
    */
   public static function formatSavedSearchFields($formValues) {
     $dateFields = array(

--- a/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -44,7 +44,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
    * @param array $formValues
    */
   public function __construct(&$formValues) {
-    parent::__construct($formValues);
+    $this->_formValues = self::formatSavedSearchFields($formValues);
 
     $this->_includeGroups = CRM_Utils_Array::value('includeGroups', $formValues, array());
     $this->_excludeGroups = CRM_Utils_Array::value('excludeGroups', $formValues, array());
@@ -456,6 +456,29 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
    */
   public function buildACLClause($tableAlias = 'contact') {
     list($this->_aclFrom, $this->_aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause($tableAlias);
+  }
+
+  /**
+   * Format saved search fields for this custom group.
+   *
+   * Note this is a function to facilitate the transition to jcalendar for
+   * saved search groups. In time it can be stripped out again.
+   *
+   * @param array $formValues
+   *
+   * @return array
+   */
+  public static function formatSavedSearchFields($formValues) {
+    $dateFields = array(
+      'start_date',
+      'end_date',
+    );
+    foreach ($formValues as $element => $value) {
+      if (in_array($element, $dateFields) && !empty($value)) {
+        $formValues[$element] = date('Y-m-d', strtotime($value));
+      }
+    }
+    return $formValues;
   }
 
 }

--- a/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -43,7 +43,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
    * @param array $formValues
    */
   public function __construct(&$formValues) {
-    $this->_formValues = $formValues;
+    $this->_formValues = self::formatSavedSearchFields($formValues);
     $this->_permissionedComponent = array('CiviContribute', 'CiviEvent');
 
     /**
@@ -371,6 +371,30 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
    */
   public function buildACLClause($tableAlias = 'contact') {
     list($this->_aclFrom, $this->_aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause($tableAlias);
+  }
+
+  /**
+   * Format saved search fields for this custom group.
+   *
+   * Note this is a function to facilitate the transition to jcalendar for
+   * saved search groups. In time it can be stripped out again.
+   *
+   * @param array $formValues
+   *
+   * @return array
+   */
+  public static function formatSavedSearchFields($formValues) {
+    $dateFields = array(
+      'start_date',
+      'end_date',
+    );
+    foreach ($formValues as $element => $value) {
+      if (in_array($element, $dateFields) && !empty($value)) {
+        $formValues[$element] = date('Y-m-d', strtotime($value));
+      }
+    }
+
+    return $formValues;
   }
 
 }

--- a/CRM/Contact/Form/Search/Custom/TagContributions.php
+++ b/CRM/Contact/Form/Search/Custom/TagContributions.php
@@ -43,7 +43,7 @@ class CRM_Contact_Form_Search_Custom_TagContributions extends CRM_Contact_Form_S
    * @param array $formValues
    */
   public function __construct(&$formValues) {
-    $this->_formValues = $formValues;
+    $this->_formValues = self::formatSavedSearchFields($formValues);
     $this->_permissionedComponent = 'CiviContribute';
 
     /**
@@ -280,6 +280,29 @@ WHERE  $where
    */
   public function buildACLClause($tableAlias = 'contact') {
     list($this->_aclFrom, $this->_aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause($tableAlias);
+  }
+
+  /**
+   * Format saved search fields for this custom group.
+   *
+   * Note this is a function to facilitate the transition to jcalendar for
+   * saved search groups. In time it can be stripped out again.
+   *
+   * @param array $formValues
+   *
+   * @return array
+   */
+  public static function formatSavedSearchFields($formValues) {
+    $dateFields = array(
+      'start_date',
+      'end_date',
+    );
+    foreach ($formValues as $element => $value) {
+      if (in_array($element, $dateFields) && !empty($value)) {
+        $formValues[$element] = date('Y-m-d', strtotime($value));
+      }
+    }
+    return $formValues;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Last activity custom search and event aggregate custom search have been updated to use jcalendar - this just handles any smart groups based on them

Before
----------------------------------------
Pre-update smart groups don't work

After
----------------------------------------
smart groups work

Technical Details
----------------------------------------
I used the methodology from ContribSybunt. I duplicated rather than
shared it because I think the future of these searches is to be more separated from each other

Comments
----------------------------------------

