### PR TITLE
Core-688 - Contacts - New Email Fix Smarty/plugins/function.crmSettin…

### DIFF
--- a/CRM/Core/Smarty/plugins/function.crmSetting.php
+++ b/CRM/Core/Smarty/plugins/function.crmSetting.php
@@ -51,7 +51,8 @@ function smarty_function_crmSetting($params, &$smarty) {
   require_once 'api/api.php';
   $result = civicrm_api('setting', 'getvalue', $params);
   unset($errorScope);
-  if ($result === FALSE) {
+  // Core-688 FALSE is returned by Boolean settings, thus giving false errors.
+  if ($result === NULL) {
     $smarty->trigger_error("Unknown error");
     return NULL;
   }


### PR DESCRIPTION
…g.php

Overview
----------------------------------------
Fix false error when executing Contacts -> New Email

Before
----------------------------------------
Warning: Smarty error: Unknown error in D:\CiviCRM_Custom.git\joomla\administrator\components\com_civicrm\civicrm\packages\Smarty\Smarty.class.php on line 1100

After
----------------------------------------
Error message no longer appears.

Technical Details
----------------------------------------
Change line 54 in ../CRM/Core/Smarty/plugins/function.crmSetting.php to 

 if ($result === NULL) {

i.e. NULL instead of FALSE
Comments
----------------------------------------
Those more expert than I may have some observations to make.

https://lab.civicrm.org/dev/core/issues/688