### PR TITLE
WIP Don't create transactions without committing/rolling back

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -355,6 +355,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
    * @param $params
    */
   public function submit(&$params) {
+    $transaction = new CRM_Core_Transaction();
     $params['now'] = date("Ymd");
 
     // 1. call begin post process
@@ -425,6 +426,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     if ($this->_activityTypeFile) {
       $className::endPostProcess($this, $params);
     }
+    $transaction->commit();
 
     return $caseObj;
   }
@@ -433,8 +435,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    $transaction = new CRM_Core_Transaction();
-
     // check if dedupe button, if so return.
     $buttonName = $this->controller->getButtonName();
     if (isset($this->_dedupeButtonName) && $buttonName == $this->_dedupeButtonName) {


### PR DESCRIPTION
Overview
----------------------------------------
On a site making heavy use of ACLs and cases I'm seeing lot's of deadlocks on the `civicrm_group_contact_cache` and `civicrm_acl_contact_cache`.  This is a result of part of that investigation.

As far as I can see here, by calling `new CRM_Core_Transaction()` we are creating a new database transaction but then we are not committing or rolling back.  Some of the called functions create their own nested transactions (eg. `XX_BAO_XX::create()`) which are created and then committed/rolled back but this won't commit/rollback this, "the parent", transaction.

I'm not certain that this will resolve the deadlocks, but it certainly can't be helping as the transaction will cause tables to be locked until it has completed.

Before
----------------------------------------
More chance of deadlocks, transactions not committed/rolled back.

After
----------------------------------------
Less chance of deadlocks, transactions committed/rolled back.

Technical Details
----------------------------------------

Comments
----------------------------------------
I also found a similar instance of transaction created but not committed in `CRM/Campaign/Page/Petition/Confirm.php` but have not investigated further.

@eileenmcnaughton @seamuslee001 I feel that deadlocks are your area of expertise...  Do you have any thoughts on this PR?