### PR TITLE
dev/core/issues/506, Fatal error on advance search when using cases from display results as

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -329,12 +329,16 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
   public static function getModeSelect() {
     self::setModeValues();
 
+    $enabledComponents = CRM_Core_Component::getEnabledComponents();
     $componentModes = array();
     foreach (self::$_modeValues as $id => & $value) {
+      if (strpos($value['component'], 'Civi') !== FALSE
+        && !array_key_exists($value['component'], $enabledComponents)
+      ) {
+        continue;
+      }
       $componentModes[$id] = $value['selectorLabel'];
     }
-
-    $enabledComponents = CRM_Core_Component::getEnabledComponents();
 
     // unset disabled components
     if (!array_key_exists('CiviMail', $enabledComponents)) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/506

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/51288859-e7e90200-19f5-11e9-9072-6b385978fc77.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/51288882-f46d5a80-19f5-11e9-8e82-8c3520c253ea.gif)

Comments
------------------------------------------
Don't display Components when they are not enabled.

