### PR TITLE
Escape the header title & section title in reports to better support extensions

### DIFF
--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -40,12 +40,12 @@
                 {/if}
                 {if !$skip}
                    {if $header.colspan}
-                       <th colspan={$header.colspan}>{$header.title}</th>
+                       <th colspan={$header.colspan}>{$header.title|escape}</th>
                       {assign var=skip value=true}
                       {assign var=skipCount value=`$header.colspan`}
                       {assign var=skipMade  value=1}
                    {else}
-                       <th {$class}>{$header.title}</th>
+                       <th {$class}>{$header.title|escape}</th>
                    {assign var=skip value=false}
                    {/if}
                 {else} {* for skip case *}
@@ -93,7 +93,7 @@
                     {$l}/if{$r}
                     <tr class="crm-report-sectionHeader crm-report-sectionHeader-{$h}"><th colspan="{$columnCount}">
 
-                        <h{$h}>{$section.title}: {$l}$printValue|default:"<em>none</em>"{$r}
+                        <h{$h}>{$section.title|escape}: {$l}$printValue|default:"<em>none</em>"{$r}
                             ({$l}sectionTotal key=$row.{$column} depth={$smarty.foreach.sections.index}{$r})
                         </h{$h}>
                     </th></tr>


### PR DESCRIPTION
Overview
----------------------------------------
Adds escaping to the title in reports. This is not required for core reports at the moment as the titles are not user entered but it supports this functionality being added securely in extensions (notably extended reports)

Before
----------------------------------------
Titles output fine, escaping not applied

After
----------------------------------------
Titles output is unchanged but if they did contain xss it would not output - there are currently no places in core where xss can be added to the title fields but there will be in extensions soon

Technical Details
----------------------------------------
In extended reports I'm making it possible for column titles to be user edited. since they will represent user input it
makes sense to escape on output. I think core makes sense as the place to do this as it is best practice
to escape all output in the smarty layer and I have tested that it still works fine

Comments
----------------------------------------

