### PR TITLE
(dev/core#635) Reduce unnecessary SQL writes

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -294,8 +294,10 @@ FROM {$from}
         return;
       }
 
-      // also record an entry in the cache key table, so we can delete it periodically
-      CRM_Core_BAO_Cache::setItem($cacheKey, 'CiviCRM Search PrevNextCache', $cacheKey);
+      if (Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
+        // SQL-backed prevnext cache uses an extra record for pruning the cache.
+        CRM_Core_BAO_Cache::setItem($cacheKey, 'CiviCRM Search PrevNextCache', $cacheKey);
+      }
     }
   }
 

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -536,11 +536,11 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
   public function getTotalCount($action) {
     // Use count from cache during paging/sorting
     if (!empty($_GET['crmPID']) || !empty($_GET['crmSID'])) {
-      $count = CRM_Core_BAO_Cache::getItem('Search Results Count', $this->_key);
+      $count = Civi::cache('long')->get("Search Results Count $this->_key");
     }
     if (empty($count)) {
       $count = $this->_query->searchQuery(0, 0, NULL, TRUE);
-      CRM_Core_BAO_Cache::setItem($count, 'Search Results Count', $this->_key);
+      Civi::cache('long')->set("Search Results Count $this->_key", $count);
     }
     return $count;
   }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1062,8 +1062,10 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       }
     }
 
-    // also record an entry in the cache key table, so we can delete it periodically
-    CRM_Core_BAO_Cache::setItem($cacheKey, 'CiviCRM Search PrevNextCache', $cacheKey);
+    if (Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
+      // SQL-backed prevnext cache uses an extra record for pruning the cache.
+      CRM_Core_BAO_Cache::setItem($cacheKey, 'CiviCRM Search PrevNextCache', $cacheKey);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
To meaningfully use [replay-on-write strategy](https://lab.civicrm.org/dev/core/issues/635), one should avoid unnecessary SQL writes.

Before
----------------------------------------
* `CRM_Contact_Selector` stores the result-count in the SQL-backed cache (`civicrm_cache`) *regardless of the configuration*.
* `CRM_Contact_Selector` and `CRM_Campaign_Selector_Search` add a cache-record to `civicrm_cache` to facilitate cleanup of `civicrm_prevnext_cache`.

After
----------------------------------------
* `CRM_Contact_Selector`  stores the result-count in the `long` cache, *which could be Redis/Memcache or SQL (depending on the local configuration)*.
* `CRM_Contact_Selector` and `CRM_Campaign_Selector_Search` add the record... but *only if `civicrm_prevnext_cache` is actually being used*.
