### PR TITLE
dev/core/issues/570, Check Dedupe fails for limited permission user

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -975,6 +975,9 @@ class CRM_Core_Permission {
       'getquick' => array(
         array('access CiviCRM', 'access AJAX API'),
       ),
+      'duplicatecheck' => array(
+        'access CiviCRM',
+      ),
     );
 
     // CRM-16963 - Permissions for country.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/570

Before
----------------------------------------
"Check For Matching Contact(s)" fails to retrieve contacts for limited permission user.

After
----------------------------------------
"Check For Matching Contact(s)"  return contacts for limited permission user.

Technical Details
----------------------------------------
"Check For Matching Contact(s)" uses 'duplicatecheck' method of Contact API. Since for this method there is no permission defined therefore it chooses default permission i.e CiviCRM Administrator permission and returns with error as 'API permission check failed for Contact....'


