### PR TITLE
dev/core#591 Exclude civicrm_tmp% from isam check

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -907,6 +907,7 @@ class CRM_Core_DAO extends DB_DataObject {
          AND TABLE_NAME LIKE 'civicrm_%'
          AND TABLE_NAME NOT LIKE 'civicrm_import_job_%'
          AND TABLE_NAME NOT LIKE '%_temp%'
+         AND TABLE_NAME NOT LIKE 'civicrm_tmp_%'
       ");
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevents inappropriate MyISAM Database Engine Error check errors on temp tables

Before
----------------------------------------
MyISAM Database Engine error message
Your database is configured to use the MyISAM database engine. CiviCRM requires InnoDB. You will need to convert any MyISAM tables in your database to InnoDB. Using MyISAM tables will result in data integrity issues.

Relating to ![tables like this](https://i.stack.imgur.com/N10jO.png)

After
----------------------------------------
no message

Technical Details
----------------------------------------
Just updates the exclude list to reflect new prefixes. Tables have been renamed recently so we should treat as a regression & merge to rc & 5.8.1

Comments
----------------------------------------
@totten 
