### PR TITLE
Phase out CIVICRM_TEMP_FORCE_UTF8

### DIFF
--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -97,8 +97,8 @@ class CRM_Utils_SQL_TempTable {
     $t->id = md5(uniqid('', TRUE));
     // The constant CIVICRM_TEMP_FORCE_DURABLE is for local debugging.
     $t->durable = CRM_Utils_Constant::value('CIVICRM_TEMP_FORCE_DURABLE', FALSE);
-    // I suspect it would be better to just say utf8=true, but a lot of existing queries don't do the utf8 bit.
-    $t->utf8 = CRM_Utils_Constant::value('CIVICRM_TEMP_FORCE_UTF8', FALSE);
+    // @deprecated This constant is deprecated and will be removed.
+    $t->utf8 = CRM_Utils_Constant::value('CIVICRM_TEMP_FORCE_UTF8', TRUE);
     $t->autodrop = FALSE;
     $t->memory = FALSE;
     return $t;


### PR DESCRIPTION
Overview
----------------------------------------
Currently, temporary tables do not set utf8 as their default character set unless CRM_Utils_SQL_TempTable::setUtf8() is called.  However, I cannot think of a reason to allow non-UTF-8 tables.

Before
----------------------------------------
Temporary tables default to whatever is the default on the MySQL server (e.g. latin1).

After
----------------------------------------
We could make them UTF-8 by default, and we could also prevent them from having some other default character set, as a simplification.  A custom character set and/or collation can still be set for specific columns.