### PR TITLE
[REF] Move addSelectWhere-like function to be located on BAO_Contribution 

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -880,6 +880,33 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function addSelectWhereClause() {
+    $whereClauses = parent::addSelectWhereClause();
+    if ($whereClauses !== []) {
+      // In this case permisssions have been applied & we assume the
+      // financialaclreport is applying these
+      // https://github.com/JMAConsulting/biz.jmaconsulting.financialaclreport/blob/master/financialaclreport.php#L107
+      return $whereClauses;
+    }
+
+    if (!CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
+      return $whereClauses;
+    }
+    $types = CRM_Financial_BAO_FinancialType::getAllEnabledAvailableFinancialTypes();
+    if (empty($types)) {
+      $whereClauses['financial_type_id'] = 'IN (0)';
+    }
+    else {
+      $whereClauses['financial_type_id'] = [
+        'IN (' . implode(',', array_keys($types)) . ')'
+      ];
+    }
+    return $whereClauses;
+  }
+
+  /**
    * @param null $status
    * @param null $startDate
    * @param null $endDate

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -360,27 +360,9 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    * @param array $whereClauses
    */
   public static function addACLClausesToWhereClauses(&$whereClauses) {
-    $originalWhereClauses = $whereClauses;
-    CRM_Utils_Hook::selectWhereClause('Contribution', $whereClauses);
-    if ($whereClauses !== $originalWhereClauses) {
-      // In this case permisssions have been applied & we assume the
-      // financialaclreport is applying these
-      // https://github.com/JMAConsulting/biz.jmaconsulting.financialaclreport/blob/master/financialaclreport.php#L107
-      return;
-    }
+    $contributionBAO = new CRM_Contribute_BAO_Contribution();
+    $whereClauses = array_merge($whereClauses, $contributionBAO->addSelectWhereClause());
 
-    if (!self::isACLFinancialTypeStatus()) {
-      return;
-    }
-    $types = self::getAllEnabledAvailableFinancialTypes();
-    if (empty($types)) {
-      $whereClauses['financial_type_id'] = 'IN (0)';
-    }
-    else {
-      $whereClauses['financial_type_id'] = [
-        'IN (' . implode(',', array_keys($types)) . ')'
-      ];
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is a code relocation / standardisation to use the std location for applying acls to contributions

Before
----------------------------------------
Function in a random place

After
----------------------------------------
Function in the std place

Technical Details
----------------------------------------
Having a function to add ACLs in addSelectWhere on the BAO is the standard. There is a question as to whether this goes on the contribution BAO or on the financialType BAO & we put something in the parent to call in the financialType acl whenever it's an FK on the entity. However, that could be resolved in a follow up

Comments
----------------------------------------
Note this is covered by the recently added annualQuery test 