### PR TITLE
Fix trailing ampersands when empty array passed as query param

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -257,11 +257,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
     $queryParts = array();
 
-    // CRM_Core_Payment::getReturnSuccessUrl() passes $query as an array
-    if (isset($query) && is_array($query)) {
-      $query = implode($separator, $query);
-    }
-
     if (
       // not using clean URLs
       !$config->cleanURL
@@ -283,7 +278,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       if ($wpPageParam) {
         $queryParts[] = $wpPageParam;
       }
-      if (isset($query)) {
+      if (!empty($query)) {
         $queryParts[] = $query;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue](https://lab.civicrm.org/dev/core/issues/666) on Lab.

Additionally removes the incorrect parsing of any arrays passed as the `$query` param to `CRM_Utils_System_WordPress::url()`. The `$query` param should never be an array because this is handled by `CRM_Utils_System::url()` beforehand and `CRM_Utils_System_WordPress::url()` should never be called directly.

Before
----------------------------------------
Calling `CRM_Utils_System::url()` with params such as:

```php
$url = CRM_Utils_System::url(
  'civicrm/some/path',
  array(), // This is the `$query` param
  TRUE,
  NULL,
  FALSE,
  TRUE
);
```

results in a URL of the form:

```
https://[domain]/civicrm/?page=CiviCRM&q=civicrm%2Fsome%2Fpath&
```

After
----------------------------------------
URLs no longer have the trailing ampersand:

```
https://[domain]/civicrm/?page=CiviCRM&q=civicrm%2Fsome%2Fpath
```