### PR TITLE
(dev/core#491) campaign cleanup for member summary report and show di…

### DIFF
--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -62,19 +62,6 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
    * Class constructor.
    */
   public function __construct() {
-
-    // UI for selecting columns to appear in the report list
-    // Array containing the columns, group_bys and filters build and provided to Form
-
-    // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($campaignEnabled) {
-      $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-      $this->activeCampaigns = $getCampaigns['campaigns'];
-      asort($this->activeCampaigns);
-    }
-
     $this->_columns = array(
       'civicrm_membership' => array(
         'dao' => 'CRM_Member_DAO_MembershipType',
@@ -186,20 +173,8 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
     );
     $this->_tagFilter = TRUE;
 
-    // If we have a campaign, build out the relevant elements
-    if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_membership']['fields']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'default' => 'false',
-      );
-      $this->_columns['civicrm_membership']['filters']['campaign_id'] = array(
-        'title' => ts('Campaign'),
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->activeCampaigns,
-        'type' => CRM_Utils_Type::T_INT,
-      );
-      $this->_columns['civicrm_membership']['group_bys']['campaign_id'] = array('title' => ts('Campaign'));
-    }
+    // If we have campaigns enabled, add those elements to both the fields, filters and group by
+    $this->addCampaignFields('civicrm_membership', TRUE);
 
     $this->_groupFilter = TRUE;
     $this->_currencyColumn = 'civicrm_contribution_currency';
@@ -642,7 +617,7 @@ GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
       // If using campaigns, convert campaign_id to campaign title
       if (array_key_exists('civicrm_membership_campaign_id', $row)) {
         if ($value = $row['civicrm_membership_campaign_id']) {
-          $rows[$rowNum]['civicrm_membership_campaign_id'] = $this->activeCampaigns[$value];
+          $rows[$rowNum]['civicrm_membership_campaign_id'] = $this->campaigns[$value];
         }
         $entryFound = TRUE;
       }


### PR DESCRIPTION
…sabled campaigns as well.


Overview
----------------------------------------
Centralize and cleanup code for campaigns in reports and show disabled campaigns as well


Before
----------------------------------------
![member_summary_before](https://user-images.githubusercontent.com/3455173/50590499-4fa93400-0eb1-11e9-849e-34ee67032bba.png)





After
----------------------------------------
![member_summary_after](https://user-images.githubusercontent.com/3455173/50590505-53d55180-0eb1-11e9-811b-474ebe2c0069.png)




Comments
----------------------------------------
Inactive campaigns can be seen in report filter and results as well.


