### PR TITLE
Fix regression whereby making receive_date required breaks back office cc

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -699,7 +699,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     // add various dates
-    $this->addField('receive_date', array('entity' => 'contribution'), TRUE, FALSE);
+    $this->addField('receive_date', array('entity' => 'contribution'), !$this->_mode, FALSE);
     $this->addField('receipt_date', array('entity' => 'contribution'), FALSE, FALSE);
     $this->addField('cancel_date', array('entity' => 'contribution', 'label' => ts('Cancelled / Refunded Date')), FALSE, FALSE);
 


### PR DESCRIPTION
Overview
----------------------------------------
Regression from https://lab.civicrm.org/dev/core/issues/680
led to https://civicrm.stackexchange.com/questions/28410/unable-to-take-credit-card-payment-after-civi-update


Before
----------------------------------------
error message staing 'Date Received is a required field.' 

After
----------------------------------------
not required when cc is present

Technical Details
----------------------------------------

Comments
----------------------------------------

