### PR TITLE
Added support to generic settings form for sorting settings by weight.

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -61,18 +61,19 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
     $this->setDefaultsForMetadataDefinedFields();
     return $this->_defaults;
   }
+
   /**
    * Build the form object.
    */
   public function buildQuickForm() {
-    $filter = array_pop($this->urlPath);
+    $filter = $this->getSettingPageFilter();
     $settings = civicrm_api3('Setting', 'getfields', [])['values'];
     foreach ($settings as $key => $setting) {
       if (isset($setting['settings_pages'][$filter])) {
         $this->_settings[$key] = $setting;
       }
     }
-    // @todo sort settings by weight.
+
     $this->addFieldsDefinedInSettingsMetadata();
 
     // @todo look at sharing the code below in the settings trait.


### PR DESCRIPTION
Overview
----------------------------------------
Added support to generic settings form for sorting settings by weight.

Before
----------------------------------------
Settings fields don't respect the weight configured in `settings_pages`. Seems likely the render order is alphabetical based on the setting name.

After
----------------------------------------
Settings fields can be ordered explicitly.

Comments
----------------------------------------
* Works well on settings pages for extensions. Wasn't sure what core pages to test.
* Where is template variable `settings_fields` used? A quick skim of the codebase suggests this variable expects an associative array, so I left it alone, since my approach uses a numerically indexed array. I don't know if templates that use this variable have a different sorting mechanism or what. If not, those templates could avail themselves of my fix by refactoring to get the setting name from the inner array rather than the key of the outer array. Anyway, I'd appreciate it if someone more familiar with this part of the codebase would weigh in. @eileenmcnaughton?