### PR TITLE
Bump Minimum Required PHP to be 5.6

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -50,7 +50,7 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   /**
    * Minimum php version required to run (equal to or lower than the minimum install version)
    */
-  const MINIMUM_PHP_VERSION = '5.5';
+  const MINIMUM_PHP_VERSION = '5.6';
 
   protected $_config;
 

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -53,7 +53,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '5.5';
+  const MIN_INSTALL_PHP_VER = '5.6';
 
   /**
    * Compute any messages which should be displayed before upgrade.

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -41,12 +41,12 @@ class CRM_Upgrade_Incremental_General {
   /**
    * The recommended PHP version.
    */
-  const RECOMMENDED_PHP_VER = '7.1';
+  const RECOMMENDED_PHP_VER = '7.2';
 
   /**
    * The previous recommended PHP version.
    */
-  const MIN_RECOMMENDED_PHP_VER = '7.0';
+  const MIN_RECOMMENDED_PHP_VER = '7.1';
 
   /**
    * The minimum PHP version required to install Civi.


### PR DESCRIPTION
Overview
----------------------------------------
This bumps the minimum required PHP version to be 5.6 as per https://civicrm.org/blog/eileen/end-of-life-plans-for-5x-php-versions-planning-for-70-eol

Before
----------------------------------------
Previously minimum php version was 5.5

After
----------------------------------------
Minimum php version is 5.6

ping @totten @eileenmcnaughton 
