### PR TITLE
remove duplicated call to createCreditNoteId()

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -495,19 +495,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       }
     }
 
-    //if contribution is created with cancelled or refunded status, add credit note id
-    if (!empty($params['contribution_status_id'])) {
-      $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-
-      if (($params['contribution_status_id'] == array_search('Refunded', $contributionStatus)
-          || $params['contribution_status_id'] == array_search('Cancelled', $contributionStatus))
-      ) {
-        if (empty($params['creditnote_id']) || $params['creditnote_id'] == "null") {
-          $params['creditnote_id'] = self::createCreditNoteId();
-        }
-      }
-    }
-
     $transaction = new CRM_Core_Transaction();
 
     try {


### PR DESCRIPTION
Overview
----------------------------------------
Remove duplicated call to `CRM_Contribute_BAO_Contribution::createCreditNoteId()` in `CRM_Contribute_BAO_Contribution::create()` method

Before
----------------------------------------
In `create()` method the function `createCreditNoteId()` is called if the Contribution to be created has status **Canceled** or **Refunded**
Then `add()` is called which does the exact same call

After
----------------------------------------
Only `add()` performs the `createCreditNoteId()` call

Technical Details
----------------------------------------
The exact same code is executed twice when creating/editing a Contribution in **Canceled** or **Refunded**. Removing the one in `create()`  method

Note extended discussion in chat at https://chat.civicrm.org/civicrm/pl/7ybsucbd1tr7bdftmb94atj6mh