### PR TITLE
Convert Campaign widgets to entityRef

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -596,66 +596,24 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
       $$fld = CRM_Utils_Array::value($fld, $campaignDetails);
     }
 
-    //lets see do we have past campaigns.
-    $hasPastCampaigns = FALSE;
-    $allActiveCampaigns = CRM_Campaign_BAO_Campaign::getCampaigns(NULL, NULL, TRUE, FALSE);
-    if (count($allActiveCampaigns) > count($campaigns)) {
-      $hasPastCampaigns = TRUE;
-    }
-    $hasCampaigns = FALSE;
-    if (!empty($campaigns)) {
-      $hasCampaigns = TRUE;
-    }
-    if ($hasPastCampaigns) {
-      $hasCampaigns = TRUE;
-      $form->add('hidden', 'included_past_campaigns');
-    }
-
     $showAddCampaign = FALSE;
-    $alreadyIncludedPastCampaigns = FALSE;
     if ($connectedCampaignId || ($isCampaignEnabled && $hasAccessCampaign)) {
       $showAddCampaign = TRUE;
-      //lets add past campaigns as options to quick-form element.
-      if ($hasPastCampaigns && $form->getElementValue('included_past_campaigns')) {
-        $campaigns = $allActiveCampaigns;
-        $alreadyIncludedPastCampaigns = TRUE;
-      }
-      $campaign = &$form->add('select',
-        'campaign_id',
-        ts('Campaign'),
-        array('' => ts('- select -')) + $campaigns,
-        FALSE,
-        array('class' => 'crm-select2')
-      );
+      $campaign = $form->addEntityRef('campaign_id', ts('Campaign'), [
+        'entity' => 'campaign',
+        'create' => TRUE,
+      ]);
       //lets freeze when user does not has access or campaign is disabled.
       if (!$isCampaignEnabled || !$hasAccessCampaign) {
         $campaign->freeze();
       }
     }
 
-    $addCampaignURL = NULL;
-    if (empty($campaigns) && $hasAccessCampaign && $isCampaignEnabled) {
-      $addCampaignURL = CRM_Utils_System::url('civicrm/campaign/add', 'reset=1');
-    }
-
-    $includePastCampaignURL = NULL;
-    if ($hasPastCampaigns && $isCampaignEnabled && $hasAccessCampaign) {
-      $includePastCampaignURL = CRM_Utils_System::url('civicrm/ajax/rest',
-        'className=CRM_Campaign_Page_AJAX&fnName=allActiveCampaigns',
-        FALSE, NULL, FALSE
-      );
-    }
-
     //carry this info to templates.
     $infoFields = array(
-      'hasCampaigns',
-      'addCampaignURL',
       'showAddCampaign',
-      'hasPastCampaigns',
       'hasAccessCampaign',
       'isCampaignEnabled',
-      'includePastCampaignURL',
-      'alreadyIncludedPastCampaigns',
     );
     foreach ($infoFields as $fld) {
       $campaignInfo[$fld] = $$fld;

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -707,4 +707,22 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
     $form->assign('campaignInfo', $campaignInfo);
   }
 
+  /**
+   * Links to create new campaigns from entityRef widget
+   *
+   * @return array|bool
+   */
+  public static function entityRefCreateLinks() {
+    if (CRM_Core_Permission::check([['administer CiviCampaign', 'manage campaign']])) {
+      return [
+        [
+          'label' => ts('New Campaign'),
+          'url' => CRM_Utils_System::url('civicrm/campaign/add', "reset=1",
+            NULL, NULL, FALSE, FALSE, TRUE),
+          'type' => 'Campaign',
+        ]];
+    }
+    return FALSE;
+  }
+
 }

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -244,23 +244,27 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     // is this Campaign active
     $this->addElement('checkbox', 'is_active', ts('Is Active?'));
 
-    $this->addButtons(array(
-        array(
-          'type' => 'upload',
-          'name' => ts('Save'),
-          'isDefault' => TRUE,
-        ),
-        array(
-          'type' => 'upload',
-          'name' => ts('Save and New'),
-          'subName' => 'new',
-        ),
-        array(
-          'type' => 'cancel',
-          'name' => ts('Cancel'),
-        ),
-      )
-    );
+    $buttons = [
+      [
+        'type' => 'upload',
+        'name' => ts('Save'),
+        'isDefault' => TRUE,
+      ],
+    ];
+    // Skip this button when adding a new campaign from an entityRef
+    if (empty($_GET['snippet']) || empty($_GET['returnExtra'])) {
+      $buttons[] = [
+        'type' => 'upload',
+        'name' => ts('Save and New'),
+        'subName' => 'new',
+      ];
+    }
+    $buttons[] = [
+      'type' => 'cancel',
+      'name' => ts('Cancel'),
+    ];
+
+    $this->addButtons($buttons);
   }
 
   /**
@@ -340,6 +344,8 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     if ($result) {
       CRM_Core_Session::setStatus(ts('Campaign %1 has been saved.', array(1 => $result->title)), ts('Saved'), 'success');
       $session->pushUserContext(CRM_Utils_System::url('civicrm/campaign', 'reset=1&subPage=campaign'));
+      $this->ajaxResponse['id'] = $result->id;
+      $this->ajaxResponse['label'] = $result->title;
     }
 
     $buttonName = $this->controller->getButtonName();

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -190,9 +190,10 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
     // script / instructions / description of petition purpose
     $this->add('wysiwyg', 'instructions', ts('Introduction'), $attributes['instructions']);
 
-    // Campaign id
-    $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(CRM_Utils_Array::value('campaign_id', $this->_values));
-    $this->add('select', 'campaign_id', ts('Campaign'), array('' => ts('- select -')) + $campaigns);
+    $this->addEntityRef('campaign_id', ts('Campaign'), [
+      'entity' => 'campaign',
+      'create' => TRUE,
+    ]);
 
     $customContactProfiles = CRM_Core_BAO_UFGroup::getProfiles(array('Individual'));
     // custom group id

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -127,13 +127,13 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
 
     $this->add('text', 'title', ts('Title'), CRM_Core_DAO::getAttribute('CRM_Campaign_DAO_Survey', 'title'), TRUE);
 
-    $surveyActivityTypes = CRM_Campaign_BAO_Survey::getSurveyActivityType();
     // Activity Type id
     $this->addSelect('activity_type_id', array('option_url' => 'civicrm/admin/campaign/surveyType'), TRUE);
 
-    // Campaign id
-    $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(CRM_Utils_Array::value('campaign_id', $this->_values));
-    $this->add('select', 'campaign_id', ts('Campaign'), array('' => ts('- select -')) + $campaigns);
+    $this->addEntityRef('campaign_id', ts('Campaign'), [
+      'entity' => 'campaign',
+      'create' => TRUE,
+    ]);
 
     // script / instructions
     $this->add('wysiwyg', 'instructions', ts('Instructions for interviewers'), array('rows' => 5, 'cols' => 40));

--- a/CRM/Campaign/Page/AJAX.php
+++ b/CRM/Campaign/Page/AJAX.php
@@ -494,39 +494,6 @@ class CRM_Campaign_Page_AJAX {
     CRM_Utils_JSON::output(array('status' => $status));
   }
 
-  public function allActiveCampaigns() {
-    $currentCampaigns = CRM_Campaign_BAO_Campaign::getCampaigns();
-    $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(NULL, NULL, TRUE, FALSE, TRUE);
-    $options = array(
-      array(
-        'value' => '',
-        'title' => ts('- select -'),
-      ),
-    );
-    foreach ($campaigns as $value => $title) {
-      $class = NULL;
-      if (!array_key_exists($value, $currentCampaigns)) {
-        $class = 'status-past';
-      }
-      $options[] = array(
-        'value' => $value,
-        'title' => $title,
-        'class' => $class,
-      );
-    }
-    $status = 'fail';
-    if (count($options) > 1) {
-      $status = 'success';
-    }
-
-    $results = array(
-      'status' => $status,
-      'campaigns' => $options,
-    );
-
-    CRM_Utils_JSON::output($results);
-  }
-
   public function campaignGroups() {
     $surveyId = CRM_Utils_Request::retrieve('survey_id', 'Positive',
       CRM_Core_DAO::$_nullObject, FALSE, NULL, 'POST'

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3642,4 +3642,16 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     return FALSE;
   }
 
+  /**
+   * Checks permission to create new contacts from entityRef widget
+   *
+   * Note: other components must return an array of links from this function,
+   * but Contacts are given special treatment - the links are in javascript already.
+   *
+   * @return bool
+   */
+  public static function entityRefCreateLinks() {
+    return CRM_Core_Permission::check([['edit all contacts', 'add contacts']]);
+  }
+
 }

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -165,11 +165,7 @@ class CRM_Contact_Form_Edit_Address {
       $form->addElement('checkbox', "address[$blockId][use_shared_address]", NULL, ts('Use another contact\'s address'));
 
       // Override the default profile links to add address form
-      $profileLinks = CRM_Core_BAO_UFGroup::getCreateLinks(array(
-          'new_individual',
-          'new_organization',
-          'new_household',
-        ), 'shared_address');
+      $profileLinks = CRM_Contact_BAO_Contact::entityRefCreateLinks() ? CRM_Core_BAO_UFGroup::getCreateLinks('', 'shared_address') : FALSE;
       $form->addEntityRef("address[$blockId][master_contact_id]", ts('Share With'), array('create' => $profileLinks));
     }
   }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3340,6 +3340,11 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     ));
     $links = $append = array();
     if (!empty($retrieved['values'])) {
+      $icons = [
+        'individual' => 'fa-user',
+        'organization' => 'fa-building',
+        'household' => 'fa-home',
+      ];
       foreach ($retrieved['values'] as $id => $profile) {
         if (in_array($profile['name'], $profiles)) {
           $links[] = array(
@@ -3347,6 +3352,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
             'url' => CRM_Utils_System::url('civicrm/profile/create', "reset=1&context=dialog&gid=$id",
               NULL, NULL, FALSE, FALSE, TRUE),
             'type' => ucfirst(str_replace('new_', '', $profile['name'])),
+            'icon' => CRM_Utils_Array::value(str_replace('new_', '', $profile['name']), $icons),
           );
         }
         else {

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1951,7 +1951,12 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $props['entity'] = _civicrm_api_get_entity_name_from_camel(CRM_Utils_Array::value('entity', $props, 'contact'));
     $props['class'] = ltrim(CRM_Utils_Array::value('class', $props, '') . ' crm-form-entityref');
 
-    if ($props['entity'] == 'contact' && isset($props['create']) && !(CRM_Core_Permission::check('edit all contacts') || CRM_Core_Permission::check('add contacts'))) {
+    if (isset($props['create']) && $props['create'] === TRUE) {
+      require_once "api/v3/utils.php";
+      $baoClass = _civicrm_api3_get_BAO($props['entity']);
+      $props['create'] = $baoClass && is_callable([$baoClass, 'entityRefCreateLinks']) ? $baoClass::entityRefCreateLinks() : FALSE;
+    }
+    if (array_key_exists('create', $props) && empty($props['create'])) {
       unset($props['create']);
     }
 

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -870,6 +870,41 @@ class CRM_Core_Resources {
       }
     }
 
+    if (in_array('CiviCampaign', $config->enableComponents)) {
+      $filters['campaign'] = [
+        ['key' => 'campaign_type_id', 'value' => ts('Campaign Type')],
+        ['key' => 'status_id', 'value' => ts('Status')],
+        [
+          'key' => 'start_date',
+          'value' => ts('Start Date'),
+          'options' => [
+            ['key' => '{">":"now"}', 'value' => ts('Upcoming')],
+            [
+              'key' => '{"BETWEEN":["now - 3 month","now"]}',
+              'value' => ts('Past 3 Months'),
+            ],
+            [
+              'key' => '{"BETWEEN":["now - 6 month","now"]}',
+              'value' => ts('Past 6 Months'),
+            ],
+            [
+              'key' => '{"BETWEEN":["now - 1 year","now"]}',
+              'value' => ts('Past Year'),
+            ],
+          ],
+        ],
+        [
+          'key' => 'end_date',
+          'value' => ts('End Date'),
+          'options' => [
+            ['key' => '{">":"now"}', 'value' => ts('In the future')],
+            ['key' => '{"<":"now"}', 'value' => ts('In the past')],
+            ['key' => '{"IS NULL":"1"}', 'value' => ts('Not set')],
+          ],
+        ],
+      ];
+    }
+
     CRM_Utils_Hook::entityRefFilters($filters);
 
     return $filters;

--- a/api/v3/Campaign.php
+++ b/api/v3/Campaign.php
@@ -97,7 +97,7 @@ function civicrm_api3_campaign_delete($params) {
  * @param array $request
  */
 function _civicrm_api3_campaign_getlist_params(&$request) {
-  $fieldsToReturn = ['title', 'campaign_type_id', 'start_date', 'end_date'];
+  $fieldsToReturn = ['title', 'campaign_type_id', 'status_id', 'start_date', 'end_date'];
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
   if (empty($request['params']['id'])) {
     $request['params'] += [
@@ -119,23 +119,27 @@ function _civicrm_api3_campaign_getlist_params(&$request) {
 function _civicrm_api3_campaign_getlist_output($result, $request) {
   $output = [];
   if (!empty($result['values'])) {
+    $config = CRM_Core_Config::singleton();
     foreach ($result['values'] as $row) {
       $data = [
         'id' => $row[$request['id_field']],
         'label' => $row[$request['label_field']],
         'description' => [
-          CRM_Core_Pseudoconstant::getLabel(
-            'CRM_Campaign_BAO_Campaign',
-            'campaign_type_id',
-            $row['campaign_type_id']
-          ),
+          CRM_Core_Pseudoconstant::getLabel('CRM_Campaign_BAO_Campaign', 'campaign_type_id', $row['campaign_type_id']),
         ],
       ];
-      $config = CRM_Core_Config::singleton();
-      $data['description'][0] .= ': ' . CRM_Utils_Date::customFormat($row['start_date'], $config->dateformatFull) . ' - ';
-      if (!empty($row['end_date'])) {
-        $data['description'][0] .= CRM_Utils_Date::customFormat($row['end_date'], $config->dateformatFull);
+      if (!empty($row['status_id'])) {
+        $data['description'][0] .= ': ' . CRM_Core_Pseudoconstant::getLabel('CRM_Campaign_BAO_Campaign', 'status_id', $row['status_id']);
       }
+      $dateString = CRM_Utils_Date::customFormat($row['start_date'], $config->dateformatFull) . ' -';
+      if (!empty($row['end_date'])) {
+        // Remove redundant years
+        if (substr($row['start_date'], 0, 4) == substr($row['end_date'], 0, 4)) {
+          $dateString = preg_replace('/[, ]*' . substr($row['start_date'], 0, 4) . '/', '', $dateString);
+        }
+        $dateString .= ' ' . CRM_Utils_Date::customFormat($row['end_date'], $config->dateformatFull);
+      }
+      $data['description'][] = $dateString;
       $output[] = $data;
     }
   }

--- a/api/v3/Campaign.php
+++ b/api/v3/Campaign.php
@@ -88,3 +88,56 @@ function civicrm_api3_campaign_get($params) {
 function civicrm_api3_campaign_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+/**
+ * Get campaign list parameters.
+ *
+ * @see _civicrm_api3_generic_getlist_params
+ *
+ * @param array $request
+ */
+function _civicrm_api3_campaign_getlist_params(&$request) {
+  $fieldsToReturn = ['title', 'campaign_type_id', 'start_date', 'end_date'];
+  $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
+  if (empty($request['params']['id'])) {
+    $request['params'] += [
+      'is_active' => 1,
+    ];
+  }
+}
+
+/**
+ * Get campaign list output.
+ *
+ * @see _civicrm_api3_generic_getlist_output
+ *
+ * @param array $result
+ * @param array $request
+ *
+ * @return array
+ */
+function _civicrm_api3_campaign_getlist_output($result, $request) {
+  $output = [];
+  if (!empty($result['values'])) {
+    foreach ($result['values'] as $row) {
+      $data = [
+        'id' => $row[$request['id_field']],
+        'label' => $row[$request['label_field']],
+        'description' => [
+          CRM_Core_Pseudoconstant::getLabel(
+            'CRM_Campaign_BAO_Campaign',
+            'campaign_type_id',
+            $row['campaign_type_id']
+          ),
+        ],
+      ];
+      $config = CRM_Core_Config::singleton();
+      $data['description'][0] .= ': ' . CRM_Utils_Date::customFormat($row['start_date'], $config->dateformatFull) . ' - ';
+      if (!empty($row['end_date'])) {
+        $data['description'][0] .= CRM_Utils_Date::customFormat($row['end_date'], $config->dateformatFull);
+      }
+      $output[] = $data;
+    }
+  }
+  return $output;
+}

--- a/js/Common.js
+++ b/js/Common.js
@@ -578,11 +578,13 @@ if (!CRM.vars) CRM.vars = {};
                 formUrl = $(this).attr('href') + '&returnExtra=display_name,sort_name' + (extra ? (',' + extra) : '');
               $el.select2('close');
               CRM.loadForm(formUrl, {
-                dialog: {width: 500, height: 220}
+                dialog: {width: '50%', height: 220}
               }).on('crmFormSuccess', function(e, data) {
                 if (data.status === 'success' && data.id) {
-                  data.label = data.extra.sort_name;
-                  CRM.status(ts('%1 Created', {1: data.extra.display_name}));
+                  if (!data.crmMessages) {
+                    CRM.status(ts('%1 Created', {1: data.label || data.extra.display_name}));
+                  }
+                  data.label = data.label || data.extra.sort_name;
                   if ($el.select2('container').hasClass('select2-container-multi')) {
                     var selection = $el.select2('data');
                     selection.push(data);
@@ -684,32 +686,16 @@ if (!CRM.vars) CRM.vars = {};
       createLinks = $el.data('create-links'),
       params = getEntityRefApiParams($el).params,
       markup = '<div class="crm-entityref-links">';
-    if (!createLinks || $el.data('api-entity').toLowerCase() !== 'contact') {
+    if (!createLinks || (createLinks === true && $el.data('api-entity').toLowerCase() !== 'contact')) {
       return '';
     }
     if (createLinks === true) {
       createLinks = params.contact_type ? _.where(CRM.config.entityRef.contactCreate, {type: params.contact_type}) : CRM.config.entityRef.contactCreate;
     }
     _.each(createLinks, function(link) {
-      var icon;
-      switch (link.type) {
-        case 'Individual':
-          icon = 'fa-user';
-          break;
-
-        case 'Organization':
-          icon = 'fa-building';
-          break;
-
-        case 'Household':
-          icon = 'fa-home';
-          break;
-      }
-      markup += ' <a class="crm-add-entity crm-hover-button" href="' + link.url + '">';
-      if (icon) {
-        markup += '<i class="crm-i ' + icon + '"></i> ';
-      }
-      markup += _.escape(link.label) + '</a>';
+      markup += ' <a class="crm-add-entity crm-hover-button" href="' + link.url + '">' +
+        '<i class="crm-i ' + (link.icon || 'fa-plus-circle') + '"></i> ' +
+        _.escape(link.label) + '</a>';
     });
     markup += '</div>';
     return markup;

--- a/templates/CRM/Campaign/Form/Survey/Main.tpl
+++ b/templates/CRM/Campaign/Form/Survey/Main.tpl
@@ -39,7 +39,7 @@
    </tr>
    <tr class="crm-campaign-survey-main-form-block-campaign_id">
      <td class="label">{$form.campaign_id.label}</td>
-     <td class="view-value">{$form.campaign_id.html} &nbsp; <span class="action-link crm-campaign-survey-new_campaign_link"><a href="{crmURL p='civicrm/campaign/add' q='reset=1'}" target="_blank" title="{ts}Opens New Campaign form in a separate window{/ts}">{ts}new campaign{/ts}</a></span>
+     <td class="view-value">{$form.campaign_id.html}
         <div class="description">{ts}Select the campaign for which survey is created.{/ts}</div>
       </td>
    </tr>

--- a/templates/CRM/Campaign/Form/addCampaignToComponent.tpl
+++ b/templates/CRM/Campaign/Form/addCampaignToComponent.tpl
@@ -2,82 +2,20 @@
 
 {if $campaignContext eq 'componentSearch'}
 
-{* add campaign in component search *}
-<tr class="{$campaignTrClass}">
+  {* add campaign in component search *}
+  <tr class="{$campaignTrClass}">
     {assign var=elementName value=$campaignInfo.elementName}
     <td class="{$campaignTdClass}">
       {$form.$elementName.label} {$form.$elementName.html}
     </td>
-</tr>
+  </tr>
 
-{else}
+{elseif $campaignInfo.showAddCampaign}
 
-{if $campaignInfo.showAddCampaign}
-
-    <tr class="{$campaignTrClass}">
-        <td class="label">{$form.campaign_id.label} {help id="id-campaign_id" file="CRM/Campaign/Form/addCampaignToComponent.hlp"}</td>
-        <td class="view-value">
-      {* lets take a call, either show campaign select drop-down or show add campaign link *}
-            {if $campaignInfo.hasCampaigns}
-            {$form.campaign_id.html|crmAddClass:huge}
-            {* show for add and edit actions *}
-          {if ( $action eq 1 or $action eq 2 )
-              and !$campaignInfo.alreadyIncludedPastCampaigns and $campaignInfo.includePastCampaignURL}
-                <br />
-                <a id='include-past-campaigns' href='#' onClick='includePastCampaigns( "campaign_id" ); return false;'>
-                   &raquo;
-                   {ts}Show past campaign(s) in this select list.{/ts}
-                </a>
-            {/if}
-            {else}
-            <div class="status">
-            {ts}There are currently no active Campaigns.{/ts}
-            {if $campaignInfo.addCampaignURL}
-              {capture assign="link"}href="{$campaignInfo.addCampaignURL}" class="action-item"{/capture}
-              {ts 1=$link}If you want to associate this record with a campaign, you can <a %1>create a campaign here</a>.{/ts}
-            {/if} {help id="id-campaign_id" file="CRM/Campaign/Form/addCampaignToComponent.hlp"}
-            </div>
-          {/if}
-        </td>
-    </tr>
-
-
-{literal}
-<script type="text/javascript">
-function includePastCampaigns()
-{
-    //hide past campaign link.
-    cj( "#include-past-campaigns" ).hide( );
-
-    var campaignUrl = {/literal}'{$campaignInfo.includePastCampaignURL}'{literal};
-    cj.post( campaignUrl,
-             null,
-             function( data ) {
-          if ( data.status != 'success' ) return;
-
-          //first reset all select options.
-         cj( "#campaign_id" ).val( '' );
-             cj( "#campaign_id" ).html( '' );
-         cj('input[name="included_past_campaigns"]').val( 1 );
-
-         var campaigns = data.campaigns;
-
-         //build the new options.
-         for ( campaign in campaigns ) {
-              title = campaigns[campaign].title;
-              value = campaigns[campaign].value;
-              className = campaigns[campaign].class;
-              if ( !title ) continue;
-              cj('#campaign_id').append( cj('<option></option>').val(value).html(title).addClass(className) );
-          }
-           },
-           'json');
-}
-</script>
-{/literal}
-
-
-{/if}{* add campaign to component if closed.  *}
+  <tr class="{$campaignTrClass}">
+    <td class="label">{$form.campaign_id.label} {help id="id-campaign_id" file="CRM/Campaign/Form/addCampaignToComponent.hlp"}</td>
+    <td class="view-value">{$form.campaign_id.html}</td>
+  </tr>
 
 {/if}{* add campaign to component search if closed. *}
 


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up the code and UI for selecting a campaign. Instead of a select list with a button to load past campaigns, now the entire list of campaigns is searchable and filterable. New campaigns can be created on-the-fly.

Before
----------------------------------------
Ugly message when there are no campaigns.
Button to load past campaigns.
No way to create a new campaign without leaving and reloading the page.

![screenshot from 2019-01-22 09-52-53](https://user-images.githubusercontent.com/2874912/51543770-5251d600-1e2c-11e9-872f-f4729fc96c3e.png)

After
----------------------------------------
New widget can filter out past campaigns and create new ones on-the-fly, so no need for the ugly message or the "show past campaigns" button. The widget also displays the campaign type, status, and dates in the results.

![screenshot from 2019-01-21 13-18-52](https://user-images.githubusercontent.com/2874912/51543779-5a117a80-1e2c-11e9-8b6c-c4616eb8d80c.png)
