### PR TITLE
dev/core#721 Fix regression on refreshing group_contact cache before checking acls

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -782,10 +782,10 @@ SELECT g.*
         while ($dao->fetch()) {
           $groupIDs[] = $dao->id;
 
-          if (($dao->saved_search_id || $dao->children || $dao->parents) &&
-            $dao->cache_date == NULL
-          ) {
-            CRM_Contact_BAO_GroupContactCache::load($dao);
+          if (($dao->saved_search_id || $dao->children || $dao->parents)) {
+            if ($dao->cache_date == NULL) {
+              CRM_Contact_BAO_GroupContactCache::load($dao);
+            }
             $groupContactCacheClause = " UNION SELECT contact_id FROM civicrm_group_contact_cache WHERE group_id IN (" . implode(', ', $groupIDs) . ")";
           }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression whereby ACLs permitting access to smart groups require the group_cache to be aged out before it is applied

https://lab.civicrm.org/dev/core/issues/721

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/721 access to contacts permitted by ACL over a smart group depend on the cache status

After
----------------------------------------
Cache rebuild independent of access to contacts

Technical Details
----------------------------------------
We seem to be checking if the cache needs a rebuild and IF SO doing 2 actions
1) rebuilding it
2) permitting access to contacts related to it

When really it should do only 1) above - this patch changes as such

This seems to be whackamole off https://github.com/civicrm/civicrm-core/pull/12344
going too far one way & https://github.com/civicrm/civicrm-core/pull/13448
fixing but adding this new variant

Comments
----------------------------------------
@jitendrapurohit @jackrabbithanna can either of you review this as you were both involved in the original PR that triggered this chain of events
