### PR TITLE
dev/core#562 remove calls to dao->free() from api folder

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -105,9 +105,6 @@ function civicrm_api3_activity_create($params) {
         $activityDAO->id = $params['id'];
         $activityDAO->is_current_revision = 0;
         if (!$activityDAO->save()) {
-          if (is_object($activityDAO)) {
-            $activityDAO->free();
-          }
           throw new API_Exception(ts("Unable to revision existing case activity."));
         }
         $createRevision = TRUE;

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -655,7 +655,6 @@ function civicrm_api3_mailing_send_test($params) {
         'email_id' => $dao->id,
       );
     }
-    $dao->free();
     foreach ($testEmailParams['emails'] as $key => $email) {
       $email = trim($email);
       $contactId = $emailId = NULL;

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -173,10 +173,8 @@ SELECT start_date, end_date, join_date, membership_type_id
     }
   }
   else {
-    $dao->free();
     throw new API_Exception('did not find a membership record');
   }
-  $dao->free();
   return $result;
 }
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -218,9 +218,6 @@ function civicrm_api3_create_success($values = 1, $params = array(), $entity = N
       $result['undefined_fields'] = array_merge($undefined);
     }
   }
-  if (is_object($dao)) {
-    $dao->free();
-  }
 
   $result['version'] = 3;
   if (is_array($values)) {


### PR DESCRIPTION
Overview
----------------------------------------
Code clean up with no functional change

Before
----------------------------------------
no change

After
----------------------------------------
no change

Technical Details
----------------------------------------
Per gitlab

The DAO object since ? 4.7.x? has been freed on _destruct. Using the ->free action has been demonstrated to create some rare bugs - ie. because query sets from the outer loop can be lost. There is no benefit in calling it any more and some harm

https://github.com/civicrm/civicrm-core/pull/13192 was the last one in this series

Comments
----------------------------------------
@aydun 