### PR TITLE
Fix undefined index warning

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -542,7 +542,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     if ($this->_action & CRM_Core_Action::VIEW) {
       $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$this->_activityId}&action=view&cid={$this->_values['source_contact_id']}");
-      CRM_Utils_Recent::add($this->_values['subject'],
+      CRM_Utils_Recent::add(CRM_Utils_Array::value('subject', $this->_values, ts('(no subject)')),
         $url,
         $this->_values['id'],
         'Activity',


### PR DESCRIPTION
Overview
------

Fixes adding an activity with no subject to the recent items list.

Before
-------

When viewing an activity with no subject, the recent items entry appears blank, and an undefined index warning appears.

After
------

The recent items entry says "(no subject)" which is consistent with the rest of the UI. No warning.