### PR TITLE
dev/core#337 Add in upgrade script to set search by range to be false…

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveNine.php
@@ -61,7 +61,7 @@ class CRM_Upgrade_Incremental_php_FiveNine extends CRM_Upgrade_Incremental_Base 
         2 => ts('Email on Hold'),
       );
       $postUpgradeMessage .= '<p>' . ts('If the setting "%1" is enabled, you should update any smart groups based on the "%2" field.', $args) . '</p>' .
-        '<p>' . ts('If you were previously on version 5.8 and altered the WYSIWYG editor setting, you should visit the <a %1>Display Preferences</a> page and re-save the WYSIWYG editor setting.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p>';
+        '<p>' . ts('If you were previously on version 5.8 and altered the WYSIWYG editor setting, you should visit the <a %1>Display Preferences</a> page and re-save the WYSIWYG editor setting.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p><p>' . ts('If you have any custom fields of type Money, Int or Float, The search by range checkbox has been unchecked for these fields. If you wish to search by range on those fields you must re-set the checkbox') . '</p>';
     }
 
     // Example: Generate a post-upgrade message.

--- a/CRM/Upgrade/Incremental/sql/5.9.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.9.beta1.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 5.9.beta1 during upgrade *}
+
+{* dev/core#337 Set search by range to be false which was the effect of the original implementation of any Money, Float, Int fields where the widget was Radio or Select *}
+UPDATE civicrm_custom_field SET is_search_range = 0 WHERE html_type IN ('Radio', 'Select') AND data_type IN ('Money', 'Float', 'Int');


### PR DESCRIPTION
… for Fields of money, float, int with widget types radio and select which were how they were effectively implemented originally

Overview
----------------------------------------
This adds in an upgrade sql step and also a post upgrade message as per @eileenmcnaughton 's comments here https://github.com/civicrm/civicrm-core/pull/13314

ping @eileenmcnaughton @totten @colemanw 
