### PR TITLE
(dev/core#646) Event date sorting doesn't work for ical listing

### DIFF
--- a/templates/CRM/Event/Page/ICalendar.tpl
+++ b/templates/CRM/Event/Page/ICalendar.tpl
@@ -41,7 +41,7 @@
 <tr class="{cycle values="odd-row,even-row"} {$row.class}">
     <td><a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`"}" title="{ts}read more{/ts}"><strong>{$event.title}</strong></a></td>
     <td>{if $event.summary}{$event.summary} (<a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`"}" title="{ts}details...{/ts}">{ts}read more{/ts}...</a>){else}&nbsp;{/if}</td>
-    <td class="nowrap">
+    <td class="nowrap" data-order="{$event.start_date|crmDate:'%Y-%m-%d'}">
         {if $event.start_date}{$event.start_date|crmDate}{if $event.end_date}<br /><em>{ts}through{/ts}</em><br />{strip}
             {* Only show end time if end date = start date *}
             {if $event.end_date|date_format:"%Y%m%d" == $event.start_date|date_format:"%Y%m%d"}


### PR DESCRIPTION
Overview
----------------------------------------
Event date sorting doesn't work for ical listing

Steps to replicate:
-------------------------

- Go to ical listing
https://dmaster.demo.civicrm.org/civicrm/event/ical?reset=1&list=1&html=1


- Click When column which correponds to the event dates

Expected : The dates should be sorted in ASC/DSC for start date
Actual : The dates get sorted in alphabetic manner


Before
----------------------------------------
![ical_before](https://user-images.githubusercontent.com/3455173/50760040-af765500-128c-11e9-9683-7d2c9f3b930e.png)

After
----------------------------------------

![ical_after](https://user-images.githubusercontent.com/3455173/50760067-b8672680-128c-11e9-894b-f9b6c6d0e702.png)




