### PR TITLE
Move pear/mail from packages to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     "pear/Auth_SASL": "1.1.0",
     "pear/Net_SMTP": "1.6.*",
     "pear/Net_socket": "1.0.*",
+    "pear/mail": "^1.4",
     "civicrm/civicrm-setup": "~0.2.0",
     "guzzlehttp/guzzle": "^6.3",
     "psr/simple-cache": "~1.0.1"
@@ -71,6 +72,7 @@
       "bash tools/scripts/composer/tcpdf-cleanup.sh",
       "bash tools/scripts/composer/pear-exception-fix.sh",
       "bash tools/scripts/composer/net-smtp-fix.sh",
+      "bash tools/scripts/composer/pear-mail-fix.sh",
       "bash tools/scripts/composer/phpword-jquery.sh"
     ],
     "post-update-cmd": [
@@ -78,6 +80,7 @@
       "bash tools/scripts/composer/tcpdf-cleanup.sh",
       "bash tools/scripts/composer/pear-exception-fix.sh",
       "bash tools/scripts/composer/net-smtp-fix.sh",
+      "bash tools/scripts/composer/pear-mail-fix.sh",
       "bash tools/scripts/composer/phpword-jquery.sh"
     ]
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a5a920dad6f16458645ee4b5944716a",
+    "content-hash": "d87e8c07e37c51a65ff849235d04e3dc",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -504,6 +504,111 @@
             "time": "2017-03-07T14:37:05+00:00"
         },
         {
+            "name": "pear/console_getopt",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Console_Getopt.git",
+                "reference": "82f05cd1aa3edf34e19aa7c8ca312ce13a6a577f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Console_Getopt/zipball/82f05cd1aa3edf34e19aa7c8ca312ce13a6a577f",
+                "reference": "82f05cd1aa3edf34e19aa7c8ca312ce13a6a577f",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Console": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net",
+                    "role": "Helper"
+                },
+                {
+                    "name": "Andrei Zmievski",
+                    "email": "andrei@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Stig Bakken",
+                    "email": "stig@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "More info available on: http://pear.php.net/package/Console_Getopt",
+            "time": "2015-07-20T20:28:12+00:00"
+        },
+        {
+            "name": "pear/mail",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Mail.git",
+                "reference": "9609ed5e42ac5b221dfd9af85de005c59d418ee7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Mail/zipball/9609ed5e42ac5b221dfd9af85de005c59d418ee7",
+                "reference": "9609ed5e42ac5b221dfd9af85de005c59d418ee7",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear-core-minimal": "~1.9",
+                "php": ">=5.2.1"
+            },
+            "require-dev": {
+                "pear/pear": "*"
+            },
+            "suggest": {
+                "pear/net_smtp": "Install optionally via your project's composer.json"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mail": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Chuck Hagenbuch",
+                    "email": "chuck@horde.org",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Richard Heyes",
+                    "email": "richard@phpguru.org",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Aleksander Machniak",
+                    "email": "alec@alec.pl",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Class that provides multiple interfaces for sending emails.",
+            "homepage": "http://pear.php.net/package/Mail",
+            "time": "2017-04-11T17:27:29+00:00"
+        },
+        {
             "name": "pear/net_smtp",
             "version": "1.6.3",
             "source": {
@@ -623,6 +728,50 @@
             ],
             "description": "More info available on: http://pear.php.net/package/Net_Socket",
             "time": "2014-02-20T19:27:06+00:00"
+        },
+        {
+            "name": "pear/pear-core-minimal",
+            "version": "v1.10.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/pear-core-minimal.git",
+                "reference": "19a3e0fcd50492c4357372f623f55f1b144346da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/19a3e0fcd50492c4357372f623f55f1b144346da",
+                "reference": "19a3e0fcd50492c4357372f623f55f1b144346da",
+                "shasum": ""
+            },
+            "require": {
+                "pear/console_getopt": "~1.4",
+                "pear/pear_exception": "~1.0"
+            },
+            "replace": {
+                "rsky/pear-core-min": "self.version"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "src/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@php.net",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Minimal set of PEAR core files to be used as composer dependency",
+            "time": "2018-12-05T20:03:52+00:00"
         },
         {
             "name": "pear/pear_exception",

--- a/tools/scripts/composer/patches/pear-mail.patch.txt
+++ b/tools/scripts/composer/patches/pear-mail.patch.txt
@@ -1,0 +1,86 @@
+diff --git a/Mail.php b/Mail.php
+index b04bc01..0e7da00 100644
+--- a/Mail.php
++++ b/Mail.php
+@@ -155,6 +155,10 @@ class Mail
+                 preg_replace('=((<CR>|<LF>|0x0A/%0A|0x0D/%0D|\\n|\\r)\S).*=i',
+                              null, $value);
+         }
++        // fix for CRM-1367
++        if (!array_key_exists('Date', $headers)) {
++            $headers['Date'] = date('r');
++        }
+     }
+ 
+     /**
+diff --git a/Mail/mail.php b/Mail/mail.php
+index ee1ecef..ae6e2e8 100644
+--- a/Mail/mail.php
++++ b/Mail/mail.php
+@@ -114,6 +114,14 @@ class Mail_mail extends Mail {
+      */
+     public function send($recipients, $headers, $body)
+     {
++        if (defined('CIVICRM_MAIL_LOG')) {
++            CRM_Utils_Mail::logger($recipients, $headers, $body);
++            // Note: "CIVICRM_MAIL_LOG_AND SEND" (space not underscore) was a typo that existed for some years, so kept here for compatibility, but it should not be used.
++            if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
++                return true;
++            }
++        }
++
+         if (!is_array($headers)) {
+             return PEAR::raiseError('$headers must be an array');
+         }
+@@ -145,7 +153,12 @@ class Mail_mail extends Mail {
+         if (is_a($headerElements, 'PEAR_Error')) {
+             return $headerElements;
+         }
+-        list(, $text_headers) = $headerElements;
++        list($from, $text_headers) = $headerElements;
++        // use Return-Path for SMTP envelope’s FROM address (if set), CRM-5946
++        if (!empty($headers['Return-Path'])) {
++            $from = $headers['Return-Path'];
++        }
++        $this->_params = "-f".$from;
+ 
+         // We only use mail()'s optional fifth parameter if the additional
+         // parameters have been provided and we're not running in safe mode.
+diff --git a/Mail/sendmail.php b/Mail/sendmail.php
+index 7e8f804..e0300a0 100644
+--- a/Mail/sendmail.php
++++ b/Mail/sendmail.php
+@@ -132,6 +132,14 @@ class Mail_sendmail extends Mail {
+      */
+     public function send($recipients, $headers, $body)
+     {
++        if (defined('CIVICRM_MAIL_LOG')) {
++            CRM_Utils_Mail::logger($recipients, $headers, $body);
++            // Note: "CIVICRM_MAIL_LOG_AND SEND" (space not underscore) was a typo that existed for some years, so kept here for compatibility, but it should not be used.
++            if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
++                return true;
++            }
++        }
++
+         if (!is_array($headers)) {
+             return PEAR::raiseError('$headers must be an array');
+         }
+diff --git a/Mail/smtp.php b/Mail/smtp.php
+index 5e698fe..5f057e2 100644
+--- a/Mail/smtp.php
++++ b/Mail/smtp.php
+@@ -255,6 +255,14 @@ class Mail_smtp extends Mail {
+      */
+     public function send($recipients, $headers, $body)
+     {
++        if (defined('CIVICRM_MAIL_LOG')) {
++            CRM_Utils_Mail::logger($recipients, $headers, $body);
++            // Note: "CIVICRM_MAIL_LOG_AND SEND" (space not underscore) was a typo that existed for some years, so kept here for compatibility, but it should not be used.
++            if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
++                return true;
++            }
++        }
++
+         $result = $this->send_or_fail($recipients, $headers, $body);
+ 
+         /* If persistent connections are disabled, destroy our SMTP object. */

--- a/tools/scripts/composer/pear-mail-fix.sh
+++ b/tools/scripts/composer/pear-mail-fix.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+## Cleanup the vendor tree. The main issue here is that civi Civi is
+## deployed as a module inside a CMS, so all its source-code gets published.
+## Some libraries distribute admin tools and sample files which should not
+## be published.
+##
+## This script should be idempotent -- if you rerun it several times, it
+## should always produce the same post-condition.
+
+## Replace a line in a file
+## This is a bit like 'sed -i', but dumber and more cross-platform.
+
+##############################################################################
+## usage: safe_delete <relpath...>
+function safe_delete() {
+  for file in "$@" ; do
+    if [ -z "$file" ]; then
+      echo "Skip: empty file name"
+    elif [ -e "$file" ]; then
+      rm -rf "$file"
+    fi
+  done
+}
+
+
+##############################################################################
+# @fixme Extend pear/mail rather than patching it.
+if ! grep -q 'CRM-1367' vendor/pear/mail/Mail.php; then
+  patch -d vendor/pear/mail -p1 < tools/scripts/composer/patches/pear-mail.patch.txt
+fi
+
+safe_delete vendor/pear/console_getopt/{package.xml,README.rst,tests}
+safe_delete vendor/pear/mail/{package.xml,README.rst,tests}
+safe_delete vendor/pear/pear-core-minimal/{package.xml,README.rst}


### PR DESCRIPTION
Overview
----------------------------------------
Move pear/mail from packages to composer.json.

Before
----------------------------------------
The old version of pear/mail in packages is not compatible with current version of PHP; see e.g. "Only variable references should be returned by reference" notice in Mail_smtp civicrm/civicrm-packages#220

After
----------------------------------------
We install the current version of pear/mail via composer and apply CiviCRM patches on top of it.

Technical Details
----------------------------------------
This PR also installs pear/console_getopt and pear/pear-core-minimal via composer, so we can remove them from packages - see civicrm/civicrm-packages#220   After applying both PRs locally, I did some quick testing to see if anything is broken - ran some cli.php commands, and sent a test email via web UI.