### PR TITLE
Call Payment.create from payment.cancel

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3339,6 +3339,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'net_amount' => CRM_Utils_Array::value('net_amount', $params, $totalAmount),
         'currency' => $params['contribution']->currency,
         'trxn_id' => $params['contribution']->trxn_id,
+        // @todo - this is getting the status id from the contribution - that is BAD - ie the contribution could be partially
+        // paid but each payment is completed. The work around is to pass in the status_id in the trxn_params but
+        // this should really default to completed (after discussion).
         'status_id' => $statusId,
         'payment_instrument_id' => CRM_Utils_Array::value('payment_instrument_id', $params, $params['contribution']->payment_instrument_id),
         'check_number' => CRM_Utils_Array::value('check_number', $params),
@@ -3893,6 +3896,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $financialTrxn = CRM_Financial_BAO_Payment::recordPayment($contributionId, $trxnsData, $participantId);
     }
     elseif ($paymentType == 'refund') {
+      $trxnsData['total_amount'] = -$trxnsData['total_amount'];
       $financialTrxn = CRM_Financial_BAO_Payment::recordRefundPayment($contributionId, $trxnsData, $updateStatus);
       if ($participantId) {
         // update participant status

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -104,15 +104,20 @@ function civicrm_api3_payment_cancel(&$params) {
     'financial_trxn_id' => $params['id'],
   ];
   $entity = civicrm_api3('EntityFinancialTrxn', 'getsingle', $eftParams);
-  $contributionId = $entity['entity_id'];
-  $params['total_amount'] = $entity['amount'];
-  unset($params['id']);
 
-  $trxn = CRM_Contribute_BAO_Contribution::recordAdditionalPayment($contributionId, $params, 'refund', NULL, FALSE);
+  $paymentParams = [
+    'total_amount' => -$entity['amount'],
+    'contribution_id' => $entity['entity_id'],
+    'trxn_date' => CRM_Utils_Array::value('trxn_date', $params, 'now'),
+  ];
 
-  $values = [];
-  _civicrm_api3_object_to_array_unique_fields($trxn, $values[$trxn->id]);
-  return civicrm_api3_create_success($values, $params, 'Payment', 'cancel', $trxn);
+  foreach (['trxn_id', 'payment_instrument_id'] as $permittedParam) {
+    if (isset($params[$permittedParam])) {
+      $paymentParams[$permittedParam] = $params[$permittedParam];
+    }
+  }
+  $result = civicrm_api3('Payment', 'create', $paymentParams);
+  return civicrm_api3_create_success($result['values'], $params, 'Payment', 'cancel');
 }
 
 /**
@@ -168,6 +173,10 @@ function _civicrm_api3_payment_create_spec(&$params) {
       'title' => 'Payment ID',
       'type' => CRM_Utils_Type::T_INT,
       'api.aliases' => ['payment_id'],
+    ],
+    'trxn_date' => [
+      'title' => 'Cancel Date',
+      'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
     ],
   ];
 }
@@ -232,6 +241,10 @@ function _civicrm_api3_payment_cancel_spec(&$params) {
       'title' => 'Payment ID',
       'type' => CRM_Utils_Type::T_INT,
       'api.aliases' => ['payment_id'],
+    ],
+    'trxn_date' => [
+      'title' => 'Cancel Date',
+      'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
     ],
   ];
 }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -204,7 +204,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'from_financial_account_id' => 7,
       'to_financial_account_id' => 6,
       'total_amount' => -30,
-      'status_id' => 1,
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'status_id', 'Refunded'),
       'is_payment' => 1,
     ];
     foreach ($expected as $key => $value) {
@@ -317,7 +317,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    */
   public function checkPaymentResult($payment, $expectedResult) {
     foreach ($expectedResult[$payment['id']] as $key => $value) {
-      $this->assertEquals($payment['values'][$payment['id']][$key], $value);
+      $this->assertEquals($payment['values'][$payment['id']][$key], $value, 'mismatch on ' . $key);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Code rationalisation Update Payment.cancel api to call Payment.create.

This includes adding handling to Payment.create for negative amounts (this handling was previously 'distributed' across the code base.

Before
----------------------------------------
Bespoke function called

After
----------------------------------------
std api called

Technical Details
----------------------------------------
@monishdeb I feel like if we can get this working then we'll have solved the blockers on the form without the risk - + we'll have only one place where the function is called.

Comments
----------------------------------------

