### PR TITLE
Add default for domain_id for report_instance.

### DIFF
--- a/api/v3/ReportInstance.php
+++ b/api/v3/ReportInstance.php
@@ -67,6 +67,7 @@ function civicrm_api3_report_instance_create($params) {
 function _civicrm_api3_report_instance_create_spec(&$params) {
   $params['report_id']['api.required'] = 1;
   $params['title']['api.required'] = 1;
+  $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
   $params['view_mode']['api.default'] = 'view';
   $params['view_mode']['title'] = ts('View Mode for Navigation URL');
   $params['view_mode']['type'] = CRM_Utils_Type::T_STRING;


### PR DESCRIPTION
Overview
----------------------------------------
Uses current domain as a sensible default for ReportInstance.create rather than it being a required field

Before
----------------------------------------
ReportInstance.create with no domain_id will give a mandatory field error

After
----------------------------------------
ReportInstance.create with no domain_id will succeed, assuming current domain

Technical Details
----------------------------------------
This is consistent with other api like Job, MembershipType, PaymentProcessor

Comments
----------------------------------------

