### PR TITLE
(dev/core#635) Deprecate CRM_Core_BAO_Cache for I/O. Optionally redirect I/O to Redis or Memcache.

### DIFF
--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -67,7 +67,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function &getItem($group, $path, $componentID = NULL) {
-    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+    if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       return $adapter::getItem($group, $path, $componentID);
     }
 
@@ -109,7 +109,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function &getItems($group, $componentID = NULL) {
-    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+    if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       return $adapter::getItems($group, $componentID);
     }
 
@@ -155,7 +155,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function setItem(&$data, $group, $path, $componentID = NULL) {
-    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+    if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       return $adapter::setItem($data, $group, $path, $componentID);
     }
 
@@ -227,7 +227,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function deleteGroup($group = NULL, $path = NULL, $clearAll = TRUE) {
-    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+    if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       return $adapter::deleteGroup($group, $path);
     }
     else {

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -64,6 +64,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    *
    * @return object
    *   The data if present in cache, else null
+   * @deprecated
    */
   public static function &getItem($group, $path, $componentID = NULL) {
     if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
@@ -105,6 +106,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    *
    * @return object
    *   The data if present in cache, else null
+   * @deprecated
    */
   public static function &getItems($group, $componentID = NULL) {
     if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
@@ -150,6 +152,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    *   (required) The path under which this item is stored.
    * @param int $componentID
    *   The optional component ID (so componenets can share the same name space).
+   * @deprecated
    */
   public static function setItem(&$data, $group, $path, $componentID = NULL) {
     if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
@@ -221,6 +224,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @param string $path
    *   Path of the item that needs to be deleted.
    * @param bool $clearAll clear all caches
+   * @deprecated
    */
   public static function deleteGroup($group = NULL, $path = NULL, $clearAll = TRUE) {
     if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -68,7 +68,8 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    */
   public static function &getItem($group, $path, $componentID = NULL) {
     if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
-      return $adapter::getItem($group, $path, $componentID);
+      $value = $adapter::getItem($group, $path, $componentID);
+      return $value;
     }
 
     if (self::$_cache === NULL) {

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -66,6 +66,10 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    *   The data if present in cache, else null
    */
   public static function &getItem($group, $path, $componentID = NULL) {
+    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+      return $adapter::getItem($group, $path, $componentID);
+    }
+
     if (self::$_cache === NULL) {
       self::$_cache = array();
     }
@@ -103,6 +107,10 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    *   The data if present in cache, else null
    */
   public static function &getItems($group, $componentID = NULL) {
+    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+      return $adapter::getItems($group, $componentID);
+    }
+
     if (self::$_cache === NULL) {
       self::$_cache = array();
     }
@@ -144,6 +152,10 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    *   The optional component ID (so componenets can share the same name space).
    */
   public static function setItem(&$data, $group, $path, $componentID = NULL) {
+    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+      return $adapter::setItem($data, $group, $path, $componentID);
+    }
+
     if (self::$_cache === NULL) {
       self::$_cache = array();
     }
@@ -211,9 +223,14 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @param bool $clearAll clear all caches
    */
   public static function deleteGroup($group = NULL, $path = NULL, $clearAll = TRUE) {
-    $table = self::getTableName();
-    $where = self::whereCache($group, $path, NULL);
-    CRM_Core_DAO::executeQuery("DELETE FROM $table WHERE $where");
+    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+      return $adapter::deleteGroup($group, $path);
+    }
+    else {
+      $table = self::getTableName();
+      $where = self::whereCache($group, $path, NULL);
+      CRM_Core_DAO::executeQuery("DELETE FROM $table WHERE $where");
+    }
 
     if ($clearAll) {
       // also reset ACL Cache

--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Core_BAO_Cache_Psr16
+ *
+ * This optional adapter to help phase-out CRM_Core_BAO_Cache.
+ *
+ * In effect, it changes the default behavior of legacy cache-consumers
+ * (CRM_Core_BAO_Cache) so that they store in the best-available tier
+ * (Reds/Memcache or SQL or array) rather than being hard-coded to SQL.
+ *
+ * It basically just calls "CRM_Utils_Cache::create()" for each $group and
+ * maps the getItem/setItem to get()/set().
+ */
+class CRM_Core_BAO_Cache_Psr16 {
+
+  /**
+   * Original BAO behavior did not do expiration. PSR-16 providers have
+   * diverse defaults. To provide some consistency, we'll pick a long(ish)
+   * TTL for everything that goes through the adapter.
+   */
+  const TTL = 86400;
+
+  /**
+   * @param string $group
+   * @return CRM_Utils_Cache_Interface
+   */
+  protected static function getGroup($group) {
+    if (!isset(Civi::$statics[__CLASS__][$group])) {
+      if (!in_array($group, self::getLegacyGroups())) {
+        Civi::log()
+          ->warning('Unrecognized BAO cache group ({group}). This should work generally, but data may not be flushed in some edge-cases. Consider migrating explicitly to PSR-16.', [
+            'group' => $group,
+          ]);
+      }
+
+      $cache = CRM_Utils_Cache::create([
+        'name' => "bao_$group",
+        'type' => array('*memory*', 'SqlGroup', 'ArrayCache'),
+        // We're replacing CRM_Core_BAO_Cache, which traditionally used a front-cache
+        // that was not aware of TTLs. So it seems more consistent/performant to
+        // use 'fast' here.
+        'withArray' => 'fast',
+      ]);
+      Civi::$statics[__CLASS__][$group] = $cache;
+    }
+    return Civi::$statics[__CLASS__][$group];
+  }
+
+  /**
+   * Retrieve an item from the DB cache.
+   *
+   * @param string $group
+   *   (required) The group name of the item.
+   * @param string $path
+   *   (required) The path under which this item is stored.
+   * @param int $componentID
+   *   The optional component ID (so componenets can share the same name space).
+   *
+   * @return object
+   *   The data if present in cache, else null
+   */
+  public static function &getItem($group, $path, $componentID = NULL) {
+    // TODO: Generate a general deprecation notice.
+    if ($componentID) {
+      Civi::log()
+        ->warning('getItem({group},{path},...) uses unsupported componentID. Consider migrating explicitly to PSR-16.', [
+          'group' => $group,
+          'path' => $path,
+        ]);
+    }
+    $value = self::getGroup($group)->get(CRM_Core_BAO_Cache::cleanKey($path));
+    return $value;
+  }
+
+  /**
+   * Retrieve all items in a group.
+   *
+   * @param string $group
+   *   (required) The group name of the item.
+   * @param int $componentID
+   *   The optional component ID (so componenets can share the same name space).
+   *
+   * @throws CRM_Core_Exception
+   */
+  public static function &getItems($group, $componentID = NULL) {
+    // Based on grepping universe, this function is not currently used.
+    // Moreover, it's hard to implement in PSR-16. (We'd have to extend the
+    // interface.) Let's wait and see if anyone actually needs this...
+    throw new \CRM_Core_Exception('Not implemented: CRM_Core_BAO_Cache_Psr16::getItems');
+  }
+
+  /**
+   * Store an item in the DB cache.
+   *
+   * @param object $data
+   *   (required) A reference to the data that will be serialized and stored.
+   * @param string $group
+   *   (required) The group name of the item.
+   * @param string $path
+   *   (required) The path under which this item is stored.
+   * @param int $componentID
+   *   The optional component ID (so componenets can share the same name space).
+   */
+  public static function setItem(&$data, $group, $path, $componentID = NULL) {
+    // TODO: Generate a general deprecation notice.
+
+    if ($componentID) {
+      Civi::log()
+        ->warning('setItem({group},{path},...) uses unsupported componentID. Consider migrating explicitly to PSR-16.', [
+          'group' => $group,
+          'path' => $path,
+        ]);
+    }
+    self::getGroup($group)
+      ->set(CRM_Core_BAO_Cache::cleanKey($path), $data, self::TTL);
+  }
+
+  /**
+   * Delete all the cache elements that belong to a group OR delete the entire cache if group is not specified.
+   *
+   * @param string $group
+   *   The group name of the entries to be deleted.
+   * @param string $path
+   *   Path of the item that needs to be deleted.
+   */
+  public static function deleteGroup($group = NULL, $path = NULL) {
+    // FIXME: Generate a general deprecation notice.
+
+    if ($path) {
+      self::getGroup($group)->delete(CRM_Core_BAO_Cache::cleanKey($path));
+    }
+    else {
+      self::getGroup($group)->clear();
+    }
+  }
+
+  /**
+   * Cleanup any caches that we've mapped.
+   *
+   * Traditional SQL-backed caches are cleared as a matter of course during a
+   * system flush (by way of "TRUNCATE TABLE civicrm_cache"). This provides
+   * a spot where the adapter can
+   */
+  public static function clearDBCache() {
+    foreach (self::getLegacyGroups() as $groupName) {
+      $group = self::getGroup($groupName);
+      $group->clear();
+    }
+  }
+
+  /**
+   * Get a list of known cache-groups
+   *
+   * @return array
+   */
+  public static function getLegacyGroups() {
+    return [
+      // Core
+      'CiviCRM Search PrevNextCache',
+      'contact fields',
+      'navigation',
+      'contact groups',
+      'custom data',
+
+      // Universe
+      'dashboard', // be.chiro.civi.atomfeeds
+      'lineitem-editor', // biz.jmaconsulting.lineitemedit
+      'HRCore_Info', // civihr/uk.co.compucorp.civicrm.hrcore
+      'CiviCRM setting Spec', // nz.co.fuzion.entitysetting
+      'descendant groups for an org', // org.civicrm.multisite
+    ];
+  }
+
+}

--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -86,7 +86,7 @@ class CRM_Core_BAO_Cache_Psr16 {
    * @return object
    *   The data if present in cache, else null
    */
-  public static function &getItem($group, $path, $componentID = NULL) {
+  public static function getItem($group, $path, $componentID = NULL) {
     // TODO: Generate a general deprecation notice.
     if ($componentID) {
       Civi::log()
@@ -95,8 +95,7 @@ class CRM_Core_BAO_Cache_Psr16 {
           'path' => $path,
         ]);
     }
-    $value = self::getGroup($group)->get(CRM_Core_BAO_Cache::cleanKey($path));
-    return $value;
+    return self::getGroup($group)->get(CRM_Core_BAO_Cache::cleanKey($path));
   }
 
   /**

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -362,6 +362,10 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       CRM_Core_DAO::executeQuery($query);
     }
 
+    if ($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) {
+      return $adapter::clearDBCache();
+    }
+
     // also delete all the import and export temp tables
     self::clearTempTables();
   }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -457,6 +457,12 @@ define('CIVICRM_DEADLOCK_RETRIES', 3);
 // define('CIVICRM_MYSQL_STRICT', TRUE );
 // }
 
+/**
+ * Specify whether the CRM_Core_BAO_Cache should use the legacy
+ * direct-to-SQL-mode or the interim PSR-16 adapter.
+ */
+// define('CIVICRM_BAO_CACHE_ADAPTER', 'CRM_Core_BAO_Cache_Psr16');
+
 if (CIVICRM_UF === 'UnitTests') {
   if (!defined('CIVICRM_CONTAINER_CACHE')) define('CIVICRM_CONTAINER_CACHE', 'auto');
   if (!defined('CIVICRM_MYSQL_STRICT')) define('CIVICRM_MYSQL_STRICT', true);


### PR DESCRIPTION
Overview
----------------------------------------

`CRM_Core_BAO_Cache` provides an interface for reading and writing cache data (`setItem($data,$group,$path)`, `getItem($group,$path)`, `getItems($group)`, `deleteGroup($group,$path)`). There are two problems with this:

* `CRM_Core_BAO_Cache` is hard-coded to an implementation with a specific data-storage policy (combining a `static::$cache` with a table SQL `civicrm_cache`). It's a fine default, but it's problematic for [dev/core#635](https://lab.civicrm.org/dev/core/issues/635) -- in rodb configuration, writing to `civicrm_cache` forces the readers to switch to the master DB and generates distributed writes.
* There's a newer standard, PSR-16, which is more flexible and complete. PSR-16 supports TTLs, default-values, multi-key operations, etc.  PSR-16 drivers can be extended/decorated/replaced.  There are third-party implementations of PSR-16. Once you transition to PSR-16 interfaces, it becomes easier to swap implementations (e.g. swapping among Redis, Memcache, MySQL, APC).

On the other hand, `CRM_Core_BAO_Cache` has been around forever. We've migrated a few of the weirdest use-cases, but I still count ten distinct cache-groups which rely on `CRM_Core_BAO_Cache` (5 from `civicrm-core` and 5 from `universe`). Removing it outright would cause breakage (or at least front-load us with a game of whack-a-mole).

This patch is the next step toward phasing-out `CRM_Core_BAO_Cache`:

* Deprecate the I/O functions in `CRM_Core_BAO_Cache`. (*Note: The I/O functions are specifically `setItem()`, `getItem()`, `getItems()`, `deleteGroup()`. Other functions -- like `cleanKey()`, `encode()`, `decode()` -- are qualitatively different.*)
* Optionally, map the deprecated functions to equivalent PSR-16 functions.

Before
----------------------------------------

* Requests for `CRM_Core_BAO_Cache` ( `setItem($data,$group,$path)`, `getItem($group,$path)`, `getItems($group)`, `deleteGroup($group, $item)` ) are *always* served by two tiers: (1) an in-memory array (`static::$cache`) and (2) an SQL table.

After
----------------------------------------

* There is a config option `define('CIVICRM_BAO_CACHE_ADAPTER',
  'CRM_Core_BAO_Cache_Psr16');`.
    * When disabled (default), `CRM_Core_BAO_Cache` continues using the old code.
    * When enabled, `CRM_Core_BAO_Cache` changes behavior. Each `$group` is mapped to a PSR-16 object.

* The class/implementation for each `$group` depends on the configuration:
    * In a typical (non-Redis/non-Memcache) deployment, the implementation is `CRM_Utils_Cache_SqlGroup`, which has the same 2-tier structure (in-memory+SQL).
    * In Redis/Memcache deployment, the implementation combines `FastArrayDecorator` with `CRM_Utils_Cache_Redis` or `CRM_Utils_Cache_Memcache`.  This gives a similar 2-tier structure (e.g. in-memory+Redis).

* In RODB configuration, I'm seeing *far fewer* occasions where it unexpectedly/unnecessarily directs the user the master DB.

Comments
----------------------------------------

This depends-on and incorporates #13500 and #13496. The commit list looks long, but it is actually only two items (at time of writing):

* *CRM_Core_BAO_Cache - Deprecate getItems(), getItem(), setItem(), deleteGroup()*
* *Allow rerouting CRM_Core_BAO_Cache::{set,get}Item(s) to PSR-16 drivers*

There are some small ways in which the PSR-16 adapter is different, e.g.

* `getItems()` will throw an exception. This is actually pretty difficult to implement in pure PSR-16. Fortunately, I can't find anything (in `civicrm-core` or `universe`) which calls it.
* All SQL-based caches are cleared when one does a system-flush (i.e. `TRUNCATE TABLE civicrm_cache`). To provide a similar behavior on non-SQL systems, we walk through the list of legacy cache-groups and clear each.
* It's conceivable that some unseen/unrecognized code intermingles calls to `CRM_Core_BAO_Cache` with direct SQL IO (`civicrm_cache`). The mingling would be poor form, but it's conceivable. Such code would be broken on non-SQL deployments.

I think these risks are pretty narrow, but they exist. At this step of the phase-out, the PSR-16 adapter requires an opt-in, so the initial risk is borne by folks who need rodb. I'd vote for dialing up the pressure gradually (e.g. after 2-3 months, change to an opt-out; and after another 2-3, remove the old code).
