### PR TITLE
dev/financial#40: Missing Financial type and Credit Account Code in Bookkeeping Transaction Report

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -769,7 +769,11 @@ WHERE li.contribution_id = %1";
           ));
           unset($updateFinancialItemInfoValues['financialTrxn']);
         }
-        elseif (!empty($updateFinancialItemInfoValues['link-financial-trxn']) && $newFinancialItem->amount != 0) {
+        elseif ($newFinancialItem->amount != 0 && !empty($trxn) &&
+          // bug in EntityFinancialTrxn.create API which doesn't recognize 0 amount
+          (!empty($updateFinancialItemInfoValues['link-financial-trxn']) ||
+           in_array($contributionStatus, ['Pending refund', 'Partially paid']))
+        ) {
           civicrm_api3('EntityFinancialTrxn', 'create', array(
             'entity_id' => $newFinancialItem->id,
             'entity_table' => 'civicrm_financial_item',

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -272,6 +272,69 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
   }
 
   /**
+   * dev-financial-40: Test that partial payment entries in entity-financial-trxn table to ensure that reverse transaction is entered
+   */
+  public function testPartialPaymentEntries() {
+    $this->registerParticipantAndPay($this->_expensiveFee);
+    $priceSetParams['price_' . $this->priceSetFieldID] = $this->veryExpensiveFeeValueID;
+    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID, 'participant');
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem);
+    $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item', 'return' => ['amount', 'entity_id']])['values'];
+    $expectedResults = [
+      [
+        'id' => 2,
+        'amount' => 100.00,
+        'entity_id' => 1,
+      ],
+      [
+        'id' => 4,
+        'amount' => -100.00, // ensure that reverse entry is entered in the EntityFinancialTrxn table on fee change to greater amount
+        'entity_id' => 2,
+      ],
+      [
+        'id' => 5,
+        'amount' => 120.00,
+        'entity_id' => 3,
+      ],
+    ];
+    foreach ($expectedResults as $key => $expectedResult) {
+      $this->checkArrayEquals($expectedResult, $actualResults[$key]);
+    }
+  }
+
+  /**
+   * dev-financial-40: Test that refund payment entries in entity-financial-trxn table to ensure that reverse transaction is entered on fee change to lesser amount
+   */
+  public function testRefundPaymentEntries() {
+    $this->registerParticipantAndPay($this->_expensiveFee);
+    $priceSetParams['price_' . $this->priceSetFieldID] = $this->cheapFeeValueID;
+    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID, 'participant');
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem);
+    $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item', 'return' => ['amount', 'entity_id']])['values'];
+    $expectedResults = [
+      [
+        'id' => 2,
+        'amount' => 100.00,
+        'entity_id' => 1,
+      ],
+      [
+        'id' => 4,
+        'amount' => -100.00, // ensure that reverse entry is entered in the EntityFinancialTrxn table
+        'entity_id' => 2,
+      ],
+      [
+        'id' => 5,
+        'amount' => 80.00,
+        'entity_id' => 3,
+      ],
+    ];
+    foreach ($expectedResults as $key => $expectedResult) {
+      $this->checkArrayEquals($expectedResult, $actualResults[$key]);
+    }
+  }
+
+
+  /**
    * Test that proper financial items are recorded for cancelled line items
    */
   public function testCRM20611() {


### PR DESCRIPTION
Overview
----------------------------------------
Following are the steps I used to replicate :

1. Do an event registration with price fee $1000
2. Change price fee to $800
3. Via Record refund backoffice form, submit refund amount $200
4. Now go to Bookkeeping transaction report, where you will find the reversal entry got blank financial type and Credit account code.

You will find similar behavior on changing the price fee to greater amount say $1200 instead of $800. Please check the Before/After screencast which shows both the refund/partial payment cases on price fee change and its effect on BK report before/after the fix respectively. 


Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/52127671-c411f700-2658-11e9-91d3-ebdb6cfa8358.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/52127689-d2601300-2658-11e9-8a7d-3bd10fccec9c.gif)


Technical Details
----------------------------------------
The BK report pulls out data correctly, so there nothing wrong in its query. In fact it exposes a bug on how we are recording financial entries in the respective table. In my finding, there is a missing entry in entity_financial_trxn table for reversal amount. 

Comments
-------------------------------
ping @kcristiano @eileenmcnaughton 