### PR TITLE
dev/core#641: Case Activity Assignment Restriction

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -190,7 +190,20 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       $xmlFile .= "</CaseRoles>\n";
     }
 
+    if (array_key_exists('restrictActivityAsgmtToCmsUser', $definition)) {
+      $xmlFile .= "<RestrictActivityAsgmtToCmsUser>" . $definition['restrictActivityAsgmtToCmsUser'] . "</RestrictActivityAsgmtToCmsUser>\n";
+    }
+
+    if (!empty($definition['activityAsgmtGrps'])) {
+      $xmlFile .= "<ActivityAsgmtGrps>\n";
+      foreach ($definition['activityAsgmtGrps'] as $value) {
+        $xmlFile .= "<Group>$value</Group>\n";
+      }
+      $xmlFile .= "</ActivityAsgmtGrps>\n";
+    }
+
     $xmlFile .= '</CaseType>';
+
     return $xmlFile;
   }
 
@@ -224,6 +237,14 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
 
     if (isset($xml->forkable)) {
       $definition['forkable'] = (int) $xml->forkable;
+    }
+
+    if (isset($xml->RestrictActivityAsgmtToCmsUser)) {
+      $definition['restrictActivityAsgmtToCmsUser'] = (int) $xml->RestrictActivityAsgmtToCmsUser;
+    }
+
+    if (isset($xml->ActivityAsgmtGrps)) {
+      $definition['activityAsgmtGrps'] = (array) $xml->ActivityAsgmtGrps->Group;
     }
 
     // set activity types

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -312,6 +312,8 @@
       $scope.caseType.definition.caseRoles = $scope.caseType.definition.caseRoles || [];
       $scope.caseType.definition.statuses = $scope.caseType.definition.statuses || [];
       $scope.caseType.definition.timelineActivityTypes = $scope.caseType.definition.timelineActivityTypes || [];
+      $scope.caseType.definition.restrictActivityAsgmtToCmsUser = $scope.caseType.definition.restrictActivityAsgmtToCmsUser || 0;
+      $scope.caseType.definition.activityAsgmtGrps = $scope.caseType.definition.activityAsgmtGrps || [];
 
       _.each($scope.caseType.definition.activitySets, function (set) {
         _.each(set.activityTypes, function (type, name) {
@@ -525,6 +527,11 @@
       });
       // Ignore if ALL or NONE selected
       $scope.caseType.definition.statuses = selectedStatuses.length == _.size($scope.selectedStatuses) ? [] : selectedStatuses;
+
+      if ($scope.caseType.definition.activityAsgmtGrps) {
+        $scope.caseType.definition.activityAsgmtGrps = $scope.caseType.definition.activityAsgmtGrps.toString().split(",");
+      }
+
       var result = crmApi('CaseType', 'create', $scope.caseType, true);
       result.then(function(data) {
         if (data.is_error === 0 || data.is_error == '0') {

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -237,7 +237,7 @@
     };
   });
 
-  crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls) {
+  crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls, crmUiHelp) {
     var REL_TYPE_CNAME, defaultAssigneeDefaultValue, ts;
 
     (function init () {
@@ -245,6 +245,7 @@
       REL_TYPE_CNAME = CRM.crmCaseType.REL_TYPE_CNAME;
 
       ts = $scope.ts = CRM.ts(null);
+      $scope.hs = crmUiHelp({file: 'CRM/Case/CaseType'});
       $scope.locks = { caseTypeName: true, activitySetName: true };
       $scope.workflows = { timeline: 'Timeline', sequence: 'Sequence' };
       defaultAssigneeDefaultValue = _.find(apiCalls.defaultAssigneeTypes.values, { is_default: '1' }) || {};

--- a/ang/crmCaseType/caseTypeDetails.html
+++ b/ang/crmCaseType/caseTypeDetails.html
@@ -41,5 +41,22 @@ The original form used table layout; don't know if we have an alternative, CSS-b
     <div crm-ui-field="{title: ts('Enabled?')}">
       <input name="is_active" type="checkbox" ng-model="caseType.is_active" ng-true-value="'1'" ng-false-value="'0'"/>
     </div>
+    <div crm-ui-field="{name: 'caseTypeDetailForm.activityAsgmtGrps', title: ts('Restrict Assignment to Groups')}">
+      <input
+        name="activityAsgmtGrps"
+        crm-ui-id="caseTypeDetailForm.activityAsgmtGrps"
+        crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, placeholder: ts('Select Group')}}"
+        ng-model="caseType.definition.activityAsgmtGrps"
+      />
+    </div>
+    <div crm-ui-field="{title: ts('Restrict Assignment to Website Users')}">
+      <input
+        name="restrictActivityAsgmtToCmsUser"
+        type="checkbox"
+        ng-model="caseType.definition.restrictActivityAsgmtToCmsUser"
+        ng-true-value="'1'"
+        ng-false-value="'0'"
+      />
+    </div>
   </div>
 </div>

--- a/ang/crmCaseType/caseTypeDetails.html
+++ b/ang/crmCaseType/caseTypeDetails.html
@@ -41,22 +41,28 @@ The original form used table layout; don't know if we have an alternative, CSS-b
     <div crm-ui-field="{title: ts('Enabled?')}">
       <input name="is_active" type="checkbox" ng-model="caseType.is_active" ng-true-value="'1'" ng-false-value="'0'"/>
     </div>
-    <div crm-ui-field="{name: 'caseTypeDetailForm.activityAsgmtGrps', title: ts('Restrict Assignment to Groups')}">
-      <input
-        name="activityAsgmtGrps"
-        crm-ui-id="caseTypeDetailForm.activityAsgmtGrps"
-        crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, placeholder: ts('Select Group')}}"
-        ng-model="caseType.definition.activityAsgmtGrps"
-      />
-    </div>
-    <div crm-ui-field="{title: ts('Restrict Assignment to Website Users')}">
-      <input
-        name="restrictActivityAsgmtToCmsUser"
-        type="checkbox"
-        ng-model="caseType.definition.restrictActivityAsgmtToCmsUser"
-        ng-true-value="'1'"
-        ng-false-value="'0'"
-      />
+    <fieldset class="crm-collapsible">
+      <legend class="collapsible-title">{{ ts('Activity assignment settings') }}</legend>
+      <div>
+        <div crm-ui-field="{name: 'caseTypeDetailForm.activityAsgmtGrps', title: ts('Restrict to Groups'), help: hs('activityAsgmtGrps')}">
+          <input
+            name="activityAsgmtGrps"
+            crm-ui-id="caseTypeDetailForm.activityAsgmtGrps"
+            crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, placeholder: ts('Select Group')}}"
+            ng-model="caseType.definition.activityAsgmtGrps"
+          />
+        </div>
+        <div crm-ui-field="{title: ts('Restrict to Website Users'), help: hs('restrictActivityAsgmtToCmsUser')}">
+          <input
+            name="restrictActivityAsgmtToCmsUser"
+            type="checkbox"
+            ng-model="caseType.definition.restrictActivityAsgmtToCmsUser"
+            ng-true-value="'1'"
+            ng-false-value="'0'"
+          />
+        </div>
+      </div>
+    </fieldset>
     </div>
   </div>
 </div>

--- a/templates/CRM/Case/CaseType.hlp
+++ b/templates/CRM/Case/CaseType.hlp
@@ -1,0 +1,11 @@
+{htxt id="activityAsgmtGrps"}
+  <p>
+    {ts}Selecting one or more groups here will limit the choices when assigning an activity.{/ts}
+  </p>
+{/htxt}
+
+{htxt id="restrictActivityAsgmtToCmsUser"}
+  <p>
+    {ts}This will limit the choices when selecting an activity assignee to contacts with a user account on this website.{/ts}
+  </p>
+{/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Currently, a user can create and assign an activity to any CiviCRM contact. This in turn sends an email notification to the assignee. However, some users have reported that they mistakenly assigned activities to contacts with similar names which meant that someone who should not have access to any details of the activity got a link in the email stating some basic details of the activity.
This PR adds the ability to restrict the assignment of case activities to a group. A user will not be able to assign activities to contacts that does not belong to the restricted groups.
Activity assignment can also be restricted to only contacts having user accounts.

Before
----------------------------------------
It is not possible to restrict the assignment of case activities to a group or to contacts having user accounts.

After
----------------------------------------
It is now possible to restrict the assignment of case activities to a group or to contacts having user accounts.


When searching for a contact to assign for an activity, it  displays only people assigned to that group - if that case type has group restriction, or it displays only contacts with user accounts if that case type has restriction to only website users. Also the option to create a new contact when that activity is associated with a case type which is restricted to a group or to only website users is removed.

![CaseTypeRestriction1](https://user-images.githubusercontent.com/6951813/54378362-717c1f80-4687-11e9-91eb-3d3e7bf03546.gif)



![case-type-assignment](https://user-images.githubusercontent.com/6951813/52279548-13f30580-295a-11e9-9aec-ed678f981367.gif)


Technical Details
----------------------------------------
Two new parameters `RestrictActivityAsgmt` and `ActivityAsgmtGrps` added for this task were simply appended to the existing xml data of the definition column for a case type.

The `buildQuickForm`  function of the `CRM_Case_Form_Activity` form class was modified to restrict the assignee related fields to only fetch contacts associated with restricted groups for case types with such restrictions or to restrict assignee related fields to only fetch contacts with user accounts when the case type is restricted to website users.
```
    if ($this->restrictAssignmentByUserAccount()) {
      $assigneeParameters = ['uf_user' => 1];
    }
    else {
      $activityAssignmentGroups = $this->getActivityAssignmentGroups();
      if (!empty($activityAssignmentGroups)) {
        $assigneeParameters = ['group' => ['IN' => $activityAssignmentGroups]];
      }
    }
```

## Comments
PR to update user guide here: https://github.com/civicrm/civicrm-user-guide/pull/375