### PR TITLE
Use icon for timepicker placeholder

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2691,7 +2691,8 @@ div.crm-container form {
 }
 
 .crm-container input.dateplugin::placeholder,
-.crm-container input.crm-form-date::placeholder {
+.crm-container input.crm-form-date::placeholder,
+.crm-container input.crm-form-time::placeholder {
   font-family: "FontAwesome";
   text-align: right;
 }

--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -36,7 +36,7 @@
         CRM.utils.copyAttributes($dataField, $timeField, ['class', 'disabled']);
         $timeField
           .addClass('crm-form-text crm-form-time')
-          .attr('placeholder', $dataField.attr('time-placeholder') === undefined ? ts('Time') : $dataField.attr('time-placeholder'))
+          .attr('placeholder', $dataField.attr('time-placeholder') === undefined ? '\uf017' : $dataField.attr('time-placeholder'))
           .attr('aria-label', $dataField.attr('time-placeholder') === undefined ? ts('Time') : $dataField.attr('time-placeholder'))
           .change(updateDataField)
           .timeEntry({


### PR DESCRIPTION
Overview
----------------------------------------
Use a placeholder icon for time input fields.

Before
----------------------------------------
Inconsistent placeholders - icon for date, text for time.

![screenshot from 2019-01-11 20-10-56](https://user-images.githubusercontent.com/2874912/51067129-29844200-15dd-11e9-9bb6-7eda9291ad68.png)


After
----------------------------------------
Consistently use icons for both fields.

![screenshot from 2019-01-11 20-06-56](https://user-images.githubusercontent.com/2874912/51067135-3acd4e80-15dd-11e9-877a-2a3ebc416776.png)

