### PR TITLE
(RFC) Fix Locale Test by re-setting the locale used to en_US and by resetting the I18n singleton

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -660,14 +660,15 @@ class CRM_Core_I18n {
    * @return CRM_Core_I18n
    */
   public static function &singleton() {
-    static $singleton = array();
-
+    if (!isset(Civi::$statics[__CLASS__]['singleton'])) {
+      Civi::$statics[__CLASS__]['singleton'] = array();
+    }
     $tsLocale = CRM_Core_I18n::getLocale();
-    if (!isset($singleton[$tsLocale])) {
-      $singleton[$tsLocale] = new CRM_Core_I18n($tsLocale);
+    if (!isset(Civi::$statics[__CLASS__]['singleton'][$tsLocale])) {
+      Civi::$statics[__CLASS__]['singleton'][$tsLocale] = new CRM_Core_I18n($tsLocale);
     }
 
-    return $singleton[$tsLocale];
+    return Civi::$statics[__CLASS__]['singleton'][$tsLocale];
   }
 
   /**

--- a/tests/phpunit/CRM/Core/I18n/LocaleTest.php
+++ b/tests/phpunit/CRM/Core/I18n/LocaleTest.php
@@ -50,6 +50,8 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
     $locale = CRM_Core_I18n::getLocale();
 
     $this->assertEquals($locale, 'fr_CA');
+    CRM_Core_I18n::singleton()->setLocale('en_US');
+    Civi::$statics['CRM_Core_I18n']['singleton'] = [];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue in unit tests where subsequent tests remain in French and not are in English because the locale has not been reset

Before
----------------------------------------
Subesquent tests would remain in french as per https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=min,CIVIVER=master,label=bknix-tmp/5951/#showFailuresLink

After
----------------------------------------
Tests Fixed because locale is reset
