### PR TITLE
dev/core#722 Display attachments in Activities tab

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -3084,6 +3084,11 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
           $values['activity_id']
         );
 
+        $attachments = CRM_Core_BAO_File::paperIconAttachment('civicrm_activity', $values['activity_id']);
+        if (!empty($attachments)) {
+          $activity['links'] .= "<br />" . implode(' ', $attachments);
+        }
+
         if ($values['is_recurring_activity']) {
           $activity['is_recurring_activity'] = CRM_Core_BAO_RecurringEntity::getPositionAndCount($values['activity_id'], 'civicrm_activity');
         }


### PR DESCRIPTION
Overview
----------------------------------------
Attachments in case activities are displayed as paper-clip icon links on the case view screen.
![case view](https://user-images.githubusercontent.com/33434409/52717953-38726180-2f9a-11e9-910d-03a20d8e8f8e.png)

It would be better if attachments are displayed in the activities tab for all other activities as well.

After
----------------------------------------
Displaying attachment icons next to action links
![activity](https://user-images.githubusercontent.com/33434409/52718066-7bccd000-2f9a-11e9-81f1-9bf823895524.png)

Technical Details
----------------------------------------
* `CRM_Activity_BAO_Activity::getContactActivitySelector()` method is only used in `CRM_Activity_Page_AJAX::getContactActivity()` which is the ajax call to fill up the activities in Activities tab. 
* I'm not sure where to add the attachments; as a separate column or inside an existing column so added them next to the action links 


https://lab.civicrm.org/dev/core/issues/722