### PR TITLE
Add main nav icon for CiviCRM (Backdrop)

### DIFF
--- a/css/backdrop.css
+++ b/css/backdrop.css
@@ -28,3 +28,9 @@
     padding: .5rem;
   }
 }
+
+/* Backdrop main navigation icon */
+#admin-bar #admin-bar-menu > li > .dropdown > li > a.civicrm {
+  background: transparent url(../i/logo_sm.png) 5% center no-repeat;
+  background-size: 16px;
+}


### PR DESCRIPTION
(since Backdrop core now has main nav icons)

Overview
----------------------------------------
_Backdrop core added nav icons in 1.12 and added a class (based on the path) to all main nav items –`civicrm` has a class but no icon._

Before
----------------------------------------
![screen shot 2019-01-16 at 11 52 45 pm](https://user-images.githubusercontent.com/871421/51298517-735c9600-19ea-11e9-9ca2-86941e3498ed.jpg)


After
----------------------------------------
![screen shot 2019-01-16 at 11 52 25 pm](https://user-images.githubusercontent.com/871421/51298521-78214a00-19ea-11e9-9bbe-bb0b6d188c43.jpg)


Technical Details
----------------------------------------
_Added styling based on https://github.com/backdrop/backdrop-issues/issues/1841 using an existing icon image that is used in the CiviCRM admin menu._

Comments
----------------------------------------
_I might have used a white logo to match the other admin icons but that may go against [brand usage policy](https://civicrm.org/trademark) and would have required an additional file to be added._
