### PR TITLE
setLocale: precaution for when setLocale is called on an unilingual site

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -667,9 +667,12 @@ class CRM_Core_I18n {
       $this->setPhpGettextLocale($locale);
     }
 
-    // for sql queries
+    // For sql queries, if running in DB multi-lingual mode.
     global $dbLocale;
-    $dbLocale = "_{$locale}";
+
+    if ($dbLocale) {
+      $dbLocale = "_{$locale}";
+    }
 
     // For self::getLocale()
     global $tsLocale;


### PR DESCRIPTION
Overview
----------------------------------------

This is a small tweak for a specific use-case:

- CiviCRM is running in a single language (i.e. not multi-lingual)
- The site is using an extension that uses `CRM_Core_I18n::setLocale()`, but not checking if the site is in multi-lingual (ex: cdntaxreceipts).

but it might also cover the use-case where a site uses the multi-gettext language option, but not multi-lingual database (ex: https://github.com/civicrm/civicrm-core/pull/13240).

Before
----------------------------------------

Calling `setLocale()` on a non-multilingual DB would cause subsequent SQL queries to fail, because the `dbLocale` suffix gets set, but the sql views do not exist.

After
----------------------------------------

DB queries do not fail.
