### PR TITLE
Fix permission checks on contact create popups

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3651,7 +3651,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    * @return bool
    */
   public static function entityRefCreateLinks() {
-    return CRM_Core_Permission::check([['edit all contacts', 'add contacts']]);
+    return CRM_Core_Permission::check([['profile create', 'profile listings and forms']]);
   }
 
 }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3328,6 +3328,9 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    * @return array
    */
   public static function getCreateLinks($profiles = '', $appendProfiles = array()) {
+    if (!CRM_Contact_BAO_Contact::entityRefCreateLinks()) {
+      return [];
+    }
     // Default to contact profiles
     if (!$profiles) {
       $profiles = array('new_individual', 'new_organization', 'new_household');


### PR DESCRIPTION
Overview
--------
The permissions checked to show buttons to create a new contact via entityRef were not the correct permissions to actually create a contact in a profile form, which meant that some users could see the buttons but not be able to add contacts.

Before
-------
Removing "profile listings and forms" and "profile create" permissions from a user would result in the buttons still appearing but an error when clicking on it.

![screenshot from 2019-01-25 16-32-38](https://user-images.githubusercontent.com/2874912/51774067-f783dd00-20be-11e9-9cc6-78c57490bf7e.png)


After
-----
Button appears correctly when user has permission. Note in screenshot the user lacks admin or profile permissions, so no create buttons are shown in the entityRef widget.

![screenshot from 2019-01-25 16-33-21](https://user-images.githubusercontent.com/2874912/51774086-079bbc80-20bf-11e9-9972-f769034c7720.png)

