### PR TITLE
(dev/core#574) Prevent memory exhaustion when generating large PDFs

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -95,21 +95,20 @@ class CRM_Utils_PDF_Utils {
     <div id=\"crm-container\">\n";
 
     // Strip <html>, <header>, and <body> tags from each page
+
     $htmlElementstoStrip = [
-      '@<head[^>]*?>.*?</head>@siu',
-      '@<script[^>]*?>.*?</script>@siu',
-      '@<body>@siu',
-      '@</body>@siu',
-      '@<html[^>]*?>@siu',
-      '@</html>@siu',
-      '@<!DOCTYPE[^>]*?>@siu',
+      '<head[^>]*?>.*?</head>',
+      '<script[^>]*?>.*?</script>',
+      '<body>',
+      '</body>',
+      '<html[^>]*?>',
+      '</html>',
+      '<!DOCTYPE[^>]*?>',
     ];
-    $htmlElementsInstead = ['', '', '', '', '', ''];
     foreach ($pages as & $page) {
-      $page = preg_replace($htmlElementstoStrip,
-        $htmlElementsInstead,
-        $page
-      );
+      foreach ($htmlElementstoStrip as $pattern) {
+        $page = mb_eregi_replace($pattern, '', $page);
+      }
     }
     // Glue the pages together
     $html .= implode("\n<div style=\"page-break-after: always\"></div>\n", $pages);


### PR DESCRIPTION
Overview
----------------------------------------
Creating large PDF crashes because of a memory error. This pull request lessens the memory impact of creating large PDFs.

Before
----------------------------------------
Creating large PDFs crashes with a memory error

After
----------------------------------------
Large pdfs get created

Technical Details
----------------------------------------
When creating a PDF, certain HTML tags get filtered out of the HTML before passing it to `wkhtml2pdf`. This was done using `preg_replace`. This method uses some memory, which sometimes is enough to make PHP run out of memory. `mb_eregi_replace` uses less memory.

Comments
----------------------------------------
The creation of a PDF sometimes still gives a memory error; however this is happening in the library snappy. [This pull request](https://github.com/KnpLabs/snappy/pull/335) should address that.
