### PR TITLE
core#644 - extract function to return correct mailbox header

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -400,7 +400,7 @@ class CRM_Contact_Form_Task_EmailCommon {
     // dev/core#357 User Emails are keyed by their id so that the Signature is able to be added
     // If we have had a contact email used here the value returned from the line above will be the
     // numerical key where as $from for use in the sendEmail in Activity needs to be of format of "To Name" <toemailaddress>
-    $from = CRM_Utils_Mail::mailboxHeader($from);
+    $from = CRM_Utils_Mail::formatFromAddress($from);
     $subject = $formValues['subject'];
 
     // CRM-13378: Append CC and BCC information at the end of Activity Details and format cc and bcc fields

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -400,13 +400,7 @@ class CRM_Contact_Form_Task_EmailCommon {
     // dev/core#357 User Emails are keyed by their id so that the Signature is able to be added
     // If we have had a contact email used here the value returned from the line above will be the
     // numerical key where as $from for use in the sendEmail in Activity needs to be of format of "To Name" <toemailaddress>
-    if (is_numeric($from)) {
-      $result = civicrm_api3('Email', 'get', [
-        'id' => $from,
-        'return' => ['contact_id.display_name', 'email'],
-      ]);
-      $from = '"' . $result['values'][$from]['contact_id.display_name'] . '" <' . $result['values'][$from]['email'] . '>';
-    }
+    $from = CRM_Utils_Mail::mailboxHeader($from);
     $subject = $formValues['subject'];
 
     // CRM-13378: Append CC and BCC information at the end of Activity Details and format cc and bcc fields

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -389,6 +389,11 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
 
     CRM_Utils_Hook::alterMailParams($params, 'messageTemplate');
 
+    // Core#644 - handle contact ID passed as "From".
+    if (isset($params['from'])) {
+      $params['from'] = CRM_Utils_Mail::formatFromAddress($params['from']);
+    }
+
     if ((!$params['groupName'] ||
         !$params['valueName']
       ) &&

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -661,7 +661,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     if (!empty($this->_params['send_receipt'])) {
 
-      $receiptFrom = $this->_params['from_email_address'];
+      $receiptFrom = CRM_Utils_Mail::mailboxHeader($this->_params['from_email_address']);
 
       if (!empty($this->_params['payment_instrument_id'])) {
         $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -661,7 +661,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     if (!empty($this->_params['send_receipt'])) {
 
-      $receiptFrom = CRM_Utils_Mail::mailboxHeader($this->_params['from_email_address']);
+      $receiptFrom = $this->_params['from_email_address'];
 
       if (!empty($this->_params['payment_instrument_id'])) {
         $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -577,4 +577,25 @@ class CRM_Utils_Mail {
     return $formattedEmail;
   }
 
+  /**
+   * When passed a value, returns the value if it's non-numeric.
+   * If it's numeric, look up the display name and email of the corresponding
+   * contact ID in RFC822 format.
+   *
+   * @param string $header
+   * @return string
+   *   The RFC822-formatted email header (display name + address)
+   */
+  public static function mailboxHeader($header) {
+    if (is_numeric($header)) {
+      $result = civicrm_api3('Email', 'get', [
+        'id' => $header,
+        'return' => ['contact_id.display_name', 'email'],
+        'sequential' => 1,
+      ])['values'][0];
+      $header = '"' . $result['contact_id.display_name'] . '" <' . $result['email'] . '>';
+    }
+    return $header;
+  }
+
 }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -582,20 +582,21 @@ class CRM_Utils_Mail {
    * If it's numeric, look up the display name and email of the corresponding
    * contact ID in RFC822 format.
    *
-   * @param string $header
+   * @param string $from
+   *   contact ID or formatted "From address", eg. 12 or "Fred Bloggs" <fred@example.org>
    * @return string
    *   The RFC822-formatted email header (display name + address)
    */
-  public static function mailboxHeader($header) {
-    if (is_numeric($header)) {
+  public static function formatFromAddress($from) {
+    if (is_numeric($from)) {
       $result = civicrm_api3('Email', 'get', [
-        'id' => $header,
+        'id' => $from,
         'return' => ['contact_id.display_name', 'email'],
         'sequential' => 1,
       ])['values'][0];
-      $header = '"' . $result['contact_id.display_name'] . '" <' . $result['email'] . '>';
+      $from = '"' . $result['contact_id.display_name'] . '" <' . $result['email'] . '>';
     }
-    return $header;
+    return $from;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Core#357 identified an issue where emails sent with a "From" address of the logged-in user send the contact ID as the "From" address instead of the correct "From" address.  This PR extracts the fix to `CRM_Utils_Mail`, cleans it up a bit for readability, and applies it to membership renewal notifications.

Before
----------------------------------------
Membership renewal notifications sent a "From" address that's the contact ID of the logged-in user.

After
----------------------------------------
Membership renewal notifications send the logged-in user's actual name/email.