### PR TITLE
Allow help text to be overridden from an .extra.hlp file

### DIFF
--- a/CRM/Core/Page/Inline/Help.php
+++ b/CRM/Core/Page/Inline/Help.php
@@ -49,14 +49,19 @@ class CRM_Core_Page_Inline_Help {
       }
       $smarty->assign('params', $args);
 
+      $output = $smarty->fetch($file);
       $extraoutput = '';
       if ($smarty->template_exists($additionalTPLFile)) {
         //@todo hook has been put here as a conservative approach
         // but probably should always run. It doesn't run otherwise because of the exit
         CRM_Utils_Hook::pageRun($this);
         $extraoutput .= trim($smarty->fetch($additionalTPLFile));
+        // Allow override param to replace default text e.g. {hlp id='foo' override=1}
+        if ($smarty->get_template_vars('override_help_text')) {
+          $output = '';
+        }
       }
-      exit($smarty->fetch($file) . $extraoutput);
+      exit($output . $extraoutput);
     }
   }
 

--- a/CRM/Core/Page/Inline/Help.php
+++ b/CRM/Core/Page/Inline/Help.php
@@ -52,9 +52,6 @@ class CRM_Core_Page_Inline_Help {
       $output = $smarty->fetch($file);
       $extraoutput = '';
       if ($smarty->template_exists($additionalTPLFile)) {
-        //@todo hook has been put here as a conservative approach
-        // but probably should always run. It doesn't run otherwise because of the exit
-        CRM_Utils_Hook::pageRun($this);
         $extraoutput .= trim($smarty->fetch($additionalTPLFile));
         // Allow override param to replace default text e.g. {hlp id='foo' override=1}
         if ($smarty->get_template_vars('override_help_text')) {

--- a/CRM/Core/Smarty/plugins/block.htxt.php
+++ b/CRM/Core/Smarty/plugins/block.htxt.php
@@ -48,8 +48,8 @@
  *   the string, translated by gettext
  */
 function smarty_block_htxt($params, $text, &$smarty) {
-  $id = $params['id'];
-  if ($id == $smarty->_tpl_vars['id']) {
+  if ($params['id'] == $smarty->_tpl_vars['id']) {
+    $smarty->assign('override_help_text', !empty($params['override']));
     return $text;
   }
   else {


### PR DESCRIPTION
Overview
---------
Help text is written in `.hlp` smarty files. You can append to the text by adding your own `.extra.hlp` file with the same name. This allows you to also override it.

**NOTE** the pageRun hook is removed from CRM_Core_Page_Inline_Help in this PR. Per discussion  - see https://github.com/civicrm/civicrm-core/pull/13488#issuecomment-456129172

Before
------
`.extra.hlp` files could append but not override help text.

After
-------
`.extra.hlp` files can be set to override on a per-item basis.

How-to
-------
1. Create an extension (and enable it)
2. Add a file: `templates/CRM/Activity/Form/Activity.extra.hlp`
3. Add this to the file:

        {htxt id="assignee_contact_id" override=1}
          <p>I'm extra!</p>
        {/htxt}

4. Go to the "new activity" screen and click the help icon for "Assigned to"
5. Note that the default help text is gone and only the text "I'm extra!" prints.
6. If you remove the `overrride=1` param, both the default help text and the new text appear, which was the previous behavior.