### PR TITLE
Fix [unreleased]  typo from https://github.com/civicrm/civicrm-core/pull/13210

### DIFF
--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -90,7 +90,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->defaults = array();
 
     $this->getUrlVariables();
-    $this->getFormValues();
+    $this->getFormVariables();
 
     if ($this->_force) {
       $this->postProcess();

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -91,7 +91,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     $this->defaults = array();
 
     $this->getUrlVariables();
-    $this->getFormValues();
+    $this->getFormVariables();
 
     if ($this->_force) {
       $this->postProcess();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a typo from #13210 

Before
----------------------------------------
Change made in #13210 calls wrong fn

After
----------------------------------------
Correct fn called

Technical Details
----------------------------------------
Looks like I tabbed it out without noticing the wrong fn name

Comments
----------------------------------------
