### PR TITLE
dev/core#407 Fix mis-saving of price field values under localisation.

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
- *
  */
 
 /**

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -145,7 +145,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           'price_field_id' => $priceField->id,
           'label' => trim($params['option_label'][$index]),
           'name' => CRM_Utils_String::munge($params['option_label'][$index], '_', 64),
-          'amount' => CRM_Utils_Rule::cleanMoney(trim($params['option_amount'][$index])),
+          'amount' => trim($params['option_amount'][$index]),
           'count' => CRM_Utils_Array::value($index, CRM_Utils_Array::value('option_count', $params), NULL),
           'max_value' => CRM_Utils_Array::value($index, CRM_Utils_Array::value('option_max_value', $params), NULL),
           'description' => CRM_Utils_Array::value($index, CRM_Utils_Array::value('option_description', $params), NULL),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a localisation bug whereby membership config on contribution pages results in it saving (or trying) to save the wrong amount for comma-decimal sites

Before
----------------------------------------
Set up a site as comma for decimal place & . for thousand separator.
-create a new membership type
- add this type to a 'non-price set' membership page
- error on save
![screenshot 2018-12-05 10 53 49](https://user-images.githubusercontent.com/336308/49475436-18c50b80-f87c-11e8-91bd-83f45a5d629d.png)


After
----------------------------------------
Saves correctly

Technical Details
----------------------------------------
The amount is being inappropriately cleaned in the BAO layer - these values should always be clean by the time they get here

Comments
----------------------------------------
@mattwire 
