### PR TITLE
dev/core#619 fix regression on Address contact-reference fields not rendering results

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1064,7 +1064,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $urlParams = "context=customfield&id={$field->id}";
           $idOfelement = $elementName;
           // dev/core#362 if in an onbehalf profile clean up the name to get rid of square brackets that break the select 2 js
-          if (strpos($elementName, '[') && strpos($elementName, ']')) {
+          // However this caused regression https://lab.civicrm.org/dev/core/issues/619 so it has been hacked back to
+          // only affecting on behalf - next time someone looks at this code it should be with a view to overhauling it
+          // rather than layering on more hacks.
+          if (substr($elementName, 0, 8) === 'onbehalf' && strpos($elementName, '[') && strpos($elementName, ']')) {
             $idOfelement = substr(substr($elementName, (strpos($elementName, '[') + 1)), 0, -1);
           }
           $customUrls[$idOfelement] = CRM_Utils_System::url('civicrm/ajax/contactref',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression whereby contact reference fields on addresses were not loading options in the autoselect. This arose from a [5.7 fix](https://lab.civicrm.org/dev/core/issues/362) to the contact reference field in on-behalf profiles 


Before
----------------------------------------
![screenshot 2019-01-03 11 11 46](https://user-images.githubusercontent.com/336308/50615204-5fc02280-0f48-11e9-8da9-0ada0b05f5a2.png)

After
----------------------------------------
![screenshot 2019-01-03 11 10 17](https://user-images.githubusercontent.com/336308/50615144-2ab3d000-0f48-11e9-88f4-2c3cf8b1c60a.png)


Technical Details
----------------------------------------
limits the handling added for onbehalf to only apply to onbehalf.


Comments
----------------------------------------
@alifrumin @pradpnayak 
