### PR TITLE
CRM/Contribute - Add query optimization for creditnote_id

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4743,7 +4743,7 @@ WHERE ft.is_payment = 1
   public static function createCreditNoteId() {
     $prefixValue = Civi::settings()->get('contribution_invoice_settings');
 
-    $creditNoteNum = CRM_Core_DAO::singleValueQuery("SELECT count(creditnote_id) as creditnote_number FROM civicrm_contribution");
+    $creditNoteNum = CRM_Core_DAO::singleValueQuery("SELECT count(creditnote_id) as creditnote_number FROM civicrm_contribution WHERE creditnote_id IS NOT NULL");
     $creditNoteId = NULL;
 
     do {


### PR DESCRIPTION
Overview
----------------------------------------
When contributions are cancelled or refunded, the field `creditnote_id` is set to the next sequential number following the last generated `creditnote_id`.

Before
----------------------------------------
The query used to determine the last `creditnote_id` looks at *all* contributions in the database.

After
----------------------------------------
The query only looks at contributions with an existing `creditnote_id`, which is typically only a small subset of all contributions.

Comments
----------------------------------------
Query runtime went from about ~2.5 seconds to ~0.01s on a relatively beefy server with >10M contributions. Thanks to @JoeMurray for the idea!
