### PR TITLE
(NFC) Fix PHP7.2 Count error on test testImportParserWtihEmployeeOfRelation…

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -64,12 +64,12 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
 
     $fields = array_keys($contactImportValues);
     $values = array_values($contactImportValues);
-    $parser = new CRM_Contact_Import_Parser_Contact($fields, NULL);
+    $parser = new CRM_Contact_Import_Parser_Contact($fields, []);
     $parser->_contactType = 'Individual';
     $parser->init();
     $this->mapRelationshipFields($fields, $parser->getAllFields());
 
-    $parser = new CRM_Contact_Import_Parser_Contact($fields, NULL, NULL, NULL, array(
+    $parser = new CRM_Contact_Import_Parser_Contact($fields, [], [], [], array(
       NULL,
       NULL,
       $fields[2],
@@ -81,7 +81,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       NULL,
       NULL,
       "organization_name",
-    ), NULL, NULL, NULL, NULL, NULL);
+    ), [], [], [], [], []);
 
     $parser->_contactType = 'Individual';
     $parser->_onDuplicate = CRM_Import_Parser::DUPLICATE_UPDATE;


### PR DESCRIPTION
…ship

Overview
----------------------------------------
This fixes an error running the test suite on PHP7.2 

```
        <testcase name="testImportParserWtihEmployeeOfRelationship" class="CRM_Contact_Import_Parser_ContactTest" file="/home/jenkins/bknix-edge/build/dcmaster/sites/all/modules/civicrm/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php" line="54" assertions="3" time="0.217434">
          <error type="PHPUnit_Framework_Error_Warning">CRM_Contact_Import_Parser_ContactTest::testImportParserWtihEmployeeOfRelationship
count(): Parameter must be an array or an object that implements Countable

/home/jenkins/bknix-edge/build/dcmaster/sites/all/modules/civicrm/CRM/Contact/Import/Parser.php:375
/home/jenkins/bknix-edge/build/dcmaster/sites/all/modules/civicrm/CRM/Contact/Import/Parser/Contact.php:199
/home/jenkins/bknix-edge/build/dcmaster/sites/all/modules/civicrm/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php:69
/home/jenkins/bknix-edge/build/dcmaster/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:192
/home/jenkins/bknix-edge/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598
</error>
        </testcase>
````
Before
----------------------------------------
Test failed on PHP7.2

After
----------------------------------------
Test Passes on PHP7.2

ping @eileenmcnaughton @totten 
