### PR TITLE
CRM-21832 - Recurring activities don't carry over custom data and tags

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -596,6 +596,14 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
       $object->find(TRUE);
 
       CRM_Core_BAO_RecurringEntity::quickAdd($object->id, $newObject->id, $entityTable);
+      CRM_Core_DAO::copyCustomFields($object->id, $newObject->id, $entityTable);
+      CRM_Core_DAO::copyGeneric('CRM_Core_DAO_EntityTag',
+        array(
+          'entity_id' => $object->id,
+          'entity_table' => $entityTable,
+        ),
+        array('entity_id' => $newObject->id)
+      );
     }
     return $newObject;
   }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -986,7 +986,8 @@ WHERE civicrm_event.is_active = 1
       array('entity_value' => $id, 'mapping_id' => $oldMapping->getId()),
       array('entity_value' => $copyEvent->id, 'mapping_id' => $copyMapping->getId())
     );
-    self::copyCustomFields($id, $copyEvent->id);
+
+    CRM_Core_DAO::copyCustomFields($id, $copyEvent->id, 'civicrm_event');
 
     $copyEvent->save();
 
@@ -994,57 +995,6 @@ WHERE civicrm_event.is_active = 1
     CRM_Utils_Hook::copy('Event', $copyEvent);
 
     return $copyEvent;
-  }
-
-  /**
-   * Method that copies custom fields values from an old event to a new one. Fixes bug CRM-19302,
-   * where if a custom field of File type was present, left both events using the same file,
-   * breaking download URL's for the old event.
-   *
-   * @param int $oldEventID
-   * @param int $newCopyID
-   */
-  public static function copyCustomFields($oldEventID, $newCopyID) {
-    // Obtain custom values for old event
-    $customParams = $htmlType = array();
-    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($oldEventID, 'Event');
-
-    // If custom values present, we copy them
-    if (!empty($customValues)) {
-      // Get Field ID's and identify File type attributes, to handle file copying.
-      $fieldIds = implode(', ', array_keys($customValues));
-      $sql = "SELECT id FROM civicrm_custom_field WHERE html_type = 'File' AND id IN ( {$fieldIds} )";
-      $result = CRM_Core_DAO::executeQuery($sql);
-
-      // Build array of File type fields
-      while ($result->fetch()) {
-        $htmlType[] = $result->id;
-      }
-
-      // Build params array of custom values
-      foreach ($customValues as $field => $value) {
-        if ($value !== NULL) {
-          // Handle File type attributes
-          if (in_array($field, $htmlType)) {
-            $fileValues = CRM_Core_BAO_File::path($value, $oldEventID);
-            $customParams["custom_{$field}_-1"] = array(
-              'name' => CRM_Utils_File::duplicate($fileValues[0]),
-              'type' => $fileValues[1],
-            );
-          }
-          // Handle other types
-          else {
-            $customParams["custom_{$field}_-1"] = $value;
-          }
-        }
-      }
-
-      // Save Custom Fields for new Event
-      CRM_Core_BAO_CustomValueTable::postProcess($customParams, 'civicrm_event', $newCopyID, 'Event');
-    }
-
-    // copy activity attachments ( if any )
-    CRM_Core_BAO_File::copyEntityFile('civicrm_event', $oldEventID, 'civicrm_event', $newCopyID);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This PR is extension to PR https://github.com/civicrm/civicrm-core/pull/11778 It adds Unit test to validate the recurring activity gets generated with custom data and tags of main activity.

Recurring activities don't carry over custom data and tags

Before
----------------------------------------
custom fields and tags on activity are not carried over the repeat activity.

After
----------------------------------------
custom fields and tags on activity are carried over all the repeat activity.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-890_
