### PR TITLE
dev/core#606: Don't redirect to the Option Groups page when page is displayed in a modal

### DIFF
--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -175,7 +175,7 @@
       {if $isLocked ne 1}
         {crmButton p="civicrm/admin/options/$gName" q='action=add&reset=1' class="new-option" icon="plus-circle"}{ts 1=$gLabel}Add %1{/ts}{/crmButton}
       {/if}
-      {crmButton p="civicrm/admin/options" q="action=browse&reset=1" class="next no-popup" icon="check"}{ts}Done{/ts}{/crmButton}
+      {crmButton p="civicrm/admin/options" q="action=browse&reset=1" class="cancel" icon="check"}{ts}Done{/ts}{/crmButton}
     </div>
 </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------

This seems like a regression caused by https://github.com/civicrm/civicrm-core/pull/12473.

When the Option Group page is open in a modal and the user clicks the "Done" button, they're redirected to the Option Groups page and lose all the data they might have already entered:

Before
----------------------------------------

![581](https://user-images.githubusercontent.com/388373/50153830-af4af100-02ae-11e9-9c0c-13a7d7e87c1f.gif)


After
----------------------------------------

Clicking "Done" simply closes the modal:

![581_fix](https://user-images.githubusercontent.com/388373/50153957-149ee200-02af-11e9-9119-561763fb74a7.gif)

Also, when opened as a full page, it still works as intended by https://github.com/civicrm/civicrm-core/pull/12473:

![581_page](https://user-images.githubusercontent.com/388373/50154016-457f1700-02af-11e9-9106-3bf2d44d8f9b.gif)


Technical Details
----------------------------------------

The cause of the issue was the change in the button classes. There is no explanation for this change either in the PR or in the Gitlab issue, so I simply reverted it to the previously used class.
