### PR TITLE
dev/core#561 - Convert grant task form to datepicker

### DIFF
--- a/CRM/Grant/Form/Task/Update.php
+++ b/CRM/Grant/Form/Task/Update.php
@@ -67,7 +67,7 @@ class CRM_Grant_Form_Task_Update extends CRM_Grant_Form_Task {
     $this->addElement('text', 'amount_granted', ts('Amount Granted'));
     $this->addRule('amount_granted', ts('Please enter a valid amount.'), 'money');
 
-    $this->addDate('decision_date', ts('Grant Decision'), FALSE, array('formatType' => 'custom'));
+    $this->add('datepicker', 'decision_date', ts('Grant Decision'), [], FALSE, ['time' => FALSE]);
 
     $this->assign('elements', array('status_id', 'amount_granted', 'decision_date'));
     $this->assign('totalSelectedGrants', count($this->_grantIds));

--- a/templates/CRM/Grant/Form/Task/Update.tpl
+++ b/templates/CRM/Grant/Form/Task/Update.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* Update Grants *}
+{* Update Grants Via Search Actions *}
 <div class="crm-block crm-form-block crm-grants-update-form-block">
     <p>{ts}Enter values for the fields you wish to update. Leave fields blank to preserve existing values.{/ts}</p>
     <table class="form-layout-compressed">
@@ -31,15 +31,10 @@
         {foreach from=$elements item=element}
             <tr class="crm-contact-custom-search-form-row-{$element}">
                 <td class="label">{$form.$element.label}</td>
-                {if $element eq 'decision_date'}
-                    <td>{include file="CRM/common/jcalendar.tpl" elementName=decision_date}<br />
-                    <span class="description">{ts}Date on which the grant decision was finalized.{/ts}</span></td>
-                {else}
-                    <td>{$form.$element.html}</td>
-                {/if}
+                <td>{$form.$element.html}</td>
             </tr>
         {/foreach}
     </table>
     <p>{ts 1=$totalSelectedGrants}Number of selected grants: %1{/ts}</p>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-</div><!-- /.crm-form-block -->
+</div>


### PR DESCRIPTION
Summary
-----
Changes one form element to datepicker widget. This is a really simple change as the field doesn't require any preprocesing (the form element never has a default value) or postprocessing (the value is simply passed through `strtotime` which works with either format).

Steps to test
-------
1. Create a grant
2. Go to **Grants -> Find Grants**
3. Select "Update Grants" from the search results Action Menu dropdown
4. Enter a value in the datepicker and save.