### PR TITLE
dev/core/issues/209: Add Cases Support To Scheduled Reminders

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -702,6 +702,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
+    $tokens = array_merge(CRM_Core_SelectValues::caseTokens(), $tokens);
     return $tokens;
   }
 

--- a/CRM/Case/ActionMapping.php
+++ b/CRM/Case/ActionMapping.php
@@ -1,0 +1,136 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\ActionSchedule\RecipientBuilder;
+
+/**
+ * Class CRM_Event_ActionMapping
+ *
+ * This defines the scheduled-reminder functionality for CiviCase entities.
+ */
+class CRM_Case_ActionMapping extends \Civi\ActionSchedule\Mapping {
+
+  /**
+   * The value for civicrm_action_schedule.mapping_id which identifies the
+   * "Case" mapping.
+   *
+   * Note: This value is chosen to match legacy DB IDs.
+   */
+  const CASE_MAPPING_ID = 99;
+
+  /**
+   * Register Activity-related action mappings.
+   *
+   * @param \Civi\ActionSchedule\Event\MappingRegisterEvent $registrations
+   */
+  public static function onRegisterActionMappings(\Civi\ActionSchedule\Event\MappingRegisterEvent $registrations) {
+    $registrations->register(CRM_Case_ActionMapping::create(array(
+      'id' => CRM_Case_ActionMapping::CASE_MAPPING_ID,
+      'entity' => 'civicrm_case',
+      'entity_label' => ts('Case'),
+      'entity_value' => 'case_type',
+      'entity_value_label' => ts('Case Type'),
+      'entity_status' => 'case_status',
+      'entity_status_label' => ts('Case Status'),
+      'entity_date_start' => 'start_date',
+      'entity_date_end' => 'end_date',
+    )));
+  }
+
+  public function getRecipientListing($type) {
+    if ($type == 'case_roles') {
+      $result = civicrm_api3('RelationshipType', 'get', array(
+        'sequential' => 1,
+        'options' => array('limit' => 0, 'sort' => "label_b_a"),
+      ))['values'];
+      $cRoles = array();
+      foreach ($result as $each) {
+        $cRoles[$each['id']] = $each['label_b_a'];
+      }
+      return $cRoles;
+    }
+    return array();
+  }
+
+  /**
+   * Get a list of recipient types.
+   *
+   * Note: A single schedule may filter on *zero* or *one* recipient types.
+   * When an admin chooses a value, it's stored in $schedule->recipient.
+   *
+   * @return array
+   *   array(string $value => string $label).
+   *   Ex: array('assignee' => 'Activity Assignee').
+   */
+  public function getRecipientTypes() {
+    return array('case_roles' => 'Case Roles');
+  }
+
+  /**
+   * Generate a query to locate recipients who match the given
+   * schedule.
+   *
+   * @param \CRM_Core_DAO_ActionSchedule $schedule
+   *   The schedule as configured by the administrator.
+   * @param string $phase
+   *   See, e.g., RecipientBuilder::PHASE_RELATION_FIRST.
+   *
+   * @param array $defaultParams
+   *
+   * @return \CRM_Utils_SQL_Select
+   * @see RecipientBuilder
+   */
+  public function createQuery($schedule, $phase, $defaultParams) {
+    $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
+    $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
+    $caseRoles = (array) \CRM_Utils_Array::explodePadded($schedule->recipient_listing);
+
+    $query = \CRM_Utils_SQL_Select::from("civicrm_case c")->param($defaultParams);
+    $query->join('r', "INNER JOIN civicrm_relationship r ON c.id = r.case_id");
+    $query->join('cs', "INNER JOIN civicrm_contact ct ON r.contact_id_b = ct.id");
+    $query->join('ce', "INNER JOIN civicrm_email ce ON ce.contact_id = ct.id");
+    if (!empty($selectedValues)) {
+      $query->where("c.case_type_id IN (#caseId)")
+        ->param('caseId', $selectedValues);
+    }
+    if (!empty($selectedStatuses)) {
+      $query->where("c.status_id IN (#selectedStatuss)")
+        ->param('selectedStatuss', $selectedStatuses);
+    }
+    $query->where("r.relationship_type_id IN (#caseRoles)")
+      ->param('caseRoles', $caseRoles);
+    $query['casAddlCheckFrom'] = 'civicrm_case c';
+    $query['casContactIdField'] = 'ct.id';
+    $query['casEntityIdField'] = 'r.case_id';
+    $query['casContactTableAlias'] = 'ct';
+    $query['casDateField'] = 'c.start_date';
+
+    $query->where('r.is_active = 1 AND c.is_deleted = 0');
+    return $query;
+  }
+
+}

--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -298,6 +298,8 @@ abstract class Mapping implements MappingInterface {
       $valueLabelMap['auto_renew_options'] = \CRM_Core_OptionGroup::values('auto_renew_options');
       $valueLabelMap['contact_date_reminder_options'] = \CRM_Core_OptionGroup::values('contact_date_reminder_options');
       $valueLabelMap['civicrm_membership_type'] = \CRM_Member_PseudoConstant::membershipType();
+      $valueLabelMap['case_type'] = \CRM_Case_PseudoConstant::caseType();
+      $valueLabelMap['case_status'] = \CRM_Case_PseudoConstant::caseStatus();
 
       $allCustomFields = \CRM_Core_BAO_CustomField::getFields('');
       $dateFields = array(

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -343,6 +343,7 @@ class Container {
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Contribute_ActionMapping_ByType', 'onRegisterActionMappings'));
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Event_ActionMapping', 'onRegisterActionMappings'));
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Member_ActionMapping', 'onRegisterActionMappings'));
+    $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Case_ActionMapping', 'onRegisterActionMappings'));
 
     if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_LISTENERS')) {
       \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_LISTENERS, array($dispatcher));

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -211,6 +211,42 @@
         showHideLimitTo();
       }
 
+      function caseRolesFilter() {
+        if(!$("#entity_1", $form).val()){
+          //alert('Select a case type');
+          return;
+        }
+        var caseType = $("#entity_1", $form).val();
+        CRM.api3('CaseType', 'get', {
+          "id": {"IN":caseType}
+        }).done(function(result) {
+          if (!CRM._.isEmpty(result.values)) {
+            var values = [];
+            CRM._.each(result.values, function(v, i) {
+              CRM._.each(v.definition.caseRoles, function(v2, j) {
+                values.push(v2.name);
+              });
+            });
+            // filter options
+            $("#recipient_listing > option").each(function(i, val) {
+              var text = $(val).text();//$("#recipient_listing option:[text='" + this + "']");
+              if ($.inArray(text, values) == -1) {
+                //alert(text);
+                $(this).remove();
+              }
+            });
+          }
+          $("#recipientList", $form).show();
+        });
+      }
+
+      $('#entity_1', $form).change(function () {
+        var recipient = $("#recipient", $form).val();
+        if (recipient == 'case_roles') {
+          populateRecipient();
+        }
+      });
+	  
       // CRM-14070 Hide limit-to when entity is activity
       function showHideLimitTo() {
         $('#limit_to', $form).toggle(!($('#entity_0', $form).val() == '1'));


### PR DESCRIPTION
Overview
----------------------------------------
This improvement is aimed at including cases in the list of entities that can be configured for scheduled reminders. This will enable us to send scheduled emails to case roles (configurable) after a predefined interval of time. This will also have the ability filter the list of these cases and only pick certain cases based on case status (configurable).

<img width="1241" alt="cases" src="https://user-images.githubusercontent.com/36624620/53080405-9f55c480-351e-11e9-92aa-15b15aaaa298.png">

Before
----------------------------------------
As things stand, there are no scheduled reminders possible for cases

After
----------------------------------------
We can configure cases scheduled reminders in the following ways: 
- Use case, case type and case status as criteria
- Select case roles (case manager and others) as the recipients
- Use case tokens
