### PR TITLE
Add default of TRUE for is_active on PaymentProcessor.create api.

### DIFF
--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -61,6 +61,7 @@ function _civicrm_api3_payment_processor_create_spec(&$params) {
   $params['payment_processor_type_id']['api.required'] = 1;
   $params['is_default']['api.default'] = 0;
   $params['is_test']['api.default'] = 0;
+  $params['is_active']['api.default'] = TRUE;
   $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
   $params['financial_account_id']['api.default'] = CRM_Financial_BAO_PaymentProcessor::getDefaultFinancialAccountID();
   $params['financial_account_id']['api.required'] = TRUE;

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -105,6 +105,7 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
       'is_recur' => $params['is_recur'],
       'payment_type' => 1,
       'payment_instrument_id' => 1,
+      'is_active' => 1,
     );
     $this->checkArrayEquals($expectedResult, $result['values'][$result['id']]);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Changes metadata on PaymentProcessor api such that is_active is true by default

Before
----------------------------------------
If PaymentProcessor.create is called with neither id or is_active passed in is_active is set to NULL

After
----------------------------------------
If PaymentProcessor.create is called with neither id or is_active passed in is_active is set to TRUE


Technical Details
----------------------------------------
This is consistent with UFGroup, CustomGroup, ComtributionPage etc

Comments
----------------------------------------

