### PR TITLE
Declare 'amount' as required on ContributionRecur api

### DIFF
--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -56,6 +56,7 @@ function _civicrm_api3_contribution_recur_create_spec(&$params) {
   $params['contact_id']['api.required'] = 1;
   $params['create_date']['api.default'] = 'now';
   $params['frequency_interval']['api.required'] = 1;
+  $params['amount']['api.required'] = 1;
   $params['start_date']['api.default'] = 'now';
   $params['modified_date']['api.default'] = 'now';
 }


### PR DESCRIPTION
Overview
----------------------------------------
Declare amount as  a required field on Contribution Recur create api - this improves the error message when it is not passed in but does not change it 

Before
----------------------------------------
Calling ContributionRecur.create with neither id or amount fails with the message 
[nativecode=1364 ** Field 'amount' doesn't have a default value]

After
----------------------------------------
Calling ContributionRecur.create with neither id or amount fails with the message 
 Mandatory key(s) missing from params array: amount

Technical Details
----------------------------------------

The field is not required at the DB level (it probably should be that too) but
it has no default value so you wind up with

[nativecode=1364 ** Field 'amount' doesn't have a default value]

Note that making it required at the DB level won't change the need for this
patch & is separate. The api declares what is required at the api level
- somethings are required at the DB level but not at the api level as they are
calculated in the BAO

Comments
----------------------------------------
This is really a bug fix rather than a change