### PR TITLE
Error on update CiviCRM profile via Drupal user edit, php 7.2

### DIFF
--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -111,7 +111,9 @@ class CRM_Utils_Request {
     }
 
     if (!isset($value) && $store) {
-      $value = $store->get($name);
+      if(is_string($name)) {
+        $value = $store->get($name);
+      }
     }
 
     if (!isset($value) && $abort) {


### PR DESCRIPTION
Overview
----------------------------------------
Error on update CiviCRM profile via Drupal user edit, php 7.2

Technical Details
----------------------------------------
Call to a member function get() on array in CRM_Utils_Request::retrieve() (line 114 of CRM/Utils/Request.php).

Comments
Drupal 7.63, PHP 7.2, CiviCRM 5.9
