### PR TITLE
Fix to Contact ID help text

### DIFF
--- a/templates/CRM/Contact/Form/Contact.hlp
+++ b/templates/CRM/Contact/Form/Contact.hlp
@@ -128,6 +128,13 @@
 <p>{ts}Upload a photo or icon that you want to be displayed when viewing this contact.{/ts}</p>
 {/htxt}
 
+{htxt id="id-contact-id-title"}
+  {ts}Contact ID{/ts}
+{/htxt}
+{htxt id="id-contact-id"}
+<p>{ts}Every contact in CiviCRM has a unique ID number. This number will never change and is the most accurate way of identifying a contact.{/ts}</p>
+{/htxt}
+
 {htxt id="id-internal-id-title"}
   {ts}Contact ID{/ts}
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Contact ID help text on Advanced Search does not show any text.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/7308809/52569539-565c8c80-2e09-11e9-887f-15eedb28aa36.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/7308809/52569593-77bd7880-2e09-11e9-907f-7afec922a258.png)


Technical Details
----------------------------------------
N/A

Comments
----------------------------------------
N/A