### PR TITLE
when using profile submit api, ensure contacts added to group and notification is sent

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2807,7 +2807,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    *
    * @return array
    */
-  public function checkFieldsEmptyValues($gid, $cid, $params, $skipCheck = FALSE) {
+  static public function checkFieldsEmptyValues($gid, $cid, $params, $skipCheck = FALSE) {
     if ($gid) {
       if (CRM_Core_BAO_UFGroup::filterUFGroups($gid, $cid) || $skipCheck) {
         $values = array();

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -280,7 +280,7 @@ function civicrm_api3_profile_submit($params) {
   // Get notify and add to group for this profile.
   $profile_actions_params = array(
     'id' => $profileID,
-    'return' => array('add_to_group_id', 'notify')
+    'return' => array('add_to_group_id', 'notify'),
   );
   $profile_actions = civicrm_api3('UFGroup', 'getsingle', $profile_actions_params);
 

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -803,6 +803,65 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
   }
 
   /**
+   * Ensure contact is added to group
+   */
+  public function testSubmitAddToGroup() {
+    // Create a group.
+    $group = civicrm_api3('Group', 'create', array('title' => 'Test Group'));
+    $group_id = $group['id'];
+    $group_name = $group['values'][$group_id]['name'];
+
+    // Create a profile that updates the group.
+    $ufGroupParams = array(
+      'group_type' => 'Individual,Contact',
+      'name' => 'test_individual_contact_profile_sparkle',
+      'title' => 'Sparkle and Shine',
+      'group_type' => 'Profile',
+      // Why isn't this called add_to_group_id like the field name??
+      'add_contact_to_group' => $group_id,
+      'api.uf_field.create' => array(
+        array(
+          'field_name' => 'first_name',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Individual',
+          'label' => 'First Name',
+        ),
+        array(
+          'field_name' => 'last_name',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Individual',
+          'label' => 'Last Name',
+        ),
+        array(
+          'field_name' => 'email',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Contact',
+          'label' => 'Email',
+        ),
+      ),
+    );
+    $profile = $this->callAPISuccess('uf_group', 'create', $ufGroupParams);
+    $profile_id = $profile['id'];
+
+    // Submit the profile.
+    $params = array(
+      'profile_id' => $profile_id,
+      'first_name' => 'Shiny',
+      'last_name' => 'Shine',
+      'email' => 'shine@example.net',
+    );
+    $result = $this->callAPISuccess('profile', 'submit', $params);
+    $contact_id = $result['id'];
+
+    // Ensure this contact has been added to the group.
+    $params = array('contact_id' => $contact_id, 'group_id' => $group_id);
+    $this->callAPISuccess('GroupContact', 'getsingle', $params);
+  }
+
+  /**
    * Helper function to create an Individual with address/email/phone info. Import UF Group and UF Fields
    * @param array $params
    *


### PR DESCRIPTION
Overview
----------------------------------------
Profiles can be configured so that users submitted via a profile are added to a specified group. In addition, profiles can be configured to notify an email address any time a profile is submitted.

Both of these settings are ignored when a profile is submitted via the profile.submit API action.

Before
----------------------------------------
When a profile is submitted via the profile.submit api, the add to group and notify settings of the profile are ignored. 

After
----------------------------------------
When a profile is submitted via the api, add to group and notify settings are respected.

Comments
----------------------------------------
Does this count as an API breaking change? It does change the behavior of the API - if anyone upgrades, and they have a profile with either email notification or add to group configured, then after the upgrade, their code will suddenly start respecting those changes.

One option would be to change the code so that those settings are ignored by default, and only respected if specified by the caller. Then it would not be an API breaking change.

However, I don't think this is a good option because it is counter intuitive to anyone using this API in the future. I think it's better to have an API breaking change (even if it means delaying the implementation) then to sneak it in with such a default setting. Open to counter arguments of course.