### PR TITLE
(dev/core#635) Implement local array-cache for use with Redis/Memcache

### DIFF
--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -118,7 +118,17 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
   }
 
   private function reobjectify($value) {
-    return is_object($value) ? unserialize(serialize($value)) : $value;
+    if (is_object($value)) {
+      return unserialize(serialize($value));
+    }
+    if (is_array($value)) {
+      foreach ($value as $p) {
+        if (is_object($p)) {
+          return unserialize(serialize($value));
+        }
+      }
+    }
+    return $value;
   }
 
   /**

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -121,4 +121,12 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
     return is_object($value) ? unserialize(serialize($value)) : $value;
   }
 
+  /**
+   * @param string $key
+   * @return int|null
+   */
+  public function getExpires($key) {
+    return $this->_expires[$key] ?: NULL;
+  }
+
 }

--- a/CRM/Utils/Cache/ArrayDecorator.php
+++ b/CRM/Utils/Cache/ArrayDecorator.php
@@ -1,0 +1,139 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ */
+
+/**
+ * Class CRM_Utils_Cache_ArrayDecorator
+ *
+ * This creates a two-tier cache-hierarchy: a thread-local, array-based cache
+ * combined with some third-party cache driver.
+ *
+ * Ex: $cache = new CRM_Utils_Cache_ArrayDecorator(new CRM_Utils_Cache_Redis(...));
+ */
+class CRM_Utils_Cache_ArrayDecorator implements CRM_Utils_Cache_Interface {
+
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
+  /**
+   * @var int
+   *   Default time-to-live (seconds) for cache items that don't have a TTL.
+   */
+  protected $defaultTimeout;
+
+  /**
+   * @var CRM_Utils_Cache_Interface
+   */
+  private $delegate;
+
+  /**
+   * @var array
+   *   Array(string $cacheKey => mixed $cacheValue).
+   */
+  private $values = [];
+
+  /**
+   * @var array
+   *   Array(string $cacheKey => int $expirationTime).
+   */
+  private $expires = [];
+
+  /**
+   * CRM_Utils_Cache_ArrayDecorator constructor.
+   * @param \CRM_Utils_Cache_Interface $delegate
+   * @param int $defaultTimeout
+   *   Default number of seconds each cache-item should endure.
+   */
+  public function __construct(\CRM_Utils_Cache_Interface $delegate, $defaultTimeout = 3600) {
+    $this->defaultTimeout = $defaultTimeout;
+    $this->delegate = $delegate;
+  }
+
+  public function set($key, $value, $ttl = NULL) {
+    if (is_int($ttl) && $ttl <= 0) {
+      return $this->delete($key);
+    }
+
+    $expiresAt = CRM_Utils_Date::convertCacheTtlToExpires($ttl, $this->defaultTimeout);
+    if ($this->delegate->set($key, [$expiresAt, $value], $ttl)) {
+      $this->values[$key] = $this->reobjectify($value);
+      $this->expires[$key] = $expiresAt;
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  public function get($key, $default = NULL) {
+    if (array_key_exists($key, $this->values) && $this->expires[$key] > CRM_Utils_Time::getTimeRaw()) {
+      return $this->reobjectify($this->values[$key]);
+    }
+
+    $nack = CRM_Utils_Cache::nack();
+    $value = $this->delegate->get($key, $nack);
+    if ($value === $nack) {
+      return $default;
+    }
+
+    $this->expires[$key] = $value[0];
+    $this->values[$key] = $value[1];
+    return $this->reobjectify($this->values[$key]);
+  }
+
+  public function delete($key) {
+    unset($this->values[$key]);
+    unset($this->expires[$key]);
+    return $this->delegate->delete($key);
+  }
+
+  public function flush() {
+    return $this->clear();
+  }
+
+  public function clear() {
+    $this->values = [];
+    $this->expires = [];
+    return $this->delegate->clear();
+  }
+
+  public function has($key) {
+    if (array_key_exists($key, $this->values) && $this->expires[$key] > CRM_Utils_Time::getTimeRaw()) {
+      return TRUE;
+    }
+    return $this->delegate->has($key);
+  }
+
+  private function reobjectify($value) {
+    return is_object($value) ? unserialize(serialize($value)) : $value;
+  }
+
+}

--- a/CRM/Utils/Cache/FastArrayDecorator.php
+++ b/CRM/Utils/Cache/FastArrayDecorator.php
@@ -1,0 +1,134 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ */
+
+/**
+ * Class CRM_Utils_Cache_FastArrayDecorator
+ *
+ * Like CRM_Utils_Cache_ArrayDecorator, this creates a two-tier cache.
+ * But it's... faster. The speed improvements are achieved by sacrificing
+ * compliance with PSR-16. Specific trade-offs:
+ *
+ * 1. TTL values are not tracked locally. Any data cached locally will stay
+ *    active until the instance is destroyed (i.e. until the request ends).
+ *    You won't notice this is you have short-lived requests and long-lived caches.
+ * 2. If you store an *object* in the local cache, the same object instance
+ *    will be used through the end of the request. If you modify a property
+ *    of the object, the change will endure within the current pageview but
+ *    will not pass-through to the persistent cache.
+ *
+ * But... it is twice as fast (on high-volume reads).
+ *
+ * Ex: $cache = new CRM_Utils_Cache_FastArrayDecorator(new CRM_Utils_Cache_Redis(...));
+ *
+ * @see CRM_Utils_Cache_ArrayDecorator
+ */
+class CRM_Utils_Cache_FastArrayDecorator implements CRM_Utils_Cache_Interface {
+
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
+  /**
+   * @var int
+   *   Default time-to-live (seconds) for cache items that don't have a TTL.
+   */
+  protected $defaultTimeout;
+
+  /**
+   * @var CRM_Utils_Cache_Interface
+   */
+  private $delegate;
+
+  /**
+   * @var array
+   *   Array(string $cacheKey => mixed $cacheValue).
+   */
+  private $values = [];
+
+  /**
+   * CRM_Utils_Cache_FastArrayDecorator constructor.
+   * @param \CRM_Utils_Cache_Interface $delegate
+   * @param int $defaultTimeout
+   *   Default number of seconds each cache-item should endure.
+   */
+  public function __construct(\CRM_Utils_Cache_Interface $delegate, $defaultTimeout = 3600) {
+    $this->defaultTimeout = $defaultTimeout;
+    $this->delegate = $delegate;
+  }
+
+  public function set($key, $value, $ttl = NULL) {
+    if (is_int($ttl) && $ttl <= 0) {
+      return $this->delete($key);
+    }
+
+    if ($this->delegate->set($key, $value, $ttl)) {
+      $this->values[$key] = $value;
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  public function get($key, $default = NULL) {
+    if (array_key_exists($key, $this->values)) {
+      return $this->values[$key];
+    }
+
+    $nack = CRM_Utils_Cache::nack();
+    $value = $this->delegate->get($key, $nack);
+    if ($value === $nack) {
+      return $default;
+    }
+
+    $this->values[$key] = $value;
+    return $value;
+  }
+
+  public function delete($key) {
+    unset($this->values[$key]);
+    return $this->delegate->delete($key);
+  }
+
+  public function flush() {
+    return $this->clear();
+  }
+
+  public function clear() {
+    $this->values = [];
+    return $this->delegate->clear();
+  }
+
+  public function has($key) {
+    return $this->delegate->has($key);
+  }
+
+}

--- a/CRM/Utils/Cache/Tiered.php
+++ b/CRM/Utils/Cache/Tiered.php
@@ -1,0 +1,186 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ */
+
+/**
+ * Class CRM_Utils_Cache_Tiered
+ *
+ * `Tiered` implements a hierarchy of fast and slow caches. For example, you
+ * might have a configuration in which:
+ *
+ *   - A local/in-memory array caches info for up to 1 minute (60s).
+ *   - A Redis cache retains info for up to 10 minutes (600s).
+ *   - A SQL cache retains info for up to 1 hour (3600s).
+ *
+ * Cached data will be written to all three tiers. When reading, you'll hit the
+ * fastest available tier.
+ *
+ * The example would be created with:
+ *
+ * $cache = new CRM_Utils_Cache_Tiered([
+ *   new CRM_Utils_Cache_ArrayCache(...),
+ *   new CRM_Utils_Cache_Redis(...),
+ *   new CRM_Utils_Cache_SqlGroup(...),
+ * ], [60, 600, 3600]);
+ *
+ * Note:
+ *  - Correctly implementing PSR-16 leads to a small amount of CPU+mem overhead.
+ *    If you need an extremely high number of re-reads within a thread and can live
+ *    with only two tiers, try CRM_Utils_Cache_ArrayDecorator or
+ *    CRM_Utils_Cache_FastArrayDecorator instead.
+ *  - With the exception of unit-testing, you should not access the underlying
+ *    tiers directly. The data-format may be different than your expectation.
+ */
+class CRM_Utils_Cache_Tiered implements CRM_Utils_Cache_Interface {
+
+  use CRM_Utils_Cache_NaiveMultipleTrait; // TODO Consider native implementation.
+
+  /**
+   * @var array
+   *   Array(int $tierNum => int $seconds).
+   */
+  protected $maxTimeouts;
+
+  /**
+   * @var array
+   *   List of cache instances, with fastest/closest first.
+   *   Array(int $tierNum => CRM_Utils_Cache_Interface).
+   */
+  protected $tiers;
+
+  /**
+   * CRM_Utils_Cache_Tiered constructor.
+   * @param array $tiers
+   *   List of cache instances, with fastest/closest first.
+   *   Must be indexed numerically (0, 1, 2...).
+   * @param array $maxTimeouts
+   *   A list of maximum timeouts for each cache-tier.
+   *   There must be at least one value in this array.
+   *   If timeouts are omitted for slower tiers, they are filled in with the last value.
+   * @throws CRM_Core_Exception
+   */
+  public function __construct($tiers, $maxTimeouts = [86400]) {
+    $this->tiers = $tiers;
+    $this->maxTimeouts = [];
+
+    foreach ($tiers as $k => $tier) {
+      $this->maxTimeouts[$k] = isset($maxTimeouts[$k])
+        ? $maxTimeouts[$k]
+        : $this->maxTimeouts[$k - 1];
+    }
+
+    for ($far = 1; $far < count($tiers); $far++) {
+      $near = $far - 1;
+      if ($this->maxTimeouts[$near] > $this->maxTimeouts[$far]) {
+        throw new \CRM_Core_Exception("Invalid configuration: Near cache #{$near} has longer timeout than far cache #{$far}");
+      }
+    }
+  }
+
+  public function set($key, $value, $ttl = NULL) {
+    if ($ttl !== NULL & !is_int($ttl) && !($ttl instanceof DateInterval)) {
+      throw new CRM_Utils_Cache_InvalidArgumentException("Invalid cache TTL");
+    }
+    foreach ($this->tiers as $tierNum => $tier) {
+      /** @var CRM_Utils_Cache_Interface $tier */
+      $effTtl = $this->getEffectiveTtl($tierNum, $ttl);
+      $expiresAt = CRM_Utils_Date::convertCacheTtlToExpires($effTtl, $this->maxTimeouts[$tierNum]);
+      if (!$tier->set($key, [0 => $expiresAt, 1 => $value], $effTtl)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  public function get($key, $default = NULL) {
+    $nack = CRM_Utils_Cache::nack();
+    foreach ($this->tiers as $readTierNum => $tier) {
+      /** @var CRM_Utils_Cache_Interface $tier */
+      $wrapped = $tier->get($key, $nack);
+      if ($wrapped !== $nack && $wrapped[0] >= CRM_Utils_Time::getTimeRaw()) {
+        list ($parentExpires, $value) = $wrapped;
+        // (Re)populate the faster caches; and then return the value we found.
+        for ($i = 0; $i < $readTierNum; $i++) {
+          $now = CRM_Utils_Time::getTimeRaw();
+          $effExpires = min($parentExpires, $now + $this->maxTimeouts[$i]);
+          $this->tiers[$i]->set($key, [0 => $effExpires, 1 => $value], $effExpires - $now);
+        }
+        return $value;
+      }
+    }
+    return $default;
+  }
+
+  public function delete($key) {
+    foreach ($this->tiers as $tier) {
+      /** @var CRM_Utils_Cache_Interface $tier */
+      $tier->delete($key);
+    }
+    return TRUE;
+  }
+
+  public function flush() {
+    return $this->clear();
+  }
+
+  public function clear() {
+    foreach ($this->tiers as $tier) {
+      /** @var CRM_Utils_Cache_Interface $tier */
+      if (!$tier->clear()) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  public function has($key) {
+    $nack = CRM_Utils_Cache::nack();
+    foreach ($this->tiers as $tier) {
+      /** @var CRM_Utils_Cache_Interface $tier */
+      $wrapped = $tier->get($key, $nack);
+      if ($wrapped !== $nack && $wrapped[0] > CRM_Utils_Time::getTimeRaw()) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  protected function getEffectiveTtl($tierNum, $ttl) {
+    if ($ttl === NULL) {
+      return $this->maxTimeouts[$tierNum];
+    }
+    else {
+      return min($this->maxTimeouts[$tierNum], $ttl);
+    }
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/ArrayDecoratorTest.php
+++ b/tests/phpunit/E2E/Cache/ArrayDecoratorTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_ArrayDecorator complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_ArrayDecoratorTest extends E2E_Cache_CacheTestCase {
+
+  /**
+   * @var CRM_Utils_Cache_Interface
+   */
+  protected $a;
+
+  public function createSimpleCache() {
+    return new CRM_Utils_Cache_ArrayDecorator(
+      $this->a = CRM_Utils_Cache::create([
+        'name' => 'e2e array-dec test',
+        'type' => ['ArrayCache'],
+      ])
+    );
+  }
+
+  public function testDoubleLifeWithDelete() {
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+
+    $this->cache->set('foo', 100);
+
+    $this->assertTrue($this->a->has('foo'));
+    $this->assertEquals(100, $this->a->get('foo', 'dfl-1')[1]);
+
+    $this->cache->set('foo', 200);
+
+    $this->assertTrue($this->a->has('foo'));
+    $this->assertEquals(200, $this->a->get('foo', 'dfl-1')[1]);
+
+    $this->cache->delete('foo');
+
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+  }
+
+  public function testDoubleLifeWithClear() {
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+
+    $this->cache->set('foo', 100);
+
+    $this->assertTrue($this->a->has('foo'));
+    $this->assertEquals(100, $this->a->get('foo', 'dfl-1')[1]);
+
+    $this->cache->clear();
+
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/FastArrayDecoratorTest.php
+++ b/tests/phpunit/E2E/Cache/FastArrayDecoratorTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_FastArrayDecorator complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_FastArrayDecoratorTest extends E2E_Cache_ArrayDecoratorTest {
+
+  /**
+   * @var CRM_Utils_Cache_Interface
+   */
+  protected $a;
+
+  public function createSimpleCache() {
+    return new CRM_Utils_Cache_FastArrayDecorator(
+      $this->a = CRM_Utils_Cache::create([
+        'name' => 'e2e fast-arr-dec test',
+        'type' => ['ArrayCache'],
+      ])
+    );
+  }
+
+  public function testSetTtl() {
+    $this->markTestSkipped('FastArrayDecorator breaks convention: Does not track TTL locally. However, TTL is passed along to delegate.');
+  }
+
+  public function testSetMultipleTtl() {
+    $this->markTestSkipped('FastArrayDecorator breaks convention: Does not track TTL locally. However, TTL is passed along to delegate.');
+  }
+
+  public function testDoubleLifeWithDelete() {
+    $this->markTestSkipped('FastArrayDecorator breaks convention: Does not track TTL locally. However, TTL is passed along to delegate.');
+  }
+
+  public function testDoubleLifeWithClear() {
+    $this->markTestSkipped('FastArrayDecorator breaks convention: Does not track TTL locally. However, TTL is passed along to delegate.');
+  }
+
+  public function testObjectDoesNotChangeInCache() {
+    $this->markTestSkipped('FastArrayDecorator breaks convention: No deep-copying cache content');
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/TieredTest.php
+++ b/tests/phpunit/E2E/Cache/TieredTest.php
@@ -1,0 +1,205 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Verify that CRM_Utils_Cache_Tiered complies with PSR-16.
+ *
+ * @group e2e
+ */
+class E2E_Cache_TieredTest extends E2E_Cache_CacheTestCase {
+  const TOLERANCE = 5;
+
+  /**
+   * @var CRM_Utils_Cache_ArrayCache
+   */
+  protected $a, $b;
+
+  protected function tearDown() {
+    if (function_exists('timecop_return')) {
+      timecop_return();
+    }
+    parent::tearDown();
+  }
+
+  public function createSimpleCache($maxTimeouts = [86400]) {
+    return new CRM_Utils_Cache_Tiered([
+      $this->a = CRM_Utils_Cache::create([
+        'name' => 'e2e tiered test a',
+        'type' => ['ArrayCache'],
+      ]),
+      $this->b = CRM_Utils_Cache::create([
+        'name' => 'e2e tiered test b',
+        'type' => ['ArrayCache'],
+      ])
+    ], $maxTimeouts);
+  }
+
+  public function testDoubleLifeWithDelete() {
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertFalse($this->b->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+    $this->assertEquals('dfl-2', $this->b->get('foo', 'dfl-2'));
+
+    $this->cache->set('foo', 100);
+
+    $this->assertTrue($this->a->has('foo'));
+    $this->assertTrue($this->b->has('foo'));
+    $this->assertEquals(100, $this->a->get('foo', 'dfl-1')[1]);
+    $this->assertEquals(100, $this->b->get('foo', 'dfl-2')[1]);
+    $this->assertEquals($this->a->get('foo'), $this->b->get('foo'));
+
+    $this->cache->set('foo', 200);
+
+    $this->assertTrue($this->a->has('foo'));
+    $this->assertTrue($this->b->has('foo'));
+    $this->assertEquals(200, $this->a->get('foo', 'dfl-1')[1]);
+    $this->assertEquals(200, $this->b->get('foo', 'dfl-2')[1]);
+    $this->assertEquals($this->a->get('foo'), $this->b->get('foo'));
+
+    $this->cache->delete('foo');
+
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertFalse($this->b->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+    $this->assertEquals('dfl-2', $this->b->get('foo', 'dfl-2'));
+  }
+
+  public function testDoubleLifeWithClear() {
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertFalse($this->b->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+    $this->assertEquals('dfl-2', $this->b->get('foo', 'dfl-2'));
+
+    $this->cache->set('foo', 100);
+
+    $this->assertTrue($this->a->has('foo'));
+    $this->assertTrue($this->b->has('foo'));
+    $this->assertEquals(100, $this->a->get('foo', 'dfl-1')[1]);
+    $this->assertEquals(100, $this->b->get('foo', 'dfl-2')[1]);
+    $this->assertEquals($this->a->get('foo'), $this->b->get('foo'));
+
+    $this->cache->clear();
+
+    $this->assertFalse($this->a->has('foo'));
+    $this->assertFalse($this->b->has('foo'));
+    $this->assertEquals('dfl-1', $this->a->get('foo', 'dfl-1'));
+    $this->assertEquals('dfl-2', $this->b->get('foo', 'dfl-2'));
+  }
+
+  public function testTieredTimeout_default() {
+    $start = CRM_Utils_Time::getTimeRaw();
+    $this->cache = $this->createSimpleCache([100, 1000]);
+
+    $this->cache->set('foo', 'bar');
+    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    // Simulate expiration & repopulation in nearest tier.
+
+    $this->a->clear();
+    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    $this->assertEquals('bar', $this->cache->get('foo'));
+    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+  }
+
+  public function testTieredTimeout_explicitLow() {
+    $start = CRM_Utils_Time::getTimeRaw();
+    $this->cache = $this->createSimpleCache([100, 1000]);
+
+    $this->cache->set('foo', 'bar', 50);
+    $this->assertApproxEquals($start + 50, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    // Simulate expiration & repopulation in nearest tier.
+
+    $this->a->clear();
+    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    $this->assertEquals('bar', $this->cache->get('foo'));
+    $this->assertApproxEquals($start + 50, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
+  }
+
+  public function testTieredTimeout_explicitMedium() {
+    $start = CRM_Utils_Time::getTimeRaw();
+    $this->cache = $this->createSimpleCache([100, 1000]);
+
+    $this->cache->set('foo', 'bar', 500);
+    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    // Simulate expiration & repopulation in nearest tier.
+
+    $this->a->clear();
+    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    $this->assertEquals('bar', $this->cache->get('foo'));
+    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
+  }
+
+  public function testTieredTimeout_explicitHigh_lateReoad() {
+    $start = CRM_Utils_Time::getTimeRaw();
+    $this->cache = $this->createSimpleCache([100, 1000]);
+
+    $this->cache->set('foo', 'bar', 5000);
+    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    // Simulate expiration & repopulation in nearest tier.
+
+    $this->a->clear();
+    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+
+    function_exists('timecop_return') ? timecop_travel(time() + self::TOLERANCE) : sleep(self::TOLERANCE);
+
+    $this->assertEquals('bar', $this->cache->get('foo'));
+    $this->assertApproxEquals($start + 100 + self::TOLERANCE, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+  }
+
+  /**
+   * Assert that two numbers are approximately equal.
+   *
+   * @param int|float $expected
+   * @param int|float $actual
+   * @param int|float $tolerance
+   * @param string $message
+   */
+  public function assertApproxEquals($expected, $actual, $tolerance, $message = NULL) {
+    if ($message === NULL) {
+      $message = sprintf("approx-equals: expected=[%.3f] actual=[%.3f] tolerance=[%.3f]", $expected, $actual, $tolerance);
+    }
+    $this->assertTrue(abs($actual - $expected) < $tolerance, $message);
+  }
+
+}


### PR DESCRIPTION
Overview
--------

Consumers of Redis or Memcached currently trigger I/O anytime they read a value from the cache -- even if the value has been read before.  This is OK if the caller is organized to do one read.  It can be even good in some edge-cases of inter-process communication.  However, if the cache is read frequently, this can lead to a lot of redundant reads; and there are certainly use-cases where we have redundant reads.

This PR allows one to define a *cache-hierarchy* -- e.g.  combining a thread-local array with an external cache (like Redis, Memcache, SQL, or a on-disk file).

Context
-------

This is an off-shoot/subset of [dev/core#635](https://lab.civicrm.org/dev/core/issues/635) and #13489.  For `dev/core#635`, we want to minimize unnecessary SQL writes (e.g.  by directing all caches to a non-SQL cache-service).  The examples I've got all use `CRM_Core_BAO_Cache`, which is hard-coded with 2-tier cache-hierarchy (thread-local array-cache plus SQL-cache).

Concurrently, there've been critiques that some of the existing Redis/Memcache consumers should be using 2-tier cache-hierarchy.

In subsequent PRs, we'll want to create a "cache-hierarchy".  With these utilities, it can be done with only 1-2 lines of extra code, and it will be PSR-16 compliant.

This depends on #13500.

Before
------

* `CRM_Utils_Cache::create(...type => *memory*...)` returns an instance for direct-access to the underlying cache.
* If you want extra caching of the results, you have to write your own.

After
-----

* `CRM_Utils_Cache::create()` accepts an option `withArray => FALSE|TRUE|fast`, which allows you to request a Redis/Memcache instance which uses a thread-local array.
* The utility class `CRM_Utils_Cache_ArrayDecorator` implements a PSR-16 compliant wrapper. It takes any cache and puts a local-array in front of it.
* The utility class `CRM_Utils_Cache_FastArrayDecorator` does the same thing, but it's *not* PSR-16 compliant.  It sacrifices some correctness in order to improve performance.
* The utility class `CRM_Utils_Cache_Tiered` allows construction of arbitrary N-tier cache hierarchies. Whereas  `ArrayDecorator` allows two specific tiers (e.g. `array => $delegate`), `Tiered` can be used with stacks  (like `array => redis => sql` or `redis => sql => file`).

Technical Details / Comments
----------------------------

I originally drafted the implementation of `Tiered` because it was a more flexible design.  Then I ran a naive benchmark to compare the 2-tier hierarchy (`array=>redis`) against direct `redis` and found... it was about the same, and sometimes slower!

There were two basic reasons for this:

1.  _Usage patterns_: Tiering isn't a universal good; it depends on usage patterns.  If you just write a record, read that record   one time, and then repeat with different records...  then tiers suck.  There's no gain from avoiding reads, and writes are   more expensive.  But if you re-read data several times, then it helps a lot.  I needed to change the benchmark to compare   performance in that usage pattern.

2. _PSR-16 Compliance_: PSR-16 standardizes certain edge-cases, esp: (a) TTL/expiration, which leads to an extra   cost for enforcing consistent expiration times and (b) mutability of `object`s, which leads to an extra cost for   copying in-memory objects (`$copy=deserialize(serialize($original))`).

The revised [benchmark script](https://gist.github.com/totten/6d6524be115c193e0704ff3cf250336d) lets us specify the #read operations.  The `ArrayDecorator` and `FastArrayDecorator` were attempts to squeeze out more performance.  And the benchmarks improved.  In the figures below, we measure the write-time (writing 1000 items) and read-time (reading 200 items).  Note how it checks performance with different `readPerItem` values (i.e.  each item is read once; or read 10 times; or read 150 times).

```
[[ trialCount=3 writeItems=1000 readItems=200 numTimesToReadEachItem=1 ]]

Mean values across all trials:

direct          write=0.1050s   read=0.0092s   readPerItem=0.00922100s
tiered          write=0.1270s   read=0.0141s   readPerItem=0.01405501s
arrdec          write=0.1122s   read=0.0108s   readPerItem=0.01083700s
fastdec         write=0.1049s   read=0.0101s   readPerItem=0.01009822s

[[ trialCount=3 writeItems=1000 readItems=200 numTimesToReadEachItem=10 ]]

Mean values across all trials:

direct          write=0.1075s   read=0.0903s   readPerItem=0.00902683s
tiered          write=0.1233s   read=0.0363s   readPerItem=0.00362550s
arrdec          write=0.1133s   read=0.0179s   readPerItem=0.00179152s
fastdec         write=0.1036s   read=0.0129s   readPerItem=0.00128693s

[[ trialCount=3 writeItems=1000 readItems=200 numTimesToReadEachItem=150 ]]

Mean values across all trials:

direct          write=0.1012s   read=1.3051s   readPerItem=0.00870067s
tiered          write=0.1202s   read=0.3467s   readPerItem=0.00231102s
arrdec          write=0.1059s   read=0.1356s   readPerItem=0.00090372s
fastdec         write=0.1028s   read=0.0611s   readPerItem=0.00040723s
```

If there's only 1 read (no *re*-reading), then direct-access is best; all others have overhead.  The overhead diminishes as you go from `Tiered` to `ArrayDecorator` to `FastArrayDecorator`.

Why include all three -- why not just do one?  Well, (1) they're already written, and the parent unit-test goes a long way to showing the correctness of each, so it's not much difference cost-wise.  (2) The best one actually depends on the situation -- why you're using a cache, how big the data-records are, how frequently the records are read.  That means the decision about which mechanism to use (in which use-cases) should not be in this PR (which just provides the utility). The decision should be made when we use the cache-hierarchy (in subsequent PRs).

Reviewer Tips
--------------

Some things that might help in evaluating this:

* Each of the new classes has a corresponding test (like `E2E_Cache_TieredTest`), and the test classes are derived from `E2E_Cache_CacheTestCase` and `\Cache\IntegrationTests\LegacySimpleCacheTest`. That class originates with the `php-cache` project and provides pretty good test-coverage for functions like `get($key, $default=NULL)`, `set($key,$value,$ttl=NULL)`, and `has($key)`.
* You can play with caches manually via `cv cli`. You may not have Redis or Memcache locally, but you can pick any cache-driver (`CRM_Utils_Cache_SqlGroup`, `CRM_Utils_Cache_ArrayCache`).
    * Step 1: Create some underlying caches (`$a, $b, ...`) and an overarching cache (`$z`), like one of these:
        * `$a=new CRM_Utils_Cache_ArrayCache([]); $z=new CRM_Utils_Cache_ArrayDecorator($a);`
        * `$a=new CRM_Utils_Cache_ArrayCache([]); $b=new CRM_Utils_Cache_ArrayCache([]); $z = new CRM_Utils_Cache_Tiered([$a, $b]);`
        * `$a=CRM_Utils_Cache::create(['name'=>'foo-mem', 'type'=>['*memory*']]); $b=CRM_Utils_Cache::create(['name'=>'foo-sql', 'type'=>['SqlGroup']]); $z=new CRM_Utils_Cache_Tiered([$a,$b])`
    * Step 2: Interact with these cache objects, e.g.
        * `$z->set('foo',123);`
        * `$z->get('foo')`
        * `$a->get('foo')`
        * `print_r($z);`
        * `print_r(['a'=>$a, 'b'=>$b, 'z'=>$z])`
