### PR TITLE
NFC: Improved documentation of crmPageTitle directive.

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -1047,6 +1047,9 @@
 
     // Sets document title & page title; attempts to override CMS title markup for the latter
     // WARNING: Use only once per route!
+    // WARNING: This directive works only if your AngularJS base page does not
+    // set a custom title (i.e., it has an initial title of "CiviCRM"). See the
+    // global variables pageTitle and documentTitle.
     // Example (same title for both): <h1 crm-page-title>{{ts('Hello')}}</h1>
     // Example (separate document title): <h1 crm-document-title="ts('Hello')" crm-page-title><i class="crm-i fa-flag"></i>{{ts('Hello')}}</h1>
     .directive('crmPageTitle', function($timeout) {


### PR DESCRIPTION
Overview
----------------------------------------
Documented assumption that AngularJS base page be named "CiviCRM".

Comments
----------------------------------------
Is there interest in removing this requirement? It seems like the values for `pageTitle` and `documentTitle` could be derived in the `link` function and assigned to local variables instead of being hardcoded to global variables. My gut, however, tells me that perhaps the code was written this way for a reason (i.e., mysterious bugs).

It is a little unusual that `update` is wrapped in a `$timeout`. If I had to guess, it's to keep the `$watch` function from triggering unnecessarily, since `update` changes both parts of the watched expression. Does this effectively make the change atomic, rather than having the `$watch` function fire once when `pageTitle` is updated and again when `documentTitle` is updated?
