### PR TITLE
optimize CRM_Utils_String::ellipsify() method

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -657,18 +657,10 @@ class CRM_Utils_String {
    * @return string
    */
   public static function ellipsify($string, $maxLen) {
-    $len = mb_strlen($string, 'UTF-8');
-    if ($len <= $maxLen) {
+    if (mb_strlen($string, 'UTF-8') <= $maxLen) {
       return $string;
     }
-    else {
-      $end = $maxLen - 3;
-      while (mb_strlen($string, 'UTF-8') > $maxLen - 3) {
-        $string = mb_substr($string, 0, $end, 'UTF-8');
-        $end = $end - 1;
-      }
-      return $string . '...';
-    }
+    return mb_substr($string, 0, $maxLen - 3, 'UTF-8') . '...';
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is a low priority micro-optimization :)  But, CRM_Utils_String::ellipsify() was originally written to truncate a UTF-8 string to given number of bytes or less, and so had the one-character-at-a-time truncation this functionality requires.  However, it was only used in the context of UTF-8 strings that needed to be truncated to given number of characters.  So in a0036c4aea71c21a82e2e07008a6906985835e94 we removed the byte-length functionality from the method. But we never removed some of the extra logic.

Before
----------------------------------------
mb_strlen() is called twice and there's an unnecessary while loop.  It will also go into an infinite loop if the $maxLen argument is less than 3.

After
----------------------------------------
We now just call mb_strlen() once and mb_substr() once.