### PR TITLE
Update Payment Notification to use greeting, remove text to 'Please print this confirmation for your records.

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -387,6 +387,11 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->_params['contact_id'] = $this->_contactId;
       $this->_params['contribution_id'] = $this->_contributionId;
 
+      // These 2 rows are temporarily added for sequencing of adding commits. They won't be needed when we
+      // switch to Payment.send_confirmation api
+      $contact = civicrm_api3('Contact', 'getsingle', ['id' => $this->_contactId, 'return' => 'email_greeting']);
+      $this->assign('emailGreeting', $contact['email_greeting_display']);
+
       $sendReceipt = $this->emailReceipt($this->_params);
       if ($sendReceipt) {
         $statusMsg .= ' ' . ts('A receipt has been emailed to the contributor.');

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -169,6 +169,8 @@ class CRM_Financial_BAO_Payment {
     $contactID = self::getPaymentContactID($contributionID);
     list($displayName, $email)  = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
     $entities['contact'] = ['id' => $contactID, 'display_name' => $displayName, 'email' => $email];
+    $contact = civicrm_api3('Contact', 'getsingle', ['id' => $contactID, 'return' => 'email_greeting']);
+    $entities['contact']['email_greeting'] = $contact['email_greeting_display'];
 
     $participantRecords = civicrm_api3('ParticipantPayment', 'get', [
       'contribution_id' => $contributionID,
@@ -214,6 +216,7 @@ class CRM_Financial_BAO_Payment {
   public static function getConfirmationTemplateParameters($entities) {
     $templateVariables = [
       'contactDisplayName' => $entities['contact']['display_name'],
+      'emailGreeting' => $entities['contact']['email_greeting'],
       'totalAmount' => $entities['payment']['total'],
       'amountOwed' => $entities['payment']['balance'],
       'totalPaid' => $entities['payment']['paid'],
@@ -263,6 +266,7 @@ class CRM_Financial_BAO_Payment {
       'refundAmount',
       'totalPaid',
       'paymentsComplete',
+      'emailGreeting'
     ];
     // These are assigned by the payment form - they still 'get through' from the
     // form for now without being in here but we should ideally load

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -102,7 +102,16 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'membership_online_receipt', 'type' => 'text'],
           ['name' => 'membership_online_receipt', 'type' => 'html'],
         ]
-      ]
+      ],
+      [
+        'version' => '5.12.alpha1',
+        'upgrade_descriptor' => ts('Update payment notification to remove print text, use email greeting'),
+        'label' => ts('Payment notification'),
+        'templates' => [
+          ['name' => 'payment_or_refund_notification', 'type' => 'text'],
+          ['name' => 'payment_or_refund_notification', 'type' => 'html'],
+        ]
+      ],
     ];
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -137,11 +137,16 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->checkResults(array(30, 70), 2);
     $mut->assertSubjects(['Payment Receipt -']);
     $mut->checkMailLog([
-      'Dear Anthony Anderson',
+      'Dear Anthony,',
       'Payment Details',
       'Total Fees: $ 100.00',
       'This Payment Amount: $ 70.00',
       'Balance Owed: $ 0.00 ',
+      'Billing Name and Address',
+      'Vancouver, AE 1321312',
+      'Visa',
+      '***********1111',
+      'Expires: May 2025',
     ]);
 
     $mut->stop();

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -132,7 +132,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id']]);
     $mut->assertSubjects(['Payment Receipt - Annual CiviCRM meet']);
     $mut->checkMailLog(array(
-      'Dear Mr. Anthony Anderson II',
+      'Dear Anthony,',
       'Total Fees: $ 300.00',
       'This Payment Amount: $ 50.00',
       'Balance Owed: $ 100.00', //150 was paid in the 1st payment.
@@ -163,7 +163,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id']]);
     $mut->assertSubjects(['Payment Receipt - Annual CiviCRM meet']);
     $mut->checkMailLog(array(
-      'Dear Mr. Anthony Anderson II',
+      'Dear Anthony,',
       'A payment has been received.',
       'Total Fees: $ 300.00',
       'This Payment Amount: $ 150.00',
@@ -212,7 +212,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id']]);
     $mut->assertSubjects(['Refund Notification - Annual CiviCRM meet']);
     $mut->checkMailLog(array(
-      'Dear Mr. Anthony Anderson II',
+      'Dear Anthony,',
       'A refund has been issued based on changes in your registration selections.',
       'Total Fees: $ 300' . $decimalSeparator . '00',
       'Refund Amount: $ -30' . $decimalSeparator . '00',

--- a/xml/templates/message_templates/payment_or_refund_notification_html.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_html.tpl
@@ -12,7 +12,8 @@
 {capture assign=emptyBlockStyle }style="padding: 10px; border-bottom: 1px solid #999;background-color: #f7f7f7;"{/capture}
 {capture assign=emptyBlockValueStyle }style="padding: 10px; border-bottom: 1px solid #999;"{/capture}
 
-<p>Dear {$contactDisplayName}</p>
+{if $emailGreeting}<p>{$emailGreeting},</p>{/if}
+
 <center>
  <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
 
@@ -29,7 +30,6 @@
       {else}
       <p>{ts}A payment has been received.{/ts}</p>
       {/if}
-      <p>{ts}Please print this confirmation for your records.{/ts}</p>
     </td>
   </tr>
   <tr>
@@ -147,7 +147,7 @@
     <tr>
       <td>
   <table style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse; width:100%;">
-    {if $contributeMode eq 'direct' and !$isAmountzero}
+    {if $billingName || $address}
           <tr>
             <th {$headerStyle}>
         {ts}Billing Name and Address{/ts}
@@ -160,7 +160,7 @@
             </td>
           </tr>
     {/if}
-    {if $contributeMode eq'direct' and !$isAmountzero}
+    {if $credit_card_number}
           <tr>
             <th {$headerStyle}>
         {ts}Credit Card Information{/ts}

--- a/xml/templates/message_templates/payment_or_refund_notification_text.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_text.tpl
@@ -1,11 +1,9 @@
-Dear {$contactDisplayName}
-{if $isRefund}
+{if $emailGreeting}{$emailGreeting},
+{/if}{if $isRefund}
 {ts}A refund has been issued based on changes in your registration selections.{/ts}
 {else}
 {ts}A payment has been received.{/ts}
 {/if}
-
-{ts}Please print this confirmation for your records.{/ts}
 
 {if $isRefund}
 ===============================================================================
@@ -46,7 +44,7 @@ Dear {$contactDisplayName}
 {if $checkNumber}
 {ts}Check Number{/ts}: {$checkNumber}
 {/if}
-{if $contributeMode eq 'direct' and !$isAmountzero}
+{if $billingName || $address}
 
 ===============================================================================
 
@@ -58,7 +56,7 @@ Dear {$contactDisplayName}
 {$address}
 {/if}
 
-{if $contributeMode eq 'direct' and !$isAmountzero}
+{if $credit_card_number}
 ===========================================================
 {ts}Credit Card Information{/ts}
 


### PR DESCRIPTION
Overview
----------------------------------------
Update Payment notification to use the value stored in email_greeting rather than display name (this has been done in other templates). 

Also remove text to 'Please print this confirmation for your records.'

Before
----------------------------------------
Addressed by display name - eg.  'Dear Mr. Anthony Anderson II,' 

Sentence Please print this confirmation for your records is  present

After
----------------------------------------
Addressed by email greeting per site config & like other templates eg.  'Dear Anthony,' 

Sentence Please print this confirmation for your records has gone

Technical Details
----------------------------------------
These changes are consistent with other changes. I also switched the parameters for when to include extra detail to deprecate contributeMode

Comments
----------------------------------------
Resolving inconsistency on greeting as pre-requisite for https://github.com/civicrm/civicrm-core/pull/13649

@magnolia61 I think this is probably one you'll be please to see
