### PR TITLE
WIP dev/core#748 Clean up transaction handling for CRM_Case_Form_Activity

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -372,7 +372,9 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         }
       }
       else {
-        $statusMsg = ts("Selected Activity cannot be deleted.");
+        CRM_Core_Session::setStatus('', ts("Selected Activity cannot be deleted."), 'warning');
+        $transaction->rollback();
+        return;
       }
 
       $tagParams = array(
@@ -382,6 +384,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       CRM_Core_BAO_EntityTag::del($tagParams);
 
       CRM_Core_Session::setStatus('', $statusMsg, 'info');
+      $transaction->commit();
       return;
     }
 
@@ -393,6 +396,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         $statusMsg = ts('The selected activity has been restored.<br />');
       }
       CRM_Core_Session::setStatus('', $statusMsg, 'info');
+      $transaction->commit();
       return;
     }
 
@@ -440,15 +444,12 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
 
       // build custom data getFields array
       $customFields = CRM_Core_BAO_CustomField::getFields('Activity', FALSE, FALSE, $this->_activityTypeId);
-      $customFields = CRM_Utils_Array::crmArrayMerge($customFields,
+      CRM_Utils_Array::crmArrayMerge($customFields,
         CRM_Core_BAO_CustomField::getFields('Activity', FALSE, FALSE,
           NULL, NULL, TRUE
         )
       );
-      $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-        $this->_activityId,
-        'Activity'
-      );
+      $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_activityId, 'Activity');
     }
 
     // assigning formatted value
@@ -581,6 +582,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       );
       CRM_Case_BAO_Case::processCaseActivity($caseParams);
     }
+    $transaction->commit();
 
     // send copy to selected contacts.
     $mailStatus = '';

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -355,6 +355,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
    * @param $params
    */
   public function submit(&$params) {
+    $transaction = new CRM_Core_Transaction();
     $params['now'] = date("Ymd");
 
     // 1. call begin post process
@@ -425,6 +426,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     if ($this->_activityTypeFile) {
       $className::endPostProcess($this, $params);
     }
+    $transaction->commit();
 
     return $caseObj;
   }
@@ -433,8 +435,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    $transaction = new CRM_Core_Transaction();
-
     // check if dedupe button, if so return.
     $buttonName = $this->controller->getButtonName();
     if (isset($this->_dedupeButtonName) && $buttonName == $this->_dedupeButtonName) {
@@ -458,6 +458,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     }
     // store the submitted values in an array
     $params = $this->controller->exportValues($this->_name);
+
     $this->submit($params);
 
     CRM_Core_Session::setStatus($params['statusMsg'], ts('Saved'), 'success');


### PR DESCRIPTION
Overview
----------------------------------------
This is part of a task to solve performance issues/deadlocks caused by smartgroups/ACLs described here: https://lab.civicrm.org/dev/core/issues/748

Transactions should be automatically terminated when PHP execution completes, but the longer we are in a transaction the longer we are locking tables that may be needed by other processes.

Before
----------------------------------------
When performing create, edit, delete actions on case activities the database transaction is not explicitly committed/rolled back so tables are locked for longer than they need to be.

After
----------------------------------------
When performing create, edit, delete actions on case activities the database transaction is committed/rolled back as soon as it is no longer needed so tables are locked for the minimum amount of time.

Technical Details
----------------------------------------
Use `$transaction->commit()`, `$transaction->rollback()`.

Comments
----------------------------------------
@seamuslee001 Would appreciate your thoughts on this if you have time?

There is also some unused variable/code cleanup in here.