### PR TITLE
dev/core#681 - Fatal Error on submitting "Change Case Status" activit…

### DIFF
--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -173,7 +173,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
 
     // Set case end_date if we're closing the case. Clear end_date if we're (re)opening it.
     if (CRM_Utils_Array::value($params['case_status_id'], $groupingValues) == 'Closed' && !empty($params['activity_date_time'])) {
-      $params['end_date'] = $params['activity_date_time'];
+      $params['end_date'] = CRM_Utils_Date::isoToMysql($params['activity_date_time']);
 
       // End case-specific relationships (roles)
       foreach ($params['target_contact_id'] as $cid) {


### PR DESCRIPTION
…y form

Overview
----------------------------------------


Before
----------------------------------------

![image](https://user-images.githubusercontent.com/5929648/51598865-6c6edf80-1f24-11e9-80bc-3d6cc5bf4b0b.png)

From Console 

    {"text":"One of parameters  (value: 2019-01-23 15:32:00) is not of the type Timestamp<p><em>
    See console for backtrace<\/em><\/p>","title":"Sorry an error occurred","type":"error","options":null}]}

After
----------------------------------------
works fine.

Technical Details
----------------------------------------
The updated datepicker submits the value as `yyyy-mm-dd hh:mm:ss` which is not validated as timestamp when fed to an sql query. 

Comments
----------------------------------------
Seems to be due to the recent datepicker updates made in the activity form.
