### PR TITLE
Disabling or deleting Expired status breaks membership status update

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2241,7 +2241,11 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
     // Tests for this function are in api_v3_JobTest. Please add tests for all updates.
 
     $updateCount = $processCount = self::updateDeceasedMembersStatuses();
-    $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
+
+    // We want all of the statuses as id => name, even the disabled ones (cf.
+    // CRM-15475), to identify which are Pending, Deceased, Cancelled, and
+    // Expired.
+    $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'validate');
     $allTypes = CRM_Member_PseudoConstant::membershipType();
 
     // This query retrieves ALL memberships of active types.
@@ -2267,11 +2271,7 @@ WHERE      civicrm_membership.is_test = 0
 
     $deceaseStatusId = array_search('Deceased', $allStatus);
     $pendingStatusId = array_search('Pending', $allStatus);
-    // CRM-15475
-    $cancelledStatusId = array_search(
-      'Cancelled',
-      CRM_Member_PseudoConstant::membershipStatus(NULL, " name = 'Cancelled' ", 'name', FALSE, TRUE)
-    );
+    $cancelledStatusId = array_search('Cancelled', $allStatus);
     // Expired is not reserved so might not exist.  A value of `0` won't break.
     $expiredStatusId = array_search('Expired', $allStatus) ?: 0;
 

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2241,7 +2241,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
     // Tests for this function are in api_v3_JobTest. Please add tests for all updates.
 
     $updateCount = $processCount = self::updateDeceasedMembersStatuses();
-    $allStatus = CRM_Member_PseudoConstant::membershipStatus();
+    $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
     $allTypes = CRM_Member_PseudoConstant::membershipType();
 
     // This query retrieves ALL memberships of active types.
@@ -2262,7 +2262,7 @@ FROM       civicrm_membership
 INNER JOIN civicrm_contact ON ( civicrm_membership.contact_id = civicrm_contact.id )
 INNER JOIN civicrm_membership_type ON
   (civicrm_membership.membership_type_id = civicrm_membership_type.id AND civicrm_membership_type.is_active = 1)
-WHERE      civicrm_membership.is_test = 0 
+WHERE      civicrm_membership.is_test = 0
            AND civicrm_contact.is_deceased = 0 ";
 
     $deceaseStatusId = array_search('Deceased', $allStatus);
@@ -2272,7 +2272,8 @@ WHERE      civicrm_membership.is_test = 0
       'Cancelled',
       CRM_Member_PseudoConstant::membershipStatus(NULL, " name = 'Cancelled' ", 'name', FALSE, TRUE)
     );
-    $expiredStatusId = array_search('Expired', $allStatus);
+    // Expired is not reserved so might not exist.  A value of `0` won't break.
+    $expiredStatusId = array_search('Expired', $allStatus) ?: 0;
 
     $query = $baseQuery . " AND civicrm_membership.is_override IS NOT NULL AND civicrm_membership.status_override_end_date IS NOT NULL";
     $dao1 = CRM_Core_DAO::executeQuery($query);

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -133,6 +133,14 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
   public function testExpiredDisabled() {
     $result = civicrm_api3('MembershipStatus', 'get', [
       'name' => "Expired",
+      'api.MembershipStatus.create' => ['label' => 'Expiiiired'],
+    ]);
+
+    // Calling it 'Expiiiired' is OK.
+    $result = $this->callAPISuccess('job', 'process_membership', []);
+
+    $result = civicrm_api3('MembershipStatus', 'get', [
+      'name' => "Expired",
       'api.MembershipStatus.create' => ['is_active' => 0],
     ]);
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -132,7 +132,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
 
   public function testExpiredDisabled() {
     $result = civicrm_api3('MembershipStatus', 'get', [
-      'label' => "Expired",
+      'name' => "Expired",
       'api.MembershipStatus.create' => ['is_active' => 0],
     ]);
 
@@ -140,7 +140,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('job', 'process_membership', []);
 
     $result = civicrm_api3('MembershipStatus', 'get', [
-      'label' => "Expired",
+      'name' => "Expired",
       'api.MembershipStatus.delete' => [],
     ]);
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -130,6 +130,40 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $this->assertEquals(empty($result), TRUE, 'Verify membership status record deletion.');
   }
 
+  public function testExpiredDisabled() {
+    $result = civicrm_api3('MembershipStatus', 'get', [
+      'label' => "Expired",
+      'api.MembershipStatus.create' => ['is_active' => 0],
+    ]);
+
+    // Disabling 'Expired' is OK.
+    $result = $this->callAPISuccess('job', 'process_membership', []);
+
+    $result = civicrm_api3('MembershipStatus', 'get', [
+      'label' => "Expired",
+      'api.MembershipStatus.delete' => [],
+    ]);
+
+    // Deleting 'Expired' is OK.
+    $result = $this->callAPISuccess('job', 'process_membership', []);
+
+    // Put things back like normal
+    $result = civicrm_api3('MembershipStatus', 'create', [
+      'name' => 'Expired',
+      'label' => 'Expired',
+      'start_event' => 'end_date',
+      'start_event_adjust_unit' => 'month',
+      'start_event_adjust_interval' => 1,
+      'is_current_member' => 0,
+      'is_admin' => 0,
+      'weight' => 4,
+      'is_default' => 0,
+      'is_active' => 1,
+      'is_reserved' => 0,
+    ]);
+
+  }
+
   public function testGetMembershipStatusByDate() {
     $params = array(
       'name' => 'Current',


### PR DESCRIPTION
Overview
----------------------------------------
The `Expired` membership status is not reserved.  That means people can disable, rename, or delete it.  However, if it was deleted, disabled, or renamed, the status update would break.

Before
----------------------------------------
If you disabled the `Expired` membership status, the "Membership status processor" scheduled job would fail with the following message:

> Finished execution of Membership status processor with result: Failure, Error message: A fatal error was triggered: One of parameters (value: ) is not of the type Integer


After
----------------------------------------
Disabling, deleting, or renaming the status doesn't cause problems.

Technical Details
----------------------------------------
In lieu of rearranging the query when there is no `Expired` status, I simply substitute `0` because it's an integer and there should be no status with that ID.

Comments
----------------------------------------
The presumption that expired memberships should not be evaluated for their status is questionable.  This doesn't address that.
