### PR TITLE
Fix order api to support a pseudoConstant for financial_type_id

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -62,6 +62,19 @@ function civicrm_api3_order_get($params) {
 }
 
 /**
+ * Adjust Metadata for Get action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_order_get_spec(&$params) {
+  $params['id']['api.aliases'] = ['order_id'];
+  $params['id']['title'] = ts('Contribution / Order ID');
+}
+
+/**
  * Add or update a Order.
  *
  * @param array $params
@@ -72,7 +85,7 @@ function civicrm_api3_order_get($params) {
  *   Api result array
  */
 function civicrm_api3_order_create(&$params) {
-  $contribution = array();
+
   $entity = NULL;
   $entityIds = array();
   if (CRM_Utils_Array::value('line_items', $params) && is_array($params['line_items'])) {
@@ -202,12 +215,20 @@ function _civicrm_api3_order_create_spec(&$params) {
     'title' => 'Total Amount',
     'api.required' => TRUE,
   );
-  $params['financial_type_id'] = array(
+  $params['financial_type_id'] = [
     'name' => 'financial_type_id',
     'title' => 'Financial Type',
     'type' => CRM_Utils_Type::T_INT,
     'api.required' => TRUE,
-  );
+    'table_name' => 'civicrm_contribution',
+    'entity' => 'Contribution',
+    'bao' => 'CRM_Contribute_BAO_Contribution',
+    'pseudoconstant' => [
+      'table' => 'civicrm_financial_type',
+      'keyColumn' => 'id',
+      'labelColumn' => 'name',
+    ],
+  ];
 }
 
 /**

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -376,6 +376,11 @@ function _civicrm_api3_get_BAO($name) {
   if ($name == 'PrintLabel') {
     return 'CRM_Badge_BAO_Layout';
   }
+  if ($name === 'Order') {
+    // Order basically maps to contribution at the top level but
+    // has enhanced access to other entities.
+    $name = 'Contribution';
+  }
   $dao = _civicrm_api3_get_DAO($name);
   if (!$dao) {
     return NULL;

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -211,7 +211,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       'contact_id' => $this->_individualId,
       'receive_date' => '2010-01-20',
       'total_amount' => 200,
-      'financial_type_id' => $this->_financialTypeId,
+      'financial_type_id' => 'Event Fee',
       'contribution_status_id' => 1,
     );
     $priceFields = $this->createPriceSet();


### PR DESCRIPTION
Overview
----------------------------------------
Adds functionality & test to support 'Event Fee' instead of '4' for Order.create financial_type_id.

This improves consistency with Contribution.create api and others

Before
----------------------------------------
civicrm_api3('Order', 'create', [
  'financial_type_id' => 'Event fee', 
  'total_amount' => 300, 
  '....
]);

Fails as financial_type_id cannot be validated

After
----------------------------------------
Above call works

Technical Details
----------------------------------------
Order.create api is an alias for Contribution.create api at the top level and it makes sense it supports the same pseudoconstants. Arguably it should start with the getfields output from Contribution.create but I've kept scope small & tested

Comments
----------------------------------------
@monishdeb @pradpnayak 