### PR TITLE
Fix broken case activity date filter

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -48,8 +48,9 @@ class CRM_Activity_Page_AJAX {
       'status_id' => 'Integer',
       'activity_deleted' => 'Boolean',
       'activity_type_id' => 'Integer',
-      'activity_date_low' => 'Date',
-      'activity_date_high' => 'Date',
+      // "Date" validation fails because it expects only numbers with no hyphens
+      'activity_date_low' => 'Alphanumeric',
+      'activity_date_high' => 'Alphanumeric',
     );
 
     $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -483,9 +483,9 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $activityStatus = CRM_Core_PseudoConstant::activityStatus();
     $form->add('select', 'status_id', ts('Status'), array("" => ts(' - any status - ')) + $activityStatus, FALSE, array('id' => 'status_id_' . $form->_caseID));
 
-    // activity dates
-    $form->addDate('activity_date_low_' . $form->_caseID, ts('Activity Dates - From'), FALSE, array('formatType' => 'searchDate'));
-    $form->addDate('activity_date_high_' . $form->_caseID, ts('To'), FALSE, array('formatType' => 'searchDate'));
+    // activity date search filters
+    $form->add('datepicker', 'activity_date_low_' . $form->_caseID, ts('Activity Dates - From'), [], FALSE, ['time' => FALSE]);
+    $form->add('datepicker', 'activity_date_high_' . $form->_caseID, ts('To'), [], FALSE, ['time' => FALSE]);
 
     if (CRM_Core_Permission::check('administer CiviCRM')) {
       $form->add('checkbox', 'activity_deleted', ts('Deleted Activities'), '', FALSE, array('id' => 'activity_deleted_' . $form->_caseID));

--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -50,12 +50,12 @@
             <td class="crm-case-caseview-form-block-activity_date_low">
               {assign var=activitylow  value=activity_date_low_$caseID}
               {$form.$activitylow.label}<br />
-              {include file="CRM/common/jcalendar.tpl" elementName=$activitylow}
+              {$form.$activitylow.html}
             </td>
             <td class="crm-case-caseview-form-block-activity_date_high">
               {assign var=activityhigh  value=activity_date_high_$caseID}
               {$form.$activityhigh.label}<br />
-              {include file="CRM/common/jcalendar.tpl" elementName=$activityhigh}
+              {$form.$activityhigh.html}
             </td>
             <td class="crm-case-caseview-form-block-activity_type_filter_id">
               {$form.activity_type_filter_id.label}<br />


### PR DESCRIPTION
Overview
------
Fixes datatable error when trying to filter case activities by date from the Case Summary screen.

![casedate](https://user-images.githubusercontent.com/2874912/51129077-780d2880-17f7-11e9-83ac-3100c81fe6b8.png)

Before
-----
When selecting a "from" or "to" date in the activity filter, an error alert appears and no results are shown.

After
----
Date filters work correctly.

Notes
------
This removes 2 more deprecated jCalendar.tpl instances :)