### PR TITLE
CRM/Event - Fix participant note search parameter being ignored

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -187,10 +187,10 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
 
       //participant note
       if (!empty($query->_returnProperties['participant_note'])) {
-        $query->_select['participant_note'] = "civicrm_note.note as participant_note";
+        $query->_select['participant_note'] = "participant_note.note as participant_note";
         $query->_element['participant_note'] = 1;
         $query->_tables['participant_note'] = 1;
-        $query->_whereTables['civicrm_note'] = 1;
+        $query->_whereTables['participant_note'] = 1;
       }
 
       if (!empty($query->_returnProperties['participant_is_pay_later'])) {
@@ -465,6 +465,13 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Event', $name, $value, $op, array('check_permission' => $checkPermission));
         $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$qillName]['title'], 2 => $op, 3 => $value));
         return;
+
+      case 'participant_note':
+        $query->_tables['civicrm_participant'] = $query->_whereTables['civicrm_participant'] = 1;
+        $query->_tables['participant_note'] = $query->_whereTables['participant_note'] = 1;
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause('participant_note.note', $op, $value, 'String');
+        $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$name]['title'], 2 => $op, 3 => $value));
+        break;
     }
   }
 
@@ -493,8 +500,8 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         break;
 
       case 'participant_note':
-        $from .= " $side JOIN civicrm_note ON ( civicrm_note.entity_table = 'civicrm_participant' AND
-                                                        civicrm_participant.id = civicrm_note.entity_id )";
+        $from .= " $side JOIN civicrm_note participant_note ON ( participant_note.entity_table = 'civicrm_participant' AND
+                                                        civicrm_participant.id = participant_note.entity_id )";
         break;
 
       case 'participant_status':

--- a/tests/phpunit/CRM/Event/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Event/BAO/QueryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Event_BAO_QueryTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function testParticipantNote() {
+    $event = $this->eventCreate();
+    $this->individualCreate([
+      'api.participant.create' => [
+        'event_id' => $event['id'],
+        'note'     => 'some_note',
+      ]
+    ]);
+    $this->individualCreate([
+      'api.participant.create' => [
+        'event_id' => $event['id'],
+        'note'     => 'some_other_note',
+      ]
+    ]);
+    $params = [
+      [
+        0 => 'participant_note',
+        1 => '=',
+        2 => 'some_note',
+        3 => 1,
+        4 => 0,
+      ]
+    ];
+
+    $query = new CRM_Contact_BAO_Query($params, NULL, NULL, FALSE, FALSE, CRM_Contact_BAO_Query::MODE_CONTACTS);
+    $sql = $query->query(FALSE);
+    $result = CRM_Core_DAO::executeQuery(implode(' ', $sql));
+    $this->assertEquals(1, $result->N);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug that prevents "Participant Note" search criteria from being applied.

Before
----------------------------------------
When the "Participant Note" field is used in Search Builder, the filter is not actually applied, instead returning all contacts matching the other criteria (if any were provided).

![Screenshot 2019-03-22 11 57 53](https://user-images.githubusercontent.com/336308/54790118-e3f98a80-4c99-11e9-82ca-930866c212ae.png)

After
----------------------------------------
"Participant Note" is used to filter results.

![Screenshot 2019-03-22 11 58 56](https://user-images.githubusercontent.com/336308/54790127-ec51c580-4c99-11e9-8ab2-b2d355382f32.png)
