### PR TITLE
core#571 - check logged in OR checksum user permissions to edit recur…

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -106,8 +106,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
     }
 
     if (!CRM_Core_Permission::check('edit contributions')) {
-      $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this, FALSE);
-      if (!CRM_Contact_BAO_Contact_Utils::validChecksum($this->_subscriptionDetails->contact_id, $userChecksum)) {
+      if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
         CRM_Core_Error::fatal(ts('You do not have permission to cancel this recurring contribution.'));
       }
       $this->_selfService = TRUE;

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -88,8 +88,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
       CRM_Core_Error::fatal('Required information missing.');
     }
     if (!CRM_Core_Permission::check('edit contributions')) {
-      $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this, FALSE);
-      if (!CRM_Contact_BAO_Contact_Utils::validChecksum($this->_subscriptionDetails->contact_id, $userChecksum)) {
+      if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
         CRM_Core_Error::fatal(ts('You do not have permission to cancel subscription.'));
       }
       $this->_selfService = TRUE;

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -124,8 +124,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
     }
 
     if (!CRM_Core_Permission::check('edit contributions')) {
-      $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this, FALSE);
-      if (!CRM_Contact_BAO_Contact_Utils::validChecksum($this->_subscriptionDetails->contact_id, $userChecksum)) {
+      if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
         CRM_Core_Error::statusBounce(ts('You do not have permission to update subscription.'));
       }
       $this->_selfService = TRUE;


### PR DESCRIPTION
…ring contributions

Overview
----------------------------------------
When self-service editing recurring contributions, Civi checks for either the "edit contributions" permission of the logged in user OR (that they are the person whose contribution it is AND they accessed the page via checksum).  We actually don't care if they accessed the page via checksum - if they're the user whose contribution it is, that's enough to give them permission.

Before
----------------------------------------
Users without "edit contributions" permission couldn't edit their own recurring contribution subscription unless they accessed the page via checksum.

After
----------------------------------------
Users without "edit contributions" permission can edit their own recurring contribution subscription, regardless of whether they have a checksum (i.e. they can also be logged in).

Comments
----------------------------------------
Thanks to @eileenmcnaughton for pointing out `CRM_Core_Form::getContactID()`!  This allowed me to fix thie problem by removing more code than I added.

I suspected there'd be copy/paste so I looked and I found it.  I updated all three locations.  I'm willing to do an extraction here but I don't know where I'd put it.  I guess instead of extending `CRM_Core_Form` I could make a new class that these three all inherit?  Let me know.

https://lab.civicrm.org/dev/core/issues/571