### PR TITLE
dev/core#748 Refactor of groupcontact and ACL cache

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -236,20 +236,47 @@ AND    $operationClause
       }
     }
 
+    // grab a lock so other processes don't compete and do the same query
+    $lock = Civi::lockManager()->acquire("data.core.aclcontact.{$userID}");
+    if (!$lock->isAcquired()) {
+      // this can cause inconsistent results since we don't know if the other process
+      // will fill up the cache before our calling routine needs it.
+      // The default 3 second timeout should be enough for the other process to finish.
+      // However this routine does not return the status either, so basically
+      // its a "lets return and hope for the best"
+      return;
+    }
+
     $tables = array();
     $whereTables = array();
 
     $permission = CRM_ACL_API::whereClause($type, $tables, $whereTables, $userID, FALSE, FALSE, TRUE);
 
     $from = CRM_Contact_BAO_Query::fromClause($whereTables);
-    CRM_Core_DAO::executeQuery("
-INSERT INTO civicrm_acl_contact_cache ( user_id, contact_id, operation )
-SELECT DISTINCT $userID as user_id, contact_a.id as contact_id, '{$operation}' as operation
-         $from
-         LEFT JOIN civicrm_acl_contact_cache ac ON ac.user_id = $userID AND ac.contact_id = contact_a.id AND ac.operation = '{$operation}'
+
+    /* Ends up something like this:
+     * CREATE TEMPORARY TABLE civicrm_temp_acl_contact_cache1310 (SELECT DISTINCT 2960 as user_id, contact_a.id as contact_id, 'View' as operation
+     * FROM civicrm_contact contact_a  LEFT JOIN civicrm_group_contact_cache `civicrm_group_contact_cache-ACL` ON contact_a.id = `civicrm_group_contact_cache-ACL`.contact_id
+     * LEFT JOIN civicrm_acl_contact_cache ac ON ac.user_id = 2960 AND ac.contact_id = contact_a.id AND ac.operation = 'View'
+     * WHERE     ( `civicrm_group_contact_cache-ACL`.group_id IN (14, 25, 46, 47, 48, 49, 50, 51) )  AND (contact_a.is_deleted = 0)
+     * AND ac.user_id IS NULL
+     * --
+     * $sql = "SELECT DISTINCT $userID as user_id, contact_a.id as contact_id, '{$operation}' as operation
+     * $from
+     * LEFT JOIN civicrm_acl_contact_cache ac ON ac.user_id = $userID AND ac.contact_id = contact_a.id AND ac.operation = '{$operation}'
+     * WHERE    $permission
+     * AND ac.user_id IS NULL
+     */
+
+    $sql = "SELECT DISTINCT $userID as user_id, contact_a.id as contact_id, '{$operation}' as operation
+     $from
 WHERE    $permission
-AND ac.user_id IS NULL
-");
+";
+    $tempTable = 'civicrm_temp_acl_contact_cache' . rand(0, 2000);
+    $insertSql = "CREATE TEMPORARY TABLE $tempTable ($sql);";
+    CRM_Core_DAO::executeQuery($insertSql);
+    CRM_Core_DAO::executeQuery("INSERT IGNORE INTO civicrm_acl_contact_cache (user_id, contact_id, operation) SELECT user_id, contact_id, operation FROM $tempTable");
+    CRM_Core_DAO::executeQuery(" DROP TEMPORARY TABLE $tempTable");
 
     // Add in a row for the logged in contact. Do not try to combine with the above query or an ugly OR will appear in
     // the permission clause.
@@ -257,10 +284,11 @@ AND ac.user_id IS NULL
       ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact'))) {
       if (!CRM_Core_DAO::singleValueQuery("
         SELECT count(*) FROM civicrm_acl_contact_cache WHERE user_id = %1 AND contact_id = %1 AND operation = '{$operation}' LIMIT 1", $queryParams)) {
-        CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl_contact_cache ( user_id, contact_id, operation ) VALUES(%1, %1, '{$operation}')", $queryParams);
+        CRM_Core_DAO::executeQuery("INSERT IGNORE INTO civicrm_acl_contact_cache ( user_id, contact_id, operation ) VALUES(%1, %1, '{$operation}')", $queryParams);
       }
     }
     Civi::$statics[__CLASS__]['processed'][$type][$userID] = 1;
+    $lock->release();
   }
 
   /**

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -148,7 +148,16 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     list($numContactsAdded, $numContactsNotAdded)
       = self::bulkAddContactsToGroup($contactIds, $groupId, $method, $status, $tracking);
 
-    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
+    // Update group contact cache
+    $group = new CRM_Contact_BAO_Group();
+    $group->id = $groupId;
+    $group->find(TRUE);
+    CRM_Contact_BAO_GroupContactCache::load($group, TRUE);
+
+    // Update contact ACL cache
+    foreach ($contactIds as $contactId) {
+      CRM_ACL_BAO_Cache::updateEntry($contactId);
+    }
 
     CRM_Utils_Hook::post('create', 'GroupContact', $groupId, $contactIds);
 
@@ -242,7 +251,16 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
       }
     }
 
-    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
+    // Update group contact cache
+    $group = new CRM_Contact_BAO_Group();
+    $group->id = $groupId;
+    $group->find(TRUE);
+    CRM_Contact_BAO_GroupContactCache::load($group, TRUE);
+
+    // Update contact ACL cache
+    foreach ($contactIds as $contactId) {
+      CRM_ACL_BAO_Cache::updateEntry($contactId);
+    }
 
     CRM_Utils_Hook::post($op, 'GroupContact', $groupId, $contactIds);
 


### PR DESCRIPTION
Overview
----------------------------------------
* Partially rewrite group and acl contact caching via CRM/Contact/BAO/GroupContact.php, CRM/Contact/BAO/GroupContactCache.php, CRM/Contact/BAO/Contact/Permission.php to reduce mysql deadlocks.
* Add a lock to CRM_Contact_BAO_Contact_Permission when rebuilding cache for a single contact ID.
* Don't clear group contact cache dates until we've rebuilt it - that should stop the scheduled cache rebuild from trying to rebuild it at the same time.  

For some background see: https://issues.civicrm.org/jira/browse/CRM-18120

### Related PRs:
  * dev/core#748 Clean up transaction handling for CRM_Case_Form_Activity https://github.com/civicrm/civicrm-core/pull/13672


Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
