### PR TITLE
installer: PHP 7.2 compatibility fixes

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1400,14 +1400,14 @@ class InstallRequirements {
    * @return int
    */
   public function hasErrors() {
-    return count($this->errors);
+    return !empty($this->errors);
   }
 
   /**
    * @return int
    */
   public function hasWarnings() {
-    return count($this->warnings);
+    return !empty($this->warnings);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

On PHP 7.2, the installer generates PHP warnings: "Warning: count(): Parameter must be an array or an object that implements Countable in [...]".

Reported: https://chat.civicrm.org/civicrm/pl/s9ehffmx9pdhjeq4azxnkmo85e


Before
----------------------------------------

warning

After
----------------------------------------

no warning

Technical Details
----------------------------------------

The variables are not properly initialized, but I didn't feel like messing around more than necessary in this deprecated code.

