### PR TITLE
[WIP] Modify backend Record Payment forms to use payment create API.

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -169,6 +169,16 @@ function _civicrm_api3_payment_create_spec(&$params) {
       'type' => CRM_Utils_Type::T_INT,
       'api.aliases' => array('payment_id'),
     ),
+    'payment_type' => array(
+      'title' => 'Payment Type',
+      'type' => CRM_Utils_Type::T_STRING,
+      'description' => ts("Type of payment - 'owed' or 'refund'."),
+    ),
+    'is_email_receipt' => array(
+      'title' => 'Send Email Receipt',
+      'type' => CRM_Utils_Type::T_BOOLEAN,
+      'description' => ts('If true, receipt is automatically emailed to contact after payment.'),
+    ),
   );
 }
 

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -137,7 +137,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->checkResults(array(30, 70), 2);
     $mut->assertSubjects(['Payment Receipt -']);
     $mut->checkMailLog([
-      'Dear Anthony Anderson',
+      'Dear ' . CRM_Contact_BAO_Contact::displayName($this->_individualId),
       'Payment Details',
       'Total Fees: $ 100.00',
       'This Payment Amount: $ 70.00',


### PR DESCRIPTION
Overview
----------------------------------------
Modify backend Record Payment forms to use payment create API and move API code to BAO layer.

Before
----------------------------------------
1. payment create api exists but is not used by backend record payment forms.
2. Email receipt is only accessible by backend forms.

After
----------------------------------------
Payment create API is used to records payments for pending or partially paid contributions.
Email receipt function is separated so that it can be also used by front-end payments.


Comments
----------------------------------------
This is a part of https://github.com/civicrm/civicrm-core/pull/12319 PR and it only contains fix for the backend payment forms. I'll create another PR to fix partial payment in front end contribution pages.

@magnolia61 Can you confirm if this works fine in your testing? Note that front end fix is yet to be created separately. Thanks.

ping @monishdeb @eileenmcnaughton 