### PR TITLE
dev/core#631 - Enable 'add new' by default on merge screen

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1433,7 +1433,16 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         }
       }
       if ($name == 'rel_table_memberships') {
-        $elements[] = array('checkbox', "operation[move_{$name}][add]", NULL, ts('add new'));
+        //Enable 'add new' checkbox if main contact does not contain any membership similar to duplicate contact.
+        $attributes = ['checked' => 'checked'];
+        $otherContactMemberships = CRM_Member_BAO_Membership::getAllContactMembership($otherId);
+        foreach ($otherContactMemberships as $membership) {
+          $mainMembership = CRM_Member_BAO_Membership::getContactMembership($mainId, $membership['membership_type_id'], FALSE);
+          if ($mainMembership) {
+            $attributes = [];
+          }
+        }
+        $elements[] = array('checkbox', "operation[move_{$name}][add]", NULL, ts('add new'), $attributes);
         $migrationInfo["operation"]["move_{$name}"]['add'] = 1;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Enable 'add new' checkbox on merge screen by default 

Before
----------------------------------------
Add new is not selected by default which does not move the membership to the main contact.

![image](https://user-images.githubusercontent.com/5929648/52714582-3c18df00-2fc0-11e9-8e1d-53d8410be65d.png)


After
----------------------------------------
'add new' is enabled by default if main contact does not contain any membership similar to other contact.

![image](https://user-images.githubusercontent.com/5929648/52714600-4935ce00-2fc0-11e9-8190-7b2be5d5cc0e.png)

See complete explanation at https://lab.civicrm.org/dev/core/issues/631#note_13435

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/631