### PR TITLE
Format details for case custom data activity in a human readable format

### DIFF
--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -136,7 +136,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
       'subject' => $this->_customTitle . " : change data",
       'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed'),
       'target_contact_id' => $this->_contactID,
-      'details' => json_encode($this->_defaults),
+      'details' => $this->formatCustomDataChangesForDetail($params),
       'activity_date_time' => date('YmdHis'),
     ];
     $activity = CRM_Activity_BAO_Activity::create($activityParams);
@@ -148,6 +148,49 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
     CRM_Case_BAO_Case::processCaseActivity($caseParams);
 
     $transaction->commit();
+  }
+
+  /**
+   * Format the custom data changes as [label]: [old value] => [new value]
+   *
+   * @param array $params New custom field values from form
+   *
+   * @return string
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function formatCustomDataChangesForDetail($params) {
+    $formattedDetails = [];
+    foreach ($params as $customField => $newCustomValue) {
+      if (substr($customField, 0, 7) == 'custom_') {
+        if ($this->_defaults[$customField] == $newCustomValue) {
+          // Don't show values that did not change
+          continue;
+        }
+        // We need custom field ID from custom_XX_1
+        list($_, $customFieldId, $_) = explode('_', $customField);
+
+        if (!empty($customFieldId) && is_numeric($customFieldId)) {
+          // Got a custom field ID
+          $label = civicrm_api3('CustomField', 'getvalue', ['id' => $customFieldId, 'return' => 'label']);
+          $oldValue = civicrm_api3('CustomValue', 'getdisplayvalue', [
+            'custom_field_id' => $customFieldId,
+            'entity_id' => $this->_entityID,
+            'custom_field_value' => $this->_defaults[$customField],
+          ]);
+          $oldValue = $oldValue['values'][$customFieldId]['display'];
+          $newValue = civicrm_api3('CustomValue', 'getdisplayvalue', [
+            'custom_field_id' => $customFieldId,
+            'entity_id' => $this->_entityID,
+            'custom_field_value' => $newCustomValue,
+          ]);
+          $newValue = $newValue['values'][$customFieldId]['display'];
+          $formattedDetails[] = $label . ': ' . $oldValue . ' => ' . $newValue;
+        }
+
+      }
+    }
+
+    return implode('<br/>', $formattedDetails);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
When a Case "Change Custom Data" activity is created the activity details are virtually unreadable to a human!  It is a json encoded array of all previous custom data values with their internal names (eg. custom_55).

This PR changes that so that only the actual changes are shown and the custom field labels are used.

Before
----------------------------------------
"Unreadable" json array of all custom data values before change:
![casecustomdataold](https://user-images.githubusercontent.com/2052161/50527156-7137a380-0ade-11e9-9f58-8a4b660b076b.png)


After
----------------------------------------
* "Human readable" list of custom field labels (as shown on the actual custom data on the case overview).
* Old and new value for each shown.
* Values that did not change are not shown.

![casecustomdatanewsome](https://user-images.githubusercontent.com/2052161/50527150-6715a500-0ade-11e9-9868-1523e933c695.png)
![casecustomdatanewall](https://user-images.githubusercontent.com/2052161/50527151-6715a500-0ade-11e9-86a3-02d3a5f5fd41.png)
![casecustomdatanewallmulti](https://user-images.githubusercontent.com/2052161/50537692-18f2b700-0b5b-11e9-96d4-6faefdb92ff0.png)


Technical Details
----------------------------------------
A new function is created to format the custom data for the activity.

Comments
----------------------------------------

