### PR TITLE
dev/core#682 Add basic contact filters to Summary Contributions Report

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4834,9 +4834,11 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   /**
    * Get a standard set of contact filters.
    *
+   * @param array $defaults
+   *
    * @return array
    */
-  public function getBasicContactFilters() {
+  public function getBasicContactFilters($defaults = array()) {
     return array(
       'sort_name' => array(
         'title' => ts('Contact Name'),
@@ -4872,7 +4874,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       'is_deceased' => array(
         'title' => ts('Deceased'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
-        'default' => 0,
+        'default' => CRM_Utils_Array::value('deceased', $defaults, 0),
       ),
       'do_not_email' => array(
         'title' => ts('Do not email'),

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -81,6 +81,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
             ),
           )
         ),
+        'filters' => $this->getBasicContactFilters(array('deceased' => NULL)),
         'grouping' => 'contact-fields',
         'group_bys' => array(
           'id' => array('title' => ts('Contact ID')),


### PR DESCRIPTION
Overview
----------------------------------------
Contributions of deleted contacts are shown on Summary Contributions Report. Adding basic contact filters to the Summary Contributions Report will prevent these "deleted" contributions from being included. In addition it will enable new possibilities when applying contact filters to the report.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/1064675/51624250-b2cf3900-1f3a-11e9-92d9-9b721f827e62.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/1064675/51624257-b5319300-1f3a-11e9-9a21-ad6ffdcec6c3.png)

Comments
----------------------------------------
As a summary report we are interested to include deceased contacts. For these reason we add a new param to the `getBasicContactFilters()` function.