### PR TITLE
Fix for dev/core#686: Make "amount statistics" columns optional

### DIFF
--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -146,7 +146,7 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
           ),
           'total_amount' => array(
             'title' => ts('Amount Statistics'),
-            'required' => TRUE,
+            'default' => TRUE,
             'statistics' => array(
               'sum' => ts('Total Payments Made'),
               'count' => ts('Contribution Count'),


### PR DESCRIPTION
Overview
----------------------------------------
Currently the column "Amount Statistics" is required on the Membership Summary report. Some people report that users find these columns confusing. This PR aims to make them optional, but enabled by default.

Before
----------------------------------------
"Amount Statistics" is required. 
![stats_required](https://user-images.githubusercontent.com/759449/51777658-9d394b00-20c3-11e9-9eaf-da5aa1a1b7d9.png)


After
----------------------------------------
"Amount Statistics" is optional. 
![stats_optional](https://user-images.githubusercontent.com/759449/51777640-809d1300-20c3-11e9-885c-ce671ee1a4d0.png)

Technical Details
----------------------------------------
Seems to "just work". Wonder why this was required in the first place. Am I inadvertently breaking anything here?

Comments
----------------------------------------
[none]
