### PR TITLE
[REF} User api rather than selector for rendering contributions on user dashboard

### DIFF
--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -58,6 +58,7 @@
                         <td>{$row.contribution_status}</td>
                         {if $invoicing && $invoices}
                           <td>
+                            {* @todo Instead of this tpl handling assign actions as an array attached the row, iterate through - will better accomodate extension overrides and competition for scarce real estate on this page*}
                             {assign var='id' value=$row.contribution_id}
                             {assign var='contact_id' value=$row.contact_id}
                             {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id"}
@@ -75,6 +76,7 @@
                           </td>
                         {/if}
                         {if $defaultInvoicePage && $row.contribution_status_name == 'Pending' }
+                          {* @todo Instead of this tpl handling assign actions as an array attached the row, iterate through - will better accomodate extension overrides and competition for scarce real estate on this page*}
                           <td>
                             {assign var='checksum_url' value=""}
                             {if $userChecksum}

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -134,7 +134,7 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
       'receive_date' => '2018-11-21 00:00:00',
       'contribution_status' => 'Completed',
       'currency' => 'USD',
-      //'receipt_date' => '2018-11-22 00:00:00',
+      'receipt_date' => '2018-11-22 00:00:00',
     ]);
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
This is a code cleanup on the user dashboard for readability, testing & performance reasons

Before
----------------------------------------
Selector invoked

After
----------------------------------------
api invoked - no user change

Technical Details
----------------------------------------
Note that preliminary tests for this were written & merged some time ago.

Reasons for the change are

1) readability - most devs are much more comfortable with reading the api code than the selector
2) performance - the contribute selector code is deeply unperformant - mostly due to the summary function which in
this case is somewhat mitigated by the limit of 12 but we are still doing something slow for no reason
3) test stability - the test for this turned out to have poor stability & hopefully this will help
4) preliminary cleanup - there are 2 existing PRs that attempt to add new buttons to this & moving towards
a cleaner tpl / php layer will help with those. In addition there is a serious performance issue to
address on the contribution summary function. Reducing use of that function should help with the cleanup effort

Comments
----------------------------------------

