### PR TITLE
l10n.js - Reload when logging in as new user

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -603,7 +603,11 @@ class CRM_Core_Resources {
 
       $tsLocale = CRM_Core_I18n::getLocale();
       // Dynamic localization script
-      $this->addScriptUrl(CRM_Utils_System::url('civicrm/ajax/l10n-js/' . $tsLocale, array('r' => $this->getCacheCode())), $jsWeight++, $region);
+      $args = [
+        'r' => $this->getCacheCode(),
+        'cid' => CRM_Core_Session::getLoggedInContactID(),
+      ];
+      $this->addScriptUrl(CRM_Utils_System::url('civicrm/ajax/l10n-js/' . $tsLocale, $args, FALSE, NULL, FALSE), $jsWeight++, $region);
 
       // Add global settings
       $settings = array(


### PR DESCRIPTION
Overview
-----
Prevents a potential bug where clientside settings are served from a stale browser cache when switching users.

Before
------
Settings that depend on the user's permissions may not be correct when switching users. To reproduce:

1. Log in as a user without "profile create" or "profile listings and forms" permission.
2. Note that when using a contactRef widget on a form, no buttons are shown to create new contacts.
3. Log out and back in as a user with the above permissions (without clearing browser caches).
4. When using a contactRef widget on a form, the buttons should be there but they are not.
5. Clear browser caches and the buttons will reappear.

![image](https://user-images.githubusercontent.com/2874912/52080391-a3b54000-2565-11e9-8f02-3ae7d7a934c8.png)

After
------
Buttons always appear correctly.