### PR TITLE
should use userFrameworkResourceURL

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -735,7 +735,7 @@ class CRM_Core_Resources {
       CRM_Admin_Page_CKEditorConfig::setConfigDefault();
       $items[] = array(
         'config' => array(
-          'wysisygScriptLocation' => Civi::paths()->getUrl("[civicrm.root]/js/wysiwyg/crm.ckeditor.js"),
+          'wysisygScriptLocation' => $config->userFrameworkResourceURL . "js/wysiwyg/crm.ckeditor.js",
           'CKEditorCustomConfig' => CRM_Admin_Page_CKEditorConfig::getConfigUrl(),
         ),
       );


### PR DESCRIPTION
Overview
----------------------------------------
The URL generated here for the wysiwyg editor will be incorrect in situations where the JS/CSS resources are in a different directory from the base Civi installation directory.  By using the userFrameworkResourceURL, it is more likely to pick up the right URL location.

Before
----------------------------------------
The wysiwyg editor script URL is generated by converting the civicrm_root value into a URL, resulting in an incorrect URL for situations where the web resources are in a different location.  Primarily, this happens in Drupal8 when the vendor directory has an .htaccess file that prevents access, so an alternative location is used for the web resources.

After
----------------------------------------
The new source for the URL value is userFrameworkResourceURL, which seems to be contextually the correct source of URLs for web-based resources anyway.

Technical Details
----------------------------------------
Simple one-line change using $config (already in scope) instead of the low-level Civi root path.

Comments
----------------------------------------
This has been tested on my local Civi/Drupal8 installation environment.
