### PR TITLE
dev/core#690 - Civi\API - Fix entity permission check for trusted calls

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -198,7 +198,7 @@ class CRM_Core_DAO_AllCoreTables {
    * @return bool
    */
   public static function isCoreTable($tableName) {
-    return FALSE !== array_search($tableName, self::tables());
+    return array_key_exists($tableName, self::tables());
   }
 
   /**

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -206,16 +206,16 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function authorizeDelegate($action, $entityTable, $entityId, $apiRequest) {
+    if ($this->isTrusted($apiRequest)) {
+      return;
+    }
+
     $entity = $this->getDelegatedEntityName($entityTable);
     if (!$entity) {
       throw new \API_Exception("Failed to run permission check: Unrecognized target entity table ($entityTable)");
     }
     if (!$entityId) {
       throw new \Civi\API\Exception\UnauthorizedException("Authorization failed on ($entity): Missing entity_id");
-    }
-
-    if ($this->isTrusted($apiRequest)) {
-      return;
     }
 
     /**

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -179,6 +179,9 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
       }
 
       if (isset($apiRequest['params']['entity_table'])) {
+        if (!\CRM_Core_DAO_AllCoreTables::isCoreTable($apiRequest['params']['entity_table'])) {
+          throw new \API_Exception("Unrecognized target entity table {$apiRequest['params']['entity_table']}");
+        }
         $this->authorizeDelegate(
           $apiRequest['action'],
           $apiRequest['params']['entity_table'],

--- a/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
+++ b/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
@@ -204,4 +204,12 @@ class CRM_Core_DAO_AllCoreTablesTest extends CiviUnitTestCase {
     $this->assertEquals($newIndices, $expectedIndices);
   }
 
+  /**
+   * Test CRM_Core_DAO_AllCoreTables::isCoreTable
+   */
+  public function testIsCoreTable() {
+    $this->assertTrue(CRM_Core_DAO_AllCoreTables::isCoreTable('civicrm_contact'), 'civicrm_contact should be a core table');
+    $this->assertFalse(CRM_Core_DAO_AllCoreTables::isCoreTable('civicrm_invalid_table'), 'civicrm_invalid_table should NOT be a core table');
+  }
+
 }

--- a/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
@@ -11,6 +11,8 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
 
   const FILE_FORBIDDEN_ID = 11;
 
+  const FILE_UNDELEGATED_ENTITY = 12;
+
   const WIDGET_ID = 20;
 
   const FORBIDDEN_ID = 30;
@@ -212,6 +214,30 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
       '$result' => $result,
     ), TRUE));
     $this->assertRegExp($expectedError, $result['error_message']);
+  }
+
+  /**
+   * Test whether trusted API calls bypass the permission check
+   *
+   */
+  public function testNotDelegated() {
+    $entity = 'FakeFile';
+    $action = 'create';
+    $params = [
+      'entity_id' => self::FILE_UNDELEGATED_ENTITY,
+      'entity_table' => 'civicrm_membership',
+      'version' => 3,
+      'debug' => 1,
+      'check_permissions' => 1,
+    ];
+    // run with permission check
+    $result = $this->kernel->run('FakeFile', 'create', $params);
+    $this->assertTrue((bool) $result['is_error'], 'Undelegated entity with check_permissions = 1 should fail');
+    $this->assertRegExp('/Unrecognized target entity table \(civicrm_membership\)/', $result['error_message']);
+    // repeat without permission check
+    $params['check_permissions'] = 0;
+    $result = $this->kernel->run('FakeFile', 'create', $params);
+    $this->assertFalse((bool) $result['is_error'], 'Undelegated entity with check_permissions = 0 should succeed');
   }
 
 }

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -160,6 +160,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
         'mime_type' => 'text/plain',
         'description' => 'My test description',
         'content' => 'My test content',
+        'check_permissions' => 1,
       ),
       "/Unrecognized target entity/",
     );


### PR DESCRIPTION
Overview
----------------------------------------
`Civi\API\Subscriber\DynamicFKAuthorization` is responsible for checking permissions on entities attached to other (parent) entities by imitating the permissions of the parent entity.

Before
----------------------------------------
When API requests with `check_permissions` set to `0` are processed, `DynamicFKAuthorization` first checks whether the parent entity is an allowed delegate, and then permits the call since it's trusted. However, if the entity is not an allowed delegate, `DynamicFKAuthorization` throws an exception.

`custom_6` is a custom file field for memberships. `civicrm_membership` is not an allowed delegate, so this API request would fail:
```php
civicrm_api3('Attachment', 'create', [
  'field_name' => 'custom_6',
  'entity_id' => 123,
  'name' => 'README.txt',
  'mime_type' => 'text/plain',
  'content' => 'Please to read the README',
  'check_permissions' => 0,
]);
```

After
----------------------------------------
`DynamicFKAuthorization` first checks whether the API request is trusted and permits the request if that's the case. Other checks are only performed if the API request is untrusted.

This API call now succeeds:
```php
civicrm_api3('Attachment', 'create', [
  'field_name' => 'custom_6',
  'entity_id' => 123,
  'name' => 'README.txt',
  'mime_type' => 'text/plain',
  'content' => 'Please to read the README',
  'check_permissions' => 0,
));
```