### PR TITLE
dev/core#589 - Fix saving autocomplete search preferences

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -58,9 +58,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
 
       $this->setDefaultsForMetadataDefinedFields();
 
-      // @todo thise should be retrievable from the above function.
-      $this->_defaults['contact_autocomplete_options'] = self::getAutocompleteContactSearch();
-      $this->_defaults['contact_reference_options'] = self::getAutocompleteContactReference();
+      // @todo these should be retrievable from the above function.
       $this->_defaults['enableSSL'] = Civi::settings()->get('enableSSL');
       $this->_defaults['verifySSL'] = Civi::settings()->get('verifySSL');
       $this->_defaults['environment'] = CRM_Core_Config::environment();
@@ -115,20 +113,6 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
    */
   public function commonProcess(&$params) {
 
-    // save autocomplete search options
-    if (!empty($params['contact_autocomplete_options'])) {
-      Civi::settings()->set('contact_autocomplete_options',
-        CRM_Utils_Array::implodePadded(array_keys($params['contact_autocomplete_options'])));
-      unset($params['contact_autocomplete_options']);
-    }
-
-    // save autocomplete contact reference options
-    if (!empty($params['contact_reference_options'])) {
-      Civi::settings()->set('contact_reference_options',
-        CRM_Utils_Array::implodePadded(array_keys($params['contact_reference_options'])));
-      unset($params['contact_reference_options']);
-    }
-
     // save components to be enabled
     if (array_key_exists('enableComponents', $params)) {
       civicrm_api3('setting', 'create', array(
@@ -176,53 +160,6 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     // also delete the IDS file so we can write a new correct one on next load
     $configFile = $config->uploadDir . 'Config.IDS.ini';
     @unlink($configFile);
-  }
-
-  /**
-   * Ugh, this shouldn't exist.
-   *
-   * Get the selected values of "contact_reference_options" formatted for checkboxes.
-   *
-   * @return array
-   */
-  public static function getAutocompleteContactReference() {
-    $cRlist = array_flip(CRM_Core_OptionGroup::values('contact_reference_options',
-      FALSE, FALSE, TRUE, NULL, 'name'
-    ));
-    $cRlistEnabled = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-      'contact_reference_options'
-    );
-    $cRSearchFields = array();
-    if (!empty($cRlist) && !empty($cRlistEnabled)) {
-      $cRSearchFields = array_combine($cRlist, $cRlistEnabled);
-    }
-    return array(
-      '1' => 1,
-    ) + $cRSearchFields;
-  }
-
-  /**
-   * Ugh, this shouldn't exist.
-   *
-   * Get the selected values of "contact_autocomplete_options" formatted for checkboxes.
-   *
-   * @return array
-   */
-  public static function getAutocompleteContactSearch() {
-    $list = array_flip(CRM_Core_OptionGroup::values('contact_autocomplete_options',
-      FALSE, FALSE, TRUE, NULL, 'name'
-    ));
-    $listEnabled = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-      'contact_autocomplete_options'
-    );
-    $autoSearchFields = array();
-    if (!empty($list) && !empty($listEnabled)) {
-      $autoSearchFields = array_combine($list, $listEnabled);
-    }
-    //Set defaults for autocomplete and contact reference options
-    return array(
-      '1' => 1,
-    ) + $autoSearchFields;
   }
 
 }

--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -38,8 +38,8 @@
 class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
 
   protected $_settings = array(
-    'contact_reference_options' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'contact_autocomplete_options' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'contact_reference_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    'contact_autocomplete_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'search_autocomplete_count' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'enable_innodb_fts' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'includeWildCardInName' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
@@ -80,11 +80,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
    * @return array
    */
   public static function getContactAutocompleteOptions() {
-    return array(
-      ts('Contact Name') => 1,
-    ) + array_flip(CRM_Core_OptionGroup::values('contact_autocomplete_options',
-      FALSE, FALSE, TRUE
-    ));
+    return [1 => ts('Contact Name')] + CRM_Core_OptionGroup::values('contact_autocomplete_options', FALSE, FALSE, TRUE);
   }
 
   /**
@@ -103,11 +99,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
    * @return array
    */
   public static function getContactReferenceOptions() {
-    return array(
-      ts('Contact Name') => 1,
-    ) + array_flip(CRM_Core_OptionGroup::values('contact_reference_options',
-      FALSE, FALSE, TRUE
-    ));
+    return [1 => ts('Contact Name')] + CRM_Core_OptionGroup::values('contact_reference_options', FALSE, FALSE, TRUE);
   }
 
 }

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -288,7 +288,8 @@ return array(
     'group' => 'core',
     'name' => 'contact_autocomplete_options',
     'type' => 'String',
-    'quick_form_type' => 'CheckBox',
+    'quick_form_type' => 'CheckBoxes',
+    'html_type' => 'checkboxes',
     'pseudoconstant' => array(
       'callback' => 'CRM_Admin_Form_Setting_Search::getContactAutocompleteOptions',
     ),
@@ -299,13 +300,15 @@ return array(
     'is_contact' => 0,
     'description' => ts("Selected fields will be displayed in back-office autocomplete dropdown search results (Quick Search, etc.). Contact Name is always included."),
     'help_text' => NULL,
+    'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
   ),
   'contact_reference_options' => array(
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
     'name' => 'contact_reference_options',
     'type' => 'String',
-    'quick_form_type' => 'CheckBox',
+    'quick_form_type' => 'CheckBoxes',
+    'html_type' => 'checkboxes',
     'pseudoconstant' => array(
       'callback' => 'CRM_Admin_Form_Setting_Search::getContactReferenceOptions',
     ),
@@ -316,6 +319,7 @@ return array(
     'is_contact' => 0,
     'description' => ts("Selected fields will be displayed in autocomplete dropdown search results for 'Contact Reference' custom fields. Contact Name is always included. NOTE: You must assign 'access contact reference fields' permission to the anonymous role if you want to use custom contact reference fields in profiles on public pages. For most situations, you should use the 'Limit List to Group' setting when configuring a contact reference field which will be used in public forms to prevent exposing your entire contact list."),
     'help_text' => NULL,
+    'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
   ),
   'contact_smart_group_display' => array(
     'group_name' => 'CiviCRM Preferences',


### PR DESCRIPTION
Overview
-------
Fixes recent regression of saving autocomplete-related preferences on the Search Settings form.

Before
------
*Autocomplete Contact Search* and *Contact Reference Options* preferences do not save when submitting the Search Settings form.
See https://lab.civicrm.org/dev/core/issues/589 for details.

After
----
Settings are able to be saved.

Technical Details
------
I'm not sure exactly what caused this to regress but there has been a lot of refactoring of the settings forms of late, with the goal of making the forms more metadata-driven. When investigating the bug I noticed those two fields were getting special treatment in a number of places, for what appeared to be legacy reasons. Instead of trying to put another band-aid on those 2 fields, I removed all of their special treatment so they are completely metadata-driven. And now they work :)