### PR TITLE
Find Contributions columns/headers not aligned when "Contributions OR Soft Credits?" filter set to "Soft Credits Only"

### DIFF
--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -61,19 +61,12 @@
           <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a></td>
         {/if}
         <td class="crm-contribution-amount">
-          {if !$row.contribution_soft_credit_amount}
              <a class="nowrap bold crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$row.contact_id`&id=`$row.contribution_id`&selector=1"}">
                &nbsp; {$row.total_amount|crmMoney:$row.currency}
             </a>
-          {/if}
           {if $row.amount_level }<br/>({$row.amount_level}){/if}
           {if $row.contribution_recur_id}<br/>{ts}(Recurring){/ts}{/if}
         </td>
-        {if $softCreditColumns}
-          <td class="right bold crm-contribution-soft_credit_amount">
-            <span class="nowrap">{$row.contribution_soft_credit_amount|crmMoney:$row.currency}</span>
-          </td>
-        {/if}
       {foreach from=$columnHeaders item=column}
         {assign var='columnName' value=$column.field_name}
         {if !$columnName}{* if field_name has not been set skip, this helps with not changing anything not specifically edited *}


### PR DESCRIPTION
Overview
----------------------------------------
Find Contributions search columns/headers not aligned when "Contributions OR Soft Credits?" filter set to "Soft Credits Only"

Before
----------------------------------------
The headers and columns do not match up
![before](https://user-images.githubusercontent.com/11323624/52079640-0ad1f500-2564-11e9-8405-7ba687f528d2.png)


After
----------------------------------------
The headers and columns line up
![after](https://user-images.githubusercontent.com/11323624/52079650-0e657c00-2564-11e9-8e14-a8ba05cf3b66.png)


