### PR TITLE
Payment.sendconfirmation api - add further tpl variables.

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -264,7 +264,10 @@ class CRM_Financial_BAO_Payment {
       'totalPaid',
       'paymentsComplete',
     ];
-    // Need to do these before switching the form over...
+    // These are assigned by the payment form - they still 'get through' from the
+    // form for now without being in here but we should ideally load
+    // and assign. Note we should update the tpl to use {if $billingName}
+    // and ditch contributeMode - although it might need to be deprecated rather than removed.
     $todoParams = [
       'contributeMode',
       'billingName',
@@ -272,8 +275,6 @@ class CRM_Financial_BAO_Payment {
       'credit_card_type',
       'credit_card_number',
       'credit_card_exp_date',
-      'eventEmail',
-      '$event.participant_role',
     ];
     $filteredParams = [];
     foreach ($testedTemplateVariables as $templateVariable) {

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -228,6 +228,7 @@ class CRM_Financial_BAO_Payment {
       'isRefund' => $entities['payment']['total_amount'] < 0,
       'isAmountzero' => $entities['payment']['total_amount'] === 0,
       'refundAmount' => ($entities['payment']['total_amount'] < 0 ? $entities['payment']['total_amount'] : NULL),
+      'paymentsComplete' => ($entities['payment']['balance'] == 0),
     ];
 
     return self::filterUntestedTemplateVariables($templateVariables);
@@ -261,10 +262,10 @@ class CRM_Financial_BAO_Payment {
       'isAmountzero',
       'refundAmount',
       'totalPaid',
+      'paymentsComplete',
     ];
     // Need to do these before switching the form over...
     $todoParams = [
-      'paymentsComplete',
       'contributeMode',
       'billingName',
       'address',

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -264,9 +264,6 @@ class CRM_Financial_BAO_Payment {
     ];
     // Need to do these before switching the form over...
     $todoParams = [
-
-
-
       'paymentsComplete',
       'contributeMode',
       'billingName',

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -216,6 +216,7 @@ class CRM_Financial_BAO_Payment {
       'contactDisplayName' => $entities['contact']['display_name'],
       'totalAmount' => $entities['payment']['total'],
       'amountOwed' => $entities['payment']['balance'],
+      'totalPaid' => $entities['payment']['paid'],
       'paymentAmount' => $entities['payment']['total_amount'],
       'checkNumber' => CRM_Utils_Array::value('check_number', $entities['payment']),
       'receive_date' => $entities['payment']['trxn_date'],
@@ -224,6 +225,9 @@ class CRM_Financial_BAO_Payment {
       'location' => CRM_Utils_Array::value('location', $entities),
       'event' => CRM_Utils_Array::value('event', $entities),
       'component' => (!empty($entities['event']) ? 'event' : 'contribution'),
+      'isRefund' => $entities['payment']['total_amount'] < 0,
+      'isAmountzero' => $entities['payment']['total_amount'] === 0,
+      'refundAmount' => ($entities['payment']['total_amount'] < 0 ? $entities['payment']['total_amount'] : NULL),
     ];
 
     return self::filterUntestedTemplateVariables($templateVariables);
@@ -253,15 +257,18 @@ class CRM_Financial_BAO_Payment {
       'paidBy',
       'isShowLocation',
       'location',
+      'isRefund',
+      'isAmountzero',
+      'refundAmount',
+      'totalPaid',
     ];
     // Need to do these before switching the form over...
     $todoParams = [
-      'isRefund',
-      'totalPaid',
-      'refundAmount',
+
+
+
       'paymentsComplete',
       'contributeMode',
-      'isAmountzero',
       'billingName',
       'address',
       'credit_card_type',

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -112,12 +112,12 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     list($lineItems, $contribution) = $this->createParticipantWithContribution();
     $event = $this->callAPISuccess('Event', 'get', []);
     $this->addLocationToEvent($event['id']);
-    $params = array(
+    $params = [
       'contribution_id' => $contribution['id'],
       'total_amount' => 50,
       'check_number' => '345',
       'trxn_date' => '2018-08-13 17:57:56',
-    );
+    ];
     $payment = $this->callAPISuccess('payment', 'create', $params);
     $this->checkPaymentResult($payment, [
       $payment['id'] => [
@@ -142,6 +142,49 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'Transaction Date: August 13th, 2018  5:57 PM',
       'event place',
       'streety street',
+    ));
+    $mut->stop();
+  }
+
+  /**
+   * Test email receipt for partial payment.
+   */
+  public function testRefundEmailReceipt() {
+    $mut = new CiviMailUtils($this);
+    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $this->callAPISuccess('payment', 'create', [
+      'contribution_id' => $contribution['id'],
+      'total_amount' => 50,
+      'check_number' => '345',
+      'trxn_date' => '2018-08-13 17:57:56',
+    ]);
+
+    $payment = $this->callAPISuccess('payment', 'create', [
+      'contribution_id' => $contribution['id'],
+      'total_amount' => -30,
+      'trxn_date' => '2018-11-13 12:01:56',
+    ]);
+
+    $this->checkPaymentResult($payment, [
+      $payment['id'] => [
+        'from_financial_account_id' => 7,
+        'to_financial_account_id' => 6,
+        'total_amount' => -30,
+        'status_id' => 1,
+        'is_payment' => 1,
+      ],
+    ]);
+
+    $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id']]);
+    $mut->assertSubjects(['Refund Notification - Annual CiviCRM meet']);
+    $mut->checkMailLog(array(
+      'Dear Mr. Anthony Anderson II',
+      'Total Fees: $ 300.00',
+      'Refund Amount: $ -30.00',
+      'Event Information and Location',
+      'Paid By: Check',
+      'Transaction Date: November 13th, 2018 12:01 PM',
+      'You Paid: $ 170.00',
     ));
     $mut->stop();
   }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -149,6 +149,33 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   /**
    * Test email receipt for partial payment.
+   */
+  public function testPaymentEmailReceiptFullyPaid() {
+    $mut = new CiviMailUtils($this);
+    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+
+    $params = [
+      'contribution_id' => $contribution['id'],
+      'total_amount' => 150,
+    ];
+    $payment = $this->callAPISuccess('payment', 'create', $params);
+
+    $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id']]);
+    $mut->assertSubjects(['Payment Receipt - Annual CiviCRM meet']);
+    $mut->checkMailLog(array(
+      'Dear Mr. Anthony Anderson II',
+      'A payment has been received.',
+      'Total Fees: $ 300.00',
+      'This Payment Amount: $ 150.00',
+      'Balance Owed: $ 0.00',
+      'Thank you for completing payment.',
+    ));
+    $mut->stop();
+    $mut->clearMessages();
+  }
+
+  /**
+   * Test email receipt for partial payment.
    *
    * @dataProvider getThousandSeparators
    *
@@ -186,6 +213,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $mut->assertSubjects(['Refund Notification - Annual CiviCRM meet']);
     $mut->checkMailLog(array(
       'Dear Mr. Anthony Anderson II',
+      'A refund has been issued based on changes in your registration selections.',
       'Total Fees: $ 300' . $decimalSeparator . '00',
       'Refund Amount: $ -30' . $decimalSeparator . '00',
       'Event Information and Location',

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -144,12 +144,19 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'streety street',
     ));
     $mut->stop();
+    $mut->clearMessages();
   }
 
   /**
    * Test email receipt for partial payment.
+   *
+   * @dataProvider getThousandSeparators
+   *
+   * @param string $thousandSeparator
    */
-  public function testRefundEmailReceipt() {
+  public function testRefundEmailReceipt($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
+    $decimalSeparator = ($thousandSeparator === ',' ? '.' : ',');
     $mut = new CiviMailUtils($this);
     list($lineItems, $contribution) = $this->createParticipantWithContribution();
     $this->callAPISuccess('payment', 'create', [
@@ -179,14 +186,15 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $mut->assertSubjects(['Refund Notification - Annual CiviCRM meet']);
     $mut->checkMailLog(array(
       'Dear Mr. Anthony Anderson II',
-      'Total Fees: $ 300.00',
-      'Refund Amount: $ -30.00',
+      'Total Fees: $ 300' . $decimalSeparator . '00',
+      'Refund Amount: $ -30' . $decimalSeparator . '00',
       'Event Information and Location',
       'Paid By: Check',
       'Transaction Date: November 13th, 2018 12:01 PM',
-      'You Paid: $ 170.00',
+      'You Paid: $ 170' . $decimalSeparator . '00',
     ));
     $mut->stop();
+    $mut->clearMessages();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Payment.sendconfirmation is an api added in 5.12 - this is part of that. The api will replace the form email confirmation logic once mature

Before
----------------------------------------
Less complete

After
----------------------------------------
More complete

Technical Details
----------------------------------------
Incorporates & extends https://github.com/civicrm/civicrm-core/pull/13609

Comments
----------------------------------------
There are a couple of parameters assigned to the template i the form - but they are not used

@jitendrapurohit I think once this is merged we could replace emailReceipt with an api call to Payment.sendconfirmation. There is nothing else in that fn that is done AND used in the tpl from what I can see
