### PR TITLE
[TEST FIX] Increase uniqueness in testSingleNowDates

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -53,8 +53,8 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
    * Test works but not both due to some form of caching going on in the SmartySingleton
    */
   public function testCreateSingleNowDated() {
-    $firstName = 'John_' . substr(sha1(rand()), 0, 7);
-    $lastName = 'Smith_' . substr(sha1(rand()), 0, 7);
+    $firstName = 'John_' . substr(sha1(rand()), 0, 7)  . uniqid();
+    $lastName = 'Smith_' . substr(sha1(rand()), 0, 7) . uniqid();
     $nameParams = array('first_name' => $firstName, 'last_name' => $lastName);
     $contactId = $this->individualCreate($nameParams);
 
@@ -145,7 +145,7 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
       'first_name' => $firstName,
       'middle_name' => '',
       'last_name' => $lastName,
-      'street_address' => '8 Hobbiton Road',
+      'street_address' => '8 Hobbiton Road' . uniqid(),
       'city' => 'The Shire',
       'state_province' => 'IL',
       'postal_code' => 5010,


### PR DESCRIPTION
Overview
----------------------------------------
Test fix - reduce number of false fails on testCreateSingleNowDated test

Before
----------------------------------------
More susceptible to false fail

After
----------------------------------------
Less susceptible

Technical Details
----------------------------------------
Reduce instances of
AuthorizeNet failed for unknown reason.E00012: You have submitted a duplicate of Subscription 5642898. A duplicate subscription will not be created

By increasing uniqueness of our parameters we reduce the risk of duplicating previous instances - over the lifetime of the test account with a.net

Comments
----------------------------------------

