### PR TITLE
Improves styling on Joomla! upgrade screen

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -390,6 +390,9 @@ body.admin.com_civicrm .container-fluid.container-main {
 	padding: 0;
 	border-top: 1px solid #787878;
 }
+body.admin.com_civicrm.task-civicrmupgrade .container-fluid.container-main {
+	padding: 0 20px 20px;
+}
 body.admin.com_civicrm #crm-nav-menu-container {
 	padding-bottom: 0 !important;
 }

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -391,7 +391,7 @@ body.admin.com_civicrm .container-fluid.container-main {
 	border-top: 1px solid #787878;
 }
 body.admin.com_civicrm.task-civicrmupgrade .container-fluid.container-main {
-	padding: 0 20px 20px;
+	padding: 10px 25px 25px;
 }
 body.admin.com_civicrm #crm-nav-menu-container {
 	padding-bottom: 0 !important;


### PR DESCRIPTION
Overview
----------------------------------------
Minor CSS padding cleanup, specific to Joomla upgrade screen, fixing a degredation from this commit (https://github.com/civicrm/civicrm-core/commit/6ada1cee014a8bd99e4778864c32c0c140c7a92e)

Before
----------------------------------------
Padding was removed from the main Joomla admin screen in this commit - https://github.com/civicrm/civicrm-core/commit/6ada1cee014a8bd99e4778864c32c0c140c7a92e - which also removed padding on the upgrade screen.
![pastedgraphic-25](https://user-images.githubusercontent.com/1175967/52535523-6ca21400-2d47-11e9-9b67-f21c9402fa21.png)


After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
![image](https://user-images.githubusercontent.com/1175967/52535727-cc99ba00-2d49-11e9-9ce1-fbe665c9be49.png)
