### PR TITLE
Don't require CiviEvent permission to create repeating activity

### DIFF
--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -203,7 +203,7 @@
   <item>
      <path>civicrm/recurringentity/preview</path>
      <page_callback>CRM_Core_Page_RecurringEntityPreview</page_callback>
-     <access_arguments>access CiviCRM,access CiviEvent</access_arguments>
+     <access_arguments>access CiviCRM</access_arguments>
      <title>Confirm dates</title>
   </item>
   <item>


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/640
Creating a repeating activity through the UI gives an Access Denied error unless the user has "access CiviEvent" permission.

**Steps to replicate**

1. Log in as a user without "access CiviEvent" permission.
2. From contact summary, Activities tab, click New Activity, choose e.g. Meeting.
3. Expand the "Repeat Activity" section, Click the "After" radio button, Save.

Before
----------------------------------------
Confirm dialog is blank. Error message appears:
"Access Denied / Ensure you are still logged in and have permission to access this feature.".
On clicking Confirm, the instances are created and listed.

After
----------------------------------------
Confirm dialog lists the instances that will be created.
On clicking Confirm, the instances are created and listed.

Technical Details
----------------------------------------
Problem occurs because the confirm dialog uses a path that requires "access CiviEvent" permission. In CRM/Core/xml/Menu/Misc.xml:

```
  <item>
     <path>civicrm/recurringentity/preview</path>
     <page_callback>CRM_Core_Page_RecurringEntityPreview</page_callback>
     <access_arguments>access CiviCRM,access CiviEvent</access_arguments>
     <title>Confirm dates</title>
  </item>
```

Problem is resolved by removing ",access CiviEvent".
