### PR TITLE
Always load recaptcha JS over HTTPS

### DIFF
--- a/CRM/Utils/ReCAPTCHA.php
+++ b/CRM/Utils/ReCAPTCHA.php
@@ -98,11 +98,10 @@ class CRM_Utils_ReCAPTCHA {
       require_once 'packages/recaptcha/recaptchalib.php';
     }
 
-    // See if we are using SSL
-    if (CRM_Utils_System::isSSL()) {
-      $useSSL = TRUE;
-    }
-    $html = recaptcha_get_html($config->recaptchaPublicKey, $error, $useSSL);
+    // Load the Recaptcha api.js over HTTPS
+    $useHTTPS = TRUE;
+
+    $html = recaptcha_get_html($config->recaptchaPublicKey, $error, $useHTTPS);
 
     $form->assign('recaptchaHTML', $html);
     $form->assign('recaptchaOptions', $config->recaptchaOptions);


### PR DESCRIPTION
Overview
----------------------------------------
Recaptcha api.js should always be loaded over HTTPS regardless if the Civi site is being served over insecure HTTP.

Before
----------------------------------------
Currently CiviCRM checks to see if the site is being served over SSL/HTTPS and attempts to load the recaptcha API over the same protocol:

```
if (CRM_Utils_System::isSSL()) {
  $useSSL = TRUE;
}
```

After
----------------------------------------
Force-set this option so the resulting include tag always loads `api.js` over `https://` as a best-practice.

Technical Details
----------------------------------------
See also `packages/recaptcha/recaptchalib.php:112`

Comments
----------------------------------------

Related: https://lab.civicrm.org/dev/core/issues/425
