### PR TITLE
Migrate date field to datepicker on ChangeCaseType form

### DIFF
--- a/CRM/Case/Form/Activity/ChangeCaseType.php
+++ b/CRM/Case/Form/Activity/ChangeCaseType.php
@@ -61,8 +61,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
 
     $defaults['is_reset_timeline'] = 1;
 
-    $defaults['reset_date_time'] = array();
-    list($defaults['reset_date_time'], $defaults['reset_date_time_time']) = CRM_Utils_Date::setDateDefaults(NULL, 'activityDateTime');
+    $defaults['reset_date_time'] = date('Y-m-d H:i:s');
     $defaults['case_type_id'] = $form->_caseTypeId;
 
     return $defaults;
@@ -88,8 +87,8 @@ class CRM_Case_Form_Activity_ChangeCaseType {
     $form->addField('case_type_id', array('context' => 'create', 'entity' => 'Case'));
 
     // timeline
-    $form->addYesNo('is_reset_timeline', ts('Reset Case Timeline?'), NULL, TRUE, array('onclick' => "return showHideByValue('is_reset_timeline','','resetTimeline','table-row','radio',false);"));
-    $form->addDateTime('reset_date_time', ts('Reset Start Date'), FALSE, array('formatType' => 'activityDateTime'));
+    $form->addYesNo('is_reset_timeline', ts('Reset Case Timeline?'), NULL, TRUE);
+    $form->add('datepicker', 'reset_date_time', ts('Reset Start Date'), NULL, FALSE, ['allowClear' => FALSE]);
   }
 
   /**
@@ -122,10 +121,6 @@ class CRM_Case_Form_Activity_ChangeCaseType {
 
     if (CRM_Utils_Array::value('is_reset_timeline', $params) == 0) {
       unset($params['reset_date_time']);
-    }
-    else {
-      // store the date with proper format
-      $params['reset_date_time'] = CRM_Utils_Date::processDate($params['reset_date_time'], $params['reset_date_time_time']);
     }
   }
 

--- a/templates/CRM/Case/Form/Activity/ChangeCaseType.tpl
+++ b/templates/CRM/Case/Form/Activity/ChangeCaseType.tpl
@@ -33,17 +33,18 @@
   <td class="label">{$form.is_reset_timeline.label}</td>
   <td>{$form.is_reset_timeline.html}</td>
     </tr>
-    <tr class="crm-case-changecasetype-form-block-reset_date_time" id="resetTimeline">
-        <td class="label">{$form.reset_date_time.label}</td>
-        <td>{include file="CRM/common/jcalendar.tpl" elementName=reset_date_time}</td>
+    <tr class="crm-case-changecasetype-form-block-reset_date_time">
+        <td class="label">{$form.reset_date_time.label} <span class="crm-marker">*</span></td>
+        <td>{$form.reset_date_time.html}</td>
     </tr>
-
-{include file="CRM/common/showHideByFieldValue.tpl"
-trigger_field_id    ="is_reset_timeline"
-trigger_value       = true
-target_element_id   ="resetTimeline"
-target_element_type ="table-row"
-field_type          ="radio"
-invert              = 0
-}
   </div>
+{literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      var $form = $('form.{/literal}{$form.formClass}{literal}');
+      $('input[name=is_reset_timeline]', $form).click(function() {
+        $('.crm-case-changecasetype-form-block-reset_date_time').toggle($(this).val() === '1');
+      })
+    })
+  </script>
+{/literal}


### PR DESCRIPTION
Migrates a field to datepicker and updates some old code.

Note: this form seems somewhat broken. The "reset timeline" option doesn't appear to do anything. Neither does the date field have any effect on anything as far as I can tell. But in my testing it's no more broken after this patch than it was before.