### PR TITLE
dev/core#397 Dedupe for Individual Birth Date Results in Error

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -72,7 +72,22 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
     // full matches, respectively)
     $where = array();
     $on = array("SUBSTR(t1.{$this->rule_field}, 1, {$this->rule_length}) = SUBSTR(t2.{$this->rule_field}, 1, {$this->rule_length})");
-    $using = array($this->rule_field);
+    $entity = CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($this->rule_table));
+    $fields = civicrm_api3($entity, 'getfields', ['action' => 'create'])['values'];
+
+    $innerJoinClauses = [
+      "t1.{$this->rule_field} IS NOT NULL",
+      "t2.{$this->rule_field} IS NOT NULL",
+      "t1.{$this->rule_field} = t2.{$this->rule_field}"
+    ];
+    if ($fields[$this->rule_field]['type'] === CRM_Utils_Type::T_DATE) {
+      $innerJoinClauses[] = "t1.{$this->rule_field} > '1000-01-01'";
+      $innerJoinClauses[] = "t2.{$this->rule_field} > '1000-01-01'";
+    }
+    else {
+      $innerJoinClauses[] = "t1.{$this->rule_field} <> ''";
+      $innerJoinClauses[] = "t2.{$this->rule_field} <> ''";
+    }
 
     switch ($this->rule_table) {
       case 'civicrm_contact':
@@ -92,7 +107,7 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
       case 'civicrm_address':
         $id = 'contact_id';
         $on[] = 't1.location_type_id = t2.location_type_id';
-        $using[] = 'location_type_id';
+        $innerJoinClauses[] = ['t1.location_type_id = t2.location_type_id'];
         if ($this->params['civicrm_address']['location_type_id']) {
           $locTypeId = CRM_Utils_Type::escape($this->params['civicrm_address']['location_type_id'], 'Integer', FALSE);
           if ($locTypeId) {
@@ -152,7 +167,6 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
       if ($this->rule_length) {
         $where[] = "SUBSTR(t1.{$this->rule_field}, 1, {$this->rule_length}) = SUBSTR('$str', 1, {$this->rule_length})";
         $where[] = "t1.{$this->rule_field} IS NOT NULL";
-        $where[] = "t1.{$this->rule_field} <> ''";
       }
       else {
         $where[] = "t1.{$this->rule_field} = '$str'";
@@ -163,15 +177,13 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
         $from = "{$this->rule_table} t1 JOIN {$this->rule_table} t2 ON (" . implode(' AND ', $on) . ")";
       }
       else {
-        $from = "{$this->rule_table} t1 JOIN {$this->rule_table} t2 USING (" . implode(', ', $using) . ")";
+        $from = "{$this->rule_table} t1 INNER JOIN {$this->rule_table} t2 ON (" . implode(' AND ', $innerJoinClauses) . ")";
       }
     }
 
     // finish building WHERE, also limit the results if requested
     if (!$this->params) {
       $where[] = "t1.$id < t2.$id";
-      $where[] = "t1.{$this->rule_field} IS NOT NULL";
-      $where[] = "t1.{$this->rule_field} <> ''";
     }
     $query = "SELECT $select FROM $from WHERE " . implode(' AND ', $where);
     if ($this->contactIds) {

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -85,7 +85,6 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     }
     $foundDupes = CRM_Dedupe_Finder::dupesInGroup($ruleGroup['id'], $this->groupID);
     $this->assertEquals(count($foundDupes), 4);
-    $this->markTestIncomplete('This currenctly fails - see https://lab.civicrm.org/dev/core/issues/397');
     CRM_Dedupe_Finder::dupes($ruleGroup['id']);
 
   }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -145,14 +145,6 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   *  Test CRM_Member_Form_Membership::buildQuickForm()
-   */
-  //function testCRMMemberFormMembershipBuildQuickForm()
-  //{
-  //    throw new PHPUnit_Framework_IncompleteTestError( "not implemented" );
-  //}
-
-  /**
    *  Test CRM_Member_Form_Membership::formRule() with a parameter
    *  that has an empty contact_select_id value
    */
@@ -1112,6 +1104,9 @@ Expires: ',
    * @return \CRM_Member_Form_Membership
    */
   protected function getForm() {
+    if (isset($_REQUEST['cid'])) {
+      unset($_REQUEST['cid']);
+    }
     $form = new CRM_Member_Form_Membership();
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $form->controller = new CRM_Core_Controller();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal error on some mysql configurations / versions when birth_date is included in a dedupe rule

Alternative attempt to https://github.com/civicrm/civicrm-core/pull/13104

https://lab.civicrm.org/dev/core/issues/397
https://issues.civicrm.org/jira/browse/CRM-17238

Before
----------------------------------------
Fatal error if dedupe is a field used to calculate dupes (mysql set up dependent)

After
----------------------------------------
Error does not appear

Technical Details
----------------------------------------
See prior conversation https://github.com/civicrm/civicrm-core/pull/13104

Comments
----------------------------------------
Adds a test previously written but marked Incomplete as it didn't pass