### PR TITLE
Revert to showing overdue activities on a case first

### DIFF
--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -74,7 +74,7 @@
     </div><!-- /.crm-accordion-wrapper -->
 {/if}
 
-    <table id="case_id_{$caseid}"  class="nestedActivitySelector crm-ajax-table" data-order='[[0,"desc"]]' data-page-length="10">
+    <table id="case_id_{$caseid}"  class="nestedActivitySelector crm-ajax-table" data-page-length="10">
       <thead><tr>
         <th data-data="activity_date_time" class="crm-case-activities-date">{ts}Date{/ts}</th>
         <th data-data="subject" cell-class="crmf-subject crm-editable" class="crm-case-activities-subject">{ts}Subject{/ts}</th>


### PR DESCRIPTION
I'd like to remove the data-order, as the BAO Case file already sorts.

Ok I put all the info in the wrong place, I opened an issue when I could have placed it here:
https://lab.civicrm.org/dev/core/issues/626