### PR TITLE
fixes core#580 - view all groups when appropriately permissioned

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -871,7 +871,7 @@ SELECT g.*
     }
 
     if ($allGroups == NULL) {
-      $allGroups = CRM_Core_PseudoConstant::allGroup();
+      $allGroups = CRM_Contact_BAO_Contact::buildOptions('group_id', NULL, ['onlyActive' => FALSE]);
     }
 
     $acls = CRM_ACL_BAO_Cache::build($contactID);

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -870,6 +870,10 @@ SELECT g.*
       return Civi::$statics[__CLASS__]['permissioned_groups'][$userCacheKey];
     }
 
+    if ($allGroups == NULL) {
+      $allGroups = CRM_Core_PseudoConstant::allGroup();
+    }
+
     $acls = CRM_ACL_BAO_Cache::build($contactID);
 
     $ids = array();

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -966,18 +966,20 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
         }
         $values[$object->id]['group_type'] = implode(', ', $types);
       }
-      $values[$object->id]['action'] = CRM_Core_Action::formLink($newLinks,
-        $action,
-        array(
-          'id' => $object->id,
-          'ssid' => $object->saved_search_id,
-        ),
-        ts('more'),
-        FALSE,
-        'group.selector.row',
-        'Group',
-        $object->id
-      );
+      if ($action) {
+        $values[$object->id]['action'] = CRM_Core_Action::formLink($newLinks,
+          $action,
+          array(
+            'id' => $object->id,
+            'ssid' => $object->saved_search_id,
+          ),
+          ts('more'),
+          FALSE,
+          'group.selector.row',
+          'Group',
+          $object->id
+        );
+      }
 
       // If group has children, add class for link to view children
       $values[$object->id]['is_parent'] = FALSE;

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -787,9 +787,8 @@ AND    contact_id IN ( $contactStr )
    * @return array|bool
    */
   public static function buildOptions($fieldName, $context = NULL, $props = array()) {
-    $params = array();
 
-    $options = CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
+    $options = CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $props, $context);
 
     // Sort group list by hierarchy
     // TODO: This will only work when api.entity is "group_contact". What about others?

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -499,7 +499,7 @@ class CRM_Core_PseudoConstant {
   }
 
   /**
-   * DEPRECATED generic populate method.
+   * @deprecated generic populate method.
    * All pseudoconstant functions that use this method are also @deprecated
    *
    * The static array $var is populated from the db

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -654,7 +654,6 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setupEditAllGroupsACL();
     $params = $this->_params;
     $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);
-    print_r($groups);
     $this->assertNotEmpty($groups, 'If Edit All Groups is granted, at least one group should be visible');
   }
 

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -650,4 +650,61 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     }
   }
 
+  public function testEditAllGroupsACL() {
+    $this->setupEditAllGroupsACL();
+    $params = $this->_params;
+    $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);
+    print_r($groups);
+    $this->assertNotEmpty($groups, 'If Edit All Groups is granted, at least one group should be visible');
+  }
+
+  /**
+   * Set up an acl allowing Authenticated contacts to Edit All Groups
+   *
+   *  You need to have pre-created these groups & created the user e.g
+   *  $this->createLoggedInUser();
+   *
+   */
+  public function setupEditAllGroupsACL() {
+    global $_REQUEST;
+    $_REQUEST = $this->_params;
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM');
+    $optionGroupID = $this->callAPISuccessGetValue('option_group', array('return' => 'id', 'name' => 'acl_role'));
+    $ov = new CRM_Core_DAO_OptionValue();
+    $ov->option_group_id = $optionGroupID;
+    $ov->value = 55;
+    if ($ov->find(TRUE)) {
+      CRM_Core_DAO::executeQuery("DELETE FROM civicrm_option_value WHERE id = {$ov->id}");
+    }
+    $optionValue = $this->callAPISuccess('option_value', 'create', array(
+      'option_group_id' => $optionGroupID,
+      'label' => 'groupmaster',
+      'value' => 55,
+    ));
+    $groupId = $this->groupCreate(['name' => 'groupmaster group']);
+    // Assign groupmaster to groupmaster group in civicrm_acl_entity_role
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO civicrm_acl_entity_role (
+      `acl_role_id`, `entity_table`, `entity_id`, `is_active`
+      ) VALUES (55, 'civicrm_group', $groupId, 1);
+    ");
+    // Put the user into this group
+    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    $this->callAPISuccess('group_contact', 'create', array(
+      'group_id' => $groupId,
+      'contact_id' => $this->_loggedInUser,
+    ));
+    // Add the ACL
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO civicrm_acl (
+      `name`, `entity_table`, `entity_id`, `operation`, `object_table`, `object_id`, `is_active`
+      )
+      VALUES (
+      'core-580', 'civicrm_acl_role', 55, 'Edit', 'civicrm_saved_search', 0, 1
+      );
+      ");
+
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Given a user who:
* Doesn't have "View All Contacts" permission;
* DOES have an ACL that gives permission to Edit "All Groups";

The "Manage Groups" screen shows no groups.

Before
----------------------------------------
Selecting "Manage Groups" with an ACL to display "All groups" shows no groups.

After
----------------------------------------
Selecting "Manage Groups" with an ACL to display "All groups" shows all groups.

Technical Details
----------------------------------------
This happens because `CRM_ACL_BAO_ACL::group()` expects an argument `$allGroups` to be passed, with an array of all the groups for this particular context.  The API code path populates this argument; the UI code path doesn't.

Comments
----------------------------------------
This is the same approach as #13242 but placing the fix in a more appropriate location.
