### PR TITLE
Fix html2pdf default PDF format when multiple pdf_format are available.

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -61,7 +61,7 @@ class CRM_Utils_PDF_Utils {
       // PDF Page Format parameters passed in
       $format = array_merge($format, $pdfFormat);
     }
-    else {
+    elseif (!empty($pdfFormat)) {
       // PDF Page Format ID passed in
       $format = CRM_Core_BAO_PdfFormat::getById($pdfFormat);
     }


### PR DESCRIPTION
Overview
----------------------------------------

How to reproduce:

* Go to "pdf format" in CiviCRM > Administer > Communications > Print Page (PDF) Formats
* Edit the current format, and add lots of padding
* Add a new format, and set only small margins, and set this new format as the default one.
* Enable Contribution PDF Receipts, from CiviCRM > Adminster > CiviContribute > Component settings (enable "tax and invoicing" then "automatically email invoice when user purchases online").
* Go to a contact record, add a new offline contribution, and check the box to send a receipt by email.

Result: the email will have a receipt.pdf that has incorrect margins, because CiviCRM will have selected the first available PDF format, rather than the default one.

Before
----------------------------------------

Wrong PDF format selected.

After
----------------------------------------

Correct PDF format selected.

Technical Details
----------------------------------------

The error in the code seems quite obvious, although it's been there for a very long time (since the SVN import), but presumably few people use this, or if they do, they usually add formats and don't encounter the bug.

In this bit of code:

```
    else {
      // PDF Page Format ID passed in
      $format = CRM_Core_BAO_PdfFormat::getById($pdfFormat);
    }
```

.. because the `pdfFormat` in the function call defaults to NULL, it would do `getByID(NULL)` and then later the code returns the first DAO result available.

Comments
----------------------------------------

Thank you!