### PR TITLE
Fix incorrect display of Line Items created via API when printing invoice (for Participants)

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -301,13 +301,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       $invoiceDate = date("F j, Y");
       $dueDate = date('F j, Y', strtotime($contributionReceiveDate . "+" . $prefixValue['due_date'] . "" . $prefixValue['due_date_period']));
 
-      if ($input['component'] == 'contribute') {
-        $lineItem = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contribID);
-      }
-      else {
-        $eid = $contribution->_relatedObjects['participant']->id;
-        $lineItem = CRM_Price_BAO_LineItem::getLineItems($eid, 'participant', NULL, TRUE, FALSE, TRUE);
-      }
+      $lineItem = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contribID);
 
       $resultPayments = civicrm_api3('Payment', 'get', [
         'sequential' => 1,

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -94,4 +94,86 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * PR 13477 - Fix incorrect display of Line Items created via API
+   * when printing invoice (for Participants).
+   */
+  public function testInvoiceForLineItems() {
+
+    $this->enableTaxAndInvoicing();
+
+    $event = $this->eventCreatePaid([]);
+
+    $individualOneId = $this->individualCreate();
+    $individualTwoId = $this->individualCreate();
+    $contactIds = [$individualOneId, $individualTwoId];
+
+    $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $event['id']);
+    $priceField = $this->callAPISuccess('PriceField', 'get', ['price_set_id' => $priceSetId]);
+    $priceFieldValues = $this->callAPISuccess('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'price_field_id' => $priceField['id'],
+    ]);
+
+    $lineItemParams = [];
+    foreach ($priceFieldValues['values'] as $key => $priceFieldValue) {
+      $lineItemParams[] = [
+        'line_item' => [
+          $priceFieldValue['id'] => [
+            'price_field_id' => $priceField['id'],
+            'label' => $priceFieldValue['label'],
+            'financial_type_id' => $priceFieldValue['financial_type_id'],
+            'price_field_value_id' => $priceFieldValue['id'],
+            'qty' => 1,
+            'field_title' => $priceFieldValue['label'],
+            'unit_price' => $priceFieldValue['amount'],
+            'line_total' => $priceFieldValue['amount'],
+            'entity_table' => 'civicrm_participant',
+          ],
+        ],
+        // participant params
+        'params' => [
+          'contact_id' => $contactIds[$key],
+          'event_id' => $event['id'],
+          'status_id' => 1,
+          'price_set_id' => $priceSetId,
+          'participant_fee_amount' => $priceFieldValue['amount'],
+          'participant_fee_level' => $priceFieldValue['label'],
+        ],
+      ];
+    }
+
+    $orderParams = [
+      'contact_id' => $individualOneId,
+      'total_amount' => array_reduce($priceFieldValues['values'], function($total, $priceFieldValue) {
+        $total += $priceFieldValue['amount'];
+        return $total;
+      }),
+      'financial_type_id' => $priceFieldValues['values'][0]['financial_type_id'],
+      'contribution_status_id' => 'Completed',
+      'currency' => 'USD',
+      'line_items' => $lineItemParams,
+    ];
+
+    $order = $this->callAPISuccess('Order', 'create', $orderParams);
+
+    $pdfParams = [
+      'output' => 'pdf_invoice',
+      'forPage' => 1,
+    ];
+
+    $invoiceHTML = CRM_Contribute_Form_Task_Invoice::printPDF([$order['id']], $pdfParams, [$individualOneId]);
+
+    $lineItems = $this->callAPISuccess('LineItem', 'get', ['contribution_id' => $order['id']]);
+
+    foreach ($lineItems['values'] as $lineItem) {
+      $this->assertContains("<font size = \"1\">$ {$lineItem['line_total']}</font>", $invoiceHTML);
+    }
+
+    $totalAmount = $this->formatMoneyInput($order['values'][$order['id']]['total_amount']);
+    $this->assertContains("TOTAL USD</font></b></td>
+                <td style = \"padding-left:34px;text-align:right;\"><font size = \"1\">$ $totalAmount</font>", $invoiceHTML);
+
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Invoices display incorrect Line Items for Participant registration when creating a contribution via `Contribution.create` (with `skipLineItems => true`) and creating the Line Items via `LineItem.create` afterwards. The same applies creating the contribution using the `Order.create`, This _technique_ is common and used in modules like Webform CiviCRM or Caldera Forms CiviCRM integrations.

Before
----------------------------------------
Invoice display incorrect Line Items
![incorrect_display](https://user-images.githubusercontent.com/3038096/51283722-055fa100-19e1-11e9-9643-871b5520593c.png)


After
----------------------------------------
![correct_display](https://user-images.githubusercontent.com/3038096/51283734-0db7dc00-19e1-11e9-85d5-240064623358.png)


Technical Details
----------------------------------------
An example of API calls to reproduce:

``` php
// create participants
  $participantOne = civicrm_api3( 'Participant', 'create', [
    'contact_id' => 203,
    'event_id' => 3,
    'role_id' => 1,
    'status_id' => 'Registerd',
    'source' => 'Source',
    'fee_level' => 'Option 1',
    ...
  ] );

  $participantTwo = civicrm_api3( 'Participant', 'create', [
    'contact_id' => 207,
    'event_id' => 3,
    'role_id' => 1,
    'status_id' => 'Registerd',
    'source' => 'Source',
    'fee_level' => 'Option 2',
    ...
  ] );

  // create contribution
  $contribution = civicrm_api3( 'Contribution', 'create', [
    'total_amount' => 24.00,
    'tax_amount' => 4.00,
    'financial_type_id' => 4,
    'contribution_status_id' => 'Completed',
    'payment_instrument_id' => 4,
    'currency' => 'GBP',
    'source' => 'Source',
    'contact_id' => 203,
    'skipLineItem' => 1
    ...
  ] );

  // create line items
  $lineItemOne = civicrm_api3( 'LineItem', 'create', [
    'price_field_id' => 47,
    'label' => 'Option 1',
    'financial_type_id' => 4,
    'non_deductible_amount' => 0.00,
    'price_field_value_id' => 77,
    'tax_rate' => 20.00,
    'tax_amount' => 2.00,
    'qty' => 1,
    'field_title' => 'Event 1',
    'unit_price' => 10.00,
    'line_total' => 10.00,
    'entity_table' => 'civicrm_participant',
    'entity_id' => $participantOne['id'],
    'contribution_id' => $contribution['id']
  ] );

  $lineItemTwo = civicrm_api3( 'LineItem', 'create', [
    'price_field_id' => 48,
    'label' => 'Option 2',
    'financial_type_id' => 4,
    'non_deductible_amount' => 0.00,
    'price_field_value_id' => 77,
    'tax_rate' => 20.00,
    'tax_amount' => 2.00,
    'qty' => 1,
    'field_title' => 'Event 1',
    'unit_price' => 10.00,
    'line_total' => 10.00,
    'entity_table' => 'civicrm_participant',
    'entity_id' => $participantTwo['id'],
    'contribution_id' => $contribution['id']
  ] );

  // create participant payment
  $participantPayment = civicrm_api3( 'ParticipantPayment', 'create', [
    'participant_id' => $participantOne['id'],
    'contribution_id' => $contribution['id']
  ] );
  ...
  // etc
```
