### PR TITLE
dev/core#588 fix "CiviMail Draft" appears twice in non-Mosaico test emails

### DIFF
--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -414,9 +414,6 @@
           }
         });
 
-        // clearly indicates that it's a draft mailing
-        params.subject = ts('[CiviMail Draft]') + ' ' + params.subject;
-
         // WORKAROUND: Mailing.create (aka CRM_Mailing_BAO_Mailing::create()) interprets scheduled_date
         // as an *intent* to schedule and creates tertiary records. Saving a draft with a scheduled_date
         // is therefore not allowed. Remove this after fixing Mailing.create's contract.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes issue where `[CiviMail Draft]` appears twice on non-Mosaico test emails. This comes at the cost of removing the single instance from Mosaico emails, but that can be fixed in `org.civicrm.flexmailer`.

Before
----------------------------------------
* `[CiviMail Draft]` appears twice in non-Mosaico test emails
* `[CiviMail Draft]`  appears once in Mosaico test emails

After
----------------------------------------
* `[CiviMail Draft]`  appears once in non-Mosaico test emails
* `[CiviMail Draft]`  appears never in Mosaico test emails

Technical Details
----------------------------------------
This reverts commit 29cfa0ffae971c99116a2a0a069c4e486b83bffa from https://github.com/civicrm/civicrm-core/pull/12758.