### PR TITLE
clean up campaigns for reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4248,6 +4248,42 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   }
 
   /**
+   * Add campaign fields.
+   *
+   * @param bool $groupBy
+   *   Add GroupBy? Not appropriate for detail report.
+   * @param bool $orderBy
+   *   Add OrderBy? Not appropriate for detail report.
+   * @param bool $filters
+   *
+   */
+  public function addCampaignFields($entityTable = 'civicrm_contribution', $groupBy = FALSE, $orderBy = FALSE, $filters = TRUE) {
+    // Check if CiviCampaign is a) enabled and b) has active campaigns
+    $config = CRM_Core_Config::singleton();
+    $campaignEnabled = in_array('CiviCampaign', $config->enableComponents);
+    if ($campaignEnabled) {
+      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, FALSE, FALSE, TRUE);
+      // If we have a campaign, build out the relevant elements
+      if (!empty($getCampaigns['campaigns'])) {
+        $campaigns = $getCampaigns['campaigns'];
+        asort($campaigns);
+        $this->_columns[$entityTable]['fields']['campaign_id'] = array('title' => ts('Campaign'), 'default' => 'false');
+        if ($filters) {
+          $this->_columns[$entityTable]['filters']['campaign_id'] = array(
+            'title' => ts('Campaign'),
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => $campaigns,
+            'type' => CRM_Utils_Type::T_INT,
+          );
+        }
+        if ($groupBy) {
+          $this->_columns[$entityTable]['group_bys']['campaign_id'] = array('title' => ts('Campaign'));
+        }
+      }
+    }
+  }
+
+  /**
    * Add address fields.
    *
    * @deprecated - use getAddressColumns which is a more accurate description

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4265,14 +4265,14 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, FALSE, FALSE, TRUE);
       // If we have a campaign, build out the relevant elements
       if (!empty($getCampaigns['campaigns'])) {
-        $campaigns = $getCampaigns['campaigns'];
-        asort($campaigns);
+        $this->campaigns = $getCampaigns['campaigns'];
+        asort($this->campaigns);
         $this->_columns[$entityTable]['fields']['campaign_id'] = array('title' => ts('Campaign'), 'default' => 'false');
         if ($filters) {
           $this->_columns[$entityTable]['filters']['campaign_id'] = array(
             'title' => ts('Campaign'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => $campaigns,
+            'options' => $this->campaigns,
             'type' => CRM_Utils_Type::T_INT,
           );
         }

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -697,7 +697,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
       // convert campaign_id to campaign title
       if (array_key_exists('civicrm_contribution_campaign_id', $row)) {
         if ($value = $row['civicrm_contribution_campaign_id']) {
-          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->activeCampaigns[$value];
+          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->campaigns[$value];
           $entryFound = TRUE;
         }
       }

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -89,15 +89,6 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
       $date['minYear']++;
     }
 
-    // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
-
     $this->_columns = array(
       'civicrm_contact' => array(
         'dao' => 'CRM_Contact_DAO_Contact',
@@ -271,19 +262,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
     );
 
     // If we have a campaign, build out the relevant elements
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_contribution']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-        'type' => CRM_Utils_Type::T_INT,
-      );
-      $this->_columns['civicrm_contribution']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-    }
+    $this->addCampaignFields('civicrm_contribution');
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Report results don't show inactive campaigns. Also the campaign code needs cleanup. This PR aims at centralising the code for future changes.

Before
----------------------------------------
![lybunt_before](https://user-images.githubusercontent.com/3455173/49432122-f926d800-f7d4-11e8-9dcf-2c4a809b3162.png)

only active campaign can be seen in the filter
![lybunt_campaign](https://user-images.githubusercontent.com/3455173/49432137-fe842280-f7d4-11e8-96a5-58877228ba7b.png)


After
----------------------------------------
![lybunt_after](https://user-images.githubusercontent.com/3455173/49432144-05129a00-f7d5-11e8-9047-a8374c62a242.png)
shows all campaigns in the filters
![lybunt_criteria_after](https://user-images.githubusercontent.com/3455173/49432159-0d6ad500-f7d5-11e8-9565-6bc2e5203ec4.png)


Comments
----------------------------------------
I will be submitting more patches for the other reports that need cleanup
