### PR TITLE
Do not attempt to store out-of-range street number

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -771,6 +771,11 @@ ORDER BY civicrm_address.is_primary DESC, civicrm_address.location_type_id DESC,
       $streetAddress = trim($streetAddress);
     }
 
+    // If street number is too large, we cannot store it.
+    if ($parseFields['street_number'] > CRM_Utils_Type::INT_MAX) {
+      return $emptyParseFields;
+    }
+
     // suffix might be like 1/2
     $matches = array();
     if (preg_match('/^\d\/\d/', $streetAddress, $matches)) {

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -73,6 +73,11 @@ class CRM_Utils_Type {
   const BLOB_SIZE = 65535;
 
   /**
+   * Maximum value of a MySQL signed INT column.
+   */
+  const INT_MAX = 2147483647;
+
+  /**
    * Gets the string representation for a data type.
    *
    * @param int $type

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -345,6 +345,14 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->assertEquals($parsedStreetAddress['street_number'], '54');
     $this->assertEquals($parsedStreetAddress['street_number_suffix'], 'A');
 
+    // Out-of-range street number to be parsed.
+    $street_address = "505050505050 Main St";
+    $parsedStreetAddress = CRM_Core_BAO_Address::parseStreetAddress($street_address);
+    $this->assertEquals($parsedStreetAddress['street_name'], '');
+    $this->assertEquals($parsedStreetAddress['street_unit'], '');
+    $this->assertEquals($parsedStreetAddress['street_number'], '');
+    $this->assertEquals($parsedStreetAddress['street_number_suffix'], '');
+
     // valid Street address to be parsed ( $locale = 'en_US' )
     $street_address = "54A Excelsior Ave. Apt 1C";
     $locale = 'en_US';


### PR DESCRIPTION
Overview
----------------------------------------
Address parsing can result in DB Error Out of range value for column 'street_number' if a (typically bogus) large street number is submitted.  We should ignore such street numbers and not attempt to store them.

Before
----------------------------------------
DB Error Out of range value for column 'street_number' while doing batch address geocoding, or editing a contact, if address parsing is enabled and someone submits "505050505050 Main St"

After
----------------------------------------
Address parsing for this address is aborted without a fatal error.