### PR TITLE
On the Contribution Detail Report link the Amount field to the contribution 

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -706,7 +706,7 @@ UNION ALL
       }
 
       // Contribution amount links to viewing contribution
-      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount', $row)) &&
+      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount_sum', $row)) &&
         CRM_Core_Permission::check('access CiviContribute')
       ) {
         $url = CRM_Utils_System::url("civicrm/contact/view/contribution",
@@ -715,8 +715,8 @@ UNION ALL
           "&action=view&context=contribution&selectedChild=contribute",
           $this->_absoluteUrl
         );
-        $rows[$rowNum]['civicrm_contribution_total_amount_link'] = $url;
-        $rows[$rowNum]['civicrm_contribution_total_amount_hover'] = ts("View Details of this Contribution.");
+        $rows[$rowNum]['civicrm_contribution_total_amount_sum_link'] = $url;
+        $rows[$rowNum]['civicrm_contribution_total_amount_sum_hover'] = ts("View Details of this Contribution.");
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
In CiviCRM 4.7.29 (not sure when this broke), the "Amount" column in the Contribution Detail Report was linked to the Contribution record, however it is not in CiviCRM 5.8. The code comments also suggest that the "Amount" column should be linked to the Contribution Record. I believe this is a regression. 

This change makes it so that the Amount field is once again linked to the Contribution record

Before
----------------------------------------
In the Contribution Detail Report the Amount column **is not**  linked to the Contribution 

See the plain text amounts in the screenshot below:
![amount](https://user-images.githubusercontent.com/11323624/50187701-e0e2ad00-02ec-11e9-8095-ae1d762a24cc.png)

After
----------------------------------------
In the Contribution Detail Report the Amount column **is**  linked to the Contribution 

See the  screenshot below:

![after](https://user-images.githubusercontent.com/11323624/50228723-a3c2fd00-0376-11e9-8507-e77445cc6c7f.png)



