### PR TITLE
Add selectWhere hook call to the query that generates the 'annual' query - the 'amount this year' on a contact dash

### DIFF
--- a/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
@@ -62,11 +62,14 @@ trait CRMTraits_Financial_FinancialACLTrait {
    * @param array $aclPermissions
    *   Array of ACL permissions in the format
    *   [[$action, $financialType], [$action, $financialType])
+   *
+   * @return int Contact ID
    */
   protected function createLoggedInUserWithFinancialACL($aclPermissions = [['view', 'Donation']]) {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
-    $this->createLoggedInUser();
+    $contactID = $this->createLoggedInUser();
     $this->addFinancialAclPermissions($aclPermissions);
+    return $contactID;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Adds a call to the selectWhere hook to the getAnnualQuery function. This function is used to generate the amount & count values for donations this year.

Before
----------------------------------------
Hook not called, less tests

After
----------------------------------------
Hook called, more tests

Technical Details
----------------------------------------
When the financial acls were developed they were added into core - tacked onto various queries. Later @colemanw developed the selectWhere hook approach for CiviCase permissions. When extending financial acls to reports we utilised this approach that had been developed in the interim https://issues.civicrm.org/jira/browse/CRM-21106 and an extension was create called 'financialaclreport'. 

We now have a situation where a site using the financial acls needs to 
1) enable the financial acls
2) install financialaclreport extension
(if they only do 1 then they will not have ACLs in the reports but it's arguably possible that some sites have this).

If we now implement the hook approach that is our new standard then financial report acl users will get the query applied twice. We have 3 options here
1) in the function addACLClausesToWhereClauses that adds the financial type acl we could check if the extension is installed and if not apply the core financial acl permission
2) In the function addACLClausesToWhereClauses that adds the financial type acl we could check if the extension is installed and if not put out a warning message
3) assume that the system check has done it's work & we don't need to handle the possibility of the financialaclreport extension not being present

I would also note that this will fail unit tests at the moment. The reason is that my digging shows that rather than the ACL applied on the line items restricting the lines included in the total it just left joins them in such that the contribution will be counted a minimum of once up to the number of permitted line items - so the only thing it achieves is making the output inaccurate. I propose we remove the line item left join for now since it is completely broken (adding the test) and resolve the bigger issue first, coming back to that if the extension does not handle it

@monishdeb @JoeMurray @pradpnayak ping

Requires https://github.com/civicrm/civicrm-core/pull/13317

Comments
----------------------------------------
My interest in this query is that it is a slow query due to an index merge & re-writing it with a better use of subqueries would reduce the time from around 30 seconds on very slow contacts to .25 seconds. However, I need to resolve what our path is with the financial acls in order to fix the query and one or two others. There are also a lot of places where the financial acls are joining in the financial type table & sometimes the line items table when they are disabled - causing a needless hindrance to the query.