### PR TITLE
Mail accounts with " in the password were failing. 

### DIFF
--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -57,12 +57,14 @@ class CRM_Mailing_MailStore {
       throw new Exception("Empty mail protocol");
     }
 
+    $password = addslashes($dao->password);
+
     switch ($protocols[$dao->protocol]) {
       case 'IMAP':
-        return new CRM_Mailing_MailStore_Imap($dao->server, $dao->username, $dao->password, (bool) $dao->is_ssl, $dao->source);
+        return new CRM_Mailing_MailStore_Imap($dao->server, $dao->username, $password, (bool) $dao->is_ssl, $dao->source);
 
       case 'POP3':
-        return new CRM_Mailing_MailStore_Pop3($dao->server, $dao->username, $dao->password, (bool) $dao->is_ssl);
+        return new CRM_Mailing_MailStore_Pop3($dao->server, $dao->username, $password, (bool) $dao->is_ssl);
 
       case 'Maildir':
         return new CRM_Mailing_MailStore_Maildir($dao->source);


### PR DESCRIPTION
Mail accounts with " in the password were failing. Presumably the same for other special characters as well. https://lab.civicrm.org/dev/core/issues/662

Overview
----------------------------------------
This is a simple PR that "escapes" passwords before they are sent to the Mail reader. The Mail reader is a separate product by zetacomponents. I thought they'd be unlikely to make this change based on our pull request. I therefore thought it best to alter the password at the point of being passed to the component. 

Before
----------------------------------------
Passwords are used exactly as they stored. If they contain a " this means they will fail.

After
----------------------------------------
Passwords change from xy"z to xy\"z meaning that they are will work with zetacodes.

Technical Details
----------------------------------------
Passwords in the MailStore are escaped before they are read by zetacodes Mail.

Comments
----------------------------------------
Working in a Production environment.
