### PR TITLE
Fix notice on first loading activity search form

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -413,7 +413,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
    *   reference to the array of default values
    */
   public function setDefaultValues() {
-    return array_merge($this->getEntityDefaults($this->getDefaultEntity()), $this->_formValues);
+    return array_merge($this->getEntityDefaults($this->getDefaultEntity()), (array) $this->_formValues);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes e-notice (recenty introduced I think) when first loading activity search page

Before
----------------------------------------

![screenshot 2019-01-02 13 42 51](https://user-images.githubusercontent.com/336308/50577780-99375600-0e94-11e9-98ac-1beff68b011f.png)


After
----------------------------------------
![screenshot 2019-01-02 13 43 30](https://user-images.githubusercontent.com/336308/50577783-ab18f900-0e94-11e9-880f-ebd9a3d004da.png)

Technical Details
----------------------------------------
Form values can be NULL

Comments
----------------------------------------
@seamuslee001 quick merge on this?
