### PR TITLE
dev/core#603 not set default value yes/no for active relationship filters

### DIFF
--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -185,8 +185,9 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
           'is_active' => array(
             'title' => ts('Active Relationship?'),
             'type' => CRM_Utils_Type::T_BOOLEAN,
-            'default' => TRUE,
-            'options' => CRM_Core_SelectValues::boolean(),
+            //MV dev/core#603, not set default values Yes/No, this cause issue when relationship fields are not selected
+            // 'default' => TRUE,
+            'options' => array('' => ts('- Select -')) + CRM_Core_SelectValues::boolean(),
           ),
         ),
       ),


### PR DESCRIPTION
Overview
----------------------------------------
On Case Summary report, 
When run report without any changes are any filters then you would this warning message
![warning message](https://user-images.githubusercontent.com/6152709/50084867-4bfa8980-01f0-11e9-95e7-223a14627814.png)


Then unselect the Staff Member Column and Relationship column on Column tab and run the report would end up with DB Error unknown column.
![unselectrelationshipfields](https://user-images.githubusercontent.com/6152709/50084883-57e64b80-01f0-11e9-9585-7cc4efd43526.png)



Before
----------------------------------------
It just returning DB error with unknown column 
![db error](https://user-images.githubusercontent.com/6152709/50084887-5ae13c00-01f0-11e9-91b1-2262014364c3.png)

I think is because of filter "Active Relationship" is set to "Yes" by default.
![filter](https://user-images.githubusercontent.com/6152709/50084967-97ad3300-01f0-11e9-91bd-d85d6731d4e8.png)


After
----------------------------------------
I have amended the boolean option to unset the default value.
![default](https://user-images.githubusercontent.com/6152709/50086077-e14b4d00-01f3-11e9-9542-05f668374190.png)

![afterthefix](https://user-images.githubusercontent.com/6152709/50085133-15713e80-01f1-11e9-8a18-1840bd2c40e6.png)
 