### PR TITLE
[code cleanup] Default wrong declared

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -87,7 +87,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
-    $this->defaults = array();
 
     $this->loadStandardSearchOptionsFromUrl();
 

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -87,7 +87,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
-    $this->defaults = array();
 
     $this->loadStandardSearchOptionsFromUrl();
     $this->loadFormValues();

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -80,8 +80,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
-    // @todo - is this an error - $this->_defaults is used.
-    $this->defaults = array();
 
     $this->loadStandardSearchOptionsFromUrl();
 

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -88,7 +88,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
-    $this->defaults = array();
 
     $this->loadStandardSearchOptionsFromUrl();
     $this->loadFormValues();

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -89,7 +89,6 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
-    $this->defaults = array();
 
     $this->loadStandardSearchOptionsFromUrl();
     $this->loadFormValues();

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -82,8 +82,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     $this->_done = FALSE;
 
-    $this->defaults = array();
-
     $this->loadStandardSearchOptionsFromUrl();
 
     // get user submitted values

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -71,7 +71,6 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
-    $this->defaults = array();
 
     $this->loadStandardSearchOptionsFromUrl();
 


### PR DESCRIPTION
Overview
----------------------------------------
the joys of copy & paste

All this classes declare $this->defaults = array() - however the variable is $this->_defaults

I grepped ->defaults & feel pretty sure the line is just to make the code less readable

Before
----------------------------------------
more code

After
----------------------------------------
less code

Technical Details
----------------------------------------


Comments
----------------------------------------

