### PR TITLE
Add new Payment.sendconfirmation api

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4000,7 +4000,8 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
    *
    * @return mixed
    */
-  public static function getPaymentInfo($id, $component, $getTrxnInfo = FALSE, $usingLineTotal = FALSE) {
+  public static function getPaymentInfo($id, $component = 'contribution', $getTrxnInfo = FALSE, $usingLineTotal = FALSE) {
+    // @todo deprecate passing in component - always call with contribution.
     if ($component == 'event') {
       $entity = 'participant';
       $entityTable = 'civicrm_participant';

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -454,6 +454,7 @@ WHERE ceft.entity_id = %1";
       return $value;
     }
 
+    // @todo - deprecate passing in entity & type - just figure out contribution id FIRST
     if ($entityName == 'participant') {
       $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $entityId, 'contribution_id', 'participant_id');
     }

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -235,3 +235,49 @@ function _civicrm_api3_payment_cancel_spec(&$params) {
     ),
   );
 }
+
+/**
+ * Send a payment confirmation.
+ *
+ * @param array $params
+ *   Input parameters.
+ *
+ * @return array
+ * @throws Exception
+ */
+function civicrm_api3_payment_sendconfirmation($params) {
+  $allowedParams = [
+    'receipt_from_email',
+    'receipt_from_name',
+    'cc_receipt',
+    'bcc_receipt',
+    'receipt_text',
+    'id',
+  ];
+  $input = array_intersect_key($params, array_flip($allowedParams));
+  // use either the contribution or membership receipt, based on whether it’s a membership-related contrib or not
+  $result = CRM_Financial_BAO_Payment::sendConfirmation($input);
+  return civicrm_api3_create_success([
+    $params['id'] => [
+      'is_sent' => $result[0],
+      'subject' => $result[1],
+      'message_txt' => $result[2],
+      'message_html' => $result[3],
+  ]]);
+}
+
+/**
+ * Adjust Metadata for sendconfirmation action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_payment_sendconfirmation_spec(&$params) {
+  $params['id'] = array(
+    'api.required' => 1,
+    'title' => ts('Payment ID'),
+    'type' => CRM_Utils_Type::T_INT,
+  );
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds a new api Payment.sendconfirmation intended to be an equivalent of
Contribution.sendconfirmation.

Before
----------------------------------------
No api for sending payment confirmations - functionality tightly coupled with one specific form

After
----------------------------------------
API exists. However the form is not switched over to use it - that is an intended outcome but this is intended only as one step towards it.

Technical Details
----------------------------------------
The key thing this needs to be able to do is to load up all
related information to assign to the template - this is not all covered in this
PR & until it is functionally equivalent to AdditionalPayment::sendEmail
we can't switch over but since it's new functionality we should be able to
merge & keep working on it.

Note that there is discussion on the PR this relates to (#13330) about what should
happen if 'Payment.create' api accepts 'is_email_receipt'. I think the most logical
outcome is that receipts would go out if it caused the contribution to be completed
(ie. we pass is_email_receipt into completetransaction api).

However, I don't feel like that is 'settled' yet - separating into a second api
(Payment.sendnotification) means we will have 2 generic function which can be called
from multiple places in the code rather than 2 functions tightly tied to the form layer.
I think it's OK if it is 2 not one

Comments
----------------------------------------

