### PR TITLE
(REF) Add CRM_Utils_Cache::nack(). Use it for NaiveHasTrait.

### DIFF
--- a/CRM/Utils/Cache/NaiveHasTrait.php
+++ b/CRM/Utils/Cache/NaiveHasTrait.php
@@ -33,17 +33,14 @@
  * The traditional CRM_Utils_Cache_Interface did not support has().
  * To get drop-in compliance with PSR-16, we use a naive adapter.
  *
- * Ideally, these should be replaced with more performant/native versions.
+ * There may be opportunities to replace/optimize in specific drivers.
  */
 trait CRM_Utils_Cache_NaiveHasTrait {
 
   public function has($key) {
-    // This is crazy-talk. If you've got an environment setup where you might
-    // be investigating this, fix your preferred cache driver by
-    // replacing `NaiveHasTrait` with a decent function.
-    $hasDefaultA = ($this->get($key, NULL) === NULL);
-    $hasDefaultB = ($this->get($key, 123) === 123);
-    return !($hasDefaultA && $hasDefaultB);
+    $nack = CRM_Utils_Cache::nack() . 'ht';
+    $value = $this->get($key, $nack);
+    return ($value !== $nack);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
When using PSR-16 to read a cached value, the `$cache->get($key)` will a return a default value on cache-miss, so it's hard to know if you've gotten a genuine value from the cache or just a default. If you need to know that, then it requires a second call to `$cache->has($key)`.

For some scenarios (esp for upcoming #13496 but also for existing `NaiveHasTrait`), it's important to know if you have a default or a cache-miss, and the code is central enough that we should avoid unnecesary roundtrips.

Before
----------------------------------------
* Most cache drivers in Civi mix-in `NaiveHasTrait`; that implementation of `$cache->has()` requires two round-trips.
* If you want to do a `$cache->has()` and `$cache->get()`, then there are typically *three* round-trips.

After
----------------------------------------
* Most cache drivers in Civi mix-in `NaiveHasTrait`; that implementation of `$cache->has()` only requires one round-trip.
* If you want to do a `$cache->has()` and `$cache->get()`, it can be handled with one round-trip:

    ```php
    $nack = CRM_Utils_Cache::nack();
    $value = $cache->get('foo', $nack);
    echo ($value === $nack) ? "Cache contains [$value]" : "Cache has no value".
    ```
