### PR TITLE
Fix period_type, duration_unit, duration_frequency to be required on membership type form

### DIFF
--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -92,15 +92,18 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       ],
       'duration_interval' => [
         'name' => 'duration_interval',
+        'required' => TRUE,
       ],
       'duration_unit' => [
         'name' => 'duration_unit',
         'description' => ts('Duration of this membership (e.g. 30 days, 2 months, 5 years, 1 lifetime)'),
+        'required' => TRUE,
       ],
       'period_type' => [
         'name' => 'period_type',
         'description' => ts("Select 'rolling' if membership periods begin at date of signup. Select 'fixed' if membership periods begin on a set calendar date."),
         'help' => ['id' => 'period-type', 'file' => "CRM/Member/Page/MembershipType.hlp"],
+        'required' => TRUE,
       ],
       'fixed_period_start_day' => [
         'name' => 'fixed_period_start_day',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a [regression](https://github.com/civicrm/civicrm-core/commit/afae744598438d792facdb7b854beba2e0213c51)  where some required fields are not showing as required

Before
----------------------------------------
Duration unit, frequency & plan type (period_type) not showing as required

After
----------------------------------------
fields required

![screenshot 2018-12-05 10 58 13](https://user-images.githubusercontent.com/336308/49475687-b9b3c680-f87c-11e8-81ee-2400601a01f8.png)


Technical Details
----------------------------------------
@mattwire this is from changes to the membership type form - I feel like we should get this merged for the rc (@monishdeb @seamuslee001 maybe one of you can merge).

I also think that MembershipType.xml should have these fields marked as required - I am always a bit hesitation to make changes like that in an update script in case a site has already some nulls & it causes pain. However, changing the schema only would change the DAO  / new installs

Comments
----------------------------------------

