### PR TITLE
If a profile is used to create a contact with a subtype the contact will not have any existing subtypes

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2121,11 +2121,17 @@ ORDER BY civicrm_email.is_primary DESC";
     ) {
       // if profile was used, and had any subtype, we obtain it from there
       //CRM-13596 - add to existing contact types, rather than overwriting
-      $data_contact_sub_type_arr = CRM_Utils_Array::explodePadded($data['contact_sub_type']);
-      if (!in_array($params['contact_sub_type_hidden'], $data_contact_sub_type_arr)) {
-        //CRM-20517 - make sure contact_sub_type gets the correct delimiters
-        $data['contact_sub_type'] = trim($data['contact_sub_type'], CRM_Core_DAO::VALUE_SEPARATOR);
-        $data['contact_sub_type'] = CRM_Core_DAO::VALUE_SEPARATOR . $data['contact_sub_type'] . CRM_Utils_Array::implodePadded($params['contact_sub_type_hidden']);
+      if (empty($data['contact_sub_type'])) {
+        // If we don't have a contact ID the $data['contact_sub_type'] will not be defined...
+        $data['contact_sub_type'] = CRM_Utils_Array::implodePadded($params['contact_sub_type_hidden']);
+      }
+      else {
+        $data_contact_sub_type_arr = CRM_Utils_Array::explodePadded($data['contact_sub_type']);
+        if (!in_array($params['contact_sub_type_hidden'], $data_contact_sub_type_arr)) {
+          //CRM-20517 - make sure contact_sub_type gets the correct delimiters
+          $data['contact_sub_type'] = trim($data['contact_sub_type'], CRM_Core_DAO::VALUE_SEPARATOR);
+          $data['contact_sub_type'] = CRM_Core_DAO::VALUE_SEPARATOR . $data['contact_sub_type'] . CRM_Utils_Array::implodePadded($params['contact_sub_type_hidden']);
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Stop PHP notices being thrown when creating a contact via profile with a subtype.

Before
----------------------------------------
PHP notices are thrown and contact_sub_type is not formatted correctly before being passed to contact create.

```
Notice: Undefined index: contact_sub_type in CRM_Contact_BAO_Contact::formatProfileContactParams() (line 2127 of /home/portalgaddumcent/drupal-7.59/sites/all/modules/civicrm/CRM/Contact/BAO/Contact.php).

Warning: in_array() expects parameter 2 to be array, null given in CRM_Contact_BAO_Contact::formatProfileContactParams() (line 2128 of /home/portalgaddumcent/drupal-7.59/sites/all/modules/civicrm/CRM/Contact/BAO/Contact.php).

Notice: Undefined index: contact_sub_type in CRM_Contact_BAO_Contact::formatProfileContactParams() (line 2130 of /home/portalgaddumcent/drupal-7.59/sites/all/modules/civicrm/CRM/Contact/BAO/Contact.php).
```

After
----------------------------------------
No PHP notices and contact_sub_type is formatted correctly before being passed to contact create.

Technical Details
----------------------------------------
Identified this during debugging of event registration with a (hidden) contact_sub_type enabled via profile.  If you look a little further up the function it should be obvious where $data['contact_sub_type'] is set and that it won't be set if there is no contact ID.

Comments
----------------------------------------
