### PR TITLE
dev/mail#36 - Fix invalid unicode characters in bounce processing

### DIFF
--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -77,6 +77,9 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
       }
     }
 
+    // replace any invalid unicode characters with replacement characters
+    $params['bounce_reason'] = mb_convert_encoding($params['bounce_reason'], 'UTF-8', 'UTF-8');
+
     // CRM-11989
     $params['bounce_reason'] = mb_strcut($params['bounce_reason'], 0, 254);
 

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Class CRM_Utils_EmailProcessorTest
+ * Class CRM_Utils_Mail_EmailProcessorTest
  * @group headless
  */
 
-class CRM_Utils_EmailProcessorTest extends CiviUnitTestCase {
+class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
 
   /**
    * Event queue record.

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -55,6 +55,19 @@ class CRM_Utils_EmailProcessorTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the job processing function can handle invalid characters.
+   */
+  public function testBounceProcessingInvalidCharacter() {
+    $this->setUpMailing();
+    $mail = 'test_invalid_character.eml';
+
+    copy(__DIR__ . '/data/bounces/' . $mail, __DIR__ . '/data/mail/' .   $mail);
+    $this->callAPISuccess('job', 'fetch_bounces', array());
+    $this->assertFalse(file_exists(__DIR__ . '/data/mail/' . $mail));
+    $this->checkMailingBounces(1);
+  }
+
+  /**
    * Tests that a multipart related email does not cause pain & misery & fatal errors.
    *
    * Sample taken from https://www.phpclasses.org/browse/file/14672.html

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/test_invalid_character.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/test_invalid_character.eml
@@ -1,0 +1,40 @@
+Delivered-To: my@example.com
+Received: by 10.2.13.84 with SMTP id 1234567890;
+        Wed, 19 Dec 2018 10:01:11 +0100 (CET)
+Return-Path: <>
+From: Postmaster@example.com
+To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+Subject: Delivery Status Notification (Failure)
+Message-ID: <abc.def.fhi@example.com>
+Date: Wed, 19 Dec 2018 10:01:07 +0100
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status; boundary="==IFJRGLKFGIR18927894UHRUHIHD"
+
+--==IFJRGLKFGIR18927894UHRUHIHD
+Content-Type: text/plain; charset=ISO-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+Your message
+
+  Subject: test
+
+was not delivered to:
+
+  my@example.com
+
+because:
+
+  Benutzer my (my@example.com) nicht im Domino-Verzeichnis aufgef=FChrt
+
+
+--==IFJRGLKFGIR18927894UHRUHIHD
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns;srv.example.com
+
+Final-Recipient: rfc822;my@example.com
+Action: failed
+Status: 5.0.0
+Diagnostic-Code: X-Notes; Benutzer my (my@example.com) nicht im Domino-Verzeichnis aufgefÅhrt
+
+--==IFJRGLKFGIR18927894UHRUHIHD


### PR DESCRIPTION
Overview
----------------------------------------
MySQL does not accept invalid unicode characters and therefore fails to write the bounce to the database if it is part of the bounce reason.
Issue tracker: https://lab.civicrm.org/dev/mail/issues/36

Before
----------------------------------------
Exception is thrown. Bounce is not stored in the datebase, but mail is moved to processed folder.

After
----------------------------------------
Invalid character are replaced with unicode replacement character. No exception. Bounce is saved.

Technical Details
----------------------------------------
Generating an invalid unicode character was not easy. Had to use a hex editor and replaced a valid character with an invalid one.
