### PR TITLE
(dev/core#649) DB error on Find Activities with follow up criteria

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -335,11 +335,11 @@ class CRM_Activity_BAO_Query {
 
       case 'parent_id':
         if ($value == 1) {
-          $query->_where[$grouping][] = "parent_id.parent_id IS NOT NULL";
+          $query->_where[$grouping][] = "civicrm_activity.parent_id IS NOT NULL";
           $query->_qill[$grouping][] = ts('Activities which have Followup Activities');
         }
         elseif ($value == 2) {
-          $query->_where[$grouping][] = "parent_id.parent_id IS NULL";
+          $query->_where[$grouping][] = "civicrm_activity.parent_id IS NULL";
           $query->_qill[$grouping][] = ts('Activities without Followup Activities');
         }
         break;


### PR DESCRIPTION
Overview
----------------------------------------

Steps to replicate: 
-------------------

- Go to *Find Activities* and set *Has a Followup Activity?* to Yes
- Hit Search and you will get DB error
Database Error Code: Unknown column 'parent_id.parent_id' in 'where clause', 1054

Before
----------------------------------------

![act_before](https://user-images.githubusercontent.com/3455173/50837156-fa719480-1380-11e9-9d79-4cf65ab2dadf.png)

After
----------------------------------------
![act_after](https://user-images.githubusercontent.com/3455173/50837164-fe9db200-1380-11e9-86a8-a2b26ce4143e.png)


