### PR TITLE
(dev/core#610) Page title displays twice on Activity form

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -330,7 +330,6 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     // Set title.
     if (isset($activityTName)) {
       $activityName = CRM_Utils_Array::value($this->_activityTypeId, $activityTName);
-      $this->assign('pageTitle', ts('%1 Activity', array(1 => $activityName)));
 
       if ($this->_currentlyViewedContactId) {
         $displayName = CRM_Contact_BAO_Contact::displayName($this->_currentlyViewedContactId);


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate :

Go to https://dmaster.demo.civicrm.org/civicrm/activity?reset=1&action=add&context=standalone&atype=2

Page title displays twice
It happens both in edit and create mode.

Before
----------------------------------------

New Activity
![activity_add_before](https://user-images.githubusercontent.com/3455173/50327883-d4419d00-0516-11e9-8b38-7de853e4d861.png)

Edit Activity
![activity_edit_before](https://user-images.githubusercontent.com/3455173/50327890-d99ee780-0516-11e9-9b01-bd1628ed671a.png)

After
----------------------------------------
New Activity
![activity_add_after](https://user-images.githubusercontent.com/3455173/50327895-ddcb0500-0516-11e9-95c3-bd0bea4a98b2.png)

Edit Activity
![activity_edit_after](https://user-images.githubusercontent.com/3455173/50327900-e4597c80-0516-11e9-988e-461c6aa054a7.png)


Comments
----------------------------------------
Remove the redundant page title