### PR TITLE
Revert "CRM-19115 - Always set the MySQL timezone offset before checking for …"

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -155,8 +155,6 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    * @return array<CRM_Utils_Check_Message> an empty array, or a list of warnings
    */
   public function checkMysqlTime() {
-    //CRM-19115 - Always set MySQL time before checking it.
-    CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
     $messages = array();
 
     $phpNow = date('Y-m-d H:i');


### PR DESCRIPTION
@MegaphoneJon @monishdeb - I think [CRM-19115](https://issues.civicrm.org/jira/browse/CRM-19115) is correct in pointing out a problem -- the timezones should always match, regardless of how you call the status-check. The problem is that *the timezones don't match in some use-cases*. The patch #8765 doesn't fix this; rather, it *hides the problem* by turning `checkMysqlTime()` into a tautology. (If you sync the timezones first, then of course the timezones will appear to be sync'd!)

Here's a more concrete example of how this is problematic:

* CiviMail has a background job for delivering messages, and this needs to fetch a list of `MailingJob`s which are ripe for delivery (i.e. where `civicrm_mailling_job.scheduled_date` is less than or equal to the current time). ([Ex code](https://github.com/civicrm/civicrm-core/blob/5.7/CRM/Mailing/BAO/MailingJob.php#L105-L124))
* The implementation of that job determines the current time by calling PHP's `$currentTime = date(...)` and then passes it as a MySQL filter (`WHERE.... scheduled_date <= $currentTime`).
* There's a PHPUnit test for this job (`api_v3_JobProcessMailingTest::testConcurrency()`) which creates a mailing and calls the background job (i.e. it calls `cv api job.process_mailing` several times).
* A few months ago, `civicrm.org` moved to a new test server -- `testConcurrency` passed in the old server and failed in the new server. Debugging this was quite difficult -- because it only failed in the new CI server and passed in all my local configurations (even though they used the same binaries and config files for PHP and MySQL!). What's been going? Well...
* The `Job.process_mailing` API only behaves correctly if PHP and MySQL agree on time. If they disagree, then you'll wind up sending emails several hours late or several hours early (depending on how much they disagree). This is much easier to identify and fix if you have a salient warning (e.g. `cv api system.check` reporting a problem with `checkMysqlTime`).

IMHO, instead of neutering the status-check, we should fix the various use-cases so that the PHP+MySQL timezones are correctly linked -- e.g. https://github.com/civicrm/cv/pull/45 aims to fix `cv` as an entry-point:

* Before applying https://github.com/civicrm/cv/pull/45...
    * `api_v3_JobProcessMailingTest` fails
    *  The following command shows mismatched times:
        * `cv ev 'print_r(["phpNow" => date("Y-m-d H:i:s"), "sqlNow" => CRM_Core_DAO::singleValueQuery("SELECT CURRENT_TIMESTAMP")]);'`
    * The `System.check` (w/original variant of `checkMysqlTime()`) reports a problem with time settings.
* After applying https://github.com/civicrm/cv/pull/45...
    * `api_v3_JobProcessMailingTest` passes
    *  The following command shows matching times:
        * `cv ev 'print_r(["phpNow" => date("Y-m-d H:i:s"), "sqlNow" => CRM_Core_DAO::singleValueQuery("SELECT CURRENT_TIMESTAMP")]);'`
    * The `System.check` (w/original variant of `checkMysqlTime()`) reports a working system.

