### PR TITLE
(dev/core#491) campaign cleanup for contribution (org) report and sho…

### DIFF
--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -53,13 +53,6 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
    */
   public function __construct() {
     self::validRelationships();
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array('CiviCampaign', $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
 
     $this->_columns = array(
       'civicrm_contact_organization' => array(
@@ -212,18 +205,8 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
       ),
     );
 
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_contribution']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-      );
-      $this->_columns['civicrm_contribution']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-    }
+    // If we have a campaign, build out the relevant elements
+    $this->addCampaignFields('civicrm_contribution');
 
     $this->_currencyColumn = 'civicrm_contribution_currency';
     parent::__construct();
@@ -559,7 +542,7 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
       // convert campaign_id to campaign title
       if (array_key_exists('civicrm_contribution_campaign_id', $row)) {
         if ($value = $row['civicrm_contribution_campaign_id']) {
-          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->activeCampaigns[$value];
+          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->campaigns[$value];
           $entryFound = TRUE;
         }
       }


### PR DESCRIPTION
…w disabled campaigns as well

Overview
----------------------------------------
Centralize and cleanup code for campaigns in reports and show disabled campaigns as well


Before
----------------------------------------
![contri_org_before](https://user-images.githubusercontent.com/3455173/50391616-2d0a7300-076d-11e9-8096-d33b1e4034cb.png)


After
----------------------------------------
![contri_org_after](https://user-images.githubusercontent.com/3455173/50391617-31369080-076d-11e9-884c-0482d6e835e0.png)


Comments
----------------------------------------
Inactive campaigns can be seen in report filter and results as well.
