### PR TITLE
Towards supporting EntityForm for 'View Action'

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -114,6 +114,10 @@ trait CRM_Core_Form_EntityFormTrait {
     $this->assign('entityTable', CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($this->getDefaultEntity())));
     $this->addCustomDataToForm();
     $this->addFormButtons();
+
+    if ($this->isViewContext()) {
+      $this->freeze();
+    }
   }
 
   /**
@@ -128,7 +132,7 @@ trait CRM_Core_Form_EntityFormTrait {
    * Add relevant buttons to the form.
    */
   protected function addFormButtons() {
-    if ($this->_action & CRM_Core_Action::VIEW || $this->_action & CRM_Core_Action::PREVIEW) {
+    if ($this->isViewContext() || $this->_action & CRM_Core_Action::PREVIEW) {
       $this->addButtons(array(
           array(
             'type' => 'cancel',
@@ -142,7 +146,7 @@ trait CRM_Core_Form_EntityFormTrait {
       $this->addButtons(array(
           array(
             'type' => 'next',
-            'name' => $this->_action & CRM_Core_Action::DELETE ? ts('Delete') : ts('Save'),
+            'name' => $this->isDeleteContext() ? ts('Delete') : ts('Save'),
             'isDefault' => TRUE,
           ),
           array(
@@ -159,19 +163,26 @@ trait CRM_Core_Form_EntityFormTrait {
    */
   protected function getEntityDefaults() {
     $defaults = [];
-    if ($this->_action != CRM_Core_Action::DELETE &&
+    if (!$this->isDeleteContext() &&
       $this->getEntityId()
     ) {
       $params = ['id' => $this->getEntityId()];
       $baoName = $this->_BAOName;
       $baoName::retrieve($params, $defaults);
     }
-    foreach ($this->entityFields as $fieldSpec) {
+    foreach ($this->entityFields as &$fieldSpec) {
       $value = CRM_Utils_Request::retrieveValue($fieldSpec['name'], $this->getValidationTypeForField($fieldSpec['name']));
       if ($value !== FALSE && $value !== NULL) {
         $defaults[$fieldSpec['name']] = $value;
       }
+      if (CRM_Utils_Array::value('formatter', $fieldSpec) == 'crmMoney') {
+        if (!empty($defaults['currency'])) {
+          $fieldSpec['formatterParam'] = $defaults['currency'];
+        }
+      }
     }
+    // Assign again as we may have modified above
+    $this->assign('entityFields', $this->entityFields);
     return $defaults;
   }
 
@@ -242,6 +253,15 @@ trait CRM_Core_Form_EntityFormTrait {
    */
   protected function isDeleteContext() {
     return ($this->_action & CRM_Core_Action::DELETE);
+  }
+
+  /**
+   * Is the form being used in the context of a view.
+   *
+   * @return bool
+   */
+  protected function isViewContext() {
+    return ($this->_action & CRM_Core_Action::VIEW);
   }
 
   protected function setEntityFieldsMetadata() {

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -63,11 +63,18 @@ class CRM_Custom_Form_CustomData {
       $entitySubType = $form->getEntitySubTypeId($subType);
     }
 
-    // when custom data is included in this page
-    if (!empty($_POST['hidden_custom'])) {
-      self::preProcess($form, $subName, $entitySubType, $groupCount, $entityName, $entityID);
-      self::buildQuickForm($form);
-      self::setDefaultValues($form);
+    if ($form->getAction() == CRM_Core_Action::VIEW) {
+      // Viewing custom data (Use with {include file="CRM/Custom/Page/CustomDataView.tpl"} in template)
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityName, NULL, $entityID, 0, $entitySubType);
+      CRM_Core_BAO_CustomGroup::buildCustomDataView($form, $groupTree, FALSE, NULL, NULL, NULL, $entityID);
+    }
+    else {
+      // Editing custom data (Use with {include file="CRM/common/customDataBlock.tpl"} in template)
+      if (!empty($_POST['hidden_custom'])) {
+        self::preProcess($form, $subName, $entitySubType, $groupCount, $entityName, $entityID);
+        self::buildQuickForm($form);
+        self::setDefaultValues($form);
+      }
     }
     // need to assign custom data type and subtype to the template
     $form->assign('customDataType', $entityName);

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -33,7 +33,7 @@
     {/capture}{help id=$help.id file=$help.file}{/if}
     {if $action == 2 && $fieldSpec.is_add_translate_dialog}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
-  <td>{$fieldSpec.pre_html_text}{if $form.$fieldName.html}{if $fieldSpec.formatter === 'crmMoney'}{$form.$fieldName.html|crmMoney}{else}{$form.$fieldName.html}{/if}{else}{$fieldSpec.place_holder}{/if}{$fieldSpec.post_html_text}<br />
+  <td>{$fieldSpec.pre_html_text}{if $form.$fieldName.html}{if $fieldSpec.formatter === 'crmMoney'}{$form.$fieldName.html|crmMoney:$fieldSpec.formatterParam}{else}{$form.$fieldName.html}{/if}{else}{$fieldSpec.place_holder}{/if}{$fieldSpec.post_html_text}<br />
     {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
     {if $fieldSpec.documentation_link}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>


### PR DESCRIPTION
Overview
----------------------------------------
"EntityForm" is quite a new thing.  @eileenmcnaughton and me have been gradually developing it.  But it's not used on any "View" forms yet.  This PR adds some preliminary support for that.

Before
----------------------------------------
Less support for EntityForm on "View" forms.

After
----------------------------------------
More support for EntityForm on "View" forms.  Specifically:
* Adds a "View" context and freezes form elements in this case.
* Adds the relevant calls to add custom data to a "View" form.
* Adds an additional parameter that can be used to pass the currency to the template.

Technical Details
----------------------------------------
Described above. Basically delete/edit contexts are currently implemented for EntityForm, this adds basic support for "View" context.

Comments
----------------------------------------
I have further work to follow that will use this...
