### PR TITLE
[minor cleanup] reduce params passed to searchQuery

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1028,8 +1028,8 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     }
     // For core searches use the searchQuery method
     else {
-      $sql = $this->_query->searchQuery($start, $end, $sort, FALSE, $this->_query->_includeContactIds,
-        FALSE, TRUE, TRUE);
+      $sql = $this->_query->getSearchSQL($start, $end, $sort, FALSE, $this->_query->_includeContactIds,
+        FALSE, TRUE);
     }
 
     // CRM-9096

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -99,10 +99,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
 
     $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
     try {
-      $resultDAO = $queryObj->searchQuery(0, 0, NULL,
-        FALSE, FALSE,
-        FALSE, FALSE,
-        FALSE);
+      $resultDAO = $queryObj->searchQuery();
       $this->assertTrue($resultDAO->fetch());
     }
     catch (PEAR_Exception $e) {
@@ -141,10 +138,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
 
     $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
     try {
-      $resultDAO = $queryObj->searchQuery(0, 0, NULL,
-        FALSE, FALSE,
-        FALSE, FALSE,
-        FALSE);
+      $resultDAO = $queryObj->searchQuery();
       $this->assertFalse($resultDAO->fetch());
     }
     catch (PEAR_Exception $e) {
@@ -189,10 +183,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
       );
 
       $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
-      $resultDAO = $queryObj->searchQuery(0, 0, NULL,
-        FALSE, FALSE,
-        FALSE, FALSE,
-        FALSE);
+      $resultDAO = $queryObj->searchQuery();
 
       if ($searchPrimary) {
         $this->assertEquals($resultDAO->N, 0);
@@ -247,10 +238,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
 
     $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
 
-    $resultDAO = $queryObj->searchQuery(0, 0, NULL,
-      FALSE, FALSE,
-      FALSE, FALSE,
-      FALSE);
+    $resultDAO = $queryObj->searchQuery();
     $resultDAO->fetch();
   }
 
@@ -282,10 +270,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $expectedSQL = "SELECT contact_a.id as contact_id, contact_a.contact_type as `contact_type`, contact_a.contact_sub_type as `contact_sub_type`, contact_a.sort_name as `sort_name`, civicrm_address.id as address_id, " . $selectClause . "  FROM civicrm_contact contact_a LEFT JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id AND civicrm_address.is_primary = 1 ) WHERE  (  ( " . $whereClause . " )  )  AND (contact_a.is_deleted = 0)    ORDER BY `contact_a`.`sort_name` ASC, `contact_a`.`id` ";
     $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
     try {
-      $this->assertEquals($expectedSQL, $queryObj->searchQuery(0, 0, NULL,
-        FALSE, FALSE,
-        FALSE, FALSE,
-        TRUE));
+      $this->assertEquals($expectedSQL, $queryObj->getSearchSQL());
       list($select, $from, $where, $having) = $queryObj->query();
       $dao = CRM_Core_DAO::executeQuery("$select $from $where $having");
       $dao->fetch();


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup

Before
----------------------------------------
less readable

After
----------------------------------------
more readable

Technical Details
----------------------------------------
Where we are retrieving the sql we can call the inner function rather than passing 'true'
in other cases we are passing default values through

in general passing lots of variables to searchQuery in order to tweak the results is a bad code smell - ideally we could have some more specific functions to call - getCount, getAlphabetQuery and with the ones which do weird stuff we'd call an extracted function that gets an array - so we don't get a sql query & then str_replace out the select clause & parts we don't want


Comments
----------------------------------------

