### PR TITLE
dev/core#691 Make default country optional on setting form

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -177,6 +177,12 @@ trait CRM_Admin_Form_SettingTrait {
           $options = civicrm_api3('Setting', 'getoptions', [
             'field' => $setting,
           ])['values'];
+          if ($props['html_type'] === 'Select' && isset($props['is_required']) && $props['is_required'] === FALSE && !isset($options[''])) {
+            // If the spec specifies the field is not required add a null option.
+            // Why not if empty($props['is_required']) - basically this has been added to the spec & might not be set to TRUE
+            // when it is true.
+            $options = ['' => ts('None')] + $options;
+          }
         }
         if ($props['type'] === 'Boolean') {
           $options = [$props['title'] => $props['name']];

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -156,11 +156,11 @@ return array(
     'html_attributes' => array(
       //'class' => 'crm-select2',
     ),
-    'default' => '1228',
     'add' => '4.4',
     'title' => 'Default Country',
     'is_domain' => 1,
     'is_contact' => 0,
+    'is_required' => FALSE,
     'description' => 'This value is selected by default when adding a new contact address.',
     'help_text' => NULL,
     'pseudoconstant' => array(

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -509,6 +509,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * CRM-19888 default country should be used if ambigous.
    */
   public function testImportAmbiguousStateCountry() {
+    $this->callAPISuccess('Setting', 'create', ['defaultContactCountry' => 1228]);
     $countries = CRM_Core_PseudoConstant::country(FALSE, FALSE);
     $this->callAPISuccess('Setting', 'create', array('countryLimit' => array(array_search('United States', $countries), array_search('Guyana', $countries), array_search('Netherlands', $countries))));
     $this->callAPISuccess('Setting', 'create', array('provinceLimit' => array(array_search('United States', $countries), array_search('Guyana', $countries), array_search('Netherlands', $countries))));

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -198,7 +198,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
    * Get Billing empty contact - this will return generic defaults
    */
   public function testProfileGetBillingEmptyContact() {
-
+    $this->callAPISuccess('Setting', 'create', ['defaultContactCountry' => 1228]);
     $params = array(
       'profile_id' => array('Billing'),
     );


### PR DESCRIPTION
Overview
----------------------------------------
Make the default country on the setting form optional

Note this also requires removing 'United States' as the default country in general - ahem!

Previous discussion / rationale https://issues.civicrm.org/jira/browse/CRM-18100

https://lab.civicrm.org/dev/core/issues/691

Before
----------------------------------------
![screenshot 2019-02-04 15 11 58](https://user-images.githubusercontent.com/336308/52186946-5ef41680-288f-11e9-830c-7799a76b516a.png)


After
----------------------------------------
![screenshot 2019-02-04 15 11 32](https://user-images.githubusercontent.com/336308/52186967-7501d700-288f-11e9-88b2-dc50b0a532de.png)


Technical Details
----------------------------------------
This introduces a new proposed value to the setting metadata spec 'is_required'. If this is set AND is FALSE then an empty option is added which the select widget seems to understand.

This means that is_required not being set !== FALSE or we'd have to do a big audit.

@colemanw @mattwire would appreciate your input

Comments
----------------------------------------
If there is a default in the metadata & the value is not set then the default will be used. Removing this default means new installs will have to set it if they want a default country. Welcome to the real world United States!