### PR TITLE
Add routine for updating smartgroups, currently handling datepicker conversion

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -196,6 +196,20 @@ class CRM_Upgrade_Incremental_Base {
   }
 
   /**
+   * Do any relevant smart group updates.
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @param string $version
+   *
+   * @return bool
+   */
+  public function updateSmartGroups($ctx, $version) {
+    $groupUpdateObject = new CRM_Upgrade_Incremental_SmartGroups($version);
+    $groupUpdateObject->updateGroups();
+    return TRUE;
+  }
+
+  /**
    * Drop a column from a table if it exist.
    *
    * @param CRM_Queue_TaskContext $ctx

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -1,0 +1,165 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ *
+ * Class to handled upgrading any saved searches with changed patterns.
+ */
+class CRM_Upgrade_Incremental_SmartGroups {
+
+  /**
+   * Version we are upgrading to.
+   *
+   * @var string
+   */
+  protected $upgradeVersion;
+
+  /**
+   * @return string
+   */
+  public function getUpgradeVersion() {
+    return $this->upgradeVersion;
+  }
+
+  /**
+   * @param string $upgradeVersion
+   */
+  public function setUpgradeVersion($upgradeVersion) {
+    $this->upgradeVersion = $upgradeVersion;
+  }
+
+  /**
+   * CRM_Upgrade_Incremental_MessageTemplates constructor.
+   *
+   * @param string $upgradeVersion
+   */
+  public function __construct($upgradeVersion) {
+    $this->setUpgradeVersion($upgradeVersion);
+  }
+
+  /**
+   * Get any conversions required for saved smart groups.
+   *
+   * @return array
+   */
+  public function getSmartGroupConversions() {
+    return [
+      [
+        'version' => '5.11.alpha1',
+        'upgrade_descriptors' => [ts('Upgrade grant smart groups to datepicker format')],
+        'actions' => [
+          'function' => 'datepickerConversion',
+          'fields' => [
+            'grant_application_received_date',
+            'grant_decision_date',
+            'grant_money_transfer_date',
+            'grant_due_date'
+          ]
+        ]
+      ]
+    ];
+  }
+
+  /**
+   * Convert any
+   * @param array $fields
+   */
+  public function datePickerConversion($fields) {
+    $fieldPossibilities = [];
+    foreach ($fields as $field) {
+      $fieldPossibilities[] = $field;
+      $fieldPossibilities[] = $field . '_high';
+      $fieldPossibilities[] = $field . '_low';
+    }
+
+    foreach ($fields as $field) {
+      $savedSearches = civicrm_api3('SavedSearch', 'get', [
+        'options' => ['limit' => 0],
+        'form_values' => ['LIKE' => "%{$field}%"],
+      ])['values'];
+      foreach ($savedSearches as $savedSearch) {
+        $formValues = $savedSearch['form_values'];
+        foreach ($formValues as $index => $formValue) {
+          if (in_array($formValue[0], $fieldPossibilities)) {
+            $formValues[$index][2] = $this->getConvertedDateValue($formValue[2]);
+          }
+        }
+        if ($formValues !== $savedSearch['form_values']) {
+          civicrm_api3('SavedSearch', 'create', ['id' => $savedSearch['id'], 'form_values' => $formValues]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Update message templates.
+   */
+  public function updateGroups() {
+    $conversions = $this->getSmartGroupConversionsToApply();
+    foreach ($conversions as $conversion) {
+      $function = $conversion['function'];
+      $this->{$function}($conversion['fields']);
+    }
+  }
+
+  /**
+   * Get any required template updates.
+   *
+   * @return array
+   */
+  public function getSmartGroupConversionsToApply() {
+    $conversions = $this->getSmartGroupConversions();
+    $return = [];
+    foreach ($conversions as $conversion) {
+      if ($conversion['version'] === $this->getUpgradeVersion()) {
+        $return[] = $conversion['actions'];
+      }
+    }
+    return $return;
+  }
+
+  /**
+   * Get converted date value.
+   *
+   * @param string $dateValue
+   *
+   * @return string
+   *   $dateValue
+   */
+  protected function getConvertedDateValue($dateValue) {
+    if (date('Y-m-d', strtotime($dateValue)) !== $dateValue
+      && date('Y-m-d H:i:s', strtotime($dateValue)) !== $dateValue
+    ) {
+      $dateValue = date('Y-m-d H:i:s', strtotime(CRM_Utils_Date::processDate($dateValue)));
+    }
+    return $dateValue;
+  }
+
+}

--- a/CRM/Upgrade/Incremental/php/FiveEleven.php
+++ b/CRM/Upgrade/Incremental/php/FiveEleven.php
@@ -67,21 +67,14 @@ class CRM_Upgrade_Incremental_php_FiveEleven extends CRM_Upgrade_Incremental_Bas
    * (change the x in the function name):
    */
 
-  //  /**
-  //   * Upgrade function.
-  //   *
-  //   * @param string $rev
-  //   */
-  //  public function upgrade_5_0_x($rev) {
-  //    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
-  //    $this->addTask('Do the foo change', 'taskFoo', ...);
-  //    // Additional tasks here...
-  //    // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
-  //    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
-  //  }
-
-  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
-  //   return TRUE;
-  // }
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_11_alpha1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+    $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', $rev);
+  }
 
 }

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -80,4 +80,23 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     ], $messages);
   }
 
+  /**
+   * Test converting a datepicker field.
+   */
+  public function testSmartGroupDatePickerConversion() {
+    $this->callAPISuccess('SavedSearch', 'create', [
+       'form_values' => [
+         ['grant_application_received_date_high', '=', '01/20/2019'],
+         ['grant_due_date_low', '=', '01/22/2019'],
+       ]
+    ]);
+    $smartGroupConversionObject = new CRM_Upgrade_Incremental_SmartGroups('5.11.alpha1');
+    $smartGroupConversionObject->updateGroups();
+    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
+    $this->assertEquals('grant_application_received_date_high', $savedSearch['form_values'][0][0]);
+    $this->assertEquals('2019-01-20 00:00:00', $savedSearch['form_values'][0][2]);
+    $this->assertEquals('grant_due_date_low', $savedSearch['form_values'][1][0]);
+    $this->assertEquals('2019-01-22 00:00:00', $savedSearch['form_values'][1][2]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Convert fields from smart groups using grant date fields to reflect new datepicker format

Before
----------------------------------------
As of #13211 the fields are converted in the search but pre-existing smart groups still use the old format for these dates

After
----------------------------------------
On upgrade the groups are updated to the new format

Technical Details
----------------------------------------
Merge in conjuction with #13211

This ties in with the larger effort in https://lab.civicrm.org/dev/core/issues/561 to remove jcalendar. I started down the path of on-form conversions but decided in the long run it would be cleaner to upgrade the groups - this approach could probably safely be applied to some already updated ones like lybunt custom search in order to remove cruft.

I think the upgrade part could be iterated on for more improvements. Campaign Search seems like the obvious next form for daterange updates

Comments
----------------------------------------
@seamuslee001 @monishdeb @mattwire 