### PR TITLE
Prev next

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4904,7 +4904,7 @@ civicrm_relationship.start_date > {$today}
     //      MySQL expect the columns present in GROUP BY, must be present in SELECT clause and that results into error, needless to have other columns.
     //   2. When GROUP BY columns are present then disable FGB otherwise it demands to add ORDER BY columns in GROUP BY and eventually in SELECT
     //     clause. This will impact the search query output.
-    $disableFullGroupByMode = ($sortByChar || !empty($groupByCols));
+    $disableFullGroupByMode = ($sortByChar || !empty($groupByCols) || $groupContacts);
 
     if ($disableFullGroupByMode) {
       CRM_Core_DAO::disableFullGroupByMode();

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4984,7 +4984,7 @@ civicrm_relationship.start_date > {$today}
     $select .= sprintf(", (%s) AS _wgt", $this->createSqlCase('contact_a.id', $cids));
     $where .= sprintf(' AND contact_a.id IN (%s)', implode(',', $cids));
     $order = 'ORDER BY _wgt';
-    $groupBy = '';
+    $groupBy = $this->_useGroupBy ? ' GROUP BY contact_a.id' : '';
     $limit = '';
     $query = "$select $from $where $groupBy $order $limit";
 

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1043,7 +1043,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     $selectSQL = "SELECT DISTINCT '$cacheKey', contact_a.id, contact_a.sort_name";
 
-    $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $selectSQL, $sql);
+    $sql = str_ireplace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $selectSQL, $sql);
     try {
       Civi::service('prevnext')->fillWithSql($cacheKey, $sql);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix search regressions introduced in 5.9 relating to caching & custom searches

Before
----------------------------------------
Under some circumstances searches which output tags or groups present all contacts in a single row

After
----------------------------------------
Correct number of rows returned

Technical Details
----------------------------------------
This arises because 'GROUP_CONCAT' is used without the GROUP BY clause due to 

https://github.com/eileenmcnaughton/civicrm-core/commit/2ca46d4d5a8cd15929ac0939ca2bb380a3de027e#diff-e54381bfdf51e31cab376c71ca0d66ffR4967

There is some somewhat unrelated bugginess about the inclusion of groups & tags that makes this hard to replicate :-(

Comments
----------------------------------------

I have also pulled in https://github.com/civicrm/civicrm-core/pull/13531 which I think is a related regression & should also go into the rc