### PR TITLE
dev/report#7 fix trxn_date on bookkeeping report

### DIFF
--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -354,7 +354,7 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
           'trxn_date' => array(
             'title' => ts('Transaction Date'),
             'default' => TRUE,
-            'type' => CRM_Utils_Type::T_DATE,
+            'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
           ),
           'trxn_id' => array(
             'title' => ts('Trans #'),
@@ -381,7 +381,7 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
           'trxn_date' => array(
             'title' => ts('Transaction Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
-            'type' => CRM_Utils_Type::T_DATE,
+            'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
           ),
           'status_id' => array(
             'title' => ts('Financial Transaction Status'),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes trxn_date on bookkeeping date time to work properly

Before
----------------------------------------
if today is February 10 and I filter Transaction Date on "Yesterday", the WHERE clause looks like:

( financial_trxn.trxn_date >= '20190209') AND ( financial_trxn.trxn_date <= '20190209' )

Only transactions that occurred exactly at midnight are included. Contrast that with the filter for Date Received:

( contribution.receive_date >= '20190209000000') AND ( contribution.receive_date <= '20190209235959' )

After
----------------------------------------
Tim included in filter

Technical Details
----------------------------------------

Comments
----------------------------------------
