### PR TITLE
Generalise the UsersTableName Setting name to support Backdrop

### DIFF
--- a/api/v3/examples/Setting/GetFields.php
+++ b/api/v3/examples/Setting/GetFields.php
@@ -1118,7 +1118,7 @@ function setting_getfields_expectedresult() {
           'maxlength' => '64',
         ),
         'default' => '',
-        'title' => 'Drupal Users Table Name',
+        'title' => 'CMS Users Table Name',
         'description' => '',
       ),
       'wpLoadPhp' => array(

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -858,8 +858,8 @@ return array(
       'size' => '32',
       'maxlength' => '64',
     ),
-    'default' => NULL,
-    'title' => ts('Drupal Users Table Name'),
+    'default' => 'users',
+    'title' => ts('CMS Users Table Name'),
     'description' => '',
   ),
   'wpLoadPhp' => array(


### PR DESCRIPTION
Overview
----------------------------------------
This is a setting that is used for both Drupal and now Backdrop so generalise the name of the setting

Before
----------------------------------------
Setting name suggested only applied to Drupal when its used for Backdrop as well

After
----------------------------------------
Clearer setting name

ping @eileenmcnaughton @laryn 