### PR TITLE
(dev/core#625) DB error on Case Summary report

### DIFF
--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -277,6 +277,13 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
     $crt = $this->_aliases['civicrm_relationship_type'];
     $ccc = $this->_aliases['civicrm_case_contact'];
 
+    foreach ($this->_columns['civicrm_relationship']['filters'] as $fieldName => $field) {
+      if (!empty($this->_params[$fieldName . '_op']) && isset($this->_params[$fieldName . '_value'])) {
+        $this->_relField = TRUE;
+        break;
+      }
+    }
+
     if ($this->_relField) {
       $this->_from = "
             FROM civicrm_contact $c


### PR DESCRIPTION
Overview
----------------------------------------
[GitLab issue 625 DB error on Case Summary report](https://lab.civicrm.org/dev/core/issues/625)

Seen on dmaster ( 5.10.alpha1 )

[Related to PR 13296](https://github.com/civicrm/civicrm-core/pull/13296)

Before
----------------------------------------
1. Go to Reports->Case Reports->New Case Report
2. Select Case Summary Report
3. Deselect "Staff Member" and "Relationship" fields
4. Go to Filters tab
5. For "Active Relationship?" select operator "Is equal to" and value "Yes"
6. Click on View Results
7. Throws the following error
![error](https://user-images.githubusercontent.com/33434409/50480245-b5d61880-09d2-11e9-97d0-5b9ffbbfb405.png)

After
----------------------------------------
Following the above steps will successfully display results.

Technical Details
----------------------------------------
Added a loop to check if any of civicrm_relationship filters are selected in params. 

Comments
----------------------------------------
Currently only checking for "<field_name>_value" keys as there are only 2 filters in civicrm_relationship table. Probably best to compare operator type and check for "_high", "_low", "_min", "_max" as well
