### PR TITLE
[REF] minor refactor around retrieving processor id for recur

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -173,19 +173,29 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    * @return array|null
    */
   public static function getPaymentProcessor($id, $mode = NULL) {
-    $sql = "
-SELECT r.payment_processor_id
-  FROM civicrm_contribution_recur r
- WHERE r.id = %1";
-    $params = array(1 => array($id, 'Integer'));
-    $paymentProcessorID = CRM_Core_DAO::singleValueQuery($sql,
-      $params
-    );
+    $paymentProcessorID = self::getPaymentProcessorID($id);
     if (!$paymentProcessorID) {
       return NULL;
     }
 
     return CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID, $mode);
+  }
+
+  /**
+   * Get the payment processor for the given recurring contribution.
+   *
+   * @param int $recurID
+   *
+   * @return int
+   *   Payment processor id. If none found return 0 which represents the
+   *   pseudo processor used for pay-later.
+   */
+  public static function getPaymentProcessorID($recurID) {
+    $recur = civicrm_api3('ContributionRecur', 'getsingle', [
+      'id' => $recurID,
+      'return' => ['payment_processor_id']
+    ]);
+    return (int) CRM_Utils_Array::value('payment_processor_id', $recur, 0);
   }
 
   /**

--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -83,11 +83,9 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
     $recurRow = array();
     $recurIDs = array();
     while ($recur->fetch()) {
-      $mode = $recur->is_test ? 'test' : 'live';
-      $paymentProcessor = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessor($recur->id,
-        $mode
-      );
-      if (!$paymentProcessor) {
+      if (empty($recur->payment_processor_id)) {
+        // it's not clear why we continue here as any without a processor id would likely
+        // be imported from another system & still seem valid.
         continue;
       }
 
@@ -121,10 +119,6 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
       );
 
       $recurIDs[] = $values['id'];
-
-      //reset $paymentObject for checking other paymenet processor
-      //recurring url
-      $paymentObject = NULL;
     }
     if (is_array($recurIDs) && !empty($recurIDs)) {
       $getCount = CRM_Contribute_BAO_ContributionRecur::getCount($recurIDs);


### PR DESCRIPTION
Overview
----------------------------------------
Minor extraction

Before
----------------------------------------
uses sql

After
----------------------------------------
uses api

Technical Details
----------------------------------------
This is primarily so that we can start calling the latter function in places where the id is only retrieved in order to check it exists -
- next steps are to deprecate & remove calls like

CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($recurID, 'recur', 'obj')

and

getPaymentProcessorForRecurringContribution (which duplicates this although I think it uses a better method to load the object.)

Note that I think we should load the manual payment processor if the value is actually empty - that makes it editable which I think makes sense where they have been added other than via normal civi mechanisms - this could include imports or just odd requirements

Comments
----------------------------------------
@mattwire 

preliminary towards https://lab.civicrm.org/dev/core/issues/704