### PR TITLE
Handle Membership Auto Renewal for Separate Membership Payment

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1798,6 +1798,15 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $tempParams['trxn_id'] = $membershipContribution->trxn_id;
     $tempParams['contributionID'] = $membershipContribution->id;
 
+    // set recurring contribution id for separate membership payment, otherwise IPN will not get processed
+    if ($membershipContribution->contribution_recur_id) {
+      $tempParams['contributionRecurID'] = $membershipContribution->contribution_recur_id;
+    }
+
+    if ($membershipContribution->contribution_page_id) {
+      $tempParams['contributionPageID'] = $membershipContribution->contribution_page_id;
+    }
+
     if ($form->_values['is_monetary'] && !$form->_params['is_pay_later'] && $minimumFee > 0.0) {
       // At the moment our tests are calling this form in a way that leaves 'object' empty. For
       // now we compensate here.


### PR DESCRIPTION
Overview
----------------------------------------
Separate membership payment on contribution form with auto renewal not get processed
Before
----------------------------------------
When creating a contribution page with a membership with the option "Separate Membership Payment" and Auto-renew with 'Give Option' / 'Required'.
On Signup page Membership Type will shown along with donation field. Choose auto-renewal option if optional.
Submit the Payment to Processor. This will create Membership record, 2 Contribution record and Recurring contribution for Membership Payment. First payment get recorded, Membership status and Contribution status get updated to 'New' and 'Completed' respectively.
On next scheduled Payment (renewal date) civicrm receive IPN response from Payment Processor but this time recurring contribution id is absent in response (which we should set during the first payment, but in case of separate membership payment we don't). IPN assume that this is single donation rather than recurring and show the message in log that is already processed.

After
----------------------------------------
Membership get auto renewed for separate payment case.

Technical Details
----------------------------------------
Pass recurring id and page id to Processor for future reference.

Issue Reported : https://lab.civicrm.org/dev/core/issues/567
