### PR TITLE
C51-384: Added case tokens on Email Activity Modal

### DIFF
--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -164,6 +164,13 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
    */
   public function listTokens() {
     $tokens = CRM_Core_SelectValues::contactTokens();
+
+    if (isset($this->_caseId) || isset($this->_caseIds)) {
+      // For a single case, list tokens relevant for only that case type
+      $caseTypeId = isset($this->_caseId) ? CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $this->_caseId, 'case_type_id') : NULL;
+      $tokens += CRM_Core_SelectValues::caseTokens($caseTypeId);
+    }
+
     return $tokens;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
As part of this PR, "Case" tokens has been added to the Email Activity Modal.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/5058867/51239771-3966a200-19a0-11e9-9637-ae43d541e36b.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/5058867/51239726-2358e180-19a0-11e9-8dba-4d10f9dcb00f.gif)

Technical Details
----------------------------------------
In `CRM/Contact/Form/Task/Email.php`, added a block of code to add the Case Tokens when `caseId` is present.
The added code is similar to https://github.com/civicrm/civicrm-core/blob/b8ebe34c530297a2c8b6a7380ac204c6153ff74c/CRM/Contact/Form/Task/PDF.php#L124
