### PR TITLE
CiviCRM API, lookup state_province_id options based on country parame…

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1320,7 +1320,7 @@ SELECT is_primary,
             $props['country_id'] = $config->defaultContactCountry;
           }
         }
-        if (!empty($props['country_id']) && $context !== 'validate') {
+        if (!empty($props['country_id'])) {
           $params['condition'] = 'country_id IN (' . implode(',', (array) $props['country_id']) . ')';
         }
         break;

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1311,7 +1311,7 @@ SELECT is_primary,
       case 'state_province':
         // change $fieldName to DB specific names.
         $fieldName = 'state_province_id';
-        if (empty($props['country_id'])) {
+        if (empty($props['country_id']) && $context !== 'validate') {
           $config = CRM_Core_Config::singleton();
           if (!empty($config->provinceLimit)) {
             $props['country_id'] = $config->provinceLimit;

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -390,4 +390,24 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->assertEquals('Individual', $result['contact_id.contact_type']);
   }
 
+  /**
+   * Test Address create with a state name that at least two countries have, e.g. Maryland, United States vs. Maryland, Liberia
+   *
+   * @see https://lab.civicrm.org/dev/core/issues/725
+   */
+  public function testCreateAddressStateProvinceIDCorrectForCountry() {
+    $params = $this->_params;
+    $params['sequential'] = 1;
+    $params['country_id'] = '1228'; // United States country id
+    $params['state_province_id'] = 'Maryland';
+    $params['city'] = 'Baltimore';
+    $params['street_address'] = '600 N Charles St.';
+    $params['postal_code'] = '21201';
+    unset($params['street_name']);
+    unset($params['street_number']);
+    $address1 = $this->callAPISuccess('address', 'create', $params);
+    // should find state_province_id of 1019, Maryland, United States ... NOT 3497, Maryland, Liberia
+    $this->assertEquals('1019', $address1['values'][0]['state_province_id']);
+  }
+
 }

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -408,6 +408,14 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $address1 = $this->callAPISuccess('address', 'create', $params);
     // should find state_province_id of 1019, Maryland, United States ... NOT 3497, Maryland, Liberia
     $this->assertEquals('1019', $address1['values'][0]['state_province_id']);
+
+    // Now try it in Liberia
+    $params = $this->_params;
+    $params['sequential'] = 1;
+    $params['country_id'] = '1122'; // Liberia country id
+    $params['state_province_id'] = 'Maryland';
+    $address2 = $this->callAPISuccess('address', 'create', $params);
+    $this->assertEquals('3497', $address2['values'][0]['state_province_id']);
   }
 
 }


### PR DESCRIPTION
…ter if present, or default country

Overview
----------------------------------------
See issue: https://lab.civicrm.org/dev/core/issues/725

Before
----------------------------------------
CiviCRM Address API incorrectly sets state_province_id for states whose name/abbreviation exist in multiple countries.

After
----------------------------------------
CiviCRM Address API correctly sets state_province_id for states whose name/abbreviation exist in multiple countries.

Technical Details
----------------------------------------
The API does not pass parameters to the functions/methods responsible for building the list of valid options for the state_province_id field, instead it produces the entire list of states in the system. API validation does not catch this situation. Then if a state name or abbreviation is used by multiple countries, the first option found is used, instead of the right one. This condition could also exist for counties. Examples are "Maryland" and "Montana" . See issue for code example.

