### PR TITLE
Membership end_date is not correctly set with 2 or more initial membership terms

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -483,7 +483,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       if (!empty($qty)) {
         $membershipTerms = $qty;
       }
-      else if(empty($numTerms)) {
+      elseif (empty($numTerms)) {
         $membershipTerms = $numTerms;
       }
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -483,7 +483,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       if (!empty($qty)) {
         $membershipTerms = $qty;
       }
-      elseif (empty($numTerms)) {
+      elseif (!empty($numTerms)) {
         $membershipTerms = $numTerms;
       }
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -467,14 +467,29 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    * @return int
    */
   public function getNumTermsByContributionAndMembershipType($membershipTypeID, $contributionID) {
-    $numTerms = CRM_Core_DAO::singleValueQuery("
-      SELECT membership_num_terms FROM civicrm_line_item li
+    $termsDAO = CRM_Core_DAO::executeQuery("
+      SELECT membership_num_terms, qty FROM civicrm_line_item li
       LEFT JOIN civicrm_price_field_value v ON li.price_field_value_id = v.id
       WHERE contribution_id = %1 AND membership_type_id = %2",
       array(1 => array($contributionID, 'Integer'), 2 => array($membershipTypeID, 'Integer'))
     );
+
+    $membershipTerms = 1;
+
+    while ($termsDAO->fetch()) {
+      $qty = $termsDAO->qty;
+      $numTerms = $termsDAO->membership_num_terms;
+
+      if (!empty($qty)) {
+        $membershipTerms = $qty;
+      }
+      else if(empty($numTerms)) {
+        $membershipTerms = $numTerms;
+      }
+    }
+
     // default of 1 is precautionary
-    return empty($numTerms) ? 1 : $numTerms;
+    return $membershipTerms;
   }
 
   /**

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -379,7 +379,7 @@ WHERE li.contribution_id = %1";
         'auto_renew' => CRM_Utils_Array::value('auto_renew', $options[$oid]),
         'html_type' => $fields['html_type'],
         'financial_type_id' => CRM_Utils_Array::value('financial_type_id', $options[$oid]),
-        'tax_amount' => CRM_Utils_Array::value('tax_amount', $options[$oid]),
+        'tax_amount' => (CRM_Utils_Array::value('tax_amount', $options[$oid]) * $qty),
         'non_deductible_amount' => CRM_Utils_Array::value('non_deductible_amount', $options[$oid]),
       );
 

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -360,6 +360,7 @@ WHERE li.contribution_id = %1";
 
     foreach ($params["price_{$fid}"] as $oid => $qty) {
       $price = $amount_override === NULL ? $options[$oid]['amount'] : $amount_override;
+      $lineTotal = $amount_override === NULL ? ($price * $qty) : $price;
 
       $participantsPerField = CRM_Utils_Array::value('count', $options[$oid], 0);
 
@@ -371,7 +372,7 @@ WHERE li.contribution_id = %1";
         'description' => CRM_Utils_Array::value('description', $options[$oid]),
         'qty' => $qty,
         'unit_price' => $price,
-        'line_total' => $qty * $price,
+        'line_total' => $lineTotal,
         'participant_count' => $qty * $participantsPerField,
         'max_value' => CRM_Utils_Array::value('max_value', $options[$oid]),
         'membership_type_id' => CRM_Utils_Array::value('membership_type_id', $options[$oid]),
@@ -379,7 +380,7 @@ WHERE li.contribution_id = %1";
         'auto_renew' => CRM_Utils_Array::value('auto_renew', $options[$oid]),
         'html_type' => $fields['html_type'],
         'financial_type_id' => CRM_Utils_Array::value('financial_type_id', $options[$oid]),
-        'tax_amount' => (CRM_Utils_Array::value('tax_amount', $options[$oid]) * $qty),
+        'tax_amount' => (CRM_Utils_Array::value('tax_amount', $options[$oid])),
         'non_deductible_amount' => CRM_Utils_Array::value('non_deductible_amount', $options[$oid]),
       );
 

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -753,9 +753,6 @@ WHERE  id = %1";
             break;
           }
           $terms = self::getMembershipTerms($params);
-          if ($amount_override == $params['total_amount']) {
-            $amount_override = NULL;
-          }
           $params["price_{$id}"] = array($params["price_{$id}"] => $terms);
           $optionValueId = CRM_Utils_Array::key($terms, $params["price_{$id}"]);
 
@@ -780,7 +777,7 @@ WHERE  id = %1";
 
         case 'Select':
           $terms = self::getMembershipTerms($params);
-          if ($amount_override == $params['total_amount']) {
+          if (isset($params['total_amount']) && ($amount_override == $params['total_amount'])) {
             $amount_override = NULL;
           }
           $params["price_{$id}"] = array($params["price_{$id}"] => $terms);
@@ -1623,12 +1620,7 @@ WHERE       ps.id = %1
    */
   public static function setLineItem($field, $lineItem, $optionValueId, &$totalTax) {
     // Here we round - i.e. after multiplying by quantity
-    if ($field['html_type'] == 'Text') {
-      $taxAmount = round($field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'], 2);
-    }
-    else {
-      $taxAmount = round($field['options'][$optionValueId]['tax_amount'], 2);
-    }
+    $taxAmount = round($field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'], 2);
     $taxRate = $field['options'][$optionValueId]['tax_rate'];
     $lineItem[$optionValueId]['tax_amount'] = $taxAmount;
     $lineItem[$optionValueId]['tax_rate'] = $taxRate;

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -757,7 +757,7 @@ WHERE  id = %1";
             $amount_override = NULL;
           }
           $params["price_{$id}"] = array($params["price_{$id}"] => $terms);
-          $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
+          $optionValueId = CRM_Utils_Array::key($terms, $params["price_{$id}"]);
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, $amount_override);
           if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
@@ -784,7 +784,7 @@ WHERE  id = %1";
             $amount_override = NULL;
           }
           $params["price_{$id}"] = array($params["price_{$id}"] => $terms);
-          $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
+          $optionValueId = CRM_Utils_Array::key($terms, $params["price_{$id}"]);
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, $amount_override);
           if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -668,6 +668,19 @@ WHERE  id = %1";
   }
 
   /**
+   * Get number of membership terms from Params.
+   * @param $params
+   * @return int
+   */
+  private static function getMembershipTerms($params) {
+    $numTerms = 1;
+    if (isset($params['num_terms'])) {
+      $numTerms = $params['num_terms'];
+    }
+    return $numTerms;
+  }
+
+  /**
    * Get line item purchase information.
    *
    * This function takes the input parameters and interprets out of it what has been purchased.
@@ -739,7 +752,11 @@ WHERE  id = %1";
           if ($params["price_{$id}"] <= 0) {
             break;
           }
-          $params["price_{$id}"] = array($params["price_{$id}"] => 1);
+          $terms = self::getMembershipTerms($params);
+          if ($amount_override == $params['total_amount']) {
+            $amount_override = NULL;
+          }
+          $params["price_{$id}"] = array($params["price_{$id}"] => $terms);
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, $amount_override);
@@ -762,10 +779,14 @@ WHERE  id = %1";
           break;
 
         case 'Select':
-          $params["price_{$id}"] = array($params["price_{$id}"] => 1);
+          $terms = self::getMembershipTerms($params);
+          if ($amount_override == $params['total_amount']) {
+            $amount_override = NULL;
+          }
+          $params["price_{$id}"] = array($params["price_{$id}"] => $terms);
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
 
-          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, CRM_Utils_Array::value('partial_payment_total', $params));
+          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, $amount_override);
           if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
             $lineItem = self::setLineItem($field, $lineItem, $optionValueId, $totalTax);
           }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -450,6 +450,91 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that membership end_date is correct for multiple terms for pending contribution
+   * @throws CiviCRM_API3_Exception
+   */
+  public function testCreatePendingWithMultipleTerms() {
+    CRM_Core_Session::singleton()->getStatus(TRUE);
+    $form = $this->getForm();
+    $form->preProcess();
+    $this->mut = new CiviMailUtils($this, TRUE);
+    $this->createLoggedInUser();
+
+    $membershipTypeAnnualRolling = $this->callAPISuccess('membership_type', 'create', array(
+      'domain_id' => 1,
+      'name' => "AnnualRollingNew",
+      'member_of_contact_id' => 23,
+      'duration_unit' => "year",
+      'minimum_fee' => 50,
+      'duration_interval' => 1,
+      'period_type' => "rolling",
+      'relationship_type_id' => 20,
+      'relationship_direction' => 'b_a',
+      'financial_type_id' => 2,
+    ));
+
+    $params = array(
+      'cid'                    => $this->_individualId,
+      'join_date'              => date('Y-m-d'),
+      'start_date'             => '',
+      'end_date'               => '',
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
+      'membership_type_id'     => array(23, $membershipTypeAnnualRolling['id']),
+      'max_related'            => '',
+      'num_terms'              => '3',
+      'record_contribution'    => 1,
+      'source'                 => '',
+      'total_amount'           => $this->formatMoneyInput(150.00),
+      'financial_type_id'      => '2',
+      'soft_credit_type_id'    => '11',
+      'soft_credit_contact_id' => '',
+      'from_email_address'     => '"Demonstrators Anonymous" <info@example.org>',
+      'receipt_text'           => '',
+    );
+
+    $form->_contactID = $this->_individualId;
+    $form->testSubmit($params);
+
+    $membership = $this->callAPISuccessGetSingle('Membership', array('contact_id' => $this->_individualId));
+    $contribution = $this->callAPISuccess('Contribution', 'get', array(
+      'contact_id' => $this->_individualId,
+    ));
+
+    $endDate = (new DateTime(date('Y-m-d')))->modify("+3 years")->modify("-1 day");
+    $endDate = $endDate->format("Y-m-d");
+
+    $this->assertEquals($endDate, $membership['end_date'], 'Membership end date should be ' . $endDate);
+    $this->assertEquals(1, count($contribution['values']), 'Pending contribution should be created.');
+
+    $contribution = $contribution['values'][$contribution['id']];
+
+    $additionalPaymentForm = new CRM_Contribute_Form_AdditionalPayment();
+    $additionalPaymentForm->testSubmit(array(
+      'total_amount'          => 150.00,
+      'trxn_date'             => date("Y-m-d H:i:s"),
+      'payment_instrument_id' => array_search('Check', $this->paymentInstruments),
+      'check_number'          => 'check-12345',
+      'trxn_id'               => '',
+      'currency'              => 'USD',
+      'fee_amount'            => '',
+      'financial_type_id'     => 1,
+      'net_amount'            => '',
+      'payment_processor_id'  => 0,
+      'contact_id'            => $this->_individualId,
+      'contribution_id'       => $contribution['id'],
+    ));
+
+    $membership = $this->callAPISuccessGetSingle('Membership', array('contact_id' => $this->_individualId));
+    $contribution = $this->callAPISuccess('Contribution', 'get', array(
+      'contact_id' => $this->_individualId,
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+    ));
+
+    $this->assertEquals($endDate, $membership['end_date'], 'Membership end date should be same (' . $endDate . ') after payment');
+    $this->assertEquals(1, count($contribution['values']), 'Completed contribution should be fetched.');
+  }
+
+  /**
    * Test the submit function of the membership form.
    *
    * @param string $thousandSeparator

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3236,7 +3236,11 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->setUpPendingContribution($this->_ids['price_field_value'][1]);
     $this->callAPISuccess('contribution', 'completetransaction', array('id' => $this->_ids['contribution']));
     $membership = $this->callAPISuccess('membership', 'getsingle', array('id' => $this->_ids['membership']));
-    $this->assertEquals(date('Y-m-d', strtotime('yesterday + 2 years')), $membership['end_date']);
+
+    $membershipEndDate = new DateTime(date("Y-m-d", strtotime($membership['start_date'])));
+    $membershipEndDate->modify("+2 years")->format("-1 day");
+
+    $this->assertEquals($membershipEndDate->format("Y-m-d"), $membership['end_date']);
     $this->cleanUpAfterPriceSets();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When we create a Membership with 2 or more initial membership terms. The initial membership end date is set correctly in CiviCRM.

However, if the related Contribution has a status of Pending, when this Contribution status is changed to Completed then the membership end date is re-calculated and using the default term, causing the end date to change.

Put simply, when user sign up with pay later option for a 3 year membership. When the payment is received this membership is then changed to 1 year when Contribution is marked as Completed.

Before - Steps to Reproduce
----------------------------------------
1. Open a Contact Page
2. Go to Membership > Create a Membership with 2 or more terms with Contribution status of Pending.
3. Verify above steps created one pending membership and one pending contribution.
4. Go to Contributions tab > Click Record Payment of latest pending contribution
5. Record all the due payment
6. Go to Memberships tab
7. Membership is active but end_date is not correct. end_date is calculated for 1 term only.

After
----------------------------------------
On Step 7 Membership end_date is set according to the selected number of terms.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-1148_
