### PR TITLE
(dev/core#285) Fixed second membership reminder

### DIFF
--- a/CRM/Contribute/ActionMapping/ByPage.php
+++ b/CRM/Contribute/ActionMapping/ByPage.php
@@ -220,4 +220,16 @@ class CRM_Contribute_ActionMapping_ByPage implements \Civi\ActionSchedule\Mappin
     return $query;
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * reset the reminder state if the trigger date changes.
+   *
+   * @return bool
+   *
+   * @param \CRM_Core_DAO_ActionSchedule $schedule
+   */
+  public function resetOnTriggerDateChange($schedule) {
+    return FALSE;
+  }
+
 }

--- a/CRM/Contribute/ActionMapping/ByType.php
+++ b/CRM/Contribute/ActionMapping/ByType.php
@@ -239,4 +239,16 @@ class CRM_Contribute_ActionMapping_ByType implements \Civi\ActionSchedule\Mappin
     return $query;
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * reset the reminder state if the trigger date changes.
+   *
+   * @return bool
+   *
+   * @param \CRM_Core_DAO_ActionSchedule $schedule
+   */
+  public function resetOnTriggerDateChange($schedule) {
+    return FALSE;
+  }
+
 }

--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -158,7 +158,7 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
     $query['casContactTableAlias'] = NULL;
     $query['casDateField'] = str_replace('event_', 'r.', $schedule->start_action_date);
     if (empty($query['casDateField']) && $schedule->absolute_date) {
-      $query['casDateField'] = $schedule->absolute_date;
+      $query['casDateField'] = "'" . CRM_Utils_Type::escape($schedule->absolute_date, 'String') . "'";
     }
 
     $query->join('r', 'INNER JOIN civicrm_event r ON e.event_id = r.id');

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -145,11 +145,6 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
     $query->where("e.status_id IN (#memberStatus)")
       ->param('memberStatus', \CRM_Member_PseudoConstant::membershipStatus(NULL, "(is_current_member = 1 OR name = 'Expired')", 'id'));
 
-    // Why is this only for civicrm_membership?
-    if ($schedule->start_action_date && $schedule->is_repeat == FALSE) {
-      $query['casUseReferenceDate'] = TRUE;
-    }
-
     return $query;
   }
 
@@ -170,6 +165,23 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
       ->join(NULL, $joins)
       ->param('#editPerm', CRM_Contact_BAO_Relationship::EDIT)
       ->where('!( e.owner_membership_id IS NOT NULL AND rela.id IS NULL and relb.id IS NULL )');
+  }
+
+  /**
+   * Determine whether a schedule based on this mapping should
+   * reset the reminder state if the trigger date changes.
+   *
+   * @return bool
+   *
+   * @param \CRM_Core_DAO_ActionSchedule $schedule
+   */
+  public function resetOnTriggerDateChange($schedule) {
+    if ($schedule->absolute_date !== NULL) {
+      return FALSE;
+    }
+    else {
+      return TRUE;
+    }
   }
 
 }

--- a/CRM/Upgrade/Incremental/sql/5.14.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.14.alpha1.mysql.tpl
@@ -1,1 +1,2 @@
 {* file to handle db changes in 5.14.alpha1 during upgrade *}
+ALTER TABLE civicrm_action_log CHANGE COLUMN reference_date reference_date datetime;

--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -341,4 +341,16 @@ abstract class Mapping implements MappingInterface {
    */
   abstract public function createQuery($schedule, $phase, $defaultParams);
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * reset the reminder state if the trigger date changes.
+   *
+   * @return bool
+   *
+   * @param \CRM_Core_DAO_ActionSchedule $schedule
+   */
+  public function resetOnTriggerDateChange($schedule) {
+    return FALSE;
+  }
+
 }

--- a/Civi/ActionSchedule/MappingInterface.php
+++ b/Civi/ActionSchedule/MappingInterface.php
@@ -145,4 +145,14 @@ interface MappingInterface {
    */
   public function createQuery($schedule, $phase, $defaultParams);
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * reset the reminder state if the trigger date changes.
+   *
+   * @return bool
+   *
+   * @param \CRM_Core_DAO_ActionSchedule $schedule
+   */
+  public function resetOnTriggerDateChange($schedule);
+
 }

--- a/xml/schema/Core/ActionLog.xml
+++ b/xml/schema/Core/ActionLog.xml
@@ -99,9 +99,10 @@
   <field>
     <name>reference_date</name>
     <title>Reference Date</title>
-    <type>date</type>
+    <type>datetime</type>
     <default>NULL</default>
     <comment>Stores the date from the entity which triggered this reminder action (e.g. membership.end_date for most membership renewal reminders)</comment>
     <add>4.6</add>
+    <change>5.14</change>
   </field>
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
With this change if you setup a reminder based on membership end date, the reminder will go out again if the membership is renewed and has a new end date.

Before
----------------------------------------
If you setup a scheduled reminder for memberships based on end date. It would send the first reminder, but if the user renewed their membership it wouldn't send out another reminder when the condition became true for the new end date.

After
----------------------------------------
Now it sends out a second reminder when the condition becomes true for the renewed membership. 


Technical Details
----------------------------------------
I made the civicrm_activity_log.reference_date field a date time instead of just a date. This lets us always store the datetime that was used for the condition check. That way if the datetime changes (like the membership end date), we now know the condition needs to be checked again.

https://lab.civicrm.org/dev/core/issues/285