### PR TITLE
dev/core#756 - CRM/Contribute - Fix multi-currency soft credit summary

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -253,15 +253,14 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
 
     $cs = CRM_Core_DAO::executeQuery($query, $params);
 
-    $count = 0;
+    $count = $countCancelled = 0;
     $amount = $average = $cancelAmount = array();
 
     while ($cs->fetch()) {
       if ($cs->amount > 0) {
         $count++;
-        $amount[] = $cs->amount;
-        $average[] = $cs->average;
-        $currency[] = $cs->currency;
+        $amount[] = CRM_Utils_Money::format($cs->amount, $cs->currency);
+        $average[] = CRM_Utils_Money::format($cs->average, $cs->currency);
       }
     }
 
@@ -271,16 +270,17 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     $cancelAmountSQL  = CRM_Core_DAO::executeQuery($query, $params);
     while ($cancelAmountSQL->fetch()) {
       if ($cancelAmountSQL->amount > 0) {
-        $count++;
-        $cancelAmount[] = $cancelAmountSQL->amount;
+        $countCancelled++;
+        $cancelAmount[] = CRM_Utils_Money::format($cancelAmountSQL->amount, $cancelAmountSQL->currency);
       }
     }
 
-    if ($count > 0) {
+    if ($count > 0 || $countCancelled > 0) {
       return array(
+        $count,
+        $countCancelled,
         implode(',&nbsp;', $amount),
         implode(',&nbsp;', $average),
-        implode(',&nbsp;', $currency),
         implode(',&nbsp;', $cancelAmount),
       );
     }

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -153,10 +153,11 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     if (!empty($softCreditList)) {
       $softCreditTotals = array();
 
-      list($softCreditTotals['amount'],
+      list($softCreditTotals['count'],
+        $softCreditTotals['cancel']['count'],
+        $softCreditTotals['amount'],
         $softCreditTotals['avg'],
-        $softCreditTotals['currency'],
-        $softCreditTotals['cancelAmount'] // to get cancel amount
+        $softCreditTotals['cancel']['amount'] // to get cancel amount
         ) = CRM_Contribute_BAO_ContributionSoft::getSoftContributionTotals($this->_contactId, $isTest);
 
       $this->assign('softCredit', TRUE);

--- a/templates/CRM/Contribute/Page/ContributionSoftTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionSoftTotals.tpl
@@ -23,43 +23,15 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $softCreditRows}
-{strip}
-{if $context neq 'membership'}
-    <table class="form-layout-compressed">
-        {include file="CRM/Contribute/Page/ContributionSoftTotals.tpl"}
-    </table>
-    <p></p>
-{/if}
-<table class="crm-softcredit-selector crm-ajax-table">
-  <thead>
-    <tr>
-      <th data-data="contributor_name">{ts}Contributor{/ts}</th>
-      <th data-data="amount">{ts}Amount{/ts}</th>
-      <th data-data="sct_label">{ts}Type{/ts}</th>
-      <th data-data="financial_type">{ts}Financial Type{/ts}</th>
-      <th data-data="receive_date" class="sorting_desc">{ts}Received{/ts}</th>
-      <th data-data="contribution_status">{ts}Status{/ts}</th>
-      <th data-data="pcp_title">{ts}Personal Campaign Page?{/ts}</th>
-      <th data-data="links" data-orderable="false">&nbsp;</th>
-    </tr>
-  </thead>
-</table>
-{/strip}
-{/if}
+{* Display soft credit totals for a contact or search result-set *}
 
-{if !empty($membership_id) && $context eq 'membership'}
-  {assign var="entityID" value=$membership_id}
-{/if}
-
-{literal}
-<script type="text/javascript">
-  (function($) {
-    CRM.$('table.crm-softcredit-selector').data({
-      "ajax": {
-        "url": {/literal}'{crmURL p="civicrm/ajax/softcontributionlist" h=0 q="snippet=4&cid=`$contactId`&context=`$context`&entityID=`$entityID`&isTest=`$isTest`"}'{literal},
-      }
-    });
-  })(CRM.$);
-</script>
-{/literal}
+<tr>
+  {if $softCreditTotals.amount}
+    <th class="contriTotalLeft right">{ts}Total Soft Credit Amount{/ts} &ndash; {$softCreditTotals.amount}</th>
+    <th class="right"> &nbsp; {ts}# Completed Soft Credits{/ts} &ndash; {$softCreditTotals.count}</th>
+    <th class="right contriTotalRight"> &nbsp; {ts}Avg Soft Credit Amount{/ts} &ndash; {$softCreditTotals.avg}</th>
+  {/if}
+  {if $softCreditTotals.cancel.amount}
+    <th class="disabled right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$softCreditTotals.cancel.amount}</th>
+  {/if}
+</tr>

--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -61,11 +61,7 @@
           {/if}
       </tr>
       {if $contributionSummary.soft_credit.count}
-      <tr>
-        <th class="contriTotalLeft right">{ts}Total Soft Credit Amount{/ts} &ndash; {$contributionSummary.soft_credit.amount}</th>
-        <th class="right"> &nbsp; {ts}# Completed Soft Credits{/ts} &ndash; {$contributionSummary.soft_credit.count}</th>
-        <th class="right contriTotalRight"> &nbsp; {ts}Avg Soft Credit Amount{/ts} &ndash; {$contributionSummary.soft_credit.avg}</th>
-      </tr>
+        {include file="CRM/Contribute/Page/ContributionSoftTotals.tpl" softCreditTotals=$contributionSummary.soft_credit}
       {/if}
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
This attempts to fix the multi-currency soft credit bug reported in [dev/core#756](https://lab.civicrm.org/dev/core/issues/756) and some inconsistencies.

Before
----------------------------------------
Viewing the contribution tab of a contact with soft credits in multiple currencies causes an exception.

After
----------------------------------------
Soft credits with multiple currencies don't cause an exception and the soft credit summary is rendered more similar to the contribution summary.

Technical Details
----------------------------------------
This changes the return value signature of `CRM_Contribute_BAO_ContributionSoft::getSoftContributionTotals()`. Looks like it's only used by one method which I adapted, but I'm not sure what the approach to backwards-compatibility is for something like that. Could also go with new method + deprecation.
