### PR TITLE
dev/core#585 Fix setting target contact on activities when creating a case with activity sequence.

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -208,8 +208,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
 
     $aTypes = $xmlProcessor->get($this->_caseType, 'ActivityTypes', TRUE);
 
-    $allActTypes = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name');
-
+    $allActTypes = CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'validate');
     $emailActivityType = array_search('Email', $allActTypes);
     $pdfActivityType = array_search('Print PDF Letter', $allActTypes);
 

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -99,7 +99,6 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
   public function process($xml, &$params) {
     $standardTimeline = CRM_Utils_Array::value('standardTimeline', $params);
     $activitySetName = CRM_Utils_Array::value('activitySetName', $params);
-    $activityTypeName = CRM_Utils_Array::value('activityTypeName', $params);
 
     if ('Open Case' == CRM_Utils_Array::value('activityTypeName', $params)) {
       // create relationships for the ones that are required

--- a/Civi/CCase/SequenceListener.php
+++ b/Civi/CCase/SequenceListener.php
@@ -120,7 +120,12 @@ class SequenceListener implements CaseChangeListener {
       'activity_date_time' => \CRM_Utils_Time::getTime('YmdHis'),
       'case_id' => $analyzer->getCaseId(),
     );
-    $r = civicrm_api3('Activity', 'create', $params);
+    $case = $analyzer->getCase();
+    if (!empty($case['contact_id'])) {
+      $params['target_id'] = \CRM_Utils_Array::first($case['contact_id']);
+    }
+
+    civicrm_api3('Activity', 'create', $params);
     $analyzer->flush();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/585

Before
----------------------------------------
Case sequence activities created with no target contact.

After
----------------------------------------
Case sequence activites created with target contact.

Technical Details
----------------------------------------
I don't claim to fully understand how this works and why it regressed in 5.6 but my proposed fix just adds the target contact id to the params passed to the activity.create api.

Comments
----------------------------------------
@stoob