### PR TITLE
Revert fix causing unreleased regression

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -695,7 +695,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     //create/update saved search record.
     $savedSearch = new CRM_Contact_BAO_SavedSearch();
     $savedSearch->id = $ssId;
-    $savedSearch->form_values = serialize($params['form_values']);
+    $savedSearch->form_values = serialize(CRM_Contact_BAO_Query::convertFormValues($params['form_values']));
     $savedSearch->mapping_id = $mappingId;
     $savedSearch->search_custom_id = CRM_Utils_Array::value('search_custom_id', $params);
     $savedSearch->save();

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -314,7 +314,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
 
     CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
 
-    $this->_formValues = $this->_params = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
+    $this->_params = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
     $this->_returnProperties = &$this->returnProperties();
     parent::postProcess();
   }

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -252,11 +252,9 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
 
     $contactID = $this->individualCreate(['custom_' . $customFieldID => 'abc']);
 
-    $formValues = ['custom_' . $customFieldID => ['LIKE' => '%a%']];
-
     $hiddenSmartParams = [
       'group_type' => ['2' => 1],
-      'form_values' => CRM_Contact_BAO_Query::convertFormValues($formValues),
+      'form_values' => ['custom_' . $customFieldID => ['LIKE' => '%a%']],
       'saved_search_id' => NULL,
       'search_custom_id' => NULL,
       'search_context' => 'advanced',


### PR DESCRIPTION
Overview
----------------------------------------
Unfortunately https://github.com/civicrm/civicrm-core/pull/13250/files which fixes https://lab.civicrm.org/dev/core/issues/469 causes this regression https://lab.civicrm.org/dev/core/issues/671

Revert for the rc & try again

Before
----------------------------------------
Some form parameters ignored in search

After
----------------------------------------
Due care & attention restored

Technical Details
----------------------------------------


Comments
----------------------------------------
@monishdeb @francescbassas we can try again against master :-)
