### PR TITLE
Deploy hotfix to fix dev/core#746 until tests can be written for fix

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -412,6 +412,8 @@ class CRM_Contact_BAO_Query {
 
   public $_pseudoConstantsSelect = array();
 
+  public $_groupUniqueKey = NULL;
+
   /**
    * Class constructor which also does all the work.
    *
@@ -3038,12 +3040,13 @@ class CRM_Contact_BAO_Query {
     //CRM-19589: contact(s) removed from a Smart Group, resides in civicrm_group_contact table
     $groupContactCacheClause = '';
     if (count($smartGroupIDs) || empty($value)) {
-      $gccTableAlias = "civicrm_group_contact_cache";
+      $this->_groupUniqueKey = uniqid();
+      $gccTableAlias = "civicrm_group_contact_cache_{$this->_groupUniqueKey}";
       $groupContactCacheClause = $this->addGroupContactCache($smartGroupIDs, $gccTableAlias, "contact_a", $op);
       if (!empty($groupContactCacheClause)) {
         if ($isNotOp) {
           $groupIds = implode(',', (array) $smartGroupIDs);
-          $gcTable = "civicrm_group_contact";
+          $gcTable = "civicrm_group_contact_{$this->_groupUniqueKey}";
           $joinClause = array("contact_a.id = {$gcTable}.contact_id");
           $this->_tables[$gcTable] = $this->_whereTables[$gcTable] = " LEFT JOIN civicrm_group_contact {$gcTable} ON (" . implode(' AND ', $joinClause) . ")";
           if (strpos($op, 'IN') !== FALSE) {
@@ -3067,6 +3070,10 @@ class CRM_Contact_BAO_Query {
     if (strpos($op, 'NULL') === FALSE) {
       $this->_qill[$grouping][] = ts("Group Status %1", array(1 => implode(' ' . ts('or') . ' ', $statii)));
     }
+  }
+
+  public function getGroupCacheTableKey() {
+    return $this->_groupUniqueKey;
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
@@ -441,7 +441,8 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE, FALSE, FALSE,
       TRUE, FALSE
     );
-    $expectedWhere = "civicrm_group_contact_cache.group_id IN (\"{$group2->id}\")";
+    $key = $query->getGroupCacheTableKey();
+    $expectedWhere = "civicrm_group_contact_cache_{$key}.group_id IN (\"{$group2->id}\")";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id = {$group2->id}");
 
@@ -452,8 +453,9 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE,
       FALSE, FALSE
     );
+    $key = $query->getGroupCacheTableKey();
     //Assert if proper where clause is present.
-    $expectedWhere = "civicrm_group_contact.group_id != {$group->id} AND civicrm_group_contact_cache.group_id IS NULL OR  ( civicrm_group_contact_cache.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
+    $expectedWhere = "civicrm_group_contact_{$key}.group_id != {$group->id} AND civicrm_group_contact_cache_{$key}.group_id IS NULL OR  ( civicrm_group_contact_cache_{$key}.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id != {$group->id}");
 
@@ -464,7 +466,8 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE,
       FALSE, FALSE
     );
-    $expectedWhere = "civicrm_group_contact_cache.group_id IN (\"{$group->id}\", \"{$group2->id}\")";
+    $key = $query->getGroupCacheTableKey();
+    $expectedWhere = "civicrm_group_contact_cache_{$key}.group_id IN (\"{$group->id}\", \"{$group2->id}\")";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id IN ({$group->id}, {$group2->id})");
 
@@ -475,7 +478,8 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
       FALSE,
       FALSE, FALSE
     );
-    $expectedWhere = "civicrm_group_contact.group_id NOT IN ( {$group->id} ) AND civicrm_group_contact_cache.group_id IS NULL OR  ( civicrm_group_contact_cache.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
+    $key = $query->getGroupCacheTableKey();
+    $expectedWhere = "civicrm_group_contact_{$key}.group_id NOT IN ( {$group->id} ) AND civicrm_group_contact_cache_{$key}.group_id IS NULL OR  ( civicrm_group_contact_cache_{$key}.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
     $this->assertContains($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id NOT IN ({$group->id})");
   }


### PR DESCRIPTION
Overview
----------------------------------------
This hotfix fixes a problem where you have 2 separate group where clauses built in a search builder and both of the groups are smart groups

Before
----------------------------------------
No results found due to table only joined once

After
----------------------------------------
The overlap of the groups found as joins are correctly made

ping @eileenmcnaughton 