### PR TITLE
dev/core#709, fixed date filter for custom fields

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2114,12 +2114,10 @@ class CRM_Report_Form extends CRM_Core_Form {
     list($from, $to) = $this->getFromTo($relative, $from, $to, $fromTime, $toTime);
 
     if ($from) {
-      $from = ($type == CRM_Utils_Type::T_DATE) ? substr($from, 0, 8) : $from;
       $clauses[] = "( {$fieldName} >= $from )";
     }
 
     if ($to) {
-      $to = ($type == CRM_Utils_Type::T_DATE) ? substr($to, 0, 8) : $to;
       $clauses[] = "( {$fieldName} <= {$to} )";
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/709

Before
----------------------------------------
Steps:

Click "View contact record"
Click "Contacts" > "Contact Reports"
Open the "Constituent Summary" report
Open the "Filters" tab
Open the "Custom set" tab
Select the "Today" option to the "Date" field
Click "Refresh Results"

Actual result: There is no contact from the precondition in the search results.
The filter by the "Date" field with "Today" option doesn't find matching contacts.
Expected result: There is contact from the precondition in the search results.

![screenshot 2019-02-14 09 10 24](https://user-images.githubusercontent.com/336308/52740664-627a6100-3038-11e9-886c-b26d4af8520a.png)


After
----------------------------------------
Date range applied ends at 235959

Technical Details
----------------------------------------


Comments
----------------------------------------

