### PR TITLE
Show Add to group on  create new report after refresh of result

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1577,7 +1577,7 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     // CRM-16274 Determine if user has 'edit all contacts' or equivalent
     $permission = CRM_Core_Permission::getPermission();
-    if ($permission == CRM_Core_Permission::EDIT &&
+    if ($this->_instanceForm && $permission == CRM_Core_Permission::EDIT &&
       $this->_add2groupSupported
     ) {
       $this->addElement('select', 'groups', ts('Group'),


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/642

Before
----------------------------------------
JS error when trying to create report

After
----------------------------------------
Actions and Add to group options are not displayed until 'View result' button is clicked at the time of creating new report