### PR TITLE
core#580 - 'View all groups' ACL fails on 'Manage Groups' screen

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -65,6 +65,10 @@ class CRM_ACL_API {
       $contactID = 0;
     }
 
+    if ($allGroups == NULL) {
+      $allGroups = CRM_Core_PseudoConstant::allGroup();
+    }
+
     return CRM_ACL_BAO_ACL::check($str, $contactID);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Given a user who:
* Doesn't have "View All Contacts" permission;
* DOES have an ACL that gives permission to Edit "All Groups";

The "Manage Groups" screen shows no groups.

Before
----------------------------------------
Selecting "Manage Groups" with an ACL to display "All groups" shows no groups.

After
----------------------------------------
Selecting "Manage Groups" with an ACL to display "All groups" shows all groups.

Technical Details
----------------------------------------
This happens because `CRM_ACL_BAO_ACL::group()` expects an argument `$allGroups` to be passed, with an array of all the groups for this particular context.  The API code path populates this argument; the UI code path doesn't.

Comments
----------------------------------------
This solution is taken partly from the API code path, which populates `$allGroups` similarly.  Call stacks showing the permission check for UI vs. API is available on the Gitlab ticket.
