### PR TITLE
Five Nine - Revise upgrade notice about Money/Int/Float fields

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveNine.php
@@ -61,7 +61,8 @@ class CRM_Upgrade_Incremental_php_FiveNine extends CRM_Upgrade_Incremental_Base 
         2 => ts('Email on Hold'),
       );
       $postUpgradeMessage .= '<p>' . ts('If the setting "%1" is enabled, you should update any smart groups based on the "%2" field.', $args) . '</p>' .
-        '<p>' . ts('If you were previously on version 5.8 and altered the WYSIWYG editor setting, you should visit the <a %1>Display Preferences</a> page and re-save the WYSIWYG editor setting.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p><p>' . ts('If you have any custom fields of type Money, Int or Float, The search by range checkbox has been unchecked for these fields. If you wish to search by range on those fields you must re-set the checkbox') . '</p>';
+        '<p>' . ts('If you were previously on version 5.8 and altered the WYSIWYG editor setting, you should visit the <a %1>Display Preferences</a> page and re-save the WYSIWYG editor setting.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p>' .
+        '<p>' . ts('If you have any custom fields of type Money, Int or Float, The search by range checkbox has been unchecked for these fields. If you wish to search by range on those fields you must re-set the checkbox') . '</p>';
     }
 
     // Example: Generate a post-upgrade message.

--- a/CRM/Upgrade/Incremental/php/FiveNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveNine.php
@@ -62,7 +62,7 @@ class CRM_Upgrade_Incremental_php_FiveNine extends CRM_Upgrade_Incremental_Base 
       );
       $postUpgradeMessage .= '<p>' . ts('If the setting "%1" is enabled, you should update any smart groups based on the "%2" field.', $args) . '</p>' .
         '<p>' . ts('If you were previously on version 5.8 and altered the WYSIWYG editor setting, you should visit the <a %1>Display Preferences</a> page and re-save the WYSIWYG editor setting.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/preferences/display', 'reset=1') . '"')) . '</p>' .
-        '<p>' . ts('If you have any custom fields of type Money, Int or Float, The search by range checkbox has been unchecked for these fields. If you wish to search by range on those fields you must re-set the checkbox') . '</p>';
+        '<p>' . ts('CiviCRM v5.9+ adds a new search preference for certain custom-fields ("Money", "Integer", or "Float" data displayed as "Select" or "Radio" fields). For continuity, any old fields have been set to continue the old user-experience. However, you may want to review these settings. (You should especially review if this site used v5.9-alpha or v5.9-beta.)') . '</p>';
     }
 
     // Example: Generate a post-upgrade message.


### PR DESCRIPTION
Overview
----------------------------------------
Revise post-upgrade message for 5.9.beta1 to be less alarming. To wit: the change is actually *preserving* user expectations/preferences for almost all users. The only possible exception would be folks who used 5.9-alpha or 5.9-beta when creating the affected fields.

See also: https://github.com/civicrm/civicrm-core/pull/13384/files#r244890998

