### PR TITLE
Optimise the loading of the CiviCRM Deduplication Exception page

### DIFF
--- a/CRM/Contact/Page/DedupeException.php
+++ b/CRM/Contact/Page/DedupeException.php
@@ -35,44 +35,6 @@
  * Main page for viewing contact.
  */
 class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
-
-  /**
-   * Heart of the viewing process.
-   *
-   * The runner gets all the meta data for the contact and calls the appropriate type of page to view.
-   */
-  public function preProcess() {
-    //fetch the dedupe exception contacts.
-    $dedupeExceptions = array();
-
-    $exception = new CRM_Dedupe_DAO_Exception();
-    $exception->find();
-    $contactIds = array();
-    while ($exception->fetch()) {
-      $key = "{$exception->contact_id1}_{$exception->contact_id2}";
-      $contactIds[$exception->contact_id1] = $exception->contact_id1;
-      $contactIds[$exception->contact_id2] = $exception->contact_id2;
-      $dedupeExceptions[$key] = array(
-        'main' => array('id' => $exception->contact_id1),
-        'other' => array('id' => $exception->contact_id2),
-      );
-    }
-    //get the dupe contacts display names.
-    if (!empty($dedupeExceptions)) {
-      $sql = 'select id, display_name from civicrm_contact where id IN ( ' . implode(', ', $contactIds) . ' )';
-      $contact = CRM_Core_DAO::executeQuery($sql);
-      $displayNames = array();
-      while ($contact->fetch()) {
-        $displayNames[$contact->id] = $contact->display_name;
-      }
-      foreach ($dedupeExceptions as $key => & $values) {
-        $values['main']['name'] = CRM_Utils_Array::value($values['main']['id'], $displayNames);
-        $values['other']['name'] = CRM_Utils_Array::value($values['other']['id'], $displayNames);
-      }
-    }
-    $this->assign('dedupeExceptions', $dedupeExceptions);
-  }
-
   /**
    * the main function that is called when the page loads,
    * it decides the which action has to be taken for the page.
@@ -80,8 +42,67 @@ class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
    * @return null
    */
   public function run() {
-    $this->preProcess();
+    $this->initializePager();
+    $this->assign('exceptions', $this->getExceptions());
     return parent::run();
+  }
+
+  /**
+   * Method to initialize pager
+   *
+   * @access protected
+   */
+  protected function initializePager() {
+    $totalitems = civicrm_api3('Exception', "getcount", array());
+    $params           = array(
+      'total' => $totalitems,
+      'rowCount' => CRM_Utils_Pager::ROWCOUNT,
+      'status' => ts('Dedupe Exceptions %%StatusMessage%%'),
+      'buttonBottom' => 'PagerBottomButton',
+      'buttonTop' => 'PagerTopButton',
+      'pageID' => $this->get(CRM_Utils_Pager::PAGE_ID),
+    );
+    $this->_pager = new CRM_Utils_Pager($params);
+    $this->assign_by_ref('pager', $this->_pager);
+  }
+
+  /**
+   * Function to get the exceptions
+   *
+   * @return array $exceptions
+   * @access protected
+   */
+  protected function getExceptions() {
+    list($offset, $limit) = $this->_pager->getOffsetAndRowCount();
+    $contactOneQ = CRM_Utils_Request::retrieve('crmContact1Q', 'String');
+    $contactTwoQ = CRM_Utils_Request::retrieve('crmContact2Q', 'String');
+
+    if (!$contactOneQ) {
+      $contactOneQ = '';
+    }
+    if (!$contactTwoQ) {
+      $contactTwoQ = '';
+    }
+
+    $this->assign('searchcontact1', $contactOneQ);
+    $this->assign('searchcontact2', $contactTwoQ);
+
+    $params = array(
+      "options"     => array('limit' => $limit, 'offset' => $offset),
+      'return' => ["contact_id1.display_name", "contact_id2.display_name", "contact_id1", "contact_id2"],
+    );
+
+    if ($contactOneQ != '') {
+      $params['contact_id1.display_name'] = array('LIKE' => '%' . $contactOneQ . '%');
+    }
+
+    if ($contactTwoQ != '') {
+      $params['contact_id2.display_name'] = array('LIKE' => '%' . $contactTwoQ . '%');
+    }
+
+    $exceptions = civicrm_api3("Exception", "get", $params);
+    $exceptions = $exceptions["values"];
+    return $exceptions;
   }
 
 }

--- a/CRM/Contact/Page/DedupeException.php
+++ b/CRM/Contact/Page/DedupeException.php
@@ -53,7 +53,20 @@ class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
    * @access protected
    */
   protected function initializePager() {
-    $totalitems = civicrm_api3('Exception', "getcount", array());
+    $params = array();
+
+    $contactOneQ = CRM_Utils_Request::retrieve('crmContact1Q', 'String');
+    $contactTwoQ = CRM_Utils_Request::retrieve('crmContact2Q', 'String');
+
+    if ($contactOneQ) {
+      $params['contact_id1.display_name'] = array('LIKE' => '%' . $contactOneQ . '%');
+    }
+
+    if ($contactTwoQ) {
+      $params['contact_id2.display_name'] = array('LIKE' => '%' . $contactTwoQ . '%');
+    }
+
+    $totalitems = civicrm_api3('Exception', "getcount", $params);
     $params           = array(
       'total' => $totalitems,
       'rowCount' => CRM_Utils_Pager::ROWCOUNT,

--- a/CRM/Contact/Page/DedupeException.php
+++ b/CRM/Contact/Page/DedupeException.php
@@ -56,14 +56,12 @@ class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
     $params = array();
 
     $contactOneQ = CRM_Utils_Request::retrieve('crmContact1Q', 'String');
-    $contactTwoQ = CRM_Utils_Request::retrieve('crmContact2Q', 'String');
 
     if ($contactOneQ) {
       $params['contact_id1.display_name'] = array('LIKE' => '%' . $contactOneQ . '%');
-    }
+      $params['contact_id2.display_name'] = array('LIKE' => '%' . $contactOneQ . '%');
 
-    if ($contactTwoQ) {
-      $params['contact_id2.display_name'] = array('LIKE' => '%' . $contactTwoQ . '%');
+      $params['options']['or'] = [["contact_id1.display_name", "contact_id2.display_name"]];
     }
 
     $totalitems = civicrm_api3('Exception', "getcount", $params);
@@ -88,17 +86,12 @@ class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
   protected function getExceptions() {
     list($offset, $limit) = $this->_pager->getOffsetAndRowCount();
     $contactOneQ = CRM_Utils_Request::retrieve('crmContact1Q', 'String');
-    $contactTwoQ = CRM_Utils_Request::retrieve('crmContact2Q', 'String');
 
     if (!$contactOneQ) {
       $contactOneQ = '';
     }
-    if (!$contactTwoQ) {
-      $contactTwoQ = '';
-    }
 
     $this->assign('searchcontact1', $contactOneQ);
-    $this->assign('searchcontact2', $contactTwoQ);
 
     $params = array(
       "options"     => array('limit' => $limit, 'offset' => $offset),
@@ -107,10 +100,9 @@ class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
 
     if ($contactOneQ != '') {
       $params['contact_id1.display_name'] = array('LIKE' => '%' . $contactOneQ . '%');
-    }
+      $params['contact_id2.display_name'] = array('LIKE' => '%' . $contactOneQ . '%');
 
-    if ($contactTwoQ != '') {
-      $params['contact_id2.display_name'] = array('LIKE' => '%' . $contactTwoQ . '%');
+      $params['options']['or'] = [["contact_id1.display_name", "contact_id2.display_name"]];
     }
 
     $exceptions = civicrm_api3("Exception", "get", $params);

--- a/api/v3/Exception.php
+++ b/api/v3/Exception.php
@@ -47,6 +47,7 @@ function civicrm_api3_exception_get($params) {
 function civicrm_api3_exception_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Exception');
 }
+
 /**
  * Delete an existing Exception.
  *

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -30,52 +30,122 @@
   <table class="no-border form-layout-compressed" id="searchOptions" style="width:100%;">
     <tr>
       <td class="crm-contact-form-block-contact1">
-        <label for="contact1">{ts}Contact 1{/ts}</label><br />
-        <input class="crm-form-text" type="text" placeholder="Search Contact1" search-column="0" />
+        <label for="search-contact1">{ts}Contact 1{/ts}</label><br />
+        <input type="text" placeholder="Search Contact1" value="{$searchcontact1}" id="search-contact1" search-column="0" />
       </td>
       <td class="crm-contact-form-block-contact2">
-        <label for="contact2">{ts}Contact 2{/ts}</label><br />
-        <input class="crm-form-text" type="text" placeholder="Search Contact2" search-column="1" />
+        <label for="search-contact2">{ts}Contact 2{/ts}</label><br />
+        <input type="text" placeholder="Search Contact2" value="{$searchcontact2}" id="search-contact2" search-column="1" />
       </td>
     </tr>
   </table>
 </div>
-<table id="dedupeExceptions" class="display crm-sortable" data-searching='true' data=filter='false'>
-  <thead>
-    <tr class="columnheader">
-      <th>{ts}Contact 1{/ts}</th>
-      <th>{ts}Contact 2 (Duplicate){/ts}</th>
-      <th data-orderable="false"></th>
-    </tr>
-  </thead>
-  <tbody>
-    {foreach from=$dedupeExceptions item=exception key=id}
-      <tr id="dupeRow_{$id}" class="{cycle values="odd-row,even-row"}">
-        <td><a href ={crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.main.id`"}>{$exception.main.name}</a></td>
-        <td><a href ={crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.other.id`"}>{$exception.other.name}</a></td>
-        <td><a id='duplicateContacts' href="#" title={ts}Remove Exception{/ts} onClick="processDupes( {$exception.main.id}, {$exception.other.id}, 'nondupe-dupe', 'dedupe-exception' );return false;">&raquo; {ts}Remove Exception{/ts}</a></td>
+
+
+<div class="crm-content-block crm-block">
+  {include file="CRM/common/pager.tpl" location="top"}
+  {include file='CRM/common/jsortable.tpl'}
+
+  <div id="claim_level-wrapper" class="dataTables_wrapper">
+    <table id="claim_level-table" class="display">
+      <thead>
+      <tr>
+        <th>{ts}Contact 1{/ts}</th>
+        <th>{ts}Contact 2 (Duplicate){/ts}</th>
       </tr>
-    {/foreach}
-  </tbody>
-</table>
+      </thead>
+      <tbody>
+      {assign var="rowClass" value="odd-row"}
+      {assign var="rowCount" value=0}
+
+      {foreach from=$exceptions key=errorId item=exception}
+        {assign var="rowCount" value=$rowCount+1}
+
+        <tr id="row{$rowCount}" class="{cycle values="odd,even"}">
+
+          <td>
+            {assign var="contact1name" value="contact_id1.display_name"}
+            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id1`"}" target="_blank">{ $exception.$contact1name }</a>
+          </td>
+          <td>
+            {assign var="contact2name" value="contact_id2.display_name"}
+            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id2`"}" target="_blank">{ $exception.$contact2name }</a>
+          </td>
+
+        </tr>
+
+        {if $rowClass eq "odd-row"}
+          {assign var="rowClass" value="even-row"}
+        {else}
+          {assign var="rowClass" value="odd-row"}
+        {/if}
+
+      {/foreach}
+      </tbody>
+    </table>
+  </div>
+  {include file="CRM/common/pager.tpl" location="bottom"}
+</div>
+
+
+
 <div class="clear"><br /></div>
 <div class="action-link">
   {crmButton p="civicrm/contact/deduperules" q="reset=1" icon="times"}{ts}Done{/ts}{/crmButton}
 </div>
 
 {* process the dupe contacts *}
-{include file="CRM/common/dedupe.tpl"}
 {literal}
   <script type="text/javascript">
-    (function($) {
-      var table = CRM.$('table#dedupeExceptions').DataTable();
+    CRM.$(function($) {
+
+      {/literal}
+        var $form = $({if empty($form.formClass)}'#crm-main-content-wrapper'{else}'form.{$form.formClass}'{/if});
+        var currentLocation = {$pager->_response.currentLocation|json_encode};
+      {literal}
+
+        var refreshing = false;
+        var timer = null;
+
       // apply the search
-      $('#searchOptions input').on( 'keyup change', function () {
-        table
-          .column($(this).attr('search-column'))
-          .search(this.value)
-          .draw();
+      $('#searchOptions input').on( 'keydown', function () {
+        clearTimeout(timer);
+        timer = setTimeout(updateTable, 500)
       });
-    })(CRM.$);
+
+      function updateTable() {
+
+        var contact1term = $('#search-contact1').val();
+        var contact2term = $('#search-contact2').val();
+
+        currentLocation = currentLocation.replace(/crmPID=\d+/, 'crmPID=' + 0);
+
+        if (currentLocation.indexOf('crmContact1Q') !== -1) {
+          currentLocation = currentLocation.replace(/crmContact1Q=\w*/, 'crmContact1Q=' + contact1term);
+        }
+        else {
+          currentLocation += '&crmContact1Q='+contact1term;
+        }
+
+        if (currentLocation.indexOf('crmContact2Q') !== -1) {
+          currentLocation = currentLocation.replace(/crmContact2Q=\w*/, 'crmContact2Q=' + contact2term);
+        }
+        else {
+          currentLocation += '&crmContact2Q='+contact2term;
+        }
+
+        refresh(currentLocation);
+      }
+
+      function refresh(url) {
+        if (!refreshing) {
+          refreshing = true;
+          var options = url ? {url: url} : {};
+          $form.off('.crm-pager').closest('.crm-ajax-container, #crm-main-content-wrapper').crmSnippet(options).crmSnippet('refresh');
+        }
+      }
+
+
+    });
   </script>
 {/literal}

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -23,6 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{include file="CRM/common/dedupe.tpl"}
 <div class="crm-accordion-header">
   {ts}Filter Contacts{/ts}
 </div>
@@ -32,7 +33,7 @@
       <tr>
         <td class="crm-contact-form-block-contact1">
           <label for="search-contact1">{ts}Contact Name{/ts}</label><br />
-          <input type="text" size="50" placeholder="Search Contacts" value="{$searchcontact1}" id="search-contact1" search-column="0" />
+          <input class="crm-form-text" type="text" size="50" placeholder="Search Contacts" value="{$searchcontact1}" id="search-contact1" search-column="0" />
         </td>
         <td class="crm-contact-form-block-search">
           <label>&nbsp;</label><br />
@@ -51,16 +52,17 @@
   <div id="claim_level-wrapper" class="dataTables_wrapper">
     <table id="claim_level-table" class="display">
       <thead>
-      <tr>
-        <th>{ts}Contact 1{/ts}</th>
-        <th>{ts}Contact 2 (Duplicate){/ts}</th>
-      </tr>
+        <tr>
+          <th>{ts}Contact 1{/ts}</th>
+          <th>{ts}Contact 2 (Duplicate){/ts}</th>
+          <th data-orderable="false"></th>
+        </tr>
       </thead>
       <tbody>
-      {assign var="rowClass" value="odd-row"}
-      {assign var="rowCount" value=0}
+        {assign var="rowClass" value="odd-row"}
+        {assign var="rowCount" value=0}
 
-      {foreach from=$exceptions key=errorId item=exception}
+        {foreach from=$exceptions key=errorId item=exception}
         {assign var="rowCount" value=$rowCount+1}
 
         <tr id="row{$rowCount}" class="{cycle values="odd,even"}">
@@ -73,7 +75,9 @@
             {assign var="contact2name" value="contact_id2.display_name"}
             <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id2`"}" target="_blank">{ $exception.$contact2name }</a>
           </td>
-
+          <td>
+            <a id='duplicateContacts' href="#" title={ts}Remove Exception{/ts} onClick="processDupes( {$exception.contact_id1}, {$exception.contact_id2}, 'nondupe-dupe', 'dedupe-exception' );return false;">&raquo; {ts}Remove Exception{/ts}</a>
+          </td>
         </tr>
 
         {if $rowClass eq "odd-row"}

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -27,18 +27,20 @@
   {ts}Filter Contacts{/ts}
 </div>
 <div class="crm-accordion-body">
-  <table class="no-border form-layout-compressed" id="searchOptions" style="width:100%;">
-    <tr>
-      <td class="crm-contact-form-block-contact1">
-        <label for="search-contact1">{ts}Contact 1{/ts}</label><br />
-        <input type="text" placeholder="Search Contact1" value="{$searchcontact1}" id="search-contact1" search-column="0" />
-      </td>
-      <td class="crm-contact-form-block-contact2">
-        <label for="search-contact2">{ts}Contact 2{/ts}</label><br />
-        <input type="text" placeholder="Search Contact2" value="{$searchcontact2}" id="search-contact2" search-column="1" />
-      </td>
-    </tr>
-  </table>
+  <form method="get">
+    <table class="no-border form-layout-compressed" id="searchOptions" style="width:100%;">
+      <tr>
+        <td class="crm-contact-form-block-contact1">
+          <label for="search-contact1">{ts}Contact Name{/ts}</label><br />
+          <input type="text" size="50" placeholder="Search Contacts" value="{$searchcontact1}" id="search-contact1" search-column="0" />
+        </td>
+        <td class="crm-contact-form-block-search">
+          <label>&nbsp;</label><br />
+          <button type="submit" class="button crm-button filtercontacts"><span><i class="crm-i fa-search"></i> Find Contacts</span></button>
+        </td>
+      </tr>
+    </table>
+  </form>
 </div>
 
 
@@ -108,7 +110,8 @@
         var timer = null;
 
       // apply the search
-      $('#searchOptions input').on( 'keydown', function () {
+      $('.filtercontacts').on( 'click', function (e) {
+        e.preventDefault();
         clearTimeout(timer);
         timer = setTimeout(updateTable, 500)
       });
@@ -116,7 +119,6 @@
       function updateTable() {
 
         var contact1term = $('#search-contact1').val();
-        var contact2term = $('#search-contact2').val();
 
         currentLocation = currentLocation.replace(/crmPID=\d+/, 'crmPID=' + 0);
 
@@ -125,13 +127,6 @@
         }
         else {
           currentLocation += '&crmContact1Q='+contact1term;
-        }
-
-        if (currentLocation.indexOf('crmContact2Q') !== -1) {
-          currentLocation = currentLocation.replace(/crmContact2Q=\w*/, 'crmContact2Q=' + contact2term);
-        }
-        else {
-          currentLocation += '&crmContact2Q='+contact2term;
         }
 
         refresh(currentLocation);


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Deduplication Exception page takes far too long to load when there are a large number of contacts that have been marked as not duplicates, possibly with thousands of contacts in the list.

The page in question is available here, /civicrm/dedupe/exception?reset=1

The problem with Dedupee page is, it fetches all the exceptions in one go on the page load. Because of this, the page takes time to load or crash before it could finish the execution for thousands of contacts in the list. 

Before
----------------------------------------
Page takes too long to load or crash for thousands of contacts in the list. 

![Screenshot 2019-04-04 13 25 39](https://user-images.githubusercontent.com/336308/55521436-3b0d4f80-56dd-11e9-8e50-d6363b18952f.png)



After
----------------------------------------
The list on the page is converted into CiviCRM AJAX Pagination so it only loads certain records from DB on page load, which gets executed quickly and without crash.

![Screenshot 2019-04-04 13 23 37](https://user-images.githubusercontent.com/336308/55521373-04cfd000-56dd-11e9-8046-ed58d737e6a6.png)

