### PR TITLE
Fix shortcode button when popup setting is disabled

### DIFF
--- a/CRM/Core/Form/ShortCode.php
+++ b/CRM/Core/Form/ShortCode.php
@@ -171,9 +171,6 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
    * Build form elements based on the above metadata.
    */
   public function buildQuickForm() {
-    CRM_Core_Resources::singleton()
-      ->addScriptFile('civicrm', 'js/crm.insert-shortcode.js');
-
     $components = CRM_Utils_Array::collect('label', $this->components);
     $data = CRM_Utils_Array::collect('select', $this->components);
 

--- a/js/crm.insert-shortcode.js
+++ b/js/crm.insert-shortcode.js
@@ -1,52 +1,60 @@
 // https://civicrm.org/licensing
 
 CRM.$(function($) {
-  var $form = $('form.CRM_Core_Form_ShortCode');
+  $('.crm-shortcode-button').click(function(e) {
+    e.preventDefault();
+    CRM.loadPage($(this).attr('href'), {dialog: {width: '50%', height: '50%'}}).on('crmLoad', loadForm);
+  });
 
-  function changeComponent() {
-    var component = $(this).val(),
-      entities = $(this).data('entities');
+  function loadForm() {
+    var $form = $('form.CRM_Core_Form_ShortCode');
 
-    $('.shortcode-param[data-components]', $form).each(function() {
-      $(this).toggle($.inArray(component, $(this).data('components')) > -1);
+    function changeComponent() {
+      var component = $(this).val(),
+        entities = $(this).data('entities');
 
-      if (entities[component]) {
-        $('input[name=entity]')
-          .val('')
-          .data('key', entities[component].key)
-          .data('select-params', null)
-          .data('api-params', null)
-          .crmEntityRef(entities[component]);
-      }
-    });
-  }
+      $('.shortcode-param[data-components]', $form).each(function() {
+        $(this).toggle($.inArray(component, $(this).data('components')) > -1);
 
-  function close() {
-    $form.closest('.ui-dialog-content').dialog('close');
-  }
-
-  function insert() {
-    var code = '[civicrm';
-    $('.shortcode-param:visible', $form).each(function() {
-      var $el = $('input:checked, select, input.crm-form-entityref', this);
-      code += ' ' + $el.data('key') + '="' + $el.val() + '"';
-    });
-    window.send_to_editor(code + ']');
-    close();
-  }
-
-  $('select[name=component]', $form).each(changeComponent).change(changeComponent);
-
-  $form.closest('.ui-dialog-content').dialog('option', 'buttons', [
-    {
-      text: ts("Insert"),
-      icons: {primary: "fa-check"},
-      click: insert
-    },
-    {
-      text: ts("Cancel"),
-      icons: {primary: "fa-times"},
-      click: close
+        if (entities[component]) {
+          $('input[name=entity]')
+            .val('')
+            .data('key', entities[component].key)
+            .data('select-params', null)
+            .data('api-params', null)
+            .crmEntityRef(entities[component]);
+        }
+      });
     }
-  ]);
+
+    function close() {
+      $form.closest('.ui-dialog-content').dialog('close');
+    }
+
+    function insert() {
+      var code = '[civicrm';
+      $('.shortcode-param:visible', $form).each(function() {
+        var $el = $('input:checked, select, input.crm-form-entityref', this);
+        code += ' ' + $el.data('key') + '="' + $el.val() + '"';
+      });
+      window.send_to_editor(code + ']');
+      close();
+    }
+
+    $('select[name=component]', $form).each(changeComponent).change(changeComponent);
+
+    $(this).dialog('option', 'buttons', [
+      {
+        text: ts("Insert"),
+        icons: {primary: "fa-check"},
+        click: insert
+      },
+      {
+        text: ts("Cancel"),
+        icons: {primary: "fa-times"},
+        click: close
+      }
+    ]);
+  }
+
 });


### PR DESCRIPTION
Overview
----------------------------------------
Allows the shortcode popup to work normally even when ajax popups are disabled in CiviCRM settings.

Depends on https://github.com/civicrm/civicrm-wordpress/pull/145 

Before
----------------------------------------
When jax popups are disabled in CiviCRM settings the WP shortcode button was broken.

After
----------------------------------------
Now works with or without the setting.

Comments
----------------------------------------
This PR isn't nearly as big as it looks. It's mostly whitespace changes.
