### PR TITLE
(dev/core#622) User Dashboard doesn't show Edit Contact Information link

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -235,7 +235,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
       );
 
       if (CRM_Core_Permission::check('access CiviCRM')) {
-        self::$_links = array_merge(self::$_links, array(
+        self::$_links += array(
           CRM_Core_Action::DISABLE => array(
             'name' => ts('Disable'),
             'url' => 'civicrm/contact/view/rel',
@@ -243,7 +243,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
             'extra' => 'onclick = "return confirm(\'' . $disableExtra . '\');"',
             'title' => ts('Disable Relationship'),
           ),
-        ));
+        );
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Edit Contact Information is not loading on the dashboard.
The buggy logic leads to having links getting overwritten.

Before
----------------------------------------
 _Edit Contact Information_ link is missing.

After
----------------------------------------
 _Edit Contact Information_ link is showing.

