### PR TITLE
campaign cleanup for sybunt report and show disabled campaigns as well

### DIFF
--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -70,15 +70,6 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
       $date['minYear']++;
     }
 
-    // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
-
     $this->_columns = array(
       'civicrm_contact' => array(
         'dao' => 'CRM_Contact_DAO_Contact',
@@ -268,18 +259,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
     );
 
     // If we have a campaign, build out the relevant elements
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_contribution']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-      );
-      $this->_columns['civicrm_contribution']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-    }
+    $this->addCampaignFields('civicrm_contribution');
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
@@ -601,7 +581,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
       // convert campaign_id to campaign title
       if (array_key_exists('civicrm_contribution_campaign_id', $row)) {
         if ($value = $row['civicrm_contribution_campaign_id']) {
-          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->activeCampaigns[$value];
+          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->campaigns[$value];
           $entryFound = TRUE;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Centralize and cleanup code for campaigns in reports and show disabled campaigns as well



Before
----------------------------------------
![sybunt_before](https://user-images.githubusercontent.com/3455173/50208249-b64d2e80-0396-11e9-9c87-f1310a467fbb.png)

After
----------------------------------------
![sybunt_after](https://user-images.githubusercontent.com/3455173/50208261-bcdba600-0396-11e9-82ee-379c908afe27.png)


Comments
----------------------------------------
Inactive campaigns can be seen in report filter and results as well.
