### PR TITLE
REF Convert deprecated functions to buildOptions for case

### DIFF
--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -112,8 +112,8 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
     $activityId = NULL,
     $key = NULL,
     $compContext = NULL) {
-    static $activityActTypes = NULL;
-    //CRM-14277 added addtitional param to handle activity search
+
+    //CRM-14277 added additional param to handle activity search
     $extraParams = "&searchContext=activity";
 
     $extraParams .= ($key) ? "&key={$key}" : NULL;
@@ -124,11 +124,10 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
     $showView = TRUE;
     $showUpdate = $showDelete = FALSE;
     $qsUpdate = NULL;
+    $url = NULL;
+    $qsView = NULL;
 
-    if (!$activityActTypes) {
-      $activeActTypes = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name', TRUE);
-    }
-    $activityTypeName = CRM_Utils_Array::value($activityTypeId, $activeActTypes);
+    $activityTypeName = CRM_Core_PseudoConstant::getName('CRM_Activity_BAO_Activity', 'activity_type_id', $activityTypeId);
 
     // CRM-7607
     // Lets allow to have normal operation for only activity types.

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -273,8 +273,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
     $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
-    // Get all activity types
-    $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name', TRUE);
+    $bulkActivityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Bulk Email');
 
     while ($result->fetch()) {
       $row = array();
@@ -313,7 +312,6 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
       if ($row['activity_is_test']) {
         $row['activity_type'] = $row['activity_type'] . " (test)";
       }
-      $bulkActivityTypeID = CRM_Utils_Array::key('Bulk Email', $activityTypes);
       $row['mailingId'] = '';
       if (
         $accessCiviMail &&

--- a/Civi/CCase/Analyzer.php
+++ b/Civi/CCase/Analyzer.php
@@ -132,6 +132,7 @@ class Analyzer {
 
   /**
    * Get a single activity record by type.
+   * This function is only used by SequenceListenerTest
    *
    * @param string $type
    * @throws \Civi\CCase\Exception\MultipleActivityException
@@ -139,7 +140,7 @@ class Analyzer {
    */
   public function getSingleActivity($type) {
     $idx = $this->getActivityIndex(array('activity_type_id', 'id'));
-    $actTypes = array_flip(\CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name'));
+    $actTypes = array_flip(\CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'validate'));
     $typeId = $actTypes[$type];
     $count = isset($idx[$typeId]) ? count($idx[$typeId]) : 0;
 

--- a/Civi/CCase/SequenceListener.php
+++ b/Civi/CCase/SequenceListener.php
@@ -51,7 +51,7 @@ class SequenceListener implements CaseChangeListener {
       return;
     }
 
-    $actTypes = array_flip(\CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name'));
+    $actTypes = array_flip(\CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'validate'));
     $actStatuses = array_flip(\CRM_Activity_BAO_Activity::getStatusesByType(\CRM_Activity_BAO_Activity::COMPLETED));
 
     $actIndex = $analyzer->getActivityIndex(array('activity_type_id', 'status_id'));


### PR DESCRIPTION
Overview
----------------------------------------
Convert `CRM_Core_PseudoConstant::activityType()` and `CRM_Core_PseudoConstant::activityStatus()` to non deprecated `buildOptions()` function.

Fix a couple of PHP notices.

Before
----------------------------------------
Deprecated code, php notices.

After
----------------------------------------
Less deprecated code, less PHP notices

Technical Details
----------------------------------------
In most cases these methods are functionally the same.  In some cases the `buildOptions()` replacement for `activityType()` function also returns campaign activities but this does not matter because the activity type arrays are being used to lookup (via array_search) specific activity types.

Comments
----------------------------------------
