### PR TITLE
dev/core#469 Fix Error on action 'Email - schedule/send via CiviMail' with multiple event names filter

### DIFF
--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -544,7 +544,9 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
       $ssId = $this->get('ssID');
       $hiddenSmartParams = array(
         'group_type' => array('2' => 1),
-        'form_values' => $this->get('formValues'),
+        // queryParams have been preprocessed esp WRT any entity reference fields - see +
+        // https://github.com/civicrm/civicrm-core/pull/13250
+        'form_values' => $this->get('queryParams'),
         'saved_search_id' => $ssId,
         'search_custom_id' => $this->get('customSearchID'),
         'search_context' => $this->get('context'),


### PR DESCRIPTION
Overview
----------------------------------------
Alternate fix to reverted https://github.com/civicrm/civicrm-core/pull/13250

Before
----------------------------------------
1) search by event name, choose more than one
2) attempt to send a CiviMail from the search results
- fails

After
----------------------------------------
Above succeeds

Technical Details
----------------------------------------
@monishdeb @francescbassas replaces reverted fix

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/469
