### PR TITLE
Fix netAmount null object on freeze

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -154,7 +154,6 @@ class CRM_Contribute_Form_AdditionalInfo {
 
     $statusName = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     if ($form->_id && $form->_values['contribution_status_id'] == array_search('Cancelled', $statusName)) {
-      $netAmount->freeze();
       $feeAmount->freeze();
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix legacy code that was left behind after PR #13183 

Before
----------------------------------------
When go to Edit Form for a Cancelled Contribution, an PHP error is displayed:
```
Error: Call to a member function freeze() on null en CRM_Contribute_Form_AdditionalInfo::buildAdditionalDetail() (línea 157 de . . ./civicrm/CRM/Contribute/Form/AdditionalInfo.php).
```

After
----------------------------------------
Contribution Edit Form is displayed correctly

Technical Details
----------------------------------------
There's no element called `$netAmount` in the form to be frozen. Removed the line
```
$netAmount->freeze();
``` 
