### PR TITLE
dev/core#739 Fix case detail report breaking when sorted by case type.

### DIFF
--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -44,9 +44,9 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
 
   protected $_includeCaseDetailExtra = FALSE;
 
-  protected $_caseDetailExtra = array();
+  protected $_caseDetailExtra = [];
 
-  protected $_customGroupExtends = array('Case');
+  protected $_customGroupExtends = ['Case'];
 
   protected $_caseTypeNameOrderBy = FALSE;
 
@@ -60,253 +60,253 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
       $this->rel_types[$relid] = $v['label_b_a'];
     }
 
-    $this->deleted_labels = array(
+    $this->deleted_labels = [
       '' => ts('- select -'),
       0 => ts('No'),
       1 => ts('Yes'),
-    );
+    ];
 
-    $this->caseActivityTypes = array();
+    $this->caseActivityTypes = [];
     foreach (CRM_Case_PseudoConstant::caseActivityType() as $typeDetail) {
       $this->caseActivityTypes[$typeDetail['id']] = $typeDetail['label'];
     }
 
-    $this->_columns = array(
-      'civicrm_case' => array(
+    $this->_columns = [
+      'civicrm_case' => [
         'dao' => 'CRM_Case_DAO_Case',
-        'fields' => array(
-          'id' => array(
+        'fields' => [
+          'id' => [
             'title' => ts('Case ID'),
             'no_display' => TRUE,
             'required' => TRUE,
-          ),
-          'subject' => array(
+          ],
+          'subject' => [
             'title' => ts('Subject'),
             'required' => TRUE,
-          ),
-          'start_date' => array(
+          ],
+          'start_date' => [
             'title' => ts('Start Date'),
             'type' => CRM_Utils_Type::T_DATE,
-          ),
-          'end_date' => array(
+          ],
+          'end_date' => [
             'title' => ts('End Date'),
             'type' => CRM_Utils_Type::T_DATE,
-          ),
-          'status_id' => array('title' => ts('Case Status')),
-          'case_type_id' => array('title' => ts('Case Type')),
-          'is_deleted' => array(
+          ],
+          'status_id' => ['title' => ts('Case Status')],
+          'case_type_id' => ['title' => ts('Case Type')],
+          'is_deleted' => [
             'title' => ts('Deleted?'),
             'default' => FALSE,
             'type' => CRM_Utils_Type::T_INT,
-          ),
-        ),
-        'filters' => array(
-          'start_date' => array(
+          ],
+        ],
+        'filters' => [
+          'start_date' => [
             'title' => ts('Start Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
             'type' => CRM_Utils_Type::T_DATE,
-          ),
-          'end_date' => array(
+          ],
+          'end_date' => [
             'title' => ts('End Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
             'type' => CRM_Utils_Type::T_DATE,
-          ),
-          'status_id' => array(
+          ],
+          'status_id' => [
             'title' => ts('Case Status'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Case_BAO_Case::buildOptions('status_id', 'search'),
-          ),
-          'case_type_id' => array(
+          ],
+          'case_type_id' => [
             'title' => ts('Case Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Case_BAO_Case::buildOptions('case_type_id', 'search'),
-          ),
-          'is_deleted' => array(
+          ],
+          'is_deleted' => [
             'title' => ts('Deleted?'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_SELECT,
             'options' => $this->deleted_labels,
             'default' => 0,
-          ),
-        ),
-        'order_bys'  => array(
-          'start_date' => array(
+          ],
+        ],
+        'order_bys' => [
+          'start_date' => [
             'title' => ts('Start Date'),
             'default_weight' => 1,
-          ),
-          'end_date' => array(
+          ],
+          'end_date' => [
             'title' => ts('End Date'),
-          ),
-          'status_id' => array(
+          ],
+          'status_id' => [
             'title' => ts('Status'),
-          ),
-          'case_type_name' => array(
+          ],
+          'case_type_name' => [
             'title' => 'Case Type',
-          ),
-        ),
-      ),
-      'civicrm_contact' => array(
+          ],
+        ],
+      ],
+      'civicrm_contact' => [
         'dao' => 'CRM_Contact_DAO_Contact',
-        'fields' => array(
-          'client_sort_name' => array(
+        'fields' => [
+          'client_sort_name' => [
             'name' => 'sort_name',
             'title' => ts('Client Name'),
             'required' => TRUE,
-          ),
-          'id' => array(
+          ],
+          'id' => [
             'no_display' => TRUE,
             'required' => TRUE,
-          ),
-        ),
-        'filters' => array(
-          'sort_name' => array('title' => ts('Client Name')),
-        ),
-      ),
-      'civicrm_relationship' => array(
+          ],
+        ],
+        'filters' => [
+          'sort_name' => ['title' => ts('Client Name')],
+        ],
+      ],
+      'civicrm_relationship' => [
         'dao' => 'CRM_Contact_DAO_Relationship',
-        'fields' => array(
-          'case_role' => array(
+        'fields' => [
+          'case_role' => [
             'name' => 'relationship_type_id',
             'title' => ts('Case Role(s)'),
-          ),
-        ),
-        'filters' => array(
-          'case_role' => array(
+          ],
+        ],
+        'filters' => [
+          'case_role' => [
             'name' => 'relationship_type_id',
             'title' => ts('Case Role(s)'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => $this->rel_types,
-          ),
-          'is_active' => array(
+          ],
+          'is_active' => [
             'title' => ts('Active Role?'),
             'type' => CRM_Utils_Type::T_BOOLEAN,
             'default' => TRUE,
             'options' => CRM_Core_SelectValues::boolean(),
-          ),
-        ),
-      ),
-      'civicrm_email' => array(
+          ],
+        ],
+      ],
+      'civicrm_email' => [
         'dao' => 'CRM_Core_DAO_Email',
-        'fields' => array(
-          'email' => array(
+        'fields' => [
+          'email' => [
             'title' => ts('Email'),
             'no_repeat' => TRUE,
-          ),
-        ),
+          ],
+        ],
         'grouping' => 'contact-fields',
-      ),
-      'civicrm_phone' => array(
+      ],
+      'civicrm_phone' => [
         'dao' => 'CRM_Core_DAO_Phone',
-        'fields' => array(
-          'phone' => array(
+        'fields' => [
+          'phone' => [
             'title' => ts('Phone'),
             'no_repeat' => TRUE,
-          ),
-        ),
+          ],
+        ],
         'grouping' => 'contact-fields',
-      ),
-      'civicrm_address' => array(
+      ],
+      'civicrm_address' => [
         'dao' => 'CRM_Core_DAO_Address',
-        'fields' => array(
+        'fields' => [
           'street_address' => NULL,
-          'state_province_id' => array(
+          'state_province_id' => [
             'title' => ts('State/Province'),
-          ),
-          'country_id' => array('title' => ts('Country')),
-        ),
+          ],
+          'country_id' => ['title' => ts('Country')],
+        ],
         'grouping' => 'contact-fields',
-        'filters' => array(
-          'country_id' => array(
+        'filters' => [
+          'country_id' => [
             'title' => ts('Country'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_PseudoConstant::country(),
-          ),
-          'state_province_id' => array(
+          ],
+          'state_province_id' => [
             'title' => ts('State/Province'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_PseudoConstant::stateProvince(),
-          ),
-        ),
-      ),
-      'civicrm_worldregion' => array(
+          ],
+        ],
+      ],
+      'civicrm_worldregion' => [
         'dao' => 'CRM_Core_DAO_Worldregion',
-        'filters' => array(
-          'worldregion_id' => array(
+        'filters' => [
+          'worldregion_id' => [
             'name' => 'id',
             'title' => ts('World Region'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_PseudoConstant::worldRegion(),
-          ),
-        ),
-      ),
-      'civicrm_country' => array(
+          ],
+        ],
+      ],
+      'civicrm_country' => [
         'dao' => 'CRM_Core_DAO_Country',
-      ),
-      'civicrm_activity_last' => array(
+      ],
+      'civicrm_activity_last' => [
         'dao' => 'CRM_Activity_DAO_Activity',
-        'fields' => array(
-          'last_activity_activity_subject' => array(
+        'fields' => [
+          'last_activity_activity_subject' => [
             'name' => 'subject',
             'title' => ts('Subject of the last activity in the case'),
-          ),
-          'last_activity_activity_type' => array(
+          ],
+          'last_activity_activity_type' => [
             'name' => 'activity_type_id',
             'title' => ts('Activity type of the last activity'),
-          ),
-          'last_activity_date_time' => array(
+          ],
+          'last_activity_date_time' => [
             'name' => 'activity_date_time',
             'title' => ts('Last Action Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
-          ),
-        ),
-        'filters' => array(
-          'last_activity_date_time' => array(
+          ],
+        ],
+        'filters' => [
+          'last_activity_date_time' => [
             'name' => 'activity_date_time',
             'title' => ts('Last Action Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
-          ),
-        ),
+          ],
+        ],
         'alias' => 'civireport_activity_last',
-      ),
-      'civicrm_activity_last_completed' => array(
+      ],
+      'civicrm_activity_last_completed' => [
         'dao' => 'CRM_Activity_DAO_Activity',
-        'fields' => array(
-          'last_completed_activity_subject' => array(
+        'fields' => [
+          'last_completed_activity_subject' => [
             'name' => 'subject',
             'title' => ts('Subject of the last completed activity in the case'),
-          ),
-          'last_completed_activity_type' => array(
+          ],
+          'last_completed_activity_type' => [
             'name' => 'activity_type_id',
             'title' => ts('Activity type of the last completed activity'),
-          ),
-          'last_completed_date_time' => array(
+          ],
+          'last_completed_date_time' => [
             'name' => 'activity_date_time',
             'title' => ts('Last Completed Action Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
-          ),
-        ),
-        'filters' => array(
-          'last_completed_date_time' => array(
+          ],
+        ],
+        'filters' => [
+          'last_completed_date_time' => [
             'name' => 'activity_date_time',
             'title' => ts('Last Completed Action Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
-          ),
-        ),
-      ),
-    );
+          ],
+        ],
+      ],
+    ];
 
-    $this->_options = array(
-      'my_cases' => array(
+    $this->_options = [
+      'my_cases' => [
         'title' => ts('My Cases'),
         'type' => 'checkbox',
-      ),
-    );
+      ],
+    ];
     parent::__construct();
   }
 
@@ -320,27 +320,27 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
   }
 
   public function caseDetailSpecialColumnsAdd() {
-    $elements = array();
+    $elements = [];
     $elements[] = &$this->createElement('select', 'case_activity_all_dates', NULL,
-      array(
+      [
         '' => ts('- select -'),
-      ) + $this->caseActivityTypes
+      ] + $this->caseActivityTypes
     );
     $this->addGroup($elements, 'case_detail_extra');
 
-    $this->_caseDetailExtra = array(
-      'case_activity_all_dates' => array(
+    $this->_caseDetailExtra = [
+      'case_activity_all_dates' => [
         'title' => ts('List of all dates of activities of Type'),
         'name' => 'activity_date_time',
-      ),
-    );
+      ],
+    ];
 
     $this->assign('caseDetailExtra', $this->_caseDetailExtra);
   }
 
   public function select() {
-    $select = array();
-    $this->_columnHeaders = array();
+    $select = [];
+    $this->_columnHeaders = [];
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
@@ -437,7 +437,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
   }
 
   public function where() {
-    $clauses = array();
+    $clauses = [];
     $this->_having = '';
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('filters', $table)) {
@@ -509,14 +509,14 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
     $sql = "{$select} {$this->_from} {$this->_where}";
     $countryCount = CRM_Core_DAO::singleValueQuery($sql);
 
-    $statistics['counts']['case'] = array(
+    $statistics['counts']['case'] = [
       'title' => ts('Total Number of Cases '),
       'value' => isset($statistics['counts']['rowsFound']) ? $statistics['counts']['rowsFound']['value'] : count($rows),
-    );
-    $statistics['counts']['country'] = array(
+    ];
+    $statistics['counts']['country'] = [
       'title' => ts('Total Number of Countries '),
       'value' => $countryCount,
-    );
+    ];
 
     return $statistics;
   }
@@ -537,7 +537,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
       return;
     }
 
-    $from = $select = array();
+    $from = $select = [];
     $case = $this->_aliases['civicrm_case'];
 
     if ($activityType = CRM_Utils_Array::value('case_activity_all_dates', $this->_params['case_detail_extra'])) {
@@ -546,10 +546,10 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
       $from[] = " LEFT JOIN civicrm_case_activity civireport_case_activity_all_{$activityType} ON ( civireport_case_activity_all_{$activityType}.case_id = {$case}.id)
                         LEFT JOIN civicrm_activity civireport_activity_all_{$activityType} ON ( civireport_activity_all_{$activityType}.id = civireport_case_activity_all_{$activityType}.activity_id AND civireport_activity_all_{$activityType}.activity_type_id = {$activityType})";
 
-      $this->_columnHeaders['case_activity_all_dates'] = array(
+      $this->_columnHeaders['case_activity_all_dates'] = [
         'title' => $this->_caseDetailExtra['case_activity_all_dates']['title'] . ": {$this->caseActivityTypes[$activityType]}",
         'type' => CRM_Utils_Array::value('type', $this->_caseDetailExtra['case_activity_all_dates']),
-      );
+      ];
     }
 
     $this->_select .= ', ' . implode(', ', $select) . ' ';
@@ -568,7 +568,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
 
     $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy} {$this->_limit}";
 
-    $rows = $graphRows = array();
+    $rows = $graphRows = [];
     $this->buildRows($sql, $rows);
 
     $this->formatDisplay($rows);
@@ -580,7 +580,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
   public function checkEnabledFields() {
     if ((isset($this->_params['case_role_value'])
         && !empty($this->_params['case_role_value'])) ||
-        (isset($this->_params['is_active_value']))
+      (isset($this->_params['is_active_value']))
     ) {
       $this->_relField = TRUE;
     }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -553,6 +553,23 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test no fatal on order by per https://lab.civicrm.org/dev/core/issues/739
+   */
+  public function testCaseDetailsCaseTypeHeader() {
+    $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => 'case/detail',
+      'fields' => ['subject' => 1, 'client_sort_name' => 1],
+       'order_bys' => [
+         1 => [
+          'column' => 'case_type_title',
+          'order' => 'ASC',
+          'section' => '1',
+        ],
+      ],
+    ]);
+  }
+
+  /**
    * Test the group filter works on the contribution summary.
    */
   public function testContributionDetailSoftCredits() {


### PR DESCRIPTION
Overview
----------------------------------------
Fix case detail report breaking when sorted by case type.



Before
----------------------------------------
Attempting to create a Case Detail report sorted by the field Case Type with the option "Section Header" checked does not work.

After
----------------------------------------
works

Technical Details
----------------------------------------
I removed the hacks to cope with poor metadata declaration & fixed the declaration - this should stop
breaking now. Test added

Comments
----------------------------------------
Array cleanup too

https://lab.civicrm.org/dev/core/issues/739