### PR TITLE
dev/core#715 - Fix delete action on RelationshipType form

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1329,6 +1329,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if ($action & (CRM_Core_Action::VIEW + CRM_Core_Action::BROWSE + CRM_Core_Action::BASIC + CRM_Core_Action::ADVANCED + CRM_Core_Action::PREVIEW)) {
       return 'get';
     }
+    if ($action & (CRM_Core_Action::DELETE)) {
+      return 'delete';
+    }
     // If you get this exception try adding more cases above.
     throw new Exception("Cannot determine api action for " . get_class($this) . '.' . 'CRM_Core_Action "' . CRM_Core_Action::description($action) . '" not recognized.');
   }

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -250,6 +250,10 @@ trait CRM_Core_Form_EntityFormTrait {
         // We can't load this field using metadata
         continue;
       }
+      if ($field != 'id' && $this->isDeleteContext()) {
+        // Delete forms don't generally present any fields to edit
+        continue;
+      }
       // Resolve action.
       if (empty($props['action'])) {
         $props['action'] = $this->getApiAction();


### PR DESCRIPTION
Overview
------
See https://lab.civicrm.org/dev/core/issues/715

Before
-------
Fatal error when deleting a relationship type

After
-----
Form works

Technical Details
--------
This fixes the bug for now but I'm not sure this is really the right fix long-term.

When I dig into the code of CRM_Core_Form_EntityFormTrait I see that every form has to declare a rather cumbersome array in `setEntityFields` which appears to duplicate metadata that could be retrieved from the api... and then another function `setEntityFieldsMetadata` which appears to supply that same information that was hard-coded in the previous function.
Couldn't all this be avoided by calling `getfields` on the entity and passing in the action? Then we'd avoid trying to retrieve inappropriate fields for that action (which was the cause of this bug) and we'd also avoid all the hard-coded (and hard-to-maintain) getfields boilerplate in the `setEntityFields` fn.