### PR TITLE
 dev/financial#36 Allow contribution import to specify label for Payment Instrument

### DIFF
--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -243,7 +243,18 @@ function _civicrm_api3_deprecated_formatted_param($params, &$values, $create = F
 
       case 'payment_instrument':
         require_once 'CRM/Core/PseudoConstant.php';
-        $values['payment_instrument_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $value);
+        $key = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $value);
+        if (!$key && ($key !== 0)) {
+          $pii_options = CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'create');
+          $lower_val = mb_strtolower($value);
+          foreach ($pii_options as $pik => $piv) {
+            if ($lower_val == mb_strtolower($piv)) {
+              $key = $pik;
+              break;
+            }
+          }
+        }
+        $values['payment_instrument_id'] = $key;
         if (empty($values['payment_instrument_id'])) {
           return civicrm_api3_create_error("Payment Instrument is not valid: $value");
         }


### PR DESCRIPTION
[dev/financial#36](https://lab.civicrm.org/dev/financial/issues/36) Allow contribution import to specify label for Payment Instrument, with case insensitivity.

Agileware ref: CIVICRM-1103

Overview
----------------------------------------
This fixes an issue where trying to import Contributions specifying the "Payment Instrument" by its label (which the user can see in the options list) would fail.

Before
----------------------------------------
To import a contribution with a Payment Instrument, the user must specify the payment instrument either by "Name", which is not necessarily the same as the Label that is shown to them.

After
----------------------------------------
If resolving the payment instrument by Name fails, the import process then tries by Label.

Technical Details
----------------------------------------
Why is the Contribution Importer using the `CRM_Utils_DeprecatedUtils` class to resolve various fields?  I don't know.  Why does this class even exist.
But this is where the error is.
Also uses comparison between the labels and given value in a case insensitive manner, using `mb_strtolower`.

Steps to Reproduce
----------------------------------------
As there's some confusion as to how this error is triggered, to reproduce it you must:

1. Edit your Payment Methods options, and correct the spelling of "Check" to "Cheque"
2. Try to import some contributions with the Payment Method column set to "Cheque"
3. This doesn't work, because the name of the Payment method is still "Check", even though the label is "Cheque"