### PR TITLE
Don't crash with missing class if action is not defined when opening new case

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -87,6 +87,9 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
    * Build the form object.
    */
   public function preProcess() {
+    if (empty($this->_action)) {
+      $this->_action = CRM_Core_Action::ADD;
+    }
 
     $this->_caseId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 


### PR DESCRIPTION
Overview
----------------------------------------
If you try and open a case without specifying the action you get an error about missing class because the classname is concatenated based on the activity type name.  But the activity type name is not defined if the action is not specified.  eg. http://localhost:8080/civicrm/case/add?reset=1&atype=13&context=standalone

Before
----------------------------------------
Crash if action not defined. Inconsistent checking for $this->_activityTypeName in some functions (eg. postProcess) but not others.

After
----------------------------------------
Action defaults to ADD. Check if $this->_activityTypeName is defined before trying to use it.


