### PR TITLE
Prevent \Civi\Token\TokenCompatSubscriber::evaluate() erroring when no contactId is given.

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -49,6 +49,9 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $messageTokens = $e->getTokenProcessor()->getMessageTokens();
 
     foreach ($e->getRows() as $row) {
+      if (empty($row->context['contactId'])) {
+        continue;
+      }
       /** @var int $contactId */
       $contactId = $row->context['contactId'];
       if (empty($row->context['contact'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Extracted from #13174 and #12012  Handle the situation when \Civi\Token\TokenCompatSubscriber::evaluate() is called with no contactId specified in the row context.  Should not error.


