### PR TITLE
fix verbiage for Edit Contact Information title

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -223,7 +223,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
           'name' => ts('Edit Contact Information'),
           'url' => 'civicrm/contact/relatedcontact',
           'qs' => 'action=update&reset=1&cid=%%cbid%%&rcid=%%cid%%',
-          'title' => ts('Edit Relationship'),
+          'title' => ts('Edit Contact Information'),
         ),
         CRM_Core_Action::VIEW => array(
           'name' => ts('Dashboard'),


### PR DESCRIPTION
Overview
----------------------------------------
fix verbiage for  Edit Contact Information title

Before
----------------------------------------
Edit Contact Information title is wrongly shown as _Edit Relationship_


After
----------------------------------------
title reads _Edit Contact Information_

Comments
----------------------------------------
Title is misleading and does not match with the name.