### PR TITLE
Dev/core#470: Current employer disapears when disabling expired relationships

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -656,7 +656,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     $relationship->id = $id;
     $relationship->find(TRUE);
 
-    //to delete relationship between household and individual                                                                                          \
+    //to delete relationship between household and individual                                                                                          
     //or between individual and organization
     if (($action & CRM_Core_Action::DISABLE) || ($action & CRM_Core_Action::DELETE)) {
       $relTypes = CRM_Utils_Array::index(array('name_a_b'), CRM_Core_PseudoConstant::relationshipType('name'));
@@ -676,12 +676,12 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
 
         if ($relationship->relationship_type_id == $employerRelTypeId && $relationship->contact_id_b == $sharedContact->employer_id) {
           $currentEmployerRlationship = new CRM_Contact_DAO_Relationship();
-			$currentEmployerRlationship->contact_id_a = $relationship->contact_id_a;
-			$currentEmployerRlationship->end_date=NULL;
-			$currentEmployerRlationship->is_active=1;
-			if(!$currentEmployerRlationship->find(TRUE)){
-					 CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
-			}
+          $currentEmployerRlationship->contact_id_a = $relationship->contact_id_a;
+          $currentEmployerRlationship->end_date=NULL;
+          $currentEmployerRlationship->is_active=1;
+          if(!$currentEmployerRlationship->find(TRUE)){
+	     CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
+          }
         }
 
       }
@@ -2277,14 +2277,14 @@ AND cc.sort_name LIKE '%$name%'";
     if ($existingTypeName !== 'Employer of') {
       return FALSE;
     }
-	//check if there are another relationship which is not expired 
-	  $relationship = new CRM_Contact_DAO_Relationship();
-      $relationship->contact_id_a = $params['contactID'];
-      $relationship->relationship_type_id = $params['relationship_type_id'];
-	  $relationship->end_date = NULL;
-	  if ($relationship->find(TRUE)) {
-		return FALSE;
-      }
+    //check if there are another relationship which is not expired
+    $relationship = new CRM_Contact_DAO_Relationship();
+    $relationship->contact_id_a = $params['contactID'];
+    $relationship->relationship_type_id = $params['relationship_type_id'];
+    $relationship->end_date = NULL;
+    if ($relationship->find(TRUE)) {
+      return FALSE;
+    }
 	  
     //Clear employer if relationship is expired.
     if (!empty($params['end_date']) && strtotime($params['end_date']) < time()) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -306,7 +306,10 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     if ($type == 6) {
       CRM_Contact_BAO_Household::updatePrimaryContact($params['contact_id_b'], $params['contact_id_a']);
     }
-    if (!empty($relationshipId) && self::isCurrentEmployerNeedingToBeCleared($params, $relationshipId, $type)) {
+    if (!empty($relationshipId) &&
+      self::isCurrentEmployerNeedingToBeCleared($params, $relationshipId, $type) &&
+      empty(self::getRelationship($params['contact_id_a'], self::CURRENT, 0, 0, 0, NULL, NULL, FALSE, ['relationship_type_id' => $relationshipTypes]))
+    ) {
       CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($params['contact_id_a']);
     }
     $relationship = new CRM_Contact_BAO_Relationship();
@@ -656,7 +659,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     $relationship->id = $id;
     $relationship->find(TRUE);
 
-    //to delete relationship between household and individual                                                                                          
+    //to delete relationship between household and individual
     //or between individual and organization
     if (($action & CRM_Core_Action::DISABLE) || ($action & CRM_Core_Action::DELETE)) {
       $relTypes = CRM_Utils_Array::index(array('name_a_b'), CRM_Core_PseudoConstant::relationshipType('name'));
@@ -674,14 +677,11 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
         // As suggested by @davecivicrm, the employee relationship type id is fetched using the CRM_Core_DAO::getFieldValue() class and method, since these ids differ from system to system.
         $employerRelTypeId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', 'Employee of', 'id', 'name_a_b');
 
-        if ($relationship->relationship_type_id == $employerRelTypeId && $relationship->contact_id_b == $sharedContact->employer_id) {
-          $currentEmployerRlationship = new CRM_Contact_DAO_Relationship();
-          $currentEmployerRlationship->contact_id_a = $relationship->contact_id_a;
-          $currentEmployerRlationship->end_date=NULL;
-          $currentEmployerRlationship->is_active=1;
-          if(!$currentEmployerRlationship->find(TRUE)){
-	     CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
-          }
+        if ($relationship->relationship_type_id == $employerRelTypeId &&
+          $relationship->contact_id_b == $sharedContact->employer_id &&
+          empty(self::getRelationship($relationship->contact_id_a, self::CURRENT, 0, 0, 0, NULL, NULL, FALSE, array('relationship_type_id' => $employerRelTypeId)))
+        ) {
+          CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
         }
 
       }
@@ -2277,15 +2277,7 @@ AND cc.sort_name LIKE '%$name%'";
     if ($existingTypeName !== 'Employer of') {
       return FALSE;
     }
-    //check if there are another relationship which is not expired
-    $relationship = new CRM_Contact_DAO_Relationship();
-    $relationship->contact_id_a = $params['contactID'];
-    $relationship->relationship_type_id = $params['relationship_type_id'];
-    $relationship->end_date = NULL;
-    if ($relationship->find(TRUE)) {
-      return FALSE;
-    }
-	  
+
     //Clear employer if relationship is expired.
     if (!empty($params['end_date']) && strtotime($params['end_date']) < time()) {
       return TRUE;

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -675,7 +675,13 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
         $employerRelTypeId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', 'Employee of', 'id', 'name_a_b');
 
         if ($relationship->relationship_type_id == $employerRelTypeId && $relationship->contact_id_b == $sharedContact->employer_id) {
-          CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
+          $currentEmployerRlationship = new CRM_Contact_DAO_Relationship();
+			$currentEmployerRlationship->contact_id_a = $relationship->contact_id_a;
+			$currentEmployerRlationship->end_date=NULL;
+			$currentEmployerRlationship->is_active=1;
+			if(!$currentEmployerRlationship->find(TRUE)){
+					 CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
+			}
         }
 
       }
@@ -2271,6 +2277,15 @@ AND cc.sort_name LIKE '%$name%'";
     if ($existingTypeName !== 'Employer of') {
       return FALSE;
     }
+	//check if there are another relationship which is not expired 
+	  $relationship = new CRM_Contact_DAO_Relationship();
+      $relationship->contact_id_a = $params['contactID'];
+      $relationship->relationship_type_id = $params['relationship_type_id'];
+	  $relationship->end_date = NULL;
+	  if ($relationship->find(TRUE)) {
+		return FALSE;
+      }
+	  
     //Clear employer if relationship is expired.
     if (!empty($params['end_date']) && strtotime($params['end_date']) < time()) {
       return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Create a current relationship (set empty end-date) on individual A as ```Employee of``` organization A and mark as current employer
2. Create a past relationship on individual A as ```Employee of``` organization B without marking as current employer
3. Run Disable expired relationships cron job

Before
----------------------------------------
Result: Clear the employer field of Contact A

After
----------------------------------------
Result: Does not clear the employer field of Contact A


Technical Details
----------------------------------------
This PR replaces https://github.com/civicrm/civicrm-core/pull/13016 after cherry-picking commits and made additional fixes on top of it. In addition, it has UT

