### PR TITLE
Make submitOnce() button js into a button parameter

### DIFF
--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -194,11 +194,13 @@ class CRM_Case_Form_Activity_OpenCase {
           'type' => 'upload',
           'name' => ts('Save'),
           'isDefault' => TRUE,
+          'submitOnce' => TRUE,
         ),
         array(
           'type' => 'upload',
           'name' => ts('Save and New'),
           'subName' => 'new',
+          'submitOnce' => TRUE,
         ),
         array(
           'type' => 'cancel',

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -641,6 +641,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   public function addButtons($params) {
     $prevnext = $spacing = array();
     foreach ($params as $button) {
+      if (!empty($button['submitOnce'])) {
+        $button['js']['onclick'] = "return submitOnce(this,'{$this->_name}','" . ts('Processing') . "');";
+      }
+
       $attrs = array('class' => 'crm-form-submit') + (array) CRM_Utils_Array::value('js', $button);
 
       if (!empty($button['class'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Multiple different forms implement the same javascript line to add a submitOnce() button handler to the submit buttons.  `CRM_Core_Form::addDefaultButtons()` has a parameter to add this but it's not really very generic as most forms call `CRM_Core_Form::addButtons()`.

This PR adds a parameter `submitOnce` to the button create array which will automatically add that handler for any button that sets that to TRUE.  The parameter is added initially for the "Open Case" form submit buttons.

Before
----------------------------------------
Every time you want a "submit only once" button you have to add the same line of javascript to the button array parameters.

After
----------------------------------------
Every time you want a "submit only once" button just add the parameter `submitOnce = TRUE`.

Technical Details
----------------------------------------


Comments
----------------------------------------
Standardise and simplify the way we add form buttons.
