### PR TITLE
CRM/Logging - Fix various bugs in schema parsing

### DIFF
--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -17,6 +17,8 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $schema->dropAllLogTables();
     CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_test_table");
     CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_test_column_info");
+    CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_test_length_change");
+    CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_test_enum_change");
   }
 
   public function queryExamples() {
@@ -129,6 +131,8 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
       test_id  int(10) unsigned NOT NULL AUTO_INCREMENT,
       test_varchar varchar(42) NOT NULL,
       test_integer int(8) NULL,
+      test_decimal decimal(20,2),
+      test_enum enum('A','B','C'),
       test_integer_default int(8) DEFAULT 42,
       test_date date DEFAULT NULL,
       PRIMARY KEY (`test_id`)
@@ -151,6 +155,13 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $this->assertEquals('8', $ci['test_integer']['LENGTH']);
     $this->assertEquals('YES', $ci['test_integer']['IS_NULLABLE']);
 
+    $this->assertEquals('decimal', $ci['test_decimal']['DATA_TYPE']);
+    $this->assertEquals('20,2', $ci['test_decimal']['LENGTH']);
+
+    $this->assertEquals('enum', $ci['test_enum']['DATA_TYPE']);
+    $this->assertEquals("'A','B','C'", $ci['test_enum']['ENUM_VALUES']);
+    $this->assertArrayNotHasKey('LENGTH', $ci['test_enum']);
+
     $this->assertEquals('42', $ci['test_integer_default']['COLUMN_DEFAULT']);
 
     $this->assertEquals('date', $ci['test_date']['DATA_TYPE']);
@@ -163,6 +174,63 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $this->assertContains('UI_external_identifier', $indexes);
     $this->assertContains('FK_civicrm_contact_employer_id', $indexes);
     $this->assertContains('index_sort_name', $indexes);
+  }
+
+  public function testLengthChange() {
+    CRM_Core_DAO::executeQuery("CREATE TABLE `civicrm_test_length_change` (
+      test_id int(10) unsigned NOT NULL AUTO_INCREMENT,
+      test_integer int(4) NULL,
+      test_decimal decimal(20,2) NULL,
+      PRIMARY KEY (`test_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci");
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+    CRM_Core_DAO::executeQuery(
+      "ALTER TABLE civicrm_test_length_change
+      CHANGE COLUMN test_integer test_integer int(6) NULL,
+      CHANGE COLUMN test_decimal test_decimal decimal(22,2) NULL"
+    );
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
+    $schema->fixSchemaDifferences();
+    // need to do it twice so the columnSpecs static is refreshed
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
+    $schema->fixSchemaDifferences();
+    $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
+    // length should increase
+    $this->assertEquals(6, $ci['log_civicrm_test_length_change']['test_integer']['LENGTH']);
+    $this->assertEquals('22,2', $ci['log_civicrm_test_length_change']['test_decimal']['LENGTH']);
+    CRM_Core_DAO::executeQuery(
+      "ALTER TABLE civicrm_test_length_change
+      CHANGE COLUMN test_integer test_integer int(4) NULL,
+      CHANGE COLUMN test_decimal test_decimal decimal(20,2) NULL"
+    );
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
+    $schema->fixSchemaDifferences();
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
+    $schema->fixSchemaDifferences();
+    $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
+    // length should not decrease
+    $this->assertEquals(6, $ci['log_civicrm_test_length_change']['test_integer']['LENGTH']);
+    $this->assertEquals('22,2', $ci['log_civicrm_test_length_change']['test_decimal']['LENGTH']);
+  }
+
+  public function testEnumChange() {
+    CRM_Core_DAO::executeQuery("CREATE TABLE `civicrm_test_enum_change` (
+      test_id int(10) unsigned NOT NULL AUTO_INCREMENT,
+      test_enum enum('A','B','C') NULL,
+      PRIMARY KEY (`test_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci");
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_enum_change CHANGE COLUMN test_enum test_enum enum('A','B','C','D') NULL");
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
+    $schema->fixSchemaDifferences();
+    // need to do it twice so the columnSpecs static is refreshed
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
+    $schema->fixSchemaDifferences();
+    $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
+    // new enum value should be included
+    $this->assertEquals("'A','B','C','D'", $ci['civicrm_test_enum_change']['test_enum']['ENUM_VALUES']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Logging_Schema` contains a number of helper methods for parsing table schemas. The results are then used to create or alter log tables.

Before
----------------------------------------
Some of these methods contain bugs that produce incorrect or incomplete results:

- `CRM_Logging_Schema::getIndexesForTable` only queries for constraints, not returning any indexes.
- `CRM_Logging_Schema::getIndexesForTable` returns an array in the form `[0 => ['constraint_name' => 'foo']]`, meaning lookups via `in_array` won't work.
- `CRM_Logging_Schema::columnSpecsOf` contains an off-by-one error and a wrongly used substr parameter causing column lengths to include surrounding parenthesis. This would result in a `varchar(42)`column returning a length of `(42)`.

After
----------------------------------------

- `CRM_Logging_Schema::getIndexesForTable` returns constraints as well as indexes.
- `CRM_Logging_Schema::getIndexesForTable` returns an array in the form of `['index1', 'index2', ...]`
- `CRM_Logging_Schema::columnSpecsOf` returns column lengths without surrounding parenthesis.