### PR TITLE
dev/core#677 EntityRef filters fixes

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -837,18 +837,18 @@ class CRM_Core_Resources {
       array('key' => 'status_id', 'value' => ts('Activity Status')),
     );
 
-    $filters['contact'] = array(
-      array('key' => 'contact_type', 'value' => ts('Contact Type')),
-      array('key' => 'group', 'value' => ts('Group'), 'entity' => 'group_contact'),
-      array('key' => 'tag', 'value' => ts('Tag'), 'entity' => 'entity_tag'),
-      array('key' => 'state_province', 'value' => ts('State/Province'), 'entity' => 'address'),
-      array('key' => 'country', 'value' => ts('Country'), 'entity' => 'address'),
-      array('key' => 'gender_id', 'value' => ts('Gender')),
-      array('key' => 'is_deceased', 'value' => ts('Deceased')),
-      array('key' => 'contact_id', 'value' => ts('Contact ID'), 'type' => 'text'),
-      array('key' => 'external_identifier', 'value' => ts('External ID'), 'type' => 'text'),
-      array('key' => 'source', 'value' => ts('Contact Source'), 'type' => 'text'),
-    );
+    $filters['contact'] = [
+      ['key' => 'contact_type', 'value' => ts('Contact Type')],
+      ['key' => 'group', 'value' => ts('Group'), 'entity' => 'group_contact'],
+      ['key' => 'tag', 'value' => ts('Tag'), 'entity' => 'entity_tag'],
+      ['key' => 'state_province', 'value' => ts('State/Province'), 'entity' => 'address'],
+      ['key' => 'country', 'value' => ts('Country'), 'entity' => 'address'],
+      ['key' => 'gender_id', 'value' => ts('Gender'), 'condition' => ['contact_type' => 'Individual']],
+      ['key' => 'is_deceased', 'value' => ts('Deceased'), 'condition' => ['contact_type' => 'Individual']],
+      ['key' => 'contact_id', 'value' => ts('Contact ID'), 'type' => 'text'],
+      ['key' => 'external_identifier', 'value' => ts('External ID'), 'type' => 'text'],
+      ['key' => 'source', 'value' => ts('Contact Source'), 'type' => 'text'],
+    ];
 
     if (in_array('CiviCase', $config->enableComponents)) {
       $filters['case'] = array(

--- a/js/Common.js
+++ b/js/Common.js
@@ -725,6 +725,10 @@ if (!CRM.vars) CRM.vars = {};
       var filter = $.extend({type: 'select', 'attributes': {}, entity: entity}, this);
       $.extend(this, filter);
       if (!params[filter.key]) {
+        // Filter out options if params don't match its condition
+        if (filter.condition && !_.isMatch(params, _.pick(filter.condition, _.keys(params)))) {
+          return;
+        }
         result.push(filter);
       }
       else if (filter.key == 'contact_type' && typeof params.contact_sub_type === 'undefined') {

--- a/js/Common.js
+++ b/js/Common.js
@@ -718,18 +718,16 @@ if (!CRM.vars) CRM.vars = {};
   function getEntityRefFilters($el) {
     var
       entity = $el.data('api-entity').toLowerCase(),
-      filters = $.extend([], CRM.config.entityRef.filters[entity] || []),
+      filters = CRM.config.entityRef.filters[entity] || [],
       params = $.extend({params: {}}, $el.data('api-params') || {}).params,
       result = [];
     $.each(filters, function() {
       var filter = $.extend({type: 'select', 'attributes': {}, entity: entity}, this);
-      if (typeof params[filter.key] === 'undefined') {
+      $.extend(this, filter);
+      if (!params[filter.key]) {
         result.push(filter);
       }
       else if (filter.key == 'contact_type' && typeof params.contact_sub_type === 'undefined') {
-        filter.options = _.remove(filter.options, function(option) {
-          return option.key.indexOf(params.contact_type + '__') === 0;
-        });
         result.push(filter);
       }
     });
@@ -772,11 +770,7 @@ if (!CRM.vars) CRM.vars = {};
         attrs += ' ' + attr + '="' + val + '"';
       });
       if (filterSpec.type === 'select') {
-        markup = '<select' + attrs + '><option value="">' + _.escape(ts('- select -')) + '</option>';
-        if (filterSpec.options) {
-          markup += CRM.utils.renderOptions(filterSpec.options, filter.value);
-        }
-        markup += '</select>';
+        markup = '<select' + attrs + '><option value="">' + _.escape(ts('- select -')) + '</option></select>';
       } else {
         markup = '<input' + attrs + '/>';
       }
@@ -789,6 +783,7 @@ if (!CRM.vars) CRM.vars = {};
    */
   function renderEntityRefFilterValue($el) {
     var
+      entity = $el.data('api-entity').toLowerCase(),
       filter = $el.data('user-filter') || {},
       filterSpec = filter.key ? _.find(getEntityRefFilters($el), {key: filter.key}) : null,
       $keyField = $('.crm-entityref-filter-key', '#select2-drop'),
@@ -797,7 +792,7 @@ if (!CRM.vars) CRM.vars = {};
       $('.crm-entityref-filter-value', '#select2-drop').remove();
       $valField = $(entityRefFilterValueMarkup(filter, filterSpec));
       $keyField.after($valField);
-      if (filterSpec.type === 'select' && !filterSpec.options) {
+      if (filterSpec.type === 'select') {
         loadEntityRefFilterOptions(filter, filterSpec, $valField, $el);
       }
     } else {
@@ -806,22 +801,36 @@ if (!CRM.vars) CRM.vars = {};
   }
 
   /**
-   * Fetch options for a filter via ajax api
+   * Fetch options for a filter from cache or ajax api
    */
   function loadEntityRefFilterOptions(filter, filterSpec, $valField, $el) {
-    $valField.prop('disabled', true);
     // Fieldname may be prefixed with joins - strip those out
-    var fieldName = _.last(filter.key.split('.'));
+    var fieldName = _.last(filter.key.split('.')),
+      params = $.extend({params: {}}, $el.data('api-params') || {}).params;
+    if (filterSpec.options) {
+      setEntityRefFilterOptions($valField, fieldName, params, filterSpec);
+      return;
+    }
+    $('.crm-entityref-filters select', '#select2-drop').prop('disabled', true);
     CRM.api3(filterSpec.entity, 'getoptions', {field: fieldName, context: 'search', sequential: 1})
       .done(function(result) {
-        var entity = $el.data('api-entity').toLowerCase(),
-          globalFilterSpec = _.find(CRM.config.entityRef.filters[entity], {key: filter.key}) || {};
+        var entity = $el.data('api-entity').toLowerCase();
         // Store options globally so we don't have to look them up again
-        globalFilterSpec.options = result.values;
-        $valField.prop('disabled', false);
-        CRM.utils.setOptions($valField, result.values);
+        filterSpec.options = result.values;
+        $('.crm-entityref-filters select', '#select2-drop').prop('disabled', false);
+        setEntityRefFilterOptions($valField, fieldName, params, filterSpec);
         $valField.val(filter.value || '');
       });
+  }
+
+  function setEntityRefFilterOptions($valField, fieldName, params, filterSpec) {
+    var values = _.cloneDeep(filterSpec.options);
+    if (fieldName === 'contact_type' && params.contact_type) {
+      values = _.remove(values, function(option) {
+        return option.key.indexOf(params.contact_type + '__') === 0;
+      });
+    }
+    CRM.utils.setOptions($valField, values);
   }
 
   //CRM-15598 - Override url validator method to allow relative url's (e.g. /index.htm)


### PR DESCRIPTION
Overview
----------------------------------------
Fixes two bugs in EntityRef widget filters (e.g. the "Refine Search..." area when entering a contact on a form).

Before
----------------------------------------

1. Contact Type filter was broken for contactRef fields that already had a contact type specified (e.g. Current Employer field is set to contact type Organization)
2. Filters specific to Individuals were showing even when a different contact type was specified (e.g. Current Employer field allowed to filter by Deceased and Gender - which are irrelevant to Organizations).

After
----------------------------------------
1. Fixed.
2. Fixed.

See https://lab.civicrm.org/dev/core/issues/677