### PR TITLE
Format token custom fields with value of 0 correctly

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -142,7 +142,7 @@ class TokenRow {
     ));
 
     // format the raw custom field value into proper display value
-    if ($fieldValue) {
+    if (isset($fieldValue)) {
       $fieldValue = \CRM_Core_BAO_CustomField::displayValue($fieldValue, $customFieldID);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Extracted from #13174 and #12012   Small bug fix so that tokens for custom values of 0 get formatted

