### PR TITLE
fix verbiage for Dashboard title

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -230,7 +230,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
           'url' => 'civicrm/user',
           'class' => 'no-popup',
           'qs' => 'reset=1&id=%%cbid%%',
-          'title' => ts('View Relationship'),
+          'title' => ts('View Contact Dashboard'),
         ),
       );
 


### PR DESCRIPTION
Overview
----------------------------------------
fix verbiage for Dashboard title

Before
----------------------------------------
User Dashboard title is wrongly shown as _View Relationship_
![dashboard_title_before](https://user-images.githubusercontent.com/3455173/50394809-e07f6180-0785-11e9-8e68-b4f57f4c052d.png)

After
----------------------------------------
title reads _View Contact Dashboard_
![dashboard_after](https://user-images.githubusercontent.com/3455173/50396395-c9de0800-078f-11e9-9260-c7ccfdf5b5b8.png)

Comments
----------------------------------------
Link when click goes to Dashboard of related contact not the relationship record
