### PR TITLE
dev/core#572 Revert customData changes in EventInfo template.

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -146,7 +146,22 @@
       <td>&nbsp;</td>
     </tr>
   </table>
-  {include file="CRM/common/customDataBlock.tpl"}
+  <div id="customData"></div>
+  {*include custom data js file*}
+  {include file="CRM/common/customData.tpl"}
+  {literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      {/literal}
+      {if $customDataSubType}
+      CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
+      {else}
+      CRM.buildCustomData( '{$customDataType}' );
+      {/if}
+      {literal}
+    });
+  </script>
+  {/literal}
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>


### PR DESCRIPTION
This reverts changes that break CKEditor integration from commit
c71da91daf7fa5c98da621720963b6a71d90bcdf.

Overview
----------------------------------------
_Fixes custom Note fields on Events no longer working with CKEditor._

Before
----------------------------------------
_The Event Info configuration page does not show the CKEditor interface for custom note fields._

After
----------------------------------------
_CKEditor integration is restored for custom note fields on the Event Info configuration page_

Technical Details
----------------------------------------
_The `CRM/common/customDataBlock.tpl` include that was changed to in a previous update does not handle building the ckeditor javascript properly, causing javascript errors when CKEditor is applied to the custom field; this PR reverts that change_
