### PR TITLE
Add extension compatibility list

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -221,7 +221,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
   }
 
   /**
-   * Get the list of local extensions and format them as a table with
+   * Get the list of remote extensions and format them as a table with
    * status and action data.
    *
    * @param array $localExtensionRows
@@ -238,7 +238,12 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
 
     // build list of available downloads
     $remoteExtensionRows = array();
+    $compat = CRM_Extension_System::getCompatibilityInfo();
+
     foreach ($remoteExtensions as $info) {
+      if (!empty($compat[$info->key]['obsolete'])) {
+        continue;
+      }
       $row = (array) $info;
       $row['id'] = $info->key;
       $action = CRM_Core_Action::UPDATE;

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -169,15 +169,30 @@ class CRM_Extension_Info {
         }
       }
       elseif ($attr === 'requires') {
-        $this->requires = array();
-        foreach ($val->ext as $ext) {
-          $this->requires[] = (string) $ext;
-        }
+        $this->requires = $this->filterRequirements($val);
       }
       else {
         $this->$attr = CRM_Utils_XML::xmlObjToArray($val);
       }
     }
+  }
+
+  /**
+   * Filter out invalid requirements, e.g. extensions that have been moved to core.
+   *
+   * @param SimpleXMLElement $requirements
+   * @return array
+   */
+  public function filterRequirements($requirements) {
+    $filtered = [];
+    $compatInfo = CRM_Extension_System::getCompatibilityInfo();
+    foreach ($requirements->ext as $ext) {
+      $ext = (string) $ext;
+      if (empty($compatInfo[$ext]['obsolete'])) {
+        $filtered[] = $ext;
+      }
+    }
+    return $filtered;
   }
 
 }

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -287,6 +287,18 @@ class CRM_Extension_System {
   }
 
   /**
+   * Returns a list keyed by extension key
+   *
+   * @return array
+   */
+  public static function getCompatibilityInfo() {
+    if (!isset(Civi::$statics[__CLASS__]['compatibility'])) {
+      Civi::$statics[__CLASS__]['compatibility'] = json_decode(file_get_contents(Civi::paths()->getPath('[civicrm.root]/extension-compatibility.json')), TRUE);
+    }
+    return Civi::$statics[__CLASS__]['compatibility'];
+  }
+
+  /**
    * Take an extension's raw XML info and add information about the
    * extension's status on the local system.
    *

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -70,7 +70,7 @@ function dm_install_core() {
   done
 
   dm_install_files "$repo" "$to" {agpl-3.0,agpl-3.0.exception,gpl,CONTRIBUTORS}.txt
-  dm_install_files "$repo" "$to" composer.json composer.lock bower.json package.json Civi.php README.md release-notes.md
+  dm_install_files "$repo" "$to" composer.json composer.lock bower.json package.json Civi.php README.md release-notes.md extension-compatibility.json
 
   mkdir -p "$to/sql"
   pushd "$repo" >> /dev/null

--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -1,0 +1,5 @@
+{
+  "com.ixiam.modules.quicksearch": {
+    "obsolete": "5.8"
+  }
+}

--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -81,4 +81,12 @@ class CRM_Extension_InfoTest extends CiviUnitTestCase {
     $this->assertTrue(is_object($exc));
   }
 
+  public function test_requirements() {
+    // Quicksearch requirement should get filtered out per extension-compatibility.json
+    $data = "<extension key='test.foo' type='module'><file>foo</file><requires><ext>example.test</ext><ext>com.ixiam.modules.quicksearch</ext></requires></extension>";
+
+    $info = CRM_Extension_Info::loadFromString($data);
+    $this->assertEquals(['example.test'], $info->requires);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Extensions whose functionality is now redundant with core may cause problems if left installed. This PR will:

- Automatically disable obsolete extensions during core upgrades.
- Filter out obsolete extensions from the list of downloadable extensions.
- Ignore obsolete extensions when considering dependencies.

Technical Details
----------------------------------------
The `extension-compatibility.json` file is a very open-ended format. For now it just contains one type of information but we can easily add to it if we want to use it for more purposes.