### PR TITLE
Move l10n.js to coreResourcesList

### DIFF
--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -397,4 +397,28 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     );
   }
 
+  /**
+   * return array
+   */
+  public function urlsToCheckIfFullyFormed() {
+    return [
+      ['civicrm/test/page', FALSE],
+      ['#', FALSE],
+      ['', FALSE],
+      ['/civicrm/test/page', TRUE],
+      ['http://test.com/civicrm/test/page', TRUE],
+      ['https://test.com/civicrm/test/page', TRUE],
+    ];
+  }
+
+  /**
+   * @param string $url
+   * @param string $expected
+   *
+   * @dataProvider urlsToCheckIfFullyFormed
+   */
+  public function testIsFullyFormedUrl($url, $expected) {
+    $this->assertEquals($expected, CRM_Core_Resources::isFullyFormedUrl($url));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This change allows core resources to be added to the list AFTER l10n variables have been initialized. This is needed by crm.menubar.js.

An upshot of this change is that hooks will be able to interact with it.

Another upshot of this change is that extensions will be able to add items to the list as fully-formed urls.

Before
----------------------------------------
l10n.js dynamic script was added outside of the coreResourcesList.

After
----------------------------------------
l10n.js dynamic script added within coreResourcesList.

Comments
----------------------------------------
This is a small chunk bitten off the mega #13582 to facilitate review.
