### PR TITLE
Fix broken date fields in survey response form

### DIFF
--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -156,9 +156,7 @@
                 {continue}
               {/if}
               <td class="compressed {$field.data_type} {$fieldName}">
-                {if ( ( $fieldName eq 'thankyou_date' ) or ( $fieldName eq 'cancel_date' ) or ( $fieldName eq 'receipt_date' ) or (  $fieldName eq 'activity_date_time') ) and $field.is_view neq 1 }
-                {include file="CRM/common/jcalendar.tpl" elementName=$fieldName elementIndex=$voterId batchUpdate=1}
-                {elseif $fieldName|substr:0:5 eq 'phone'}
+                {if $fieldName|substr:0:5 eq 'phone'}
                   {assign var="phone_ext_field" value=$fieldName|replace:'phone':'phone_ext'}
                   {$form.field.$voterId.$fieldName.html}
                   {if $form.field.$voterId.$phone_ext_field.html}


### PR DESCRIPTION
Overview
-------
Fixes a couple broken date fields in the **Record Survey Responses** screen.

Before
----
![screenshot from 2019-01-21 13-18-52](https://user-images.githubusercontent.com/2874912/51492230-1e6ca700-1d7f-11e9-82f9-d6ddf349156d.png)

After
------
![screenshot from 2019-01-21 13-11-31](https://user-images.githubusercontent.com/2874912/51492210-0432c900-1d7f-11e9-917e-99ad41c12c54.png)

How to
-----
1. Create a profile that includes the "Activity Date" field.
2. Configure a survey and include the profile.
3. Reserve respondents and go to the "Record Responses" screen.
4. The datepicker for the "Activity Date" field will be broken without this PR.

Notes
------
I was grepping for instances of `jcalendar.tpl` and found this one. But I couldn't find any corresponding form code to update. It looks to me like those fields have already been converted. Testing confirms this - the fields are actually broken because this tpl hasn't been updated to reflect the changed form code.