### PR TITLE
PCP report - fix number of donors and total committed.

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2864,7 +2864,16 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     $this->storeGroupByArray();
 
     if (!empty($this->_groupByArray)) {
-      $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, $this->_groupByArray);
+      if ($this->optimisedForOnlyFullGroupBy) {
+        // We should probably deprecate this code path. What happens here is that
+        // the group by is amended to reflect the select columns. This often breaks the
+        // results. Retrofitting group strict group by onto existing report classes
+        // went badly.
+        $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, $this->_groupByArray);
+      }
+      else {
+        $this->_groupBy = ' GROUP BY ' . implode($this->_groupByArray);
+      }
     }
   }
 

--- a/CRM/Report/Form/Contribute/PCP.php
+++ b/CRM/Report/Form/Contribute/PCP.php
@@ -125,6 +125,14 @@ class CRM_Report_Form_Contribute_PCP extends CRM_Report_Form {
             'type' => CRM_Utils_Type::T_STRING,
           ),
         ),
+        'group_bys' => array(
+          'pcp_id' => array(
+            'name' => 'id',
+            'required' => TRUE,
+            'default' => TRUE,
+            'title' => ts('Personal Campaign Page'),
+          ),
+        ),
         'grouping' => 'pcp-fields',
       ),
       'civicrm_contribution_soft' => array(
@@ -204,6 +212,7 @@ class CRM_Report_Form_Contribute_PCP extends CRM_Report_Form {
     );
 
     parent::__construct();
+    $this->optimisedForOnlyFullGroupBy = FALSE;
   }
 
   public function from() {
@@ -234,10 +243,6 @@ LEFT JOIN civicrm_event {$this->_aliases['civicrm_event']}
 
     // for credit card type
     $this->addFinancialTrxnFromClause();
-  }
-
-  public function groupBy() {
-    $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, "{$this->_aliases['civicrm_pcp']}.id");
   }
 
   public function orderBy() {

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -33,6 +33,8 @@
  */
 class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
 
+  use CRMTraits_PCP_PCPTestTrait;
+
   /**
    * Sets up the fixture, for example, opens a network connection.
    * This method is called before a test is executed.
@@ -124,56 +126,6 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
     $this->assertDBRowNotExist('CRM_PCP_DAO_PCP', $pcpId,
       'Database check PCP deleted successfully.'
     );
-  }
-
-  /**
-   * Build params.
-   */
-  private function pcpBlockParams() {
-    $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');
-    $contribPageId = $contribPage->id;
-    $supporterProfile = CRM_Core_DAO::createTestObject('CRM_Core_DAO_UFGroup');
-    $supporterProfileId = $supporterProfile->id;
-
-    $params = array(
-      'entity_table' => 'civicrm_contribution_page',
-      'entity_id' => $contribPageId,
-      'supporter_profile_id' => $supporterProfileId,
-      'target_entity_id' => 1,
-      'is_approval_needed' => 1,
-      'is_tellfriend_enabled' => 1,
-      'tellfriend_limit' => 1,
-      'link_text' => 'Create your own PCP',
-      'is_active' => 1,
-    );
-
-    return $params;
-  }
-
-  /**
-   * Build params.
-   */
-  private function pcpParams() {
-    $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
-    $contactId = $contact->id;
-    $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');
-    $contribPageId = $contribPage->id;
-
-    $params = array(
-      'contact_id' => $contactId,
-      'status_id' => '1',
-      'title' => 'My PCP',
-      'intro_text' => 'Hey you, contribute now!',
-      'page_text' => 'You better give more.',
-      'donate_link_text' => 'Donate Now',
-      'page_id' => $contribPageId,
-      'is_thermometer' => 1,
-      'is_honor_roll' => 1,
-      'goal_amount' => 10000.00,
-      'is_active' => 1,
-    );
-
-    return $params;
   }
 
   /**

--- a/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
+++ b/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Trait CRMTraits_PCP_PCPTestTrait
+ *
+ * Traits for testing PCP pages.
+ */
+trait CRMTraits_PCP_PCPTestTrait {
+  /**
+   * Build and return pcpBlock params.
+   *
+   * Create the necessary initial objects for a pcpBlock, then return the
+   * params needed to create the pcpBlock.
+   *
+   */
+  public function pcpBlockParams() {
+    $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');
+    $contribPageId = $contribPage->id;
+    $supporterProfile = CRM_Core_DAO::createTestObject('CRM_Core_DAO_UFGroup');
+    $supporterProfileId = $supporterProfile->id;
+
+    $params = array(
+      'entity_table' => 'civicrm_contribution_page',
+      'entity_id' => $contribPageId,
+      'supporter_profile_id' => $supporterProfileId,
+      'target_entity_id' => 1,
+      'is_approval_needed' => 1,
+      'is_tellfriend_enabled' => 1,
+      'tellfriend_limit' => 1,
+      'link_text' => 'Create your own PCP',
+      'is_active' => 1,
+    );
+
+    return $params;
+  }
+
+  /**
+   * Build and return pcp params.
+   *
+   * Create the necessary initial objects for a pcp page, then return the
+   * params needed to create the pcp page.
+   */
+  public function pcpParams() {
+    $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
+    $contactId = $contact->id;
+    $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');
+    $contribPageId = $contribPage->id;
+
+    $params = array(
+      'contact_id' => $contactId,
+      'status_id' => '1',
+      'title' => 'My PCP',
+      'intro_text' => 'Hey you, contribute now!',
+      'page_text' => 'You better give more.',
+      'donate_link_text' => 'Donate Now',
+      'page_id' => $contribPageId,
+      'is_thermometer' => 1,
+      'is_honor_roll' => 1,
+      'goal_amount' => 10000.00,
+      'is_active' => 1,
+    );
+
+    return $params;
+  }
+
+}


### PR DESCRIPTION

Overview
----------------------------------------

Ensure number of donors and committed amount fields are properly calculated in the PCP
report.

See: https://lab.civicrm.org/dev/core/issues/586

Before
----------------------------------------

Instead of displaying the sum of all committed contributions, the report shows just one committed contribution.

Instead of showing the total count of all donors, the report shows the soft contribution id of one of the donors.

![pcp-report-before](https://user-images.githubusercontent.com/4511942/49832168-ed528d00-fd63-11e8-94fe-c12dfcd10816.png)

After
----------------------------------------

Data is correct.

![pcp-report-after](https://user-images.githubusercontent.com/4511942/49832183-f6435e80-fd63-11e8-8a33-7aad89964174.png)

Technical Details
----------------------------------------
I'm simply adding a dbAlias line for the two fields.

