### PR TITLE
dev/core#989Allow Permissioned contact to download the invoice

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1642,8 +1642,11 @@ class CRM_Core_Permission {
    */
   public static function checkDownloadInvoice() {
     $cid = CRM_Core_Session::getLoggedInContactID();
+    $cidOther = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullArray);
+    // allow permissioned contact to download the invoice
     if (CRM_Core_Permission::check('access CiviContribute') ||
-      (CRM_Core_Permission::check('view my invoices') && $_GET['cid'] == $cid)
+      (CRM_Core_Permission::check('view my invoices') && $_GET['cid'] == $cid) ||
+      CRM_Contact_BAO_Contact_Permission::relationshipList(array($cidOther))
     ) {
       return TRUE;
     }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1645,7 +1645,7 @@ class CRM_Core_Permission {
     $cidOther = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullArray);
     // allow permissioned contact to download the invoice
     if (CRM_Core_Permission::check('access CiviContribute') ||
-      (CRM_Core_Permission::check('view my invoices') && $_GET['cid'] == $cid) ||
+      (CRM_Core_Permission::check('view my invoices') && $cidOther == $cid) ||
       CRM_Contact_BAO_Contact_Permission::relationshipList(array($cidOther))
     ) {
       return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
To Print other contact Invoice Logged in contact need 'access CiviContribute' permission
To Print own Invoice Logged in contact need 'view my invoices' Permission.
If user role only have 'view my invoices' permission and want to print invoice of contact which have Permissioned relationship. It gives access denied message.
(e.g. Employee should print invoice of Employer contact if relationship is Permissioned)

Before
----------------------------------------
it was not allowing download invoice for Permissioned relationship contact.

After
----------------------------------------
It allow to download invoice for Permissioned relationship contact.