### PR TITLE
Force utf8mb4 query to throw exception as the check expects

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -939,6 +939,8 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       return $messages;
     }
 
+    // Force utf8mb4 query to throw exception as the check expects.
+    $errorScope = CRM_Core_TemporaryErrorScope::useException();
     try {
       // Create a temporary table to avoid implicit commit.
       CRM_Core_DAO::executeQuery('CREATE TEMPORARY TABLE civicrm_utf8mb4_test (id VARCHAR(255), PRIMARY KEY(id(255))) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC ENGINE=INNODB');


### PR DESCRIPTION
Fixes dev/core#749

Overview
----------------------------------------
The utf8mb4 compatibility check should throw and catch an exception, but instead is throwing a fatal error.

Before
----------------------------------------
See bug report at https://lab.civicrm.org/dev/core/issues/749

After
----------------------------------------
Hopefully it will now throw an exception? But needs testing.