### PR TITLE
[unused code cleanup] Remove unused 'signupType' url support

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -323,34 +323,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       }
     }
 
-    // Added for membership search
-
-    $signupType = CRM_Utils_Request::retrieve('signupType', 'Positive');
-
-    if ($signupType) {
-      $this->_formValues['activity_role'] = 1;
-      $this->_defaults['activity_role'] = 1;
-      $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, FALSE, FALSE, 'name');
-
-      $renew = CRM_Utils_Array::key('Membership Renewal', $activityTypes);
-      $signup = CRM_Utils_Array::key('Membership Signup', $activityTypes);
-
-      switch ($signupType) {
-        case 3: // signups and renewals
-          $this->_formValues['activity_type_id'][$renew] = 1;
-          $this->_defaults['activity_type_id'][$renew] = 1;
-        case 1: // signups only
-          $this->_formValues['activity_type_id'][$signup] = 1;
-          $this->_defaults['activity_type_id'][$signup] = 1;
-          break;
-
-        case 2: // renewals only
-          $this->_formValues['activity_type_id'][$renew] = 1;
-          $this->_defaults['activity_type_id'][$renew] = 1;
-          break;
-      }
-    }
-
     $dateLow = CRM_Utils_Request::retrieve('dateLow', 'String');
 
     if ($dateLow) {

--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -306,65 +306,38 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
 
     $totalCount['premonth']['new'] = array(
       'count' => $newCountPreMonth,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=1&dateLow=$preMonth&dateHigh=$preMonthEnd"
-      //),
     );
 
     $totalCount['premonth']['renew'] = array(
       'count' => $renewCountPreMonth,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=2&dateLow=$preMonth&dateHigh=$preMonthEnd"
-      //),
     );
 
     $totalCount['premonth']['total'] = array(
       'count' => $totalCountPreMonth,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=3&dateLow=$preMonth&dateHigh=$preMonthEnd"
-      //),
     );
 
     $totalCount['month']['new'] = array(
       'count' => $newCountMonth,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=1&dateLow=$monthStart&dateHigh=$ymd"
-      //),
     );
 
     $totalCount['month']['renew'] = array(
       'count' => $renewCountMonth,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=2&dateLow=$monthStart&dateHigh=$ymd"
-      //),
     );
 
     $totalCount['month']['total'] = array(
       'count' => $totalCountMonth,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=3&dateLow=$monthStart&dateHigh=$ymd"
-      //),
     );
 
     $totalCount['year']['new'] = array(
       'count' => $newCountYear,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=1&dateLow=$yearStart&dateHigh=$ymd"
-      //),
     );
 
     $totalCount['year']['renew'] = array(
       'count' => $renewCountYear,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=2&dateLow=$yearStart&dateHigh=$ymd"
-      //),
     );
 
     $totalCount['year']['total'] = array(
       'count' => $totalCountYear,
-      //'url' => CRM_Utils_System::url('civicrm/activity/search',
-      //  "reset=1&force=1&signupType=3&dateLow=$yearStart&dateHigh=$ymd"
-      //),
     );
 
     $totalCount['current']['total'] = array(


### PR DESCRIPTION
Overview
----------------------------------------
The use of this was removed in https://github.com/civicrm/civicrm-core/pull/911
on the basis it didn't work.

This is just cleanup not done then.

Before
----------------------------------------
code exists, unused, unloved & non-functional per #911 (oh the irony that @agh1 got pr 911)

After
----------------------------------------
poof

Technical Details
----------------------------------------
Note we shouldn't comment stuff out we should remove it as a rule


Comments
----------------------------------------
@agh1 @yashodha you were involved in #911 - wanna check this?
