### PR TITLE
dev/mail#37 - Replace non-supported 4-byte unicode characters in bounce processing

### DIFF
--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -80,6 +80,10 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
     // replace any invalid unicode characters with replacement characters
     $params['bounce_reason'] = mb_convert_encoding($params['bounce_reason'], 'UTF-8', 'UTF-8');
 
+    // dev/mail#37 Replace 4-byte utf8 characaters with the unicode replacement character
+    // while CiviCRM does not support utf8mb4 for MySQL
+    $params['bounce_reason'] = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $params['bounce_reason']);
+
     // CRM-11989
     $params['bounce_reason'] = mb_strcut($params['bounce_reason'], 0, 254);
 

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -68,6 +68,19 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that the job processing function can handle incoming utf8mb4 characters.
+   */
+  public function testBounceProcessingUTF8mb4() {
+    $this->setUpMailing();
+    $mail = 'test_utf8mb4_character.txt';
+
+    copy(__DIR__ . '/data/bounces/' . $mail, __DIR__ . '/data/mail/' .   $mail);
+    $this->callAPISuccess('job', 'fetch_bounces', array());
+    $this->assertFalse(file_exists(__DIR__ . '/data/mail/' . $mail));
+    $this->checkMailingBounces(1);
+  }
+
+  /**
    * Tests that a multipart related email does not cause pain & misery & fatal errors.
    *
    * Sample taken from https://www.phpclasses.org/browse/file/14672.html

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/test_utf8mb4_character.txt
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/test_utf8mb4_character.txt
@@ -1,0 +1,15 @@
+Delivered-To: my@example.com
+Received: by 10.2.13.84 with SMTP id 1234567890;
+        Wed, 19 Dec 2018 10:01:11 +0100 (CET)
+Return-Path: <>
+From: my@example.com
+To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+Subject: Vacation
+Message-ID: <abc.def.fhi@example.com>
+Date: Wed, 19 Dec 2018 10:01:07 +0100
+MIME-Version: 1.0
+Auto-Submitted: auto-replied (vacation)
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+SSBhbSBvbiB2YWNhdGlvbiDwn4y0

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/test_utf8mb4_character.txt
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/test_utf8mb4_character.txt
@@ -12,4 +12,4 @@ Auto-Submitted: auto-replied (vacation)
 Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: base64
 
-SSBhbSBvbiB2YWNhdGlvbiDwn4y0
+8J+MtCBJIGFtIG9uIHZhY2F0aW9uIPCfjLQ=


### PR DESCRIPTION
Overview
----------------------------------------
When the bounced message contains any 4-byte unicode character, it cannot be saved to the database due to the currently missing support for utf8mb4 in CiviCRM.

Issue tracker: https://lab.civicrm.org/dev/mail/issues/37

Before
----------------------------------------
Exception is thrown. Bounce is not stored in the datebase, but mail is moved to processed folder.

After
----------------------------------------
4-bytes unicode characters are replaced with unicode replacement characters. No exception thrown. Bounce is saved.

Technical Details
----------------------------------------
Once there is a way to support utf8mb4 this may have to change again.
