### PR TITLE
dev/core#576 Fix the generation of DAO files because version comparis…

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -94,11 +94,11 @@ class CRM_Core_CodeGen_Specification {
     $tables = array();
     foreach ($dbXML->tables as $tablesXML) {
       foreach ($tablesXML->table as $tableXML) {
-        if ($this->value('drop', $tableXML, 0) > 0 and $this->value('drop', $tableXML, 0) <= $this->buildVersion) {
+        if ($this->value('drop', $tableXML, 0) > 0 && version_compare($this->value('drop', $tableXML, 0), $this->buildVersion, '<=')) {
           continue;
         }
 
-        if ($this->value('add', $tableXML, 0) <= $this->buildVersion) {
+        if (version_compare($this->value('add', $tableXML, 0), $this->buildVersion, '<=')) {
           $this->getTable($tableXML, $database, $tables);
         }
       }
@@ -222,11 +222,11 @@ class CRM_Core_CodeGen_Specification {
 
     $fields = array();
     foreach ($tableXML->field as $fieldXML) {
-      if ($this->value('drop', $fieldXML, 0) > 0 and $this->value('drop', $fieldXML, 0) <= $this->buildVersion) {
+      if ($this->value('drop', $fieldXML, 0) > 0 && version_compare($this->value('drop', $fieldXML, 0), $this->buildVersion, '<=')) {
         continue;
       }
 
-      if ($this->value('add', $fieldXML, 0) <= $this->buildVersion) {
+      if (version_compare($this->value('add', $fieldXML, 0), $this->buildVersion, '<=')) {
         $this->getField($fieldXML, $fields);
       }
     }
@@ -240,7 +240,7 @@ class CRM_Core_CodeGen_Specification {
     if ($this->value('index', $tableXML)) {
       $index = array();
       foreach ($tableXML->index as $indexXML) {
-        if ($this->value('drop', $indexXML, 0) > 0 and $this->value('drop', $indexXML, 0) <= $this->buildVersion) {
+        if ($this->value('drop', $indexXML, 0) > 0 && version_compare($this->value('drop', $indexXML, 0), $this->buildVersion, '<=')) {
           continue;
         }
 
@@ -254,10 +254,10 @@ class CRM_Core_CodeGen_Specification {
       $foreign = array();
       foreach ($tableXML->foreignKey as $foreignXML) {
 
-        if ($this->value('drop', $foreignXML, 0) > 0 and $this->value('drop', $foreignXML, 0) <= $this->buildVersion) {
+        if ($this->value('drop', $foreignXML, 0) > 0 && version_compare($this->value('drop', $foreignXML, 0), $this->buildVersion, '<=')) {
           continue;
         }
-        if ($this->value('add', $foreignXML, 0) <= $this->buildVersion) {
+        if (version_compare($this->value('add', $foreignXML, 0), $this->buildVersion, '<=')) {
           $this->getForeignKey($foreignXML, $fields, $foreign, $name);
         }
       }
@@ -267,10 +267,10 @@ class CRM_Core_CodeGen_Specification {
     if ($this->value('dynamicForeignKey', $tableXML)) {
       $dynamicForeign = array();
       foreach ($tableXML->dynamicForeignKey as $foreignXML) {
-        if ($this->value('drop', $foreignXML, 0) > 0 and $this->value('drop', $foreignXML, 0) <= $this->buildVersion) {
+        if ($this->value('drop', $foreignXML, 0) > 0 && version_compare($this->value('drop', $foreignXML, 0), $this->buildVersion, '<=')) {
           continue;
         }
-        if ($this->value('add', $foreignXML, 0) <= $this->buildVersion) {
+        if (version_compare($this->value('add', $foreignXML, 0), $this->buildVersion, '<=')) {
           $this->getDynamicForeignKey($foreignXML, $dynamicForeign, $name);
         }
       }


### PR DESCRIPTION
…ion fails and use standard version_compare function to assit us

Overview
----------------------------------------
This fixes test failures we are seeing on master since version was changed to 5.10. As per https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=max,CIVIVER=master,label=bknix-tmp/5944/

Before
----------------------------------------
Test fails because the comparison between 5.3 and 5.10 fails to detect 5.10 is > than 5.3 so doesn't add the field created_id for civicrm_file

After
----------------------------------------
It correctly calculates the difference between the versions and tests pass

ping @eileenmcnaughton @totten 