### PR TITLE
Improved support for case variability in UF* API calls.

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -120,8 +120,12 @@ class CRM_Utils_String {
     $fragments = explode('_', $string);
     foreach ($fragments as & $fragment) {
       $fragment = ucfirst($fragment);
+      // Special case: UFGroup, UFJoin, UFMatch, UFField (if passed in without underscores)
+      if (strpos($fragment, 'Uf') === 0 && strlen($string) > 2) {
+        $fragment = 'UF' . ucfirst(substr($fragment, 2));
+      }
     }
-    // Special case: UFGroup, UFJoin, UFMatch, UFField
+    // Special case: UFGroup, UFJoin, UFMatch, UFField (if passed in underscore-separated)
     if ($fragments[0] === 'Uf') {
       $fragments[0] = 'UF';
     }


### PR DESCRIPTION
Overview
----------------------------------------
Improved support for case variability in `UF*` API calls as envisioned in [CRM-15988](https://issues.civicrm.org/jira/browse/CRM-15988).

Before
----------------------------------------
### Case 1:

Execute the following in a page:

```php
civicrm_api3('ufgroup', 'getlist', []);
```

Observe fatal error:

> CiviCRM_API3_Exception: API (Ufgroup, get) does not exist (join the API team and implement it!) in civicrm_api3() (line 45 of /path/to/civicrm/api/api.php).

### Case 2:
I encountered the following problem while testing @eileenmcnaughton's recent work on settings and the generic settings form in particular.

1. Declare a setting, specifying UFGroup as the entity for an entityRef widget, e.g.:

```php
return array(
  $setting => array(
    ...
    'name' => $setting,
    // Note that using other forms of the entity name
    // (e.g., uf_group) does not change the outcome.
    'entity_reference_options' => ['entity' => 'UFGroup'],
    'html_type' => 'entity_reference',
    'settings_pages' => [
      'myext' => [
        'weight' => 5,
      ],
    ],
    ...
  ),
);
```
2. Visit the `myext` settings page and observe the following fatal error:

> CiviCRM_API3_Exception: "API (Ufgroup, get) does not exist (join the API team and implement it!)"
>
> <span>#</span>0 /path/to/civicrm/CRM/Core/Form/Renderer.php(250): civicrm_api3("ufgroup", "getlist", (Array:2))
> <span>#</span>1 /path/to/civicrm/CRM/Core/Form/Renderer.php(204): CRM_Core_Form_Renderer::preProcessEntityRef(Object(HTML_QuickForm_text))
> ...

After
----------------------------------------
No fatal error. The API works as expected.

Technical Details
----------------------------------------
This is clearly a hack, but at least it lives next to a similar, pre-existing hack. Open to suggestions for another home for this (or a similar) fix.