### PR TITLE
Convert Paypal Standard IPN payment_date to system's time zone

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -394,6 +394,8 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $paymentDate = $this->retrieve('payment_date', 'String', FALSE);
     if (!empty($paymentDate)) {
       $receiveDateTime = new DateTime($paymentDate);
+      $systemTimeZone = new DateTimeZone(date_default_timezone_get());
+      $receiveDateTime->setTimezone($systemTimeZone);
       $input['receive_date'] = $receiveDateTime->format('YmdHis');
     }
   }

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -394,7 +394,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $paymentDate = $this->retrieve('payment_date', 'String', FALSE);
     if (!empty($paymentDate)) {
       $receiveDateTime = new DateTime($paymentDate);
-      $systemTimeZone = new DateTimeZone(date_default_timezone_get());
+      $systemTimeZone = new DateTimeZone(CRM_Core_Config::singleton()->userSystem->getTimeZoneString());
       $receiveDateTime->setTimezone($systemTimeZone);
       $input['receive_date'] = $receiveDateTime->format('YmdHis');
     }

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -394,6 +394,10 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $paymentDate = $this->retrieve('payment_date', 'String', FALSE);
     if (!empty($paymentDate)) {
       $receiveDateTime = new DateTime($paymentDate);
+      /**
+       * The `payment_date` that Paypal sends back is in their timezone. Example return: 08:23:05 Jan 11, 2019 PST
+       * Subsequently, we need to account for that, otherwise the recieve time will be incorrect for the local system
+       */
       $systemTimeZone = new DateTimeZone(CRM_Core_Config::singleton()->userSystem->getTimeZoneString());
       $receiveDateTime->setTimezone($systemTimeZone);
       $input['receive_date'] = $receiveDateTime->format('YmdHis');


### PR DESCRIPTION
Overview
----------------------------------------
Convert `payment_date` received with the Paypal Standard IPN to the system's time zone

Before
----------------------------------------
Currently, `payment_date` is set to (presumably) the local time for Paypal (a Pacific time zone of `PST` or `PDT` is part of the timestamp). This leads to the wrong time being written to the database.

After
----------------------------------------
The timestamp is adjusted to the system's time zone.

Technical Details
----------------------------------------
Relatively straight forward fix.

Just build a `DateTimeZone` object for the system's TZ and convert the `$receiveDateTime` objecting using the `setTimezone` method.