### PR TITLE
dev/core#737 - SMS not sent if 'Send Immediately' option is chosen on…

### DIFF
--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -152,7 +152,7 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
       CRM_Core_Error::fatal(ts('Could not find a mailing id'));
     }
 
-    $send_option = $this->controller->exportValue($this->_name, 'send_option');
+    $params['send_option'] = $this->controller->exportValue($this->_name, 'send_option');
     if (isset($params['send_option']) && $params['send_option'] == 'send_immediate') {
       $params['scheduled_date'] = date('YmdHis');
     }


### PR DESCRIPTION
… the last screen

Overview
----------------------------------------
SMS not sent if "Send Immediately" option is chosen on the last screen

Before
----------------------------------------
No SMS is sent if "Send Immediately" option is chosen for the SMS mailing. schedule date is set to NULL.

After
----------------------------------------
works fine

Comments
----------------------------------------
related to https://github.com/civicrm/civicrm-core/pull/13001

Gitlab - https://lab.civicrm.org/dev/core/issues/737
