### PR TITLE
Cache case count when getting list of cases so query is executed once instead of three times

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -588,9 +588,14 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
     $condition = NULL;
     $casesList = array();
 
-    //validate access for own cases.
+    // validate access for own cases.
     if (!self::accessCiviCase()) {
       return $getCount ? 0 : $casesList;
+    }
+
+    // Return cached value instead of re-running query
+    if (isset(Civi::$statics[__CLASS__]['totalCount']) && $getCount) {
+      return Civi::$statics[__CLASS__]['totalCount'];
     }
 
     $type = CRM_Utils_Array::value('type', $params, 'upcoming');
@@ -610,7 +615,7 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
       $caseActivityIDColumn = 'case_recent_activity_id';
     }
 
-    //validate access for all cases.
+    // validate access for all cases.
     if ($allCases && !CRM_Core_Permission::check('access all cases and activities')) {
       $allCases = FALSE;
     }
@@ -631,7 +636,7 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
     }
     $condition = implode(' AND ', $whereClauses);
 
-    $totalCount = CRM_Core_DAO::singleValueQuery(self::getCaseActivityCountQuery($type, $userID, $condition));
+    Civi::$statics[__CLASS__]['totalCount'] = $totalCount = CRM_Core_DAO::singleValueQuery(self::getCaseActivityCountQuery($type, $userID, $condition));
     if ($getCount) {
       return $totalCount;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Add caching for a case count query that is used on the case dashboard when listing cases.

Before
----------------------------------------
Cases are counted three times (query is run three times)

After
----------------------------------------
Cases are counted once (query is run once and then cached value is used).

Technical Details
----------------------------------------
Each time the function is called the query was executed.  We add a static cache in the standard way so the query is only executed once.

Comments
----------------------------------------
@lcdservices Is this one you could review?
