### PR TITLE
Convert deprecated OptionGroup::getLabel to PseudoConstant::getLabel for cases

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -726,7 +726,7 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
             );
           }
         }
-        if (self::checkPermission($actId, 'edit', $case['activity_type_id'], $userID)) {
+        if (isset($case['activity_type_id']) && self::checkPermission($actId, 'edit', $case['activity_type_id'], $userID)) {
           $casesList[$key]['date'] .= sprintf('<a class="action-item crm-hover-button" href="%s" title="%s"><i class="crm-i fa-pencil"></i></a>',
             CRM_Utils_System::url('civicrm/case/activity', array('reset' => 1, 'cid' => $case['contact_id'], 'caseid' => $case['case_id'], 'action' => 'update', 'id' => $actId)),
             ts('Edit activity')

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -272,14 +272,17 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     $this->assign('urlPath', 'civicrm/case/activity');
 
     $encounterMediums = CRM_Case_PseudoConstant::encounterMedium();
+
     if ($this->_activityTypeFile == 'OpenCase' && $this->_action == CRM_Core_Action::UPDATE) {
       $this->getElement('activity_date_time')->freeze();
 
-      // Fixme: what's the justification for this? It seems like it is just re-adding an option in case it is the default and disabled.
-      // Is that really a big problem?
-      $this->_encounterMedium = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $this->_activityId, 'medium_id');
-      if (!array_key_exists($this->_encounterMedium, $encounterMediums)) {
-        $encounterMediums[$this->_encounterMedium] = CRM_Core_OptionGroup::getLabel('encounter_medium', $this->_encounterMedium, FALSE);
+      if ($this->_activityId) {
+        // Fixme: what's the justification for this? It seems like it is just re-adding an option in case it is the default and disabled.
+        // Is that really a big problem?
+        $this->_encounterMedium = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $this->_activityId, 'medium_id');
+        if (!array_key_exists($this->_encounterMedium, $encounterMediums)) {
+          $encounterMediums[$this->_encounterMedium] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'medium_id', $this->_encounterMedium);
+        }
       }
     }
 

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -105,10 +105,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
 
     foreach ($form->_defaultCaseStatus as $keydefault => $valdefault) {
       if (!array_key_exists($valdefault, $form->_caseStatus)) {
-        $form->_caseStatus[$valdefault] = CRM_Core_OptionGroup::getLabel('case_status',
-          $valdefault,
-          FALSE
-        );
+        $form->_caseStatus[$valdefault] = CRM_Core_PseudoConstant::getLabel('CRM_Case_BAO_Case', 'status_id', $valdefault);
       }
     }
     $element = $form->add('select', 'case_status_id', ts('Case Status'),

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -129,20 +129,9 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
       $case['subject'] = $dao->subject;
       $case['start_date'] = $dao->start_date;
       $case['end_date'] = $dao->end_date;
-      // FIXME: when we resolve if case_type_is single or multi-select
-      if (strpos($dao->case_type_id, CRM_Core_DAO::VALUE_SEPARATOR) !== FALSE) {
-        $caseTypeID = substr($dao->case_type_id, 1, -1);
-      }
-      else {
-        $caseTypeID = $dao->case_type_id;
-      }
-      $caseTypeIDs = explode(CRM_Core_DAO::VALUE_SEPARATOR,
-        $dao->case_type_id
-      );
-
       $case['caseType'] = CRM_Case_BAO_Case::getCaseType($caseID);
       $case['caseTypeName'] = CRM_Case_BAO_Case::getCaseType($caseID, 'name');
-      $case['status'] = CRM_Core_OptionGroup::getLabel('case_status', $dao->status_id, FALSE);
+      $case['status'] = CRM_Core_PseudoConstant::getLabel('CRM_Case_BAO_Case', 'status_id', $dao->status_id);
     }
     return $case;
   }
@@ -477,9 +466,7 @@ WHERE      a.id = %1
     if ($activityDAO->medium_id) {
       $activity['fields'][] = array(
         'label' => ts('Medium'),
-        'value' => CRM_Core_OptionGroup::getLabel('encounter_medium',
-          $activityDAO->medium_id, FALSE
-        ),
+        'value' => CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'medium_id', $activityDAO->medium_id),
         'type' => 'String',
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
Convert a deprecated function for cases

Before
----------------------------------------
Uses the deprecated `CRM_Core_OptionGroup::getLabel` function which logs a deprecated warning.

After
----------------------------------------
Use the replacement `CRM_Core_PseudoConstant::getLabel` function.

Technical Details
----------------------------------------
Default context for getLabel is "get" which means we get translated labels and disabled values.  So it matches previous behaviour.

Comments
----------------------------------------

