### PR TITLE
geocode job: Do not return more messages than can fit in the log data column

### DIFF
--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -287,7 +287,18 @@ class CRM_Utils_Address_BatchUpdate {
   public function returnResult() {
     $result = array();
     $result['is_error'] = $this->returnError;
-    $result['messages'] = implode("", $this->returnMessages);
+    $result['messages'] = '';
+    // Pad message size to allow for prefix added by CRM_Core_JobManager.
+    $messageSize = 255;
+    // Ensure that each message can fit in the civicrm_job_log.data column.
+    foreach ($this->returnMessages as $message) {
+      $messageSize += strlen($message);
+      if ($messageSize > CRM_Utils_Type::BLOB_SIZE) {
+        $result['messages'] .= '...';
+        break;
+      }
+      $result['messages'] .= $message;
+    }
     return $result;
   }
 

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -68,6 +68,11 @@ class CRM_Utils_Type {
     HUGE = 45;
 
   /**
+   * Maximum size of a MySQL BLOB or TEXT column in bytes.
+   */
+  const BLOB_SIZE = 65535;
+
+  /**
    * Gets the string representation for a data type.
    *
    * @param int $type


### PR DESCRIPTION
Overview
----------------------------------------
Once a site has over 500 unparseable\* addresses, the job log cannot be saved when running the address geocoder job, because it returns more links to unparsed contacts than can fit in the civicrm_job_log.data column.

Here I patch the job to stop adding messages once they reach the 65535 byte limit of the column.

Before
----------------------------------------
DB Error: Data too long for column 'data' at row 1

After
----------------------------------------
We stop adding log messages once the column size in bytes is reached.  The log message has "..." appended and job log can be saved.

Technical Details
----------------------------------------
Added a CRM_Utils_Type::BLOB_SIZE constant so this 65535 size for BLOB and TEXT columns could easily be used elsewhere if needed.

Comments
----------------------------------------
\* It appears that CiviCRM does not have address parsing rules to handle countries that place the street number after the street name, for example Brazil, Germany, Sweden, etc. See https://en.wikipedia.org/wiki/Address#Format_by_country_and_area