### PR TITLE
correct syntax "IS NOT NULL" to get pledge payment count

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -1145,7 +1145,7 @@ SELECT  pledge.contact_id              as contact_id,
 
     return civicrm_api3('pledge_payment', 'getcount', array(
       'pledge_id' => $pledgeID,
-      'contribution_id' => array('NOT NULL' => TRUE),
+      'contribution_id' => array('IS NOT NULL' => TRUE),
     ));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Get Count for Pledge Payment.
Once Pledge have payment (status is In-Progress), we can not update the pledge amount and number of instalment.
but if Pledge have payment and some payment status is overdue then Pledge status change to 'overdue' and this allow to update pledge amount and number of instalment.

Before
----------------------------------------
API return 0 count

After
----------------------------------------
API return actual payment count. Edit screen screen get freezed.

Technical Details
----------------------------------------
correct syntax for is not null
