### PR TITLE
dev/core#676 Disable GeoCoding Tests for PR jobs and re-enable Mailin…

### DIFF
--- a/tests/phpunit/CRM/Utils/GeocodeTest.php
+++ b/tests/phpunit/CRM/Utils/GeocodeTest.php
@@ -13,6 +13,10 @@ class CRM_Utils_GeocodeTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
+  /**
+   * Test the format returned by Google GeoCoding
+   * @group ornery
+   */
   public function testStateProvinceFormat() {
     $params = array('state_province_id' => 1022, 'country' => 'U.S.A');
     $formatted = CRM_Utils_Geocode_Google::format($params);
@@ -24,6 +28,10 @@ class CRM_Utils_GeocodeTest extends CiviUnitTestCase {
     $this->assertApproxEquals('-94.68', $params['geo_code_2'], 1);
   }
 
+  /**
+   * Test Geoging Method off
+   * @group ornery
+   */
   public function testGeocodeMethodOff() {
     // Set a geocoding provider.
     $result = civicrm_api3('Setting', 'create', array(

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -337,7 +337,6 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
    *    The total number of contacts for whom messages should have
    *    been sent.
    * @dataProvider concurrencyExamples
-   * @group ornery
    */
   public function testConcurrency($settings, $expectedTallies, $expectedTotal) {
     $settings = array_merge($this->defaultSettings, $settings);


### PR DESCRIPTION
…g Test jobs for PRs previously disabled now fixed

Overview
----------------------------------------
This disables GeoCoding jobs for PR tests (will still run in matrix tests) and re-enables the Process Mailing Job previously disabled

ping @eileenmcnaughton @colemanw @totten 