### PR TITLE
dev/core#670 - Fix Saving of Case Activity tags

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -1066,9 +1066,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       if (!is_array($params['tag'])) {
         $params['tag'] = explode(',', $params['tag']);
       }
-      foreach ($params['tag'] as $tag) {
-        $tagParams[$tag] = 1;
-      }
+
+      $tagParams = array_fill_keys($params['tag'], 1);
     }
 
     // Save static tags.

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -543,9 +543,11 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         // add tags if exists
         $tagParams = array();
         if (!empty($params['tag'])) {
-          foreach ($params['tag'] as $tag) {
-            $tagParams[$tag] = 1;
+          if (!is_array($params['tag'])) {
+            $params['tag'] = explode(',', $params['tag']);
           }
+
+          $tagParams = array_fill_keys($params['tag'], 1);
         }
 
         //save static tags


### PR DESCRIPTION
Overview
----------------------------------------
When editing an Activity for cases, the selected `tags` are not saved.
This PR fixes the bug.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/5058867/51369913-4b208480-1b1b-11e9-8adc-d55bc3fce52f.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/5058867/51369965-77d49c00-1b1b-11e9-856f-d32005aa26c8.gif)

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/blob/3bf2661bd263d718e867ad5170965d1bcb110df6/CRM/Case/Form/Activity.php#L546 it is assumed that `$params['tag']` is an array, but actually is a comma separated string.

But in the parent class `CRM_Activity_Form_Activity`, this feature works because of the code https://github.com/civicrm/civicrm-core/blob/43076c76f4724d0f42ceb03b46acfbce2c751233/CRM/Activity/Form/Activity.php#L1066, which converts the string to an Array.

So similar code needs to be implemented in `CRM_Case_Form_Activity`. 
```php
if (!empty($params['tag'])) {
  if (!is_array($params['tag'])) {
    $params['tag'] = explode(',', $params['tag']);
  }
  foreach ($params['tag'] as $tag) {
    $tagParams[$tag] = 1;
  }
}
```

Also the following code has been refactored to use  `array_fill_keys`.
```
foreach ($params['tag'] as $tag) {
  $tagParams[$tag] = 1;
}
```