### PR TITLE
reporting#10 - fix pagination on Contribution Detail report

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -472,9 +472,10 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
    *
    * @return string
    */
-  public function buildQuery($applyLimit = TRUE) {
+  public function buildQuery($applyLimit = FALSE) {
     if ($this->isTempTableBuilt) {
-      return "SELECT * FROM civireport_contribution_detail_temp3 $this->_orderBy";
+      $this->limit();
+      return "SELECT SQL_CALC_FOUND_ROWS * FROM civireport_contribution_detail_temp3 $this->_orderBy $this->_limit";
     }
     return parent::buildQuery($applyLimit);
   }
@@ -509,7 +510,6 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
     // 1. use main contribution query to build temp table 1
     $sql = $this->buildQuery();
     $this->createTemporaryTable('civireport_contribution_detail_temp1', $sql);
-    $this->setPager();
 
     // 2. customize main contribution query for soft credit, and build temp table 2 with soft credit contributions only
     $this->queryMode = 'SoftCredit';


### PR DESCRIPTION
Overview
----------------------------------------
The Contribution Detail report doesn't show pagination when Full Group By is enabled.

Before
----------------------------------------
![selection_805](https://user-images.githubusercontent.com/1796012/53215029-e32ef380-361c-11e9-8067-ffd606f4fe3e.png)

After
----------------------------------------
![selection_804](https://user-images.githubusercontent.com/1796012/53215033-e75b1100-361c-11e9-8a3b-e0781702c313.png)


Technical Details
----------------------------------------
There were 2.5 bugs that needed to be fixed:
* The first temp table for this report sets a limit of 50 rows - so the second time through `buildQuery()`, the SQL statement `SELECT * FROM civireport_contribution_detail_temp3 $this->_orderBy` will never return more than 50, so the pager won't be set.
* `setPager()` assumes that a) the last SQL statement executed includes `SQL_CALC_FOUND_ROWS`; b) that `$this->limit` is set.

Finally, I found a call to `setPager()` in a place where it would never be correct (on a temp table that's not the "final" temp table) so I removed it.

Comments
----------------------------------------
I tried writing a test - but I couldn't determine how to write a method of `CiviReportTestCase` or `CiviUnitTestCase` that retrieved the template object.  I know it's a protected property of the report object, which is retrievable by `getReportObject()`.  If that method existed, I could write the test.


This is identical to #13665 but it's against the rc, per the request of @eileenmcnaughton.