### PR TITLE
Add a "Contact Type" filter to the Contribution Summary Report

### DIFF
--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -88,6 +88,11 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
             'title' => ts('Contact Name'),
           ),
         ),
+        'filters' => array(
+          'contact_type' => array(
+            'title' => ts('Contact Type'),
+          ),
+        ),
       ),
       'civicrm_email' => array(
         'dao' => 'CRM_Core_DAO_Email',


### PR DESCRIPTION
Overview
----------------------------------------
This change adds a "Contact Type" filter to the  Contribution Summary Report

Before
----------------------------------------
No "Contact Type" filter Contribution Summary Report
![nocontacttype](https://user-images.githubusercontent.com/11323624/52085344-44116180-2572-11e9-8514-43c2360fa955.png)

After
----------------------------------------
"Contact Type" filter on the Contribution Summary Report
![contacttypefilter](https://user-images.githubusercontent.com/11323624/52085352-496eac00-2572-11e9-9b10-17d103af0d2b.png)


