### PR TITLE
dev/core#680 make receive_date required on backoffice contribution form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -699,7 +699,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     // add various dates
-    $this->addField('receive_date', array('entity' => 'contribution'), FALSE, FALSE);
+    $this->addField('receive_date', array('entity' => 'contribution'), TRUE, FALSE);
     $this->addField('receipt_date', array('entity' => 'contribution'), FALSE, FALSE);
     $this->addField('cancel_date', array('entity' => 'contribution', 'label' => ts('Cancelled / Refunded Date')), FALSE, FALSE);
 

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -106,6 +106,7 @@ function _civicrm_api3_contribution_create_spec(&$params) {
   $params['total_amount']['api.required'] = 1;
   $params['payment_instrument_id']['api.aliases'] = array('payment_instrument');
   $params['receive_date']['api.default'] = 'now';
+  $params['receive_date']['api.required'] = TRUE;
   $params['payment_processor'] = array(
     'name' => 'payment_processor',
     'title' => 'Payment Processor ID',


### PR DESCRIPTION
Overview
----------------------------------------
Make receive_date required on backoffice contribution form.

This doesn't appear to be a recent regression but it is commonly understood that this is a required field and unsetting it causes invalid contributions. I put it against the rc because it seems both trivial and clear cut

Before
----------------------------------------
![screenshot 2019-02-05 21 09 41](https://user-images.githubusercontent.com/336308/52260258-5f250c80-298a-11e9-8830-984dc7682c51.png)


After
----------------------------------------
![screenshot 2019-02-05 21 09 02](https://user-images.githubusercontent.com/336308/52260240-4caad300-298a-11e9-9aac-ef0b98cfdc7a.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
Discussion on https://lab.civicrm.org/dev/core/issues/680#note_13205
