### PR TITLE
dev/mail#32 - Making mailing test email non-case-sensitive

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -632,7 +632,7 @@ function civicrm_api3_mailing_send_test($params) {
   $testEmailParams['scheduled_date'] = CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s'));
   $job = civicrm_api3('MailingJob', 'create', $testEmailParams);
   $testEmailParams['job_id'] = $job['id'];
-  $testEmailParams['emails'] = array_key_exists('test_email', $testEmailParams) ? explode(',', $testEmailParams['test_email']) : NULL;
+  $testEmailParams['emails'] = array_key_exists('test_email', $testEmailParams) ? explode(',', strtolower($testEmailParams['test_email'])) : NULL;
   if (!empty($params['test_email'])) {
     $query = CRM_Utils_SQL_Select::from('civicrm_email e')
         ->select(array('e.id', 'e.contact_id', 'e.email'))

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -409,8 +409,9 @@ class api_v3_MailingTest extends CiviUnitTestCase {
 
     $mail = $this->callAPISuccess('mailing', 'create', $this->_params);
 
-    $params = array('mailing_id' => $mail['id'], 'test_email' => 'alice@example.org', 'test_group' => NULL);
+    $params = array('mailing_id' => $mail['id'], 'test_email' => 'ALicE@example.org', 'test_group' => NULL);
     // Per https://lab.civicrm.org/dev/core/issues/229 ensure this is not passed through!
+    // Per https://lab.civicrm.org/dev/mail/issues/32 test non-lowercase email
     $params['id'] = $mail['id'];
     $deliveredInfo = $this->callAPISuccess($this->_entity, 'send_test', $params);
     $this->assertEquals(1, $deliveredInfo['count']); // verify mail has been sent to user by count


### PR DESCRIPTION
As per https://lab.civicrm.org/dev/mail/issues/32

Added call to strtolower() when processing the user-provided test email addresses for a mailing. Updated MailingTest.php:testMailerSendTest_email to use a mixed-case email.
