### PR TITLE
geocode job: Provide country_id to geocoders.

### DIFF
--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -158,6 +158,7 @@ class CRM_Utils_Address_BatchUpdate {
                a.street_address,
                a.city,
                a.postal_code,
+               a.country_id,
                s.name as state,
                o.name as country
     FROM       civicrm_contact  c
@@ -181,6 +182,7 @@ class CRM_Utils_Address_BatchUpdate {
         'city' => $dao->city,
         'state_province' => $dao->state,
         'country' => $dao->country,
+        'country_id' => $dao->country_id,
       );
 
       $addressParams = array();


### PR DESCRIPTION
Overview
----------------------------------------
The org.wikimedia.geocoder extension has an issue where it doesn't receive the expected country_id when executing via the batch geocode job.  See https://github.com/eileenmcnaughton/org.wikimedia.geocoder/pull/7    I think this would best be fixed upstream in Civi, rather than extensions having to lookup country ID.

Before
----------------------------------------
Geocoders receive country name, but not country_id.

After
----------------------------------------
Geocoders also receive country_id.