### PR TITLE
Fix PHP 7 strict warnings CRM_Core_DAO::getContactIDsFromComponent passed by reference

### DIFF
--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -177,7 +177,7 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
    * For example, for cases we need to override this function as the table name is civicrm_case_contact
    */
   public function setContactIDs() {
-    $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent($this->_entityIds,
+    $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_entityIds,
       $this::$tableName
     );
   }

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -130,7 +130,7 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
    * since its used for things like send email
    */
   public function setContactIDs() {
-    $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent($this->_participantIds,
+    $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_participantIds,
       'civicrm_participant'
     );
   }

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -120,7 +120,7 @@ class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
    * since its used for things like send email
    */
   public function setContactIDs() {
-    $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent($this->_grantIds,
+    $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_grantIds,
       'civicrm_grant'
     );
   }

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -130,7 +130,7 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
    * since its used for things like send email
    */
   public function setContactIDs() {
-    $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent($this->_memberIds,
+    $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_memberIds,
       'civicrm_membership'
     );
   }

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -114,7 +114,7 @@ class CRM_Pledge_Form_Task extends CRM_Core_Form_Task {
    * since its used for things like send email
    */
   public function setContactIDs() {
-    $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent($this->_pledgeIds,
+    $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_pledgeIds,
       'civicrm_pledge'
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes PHP 7 strict warnings on several search task forms, i.e. creating a PDF letter after searching for Memberships or Event participants.

Before
----------------------------------------
PHP notices are displayed when the search task forms are displayed for Memberships, Event participants on PHP7+.

After
----------------------------------------
No PHP notices are displayed for those forms.

Technical Details
----------------------------------------
The e-notices were caused by this obsolete pattern; the & can be safely removed:
```php
    $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent($this->_memberIds,
      'civicrm_membership'
    );
```
It is present in
```
CRM/Event/Form/Task.php
CRM/Grant/Form/Task.php
CRM/Pledge/Form/Task.php
CRM/Core/Form/Task.php
```
and had already been resolved in:
```
CRM/Case/Form/Task.php
CRM/Contribute/Form/Task.php
```
Comments
----------------------------------------
For Pledges, Grants and Core, although the same obsolete pattern was present it does not appear to be used. I have changed these in line with Membership and Event and tested.
