### PR TITLE
dev/core#561 Convert Scheduled Reminders Form to use datepicker and e…

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -194,7 +194,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $freqUnitsDisplay[$val] = ts('%1(s)', array(1 => $label));
     }
 
-    $this->addDate('absolute_date', ts('Start Date'), FALSE, array('formatType' => 'mailing'));
+    $this->add('datepicker', 'absolute_date', ts('Start Date'), [], FALSE, array('time' => FALSE));
 
     //reminder_frequency
     $this->add('select', 'start_action_unit', ts('Frequency'), $freqUnitsDisplay, TRUE);
@@ -342,8 +342,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     }
 
     if (!CRM_Utils_System::isNull($fields['absolute_date'])) {
-      if (CRM_Utils_Date::format(CRM_Utils_Date::processDate($fields['absolute_date'], NULL)) < CRM_Utils_Date::format(date('Ymd'))) {
+      if ($fields['absolute_date'] < date('Y-m-d')) {
         $errors['absolute_date'] = ts('Absolute date cannot be earlier than the current time.');
+      }
+    }
+    else {
+      if (CRM_Utils_System::isNull($fields['start_action_offset'])) {
+        $errors['start_action_offset'] = ts('Start Action Offset must be filled in or Absolute Date set');
       }
     }
     if (!CRM_Utils_Rule::email($fields['from_email']) && (!$mode || $mode != 'SMS')) {
@@ -403,10 +408,6 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       }
       else {
         $defaults['entity'] = $entityStatus;
-      }
-      if ($absoluteDate = CRM_Utils_Array::value('absolute_date', $defaults)) {
-        list($date, $time) = CRM_Utils_Date::setDateDefaults($absoluteDate);
-        $defaults['absolute_date'] = $date;
       }
 
       if ($recipientListing = CRM_Utils_Array::value('recipient_listing', $defaults)) {
@@ -522,10 +523,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       'end_date',
     );
 
-    if ($absoluteDate = CRM_Utils_Array::value('absolute_date', $params)) {
-      $params['absolute_date'] = CRM_Utils_Date::processDate($absoluteDate);
-    }
-    else {
+    if (!CRM_Utils_Array::value('absolute_date', $params)) {
       $params['absolute_date'] = 'null';
     }
     foreach ($moreKeys as $mkey) {

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -44,7 +44,7 @@
 
     <tr class="crm-scheduleReminder-form-block-when">
         <td class="right">{$form.start_action_offset.label}</td>
-        <td colspan="3">{include file="CRM/common/jcalendar.tpl" elementName=absolute_date} <strong id='OR'>OR</strong><br /></td>
+        <td colspan="3">{$form.absolute_date.html} <strong id='OR'>OR</strong><br /></td>
     </tr>
 
     <tr id="relativeDate" class="crm-scheduleReminder-form-block-description">


### PR DESCRIPTION
…nsure that either start_action_offset or absolute_date is filled in

Overview
----------------------------------------
This converts the scheduled reminders form from using jcalender to using date picker. It also ensures that if you don't input an absolute date you have to set the field `start_action_offset` 

Before
----------------------------------------
Deprecated calendar function was used

After
----------------------------------------
Modern Datepicker was used

ping @eileenmcnaughton @mattwire @monishdeb @colemanw 