### PR TITLE
dev/report#5 - Fix mailing report unique count issue

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2198,6 +2198,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
                'forward',
                'reply',
                'opened',
+               'opened_unique',
                'optout',
              ) as $key) {
       $url = 'mailing/detail';
@@ -2235,6 +2236,12 @@ ORDER BY   civicrm_email.is_bulkmail DESC
           break;
 
         case 'opened':
+          $url = "mailing/opened";
+          $searchFilter .= "&mailing_open_status=Y";
+          $reportFilter .= "&distinct=0"; // do not use group by clause in report, because same report used for total and unique open
+          break;
+
+        case 'opened_unique':
           $url = "mailing/opened";
           $searchFilter .= "&mailing_open_status=Y";
           break;

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2236,11 +2236,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
           break;
 
         case 'opened':
-          $url = "mailing/opened";
-          $searchFilter .= "&mailing_open_status=Y";
           $reportFilter .= "&distinct=0"; // do not use group by clause in report, because same report used for total and unique open
-          break;
-
         case 'opened_unique':
           $url = "mailing/opened";
           $searchFilter .= "&mailing_open_status=Y";

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -289,13 +289,19 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
   }
 
   public function groupBy() {
-    $groupBys = empty($this->_params['charts']) ? array("civicrm_mailing_event_queue.email_id") : array("{$this->_aliases['civicrm_mailing']}.id");
-
-    if (!empty($this->_params['unique_opens_value'])) {
-      $groupBys[] = "civicrm_mailing_event_queue.id";
+    $groupBys = array();
+    // Do not use group by clause if distinct = 0 mentioned in url params. flag is used in mailing report screen, default value is TRUE
+    // this report is used to show total opened and unique opened
+    if (CRM_Utils_Request::retrieve('distinct', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, TRUE)) {
+      $groupBys = empty($this->_params['charts']) ? array("civicrm_mailing_event_queue.email_id") : array("{$this->_aliases['civicrm_mailing']}.id");
+      if (!empty($this->_params['unique_opens_value'])) {
+        $groupBys[] = "civicrm_mailing_event_queue.id";
+      }
     }
-    $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, $groupBys);
-    $this->_groupBy = "GROUP BY " . implode(', ', $groupBys);
+    if (!empty($groupBys)) {
+      $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, $groupBys);
+      $this->_groupBy = "GROUP BY " . implode(', ', $groupBys);
+    }
   }
 
   public function postProcess() {

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -299,7 +299,6 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
       }
     }
     if (!empty($groupBys)) {
-      $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, $groupBys);
       $this->_groupBy = "GROUP BY " . implode(', ', $groupBys);
     }
   }

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -37,7 +37,7 @@
   {if $report.mailing.open_tracking}
     <tr><td class="label"><a href="{$report.event_totals.links.opened}&distinct=1">{ts}Unique Opens{/ts}</a></td>
         <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%)</td>
-        <td>{$report.event_totals.actionlinks.opened}</td></tr>
+        <td>{$report.event_totals.actionlinks.opened_unique}</td></tr>
     <tr><td class="label"><a href="{$report.event_totals.links.opened}">{ts}Total Opens{/ts}</a></td>
         <td>{$report.event_totals.total_opened}</td>
         <td>{$report.event_totals.actionlinks.opened}</td></tr>

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -212,6 +212,19 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test getrows on Mailing Opened report.
+   */
+  public function testReportTemplateGetRowsMailingUniqueOpened() {
+    $description = "Retrieve rows from a mailing opened report template.";
+    $result = $this->callAPIAndDocument('report_template', 'getrows', array(
+      'report_id' => 'Mailing/opened',
+      'options' => array('metadata' => array('labels', 'title')),
+    ), __FUNCTION__, __FILE__, $description, 'Getrows');
+
+    $this->assertEquals(4, $result['count']);
+  }
+
+  /**
    * Test api to get rows from reports.
    *
    * @dataProvider getReportTemplates

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -192,7 +192,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    */
   public function testReportTemplateGetRowsContactSummary() {
     $description = "Retrieve rows from a report template (optionally providing the instance_id).";
-    $result = $this->callAPIAndDocument('report_template', 'getrows', array(
+    $result = $this->callApiSuccess('report_template', 'getrows', array(
       'report_id' => 'contact/summary',
       'options' => array('metadata' => array('labels', 'title')),
     ), __FUNCTION__, __FILE__, $description, 'Getrows');
@@ -216,12 +216,37 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    */
   public function testReportTemplateGetRowsMailingUniqueOpened() {
     $description = "Retrieve rows from a mailing opened report template.";
+    $op = new PHPUnit_Extensions_Database_Operation_Insert();
+    $op->execute($this->_dbconn,
+      $this->createFlatXMLDataSet(
+        dirname(__FILE__) . '/../../CRM/Mailing/BAO/queryDataset.xml'
+      )
+    );
+
+    // Check total rows without distinct
+    global $_REQUEST;
+    $_REQUEST['distinct'] = 0;
     $result = $this->callAPIAndDocument('report_template', 'getrows', array(
       'report_id' => 'Mailing/opened',
       'options' => array('metadata' => array('labels', 'title')),
     ), __FUNCTION__, __FILE__, $description, 'Getrows');
+    $this->assertEquals(14, $result['count']);
 
-    $this->assertEquals(4, $result['count']);
+    // Check total rows with distinct
+    $_REQUEST['distinct'] = 1;
+    $result = $this->callAPIAndDocument('report_template', 'getrows', array(
+      'report_id' => 'Mailing/opened',
+      'options' => array('metadata' => array('labels', 'title')),
+    ), __FUNCTION__, __FILE__, $description, 'Getrows');
+    $this->assertEquals(5, $result['count']);
+
+    // Check total rows with distinct by passing NULL value to distinct parameter
+    $_REQUEST['distinct'] = NULL;
+    $result = $this->callAPIAndDocument('report_template', 'getrows', array(
+      'report_id' => 'Mailing/opened',
+      'options' => array('metadata' => array('labels', 'title')),
+    ), __FUNCTION__, __FILE__, $description, 'Getrows');
+    $this->assertEquals(5, $result['count']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Go to Mailing >> Scheduled and Sent Mailings >> Report
2. Unique Opens  -> (click) Report
3. Total Opens   -> (click) Report

Both Report show same count.

Before
----------------------------------------
Both Report showing same count (Unique report is in-correct)

After
----------------------------------------
Unique Opens Report has less value as compared to Total Opens