### PR TITLE
dev/core#673 - Add filter for deleted contacts on Repeat Contributions Report

### DIFF
--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -134,6 +134,11 @@ class CRM_Report_Form_Contribute_Repeat extends CRM_Report_Form {
             'name' => 'percentage_change',
             'dbAlias' => '( ( contribution_civireport2.total_amount_sum - contribution_civireport1.total_amount_sum ) * 100 / contribution_civireport1.total_amount_sum )',
           ),
+          'is_deleted' => array(
+             'title' => ts('Is Deleted'),
+             'default' => 0,
+             'type' => CRM_Utils_Type::T_BOOLEAN,
+          ),
         ),
         'group_bys' => array(
           'id' => array(

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -135,9 +135,9 @@ class CRM_Report_Form_Contribute_Repeat extends CRM_Report_Form {
             'dbAlias' => '( ( contribution_civireport2.total_amount_sum - contribution_civireport1.total_amount_sum ) * 100 / contribution_civireport1.total_amount_sum )',
           ),
           'is_deleted' => array(
-             'title' => ts('Is Deleted'),
-             'default' => 0,
-             'type' => CRM_Utils_Type::T_BOOLEAN,
+            'title' => ts('Is Deleted'),
+            'default' => 0,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
           ),
         ),
         'group_bys' => array(


### PR DESCRIPTION
Overview
----------------------------------------
Add a filter for deleted contacts on Repeat Contribution Report set for show only non deleted contacts as default.

Technical Details
----------------------------------------
Contributions of deleted contacts will no longer be shown.
