### PR TITLE
dev/core#706 Edit contribution : wrong decimal separator on total_amount for participant(s)

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -366,8 +366,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('newCredit', CRM_Core_Config::isEnabledBackOfficeCreditCardPayments());
 
     // Fix the display of the monetary value, CRM-4038.
-    if ($total_value = isset($defaults['total_amount'])) {
-      $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'], NULL, '%a');
+    if (isset($defaults['total_amount'])) {
+      $total_value = $defaults['total_amount'];
+      $defaults['total_amount'] = CRM_Utils_Money::format($total_value, NULL, '%a');
       if (!empty($defaults['tax_amount'])) {
         $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
         if (!(CRM_Utils_Array::value('membership', $componentDetails) || CRM_Utils_Array::value('participant', $componentDetails))) {

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -366,15 +366,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('newCredit', CRM_Core_Config::isEnabledBackOfficeCreditCardPayments());
 
     // Fix the display of the monetary value, CRM-4038.
-    if (isset($defaults['total_amount'])) {
+    if ($total_value = isset($defaults['total_amount'])) {
+      $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'], NULL, '%a');
       if (!empty($defaults['tax_amount'])) {
         $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
         if (!(CRM_Utils_Array::value('membership', $componentDetails) || CRM_Utils_Array::value('participant', $componentDetails))) {
-          $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'] - $defaults['tax_amount'], NULL, '%a');
+          $defaults['total_amount'] = CRM_Utils_Money::format($total_value - $defaults['tax_amount'], NULL, '%a');
         }
-      }
-      else {
-        $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'], NULL, '%a');
       }
     }
 


### PR DESCRIPTION
## Overview
Wrong decimal separator on total_amount for participant(s)

## Before
When I want to register a participant payment, I can not save it because the amount is not in a valid format. 

![Screenshot 2019-03-18 12 28 31](https://user-images.githubusercontent.com/336308/54499716-bbac1c00-4979-11e9-9184-0c738fe1f0f6.png)


## After
There is a comma instead of a point sign, I can save the contribution.
![Screenshot 2019-03-18 12 30 20](https://user-images.githubusercontent.com/336308/54499722-c6ff4780-4979-11e9-89ce-d4d41f7f85ab.png)



## Technical Details

## Comments
https://lab.civicrm.org/dev/core/issues/706