### PR TITLE
[REF] Rename recently added getUrlVariables getFormVariables function…

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -89,7 +89,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    $this->getUrlVariables();
+    $this->loadStandardSearchOptionsFromUrl();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -77,7 +77,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     $this->_printButtonName = $this->getButtonName('next', 'print');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
-    $this->getUrlVariables();
+    $this->loadStandardSearchOptionsFromUrl();
 
     //operation for state machine.
     $this->_operation = CRM_Utils_Request::retrieve('op', 'String', $this, FALSE, 'reserve');

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -89,8 +89,8 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    $this->getUrlVariables();
-    $this->getFormVariables();
+    $this->loadStandardSearchOptionsFromUrl();
+    $this->loadFormValues();
 
     if ($this->_force) {
       $this->postProcess();

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -83,7 +83,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     // @todo - is this an error - $this->_defaults is used.
     $this->defaults = array();
 
-    $this->getUrlVariables();
+    $this->loadStandardSearchOptionsFromUrl();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -321,7 +321,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    * we allow the controller to set force/reset externally, useful when we are being
    * driven by the wizard framework
    */
-  protected function getUrlVariables() {
+  protected function loadStandardSearchOptionsFromUrl() {
     $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
@@ -335,7 +335,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    *
    * Get it from controller only if form has been submitted, else preProcess has set this
    */
-  protected function getFormVariables() {
+  protected function loadFormValues() {
     if (!empty($_POST)  && !$this->controller->isModal()) {
       $this->_formValues = $this->controller->exportValues($this->_name);
     }

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -90,8 +90,8 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    $this->getUrlVariables();
-    $this->getFormVariables();
+    $this->loadStandardSearchOptionsFromUrl();
+    $this->loadFormValues();
 
     if ($this->_force) {
       $this->postProcess();

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -79,8 +79,8 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    $this->getUrlVariables();
-    $this->getFormVariables();
+    $this->loadStandardSearchOptionsFromUrl();
+    $this->loadFormValues();
 
     if ($this->_force) {
       $this->postProcess();

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -84,7 +84,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     $this->defaults = array();
 
-    $this->getUrlVariables();
+    $this->loadStandardSearchOptionsFromUrl();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -73,7 +73,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     $this->_done = FALSE;
     $this->defaults = array();
 
-    $this->getUrlVariables();
+    $this->loadStandardSearchOptionsFromUrl();
 
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this


### PR DESCRIPTION
…s to be loadStandardSearchOptionsFromUrl loadFormValues

Overview
----------------------------------------
This picks up @totten 's comment from https://github.com/civicrm/civicrm-core/pull/13210/files#r238478842 and makes the function names more explicit about what they do

Before
----------------------------------------
Unclear function names 

After
----------------------------------------
Clearer function Names

ping @eileenmcnaughton @totten 
