### PR TITLE
dev/core#519 - Avoid adding contribution fields in event receipts

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2789,24 +2789,27 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', NULL, $this->id);
+    // dev/core#519 Avoid adding Contribution custom fields in event receipt.
+    if ($this->_component == 'contribute') {
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', NULL, $this->id);
 
-    $customGroup = array();
-    foreach ($groupTree as $key => $group) {
-      if ($key === 'info') {
-        continue;
-      }
+      $customGroup = array();
+      foreach ($groupTree as $key => $group) {
+        if ($key === 'info') {
+          continue;
+        }
 
-      foreach ($group['fields'] as $k => $customField) {
-        $groupLabel = $group['title'];
-        if (!empty($customField['customValue'])) {
-          foreach ($customField['customValue'] as $customFieldValues) {
-            $customGroup[$groupLabel][$customField['label']] = CRM_Utils_Array::value('data', $customFieldValues);
+        foreach ($group['fields'] as $k => $customField) {
+          $groupLabel = $group['title'];
+          if (!empty($customField['customValue'])) {
+            foreach ($customField['customValue'] as $customFieldValues) {
+              $customGroup[$groupLabel][$customField['label']] = CRM_Utils_Array::value('data', $customFieldValues);
+            }
           }
         }
       }
+      $values['customGroup'] = $customGroup;
     }
-    $values['customGroup'] = $customGroup;
 
     $values['is_pay_later'] = $this->is_pay_later;
 


### PR DESCRIPTION
Overview
----------------------------------------
Receipts for events paid via PayPal have extra information related to contribution.

Before
----------------------------------------
I get the custom fields added for Events in the receipt which is expected behaviour. But along with that I also got the custom fields added for Contribution.

I have an event named Test Conference. and I have added custom group named `Gift Aid` for contributions. Now when I registered for the event. The receipt in the mail contained contribution custom fields. (Please See the screenshots attached).
1. Event receipt:
![image](https://user-images.githubusercontent.com/30790755/50831780-01dd7180-1372-11e9-8a86-be63b506dbcf.png)

2. Contribution related custom fields in the receipt.
![image](https://user-images.githubusercontent.com/30790755/50831820-20436d00-1372-11e9-91ce-bb0e5348f722.png)

After
----------------------------------------
Event receipts does not include extra information related to contribution.

Technical Details
----------------------------------------
I found that the code which generated the message values for contribution was also getting executed for Events. I just added a condition to check if its Contribution in CRM/Contribute/BAO/Contribution.php.

Comments
----------------------------------------
Please check the discussion here https://lab.civicrm.org/dev/core/issues/519 and https://civicrm.stackexchange.com/questions/27248/event-receipts-for-paid-events-contains-extraneous-information
Produces only if using PayPal Standard,sagepay payment processor.
