### PR TITLE
CRM/Logging - Fix log table exceptions

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -858,7 +858,11 @@ COLS;
       foreach ($columns as $column) {
         $tableExceptions = array_key_exists('exceptions', $this->logTableSpec[$table]) ? $this->logTableSpec[$table]['exceptions'] : array();
         // ignore modified_date changes
-        if ($column != 'modified_date' && !in_array($column, $tableExceptions)) {
+        $tableExceptions[] = 'modified_date';
+        // exceptions may be provided with or without backticks
+        $excludeColumn = in_array($column, $tableExceptions) ||
+          in_array(str_replace('`', '', $column), $tableExceptions);
+        if (!$excludeColumn) {
           $cond[] = "IFNULL(OLD.$column,'') <> IFNULL(NEW.$column,'')";
         }
       }

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -100,4 +100,27 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $this->assertTrue(empty($diffs['OBSOLETE']));
   }
 
+  /**
+   * Test logging trigger definition
+   */
+  public function testTriggerInfo() {
+    $info = [];
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+    $schema->triggerInfo($info, 'civicrm_group');
+    // should have 3 triggers (insert/update/delete)
+    $this->assertCount(3, $info);
+    foreach ($info as $trigger) {
+      // table for trigger should be civicrm_group
+      $this->assertEquals('civicrm_group', $trigger['table'][0]);
+      if ($trigger['event'][0] == 'UPDATE') {
+        // civicrm_group.cache_date should be an exception, i.e. not logged
+        $this->assertNotContains(
+          "IFNULL(OLD.`cache_date`,'') <> IFNULL(NEW.`cache_date`,'')",
+          $trigger['sql']
+        );
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug with log table exceptions not being observed.

Before
----------------------------------------
Log table exceptions defined in `CRM_Logging_Schema` or via `hook_civicrm_alterLogTables` are not applied unless they're provided with backticks surrounding the column names.

After
----------------------------------------
Log table exceptions are applied for columns provided with and without backticks.

Comments
----------------------------------------
Not sure if this never worked or was dependent on a certain version/fork of MySQL. This fix should work with all sane MySQL versions.
