### PR TITLE
(dev/core#491) campaign cleanup for participant listing report and sh…

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -38,7 +38,6 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form_Event {
   protected $_groupFilter = TRUE;
   protected $_tagFilter = TRUE;
   protected $_balance = FALSE;
-  protected $activeCampaigns;
 
   protected $_customGroupExtends = array(
     'Participant',
@@ -54,15 +53,6 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form_Event {
    */
   public function __construct() {
     $this->_autoIncludeIndexedFieldsAsOrderBys = 1;
-
-    // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
 
     $this->_columns = array(
       'civicrm_contact' => array(
@@ -398,22 +388,8 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form_Event {
     // & behaviour across reports but trying for no change at this point.
     $this->_columns['civicrm_contact']['fields']['sort_name']['no_display'] = TRUE;
 
-    // If we have active campaigns add those elements to both the fields and filters
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_participant']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-      );
-      $this->_columns['civicrm_participant']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-      $this->_columns['civicrm_participant']['order_bys']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-      );
-    }
+    // If we have campaigns enabled, add those elements to both the fields, filters and sorting
+    $this->addCampaignFields('civicrm_participant', FALSE, TRUE);
 
     $this->_currencyColumn = 'civicrm_participant_fee_currency';
     parent::__construct();
@@ -769,7 +745,7 @@ ORDER BY  cv.label
       }
 
       // Convert campaign_id to campaign title
-      $this->_initBasicRow($rows, $entryFound, $row, 'civicrm_participant_campaign_id', $rowNum, $this->activeCampaigns);
+      $this->_initBasicRow($rows, $entryFound, $row, 'civicrm_participant_campaign_id', $rowNum, $this->campaigns);
 
       // handle contribution status
       $this->_initBasicRow($rows, $entryFound, $row, 'civicrm_contribution_contribution_status_id', $rowNum, $contributionStatus);


### PR DESCRIPTION
…ow disabled campaigns as well.

Overview
----------------------------------------
Centralize and cleanup code for campaigns in reports and show disabled campaigns as well


Before
----------------------------------------

![part_before](https://user-images.githubusercontent.com/3455173/50574511-11a80380-0e10-11e9-9793-8e50e242a49a.png)



After
----------------------------------------
![part_after](https://user-images.githubusercontent.com/3455173/50574516-153b8a80-0e10-11e9-9453-54daee828850.png)



Comments
----------------------------------------
Inactive campaigns can be seen in report filter and results as well.
