### PR TITLE
[REF] Export cleanup - filter at point of query on postal exports

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3528,7 +3528,7 @@ WHERE  $smartGroupClause
    * @param array $values
    */
   public function street_address(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    list($name, $op, $value, $grouping) = $values;
 
     if (!$op) {
       $op = 'LIKE';
@@ -3921,7 +3921,7 @@ WHERE  $smartGroupClause
    * @param $values
    */
   public function privacy(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    list($name, $op, $value, $grouping) = $values;
     //fixed for profile search listing CRM-4633
     if (strpbrk($value, "[")) {
       $value = "'{$value}'";


### PR DESCRIPTION
Overview
----------------------------------------
Follow on from https://github.com/civicrm/civicrm-core/pull/13213/files 
This culls out the non-postal rows at the query rather than deleting them at the end

Before
----------------------------------------
Query fetches rows that can't be emailed and THEN they are culled

After
----------------------------------------
Where filters added to query

Technical Details
----------------------------------------

Comments
----------------------------------------

