### PR TITLE
WIP Refactor smartgroup query to simplify and improve performance

### DIFF
--- a/CRM/Utils/PagerAToZ.php
+++ b/CRM/Utils/PagerAToZ.php
@@ -113,7 +113,7 @@ class CRM_Utils_PagerAToZ {
 
     $dynamicAlphabets = array();
     while ($result->fetch()) {
-      $dynamicAlphabets[] = $result->sort_name;
+      $dynamicAlphabets[] = strtoupper($result->sort_name);
     }
     return $dynamicAlphabets;
   }


### PR DESCRIPTION
Overview
----------------------------------------
*Jenkins advice please?*

The actual queries being generated (that you sent over) are completely nuts! Tonnes of LEFT JOINS on the same table for the same information and the first, slowest, query is just to generate any extended characters for the alphabet pager across the top of the search results!

I've done two things:
1. Removed both "UPPER()" functions from the "alphabet" query (as that stops it using indexes) and moved that to the PHP level.
2. Refactored the query generation so it only adds a single LEFT JOIN for all the group contacts which are "Added". (TODO: I haven't touched the code which generates LEFT JOIN for group contacts which are "Removed" as they don't seem to use that on xx.org).

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
