### PR TITLE
Payment.sendconfirmation api - add further tpl variables.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4832,7 +4832,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     $balanceTrxnParams['from_financial_account_id'] = $fromFinancialAccountId;
     $balanceTrxnParams['total_amount'] = $params['total_amount'];
     $balanceTrxnParams['contribution_id'] = $params['contribution_id'];
-    $balanceTrxnParams['trxn_date'] = !empty($params['contribution_receive_date']) ? $params['contribution_receive_date'] : date('YmdHis');
+    $balanceTrxnParams['trxn_date'] = CRM_Utils_Array::value('trxn_date', $params, CRM_Utils_Array::value('contribution_receive_date', $params, date('YmdHis')));
     $balanceTrxnParams['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
     $balanceTrxnParams['net_amount'] = CRM_Utils_Array::value('total_amount', $params);
     $balanceTrxnParams['currency'] = $contribution['currency'];

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -177,6 +177,13 @@ class CRM_Financial_BAO_Payment {
     ])['values'];
     if (!empty($participantRecords)) {
       $entities['event'] = civicrm_api3('Event', 'getsingle', ['id' => $participantRecords[0]['api.Participant.get']['values'][0]['event_id']]);
+      if (!empty($entities['event']['is_show_location'])) {
+        $locationParams = [
+          'entity_id' => $entities['event']['id'],
+          'entity_table' => 'civicrm_event',
+        ];
+        $entities['location'] = CRM_Core_BAO_Location::getValues($locationParams, TRUE);
+      }
     }
 
     return $entities;
@@ -210,16 +217,14 @@ class CRM_Financial_BAO_Payment {
       'totalAmount' => $entities['payment']['total'],
       'amountOwed' => $entities['payment']['balance'],
       'paymentAmount' => $entities['payment']['total_amount'],
-      'event' => NULL,
-      'component' => 'contribution',
       'checkNumber' => CRM_Utils_Array::value('check_number', $entities['payment']),
       'receive_date' => $entities['payment']['trxn_date'],
       'paidBy' => CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_FinancialTrxn', 'payment_instrument_id', $entities['payment']['payment_instrument_id']),
+      'isShowLocation' => (!empty($entities['event']) ? $entities['event']['is_show_location'] : FALSE),
+      'location' => CRM_Utils_Array::value('location', $entities),
+      'event' => CRM_Utils_Array::value('event', $entities),
+      'component' => (!empty($entities['event']) ? 'event' : 'contribution'),
     ];
-    if (!empty($entities['event'])) {
-      $templateVariables['component'] = 'event';
-      $templateVariables['event'] = $entities['event'];
-    }
 
     return self::filterUntestedTemplateVariables($templateVariables);
   }
@@ -246,6 +251,8 @@ class CRM_Financial_BAO_Payment {
       'checkNumber',
       'receive_date',
       'paidBy',
+      'isShowLocation',
+      'location',
     ];
     // Need to do these before switching the form over...
     $todoParams = [
@@ -260,8 +267,6 @@ class CRM_Financial_BAO_Payment {
       'credit_card_type',
       'credit_card_number',
       'credit_card_exp_date',
-      'isShowLocation',
-      'location',
       'eventEmail',
       '$event.participant_role',
     ];

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -212,6 +212,9 @@ class CRM_Financial_BAO_Payment {
       'paymentAmount' => $entities['payment']['total_amount'],
       'event' => NULL,
       'component' => 'contribution',
+      'checkNumber' => CRM_Utils_Array::value('check_number', $entities['payment']),
+      'receive_date' => $entities['payment']['trxn_date'],
+      'paidBy' => CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_FinancialTrxn', 'payment_instrument_id', $entities['payment']['payment_instrument_id']),
     ];
     if (!empty($entities['event'])) {
       $templateVariables['component'] = 'event';
@@ -240,6 +243,9 @@ class CRM_Financial_BAO_Payment {
       'paymentAmount',
       'event',
       'component',
+      'checkNumber',
+      'receive_date',
+      'paidBy',
     ];
     // Need to do these before switching the form over...
     $todoParams = [
@@ -247,9 +253,6 @@ class CRM_Financial_BAO_Payment {
       'totalPaid',
       'refundAmount',
       'paymentsComplete',
-      'receive_date',
-      'paidBy',
-      'checkNumber',
       'contributeMode',
       'isAmountzero',
       'billingName',

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -113,6 +113,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $params = array(
       'contribution_id' => $contribution['id'],
       'total_amount' => 50,
+      'check_number' => '345',
+      'trxn_date' => '2018-08-13 17:57:56',
     );
     $payment = $this->callAPISuccess('payment', 'create', $params);
     $this->checkPaymentResult($payment, [
@@ -133,6 +135,9 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'This Payment Amount: $ 50.00',
       'Balance Owed: $ 100.00', //150 was paid in the 1st payment.
       'Event Information and Location',
+      'Paid By: Check',
+      'Check Number: 345',
+      'Transaction Date: August 13th, 2018  5:57 PM',
     ));
     $mut->stop();
   }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -110,6 +110,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   public function testPaymentEmailReceipt() {
     $mut = new CiviMailUtils($this);
     list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $event = $this->callAPISuccess('Event', 'get', []);
+    $this->addLocationToEvent($event['id']);
     $params = array(
       'contribution_id' => $contribution['id'],
       'total_amount' => 50,
@@ -138,6 +140,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'Paid By: Check',
       'Check Number: 345',
       'Transaction Date: August 13th, 2018  5:57 PM',
+      'event place',
+      'streety street',
     ));
     $mut->stop();
   }
@@ -628,6 +632,29 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', array(
       'id' => $contribution['id'],
     ));
+  }
+
+  /**
+   * Add a location to our event.
+   *
+   * @param int $eventID
+   */
+  protected function addLocationToEvent($eventID) {
+    $addressParams = [
+      'name' => 'event place',
+      'street_address' => 'streety street',
+      'location_type_id' => 1,
+      'is_primary' => 1,
+    ];
+    // api requires contact_id - perhaps incorrectly but use add to get past that.
+    $address = CRM_Core_BAO_Address::add($addressParams);
+
+    $location = $this->callAPISuccess('LocBlock', 'create', ['address_id' => $address->id]);
+    $this->callAPISuccess('Event', 'create', [
+      'id' => $eventID,
+      'loc_block_id' => $location['id'],
+      'is_show_location' => TRUE,
+    ]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Payment.sendconfirmation is an api added in 5.12 - this is part of that. The api will replace the form email confirmation logic once mature

Before
----------------------------------------
Less complete

After
----------------------------------------
More complete

Technical Details
----------------------------------------
@jitendrapurohit I've added some more params + tests for the same.

I also had to add support in the Payment.create api for the 'trxn_date' parameter - @monishdeb this feels safe to me but your thoughts

Comments
----------------------------------------

