### PR TITLE
Move the code to add or clear employer from relationship backoffice form to BAO

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -451,7 +451,10 @@ WHERE id={$contactId}; ";
         $relationship->relationship_type_id = $relTypeId;
 
         if ($relationship->find(TRUE)) {
-          CRM_Contact_BAO_Relationship::setIsActive($relationship->id, FALSE);
+          // We only want to disable the relationship here so there is no need to call CRM_Contact_BAO_Relationship::setIsActive()
+          // as it execute Relationship API which not only disable the relationship but also clear the employer field of contact.
+          $relationship->is_active = FALSE;
+          $relationship->save();
           CRM_Contact_BAO_Relationship::relatedMemberships($contactId, $relMembershipParams,
             $ids = array(),
             CRM_Core_Action::DELETE

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -411,8 +411,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     $note = !empty($params['note']) ? $params['note'] : '';
     $this->saveRelationshipNotes($relationshipIds, $note);
 
-    $this->setEmploymentRelationship($params, $relationshipIds);
-
     // Refresh contact tabs which might have been affected
     $this->ajaxResponse = array(
       'reloadBlocks' => array('#crm-contactinfo-content'),
@@ -631,29 +629,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       if (!empty($action)) {
         civicrm_api3('note', $action, $noteParams);
       }
-    }
-  }
-
-  /**
-   * Sets current employee/employer relationship
-   *
-   * @param $params
-   * @param array $relationshipIds
-   */
-  private function setEmploymentRelationship($params, $relationshipIds) {
-    $employerParams = array();
-    foreach ($relationshipIds as $id) {
-      if (!CRM_Contact_BAO_Relationship::isCurrentEmployerNeedingToBeCleared($params, $id)
-        //don't think this is required to check again.
-        && $this->_allRelationshipNames[$params['relationship_type_id']]["name_a_b"] == 'Employee of') {
-        // Fixme this is dumb why do we have to look this up again?
-        $rel = CRM_Contact_BAO_Relationship::getRelationshipByID($id);
-        $employerParams[$rel->contact_id_a] = $rel->contact_id_b;
-      }
-    }
-    if (!empty($employerParams)) {
-      // @todo this belongs in the BAO.
-      CRM_Contact_BAO_Contact_Utils::setCurrentEmployer($employerParams);
     }
   }
 

--- a/api/v3/Relationship.php
+++ b/api/v3/Relationship.php
@@ -57,6 +57,11 @@ function _civicrm_api3_relationship_create_spec(&$params) {
   $params['contact_id_a']['api.required'] = 1;
   $params['contact_id_b']['api.required'] = 1;
   $params['relationship_type_id']['api.required'] = 1;
+  $params['is_current_employer'] = [
+    'title' => 'Is Current Employer?',
+    'description' => 'This is a optional parameter used to add employer contact when \'Employee Of\' relationship is created',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  ];
   $params['is_active']['api.default'] = 1;
 }
 

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -85,7 +85,6 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       'start_date' => '2008-12-20',
       'is_active' => 1,
     );
-
   }
 
   /**
@@ -122,8 +121,6 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       'contact_id_b' => $this->_cId_b,
       'relationship_type_id' => $employerRelationshipID,
     ));
-    $params = array($this->_cId_a => $this->_cId_b);
-    CRM_Contact_BAO_Contact_Utils::setCurrentEmployer($params);
 
     //Check if current employer is correctly set.
     $employer = $this->callAPISuccessGetValue('Contact', array(
@@ -440,6 +437,51 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $params['id'] = $result['id'];
     $this->callAPISuccess('relationship', 'delete', $params);
     $this->relationshipTypeDelete($this->_relTypeID);
+  }
+
+  /**
+   * Check employee relationship creation using backend form
+   */
+  public function testRelationshipCreateWithEmployerData() {
+    // CASE A: Create a current employee relationship without setting end date, ensure that employer field is set
+    $params = [
+      'relationship_type_id' => '5_a_b',
+      'related_contact_id' => $this->_cId_b,
+      'start_date' => '2008-12-20',
+      'end_date' => NULL,
+      'is_active' => 1,
+      'is_current_employer' => 1,
+      'is_permission_a_b' => 0,
+      'is_permission_b_a' => 0,
+    ];
+    $reln = new CRM_Contact_Form_Relationship();
+    $reln->_action = CRM_Core_Action::ADD;
+    $reln->_contactId = $this->_cId_a;
+    list ($params, $relationshipIds) = $reln->submit($params);
+
+    $this->assertEquals(
+      $this->_cId_b,
+      $this->callAPISuccess('Contact', 'getvalue', [
+        'id' => $this->_cId_a,
+        'return' => 'current_employer_id',
+    ]));
+
+    // CASE B: Create a past employee relationship by setting end date of past, ensure that employer field is cleared
+    $params = [
+      'relationship_type_id' => '5_a_b',
+      'related_contact_id' => $this->_cId_b,
+      'end_date' => '2010-12-20', // set date to past date
+    ];
+    $reln->_action = CRM_Core_Action::UPDATE;
+    $reln->_relationshipId = $relationshipIds[0];
+    list ($params, $relationshipIds) = $reln->submit($params);
+
+    $this->assertEmpty($this->callAPISuccess('Contact', 'getvalue', [
+      'id' => $this->_cId_a,
+      'return' => 'current_employer_id',
+    ]));
+
+    $this->callAPISuccess('relationship', 'delete', ['id' => $relationshipIds[0]]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
The Relationship backoffice form has a core function ```setEmploymentRelationship()``` responsible for adding/clearing employer data to an individual contact when a 'Employee of' relationship is added/updated. This code needs to present at the BAO level so that Relationship.create API can 

Before
----------------------------------------
Relationship.create API cannot add the employer contact after a current 'Employee of' relationship is created

After
----------------------------------------
1. Relation.create API can add/clear the employer contact after a current 'Employee of' relationship is created or expired.
2. Added an optional relationship.create API parameter ```is_current_employer```

Technical Details
----------------------------------------
The added UT ensures that it doesn't break the logic in API or at form level.

Comments
----------------------------------------
ping @eileenmcnaughton @jitendrapurohit @mattwire @seamuslee001 
