### PR TITLE
(dev/core#616) Fix Print/merge document for memberships: Preview creating activities; standardise preview code for contacts, cases, contributions & memberships

### DIFF
--- a/CRM/Member/Form/Task/PDFLetterCommon.php
+++ b/CRM/Member/Form/Task/PDFLetterCommon.php
@@ -41,7 +41,7 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
   }
 
   /**
-   * Generate htmlfor pdf letters.
+   * Generate html for pdf letters.
    *
    * @param array $membershipIDs
    * @param array $returnProperties


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/616. Print/merge document for memberships should not creates activities when the Preview button is clicked. This PR resolves that, making the behaviour for Memberships consistent with that of Contacts.

Before
----------------------------------------
Activities will be created after clicking Preview:
1. Find Memberships, use any criteria
2. Select some memberships and select the 'Print/merge document for memberships'
3. Click Preview - PDF will be created
4. Find Activities, search using appropriate criteria (Today) - activities will be seen for this task.

After
----------------------------------------
Activities will not be created after clicking Preview.

Technical Details
----------------------------------------
When [CRM-16725](https://issues.civicrm.org/jira/browse/CRM-16725) / [PR #6888](https://github.com/civicrm/civicrm-core/pull/6888) added the Preview button, it did not implement any code in `CRM_Member_Form_Task_PDFLetterCommon` to make Preview work for Membership search tasks, only Contacts.

~~The few lines of code that this PR adds were taken from `CRM_Contact_Form_Task_PDFLetterCommon::postProcess()` (almost verbatim except for the button name).~~

To help standardise the behaviour, the logic associated with `$isLiveMode` in `CRM_Contact_Form_Task_PDFLetterCommon::postProcess()` is moved into a new function `CRM_Contact_Form_Task_PDFLetterCommon::isLiveMode()`. It is called from CRM_Contact_Form_Task_PDFLetterCommon::createActivities()`, which was already common to the PDF letter forms for memberships, contacts, contributions and cases.

Comments
----------------------------------------
There is duplication between the contact and membership PDF letter code but it didn't seem straightforward to remove it due to the code for each being based on contact IDs and membership IDs respectively.

@aydun has done some good work in [PR #12012](https://github.com/civicrm/civicrm-core/pull/12012) for PDFs for Activities and improving the code structure. I spent a short time looking at this and suspect that it would be best to do similar for Memberships after #12012 is finalised.
