### PR TITLE
Fix unreleased regression on building GroupContact clause

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -774,60 +774,27 @@ SELECT g.*
  AND   g.is_active = 1
 ";
         $dao = CRM_Core_DAO::executeQuery($query);
-        $staticGroupIDs = array();
-        $cachedGroupIDs = array();
+        $groupIDs = [];
+        $groupContactCacheClause = FALSE;
         while ($dao->fetch()) {
-          // currently operation is restricted to VIEW/EDIT
-          if ($dao->where_clause) {
-            if ($dao->select_tables) {
-              $tmpTables = array();
-              foreach (unserialize($dao->select_tables) as $tmpName => $tmpInfo) {
-                if ($tmpName == '`civicrm_group_contact-' . $dao->id . '`') {
-                  $tmpName = '`civicrm_group_contact-ACL`';
-                  $tmpInfo = str_replace('civicrm_group_contact-' . $dao->id, 'civicrm_group_contact-ACL', $tmpInfo);
-                }
-                elseif ($tmpName == '`civicrm_group_contact_cache_' . $dao->id . '`') {
-                  $tmpName = '`civicrm_group_contact_cache-ACL`';
-                  $tmpInfo = str_replace('civicrm_group_contact_cache_' . $dao->id, 'civicrm_group_contact_cache-ACL', $tmpInfo);
-                }
-                $tmpTables[$tmpName] = $tmpInfo;
-              }
-              $tables = array_merge($tables,
-                $tmpTables
-              );
-            }
-            if ($dao->where_tables) {
-              $tmpTables = array();
-              foreach (unserialize($dao->where_tables) as $tmpName => $tmpInfo) {
-                if ($tmpName == '`civicrm_group_contact-' . $dao->id . '`') {
-                  $tmpName = '`civicrm_group_contact-ACL`';
-                  $tmpInfo = str_replace('civicrm_group_contact-' . $dao->id, 'civicrm_group_contact-ACL', $tmpInfo);
-                  $staticGroupIDs[] = $dao->id;
-                }
-                elseif ($tmpName == '`civicrm_group_contact_cache_' . $dao->id . '`') {
-                  $tmpName = '`civicrm_group_contact_cache-ACL`';
-                  $tmpInfo = str_replace('civicrm_group_contact_cache_' . $dao->id, 'civicrm_group_contact_cache-ACL', $tmpInfo);
-                  $cachedGroupIDs[] = $dao->id;
-                }
-                $tmpTables[$tmpName] = $tmpInfo;
-              }
-              $whereTables = array_merge($whereTables, $tmpTables);
-            }
-          }
+          $groupIDs[] = $dao->id;
 
           if (($dao->saved_search_id || $dao->children || $dao->parents) &&
             $dao->cache_date == NULL
           ) {
             CRM_Contact_BAO_GroupContactCache::load($dao);
+            $groupContactCacheClause = " UNION SELECT contact_id FROM civicrm_group_contact_cache WHERE group_id IN (" . implode(', ', $groupIDs) . ")";
           }
+
         }
 
-        if ($staticGroupIDs) {
-          $clauses[] = '( `civicrm_group_contact-ACL`.group_id IN (' . implode(', ', $staticGroupIDs) . ') AND `civicrm_group_contact-ACL`.status IN ("Added") )';
-        }
-
-        if ($cachedGroupIDs) {
-          $clauses[] = '`civicrm_group_contact_cache-ACL`.group_id IN (' . implode(', ', $cachedGroupIDs) . ')';
+        if ($groupIDs) {
+          $clauses[] = "(
+            `contact_a`.id IN (
+               SELECT contact_id FROM civicrm_group_contact WHERE group_id IN (" . implode(', ', $groupIDs) . ") AND status = 'Added'
+               $groupContactCacheClause
+             )
+          )";
         }
       }
     }

--- a/api/v3/Acl.php
+++ b/api/v3/Acl.php
@@ -44,6 +44,16 @@ function civicrm_api3_acl_create($params) {
 }
 
 /**
+ * Acl create metadata.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_acl_create_spec(&$params) {
+  $params['is_active']['api.default'] = 1;
+  $params['entity_table']['api.default'] = 'civicrm_acl_role';
+}
+
+/**
  * Get an Acl.
  *
  * @param array $params

--- a/api/v3/AclRole.php
+++ b/api/v3/AclRole.php
@@ -43,6 +43,16 @@ function civicrm_api3_acl_role_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'EntityRole');
 }
 
+
+/**
+ * AclRole create metadata.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_acl_role_create_spec(&$params) {
+  $params['is_active']['api.default'] = 1;
+}
+
 /**
  * Get an AclRole.
  *

--- a/tests/phpunit/CRMTraits/ACL/PermissionTrait.php
+++ b/tests/phpunit/CRMTraits/ACL/PermissionTrait.php
@@ -36,6 +36,13 @@ trait CRMTraits_ACL_PermissionTrait {
   protected $allowedContacts = [];
 
   /**
+   * Ids created for the scenario in use.
+   *
+   * @var array
+   */
+  protected $scenarioIDs = [];
+
+  /**
    * All results returned.
    *
    * @implements CRM_Utils_Hook::aclWhereClause
@@ -92,6 +99,61 @@ trait CRMTraits_ACL_PermissionTrait {
    */
   public function aclWhereOnlyOne($type, &$tables, &$whereTables, &$contactID, &$where) {
     $where = " contact_a.id = " . $this->allowedContactId;
+  }
+
+  /**
+   * Set up a core ACL.
+   *
+   * It is recommended that this helper function is accessed through a scenario function.
+   *
+   * @param array $permissionedEntities Array of groups for whom ACLs enable access.
+   * @param string|int $groupAllowedAccess Group permitted to access the permissioned Group
+   *   An ID of 0 means that 'Everyone' can access the group.
+   * @param string $operation View|Edit|Create|Delete|Search|All
+   * @param string $entity Group|CustomGroup|Profile|Event
+   *
+   * @throws CRM_Core_Exception
+   */
+  public function setupCoreACLPermittedToGroup($permissionedEntities = [], $groupAllowedAccess = 'Everyone', $operation = 'View', $entity = 'Group') {
+    $tableMap = ['Group' => 'civicrm_saved_search', 'CustomGroup' => 'civicrm_custom_group', 'Profile' => 'civicrm_uf_match', 'Event' => 'civicrm_event'];
+    $entityTable = $tableMap[$entity];
+
+    $permittedRoleID = ($groupAllowedAccess === 'Everyone') ? 0 : $groupAllowedAccess;
+    if ($permittedRoleID !== 0) {
+      throw new CRM_Core_Exception('only handling everyone group as yet');
+    }
+
+    foreach ($permissionedEntities as $permissionedEntityID) {
+      $this->callAPISuccess('Acl', 'create', [
+        'name' => uniqid(),
+        'operation' => $operation,
+        'entity_id' => $permittedRoleID,
+        'object_id' => $permissionedEntityID,
+        'object_table' => $entityTable,
+      ]);
+    }
+  }
+
+  /**
+   * Set up a scenario where everyone can access the permissioned group.
+   *
+   * A scenario in this class involves multiple defined assets. In this case we create
+   * - a group to which the everyone has permission
+   * - a contact in the group
+   * - a contact not in the group
+   *
+   * These are arrayed as follows
+   *   $this->scenarioIDs['Contact'] = ['permitted_contact' => x, 'non_permitted_contact' => y]
+   *   $this->scenarioIDs['Group'] = ['permitted_group' => x]
+   */
+  public function setupScenarioCoreACLEveryonePermittedToGroup() {
+    $this->quickCleanup(['civicrm_acl_cache', 'civicrm_acl_contact_cache']);
+    $this->scenarioIDs['Group']['permitted_group'] = $this->groupCreate();
+    $this->scenarioIDs['Contact']['permitted_contact'] = $this->individualCreate();
+    $result = $this->callAPISuccess('GroupContact', 'create', ['group_id' => $this->scenarioIDs['Group']['permitted_group'], 'contact_id' => $this->scenarioIDs['Contact']['permitted_contact'], 'status' => 'Added']);
+    $this->scenarioIDs['Contact']['non_permitted_contact'] = $this->individualCreate();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+    $this->setupCoreACLPermittedToGroup([$this->scenarioIDs['Group']['permitted_group']]);
   }
 
 }

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -664,4 +664,15 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     return $contacts;
   }
 
+  /**
+   * Test that the 'everyone' group can be given access to a contact.
+   */
+  public function testGetACLEveryonePermittedEntity() {
+    $this->setupScenarioCoreACLEveryonePermittedToGroup();
+    $this->callAPISuccess('Contact', 'getsingle', [
+      'id' => $this->scenarioIDs['Contact']['permitted_contact'],
+      'check_permissions' => 1,
+    ]);
+  }
+
 }

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -669,10 +669,15 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    */
   public function testGetACLEveryonePermittedEntity() {
     $this->setupScenarioCoreACLEveryonePermittedToGroup();
-    $this->callAPISuccess('Contact', 'getsingle', [
+    $this->callAPISuccessGetCount('Contact', [
       'id' => $this->scenarioIDs['Contact']['permitted_contact'],
       'check_permissions' => 1,
-    ]);
+    ], 1);
+
+    $this->callAPISuccessGetCount('Contact', [
+      'id' => $this->scenarioIDs['Contact']['non_permitted_contact'],
+      'check_permissions' => 1,
+    ], 0);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds a unit test & fixes an unreleased regression caused by https://github.com/civicrm/civicrm-core/pull/12344

Before
----------------------------------------
A fix to searching groups by not in caused acl users to not be able to see people in groups they can access.

After
----------------------------------------
Regression fixed & tested

Technical Details
----------------------------------------
There is a lot of complexity in the ACL::whereClause function to add smart group tables in but is also unecessary IMHO since we basically just need to know if the contacts are in the specified groups.  I don't have a good way to performance test this change but it is consistent with changes elsewhere that perform well. Unit test added

Comments
----------------------------------------

