### PR TITLE
Donot show delete task option on create new report

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1633,6 +1633,7 @@ class CRM_Report_Form extends CRM_Core_Form {
           )),
         ),
       );
+      unset($actions['report_instance.delete']);
     }
 
     if (!$this->_csvSupported) {


### PR DESCRIPTION
Overview
----------------------------------------
When a user creates new report from template the Actions drop down shows delete option, when selected throws fatal error.

Before
----------------------------------------
Delete option visible in Actions on  Create New report

After
----------------------------------------
Delete option not available in Actions on  Create New report

Technical Details
----------------------------------------
It doesn't make sense to show delete option before report is created