### PR TITLE
CRM-19115 - Synchronize PHP=>MySQL active timezone for all backend scripts

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1474,7 +1474,11 @@ class CRM_Utils_System {
       $params = array();
     }
     $config = CRM_Core_Config::singleton();
-    return $config->userSystem->loadBootStrap($params, $loadUser, $throwError, $realPath);
+    $result = $config->userSystem->loadBootStrap($params, $loadUser, $throwError, $realPath);
+    if (is_callable([$config->userSystem, 'setMySQLTimeZone'])) {
+      $config->userSystem->setMySQLTimeZone();
+    }
+    return $result;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In [CRM-19115](https://issues.civicrm.org/jira/browse/CRM-19115), it was previously observed that `checkMysqlTime` fails when run in some backend/background environments (e.g. REST). This patch is an alternative which tries to fix the problem (mismatch in PHP-MySQL times for `extern/rest.php`use-cases) rather than the symptom (undesireable error message).

NOTE: For testing, I used the spare CI test node (which has mismatched PHP-MySQL default timezones) and applied #13218 (to re-enable `checkMysqlTime`). In that environment, one could check if the REST end-point has the correct behavior by running:

```
curl 'http://example.com:8001/sites/all/modules/civicrm/extern/rest.php?entity=System&action=check&api_key=FIXME_API_KEY&key=FIXME_SITE_KEY&json=%7B%7D' \
  | json_pp | less
```

Then simply observe whether `checkMysqlTime` reports an error.

Before
----------------------------------------
* The curl request for `System.check` reports that `checkMysqlTime` fails -- PHP+MySQL are not aligned.

After
----------------------------------------
* The curl request for `System.check` reports that `checkMysqlTime` passes -- PHP+MySQL are aligned.
