### PR TITLE
[REF] switch from (undeclared) class property to local variable.

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -115,10 +115,9 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
    */
   public function buildUserDashBoard() {
     //build component selectors
-    $dashboardElements = array();
-    $config = CRM_Core_Config::singleton();
+    $dashboardElements = [];
 
-    $this->_userOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    $dashboardOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
       'user_dashboard_options'
     );
 
@@ -130,7 +129,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
         continue;
       }
 
-      if (!empty($this->_userOptions[$name]) &&
+      if (!empty($dashboardOptions[$name]) &&
         (CRM_Core_Permission::access($component->name) ||
           CRM_Core_Permission::check($elem['perm'][0])
         )
@@ -148,7 +147,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     }
 
     // CRM-16512 - Hide related contact table if user lacks permission to view self
-    if (!empty($this->_userOptions['Permissioned Orgs']) && CRM_Core_Permission::check('view my contact')) {
+    if (!empty($dashboardOptions['Permissioned Orgs']) && CRM_Core_Permission::check('view my contact')) {
       $dashboardElements[] = array(
         'class' => 'crm-dashboard-permissionedOrgs',
         'templatePath' => 'CRM/Contact/Page/View/RelationshipSelector.tpl',
@@ -158,7 +157,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
 
     }
 
-    if (!empty($this->_userOptions['PCP'])) {
+    if (!empty($dashboardOptions['PCP'])) {
       $dashboardElements[] = array(
         'class' => 'crm-dashboard-pcp',
         'templatePath' => 'CRM/Contribute/Page/PcpUserDashboard.tpl',
@@ -170,7 +169,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
       $this->assign('pcpInfo', $pcpInfo);
     }
 
-    if (!empty($this->_userOptions['Assigned Activities']) && empty($this->_isChecksumUser)) {
+    if (!empty($dashboardOptions['Assigned Activities']) && empty($this->_isChecksumUser)) {
       // Assigned Activities section
       $dashboardElements[] = array(
         'class' => 'crm-dashboard-assignedActivities',
@@ -186,9 +185,9 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     $this->assign('dashboardElements', $dashboardElements);
 
     // return true when 'Invoices / Credit Notes' checkbox is checked
-    $this->assign('invoices', $this->_userOptions['Invoices / Credit Notes']);
+    $this->assign('invoices', $dashboardOptions['Invoices / Credit Notes']);
 
-    if (!empty($this->_userOptions['Groups'])) {
+    if (!empty($dashboardOptions['Groups'])) {
       $this->assign('showGroup', TRUE);
       //build group selector
       $gContact = new CRM_Contact_Page_View_UserDashBoard_GroupContact();

--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -58,16 +58,12 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
   public function __construct() {
     parent::__construct();
 
-    $check = CRM_Core_Permission::check('access Contact Dashboard');
-
-    if (!$check) {
+    if (!CRM_Core_Permission::check('access Contact Dashboard')) {
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/dashboard', 'reset=1'));
     }
 
     $this->_contactId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
+    $userID = CRM_Core_Session::singleton()->getLoggedInContactID();
 
     $userChecksum = $this->getUserChecksum();
     $validUser = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
undeclared class property used, extraneous config call

After
----------------------------------------
local var used, extraneous call removed

Technical Details
----------------------------------------
We either needed to declare the variable on the class & make it a local variable. Switching
to a local var reflects the fact it is never accessed from outside thie function & improves readability.

grepping for _userOptions returns nothing after this.

I also removed an extraneous config singleton call. I can't see a strong case that either of
these changes will affect the intermittent fails but ... maybe?

Comments
----------------------------------------
@seamuslee001 @mattwire either of you OK to check this - should be pretty simple as it's just preliminary to my next step (using the api to get the contribution rows rather than Selector object - in order to simplify some performance fixes & hopefully deal to the intermittent test fail)
