### PR TITLE
Simplify billingblock in Contribution/Form/Main template

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -293,10 +293,7 @@
   </fieldset>
   {/if}
 
-  <div id="billing-payment-block">
-    {include file="CRM/Financial/Form/Payment.tpl" snippet=4}
-  </div>
-  {include file="CRM/common/paymentBlock.tpl"}
+  {include file="CRM/Core/BillingBlockWrapper.tpl"}
 
   <div class="crm-public-form-item crm-group custom_post_profile-group">
   {include file="CRM/UF/Form/Block.tpl" fields=$customPost}


### PR DESCRIPTION
Overview
----------------------------------------
Simplify billingblock in Contribution/Form/Main template

Before
----------------------------------------
Contribution page includes CRM/Financial/Form/Payment.tpl which includes CRM/Core/BillingBlock.tpl which adds another `<div id="billing-payment-block"> ending up with one nested inside the other.  snippet=4 parameter in the template has no effect, it's an URL param to specify a JSON response, but we are not loading via AJAX...

After
----------------------------------------
We use the `CRM/Core/BillingBlockWrapper.tpl` like everywhere else that displays a payment screen.

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton @monishdeb @pradpnayak Are one of you able to test this?  There should be no difference - I've tested using webform_civicrm, a contribution page with single/multiple payment processors and via a backend credit card contribution form.
