### PR TITLE
Unable to mark price set field as inactive

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -689,7 +689,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       $params['option_weight'] = array(1 => $params['weight']);
       $params['option_financial_type_id'] = array(1 => $params['financial_type_id']);
       $params['option_visibility_id'] = array(1 => CRM_Utils_Array::value('visibility_id', $params));
-      $params['is_active'] = array(1 => 1);
+      $params['is_active'] = array(1 => $params['is_active']);
     }
 
     if ($this->_fid) {

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -689,7 +689,6 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       $params['option_weight'] = array(1 => $params['weight']);
       $params['option_financial_type_id'] = array(1 => $params['financial_type_id']);
       $params['option_visibility_id'] = array(1 => CRM_Utils_Array::value('visibility_id', $params));
-      $params['is_active'] = array(1 => $params['is_active']);
     }
 
     if ($this->_fid) {


### PR DESCRIPTION
Overview
----------------------------------------
When you edit a price field (via CiviCRM/Events/Manage Price Sets/View and Edit Price Fields/Edit Price Field) and uncheck the "Active?" checkbox and click save, the change is not saved and the field remains active. This fail only for Text/Numeric. Checking the "Active?" (when the field is disabled) it does work and the field is enabled.
![screenshot-1 1](https://user-images.githubusercontent.com/36624620/49895224-ea47c180-fe75-11e8-97d0-6dc482385b90.png)

After
----------------------------------------
We can set a price field to both 'enabled' and 'inactive' without issues

Technical Details
----------------------------------------
In CRM/Price/Form/Field.php postprocess, when html_type is 'Text', the params are modified as per the option group and option value. Here 'is_active' param is always set to 1 and so it cannot be set to inactive.
This PR fixes it by using 'is_active' from params instead of always using 1.
