### PR TITLE
Standardize format for entityRef create links

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -708,7 +708,7 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
    *
    * @return array|bool
    */
-  public static function entityRefCreateLinks() {
+  public static function getEntityRefCreateLinks() {
     if (CRM_Core_Permission::check([['administer CiviCampaign', 'manage campaign']])) {
       return [
         [

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -165,7 +165,7 @@ class CRM_Contact_Form_Edit_Address {
       $form->addElement('checkbox', "address[$blockId][use_shared_address]", NULL, ts('Use another contact\'s address'));
 
       // Override the default profile links to add address form
-      $profileLinks = CRM_Contact_BAO_Contact::entityRefCreateLinks() ? CRM_Core_BAO_UFGroup::getCreateLinks('', 'shared_address') : FALSE;
+      $profileLinks = CRM_Contact_BAO_Contact::getEntityRefCreateLinks('shared_address');
       $form->addEntityRef("address[$blockId][master_contact_id]", ts('Share With'), array('create' => $profileLinks));
     }
   }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3321,57 +3321,6 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
   }
 
   /**
-   * @param array|string $profiles - name of profile(s) to create links for
-   * @param array $appendProfiles
-   *   Name of profile(s) to append to each link.
-   *
-   * @return array
-   */
-  public static function getCreateLinks($profiles = '', $appendProfiles = array()) {
-    if (!CRM_Contact_BAO_Contact::entityRefCreateLinks()) {
-      return [];
-    }
-    // Default to contact profiles
-    if (!$profiles) {
-      $profiles = array('new_individual', 'new_organization', 'new_household');
-    }
-    $profiles = (array) $profiles;
-    $toGet = array_merge($profiles, (array) $appendProfiles);
-    $retrieved = civicrm_api3('uf_group', 'get', array(
-      'name' => array('IN' => $toGet),
-      'is_active' => 1,
-    ));
-    $links = $append = array();
-    if (!empty($retrieved['values'])) {
-      $icons = [
-        'individual' => 'fa-user',
-        'organization' => 'fa-building',
-        'household' => 'fa-home',
-      ];
-      foreach ($retrieved['values'] as $id => $profile) {
-        if (in_array($profile['name'], $profiles)) {
-          $links[] = array(
-            'label' => $profile['title'],
-            'url' => CRM_Utils_System::url('civicrm/profile/create', "reset=1&context=dialog&gid=$id",
-              NULL, NULL, FALSE, FALSE, TRUE),
-            'type' => ucfirst(str_replace('new_', '', $profile['name'])),
-            'icon' => CRM_Utils_Array::value(str_replace('new_', '', $profile['name']), $icons),
-          );
-        }
-        else {
-          $append[] = $id;
-        }
-      }
-      foreach ($append as $id) {
-        foreach ($links as &$link) {
-          $link['url'] .= ",$id";
-        }
-      }
-    }
-    return $links;
-  }
-
-  /**
    * Retrieve groups of  profiles.
    *
    * @param int $profileID

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1958,11 +1958,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $props['entity'] = _civicrm_api_get_entity_name_from_camel(CRM_Utils_Array::value('entity', $props, 'contact'));
     $props['class'] = ltrim(CRM_Utils_Array::value('class', $props, '') . ' crm-form-entityref');
 
-    if (isset($props['create']) && $props['create'] === TRUE) {
-      require_once "api/v3/utils.php";
-      $baoClass = _civicrm_api3_get_BAO($props['entity']);
-      $props['create'] = $baoClass && is_callable([$baoClass, 'entityRefCreateLinks']) ? $baoClass::entityRefCreateLinks() : FALSE;
-    }
     if (array_key_exists('create', $props) && empty($props['create'])) {
       unset($props['create']);
     }

--- a/js/Common.js
+++ b/js/Common.js
@@ -685,12 +685,13 @@ if (!CRM.vars) CRM.vars = {};
     var
       createLinks = $el.data('create-links'),
       params = getEntityRefApiParams($el).params,
+      entity = $el.data('api-entity').toLowerCase(),
       markup = '<div class="crm-entityref-links">';
-    if (!createLinks || (createLinks === true && $el.data('api-entity').toLowerCase() !== 'contact')) {
+    if (!createLinks || (createLinks === true && !CRM.config.entityRef.links[entity])) {
       return '';
     }
     if (createLinks === true) {
-      createLinks = params.contact_type ? _.where(CRM.config.entityRef.contactCreate, {type: params.contact_type}) : CRM.config.entityRef.contactCreate;
+      createLinks = params.contact_type ? _.where(CRM.config.entityRef.links[entity], {type: params.contact_type}) : CRM.config.entityRef.links[entity];
     }
     _.each(createLinks, function(link) {
       markup += ' <a class="crm-add-entity crm-hover-button" href="' + link.url + '">' +


### PR DESCRIPTION
Overview
----------------------------------------
This continues some refactoring done in #13625 and #13491 to make entityRef links easier for developers to work with.

Before
----------------------------------------
Create links for contacts were given special treatment and were pre-loaded to the clientside. Others had to be loaded at runtime.

After
----------------------------------------
All links treated the same and pre-loaded to the clientside so that they work equally well with all entities.

Technical Details
----------------------------------------
This should make the code easier to understand and also will make entityRef widgets easier to add dynamically e.g. with Angular-based pages.