### PR TITLE
Fix full group by in search builder when using tags

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4984,7 +4984,7 @@ civicrm_relationship.start_date > {$today}
     $select .= sprintf(", (%s) AS _wgt", $this->createSqlCase('contact_a.id', $cids));
     $where .= sprintf(' AND contact_a.id IN (%s)', implode(',', $cids));
     $order = 'ORDER BY _wgt';
-    $groupBy = '';
+    $groupBy = ($this->_useGroupBy) ? 'GROUP BY contact_a.id' : '';
     $limit = '';
     $query = "$select $from $where $groupBy $order $limit";
 


### PR DESCRIPTION
Overview
----------------------------------------
When using search builder and searching by tag only a single contact is displayed in the search results but the count is correct (eg 49).  When changing the number of displayed per page a mysql full group by error occurs as there is no group by clause (for contact_a.id).

Example search using demo data:
![localhost_8080_civicrm_contact_search_builder__qf_builder_display true qfkey e440a2cdbae102a67e5af63726ae054c_6804](https://user-images.githubusercontent.com/2052161/51743321-33ee1380-2094-11e9-9fda-47e7ea42155a.png)

Before
----------------------------------------
Search builder does not display results properly when searching by tag.

After
----------------------------------------
Search builder does display results properly when searching by tag.

Technical Details
----------------------------------------
This is another fullgroupby issue.

Comments
----------------------------------------
@seamuslee001 Tagging you as the resident fullgroupby expert!