### PR TITLE
(dev/core#491) Standardise the adding of campaign fields on the maili…

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -45,8 +45,6 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
     'bar_3dChart' => 'Bar Chart',
   );
 
-  public $campaignEnabled = FALSE;
-
   /**
    * Class constructor.
    */
@@ -297,23 +295,8 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
         ),
       ),
     );
-    $config = CRM_Core_Config::singleton();
-    $this->campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($this->campaignEnabled) {
-      $this->_columns['civicrm_campaign'] = array(
-        'dao' => 'CRM_Campaign_DAO_Campaign',
-        'fields' => array(
-          'title' => array(
-            'title' => ts('Campaign Name'),
-          ),
-        ),
-        'filters' => array(
-          'title' => array(
-            'type' => CRM_Utils_Type::T_STRING,
-          ),
-        ),
-      );
-    }
+    // If we have campaigns enabled, add those elements to both the fields, filters.
+    $this->addCampaignFields('civicrm_mailing');
     parent::__construct();
   }
 
@@ -428,12 +411,6 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
         LEFT JOIN civicrm_mailing_group {$this->_aliases['civicrm_mailing_group']}
     ON {$this->_aliases['civicrm_mailing_group']}.mailing_id = {$this->_aliases['civicrm_mailing']}.id";
     }
-    if ($this->campaignEnabled) {
-      $this->_from .= "
-        LEFT JOIN civicrm_campaign {$this->_aliases['civicrm_campaign']}
-        ON {$this->_aliases['civicrm_campaign']}.id = {$this->_aliases['civicrm_mailing']}.campaign_id";
-    }
-
     // need group by and order by
 
     //print_r($this->_from);
@@ -676,6 +653,13 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
         }
         if (array_key_exists('civicrm_mailing_event_opened_open_count', $row)) {
           $rows[$rowNum]['civicrm_mailing_event_opened_open_count'] = CRM_Mailing_Event_BAO_Opened::getTotalCount($row['civicrm_mailing_id']);
+          $entryFound = TRUE;
+        }
+      }
+      // convert campaign_id to campaign title
+      if (array_key_exists('civicrm_mailing_campaign_id', $row)) {
+        if ($value = $row['civicrm_mailing_campaign_id']) {
+          $rows[$rowNum]['civicrm_mailing_campaign_id'] = $this->campaigns[$value];
           $entryFound = TRUE;
         }
       }

--- a/CRM/Upgrade/Incremental/php/FiveThirteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirteen.php
@@ -55,10 +55,11 @@ class CRM_Upgrade_Incremental_php_FiveThirteen extends CRM_Upgrade_Incremental_B
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
-    // Example: Generate a post-upgrade message.
-    // if ($rev == '5.12.34') {
-    //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");
-    // }
+    $config = CRM_Core_Config::singleton();
+    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
+    if ($rev == '5.13.alpha1' && $campaignEnabled) {
+      $postUpgradeMessage .= '<br /><br />' . ts("If you have created a report based on the Mailing Summary Report template and it outputs or filters on campaigns, You will need to go back to that report and re-save the report after selecting and or setting the campaign filters up again");
+    }
   }
 
   /*


### PR DESCRIPTION
…ng summary report and add a post upgrade message about needing to re-save report given the changes made to the report template

Overview
----------------------------------------
This standardises the way campaign fields are added to the mailing summary report and removes a join from the report

Before
----------------------------------------
Campaign fields were in a non standardard way 

![Screenshot 2019-03-12 10 28 59](https://user-images.githubusercontent.com/336308/54159533-0fb68c80-44b2-11e9-8f9b-fdf21c39e848.png)


After
----------------------------------------
Campaign fields added in standard way
![Screenshot 2019-03-12 10 31 30](https://user-images.githubusercontent.com/336308/54159550-1ba24e80-44b2-11e9-83b9-d0c8ee9ae87a.png)


@eileenmcnaughton @yashodha this one i felt needed a post upgrade message because we are actually changing the field names here and changing the way the report outputs in a greater way than the others
