### PR TITLE
reporting#9: parity between getContactFields and getBasicContactFields

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4758,7 +4758,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
 
   /**
    * Get a standard set of contact fields.
-   *
+   * @deprecated - use getColumns('Contact') instead
    * @return array
    */
   public function getBasicContactFields() {
@@ -5398,7 +5398,45 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'is_filters' => TRUE,
         'is_group_bys' => FALSE,
       ),
+      $options['prefix'] . 'external_identifier' => array(
+        'title' => $options['prefix_label'] . ts('Contact identifier from external system'),
+        'name' => 'external_identifier',
+        'is_fields' => TRUE,
+        'is_filters' => FALSE,
+        'is_group_bys' => FALSE,
+        'is_order_bys' => TRUE,
+      ),
+      $options['prefix'] . 'preferred_language' => array(
+        'title' => $options['prefix_label'] . ts('Preferred Language'),
+        'name' => 'preferred_language',
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_group_bys' => TRUE,
+        'is_order_bys' => TRUE,
+      ),
     );
+    foreach ([
+      'postal_greeting_display' => 'Postal Greeting',
+      'email_greeting_display' => 'Email Greeting',
+      'addressee_display' => 'Addressee',
+    ] as $field => $title) {
+      $spec[$options['prefix'] . $field] = array(
+        'title' => $options['prefix_label'] . ts($title),
+        'name' => $field,
+        'is_fields' => TRUE,
+        'is_filters' => FALSE,
+        'is_group_bys' => FALSE,
+      );
+    }
+    foreach (['do_not_email', 'do_not_phone', 'do_not_mail', 'do_not_sms', 'is_opt_out'] as $field) {
+      $spec[$options['prefix'] . $field] = [
+        'name' => $field,
+        'type' => CRM_Utils_Type::T_BOOLEAN,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_group_bys' => FALSE,
+      ];
+    }
     $individualFields = array(
       $options['prefix'] . 'first_name' => array(
         'name' => 'first_name',
@@ -5467,6 +5505,20 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'is_fields' => FALSE,
         'is_filters' => TRUE,
         'is_group_bys' => FALSE,
+      ),
+      $options['prefix'] . 'job_title' => array(
+        'name' => 'job_title',
+        'is_fields' => TRUE,
+        'is_filters' => FALSE,
+        'is_group_bys' => FALSE,
+      ),
+      $options['prefix'] . 'employer_id' => array(
+        'title' => $options['prefix_label'] . ts('Current Employer'),
+        'type' => CRM_Utils_Type::T_INT,
+        'name' => 'employer_id',
+        'is_fields' => TRUE,
+        'is_filters' => FALSE,
+        'is_group_bys' => TRUE,
       ),
     );
     if (!$options['contact_type'] || $options['contact_type'] === 'Individual') {


### PR DESCRIPTION
Overview
----------------------------------------
@eileen has ported some of the cleaner code for defining report specs from Extended Reports to core in the form of getColumns() and getContactColumns().  Since this appears to be the direction we're headed in, I think it makes sense to deprecate getBasicContactColumns(), which does a similar job.  However, getBasicContactColumns() adds a bunch of fields to core reports that getContactColumns doesn't.

My PR adds all the missing fields to getContactColumns (except for "Organization Name"; this seems unnecessary since it will virtually always match the display name).  I also mark getBasicContactFields() as deprecated so future cleanup can target reports using it.

Before
----------------------------------------
Reports using `getContactColumns` and `getBasicContactColumns` have different columns displayed.

After
----------------------------------------
Reports using `getContactColumns` and `getBasicContactColumns` show the same columns.  `getBasicContactColumns` is labeled as deprecated.

Comments
----------------------------------------
"Contribution Details" is a report that uses `getContactColumns`, so it's good to use for checking the results.


https://lab.civicrm.org/dev/report/issues/9