### PR TITLE
Notice errors in getLocBlock()

### DIFF
--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -221,7 +221,7 @@ class CRM_Core_Page_AJAX_Location {
 
       $result = [];
       $addressOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-        'address_options', true, NULL, true
+        'address_options', TRUE, NULL, TRUE
       );
       // lets output only required fields.
       foreach ($addressOptions as $element => $isSet) {
@@ -277,4 +277,5 @@ class CRM_Core_Page_AJAX_Location {
       CRM_Utils_JSON::output($result);
     }
   }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
A few notice errors in CRM_Core_Page_AJAX_Location::getLocBlock() when trying to use an existing address.

Notice: Undefined variable: eventId in CRM_Core_Page_AJAX_Location::getLocBlock() (line 217 /civicrm/CRM/Core/Page/AJAX/Location.php)

Notice: Undefined variable: location in CRM_Core_Page_AJAX_Location::getLocBlock() (line 245 /civicrm/CRM/Core/Page/AJAX/Location.php)

Notice: Undefined variable: location in CRM_Core_Page_AJAX_Location::getLocBlock() (line 263 /civicrm/CRM/Core/Page/AJAX/Location.php)

Just needs some isset/empty checks on the location and eventId variables.  

Before
----------------------------------------
It currently passes the check on $evenId even though it's an empty string, this sets off a cascade of notice errors.

After
----------------------------------------
No errors.

Technical Details
----------------------------------------
My IDE changed a few array() statements to [].  Otherwise the main changes are on lines 212, 217, 261
