### PR TITLE
Search Builder fails with an error when searching for State if the location type differs from the display name.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2130,7 +2130,7 @@ class CRM_Contact_BAO_Query {
 
     $setTables = TRUE;
 
-    $locationType = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $locationType = CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');
     if (isset($locType[1]) && is_numeric($locType[1])) {
       $lType = $locationType[$locType[1]];
     }

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -235,9 +235,8 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
       ],
     ];
 
-    /* update with the api does not work because it updates both the name and the
-       the display_name. Plain SQL however does the job
-    */
+    // update with the api does not work because it updates both the name and the
+    // the display_name. Plain SQL however does the job
     CRM_Core_DAO::executeQuery('update civicrm_location_type set name=%2 where id=%1',
       [
         1 => [4, 'Integer'],

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -209,6 +209,52 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
+   *  Test created to prove failure of search on state when location
+   *  display name is different form location name (issue 607)
+   */
+  public function testSearchOtherLocationUpperLower() {
+
+    $params = [
+      0 => [
+        0 => 'state_province-4',
+        1 => 'IS NOT EMPTY',
+        2 => '',
+        3 => 1,
+        4 => 0,
+      ],
+    ];
+    $returnProperties = [
+      'contact_type' => 1,
+      'contact_sub_type' => 1,
+      'sort_name' => 1,
+      'location' => [
+        'other' => [
+          'location_type' => 4,
+          'state_province' => 1,
+        ],
+      ],
+    ];
+
+    /* update with the api does not work because it updates both the name and the
+       the display_name. Plain SQL however does the job
+    */
+    CRM_Core_DAO::executeQuery('update civicrm_location_type set name=%2 where id=%1',
+      [
+        1 => [4, 'Integer'],
+        2 => ['other', 'String'],
+      ]);
+
+    $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
+
+    $resultDAO = $queryObj->searchQuery(0, 0, NULL,
+      FALSE, FALSE,
+      FALSE, FALSE,
+      FALSE);
+    $resultDAO->fetch();
+  }
+
+
+  /**
    * CRM-14263 search builder failure with search profile & address in criteria.
    *
    * We are retrieving primary here - checking the actual sql seems super prescriptive - but since the massive query object has


### PR DESCRIPTION
Overview
----------------------------------------
Search Builder fails with an error when searching for State if the location type differs from the display name.

To reproduce
- Goto https://dmaster.demo.civicrm.org/civicrm/admin/locationType?reset=1
- Change the name of Other (nr 4) to other.
- Start the search builder.
- Create the following search 
![screen01](https://user-images.githubusercontent.com/14834891/50159354-c8679800-02d6-11e9-8975-7f667595cc6b.jpg)
The search ends with a DB Error - Syntax Error


Before
----------------------------------------
To reproduce
- Goto https://dmaster.demo.civicrm.org/civicrm/admin/locationType?reset=1
- Change the name of Other (nr 4) to other.
- Start the search builder.
- Create the following search 
![screen01](https://user-images.githubusercontent.com/14834891/50159354-c8679800-02d6-11e9-8975-7f667595cc6b.jpg)
The search ends with a DB Error - Syntax Error

After
----------------------------------------
The same as above except that the search now gives a result.

Technical Details
----------------------------------------
The cause of the problem is that locationtypes can be retrieved on two different ways in CiviCRM e.g.
`CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');`
and 
` CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id')`

When name and display_name have a different case these functions return different results.

My solution is to replace the second with the first.

A test is added to the PR. It fails with unknown variable. I do not know how to catch it

Comments
----------------------------------------
Also on gitlab (https://lab.civicrm.org/dev/core/issues/607).
In the test database name and display are the same. The effect is that this kind of bug is not catched. Tip for implementers. Take care that name and display name are always the same.
