### PR TITLE
Fix php 7.2 countable warning

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1719,7 +1719,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         );
         $prefixValue = Civi::settings()->get('contribution_invoice_settings');
         $invoicing = CRM_Utils_Array::value('invoicing', $prefixValue);
-        if (count($taxAmt) > 0 && (isset($invoicing) && isset($prefixValue['is_email_pdf']))) {
+        if (!empty($taxAmt) && (isset($invoicing) && isset($prefixValue['is_email_pdf']))) {
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $contributionId;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a notice on php 7.2

Before
----------------------------------------
per https://lab.civicrm.org/dev/core/issues/406#note_12393
Warning: count(): Parameter must be an array or an object that implements Countable in CRM_Event_Form_Participant->submit() (line 1722 of .../all/modules/civicrm/CRM/Event/Form/Participant.php).

After
----------------------------------------
no notice

Technical Details
----------------------------------------
if $taxAmt is NULL then it will give the error !empty works on NULL and on an empty array

Comments
----------------------------------------
@seamuslee001 I could be convinced to put this against the rc just on the basis we are now recommending php 7.2
