### PR TITLE
Membership custom fields sometimes don't display

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -581,7 +581,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     );
 
     if (!empty($this->_recurPaymentProcessors)) {
-      $memTypeJs['onChange'] = "" . $memTypeJs['onChange'] . "buildAutoRenew(this.value, null, '{$this->_mode}');";
+      $memTypeJs['onChange'] = "" . $memTypeJs['onChange'] . " buildAutoRenew(this.value, null, '{$this->_mode}');";
     }
 
     $this->add('text', 'max_related', ts('Max related'),

--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -6,9 +6,10 @@
   <script type="text/javascript">
     CRM.$(function($) {
       {/literal}
-      CRM.buildCustomData( '{$customDataType}' );
       {if $customDataSubType}
-      CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
+        CRM.buildCustomData('{$customDataType}', {$customDataSubType});
+      {else}
+        CRM.buildCustomData('{$customDataType}');
       {/if}
       {literal}
     });


### PR DESCRIPTION
Overview
----------------------------------------
There is a very irritating issue to do with displaying custom fields in Memberships, where some custom field sets don't appear -- sometimes! So if you have Set 1, Set 2, and Set 3, you can edit a membership and sometimes Set 1 will be there and sometimes it won't.

I've just replicated this on the staging site. Here's how to do it:

1. On a Wordpress or Drupal demo site, create three Custom Data sets. These should apply to Memberships. The first should apply to the 'Student' membership type, and the second and third should be for 'All' membership types. Let's say they're called Set 1, Set 2, and Set 3.

2. Create a single field in each one.

3. Create a Student membership on someone's record.

4. Click edit on the membership, from the memberships tab. Do this repeatedly, then close the pop-up. Sometimes Set 1 will appear and sometimes it won't. (actually, I'm pretty sure it appears then disappears)

Before
----------------------------------------
Custom data is built twice, first without a customdata subtype and then with a customdata subtype.  Depending on the speed of page load / order of execution customdata specific to a subtype may or may not be displayed.

After
----------------------------------------
Custom data is built once on the form.  Either with a subtype or without a subtype as required.

Technical Details
----------------------------------------
This code was extracted relatively recently as part of efforts to improve custom data handling on forms.  No changes were made at the time but the same code pattern appears in multiple places, sometimes with each CRM.buildCustomData wrapped in an if statement, sometimes no if statement for the first one - meaning it will run twice if the form has a subtype (eg membership_type, case_type).

Comments
----------------------------------------
@bhahumanists Are you able to confirm this fixes the issue?