### PR TITLE
Fix  \Civi\Token\TokenRow::customToken() failure if field is not set

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -136,10 +136,11 @@ class TokenRow {
    */
   public function customToken($entity, $customFieldID, $entityID) {
     $customFieldName = "custom_" . $customFieldID;
-    $fieldValue = civicrm_api3($entity, 'getvalue', array(
+    $record = civicrm_api3($entity, "getSingle", [
       'return' => $customFieldName,
-      'id' => $entityID,
-    ));
+       'id' => $entityID,
+    ]);
+    $fieldValue = \CRM_Utils_Array::value($customFieldName, $record, '');
 
     // format the raw custom field value into proper display value
     if ($fieldValue) {


### PR DESCRIPTION
Overview
----------------------------------------
Extracted from #13174 and #12012
Fixes a problem in \Civi\Token\TokenRow::customToken().  If the field is not set or does not exist, the getValue API call blows up, so use 

Before
----------------------------------------
Calling  \Civi\Token\TokenRow::customToken() with a custom field that is not set fails

After
----------------------------------------
Calling  \Civi\Token\TokenRow::customToken() with a custom field that is not set works

