### PR TITLE
Auto-open campaign widget and sort by start date

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -602,6 +602,7 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
       $campaign = $form->addEntityRef('campaign_id', ts('Campaign'), [
         'entity' => 'campaign',
         'create' => TRUE,
+        'select' => ['minimumInputLength' => 0],
       ]);
       //lets freeze when user does not has access or campaign is disabled.
       if (!$isCampaignEnabled || !$hasAccessCampaign) {

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -193,6 +193,7 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
     $this->addEntityRef('campaign_id', ts('Campaign'), [
       'entity' => 'campaign',
       'create' => TRUE,
+      'select' => ['minimumInputLength' => 0],
     ]);
 
     $customContactProfiles = CRM_Core_BAO_UFGroup::getProfiles(array('Individual'));

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -132,6 +132,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
     $this->addEntityRef('campaign_id', ts('Campaign'), [
       'entity' => 'campaign',
       'create' => TRUE,
+      'select' => ['minimumInputLength' => 0],
     ]);
 
     // script / instructions

--- a/api/v3/Campaign.php
+++ b/api/v3/Campaign.php
@@ -100,6 +100,7 @@ function _civicrm_api3_campaign_getlist_params(&$request) {
   $fieldsToReturn = ['title', 'campaign_type_id', 'status_id', 'start_date', 'end_date'];
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
   if (empty($request['params']['id'])) {
+    $request['params']['options']['sort'] = 'start_date DESC, title';
     $request['params'] += [
       'is_active' => 1,
     ];


### PR DESCRIPTION
Overview
--------
A followup from #13491 to make the widget act more like before.

Before
------
Widget requires search term before it displays any campaigns. This was done so that the filters are more discoverable, but the downside is that campaigns can't be browsed as easily.

After
-----
The widget will auto-open and sort by start date, which should put the more current campaigns at the top.

Comments
------
This isn't a perfect solution but is probably the best trade-off we can get right now:

- Sorting by end_date would be better than sorting by start_date, but the underlying api3 can't do it correctly (items with end_date of null end up at the bottom of the list rather than the top where we'd want them).
- The filters will be harder to discover this way, but with no results people will see them.