### PR TITLE
[REF] refactor shared search functions in pre-Process

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -82,14 +82,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    // we allow the controller to set force/reset externally, useful when we are being
-    // driven by the wizard framework
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-
-    $this->assign("context", $this->_context);
+    $this->getUrlVariables();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -77,12 +77,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     $this->_printButtonName = $this->getButtonName('next', 'print');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
-    //we allow the controller to set force/reset externally,
-    //useful when we are being driven by the wizard framework
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
+    $this->getUrlVariables();
 
     //operation for state machine.
     $this->_operation = CRM_Utils_Request::retrieve('op', 'String', $this, FALSE, 'reserve');

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -89,32 +89,8 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    /*
-     * we allow the controller to set force/reset externally, useful when we are being
-     * driven by the wizard framework
-     */
-
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-
-    $this->assign('context', $this->_context);
-
-    // get user submitted values
-    // get it from controller only if form has been submitted, else preProcess has set this
-    if (!empty($_POST) && !$this->controller->isModal()) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
-    else {
-      $this->_formValues = $this->get('formValues');
-    }
-
-    if (empty($this->_formValues)) {
-      if (isset($this->_ssID)) {
-        $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
-      }
-    }
+    $this->getUrlVariables();
+    $this->getFormValues();
 
     if ($this->_force) {
       $this->postProcess();

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -83,17 +83,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     // @todo - is this an error - $this->_defaults is used.
     $this->defaults = array();
 
-    /*
-     * we allow the controller to set force/reset externally, useful when we are being
-     * driven by the wizard framework
-     */
-
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-
-    $this->assign("context", $this->_context);
+    $this->getUrlVariables();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -237,4 +237,37 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
 
   }
 
+  /**
+   * we allow the controller to set force/reset externally, useful when we are being
+   * driven by the wizard framework
+   */
+  protected function getUrlVariables() {
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
+    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
+    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
+    $this->_ssID = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);
+    $this->assign("context", $this->_context);
+  }
+
+  /**
+   * Get user submitted values.
+   *
+   * Get it from controller only if form has been submitted, else preProcess has set this
+   */
+  protected function getFormVariables() {
+    if (!empty($_POST)  && !$this->controller->isModal()) {
+      $this->_formValues = $this->controller->exportValues($this->_name);
+    }
+    else {
+      $this->_formValues = $this->get('formValues');
+    }
+
+    if (empty($this->_formValues)) {
+      if (isset($this->_ssID)) {
+        $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
+      }
+    }
+  }
+
 }

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -90,31 +90,8 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    /*
-     * we allow the controller to set force/reset externally, useful when we are being
-     * driven by the wizard framework
-     */
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-    $this->_ssID = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);
-    $this->assign("context", $this->_context);
-
-    // get user submitted values
-    // get it from controller only if form has been submitted, else preProcess has set this
-    if (!empty($_POST) && !$this->controller->isModal()) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
-    else {
-      $this->_formValues = $this->get('formValues');
-    }
-
-    if (empty($this->_formValues)) {
-      if (isset($this->_ssID)) {
-        $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
-      }
-    }
+    $this->getUrlVariables();
+    $this->getFormValues();
 
     if ($this->_force) {
       $this->postProcess();

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -29,16 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
- *
  */
 
 /**
- * Files required
- */
-
-/**
- * This file is for civigrant search
+ * This file is for CiviGrant search
  */
 class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
 
@@ -57,9 +51,9 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
   protected $_single = FALSE;
 
   /**
-   * Are we restricting ourselves to a single contact.
+   * Return limit.
    *
-   * @var boolean
+   * @var int
    */
   protected $_limit = NULL;
 
@@ -67,6 +61,8 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
    * Prefix for the controller.
    */
   protected $_prefix = "grant_";
+
+  protected $entity = 'grant';
 
   /**
    * Processing needed for buildForm and later.
@@ -83,32 +79,8 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    /*
-     * we allow the controller to set force/reset externally, useful when we are being
-     * driven by the wizard framework
-     */
-
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-
-    $this->assign("context", $this->_context);
-
-    // get user submitted values
-    // get it from controller only if form has been submitted, else preProcess has set this
-    if (!empty($_POST)) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
-    else {
-      $this->_formValues = $this->get('formValues');
-    }
-
-    if (empty($this->_formValues)) {
-      if (isset($this->_ssID)) {
-        $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
-      }
-    }
+    $this->getUrlVariables();
+    $this->getFormVariables();
 
     if ($this->_force) {
       $this->postProcess();
@@ -154,9 +126,6 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
 
   /**
    * Build the form object.
-   *
-   *
-   * @return void
    */
   public function buildQuickForm() {
     parent::buildQuickForm();

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -84,17 +84,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     $this->defaults = array();
 
-    /*
-     * we allow the controller to set force/reset externally, useful when we are being
-     * driven by the wizard framework
-     */
-
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-
-    $this->assign("context", $this->_context);
+    $this->getUrlVariables();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -73,15 +73,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    // we allow the controller to set force/reset externally, useful when we are being
-    // driven by the wizard framework
-
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
-    $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-
-    $this->assign("context", $this->_context);
+    $this->getUrlVariables();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this


### PR DESCRIPTION
Overview
----------------------------------------
Minor refactor in search forms to share duplicated code

Before
----------------------------------------
more code

After
----------------------------------------
less code

Technical Details
----------------------------------------
This simply reduces some duplicate code in the search forms. I could certainly go further with this tidy up - I desisted not to blow up scope too much

Comments
----------------------------------------
this is preliminary to removing jcalendar from grant search
