### PR TITLE
Fix contact ID help on advanced search

### DIFF
--- a/templates/CRM/Contact/Form/Contact.hlp
+++ b/templates/CRM/Contact/Form/Contact.hlp
@@ -128,10 +128,10 @@
 <p>{ts}Upload a photo or icon that you want to be displayed when viewing this contact.{/ts}</p>
 {/htxt}
 
-{htxt id="id-internal-id-title"}
+{htxt id="id-contact-id-title"}
   {ts}Contact ID{/ts}
 {/htxt}
-{htxt id="id-internal-id"}
+{htxt id="id-contact-id"}
 <p>{ts}Every contact in CiviCRM has a unique ID number. This number will never change and is the most accurate way of identifying a contact.{/ts}</p>
 {/htxt}
 

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -63,7 +63,7 @@
               </td>
               {if $contactId}
                 <td>
-                  <label for="internal_identifier_display">{ts}Contact ID{/ts} {help id="id-internal-id"}</label><br />
+                  <label for="internal_identifier_display">{ts}Contact ID{/ts} {help id="id-contact-id"}</label><br />
                   <input id="internal_identifier_display" type="text" class="crm-form-text six" size="6" readonly="readonly" value="{$contactId}">
                 </td>
               {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes #13568 - Contact ID help text on Advanced Search does not show any text.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/7308809/52569539-565c8c80-2e09-11e9-887f-15eedb28aa36.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/7308809/52569593-77bd7880-2e09-11e9-907f-7afec922a258.png)

Technical details
----------------------------------------
2 forms were sharing the same help text, so they have to call it by the same name. Since "internal id" isn't a real thing I switched it to match the other form.