### PR TITLE
Use temp table methods; provide TempTable::getCreateSql() method for debugging

### DIFF
--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -153,12 +153,10 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     $form->assign('taskName', CRM_Utils_Array::value($form->_task, $crmContactTaskTasks));
 
     if ($useTable) {
-      $form->_componentTable = CRM_Utils_SQL_TempTable::build()->setCategory('tskact')->setDurable()->setId($qfKey)->getName();
-      $sql = " DROP TABLE IF EXISTS {$form->_componentTable}";
-      CRM_Core_DAO::executeQuery($sql);
-
-      $sql = "CREATE TABLE {$form->_componentTable} ( contact_id int primary key) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci";
-      CRM_Core_DAO::executeQuery($sql);
+      $tempTable = CRM_Utils_SQL_TempTable::build()->setCategory('tskact')->setDurable()->setId($qfKey)->setUtf8();
+      $form->_componentTable = $tempTable->getName();
+      $tempTable->drop();
+      $tempTable->createWithColumns('contact_id int primary key');
     }
 
     // all contacts or action = save a search

--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -88,6 +88,8 @@ class CRM_Utils_SQL_TempTable {
 
   protected $memory;
 
+  protected $createSql;
+
   /**
    * @return CRM_Utils_SQL_TempTable
    */
@@ -138,6 +140,7 @@ class CRM_Utils_SQL_TempTable {
       ($selectQuery instanceof CRM_Utils_SQL_Select ? $selectQuery->toSQL() : $selectQuery)
     );
     CRM_Core_DAO::executeQuery($sql, array(), TRUE, NULL, TRUE, FALSE);
+    $this->createSql = $sql;
     return $this;
   }
 
@@ -157,6 +160,7 @@ class CRM_Utils_SQL_TempTable {
       $this->utf8 ? self::UTF8 : ''
     );
     CRM_Core_DAO::executeQuery($sql, array(), TRUE, NULL, TRUE, FALSE);
+    $this->createSql = $sql;
     return $this;
   }
 
@@ -206,6 +210,13 @@ class CRM_Utils_SQL_TempTable {
    */
   public function getId() {
     return $this->id;
+  }
+
+  /**
+   * @return string|NULL
+   */
+  public function getCreateSql() {
+    return $this->createSql;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Use TempTable methods to create some more temp tables; add TempTable::getCreateSql() method for debugging purposes.

Before
----------------------------------------
Temp tables are created via SQL statements.

After
----------------------------------------
TempTable methods are used instead; a new method allows developers to print the automatically generated create statement.