### PR TITLE
dev/mail#35 Ensure that Public View link is visible in Scheduled and …

### DIFF
--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -441,13 +441,14 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
 
         $validLinks = $actionLinks;
         if (($mailingUrl = CRM_Mailing_BAO_Mailing::getPublicViewUrl($row['id'])) != FALSE) {
-          $validLinks[] = array(
+          $validLinks[CRM_Core_Action::BROWSE] = array(
             'name' => ts('Public View'),
             'url' => 'civicrm/mailing/view',
             'qs' => 'id=%%mid%%&reset=1',
             'title' => ts('Public View'),
             'fe' => TRUE,
           );
+          $actionMask |= CRM_Core_Action::BROWSE;
         }
 
         $rows[$key]['action'] = CRM_Core_Action::formLink(


### PR DESCRIPTION
…Sent Screens

Overview
----------------------------------------
The code in the Action Links for Mailing Scheduled and Sent and Draft and Unscheduled mailings suggests that a public view link should be there if the mailing is public but it currently doesn't show

Before
----------------------------------------
No public view link

After
----------------------------------------
Public View link shows

ping @mattwire @yashodha @monishdeb @eileenmcnaughton 
