### PR TITLE
dev/core#582 - Search Builder: Switch to new date/timepicker widget

### DIFF
--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -97,9 +97,7 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
     $fieldNameTypes = [];
     foreach ($fields as $name => $field) {
       // Assign date type to respective field name, which will be later used to modify operator list
-      if ($type = CRM_Utils_Array::key(CRM_Utils_Array::value('type', $field), CRM_Utils_Type::getValidTypes())) {
-        $fieldNameTypes[$name] = $type;
-      }
+      $fieldNameTypes[$name] = CRM_Utils_Type::typeToString(CRM_Utils_Array::value('type', $field));
       // it's necessary to know which of the fields are searchable by label
       if (isset($field['searchByLabel']) && $field['searchByLabel']) {
         $searchByLabelFields[] = $name;
@@ -278,6 +276,12 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
             }
             elseif (trim($v[2])) {
               //else check value for rest of the Operators
+              if ($type == 'Date' || $type == 'Timestamp') {
+                $v[2] = CRM_Utils_Date::processDate($v[2]);
+                if ($type == 'Date') {
+                  $v[2] = substr($v[2], 0, 8);
+                }
+              }
               $error = CRM_Utils_Type::validate($v[2], $type, FALSE);
               if ($error != $v[2]) {
                 $errorMsg["value[$v[3]][$v[4]]"] = ts("Please enter a valid value.");

--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -193,13 +193,23 @@
     if (!datePickerOp) {
       removeDate(row);
     }
-    else if (!input.hasClass('crm-form-date')) {
-      input.addClass('crm-form-date').attr({placeholder: '\uF073'}).datepicker({
-        dateFormat: 'yymmdd',
-        changeMonth: true,
-        changeYear: true,
-        yearRange: '-100:+20'
-      });
+    else if (!$('input.crm-hidden-date', row).length) {
+      // Unfortunately the search builder form expects yyyymmdd and crmDatepicker gives yyyy-mm-dd so we have to fudge it
+      var val = input.val();
+      if (val && val.length === 8) {
+        input.val(val.substr(0, 4) + '-' + val.substr(4, 2) + '-' + val.substr(6, 2));
+      }
+      input
+        .on('change.searchBuilder', function() {
+          if ($(this).val()) {
+            $(this).val($(this).val().replace(/-/g, ''));
+          }
+        })
+        .crmDatepicker({
+          time: false,
+          yearRange: '-100:+20'
+        })
+        .trigger('change', ['userInput']);
     }
   }
 
@@ -208,10 +218,7 @@
    * @param row: jQuery object
    */
   function removeDate(row) {
-    var input = $('.crm-search-value input', row);
-    if (input.hasClass('crm-form-date')) {
-      input.removeClass('crm-form-date').val('').attr('placeholder', '').datepicker('destroy');
-    }
+    $('.crm-search-value input.crm-hidden-date', row).off('.searchBuilder').crmDatepicker('destroy');
   }
 
   /**

--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -193,8 +193,8 @@
     if (!datePickerOp) {
       removeDate(row);
     }
-    else if (!input.hasClass('hasDatepicker')) {
-      input.addClass('dateplugin').datepicker({
+    else if (!input.hasClass('crm-form-date')) {
+      input.addClass('crm-form-date').attr({placeholder: '\uF073'}).datepicker({
         dateFormat: 'yymmdd',
         changeMonth: true,
         changeYear: true,
@@ -209,8 +209,8 @@
    */
   function removeDate(row) {
     var input = $('.crm-search-value input', row);
-    if (input.hasClass('hasDatepicker')) {
-      input.removeClass('dateplugin').val('').datepicker('destroy');
+    if (input.hasClass('crm-form-date')) {
+      input.removeClass('crm-form-date').val('').attr('placeholder', '').datepicker('destroy');
     }
   }
 

--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -48,10 +48,8 @@
       buildSelect(row, field, op, false);
     }
 
-    if ((field in CRM.searchBuilder.fieldTypes) === true &&
-      CRM.searchBuilder.fieldTypes[field] == 'Date'
-    ) {
-      buildDate(row, op);
+    if (CRM.searchBuilder.fieldTypes[field] === 'Date' || CRM.searchBuilder.fieldTypes[field] === 'Timestamp') {
+      buildDate(row, op, CRM.searchBuilder.fieldTypes[field] === 'Timestamp');
     }
     else {
       removeDate(row);
@@ -178,7 +176,7 @@
    * @param row: jQuery object
    */
   function removeSelect(row) {
-    $('.crm-search-value input', row).show();
+    $('.crm-search-value input', row).not('.crm-hidden-date').show();
     $('.crm-search-value select', row).remove();
   }
 
@@ -186,7 +184,7 @@
    * Add a datepicker if appropriate for this operation
    * @param row: jQuery object
    */
-  function buildDate(row, op) {
+  function buildDate(row, op, time) {
     var input = $('.crm-search-value input', row);
     // These are operations that should not get a datepicker
     var datePickerOp = ($.inArray(op, ['IN', 'NOT IN', 'LIKE', 'RLIKE']) < 0);
@@ -198,18 +196,20 @@
       var val = input.val();
       if (val && val.length === 8) {
         input.val(val.substr(0, 4) + '-' + val.substr(4, 2) + '-' + val.substr(6, 2));
+      } else if (val && val.length === 14) {
+        input.val(val.substr(0, 4) + '-' + val.substr(4, 2) + '-' + val.substr(6, 2) + ' ' + val.substr(8, 2) + ':' + val.substr(10, 2) + ':' + val.substr(12, 2));
       }
       input
         .on('change.searchBuilder', function() {
           if ($(this).val()) {
-            $(this).val($(this).val().replace(/-/g, ''));
+            $(this).val($(this).val().replace(/[: -]/g, ''));
           }
         })
         .crmDatepicker({
-          time: false,
+          time: time,
           yearRange: '-100:+20'
         })
-        .trigger('change', ['userInput']);
+        .triggerHandler('change', ['userInput']);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes some recent regressions with missing datepicker widgets and icons in searchbuilder by using the new `crmDatepicker` widget. This has the upshot of solving 2 longstanding searchbuilder shortcomings: date wasn't displayed in a human-readable format, and time wasn't available to select.

Before
----------------------------------------
Datepicker icon missing in Search Builder date fields.
Datepicker values display in machine format.
No datepicker for Search Builder datetime fields.

After
----------------------------------------
Icon restored for date fields.
Datepicker uses human-readable format.
Date+time widget for datetime fields.

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/582
