### PR TITLE
Support customdata subtype on entityform (for activity/relationship types)

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -34,6 +34,13 @@
 trait CRM_Core_Form_EntityFormTrait {
 
   /**
+   * The entity subtype ID (eg. for Relationship / Activity)
+   *
+   * @var int
+   */
+  protected $_entitySubTypeId;
+
+  /**
    * Get entity fields for the entity to be added to the form.
    *
    * @return array
@@ -66,6 +73,21 @@ trait CRM_Core_Form_EntityFormTrait {
   public function getEntityId() {
     return $this->_id;
   }
+
+  /**
+   * Get the entity subtype ID being edited
+   *
+   * @param $subTypeId
+   *
+   * @return int|null
+   */
+  public function getEntitySubTypeId($subTypeId) {
+    if ($subTypeId) {
+      return $subTypeId;
+    }
+    return $this->_entitySubTypeId;
+  }
+
   /**
    * If the custom data is in the submitted data (eg. added via ajax loaded form) add to form.
    */

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -55,16 +55,17 @@ class CRM_Custom_Form_CustomData {
   public static function addToForm(&$form, $subType = NULL, $subName = NULL, $groupCount = 1) {
     $entityName = $form->getDefaultEntity();
     $entityID = $form->getEntityId();
+    $entitySubType = $form->getEntitySubTypeId($subType);
 
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {
-      self::preProcess($form, $subName, $subType, $groupCount, $entityName, $entityID);
+      self::preProcess($form, $subName, $entitySubType, $groupCount, $entityName, $entityID);
       self::buildQuickForm($form);
       self::setDefaultValues($form);
     }
     // need to assign custom data type and subtype to the template
     $form->assign('customDataType', $entityName);
-    $form->assign('customDataSubType', $subType);
+    $form->assign('customDataSubType', $entitySubType);
     $form->assign('entityID', $entityID);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Support custom data subtype on entityform (so we can display/edit custom data for entity subtypes (eg. activity types, relationship types).

Before
----------------------------------------
Could not specify custom data subtype on entity form.

After
----------------------------------------
Can specify custom data subtype on entity form.

Technical Details
----------------------------------------
Similar to how we implemented custom data type.

Comments
----------------------------------------
@eileenmcnaughton Working towards converting the relationship view/edit/delete form (see https://github.com/mattwire/civicrm-core/tree/entityform_relationshipform).  I need to be able to specify the custom data subtype.
