### PR TITLE
REF Remove undefined variable when creating note

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -379,9 +379,6 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       }
       else {
         $contactId = $contact->id;
-        if (isset($note['contact_id'])) {
-          $contactId = $note['contact_id'];
-        }
         //if logged in user, overwrite contactId
         if ($userID) {
           $contactId = $userID;


### PR DESCRIPTION
Overview
----------------------------------------
Just remove an if statement that can never be true

Before
----------------------------------------
The variable `$note` can never be defined when we get to the else so the code will never run.

After
----------------------------------------
Remove the code that will never run.

Technical Details
----------------------------------------

Comments
----------------------------------------
