### PR TITLE
(dev/core#491) campaign cleanup for 'pledged but not paid' report and…

### DIFF
--- a/CRM/Report/Form/Pledge/Pbnp.php
+++ b/CRM/Report/Form/Pledge/Pbnp.php
@@ -49,12 +49,6 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
 
     // Check if CiviCampaign is a) enabled and b) has active campaigns
     $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
 
     $this->_columns = array(
       'civicrm_contact' => array(
@@ -184,18 +178,7 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
     );
 
     // If we have a campaign, build out the relevant elements
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_pledge']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-      );
-      $this->_columns['civicrm_pledge']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-    }
+    $this->addCampaignFields('civicrm_pledge');
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
@@ -359,7 +342,7 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
       // If using campaigns, convert campaign_id to campaign title
       if (array_key_exists('civicrm_pledge_campaign_id', $row)) {
         if ($value = $row['civicrm_pledge_campaign_id']) {
-          $rows[$rowNum]['civicrm_pledge_campaign_id'] = $this->activeCampaigns[$value];
+          $rows[$rowNum]['civicrm_pledge_campaign_id'] = $this->campaigns[$value];
         }
         $entryFound = TRUE;
       }

--- a/CRM/Report/Form/Pledge/Pbnp.php
+++ b/CRM/Report/Form/Pledge/Pbnp.php
@@ -46,10 +46,6 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
    * Class constructor.
    */
   public function __construct() {
-
-    // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-
     $this->_columns = array(
       'civicrm_contact' => array(
         'dao' => 'CRM_Contact_DAO_Contact',


### PR DESCRIPTION
… show disabled campaigns as well.

Overview
----------------------------------------
Centralize and cleanup code for campaigns in reports and show disabled campaigns as well


Before
----------------------------------------

![pbnp_before](https://user-images.githubusercontent.com/3455173/50474155-c6dc5500-09e5-11e9-86d4-b035aedae4d2.png)


After
----------------------------------------
![pbnp_after](https://user-images.githubusercontent.com/3455173/50474161-cfcd2680-09e5-11e9-8e54-0fbe8db583c4.png)


Comments
----------------------------------------
Inactive campaigns can be seen in report filter and results as well.
