### PR TITLE
dev/core#742 Fix XML parasing by swapping & for ,

### DIFF
--- a/CRM/Core/xml/Menu/Activity.xml
+++ b/CRM/Core/xml/Menu/Activity.xml
@@ -7,7 +7,7 @@
      <page_callback>CRM_Activity_Form_Activity</page_callback>
      <access_arguments>access CiviCRM</access_arguments>
      <page_arguments>attachUpload=1</page_arguments>
-     <path_arguments>action=add&amp;context=standalone</path_arguments>
+     <path_arguments>action=add,context=standalone</path_arguments>
   </item>
   <item>
      <path>civicrm/activity/view</path>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes warnings about failing to parase the XML file

Before
----------------------------------------
Warnings about libxml failing to parase Activity XML

After
----------------------------------------
No warnings

Technical Details
----------------------------------------
Seems like even tho `&amp;` looks fine to parse the XML processor doesn't like it. However it seems looking at https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Menu.php#L364 there seems to have been a work around which is to use , instead of & in the xml to separate the separate path arguments 

ping @eileenmcnaughton @totten 