### PR TITLE
Export merge to household - fix DB error relating to fields too long for table.

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -562,7 +562,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * Test exporting relationships.
    */
   public function testExportRelationshipsMergeToHouseholdAllFields() {
-    $this->markTestIncomplete('Does not yet work under CI due to mysql limitation (number of columns in table). Works on some boxes');
     list($householdID) = $this->setUpHousehold();
     list($tableName) = CRM_Export_BAO_Export::exportComponents(
       FALSE,
@@ -583,12 +582,13 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     );
     $dao = CRM_Core_DAO::executeQuery("SELECT * FROM {$tableName}");
     while ($dao->fetch()) {
+      $this->assertEquals('Unit Test household', $dao->display_name);
       $this->assertEquals('Portland', $dao->city);
       $this->assertEquals('ME', $dao->state_province);
       $this->assertEquals($householdID, $dao->civicrm_primary_id);
       $this->assertEquals($householdID, $dao->civicrm_primary_id);
-      $this->assertEquals('Unit Test Household', $dao->addressee);
-      $this->assertEquals('Unit Test Household', $dao->display_name);
+      $this->assertEquals('Unit Test household', $dao->addressee);
+      $this->assertEquals(1, $dao->N);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal error when trying to combine merge households and 'primary fields' on some mysql configs

Before
----------------------------------------
depending on mysql this could result in a DB error 

Database Error Code: Row size too large (> 8126). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline., 1118

After
----------------------------------------
Less fields written to the temp table so DB error not encountered

Technical Details
----------------------------------------
The key fix here is that the fields for merging to household are no longer added to the temporary table.

They are fully loaded in php anyway so there is no performance gain using a temp table.
Instead we iterate them in php as we process each row. 

Comments
----------------------------------------
@mattwire @twomice @monishdeb - this is the PR that actually fixes the DB error after all the prep work.

It will need a bit of testing! I have just done very basic tests so far.
