### PR TITLE
Display error instead of fatal error when trying to view a case that you don't have permission to access

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -74,7 +74,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
 
     // Access check.
     if (!CRM_Case_BAO_Case::accessCase($this->_caseID, FALSE)) {
-      CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this case.'));
     }
 
     $fulltext = CRM_Utils_Request::retrieve('context', 'Alphanumeric');


### PR DESCRIPTION
Overview
----------------------------------------
The fatal error page is not user-friendly and suggests something has gone wrong with the system - it is also deprecated.  In this case the fatal error page is shown if you click "Manage" on a case which you don't have permission to access - this PR changes that to `statusBounce()` so the user remains on the case dashboard and is shown an error popup instead.

Before
----------------------------------------
Fatal error page when trying to access case from dashboard with filter set to "All cases" and clicking "Manage" on a case that you do not have access to.

After
----------------------------------------
"Friendly error" when trying to access case from dashboard with filter set to "All cases" and clicking "Manage" on a case that you do not have access to.
![portal gaddumcentre co uk_civicrm_case_reset 1](https://user-images.githubusercontent.com/2052161/51744842-fd66c780-2098-11e9-8c1e-874b0bdc33a9.png)


Technical Details
----------------------------------------
In general swapping `CRM_Core_Error::fatal()` for `CRM_Core_Error::statusBounce()` is ok for forms when something "normal" is happening.  An SQL query failure for example you might expect to see the fatal error screen as that is not a "normal" situation.

Comments
----------------------------------------
