### PR TITLE
[REF] Move entityRef filters into their respective BAOs

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -3228,4 +3228,14 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
     return FALSE;
   }
 
+  /**
+   * @return array
+   */
+  public static function getEntityRefFilters() {
+    return [
+      ['key' => 'activity_type_id', 'value' => ts('Activity Type')],
+      ['key' => 'status_id', 'value' => ts('Activity Status')],
+    ];
+  }
+
 }

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -666,6 +666,44 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
   }
 
   /**
+   * @return array
+   */
+  public static function getEntityRefFilters() {
+    return [
+      ['key' => 'campaign_type_id', 'value' => ts('Campaign Type')],
+      ['key' => 'status_id', 'value' => ts('Status')],
+      [
+        'key' => 'start_date',
+        'value' => ts('Start Date'),
+        'options' => [
+          ['key' => '{">":"now"}', 'value' => ts('Upcoming')],
+          [
+            'key' => '{"BETWEEN":["now - 3 month","now"]}',
+            'value' => ts('Past 3 Months'),
+          ],
+          [
+            'key' => '{"BETWEEN":["now - 6 month","now"]}',
+            'value' => ts('Past 6 Months'),
+          ],
+          [
+            'key' => '{"BETWEEN":["now - 1 year","now"]}',
+            'value' => ts('Past Year'),
+          ],
+        ],
+      ],
+      [
+        'key' => 'end_date',
+        'value' => ts('End Date'),
+        'options' => [
+          ['key' => '{">":"now"}', 'value' => ts('In the future')],
+          ['key' => '{"<":"now"}', 'value' => ts('In the past')],
+          ['key' => '{"IS NULL":"1"}', 'value' => ts('Not set')],
+        ],
+      ],
+    ];
+  }
+
+  /**
    * Links to create new campaigns from entityRef widget
    *
    * @return array|bool

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -3261,4 +3261,28 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
     return "$name <$address>";
   }
 
+  /**
+   * @return array
+   */
+  public static function getEntityRefFilters() {
+    $filters = [
+      [
+        'key' => 'case_id.case_type_id',
+        'value' => ts('Case Type'),
+        'entity' => 'Case',
+      ],
+      [
+        'key' => 'case_id.status_id',
+        'value' => ts('Case Status'),
+        'entity' => 'Case',
+      ],
+    ];
+    foreach (CRM_Contact_BAO_Contact::getEntityRefFilters() as $filter) {
+      $filter += ['entity' => 'contact'];
+      $filter['key'] = 'contact_id.' . $filter['key'];
+      $filters[] = $filter;
+    }
+    return $filters;
+  }
+
 }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3660,4 +3660,22 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     return CRM_Core_Permission::check([['profile create', 'profile listings and forms']]);
   }
 
+  /**
+   * @return array
+   */
+  public static function getEntityRefFilters() {
+    return [
+      ['key' => 'contact_type', 'value' => ts('Contact Type')],
+      ['key' => 'group', 'value' => ts('Group'), 'entity' => 'group_contact'],
+      ['key' => 'tag', 'value' => ts('Tag'), 'entity' => 'entity_tag'],
+      ['key' => 'state_province', 'value' => ts('State/Province'), 'entity' => 'address'],
+      ['key' => 'country', 'value' => ts('Country'), 'entity' => 'address'],
+      ['key' => 'gender_id', 'value' => ts('Gender'), 'condition' => ['contact_type' => 'Individual']],
+      ['key' => 'is_deceased', 'value' => ts('Deceased'), 'condition' => ['contact_type' => 'Individual']],
+      ['key' => 'contact_id', 'value' => ts('Contact ID'), 'type' => 'text'],
+      ['key' => 'external_identifier', 'value' => ts('External ID'), 'type' => 'text'],
+      ['key' => 'source', 'value' => ts('Contact Source'), 'type' => 'text'],
+    ];
+  }
+
 }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2811,6 +2811,13 @@ SELECT contact_id
   }
 
   /**
+   * @return array
+   */
+  public static function getEntityRefFilters() {
+    return [];
+  }
+
+  /**
    * Get exportable fields with pseudoconstants rendered as an extra field.
    *
    * @param string $baoClass

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2370,4 +2370,32 @@ LEFT  JOIN  civicrm_price_field_value value ON ( value.id = lineItem.price_field
     return CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
   }
 
+  /**
+   * @return array
+   */
+  public static function getEntityRefFilters() {
+    return [
+      ['key' => 'event_type_id', 'value' => ts('Event Type')],
+      [
+        'key' => 'start_date',
+        'value' => ts('Start Date'),
+        'options' => [
+          ['key' => '{">":"now"}', 'value' => ts('Upcoming')],
+          [
+            'key' => '{"BETWEEN":["now - 3 month","now"]}',
+            'value' => ts('Past 3 Months'),
+          ],
+          [
+            'key' => '{"BETWEEN":["now - 6 month","now"]}',
+            'value' => ts('Past 6 Months'),
+          ],
+          [
+            'key' => '{"BETWEEN":["now - 1 year","now"]}',
+            'value' => ts('Past Year'),
+          ],
+        ],
+      ],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an old FIXME in the code by moving entityRef filters into a more logical place.

Before
----------------------------------------
Code all jammed into an illogical place.

After
----------------------------------------
Code in a better place. More future-proof and extensible.

Technical Details
----------------------------------------
New entities (including entities from extensions) can now declare entityRef filters simply by placing them in their BAO class.

Comments
----------------------------------------
This is the beginning of a larger cleanup/refactor.