### PR TITLE
Allow the Paypal IPN to work with Drupal 8

### DIFF
--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -48,6 +48,10 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
    * @return bool
    */
   public function check($str, $userId = NULL) {
+    if (!\Drupal::hasContainer()) {
+      return FALSE;
+    }
+
     $str = $this->translatePermission($str, 'Drupal', array(
       'view user account' => 'access user profiles',
     ));

--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -53,7 +53,7 @@ else {
 }
 try {
   //CRM-18245
-  if ($config->userFramework == 'Joomla') {
+  if (in_array($config->userFramework, array('Drupal8', 'Joomla'))) {
     CRM_Utils_System::loadBootStrap();
   }
   $paypalIPN->main();


### PR DESCRIPTION
Overview
----------------------------------------
Currently, the ipn.php script doesn't work on Drupal 8.

Before
----------------------------------------
PHP Fatal Error

After
----------------------------------------
Appears to work as expected :-)

Technical Details
----------------------------------------
The main issue is that Drupal isn't bootstrapped. However, that isn't totally enough, because there's a permission check that somehow manages to happen before the Drupal container can get set on the `\Drupal` static class. The permission check isn't useful anyway in this situation, and it would probably be nice in general if `CRM_Core_Permission_Drupal8::check()` wouldn't throw an exception when called when Drupal is not ready.

