### PR TITLE
Fix undefined throwing error in CRM.checkPerm

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1497,7 +1497,7 @@ if (!CRM.vars) CRM.vars = {};
   // Determine if a user has a given permission.
   // @see CRM_Core_Resources::addPermissions
   CRM.checkPerm = function(perm) {
-    return CRM.permissions[perm];
+    return CRM.permissions && CRM.permissions[perm];
   };
 
   // Round while preserving sigfigs


### PR DESCRIPTION
Overview
------
Fixes https://github.com/civicrm/org.civicrm.tutorial/issues/5

Before
-----
The `CRM.checkPerm()` function might throw an error if no permissions had been set server-side.

After
----
The function returns `undefined` rather than throwing an error if no permissions have been defined.