### PR TITLE
Assign auto-renew options properly to the contribution page if memberships are added via priceset

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1207,6 +1207,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             }
           }
         }
+
+        // Loop through each membership type on the contribution page and assign details to the form
         foreach ($membershipTypeIds as $value) {
           $memType = $membershipTypeValues[$value];
           if ($selectedMembershipTypeID != NULL) {
@@ -1232,8 +1234,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
             if ($allowAutoRenewOpt) {
               $javascriptMethod = array('onclick' => "return showHideAutoRenew( this.value );");
-              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = (int) $memType['auto_renew'] * CRM_Utils_Array::value($value, CRM_Utils_Array::value('auto_renew', $this->_membershipBlock));
               $allowAutoRenewMembership = TRUE;
+              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = $memType['auto_renew'];
             }
             else {
               $javascriptMethod = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
If you assign multiple memberships to a contribution page via a priceset the auto-renew options are not properly assigned to the form and you cannot create an auto-renew membership.

To reproduce:
1. Create a contribution page.
2. Create a membership priceset containing 2 or more membership types which have auto-renew set to optional/mandatory.
3. Make sure you only have payment processor(s) supporting recurring payments assigned to the contribution page.
4. Load the contribution page and select one of the memberships.
5. Confirm and pay.

Before
----------------------------------------
The "Membership will be renewed automatically" for mandatory or the "Renew my membership automatically" checkbox for optional will not display below the membership radios once you've selected one of them.
On submitting the contribution page a recurring contribution will NOT be created.

After
----------------------------------------
The "Membership will be renewed automatically" for mandatory or the "Renew my membership automatically" checkbox for optional will display below the membership radios once you've selected one of them.
On submitting the contribution page a recurring contribution will be created.

Technical Details
----------------------------------------
We move the check for non auto-renew payment processors outside of the foreach block as we should only be checking this once per load.
Then we build the autorenew options for the form based on each membership.

Comments
----------------------------------------
@pradpnayak @monishdeb Is this one you could look at?