### PR TITLE
reporting-11 - fix Soft Credit report with full group by

### DIFF
--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -535,21 +535,10 @@ GROUP BY   {$this->_aliases['civicrm_contribution']}.currency
     $this->buildACLClause(array('constituentname', 'contact_civireport'));
     $sql = $this->buildQuery();
 
-    $dao = CRM_Core_DAO::executeQuery($sql);
     $rows = $graphRows = array();
-    $count = 0;
-    while ($dao->fetch()) {
-      $row = array();
-      foreach ($this->_columnHeaders as $key => $value) {
-        $row[$key] = $dao->$key;
-      }
-      $rows[] = $row;
-    }
-    $this->formatDisplay($rows);
+    $this->buildRows($sql, $rows);
 
-    // to hide the contact ID field from getting displayed
-    unset($this->_columnHeaders['civicrm_contact_id_constituent']);
-    unset($this->_columnHeaders['civicrm_contact_id_creditor']);
+    $this->formatDisplay($rows);
 
     // assign variables to templates
     $this->doTemplateAssignment($rows);


### PR DESCRIPTION
Overview
----------------------------------------
Soft Credit report fails when Only Full Group By is enabled.

This is replicable by running the report with no changes to defaults on dmaster.

Before
----------------------------------------
You get a fatal error when running Soft Credit report with FGB enabled.

After
----------------------------------------
Report works.

Technical Details
----------------------------------------
The cause is that the Soft Credit report overrides CRM_Core_Form::postProcess() and calls CRM_Core_DAO::executeQuery() directly instead of CRM_Core_Form::buildRows(), which the FGB safeguards exist.  So even though the report is marked as not optimized for FGB, it makes no difference.

Comments
----------------------------------------
The lines that unset the contact ID field from getting displayed have no effect, I imagine this is handled in `CRM_Core_Form::alterDisplay()` these days.  So I removed those as well.
