### PR TITLE
dev/core/issues/636 - Custom field for Address: The "No" value is not defaulted

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -413,7 +413,7 @@ class CRM_Contact_Form_Edit_Address {
       // since we change element name for address custom data, we need to format the setdefault values
       $addressDefaults = array();
       foreach ($defaults as $key => $val) {
-        if (empty($val)) {
+        if (!isset($val)) {
           continue;
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/636

Before
----------------------------------------
![address custom field](https://user-images.githubusercontent.com/2053075/50686060-a9c20a80-1013-11e9-8974-8e70469f7d1e.gif)

After
----------------------------------------
![address custom field-after](https://user-images.githubusercontent.com/2053075/50686208-3e2c6d00-1014-11e9-8406-734f536bec65.gif)


Technical Details
----------------------------------------
If the value is set to 0 or FALSE !empty() will return FALSE, but isset() will return TRUE. Hence using isset() to check if the variable has not empty value.
