### PR TITLE
GitLab issue 652 Copying activity file custom data doesn't copy mime …

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -3109,7 +3109,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
             $fileValues = CRM_Core_BAO_File::path($value, $params['activityID']);
             $customParams["custom_{$key}_-1"] = array(
               'name' => $fileValues[0],
-              'path' => $fileValues[1],
+              'type' => $fileValues[1],
             );
           }
           else {


### PR DESCRIPTION
Overview
----------------------------------------
[GitLab Issue 652 Copying activity file custom data doesn't copy mime type
](https://lab.civicrm.org/dev/core/issues/652)

Before
----------------------------------------
1. Create custom data set for Activities
2. Create custom field of type File
3. Create any type of new activity such as Phone Call
4. Upload an image in the custom field
5. Create another activity without any custom data
6. Note the id's of the 2 activities
6. In your custom extension, run the following code to copy custom fields from 1st activity to the 2nd 

```php 
$params = array(
    'activityID' => $first_activity_id,
    'mainActivityId' => $second_activity_id,
);
CRM_Activity_BAO_Activity::copyExtendedActivityData($params);
```

7. Inspect civicrm_file table
8. The new entry doesn't have mime_type set

After
----------------------------------------
* In `copyExtendedActivityData()` method in CRM/Activity/BAO/Activity.php 'path' was renamed to 'type' in the following coding block

```php
$customParams["custom_{$key}_-1"] = array(
    'name' => $fileValues[0],
    'path' => $fileValues[1],
);
```
* Mime type is getting set after the change

Technical Details
----------------------------------------
* In `copyExtendedActivityData()` method in CRM/Activity/BAO/Activity.php 'path' should be renamed to 'type' in the following coding block

```php
$customParams["custom_{$key}_-1"] = array(
    'name' => $fileValues[0],
    'path' => $fileValues[1],
);
```
![activity](https://user-images.githubusercontent.com/33434409/50890890-0007c280-13f3-11e9-8e49-d9831783cfa5.png)

* This is because in `formatCustomField()` method in CRM/Core/BAO/CustomField.php, the mimeType variable uses 'type' not path

```php
// If we are already passing the file id as a value then retrieve and set the file data
if (CRM_Utils_Rule::integer($value)) {
    $fileDAO = new CRM_Core_DAO_File();
    $fileDAO->id = $value;
    $fileDAO->find(TRUE);
    if ($fileDAO->N) {
        $fileID = $value;
        $fName = $fileDAO->uri;
        $mimeType = $fileDAO->mime_type;
    }
} else {
    $fName = $value['name'];
    $mimeType = $value['type'];
}
```
![customfield](https://user-images.githubusercontent.com/33434409/50890915-0a29c100-13f3-11e9-8d65-500cf698c287.png)

* Furthermore the `path()` method in CRM/Core/BAO/File.php which is used by `copyExtendedActivityData()` returns path and mime type 

![file](https://user-images.githubusercontent.com/33434409/50890928-101fa200-13f3-11e9-90e7-6097f468576f.png)

Comments
----------------------------------------
