### PR TITLE
(dev/core#491) campaign cleanup for pledge detail report and show dis…

### DIFF
--- a/CRM/Report/Form/Pledge/Detail.php
+++ b/CRM/Report/Form/Pledge/Detail.php
@@ -71,14 +71,6 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
     $this->_pledgeStatuses = CRM_Core_OptionGroup::values('pledge_status',
       FALSE, FALSE, FALSE, NULL, 'label'
     );
-    // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
 
     $this->_columns = array(
       'civicrm_contact' => array(
@@ -199,21 +191,7 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
     $this->_columns += $this->getAddressColumns(array('group_by' => FALSE)) + $this->getPhoneColumns();
 
     // If we have a campaign, build out the relevant elements
-    $this->_tagFilter = TRUE;
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_pledge']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-      );
-      $this->_columns['civicrm_pledge']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-      $this->_columns['civicrm_pledge']['group_bys']['campaign_id'] = array('title' => ts('Campaign'));
-
-    }
+    $this->addCampaignFields('civicrm_pledge', TRUE);
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
@@ -599,7 +577,7 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
       // If using campaigns, convert campaign_id to campaign title
       if (array_key_exists('civicrm_pledge_campaign_id', $row)) {
         if ($value = $row['civicrm_pledge_campaign_id']) {
-          $rows[$rowNum]['civicrm_pledge_campaign_id'] = $this->activeCampaigns[$value];
+          $rows[$rowNum]['civicrm_pledge_campaign_id'] = $this->campaigns[$value];
         }
         $entryFound = TRUE;
       }


### PR DESCRIPTION
…abled campaigns as well

Overview
----------------------------------------
Centralize and cleanup code for campaigns in reports and show disabled campaigns as well


Before
----------------------------------------
![pledg_detail_before](https://user-images.githubusercontent.com/3455173/50466603-920bd600-09c4-11e9-9e01-23f468861c27.png)



After
----------------------------------------
![pledge_detail_after](https://user-images.githubusercontent.com/3455173/50466606-9637f380-09c4-11e9-972d-f61b26fe4499.png)


Comments
----------------------------------------
Inactive campaigns can be seen in report filter and results as well.
