### PR TITLE
(NFC) Ensure that when loading in the test data it is done with UTF8 …

### DIFF
--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -15,6 +15,9 @@ class Data {
     \Civi\Test::schema()->truncateAll();
 
     \Civi\Test::schema()->setStrict(FALSE);
+
+    // Ensure that when we populate the database it is done in utf8 mode
+    \Civi\Test::execute('SET NAMES utf8');
     $sqlDir = dirname(dirname(__DIR__)) . "/sql";
 
     $query2 = file_get_contents("$sqlDir/civicrm_data.mysql");


### PR DESCRIPTION
…encoding

Overview
----------------------------------------
When the test databases are loaded in with some standard data it appears at the moment they are not loaded in using utf8 encoding which means characters such as the Euro symbol can co astray

Before
----------------------------------------
Loaded in in non UTF8 format

After
----------------------------------------
Loaded in using UTF8 Format

ping @eileenmcnaughton @totten 
