### PR TITLE
dev/core#695 - Make custom searches slightly less fragile

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1043,7 +1043,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     $selectSQL = "SELECT DISTINCT '$cacheKey', contact_a.id, contact_a.sort_name";
 
-    $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $selectSQL, $sql);
+    $sql = str_ireplace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $selectSQL, $sql);
     try {
       Civi::service('prevnext')->fillWithSql($cacheKey, $sql);
     }


### PR DESCRIPTION
Overview
----------------------------------------
See description in https://lab.civicrm.org/dev/core/issues/695

Before
----------------------------------------
A custom search where `contactIDs()` returns `contact_a.id AS contact_id` does not populate the prevnext cache resulting in result selections not being saved.  But `contact_a.id as contact_id` works - ie case sensitive.

After
----------------------------------------
`contact_a.id AS contact_id` and `contact_a.id as contact_id` both work

