### PR TITLE
dev/core#595 Fix label default not being set on membership status form

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -146,7 +146,7 @@ trait CRM_Core_Form_EntityFormTrait {
     }
     foreach ($this->entityFields as $fieldSpec) {
       $value = CRM_Utils_Request::retrieveValue($fieldSpec['name'], $this->getValidationTypeForField($fieldSpec['name']));
-      if ($value !== FALSE) {
+      if ($value !== FALSE && $value !== NULL) {
         $defaults[$fieldSpec['name']] = $value;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Pre-saved value for label not loading on membership status form

Before
----------------------------------------
Value not loading

After
----------------------------------------
Value loading

Technical Details
----------------------------------------
Code exists to retrieve the value from the url if it exists - code  only takes from the url if the value is usable & had defined usable too broadly. FALSE is unusable due to failing validation whereas NULL is not present

Comments
----------------------------------------
@davejenx  - will also back port to 5.8