### PR TITLE
Add payment_processor column/filter to recurring contribution report

### DIFF
--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -179,6 +179,9 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
           'failure_retry_date' => array(
             'title' => ts('Failure Retry Date'),
           ),
+          'payment_processor_id' => array(
+            'title' => ts('Payment Processor'),
+          ),
         ),
         'filters' => array(
           'contribution_status_id' => array(
@@ -244,6 +247,13 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
             'description' => "does this work?",
             'operatorType' => CRM_Report_Form::OP_DATE,
             'pseudofield' => TRUE,
+          ),
+          'payment_processor_id' => array(
+            'title' => ts('Payment Processor'),
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => CRM_Contribute_BAO_ContributionRecur::buildOptions('payment_processor_id', 'get'),
+            'default' => NULL,
+            'type' => CRM_Utils_Type::T_INT,
           ),
         ),
       ),
@@ -389,6 +399,10 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
 
       if (!empty($row['civicrm_financial_trxn_card_type_id'])) {
         $rows[$rowNum]['civicrm_financial_trxn_card_type_id'] = $this->getLabels($row['civicrm_financial_trxn_card_type_id'], 'CRM_Financial_DAO_FinancialTrxn', 'card_type_id');
+      }
+
+      if (!empty($row['civicrm_contribution_recur_payment_processor_id'])) {
+        $rows[$rowNum]['civicrm_contribution_recur_payment_processor_id'] = $this->getLabels($row['civicrm_contribution_recur_payment_processor_id'], 'CRM_Contribute_BAO_ContributionRecur', 'payment_processor_id');
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Add payment_processor column/filter to the recurring contribution report.  Previously it was *extremely* difficult to get this data out via search/report if you want to target a specific payment processor.

Accessible via https://example.org/civicrm/report/contribute/recur?reset=1

Before
----------------------------------------
Difficult to get this data out via search/report if you want to target a specific payment processor.

After
----------------------------------------
Easy to get this data out via search/report if you want to target a specific payment processor.

![Screenshot 2019-04-05 11 54 21](https://user-images.githubusercontent.com/336308/55593760-9866d680-5799-11e9-96d1-0cf9d19486fb.png)


Technical Details
----------------------------------------
ContributionRecur entity is already available so we just expose another field and use a pseudoconstant to get the list of payment processors/format them for display.

Comments
----------------------------------------
@bhahumanists I think you might find this useful? Would you be able to test/review?
