### PR TITLE
dev/core#592 Add default for  in Exception class.

### DIFF
--- a/api/Exception.php
+++ b/api/Exception.php
@@ -106,7 +106,7 @@ class CiviCRM_API3_Exception extends Exception {
    * @param Exception|NULL $previous
    *   A previous exception which caused this new exception.
    */
-  public function __construct($message, $error_code, $extraParams = array(), Exception $previous = NULL) {
+  public function __construct($message, $error_code = 0, $extraParams = array(), Exception $previous = NULL) {
     parent::__construct(ts($message));
     $this->extraParams = $extraParams + array('error_code' => $error_code);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes non-fatal error
```
ArgumentCountError: Too few arguments to function CiviCRM_API3_Exception::__construct(), 1 passed in [drupal root]/sites/all/modules/civicrm/Civi/API/Api3SelectQuery.php on line 130 and at least 2 expected in CiviCRM_API3_Exception->__construct()
```

Before
----------------------------------------
Above error occurs... when an error occurs

After
----------------------------------------
Only the error occurs....

Technical Details
----------------------------------------
Throw line is
```
            throw new \CiviCRM_API3_Exception("'$key' specified in OR group but not added to params");
```

parent is 
```
    public function __construct($message = "", $code = 0, Throwable $previous = null) { }
```

so adding a default is closer to the parent

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/592