### PR TITLE
(dev/core#705) Disabling Alphabetical Pager is not respected for cont…

### DIFF
--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -420,8 +420,10 @@ AND         cp.page_type = 'contribute'
     $params = array();
 
     $whereClause = $this->whereClause($params, FALSE);
-    $this->pagerAToZ($whereClause, $params);
-
+    $config = CRM_Core_Config::singleton();
+    if ($config->includeAlphabeticalPager) {
+      $this->pagerAToZ($whereClause, $params);
+    }
     $params = array();
     $whereClause = $this->whereClause($params, TRUE);
     $this->pager($whereClause, $params);


### PR DESCRIPTION
…ribution pages.

Overview
----------------------------------------
Steps to replicate :

Go to Admin > Search Preferences and turn off Include Alphabetical Pager

A to Z Pager is off for Find Contacts, Find Contributions, etc
However it is still shown on _Manage Contribution Pages_.

https://lab.civicrm.org/dev/core/issues/705

Before
----------------------------------------
Alphabetical Pager is visible on Manage Contribution Pages

After
----------------------------------------
Alphabetical Pager is not visible on Manage Contribution Pages

Comments
----------------------------------------
This is keeping it consistent with other selectors where Alphabetical Pager is already suppressed.