### PR TITLE
Viewing Contact Note comments is broken in 5.10.4.

### DIFF
--- a/templates/CRM/Contact/Page/View/Note.tpl
+++ b/templates/CRM/Contact/Page/View/Note.tpl
@@ -116,13 +116,13 @@
 
     function showHideComments( noteId ) {
 
-        elRow = cj('tr#cnote_'+ noteId)
+        elRow = cj('tr#Note-'+ noteId)
 
         if (elRow.hasClass('view-comments')) {
             cj('tr.note-comment_'+ noteId).remove()
-            commentRows['cnote_'+ noteId] = {};
-            cj('tr#cnote_'+ noteId +' span.icon_comments_show').show();
-            cj('tr#cnote_'+ noteId +' span.icon_comments_hide').hide();
+            commentRows['Note-'+ noteId] = {};
+            cj('tr#Note-'+ noteId +' span.icon_comments_show').show();
+            cj('tr#Note-'+ noteId +' span.icon_comments_hide').hide();
             elRow.removeClass('view-comments');
         } else {
             var getUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0}"{literal};
@@ -135,7 +135,7 @@
         var urlTemplate = '{/literal}{crmURL p='civicrm/contact/view' q="reset=1&cid=" h=0 }{literal}'
         if (response['values'][0] && response['values'][0].entity_id) {
             var noteId = response['values'][0].entity_id
-            var row = cj('tr#cnote_'+ noteId);
+            var row = cj('tr#Note-'+ noteId);
 
             row.addClass('view-comments');
 
@@ -145,20 +145,20 @@
                 var rowClassOddEven = 'even'
             }
 
-            if ( commentRows['cnote_'+ noteId] ) {
-                for ( var i in commentRows['cnote_'+ noteId] ) {
+            if ( commentRows['Note-'+ noteId] ) {
+                for ( var i in commentRows['Note-'+ noteId] ) {
                     return false;
                 }
             } else {
-                commentRows['cnote_'+ noteId] = {};
+                commentRows['Note-'+ noteId] = {};
             }
             for (i in response['values']) {
                 if ( response['values'][i].id ) {
-                    if ( commentRows['cnote_'+ noteId] &&
-                        commentRows['cnote_'+ noteId][response['values'][i].id] ) {
+                    if ( commentRows['Note-'+ noteId] &&
+                        commentRows['Note-'+ noteId][response['values'][i].id] ) {
                         continue;
                     }
-                    str = '<tr id="cnote_'+ response['values'][i].id +'" class="'+ rowClassOddEven +' note-comment_'+ noteId +'">'
+                    str = '<tr id="Note-'+ response['values'][i].id +'" class="'+ rowClassOddEven +' note-comment_'+ noteId +'">'
                         + '<td></td>'
                         + '<td style="padding-left: 2em">'
                         + response['values'][i].note
@@ -172,13 +172,13 @@
                         + response['values'][i].attachment
                         + '</td><td>'+ commentAction.replace(/{cid}/g, response['values'][i].createdById).replace(/{id}/g, response['values'][i].id) +'</td></tr>'
 
-                    commentRows['cnote_'+ noteId][response['values'][i].id] = str;
+                    commentRows['Note-'+ noteId][response['values'][i].id] = str;
                 }
             }
-            drawCommentRows('cnote_'+ noteId);
+            drawCommentRows('Note-'+ noteId);
 
-            cj('tr#cnote_'+ noteId +' span.icon_comments_show').hide();
-            cj('tr#cnote_'+ noteId +' span.icon_comments_hide').show();
+            cj('tr#Note-'+ noteId +' span.icon_comments_show').hide();
+            cj('tr#Note-'+ noteId +' span.icon_comments_hide').show();
         } else {
             CRM.alert('{/literal}{ts escape="js"}There are no comments for this note{/ts}{literal}', '{/literal}{ts escape="js"}None Found{/ts}{literal}', 'alert');
         }
@@ -190,7 +190,7 @@
         row = cj('tr#'+ rowId)
         for (i in commentRows[rowId]) {
             row.after(commentRows[rowId][i]);
-            row = cj('tr#cnote_'+ i);
+            row = cj('tr#Note-'+ i);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When I look at the Notes tab on a Contact record I see a caret next to Notes that have Comments. On earlier versions of CiviCRM, clicking that icon 'opened' or 'closed' the comments. 

Before
----------------------------------------
In version 5.10.4 clicking this icon does nothing.
![before](https://user-images.githubusercontent.com/3735621/53427986-f3c1de00-3a0f-11e9-97f9-c6a79e82a49e.gif)


After
----------------------------------------
With this commit the comments 'open' and 'close' again.
![after](https://user-images.githubusercontent.com/3735621/53428023-05a38100-3a10-11e9-971f-6335a08dbb3a.gif)


Technical Details
----------------------------------------
Updated the Javascript to use "Note-NNNNN" rather than "cnote_NNNN" as the ID of Note rows.
Completes change started in commit 57abcbbf5cf85b1266377e0ad9af4fb5865d5bc0


Comments
----------------------------------------
Thanks @kenwest for submitting the fix.