### PR TITLE
(dev/core#594) Fix key-value mappings for WYSIWYG setting (editor_id). Accept keyColumn option.

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveNine.php
@@ -60,7 +60,8 @@ class CRM_Upgrade_Incremental_php_FiveNine extends CRM_Upgrade_Incremental_Base 
         1 => ts('Enable multiple bulk email address for a contact'),
         2 => ts('Email on Hold'),
       );
-      $postUpgradeMessage .= '<p>' . ts('If the setting "%1" is enabled, you should update any smart groups based on the "%2" field.', $args) . '</p>';
+      $postUpgradeMessage .= '<p>' . ts('If the setting "%1" is enabled, you should update any smart groups based on the "%2" field.', $args) . '</p>' .
+        '<p>' . ts('If you were previously on version 5.8 and you altered your WYSIWYG editor setting you should visit the <a %1>Display Preferences</a> page and check the editor setting', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p>';
     }
 
     // Example: Generate a post-upgrade message.

--- a/CRM/Upgrade/Incremental/php/FiveNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveNine.php
@@ -61,7 +61,7 @@ class CRM_Upgrade_Incremental_php_FiveNine extends CRM_Upgrade_Incremental_Base 
         2 => ts('Email on Hold'),
       );
       $postUpgradeMessage .= '<p>' . ts('If the setting "%1" is enabled, you should update any smart groups based on the "%2" field.', $args) . '</p>' .
-        '<p>' . ts('If you were previously on version 5.8 and you altered your WYSIWYG editor setting you should visit the <a %1>Display Preferences</a> page and check the editor setting', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p>';
+        '<p>' . ts('If you were previously on version 5.8 and altered the WYSIWYG editor setting, you should visit the <a %1>Display Preferences</a> page and re-save the WYSIWYG editor setting.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p>';
     }
 
     // Example: Generate a post-upgrade message.

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -161,8 +161,12 @@ function civicrm_api3_setting_getoptions($params) {
     return civicrm_api3_create_success($values, $params, 'Setting', 'getoptions');
   }
   elseif (!empty($pseudoconstant['optionGroupName'])) {
+    $keyColumn = 'value';
+    if (!empty($pseudoconstant['keyColumn'])) {
+      $keyColumn = $pseudoconstant['keyColumn'];
+    }
     return civicrm_api3_create_success(
-      CRM_Core_OptionGroup::values($pseudoconstant['optionGroupName'], FALSE, FALSE, TRUE),
+      CRM_Core_OptionGroup::values($pseudoconstant['optionGroupName'], FALSE, FALSE, TRUE, NULL, 'label', TRUE, FALSE, $keyColumn),
       $params, 'Setting', 'getoptions'
     );
   }

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -220,6 +220,7 @@ return array(
     'title' => ts('Wysiwig Editor'),
     'pseudoconstant' => array(
       'optionGroupName' => 'wysiwyg_editor',
+      'keyColumn' => 'name',
     ),
     'is_domain' => 1,
     'is_contact' => 0,


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where by the editor_id setting does not work properly because the javascript and other parts are expecting the string of the name of the Editor whereas in https://github.com/civicrm/civicrm-core/commit/719eda4a59b6c95aa670ce9c95aa10d2f91478ac#diff-45cac86e3687ecb3e1996985223d2a31 it was changed to keyed on values because that is what is the default for settings pseduoconstants 

Before
----------------------------------------
* Saving the `editor_id` in the GUI leads to an invalid setting.
* In the metadata used for `Settings.getoptions` in APIv3, one can set an `optionGroupName`. The key-value mappings are implicitly based on `value=>label`.

After
----------------------------------------
* Saving the `editor_id` in the GUI leads to a valid setting.
* In the metadata used for `Settings.getoptions` in APIv3, one can set an `optionGroupName`.  By default, the key-value mappings are based on `value=>label` (as before), but one may optionally customize with the `keyColumn`. This parallels the [XML Schema convention](https://docs.civicrm.org/dev/en/latest/framework/database/schema-definition/#table-field-pseudoconstant) that shapes most generic `*.getoptions` calls.

ping @mattwire @monishdeb @andrewpthompson @MegaphoneJon 
