### PR TITLE
[REF] Fix silly function to do less handling of non-existent scenarios

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4002,8 +4002,6 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
    */
   public static function getPaymentInfo($id, $component, $getTrxnInfo = FALSE, $usingLineTotal = FALSE) {
     if ($component == 'event') {
-      $entity = 'participant';
-      $entityTable = 'civicrm_participant';
       $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $id, 'contribution_id', 'participant_id');
 
       if (!$contributionId) {
@@ -4017,14 +4015,10 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
       }
     }
     elseif ($component == 'membership') {
-      $entity = $component;
-      $entityTable = 'civicrm_membership';
       $contributionId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $id, 'contribution_id', 'membership_id');
     }
     else {
       $contributionId = $id;
-      $entity = 'contribution';
-      $entityTable = 'civicrm_contribution';
     }
 
     $total = CRM_Core_BAO_FinancialTrxn::getBalanceTrxnAmt($contributionId);
@@ -4041,7 +4035,8 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
       $total = $total['total_amount'];
     }
 
-    $paymentBalance = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($id, $entity, FALSE, $total);
+    $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($contributionId, $total);
+
     $contribution = civicrm_api3('Contribution', 'getsingle', array('id' => $contributionId, 'return' => array('currency', 'is_pay_later', 'contribution_status_id', 'financial_type_id')));
 
     $info['payLater'] = $contribution['is_pay_later'];

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -437,18 +437,21 @@ WHERE ceft.entity_id = %1";
   }
 
   /**
-   * get partial payment amount and type of it.
+   * get partial payment amount.
+   *
+   * @deprecated
+   *
+   * This function basically calls CRM_Contribute_BAO_Contribution::getContributionBalance
+   * - just do that. If need be we could have a fn to get the contribution id but
+   * chances are the calling functions already know it anyway.
    *
    * @param int $entityId
    * @param string $entityName
-   * @param bool $returnType
    * @param int $lineItemTotal
    *
-   * @return array|int|NULL|string
-   *   [payment type => amount]
-   *   payment type: 'amount_owed' or 'refund_due'
+   * @return array
    */
-  public static function getPartialPaymentWithType($entityId, $entityName = 'participant', $returnType = TRUE, $lineItemTotal = NULL) {
+  public static function getPartialPaymentWithType($entityId, $entityName = 'participant', $lineItemTotal = NULL) {
     $value = NULL;
     if (empty($entityName)) {
       return $value;
@@ -467,17 +470,13 @@ WHERE ceft.entity_id = %1";
 
     if ($contributionId && $financialTypeId) {
 
-      $value = CRM_Contribute_BAO_Contribution::getContributionBalance($contributionId, $lineItemTotal);
-
-      $paymentVal = $value;
-      if ($returnType) {
-        $value = array();
-        if ($paymentVal < 0) {
-          $value['refund_due'] = $paymentVal;
-        }
-        elseif ($paymentVal > 0) {
-          $value['amount_owed'] = $paymentVal;
-        }
+      $paymentVal = CRM_Contribute_BAO_Contribution::getContributionBalance($contributionId, $lineItemTotal);
+      $value = [];
+      if ($paymentVal < 0) {
+        $value['refund_due'] = $paymentVal;
+      }
+      elseif ($paymentVal > 0) {
+        $value['amount_owed'] = $paymentVal;
       }
     }
     return $value;

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -371,7 +371,7 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
       'source' => 'SSF',
       'contribution_status_id' => 1,
     ));
-    $balance = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($contribution['id'], 'contribution', FALSE, $totalAmount);
+    $balance = CRM_Contribute_BAO_Contribution::getContributionBalance($contribution['id'], $totalAmount);
     $this->assertEquals(0.0, $balance);
     Civi::settings()->revert('contribution_invoice_settings');
   }


### PR DESCRIPTION
Overview
----------------------------------------
code cleanup

Before
----------------------------------------
1. Function getPaymentInfo calls getPartialPaymentWithType which calls CRM_Contribute_BAO_Contribution::getContributionBalance
2. Function getPaymentInfo accepts a parameter $returnType and has code handling for it, but no code ever passed this

After
----------------------------------------
1. Function getPaymentInfo calls CRM_Contribute_BAO_Contribution::getContributionBalance
2. parameter $returnType removed from getPartialPaymentWithType

Technical Details
----------------------------------------
Really I don't think getPartialPaymentWithType has any reason to exist. I kept to this small change however because I think it's pretty easy to review. If anyone wants to tackle fully getting rid of it I'm happy to do that PR or review it

Comments
----------------------------------------
@mattwire @pradpnayak @monishdeb I'm sure you must have been annoyed by this at some point

**testing note**
this code has existing test coverage