### PR TITLE
Switch additional payment form to use Payment.sendconfirmation api

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -183,16 +183,28 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
    * Test the submit function that completes the partially paid Contribution with multiple payments.
    */
   public function testMultiplePaymentForPartiallyPaidContributionWithOneCreditCardPayment() {
+    $mut = new CiviMailUtils($this, TRUE);
     $this->createContribution('Partially paid');
 
     // pay additional amount
-    $this->submitPayment(50);
+    $this->submitPayment(50, NULL, TRUE);
     $contribution = $this->callAPISuccessGetSingle('Contribution', array('id' => $this->_contributionId));
     $this->assertEquals('Partially paid', $contribution['contribution_status']);
 
     // pay additional amount by using credit card
     $this->submitPayment(20, 'live');
     $this->checkResults(array(30, 50, 20), 3);
+    $mut->assertSubjects(array('Payment Receipt -'));
+    $mut->checkMailLog(array(
+      'Dear Anthony Anderson',
+      'A payment has been received',
+      'Total Fees: $ 100.00',
+      'This Payment Amount: $ 50.00',
+      'Balance Owed: $ 20.00 ',
+      'Paid By: Check',
+      'Check Number: check-12345',
+    ));
+    $mut->stop();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -122,6 +122,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_mailing_spool ORDER BY id DESC');
     parent::tearDown();
   }
 
@@ -150,6 +151,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     ]);
 
     $mut->stop();
+    $mut->clearMessages();
   }
 
   /**
@@ -185,6 +187,14 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
   public function testMultiplePaymentForPartiallyPaidContributionWithOneCreditCardPayment() {
     $mut = new CiviMailUtils($this, TRUE);
     $this->createContribution('Partially paid');
+    // In general when there is tpl leakage we try to fix. At the moment, however,
+    // the tpl leakage on credit card related things is kind of 'by-design' - or
+    // at least we haven't found a way to replace the way in with Payment.send_confirmation
+    // picks them up from the form process so we will just clear templates here to stop leakage
+    // from previous tests causing a fail.
+    // The reason this is hard to fix is that we save a billing address per contribution not
+    // per payment so it's a problem with the data model
+    CRM_Core_Smarty::singleton()->clearTemplateVars();
 
     // pay additional amount
     $this->submitPayment(50, NULL, TRUE);
@@ -195,7 +205,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->submitPayment(20, 'live');
     $this->checkResults(array(30, 50, 20), 3);
     $mut->assertSubjects(array('Payment Receipt -'));
-    $mut->checkMailLog(array(
+    $mut->checkMailLog([
       'Dear Anthony,',
       'A payment has been received',
       'Total Fees: $ 100.00',
@@ -203,8 +213,13 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'Balance Owed: $ 20.00 ',
       'Paid By: Check',
       'Check Number: check-12345',
-    ));
+    ],
+    [
+      'Billing Name and Address',
+      'Visa',
+    ]);
     $mut->stop();
+    $mut->clearMessages();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -196,7 +196,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->checkResults(array(30, 50, 20), 3);
     $mut->assertSubjects(array('Payment Receipt -'));
     $mut->checkMailLog(array(
-      'Dear Anthony Anderson',
+      'Dear Anthony,',
       'A payment has been received',
       'Total Fees: $ 100.00',
       'This Payment Amount: $ 50.00',


### PR DESCRIPTION
Overview
----------------------------------------
This is primarily code cleanup but as part of getting test consistency it switches to using 'email greeting' rather than display name - consistent with other tpls & removes the 'please print this...' text

Before
----------------------------------------
Code on form in unshareable way

After
----------------------------------------
API used

Technical Details
----------------------------------------
SInce I needed to alter the tpl I reviewed the values used in the various if clauses - $contributeMode is deprecated and a payment  is never submitted with isAmountZero so I removed those from the if in favour of values that better reflect if the fields should show & which are only assigned while processing payments. 

I added testing for display of credit card & address fields

Comments
----------------------------------------
@monishdeb ping -  but I'll see what tests think first - I could make the tpl changes first if you'd prefer
