### PR TITLE
dev/core#651 Fix group by on export soft credits (possible recent regression, clearly wrong).

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -124,7 +124,7 @@ class CRM_Export_BAO_Export {
    *   Group By Clause
    */
   public static function getGroupBy($processor, $returnProperties, $query) {
-    $groupBy = '';
+    $groupBy = NULL;
     $exportMode = $processor->getExportMode();
     $queryMode = $processor->getQueryMode();
     if (!empty($returnProperties['tags']) || !empty($returnProperties['groups']) ||
@@ -140,7 +140,7 @@ class CRM_Export_BAO_Export {
         $groupBy = 'civicrm_contribution.id';
         if (CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled()) {
           // especial group by  when soft credit columns are included
-          $groupBy = array('contribution_search_scredit_combined.id', 'contribution_search_scredit_combined.scredit_id');
+          $groupBy = ['contribution_search_scredit_combined.id', 'contribution_search_scredit_combined.scredit_id'];
         }
         break;
 
@@ -157,7 +157,7 @@ class CRM_Export_BAO_Export {
       $groupBy = "civicrm_activity.id ";
     }
 
-    return $groupBy ? ' GROUP BY ' . $groupBy : '';
+    return $groupBy ? ' GROUP BY ' . implode(', ', (array) $groupBy) : '';
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix for exporting contribution search results not grouping soft credits correctly

In my test I used this search
![screenshot 2019-02-05 19 13 43](https://user-images.githubusercontent.com/336308/52256079-3a289d80-297a-11e9-97f9-199578fbb041.png)

and this mapping
![screenshot 2019-02-05 19 13 32](https://user-images.githubusercontent.com/336308/52256081-3b59ca80-297a-11e9-8025-06ed892f53f8.png)


Before
----------------------------------------
only 3 rows exported - grouped across scredits

![screenshot 2019-02-05 19 12 45](https://user-images.githubusercontent.com/336308/52256165-8e338200-297a-11e9-9346-3061b1d0cb15.png)

After
----------------------------------------
mo better rows


![screenshot 2019-02-05 19 14 48](https://user-images.githubusercontent.com/336308/52256171-97245380-297a-11e9-80ee-2a15a1c10341.png)


Technical Details
----------------------------------------
As pointed out by the reporter the group by is being calculated as if it were a string but it's an array, this fixes.

This code has been touched recently so it might be a recent regression. 5.10 is the first release in a long time where
export is working in some mysql / output configs after a big refactor to get rid of wide temp tables


Comments
----------------------------------------

