### PR TITLE
use number widget for weight and other numeric fields in more forms

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -273,7 +273,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       );
     }
 
-    $this->add('text',
+    $this->add('number',
       'weight',
       ts('Order'),
       CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'weight'),

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -177,7 +177,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->add('datepicker', 'start_date', ts('Start'), [], !$this->_isTemplate, ['time' => TRUE]);
     $this->add('datepicker', 'end_date', ts('End'), [], FALSE, ['time' => TRUE]);
 
-    $this->add('text', 'max_participants', ts('Max Number of Participants'),
+    $this->add('number', 'max_participants', ts('Max Number of Participants'),
       array('onchange' => "if (this.value != '') {cj('#id-waitlist').show(); showHideByValue('has_waitlist','0','id-waitlist-text','table-row','radio',false); showHideByValue('has_waitlist','0','id-event_full','table-row','radio',true); return;} else {cj('#id-event_full, #id-waitlist, #id-waitlist-text').hide(); return;}")
     );
     $this->addRule('max_participants', ts('Max participants should be a positive number'), 'positiveInteger');

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -600,7 +600,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     }
 
     if ($this->_action & CRM_Core_Action::ADD) {
-      $this->add('text', 'num_terms', ts('Number of Terms'), array('size' => 6));
+      $this->add('number', 'num_terms', ts('Number of Terms'), array('size' => 6));
     }
 
     $this->add('text', 'source', ts('Source'),

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -345,7 +345,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::financialType()
     );
 
-    $this->add('text', 'num_terms', ts('Extend Membership by'), array('onchange' => "setPaymentBlock();"), TRUE);
+    $this->add('number', 'num_terms', ts('Extend Membership by'), array('onchange' => "setPaymentBlock();"), TRUE);
     $this->addRule('num_terms', ts('Please enter a whole number for how many periods to renew.'), 'integer');
 
     if (CRM_Core_Permission::access('CiviContribute') && !$this->_mode) {

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -391,7 +391,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id =1 AND cc.is_test = 0";
 
     $form->addElement('checkbox', 'is_tellfriend_enabled', ts("Allow 'Tell a friend' functionality"), NULL, array('onclick' => "return showHideByValue('is_tellfriend_enabled',true,'tflimit','table-row','radio',false);"));
 
-    $form->add('text',
+    $form->add('number',
       'tellfriend_limit',
       ts("'Tell a friend' maximum recipients limit"),
       CRM_Core_DAO::getAttribute('CRM_PCP_DAO_PCPBlock', 'tellfriend_limit')

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -273,7 +273,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     );
     $this->addRule('installments', ts('Please enter a valid number of installments.'), 'positiveInteger');
 
-    $frequencyInterval = $this->add('text', 'frequency_interval', ts('every'),
+    $frequencyInterval = $this->add('number', 'frequency_interval', ts('every'),
       $attributes['pledge_frequency_interval'], TRUE
     );
     $this->addRule('frequency_interval', ts('Please enter a number for frequency (e.g. every "3" months).'), 'positiveInteger');
@@ -289,7 +289,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       TRUE
     );
 
-    $frequencyDay = $this->add('text', 'frequency_day', ts('Payments are due on the'), $attributes['frequency_day'], TRUE);
+    $frequencyDay = $this->add('number', 'frequency_day', ts('Payments are due on the'), $attributes['frequency_day'], TRUE);
     $this->addRule('frequency_day', ts('Please enter a valid payment due day.'), 'positiveInteger');
 
     $this->add('text', 'eachPaymentAmount', ts('each'), array(

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -176,7 +176,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
           '' => ' ',
         ) + $membershipTypes, FALSE,
         array('onClick' => "calculateRowValues( );"));
-        $this->add('text', 'membership_num_terms', ts('Number of Terms'), $attributes['membership_num_terms']);
+        $this->add('number', 'membership_num_terms', ts('Number of Terms'), $attributes['membership_num_terms']);
       }
       else {
         $allComponents = explode(CRM_Core_DAO::VALUE_SEPARATOR, $extendComponentId);
@@ -184,10 +184,10 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
         if (in_array($eventComponentId, $allComponents)) {
           $this->isEvent = TRUE;
           // count
-          $this->add('text', 'count', ts('Participant Count'));
+          $this->add('number', 'count', ts('Participant Count'));
           $this->addRule('count', ts('Please enter a valid Max Participants.'), 'positiveInteger');
 
-          $this->add('text', 'max_value', ts('Max Participants'));
+          $this->add('number', 'max_value', ts('Max Participants'));
           $this->addRule('max_value', ts('Please enter a valid Max Participants.'), 'positiveInteger');
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
use number wiget for weight and other numeric fields in all forms and keep it consistent.

Before
----------------------------------------
Forms have _weight and other numeric_ fields as plain-text input.



After
----------------------------------------
All of the forms have _weight and other numeric_ fields as number input widget keeping in consistent with other screen across CRM.



