### PR TITLE
dev/core#693 : On contact summary page, on submitting a 'New Case' form doesn't redirect to 'Manage Case' screen

### DIFF
--- a/templates/CRM/Case/Page/Tab.tpl
+++ b/templates/CRM/Case/Page/Tab.tpl
@@ -60,7 +60,7 @@
           call_user_func(array('CRM_Core_Permission','check'), 'add cases') ) AND
         $allowToAddNewCase}
         <div class="action-link">
-        <a accesskey="N" href="{$newCaseURL}" class="button"><span><i class="crm-i fa-plus-circle"></i> {ts}Add Case{/ts}</span></a>
+        <a accesskey="N" href="{$newCaseURL}" class="button no-popup"><span><i class="crm-i fa-plus-circle"></i> {ts}Add Case{/ts}</span></a>
         </div>
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Go to Case tab in Contact summary page.
2. Click on 'Add Case' button which opens the 'New Case' backoffice form in a popup.
3. Fill and submit the form which simply closes the popup and does not redirect to the 'Manage Case' screen. Although the redirect url is declared in [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/Form/Activity/OpenCase.php#L355)  

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/52197893-2c462000-2887-11e9-8be4-695d29cb6847.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/52197915-37994b80-2887-11e9-9b12-8299cf8f0533.gif)


Technical Details
----------------------------------------
Add 'no-popup' class to 'Add Case' button so that 'New Case' backoffice form always opens in a new window and thus redirects to 'Manage Case' on submit

Comments
----------------------------------------
ping @lcdservices @colemanw 