### PR TITLE
Load hooks during upgrade mode

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -275,9 +275,9 @@ class CRM_Extension_Mapper {
    *   array(array('prefix' => $, 'file' => $))
    */
   public function getActiveModuleFiles($fresh = FALSE) {
-    $config = CRM_Core_Config::singleton();
-    if ($config->isUpgradeMode() || !defined('CIVICRM_DSN')) {
-      return []; // hmm, ok
+    if (!defined('CIVICRM_DSN')) {
+      // hmm, ok
+      return [];
     }
 
     $moduleExtensions = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Allow extensions to load hooks during upgrade

Before
----------------------------------------
Extensions hooks ignored during upgrade

After
----------------------------------------
Extension hooks loaded

Technical Details
----------------------------------------
For unknown, svn, reasons extension hooks are not loaded during upgrade
(this doesn't apply to drupal modules) - this causes some fairly serious problems
1) settings are re-loaded & cached with settings from extensions being lost
2) trigger alter hooks are lost this means
 - the summary fields triggers are frequently lost on upgrade
 - hooks that unset various tables to prevent them from being logged can fail, resulting in those log tables being created
 - hooks that specify the table should be innodb can fail to run, resulting in archive format.

I can't think WHY we do this? Presumably there was some problem that would have been better solved another
way but which was solved this way?

Comments
----------------------------------------
@totten do you have any thoughts on why this was in the code?
