### PR TITLE
Php 7.2 warning message  fix on install.

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -424,15 +424,18 @@ else {
  *  $description[2] - The test error to show, if it goes wrong
  */
 class InstallRequirements {
-  var $errors, $warnings, $tests, $conn;
+  protected $errors = [];
+  protected $warnings = [];
+  var $tests, $conn;
 
   // @see CRM_Upgrade_Form::MINIMUM_THREAD_STACK
   const MINIMUM_THREAD_STACK = 192;
 
   /**
    * Just check that the database configuration is okay.
-   * @param $databaseConfig
-   * @param $dbName
+   *
+   * @param array $databaseConfig
+   * @param string $dbName
    */
   public function checkdatabase($databaseConfig, $dbName) {
     if ($this->requireFunction('mysqli_connect',
@@ -485,7 +488,7 @@ class InstallRequirements {
         );
         if (!CRM_Core_DAO::requireSafeDBName($databaseConfig['database'])) {
           $this->error($testDetails);
-          return FALSE;
+          return;
         }
         else {
           $this->testing($testDetails);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a warning message when installing on php 7.2

Before
----------------------------------------
![error](https://chat.civicrm.org/files/4m5ryagd5bbupfhqj73zjzto8e/public?h=z-44ze7Z2Ax1SYk5X_1oJqLQo6TO61NlgQCJzWrDYs0)

After
----------------------------------------
fixed

Technical Details
----------------------------------------
This declares errors and warnings as class properties to avoid
errors on counting them.

Also remove an unused return false as this is not consistent with the rest of the
function

Comments
----------------------------------------

