### PR TITLE
Record change log entry when contact is moved to or restored from trash

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1204,6 +1204,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
 
     $contact->copyValues($updateParams);
     $contact->save();
+    CRM_Core_BAO_Log::register($contact->id, 'civicrm_contact', $contact->id);
 
     CRM_Utils_Hook::post('update', $contact->contact_type, $contact->id, $contact);
 


### PR DESCRIPTION
Overview
----------------------------------------
Record a change log entry when contact is moved to trash or restored from trash.

Before
----------------------------------------
There is no change log entry when someone moves a contact to trash.

After
----------------------------------------
Change log entry is automatically created.