### PR TITLE
removed unwanted parameter from getLineItems()

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -178,7 +178,7 @@ WHERE li.contribution_id = %1";
    * @return array
    */
   public static function getLineItemsByContributionID($contributionID) {
-    return self::getLineItems($contributionID, 'contribution', NULL, TRUE, TRUE, " WHERE contribution_id = " . (int) $contributionID);
+    return self::getLineItems($contributionID, 'contribution', NULL, TRUE, TRUE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
getLineItems() function params was changed at https://github.com/civicrm/civicrm-core/commit/77dbdcbc288#diff-e57ed384488b5985e5a0a5c166a6b0f0R199 but was missed to update [getLineItemsByContributionID()](https://github.com/civicrm/civicrm-core/blob/77dbdcbc2882e4d789e47fe2c9226377a208344c/CRM/Price/BAO/LineItem.php#L178) function

