### PR TITLE
reporting#8 - add thank-you dates to Contribution Summary/Detail reports

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -156,6 +156,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
           'trxn_id' => NULL,
           'receive_date' => array('default' => TRUE),
           'receipt_date' => NULL,
+          'thankyou_date' => NULL,
           'total_amount' => array(
             'title' => ts('Amount'),
             'required' => TRUE,
@@ -192,6 +193,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
             ),
           ),
           'receive_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
+          'thankyou_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
           'contribution_source' => array(
             'title' => ts('Source'),
             'name' => 'source',
@@ -239,6 +241,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
           'contribution_status_id' => array('title' => ts('Contribution Status')),
           'payment_instrument_id' => array('title' => ts('Payment Method')),
           'receive_date' => array('title' => ts('Date Received')),
+          'thankyou_date' => array('title' => ts('Thank-you Date')),
         ),
         'group_bys' => array(
           'contribution_id' => array(

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -149,6 +149,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
         'grouping' => 'contri-fields',
         'filters' => array(
           'receive_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
+          'thankyou_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
           'contribution_status_id' => array(
             'title' => ts('Contribution Status'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,


### PR DESCRIPTION
Overview
----------------------------------------
Adds the "thank you date" field to the Contribution Summary and Detail reports.

Before
----------------------------------------
Can't select thank-you date as a filter, sort or column on contribution detail report.  Can't select it as a filter on contribution summary report.

After
----------------------------------------
You can do the thing.

Technical Details
----------------------------------------
I'm not the one to say, but I think this just needs an `r-run`.