### PR TITLE
fixes core#609 - view 'Advanced Search' links without 'view all conta…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2179,12 +2179,10 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     );
 
     $actionLinks = array(CRM_Core_Action::VIEW => array('name' => ts('Report')));
-    if (CRM_Core_Permission::check('view all contacts')) {
-      $actionLinks[CRM_Core_Action::ADVANCED] = array(
-        'name' => ts('Advanced Search'),
-        'url' => 'civicrm/contact/search/advanced',
-      );
-    }
+    $actionLinks[CRM_Core_Action::ADVANCED] = array(
+      'name' => ts('Advanced Search'),
+      'url' => 'civicrm/contact/search/advanced',
+    );
     $action = array_sum(array_keys($actionLinks));
 
     $report['event_totals']['actionlinks'] = array();


### PR DESCRIPTION
…cts' permission

Overview
----------------------------------------
You currently need "View All Contacts" permission to see the "Advanced Search" link on a mailing report, but not the "Report" link.  This is inconsistent, and I can't think of a use case where the inconsistency is desirable.

Before
----------------------------------------
The "Advanced Search" links (see screenshot) are missing unless you have "View All Contacts" permission.
![selection_721](https://user-images.githubusercontent.com/1796012/50651186-9a2dbd80-0f50-11e9-9dae-03d627ef428c.png)

After
----------------------------------------
Advanced Search links are present.

Technical Details
----------------------------------------
We're simply removing the permission check.

Comments
----------------------------------------
I considered the argument that this search gives you incomplete results because you can't see all contacts.  However, this is true for ANY search as a user who can't see all contacts, and is also applicable to the "Report" link, which is not permissioned.
