### PR TITLE
 EntityRef - standardize on PascalCase for entity name and fix minor bug

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -599,7 +599,7 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
     if ($connectedCampaignId || ($isCampaignEnabled && $hasAccessCampaign)) {
       $showAddCampaign = TRUE;
       $campaign = $form->addEntityRef('campaign_id', ts('Campaign'), [
-        'entity' => 'campaign',
+        'entity' => 'Campaign',
         'create' => TRUE,
         'select' => ['minimumInputLength' => 0],
       ]);

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -191,7 +191,7 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
     $this->add('wysiwyg', 'instructions', ts('Introduction'), $attributes['instructions']);
 
     $this->addEntityRef('campaign_id', ts('Campaign'), [
-      'entity' => 'campaign',
+      'entity' => 'Campaign',
       'create' => TRUE,
       'select' => ['minimumInputLength' => 0],
     ]);

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -130,7 +130,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
     $this->addSelect('activity_type_id', array('option_url' => 'civicrm/admin/campaign/surveyType'), TRUE);
 
     $this->addEntityRef('campaign_id', ts('Campaign'), [
-      'entity' => 'campaign',
+      'entity' => 'Campaign',
       'create' => TRUE,
       'select' => ['minimumInputLength' => 0],
     ]);

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -3278,7 +3278,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
       ],
     ];
     foreach (CRM_Contact_BAO_Contact::getEntityRefFilters() as $filter) {
-      $filter += ['entity' => 'contact'];
+      $filter += ['entity' => 'Contact'];
       $filter['key'] = 'contact_id.' . $filter['key'];
       $filters[] = $filter;
     }

--- a/CRM/Case/Form/AddToCaseAsRole.php
+++ b/CRM/Case/Form/AddToCaseAsRole.php
@@ -23,7 +23,7 @@ class CRM_Case_Form_AddToCaseAsRole extends CRM_Contact_Form_Task {
     $this->addEntityRef(
       'assign_to',
       ts('Assign to'),
-      array('entity' => 'case'),
+      array('entity' => 'Case'),
       TRUE
     );
 

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3704,10 +3704,10 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
   public static function getEntityRefFilters() {
     return [
       ['key' => 'contact_type', 'value' => ts('Contact Type')],
-      ['key' => 'group', 'value' => ts('Group'), 'entity' => 'group_contact'],
-      ['key' => 'tag', 'value' => ts('Tag'), 'entity' => 'entity_tag'],
-      ['key' => 'state_province', 'value' => ts('State/Province'), 'entity' => 'address'],
-      ['key' => 'country', 'value' => ts('Country'), 'entity' => 'address'],
+      ['key' => 'group', 'value' => ts('Group'), 'entity' => 'GroupContact'],
+      ['key' => 'tag', 'value' => ts('Tag'), 'entity' => 'EntityTag'],
+      ['key' => 'state_province', 'value' => ts('State/Province'), 'entity' => 'Address'],
+      ['key' => 'country', 'value' => ts('Country'), 'entity' => 'Address'],
       ['key' => 'gender_id', 'value' => ts('Gender'), 'condition' => ['contact_type' => 'Individual']],
       ['key' => 'is_deceased', 'value' => ts('Deceased'), 'condition' => ['contact_type' => 'Individual']],
       ['key' => 'contact_id', 'value' => ts('Contact ID'), 'type' => 'text'],

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1093,7 +1093,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         else {
           // FIXME: This won't work with customFieldOptions hook
           $attributes += array(
-            'entity' => 'option_value',
+            'entity' => 'OptionValue',
             'placeholder' => $placeholder,
             'multiple' => $search,
             'api' => array(

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1936,10 +1936,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param array $props
    *   Mix of html and widget properties, including:.
    *   - select - params to give to select2 widget
-   *   - entity - defaults to contact
+   *   - entity - defaults to Contact
    *   - create - can the user create a new entity on-the-fly?
    *             Set to TRUE if entity is contact and you want the default profiles,
-   *             or pass in your own set of links. @see CRM_Core_BAO_UFGroup::getCreateLinks for format
+   *             or pass in your own set of links. @see CRM_Campaign_BAO_Campaign::getEntityRefCreateLinks for format
    *             note that permissions are checked automatically
    *   - api - array of settings for the getlist api wrapper
    *          note that it accepts a 'params' setting which will be passed to the underlying api
@@ -1951,11 +1951,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return HTML_QuickForm_Element
    */
   public function addEntityRef($name, $label = '', $props = array(), $required = FALSE) {
-    require_once "api/api.php";
-    $config = CRM_Core_Config::singleton();
     // Default properties
     $props['api'] = CRM_Utils_Array::value('api', $props, array());
-    $props['entity'] = _civicrm_api_get_entity_name_from_camel(CRM_Utils_Array::value('entity', $props, 'contact'));
+    $props['entity'] = CRM_Utils_String::convertStringToCamel(CRM_Utils_Array::value('entity', $props, 'Contact'));
     $props['class'] = ltrim(CRM_Utils_Array::value('class', $props, '') . ' crm-form-entityref');
 
     if (array_key_exists('create', $props) && empty($props['create'])) {

--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -314,20 +314,20 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
    * @param HTML_QuickForm_element $field
    */
   public function renderFrozenEntityRef(&$el, $field) {
-    $entity = strtolower($field->getAttribute('data-api-entity'));
+    $entity = $field->getAttribute('data-api-entity');
     $vals = json_decode($field->getAttribute('data-entity-value'), TRUE);
     $display = array();
 
     // Custom fields of type contactRef store their data in a slightly different format
-    if ($field->getAttribute('data-crm-custom') && $entity == 'contact') {
+    if ($field->getAttribute('data-crm-custom') && $entity == 'Contact') {
       $vals = array(array('id' => $vals['id'], 'label' => $vals['text']));
     }
 
     foreach ($vals as $val) {
       // Format contact as link
-      if ($entity == 'contact' && CRM_Contact_BAO_Contact_Permission::allow($val['id'], CRM_Core_Permission::VIEW)) {
+      if ($entity == 'Contact' && CRM_Contact_BAO_Contact_Permission::allow($val['id'], CRM_Core_Permission::VIEW)) {
         $url = CRM_Utils_System::url("civicrm/contact/view", array('reset' => 1, 'cid' => $val['id']));
-        $val['label'] = '<a class="view-' . $entity . ' no-popup" href="' . $url . '" title="' . ts('View Contact') . '">' . $val['label'] . '</a>';
+        $val['label'] = '<a class="view-contact no-popup" href="' . $url . '" title="' . ts('View Contact') . '">' . $val['label'] . '</a>';
       }
       $display[] = $val['label'];
     }

--- a/CRM/Core/Form/Tag.php
+++ b/CRM/Core/Form/Tag.php
@@ -78,7 +78,7 @@ class CRM_Core_Form_Tag {
         $tagset[$tagsetItem]['tagsetElementName'] = $tagsetElementName;
 
         $form->addEntityRef("{$tagsetElementName}[{$parentId}]", $parentNameItem, array(
-          'entity' => 'tag',
+          'entity' => 'Tag',
           'multiple' => TRUE,
           'create' => !$skipTagCreate,
           'api' => array('params' => array('parent_id' => $parentId)),

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -830,12 +830,12 @@ class CRM_Core_Resources {
       if (class_exists($baoName)) {
         $filters = $baoName::getEntityRefFilters();
         if ($filters) {
-          $data['filters'][_civicrm_api_get_entity_name_from_camel($entity)] = $filters;
+          $data['filters'][$entity] = $filters;
         }
         if (is_callable([$baoName, 'getEntityRefCreateLinks'])) {
           $createLinks = $baoName::getEntityRefCreateLinks();
           if ($createLinks) {
-            $data['links'][_civicrm_api_get_entity_name_from_camel($entity)] = $createLinks;
+            $data['links'][$entity] = $createLinks;
           }
         }
       }

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -581,14 +581,14 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
     $form->assign('dataURLEventFee', $dataURLEventFee);
 
     $form->addEntityRef('event_id', ts('Event Name'), array(
-        'entity' => 'event',
+        'entity' => 'Event',
         'placeholder' => ts('- any -'),
         'multiple' => 1,
         'select' => array('minimumInputLength' => 0),
       )
     );
     $form->addEntityRef('event_type_id', ts('Event Type'), array(
-        'entity' => 'option_value',
+        'entity' => 'OptionValue',
         'placeholder' => ts('- any -'),
         'select' => array('minimumInputLength' => 0),
         'api' => array(

--- a/CRM/Event/Form/ManageEvent/Conference.php
+++ b/CRM/Event/Form/ManageEvent/Conference.php
@@ -57,7 +57,7 @@ class CRM_Event_Form_ManageEvent_Conference extends CRM_Event_Form_ManageEvent {
     );
 
     $this->addEntityRef('parent_event_id', ts('Parent Event'), array(
-        'entity' => 'event',
+        'entity' => 'Event',
         'placeholder' => ts('- any -'),
         'select' => array('minimumInputLength' => 0),
       )

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -635,7 +635,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     $eventFieldParams = array(
-      'entity' => 'event',
+      'entity' => 'Event',
       'select' => array('minimumInputLength' => 0),
       'api' => array(
         'extra' => array('campaign_id', 'default_role_id', 'event_type_id'),

--- a/CRM/Report/Form/Event/ParticipantListCount.php
+++ b/CRM/Report/Form/Event/ParticipantListCount.php
@@ -238,7 +238,7 @@ class CRM_Report_Form_Event_ParticipantListCount extends CRM_Report_Form_Event {
             'operatorType' => CRM_Report_Form::OP_ENTITYREF,
             'type' => CRM_Utils_Type::T_INT,
             'attributes' => array(
-              'entity' => 'event',
+              'entity' => 'Event',
               'select' => array('minimumInputLength' => 0),
             ),
           ),

--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -180,7 +180,7 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form_Event {
             'operatorType' => CRM_Report_Form::OP_ENTITYREF,
             'type' => CRM_Utils_Type::T_INT,
             'attributes' => array(
-              'entity' => 'event',
+              'entity' => 'Event',
               'select' => array('minimumInputLength' => 0),
             ),
           ),

--- a/js/Common.js
+++ b/js/Common.js
@@ -712,9 +712,8 @@ if (!CRM.vars) CRM.vars = {};
       filters = CRM.config.entityRef.filters[entity] || [],
       params = $.extend({params: {}}, $el.data('api-params') || {}).params,
       result = [];
-    $.each(filters, function() {
-      var filter = $.extend({type: 'select', 'attributes': {}, entity: entity}, this);
-      $.extend(this, filter);
+    _.each(filters, function(filter) {
+      _.defaults(filter, {type: 'select', 'attributes': {}, entity: entity});
       if (!params[filter.key]) {
         // Filter out options if params don't match its condition
         if (filter.condition && !_.isMatch(params, _.pick(filter.condition, _.keys(params)))) {

--- a/js/Common.js
+++ b/js/Common.js
@@ -466,7 +466,7 @@ if (!CRM.vars) CRM.vars = {};
         var entity = $(this).data('api-entity') || '';
         $(this)
           .off('.crmEntity')
-          .removeClass('crm-form-entityref crm-' + entity.toLowerCase() + '-ref')
+          .removeClass('crm-form-entityref crm-' + _.kebabCase(entity) + '-ref')
           .crmSelect2('destroy');
       });
     }
@@ -475,13 +475,17 @@ if (!CRM.vars) CRM.vars = {};
     return $(this).each(function() {
       var
         $el = $(this).off('.crmEntity'),
-        entity = options.entity || $el.data('api-entity') || 'contact',
+        entity = options.entity || $el.data('api-entity') || 'Contact',
         selectParams = {};
+      // Legacy: fix entity name if passed in as snake case
+      if (entity.charAt(0).toUpperCase() !== entity.charAt(0)) {
+        entity = _.capitalize(_.camelCase(entity));
+      }
       $el.data('api-entity', entity);
       $el.data('select-params', $.extend({}, $el.data('select-params') || {}, options.select));
       $el.data('api-params', $.extend(true, {}, $el.data('api-params') || {}, options.api));
       $el.data('create-links', options.create || $el.data('create-links'));
-      $el.addClass('crm-form-entityref crm-' + entity.toLowerCase() + '-ref');
+      $el.addClass('crm-form-entityref crm-' + _.kebabCase(entity) + '-ref');
       var settings = {
         // Use select2 ajax helper instead of CRM.api3 because it provides more value
         ajax: {
@@ -527,7 +531,7 @@ if (!CRM.vars) CRM.vars = {};
         }
       };
       // Create new items inline - works for tags
-      if ($el.data('create-links') && entity.toLowerCase() === 'tag') {
+      if ($el.data('create-links') && entity === 'Tag') {
         selectParams.createSearchChoice = function(term, data) {
           if (!_.findKey(data, {label: term})) {
             return {id: "0", term: term, label: term + ' (' + ts('new tag') + ')'};
@@ -685,7 +689,7 @@ if (!CRM.vars) CRM.vars = {};
     var
       createLinks = $el.data('create-links'),
       params = getEntityRefApiParams($el).params,
-      entity = $el.data('api-entity').toLowerCase(),
+      entity = $el.data('api-entity'),
       markup = '<div class="crm-entityref-links">';
     if (!createLinks || (createLinks === true && !CRM.config.entityRef.links[entity])) {
       return '';
@@ -704,7 +708,7 @@ if (!CRM.vars) CRM.vars = {};
 
   function getEntityRefFilters($el) {
     var
-      entity = $el.data('api-entity').toLowerCase(),
+      entity = $el.data('api-entity'),
       filters = CRM.config.entityRef.filters[entity] || [],
       params = $.extend({params: {}}, $el.data('api-params') || {}).params,
       result = [];
@@ -774,7 +778,6 @@ if (!CRM.vars) CRM.vars = {};
    */
   function renderEntityRefFilterValue($el) {
     var
-      entity = $el.data('api-entity').toLowerCase(),
       filter = $el.data('user-filter') || {},
       filterSpec = filter.key ? _.find(getEntityRefFilters($el), {key: filter.key}) : null,
       $keyField = $('.crm-entityref-filter-key', '#select2-drop'),

--- a/settings/Multisite.setting.php
+++ b/settings/Multisite.setting.php
@@ -58,7 +58,7 @@ return array(
     'title' => ts('Multisite Domain Group'),
     'type' => 'Integer',
     'html_type' => 'entity_reference',
-    'entity_reference_options' => ['entity' => 'group', 'select' => array('minimumInputLength' => 0)],
+    'entity_reference_options' => ['entity' => 'Group', 'select' => array('minimumInputLength' => 0)],
     'default' => '0',
     'add' => '4.1',
     'is_domain' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
Just some cleanup related to EntityRef fields.

Before
----------------------------------------
EntityRef fields could theoretically accept snake_case or camelCase for the entity name, but they were not very internally consistent and might break with some compound words.

After
----------------------------------------
Standardize entityRef fields to always use the PascalCase version of the entity. Still accept other formats for legacy reasons.

Technical Details
----------------------------------------
Also includes a minor bugfix - option lists were not being cached in the entityRef filters, so ajax calls to api.getoptions were being made more often than necessary.
