### PR TITLE
use number widget for weight fields in all forms

### DIFF
--- a/CRM/Admin/Form/LabelFormats.php
+++ b/CRM/Admin/Form/LabelFormats.php
@@ -128,7 +128,7 @@ class CRM_Admin_Form_LabelFormats extends CRM_Admin_Form {
     $this->add('text', 'SpaceY', ts('Vertical Spacing'), array('size' => 8, 'maxlength' => 8) + $disabled, $required);
     $this->add('text', 'lPadding', ts('Left Padding'), array('size' => 8, 'maxlength' => 8), $required);
     $this->add('text', 'tPadding', ts('Top Padding'), array('size' => 8, 'maxlength' => 8), $required);
-    $this->add('text', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_BAO_LabelFormat', 'weight'), TRUE);
+    $this->add('number', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_BAO_LabelFormat', 'weight'), TRUE);
 
     $this->addRule('label', ts('Name already exists in Database.'), 'objectExists', array(
       'CRM_Core_BAO_LabelFormat',

--- a/CRM/Admin/Form/ParticipantStatusType.php
+++ b/CRM/Admin/Form/ParticipantStatusType.php
@@ -64,7 +64,7 @@ class CRM_Admin_Form_ParticipantStatusType extends CRM_Admin_Form {
     $this->add('checkbox', 'is_active', ts('Active?'));
     $this->add('checkbox', 'is_counted', ts('Counted?'));
 
-    $this->add('text', 'weight', ts('Order'), $attributes['weight'], TRUE);
+    $this->add('number', 'weight', ts('Order'), $attributes['weight'], TRUE);
 
     $this->addSelect('visibility_id', array('label' => ts('Visibility'), 'required' => TRUE));
 

--- a/CRM/Admin/Form/PdfFormats.php
+++ b/CRM/Admin/Form/PdfFormats.php
@@ -77,7 +77,7 @@ class CRM_Admin_Form_PdfFormats extends CRM_Admin_Form {
     $this->add('text', 'margin_right', ts('Right Margin'), array('size' => 8, 'maxlength' => 8), TRUE);
     $this->add('text', 'margin_top', ts('Top Margin'), array('size' => 8, 'maxlength' => 8), TRUE);
     $this->add('text', 'margin_bottom', ts('Bottom Margin'), array('size' => 8, 'maxlength' => 8), TRUE);
-    $this->add('text', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_BAO_PdfFormat', 'weight'), TRUE);
+    $this->add('number', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_BAO_PdfFormat', 'weight'), TRUE);
 
     $this->addRule('name', ts('Name already exists in Database.'), 'objectExists', array(
         'CRM_Core_BAO_PdfFormat',

--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -165,7 +165,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
       );
 
       // weight
-      $this->add('text', "option_weight[$i]", ts('Order'),
+      $this->add('number', "option_weight[$i]", ts('Order'),
         $optionAttributes['weight']
       );
 

--- a/CRM/Campaign/Form/SurveyType.php
+++ b/CRM/Campaign/Form/SurveyType.php
@@ -129,7 +129,7 @@ class CRM_Campaign_Form_SurveyType extends CRM_Admin_Form {
     ) {
       $this->freeze(array('label', 'is_active'));
     }
-    $this->add('text', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'weight'), TRUE);
+    $this->add('number', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'weight'), TRUE);
 
     $this->assign('id', $this->_id);
   }

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -416,7 +416,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       );
 
       // weight
-      $this->add('text', "option_weight[$i]", ts('Order'),
+      $this->add('number', "option_weight[$i]", ts('Order'),
         $optionAttributes['weight']
       );
 

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -307,7 +307,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     $this->add('wysiwyg', 'help_post', ts('Post-form Help'), $attributes['help_post']);
 
     // weight
-    $this->add('text', 'weight', ts('Order'), $attributes['weight'], TRUE);
+    $this->add('number', 'weight', ts('Order'), $attributes['weight'], TRUE);
     $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
     // display style

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -182,7 +182,7 @@ class CRM_Custom_Form_Option extends CRM_Core_Form {
 
       $this->add('textarea', 'description', ts('Description'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'description'));
       // weight
-      $this->add('text', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'weight'), TRUE);
+      $this->add('number', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'weight'), TRUE);
       $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
       // is active ?

--- a/CRM/Member/Form/MembershipStatus.php
+++ b/CRM/Member/Form/MembershipStatus.php
@@ -153,7 +153,7 @@ class CRM_Member_Form_MembershipStatus extends CRM_Core_Form {
     );
     $this->add('checkbox', 'is_current_member', ts('Current Membership?'));
 
-    $this->add('text', 'weight', ts('Order'),
+    $this->add('number', 'weight', ts('Order'),
       CRM_Core_DAO::getAttribute('CRM_Member_DAO_MembershipStatus', 'weight')
     );
     $this->add('checkbox', 'is_default', ts('Default?'));

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -292,7 +292,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       }
 
       // weight
-      $this->add('text', 'option_weight[' . $i . ']', ts('Order'), $attributes['weight']);
+      $this->add('number', 'option_weight[' . $i . ']', ts('Order'), $attributes['weight']);
 
       // is active ?
       $this->add('checkbox', 'option_status[' . $i . ']', ts('Active?'));
@@ -311,7 +311,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     $this->add('checkbox', 'is_display_amounts', ts('Display Amount?'));
 
     // weight
-    $this->add('text', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'weight'), TRUE);
+    $this->add('number', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'weight'), TRUE);
     $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
     // checkbox / radio options per line

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -232,7 +232,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
       $this->add('textarea', 'help_post', ts('Post Option Help'));
 
       // weight
-      $this->add('text', 'weight', ts('Order'), NULL, TRUE);
+      $this->add('number', 'weight', ts('Order'), NULL, TRUE);
       $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
       // is active ?

--- a/CRM/Report/Form/Register.php
+++ b/CRM/Report/Form/Register.php
@@ -101,7 +101,7 @@ class CRM_Report_Form_Register extends CRM_Core_Form {
     $this->add('text', 'label', ts('Title'), array('size' => 40), TRUE);
     $this->add('text', 'value', ts('URL'), array('size' => 40), TRUE);
     $this->add('text', 'name', ts('Class'), array('size' => 40), TRUE);
-    $element = $this->add('text', 'weight', ts('Order'), array('size' => 4), TRUE);
+    $element = $this->add('number', 'weight', ts('Order'), array('size' => 4), TRUE);
     // $element->freeze( );
     $this->add('text', 'description', ts('Description'), array('size' => 40), TRUE);
 

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -439,7 +439,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFField');
 
     // weight
-    $this->add('text', 'weight', ts('Order'), $attributes['weight'], TRUE);
+    $this->add('number', 'weight', ts('Order'), $attributes['weight'], TRUE);
     $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
     $this->add('textarea', 'help_pre', ts('Field Pre Help'), $attributes['help_pre']);

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -184,7 +184,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     $this->add('wysiwyg', 'help_post', ts('Post-form Help'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'help_post'));
 
     // weight
-    $this->add('text', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFJoin', 'weight'), TRUE);
+    $this->add('number', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFJoin', 'weight'), TRUE);
     $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
     // is this group active ?


### PR DESCRIPTION
Overview
----------------------------------------
use number wiget for weight fields in all forms and keep it consistent.

Before
----------------------------------------
Forms have _weight_ field as plain-text input.



After
----------------------------------------
All of the forms have _weight_ field as number input widget keeping in consistent with other screen across CRM.



