### PR TITLE
dev/core#529 open search panes when when reviewing smart groups if they have stuff selected

### DIFF
--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -126,9 +126,8 @@ CRM.$(function($) {
       {include file="CRM/Contact/Form/Search/Criteria/Basic.tpl"}
     </div>
   </div>
-
   {foreach from=$allPanes key=paneName item=paneValue}
-    <div class="crm-accordion-wrapper crm-ajax-accordion crm-{$paneValue.id}-accordion {if $paneValue.open eq 'true' and $openedPanes.$paneName} {else}collapsed{/if}">
+    <div class="crm-accordion-wrapper crm-ajax-accordion crm-{$paneValue.id}-accordion {if $paneValue.open eq 'true' || $openedPanes.$paneName} {else}collapsed{/if}">
       <div class="crm-accordion-header" id="{$paneValue.id}">
         {$paneName}
       </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a scenario where some search criteria can be lost when editing smart groups


Before
----------------------------------------
To replicate - create a smart group based on an activity. Go into the group & go to edit smart group criteria - pane
is not open and risks being ignored.


After
----------------------------------------
Accordian pane is opened on load if there are activity criteria. Criteria are respected


Technical Details
----------------------------------------
This is a generic fix for https://lab.civicrm.org/dev/core/issues/529 but I don't know if there are variants of that that are NOT fixed by this

I think this was just oversight in the tpl & the openedPanes should override any defaults for the pane

Comments
----------------------------------------

@kcristiano this was one you put on our radar