### PR TITLE
 Add \Civi\Token\TokenProcessor::getContextValues()

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -177,14 +177,28 @@ class TokenProcessor {
    * @return array
    *   Ex: [12, 34, 56].
    */
-  public function getContextValues($field) {
+  public function getContextValues($field, $subfield = NULL) {
     $values = [];
     if (isset($this->context[$field])) {
-      $values[] = $this->context[$field];
+      if ($subfield) {
+        if (isset($this->context[$field]->$subfield)) {
+          $values[] = $this->context[$field]->$subfield;
+        }
+      }
+      else {
+        $values[] = $this->context[$field];
+      }
     }
     foreach ($this->getRows() as $row) {
       if (isset($row->context[$field])) {
-        $values[] = $row->context[$field];
+        if ($subfield) {
+          if (isset($row->context[$field]->$subfield)) {
+            $values[] = $row->context[$field]->$subfield;
+          }
+        }
+        else {
+          $values[] = $row->context[$field];
+        }
       }
     }
     $values = array_unique($values);

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -169,6 +169,29 @@ class TokenProcessor {
   }
 
   /**
+   * Get a list of all unique values for a given context field,
+   * whether defined at the processor or row level.
+   *
+   * @param string $field
+   *   Ex: 'contactId'.
+   * @return array
+   *   Ex: [12, 34, 56].
+   */
+  public function getContextValues($field) {
+    $values = [];
+    if (isset($this->context[$field])) {
+      $values[] = $this->context[$field];
+    }
+    foreach ($this->getRows() as $row) {
+      if (isset($row->context[$field])) {
+        $values[] = $row->context[$field];
+      }
+    }
+    $values = array_unique($values);
+    return $values;
+  }
+
+  /**
    * Get the list of available tokens.
    *
    * @return array

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -59,6 +59,22 @@ class TokenProcessorTest extends \CiviUnitTestCase {
   }
 
   /**
+   * Check that getContextValues() returns the correct data
+   */
+  public function testGetContextValues() {
+    $p = new TokenProcessor($this->dispatcher, array(
+      'controller' => __CLASS__,
+      'omega' => '99',
+    ));
+    $p->addRow()->context('id', 10)->context('omega', '98');
+    $p->addRow()->context('id', 10)->context('contact', (object) ['cid' => 10]);
+    $p->addRow()->context('id', 11)->context('contact', (object) ['cid' => 11]);
+    $this->assertArrayValuesEqual([10, 11], $p->getContextValues('id'));
+    $this->assertArrayValuesEqual(['99', '98'], $p->getContextValues('omega'));
+    $this->assertArrayValuesEqual([10, 11], $p->getContextValues('contact', 'cid'));
+  }
+
+  /**
    * Check that the TokenRow helper can correctly read/update token
    * values.
    */

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -687,6 +687,18 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   /**
    * @param $expected
    * @param $actual
+   */
+  public function assertArrayValuesEqual($array1, $array2) {
+    $array1 = array_values($array1);
+    $array2 = array_values($array2);
+    sort($array1);
+    sort($array2);
+    $this->assertEquals($array1, $array2);
+  }
+
+  /**
+   * @param $expected
+   * @param $actual
    * @param string $message
    */
   public function assertType($expected, $actual, $message = '') {


### PR DESCRIPTION
Overview
----------------------------------------
Another group of changes extracted from #13174 

This adds a helper function to get Context values from TokenProcessor and TokenRows.

There are no user-visible changes.  The new function is to support #12012

