### PR TITLE
campaign clean up for contribution details report

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4283,7 +4283,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
 
         if ($orderBy) {
           $this->_columns[$entityTable]['order_bys']['campaign_id'] = array('title' => ts('Campaign'));
-	}
+        }
       }
     }
   }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4276,9 +4276,14 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
             'type' => CRM_Utils_Type::T_INT,
           );
         }
+
         if ($groupBy) {
           $this->_columns[$entityTable]['group_bys']['campaign_id'] = array('title' => ts('Campaign'));
         }
+
+        if ($orderBy) {
+          $this->_columns[$entityTable]['order_bys']['campaign_id'] = array('title' => ts('Campaign'));
+	}
       }
     }
   }

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -86,15 +86,6 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
    */
   public function __construct() {
     $this->_autoIncludeIndexedFieldsAsOrderBys = 1;
-    // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, FALSE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
-
     $this->_columns = array_merge($this->getColumns('Contact', array(
       'order_bys_defaults' => array('sort_name' => 'ASC '),
       'fields_defaults' => array('sort_name'),
@@ -355,20 +346,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
 
-    // If we have active campaigns add those elements to both the fields and filters
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_contribution']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-      );
-      $this->_columns['civicrm_contribution']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-      $this->_columns['civicrm_contribution']['order_bys']['campaign_id'] = array('title' => ts('Campaign'));
-    }
+   // If we have campaigns enabled, add those elements to both the fields, filters and sorting
+    $this->addCampaignFields('civicrm_contribution', FALSE, TRUE);
 
     $this->_currencyColumn = 'civicrm_contribution_currency';
     parent::__construct();
@@ -723,7 +702,7 @@ UNION ALL
       // convert campaign_id to campaign title
       if (array_key_exists('civicrm_contribution_campaign_id', $row)) {
         if ($value = $row['civicrm_contribution_campaign_id']) {
-          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->activeCampaigns[$value];
+          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->campaigns[$value];
           $entryFound = TRUE;
         }
       }

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -345,8 +345,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
     $this->_columns['civicrm_contact']['fields']['sort_name']['title'] = ts('Donor Name');
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
-
-   // If we have campaigns enabled, add those elements to both the fields, filters and sorting
+    // If we have campaigns enabled, add those elements to both the fields, filters and sorting
     $this->addCampaignFields('civicrm_contribution', FALSE, TRUE);
 
     $this->_currencyColumn = 'civicrm_contribution_currency';


### PR DESCRIPTION
Overview
----------------------------------------
Centralize and cleanup code for campaigns in reports and show disabled campaigns as well

Before
----------------------------------------
![details_before](https://user-images.githubusercontent.com/3455173/50286613-f808d280-0485-11e9-9e21-cf8a9fc224c0.png)


After
----------------------------------------

![details_after](https://user-images.githubusercontent.com/3455173/50286619-fd661d00-0485-11e9-862c-a32bd76b4f17.png)


Comments
----------------------------------------
Inactive campaigns can be seen in report filter and results as well.
