### PR TITLE
Render Note field tokens correctly - they are already HTML.

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -218,6 +218,7 @@ class TokenRow {
       case 'text/html':
         // Plain => HTML.
         foreach ($textTokens as $entity => $values) {
+          $entityFields = civicrm_api3($entity, "getFields", array('api_action' => 'get'));
           foreach ($values as $field => $value) {
             if (!isset($htmlTokens[$entity][$field])) {
               // CRM-18420 - Activity Details Field are enclosed within <p>,
@@ -225,6 +226,10 @@ class TokenRow {
               // conversion of these tags resulting in raw HTML.
               if ($entity == 'activity' && $field == 'details') {
                 $htmlTokens[$entity][$field] = $value;
+              }
+              elseif (\CRM_Utils_Array::value('data_type', \CRM_Utils_Array::value($field, $entityFields['values'])) == 'Memo') {
+                // Memo fields aka custom fields of type Note are html.
+                $htmlTokens[$entity][$field] = CRM_Utils_String::purifyHTML($value);
               }
               else {
                 $htmlTokens[$entity][$field] = htmlentities($value);


### PR DESCRIPTION
Overview
----------------------------------------
Extracted from #13174 and #12012  Small bug fix so that tokens of Note fields are rendered correctly.  They are already HTML so don't convert them to HTML again.
