### PR TITLE
Core/dev#692 : Use url search arguments in Activity Search forms [sub-PR of #13651]

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -325,14 +325,12 @@ class CRM_Activity_BAO_Query {
         }
 
       case 'activity_tags':
-        $value = array_keys($value);
-        $activityTags = CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', ['onlyActive' => FALSE]);
+        $value = (array) $value;
+        $activityTags = CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', array('onlyActive' => FALSE));
 
-        $names = [];
-        if (is_array($value)) {
-          foreach ($value as $k => $v) {
-            $names[] = $activityTags[$v];
-          }
+        $names = array();
+        foreach ($value as $k => $v) {
+          $names[] = $activityTags[$v];
         }
         $query->_where[$grouping][] = "civicrm_activity_tag.tag_id IN (" . implode(",", $value) . ")";
         $query->_qill[$grouping][] = ts('Activity Tag %1', [1 => $op]) . ' ' . implode(' ' . ts('OR') . ' ', $names);

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -530,7 +530,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
      * we allow the controller to set force/reset externally, useful when we are being
      * driven by the wizard framework
      */
-
     $this->_groupID = CRM_Utils_Request::retrieve('gid', 'Positive', $this);
     $this->_amtgID = CRM_Utils_Request::retrieve('amtgID', 'Positive', $this);
     $this->_sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter', 'String', $this);
@@ -754,6 +753,32 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
+   * Responsible to set search params found as url arguments
+   */
+  public static function setSearchParamFromUrl(&$form) {
+    if (!CRM_Utils_Request::retrieve('force', 'Boolean', $form, FALSE) && empty($form->_ssID)) {
+      return;
+    }
+
+    $searchFields = array_merge(
+      CRM_Utils_Array::collect('data_type', CRM_Contact_Form_Search_Criteria::getBasicSearchFields()),
+      CRM_Utils_Array::collect('data_type', CRM_Contact_Form_Search_Criteria::getDemographicsSearchFields()),
+      CRM_Utils_Array::collect('data_type', CRM_Contact_Form_Search_Criteria::getLocationSearchFields()),
+      CRM_Utils_Array::collect('data_type', CRM_Contact_Form_Search_Criteria::getChangeLogSearchFields()),
+      CRM_Utils_Array::collect('data_type', CRM_Contact_Form_Search_Criteria::getCustomSearchFields())
+    );
+    foreach ($searchFields as $name => $type) {
+      if ($value = CRM_Utils_Request::retrieve($name, $type)) {
+        $form->_formValues[$name] = $value;
+      }
+    }
+
+    $form->_params = CRM_Contact_BAO_Query::convertFormValues($form->_formValues);
+    $form->set('formValues', $form->_formValues);
+    $form->set('queryParams', $form->_params);
+  }
+
+  /**
    * @return array
    */
   public function &getFormValues() {
@@ -807,6 +832,8 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     if (!CRM_Core_Permission::check('access deleted contacts')) {
       unset($this->_formValues['deleted_contacts']);
     }
+
+    $this->loadSearchParamsFromUrl();
 
     $this->set('type', $this->_action);
     $this->set('formValues', $this->_formValues);

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -101,7 +101,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
    *
    * @var array
    */
-  protected $_params;
+  public $_params;
 
   /**
    * The return properties used for search.
@@ -769,6 +769,11 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     );
     foreach ($searchFields as $name => $type) {
       if ($value = CRM_Utils_Request::retrieve($name, $type)) {
+        $value = $form->formatSpecialFormValue($name, $value, $type);
+        if (strstr($name, '_date_relative')) {
+          $fieldName = str_replace('_relative', '', $name);
+          list($form->_formValues[$fieldName . '_low'], $form->_formValues[$fieldName . '_high']) = CRM_Utils_Date::getFromTo($value, NULL, NULL);
+        }
         $form->_formValues[$name] = $value;
       }
     }

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -200,10 +200,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       $this->_ssID = $this->get('ssID');
     }
 
-    $defaults = array_merge($this->_formValues, array(
-      'privacy_toggle' => 1,
-      'operator' => 'AND',
-    ));
+    $defaults = array_merge(['privacy_toggle' => 1, 'operator' => 'AND'], $this->_formValues);
     $this->normalizeDefaultValues($defaults);
 
     if ($this->_context === 'amtg') {

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -266,7 +266,6 @@ class CRM_Contact_Form_Search_Criteria {
   /**
    * Return list of basic contact fields that can be displayed for the basic search section.
    *
-   * @param array
    */
   public static function getBasicSearchFields() {
     return [
@@ -298,6 +297,10 @@ class CRM_Contact_Form_Search_Criteria {
         'help' => ['id' => 'id-all-tag-types'],
         'data_type' => 'String',
       ],
+      'deleted_contacts' => [
+        'name' => 'deleted_contacts',
+        'data_type' => 'Positive',
+      ],
       'phone_numeric' => [
         'name' => 'phone_numeric',
         'description' => ts('Punctuation and spaces are ignored.'),
@@ -310,6 +313,14 @@ class CRM_Contact_Form_Search_Criteria {
         'class' => 'search-field__span-2',
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/privacy_toggle.tpl',
         'data_type' => 'Integer',
+      ],
+      'privacy_options' => [
+        'name' => 'privacy_options',
+        'data_type' => 'String',
+      ],
+      'privacy_operator' => [
+        'name' => 'privacy_operator',
+        'data_type' => 'String',
       ],
       'preferred_communication_method' => [
         'name' => 'preferred_communication_method',
@@ -343,8 +354,6 @@ class CRM_Contact_Form_Search_Criteria {
 
   /**
    * Return list of location fields that can be displayed for the Address search section.
-   *
-   * @param array
    */
   public static function getLocationSearchFields() {
     return array(
@@ -366,8 +375,6 @@ class CRM_Contact_Form_Search_Criteria {
 
   /**
    * Return list of demographic fields that can be displayed for the Demographics search section.
-   *
-   * @param array
    */
   public static function getDemographicsSearchFields() {
     return [
@@ -384,6 +391,8 @@ class CRM_Contact_Form_Search_Criteria {
     return [
       'changed_by' => ['title' => ts('Modified By'), 'data_type' => 'String'],
       'log_date' => ['title' => NULL, 'data_type' => 'Positive'],
+      'log_date_low' => ['title' => NULL, 'data_type' => 'Date'],
+      'log_date_high' => ['title' => NULL, 'data_type' => 'Date'],
       'log_date_relative' => ['data_type' => 'String'],
     ];
   }
@@ -391,10 +400,12 @@ class CRM_Contact_Form_Search_Criteria {
   /**
    * Return list of custom fields that can be displayed for the Custom Fields search section.
    *
-   * @param array
+   * @param array $extends
+   *
+   * return array
    */
-  public static function getCustomSearchFields() {
-    $extends = array_merge(array('Contact', 'Individual', 'Household', 'Organization', 'Address'),
+  public static function getCustomSearchFields($extends = NULL) {
+    $extends = $extends ?: array_merge(array('Contact', 'Individual', 'Household', 'Organization', 'Address'),
       CRM_Contact_BAO_ContactType::subTypes()
     );
     $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE,

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -260,66 +260,155 @@ class CRM_Contact_Form_Search_Criteria {
    * @param CRM_Core_Form $form
    */
   protected static function setBasicSearchFields($form) {
-    $userFramework = CRM_Core_Config::singleton()->userFramework;
+    $form->assign('basicSearchFields', self::getBasicSearchFields());
+  }
 
-    $form->assign('basicSearchFields', [
-      'sort_name' => ['name' => 'sort_name'],
-      'email' => ['name' => 'email'],
-      'contact_type' => ['name' => 'contact_type'],
+  /**
+   * Return list of basic contact fields that can be displayed for the basic search section.
+   *
+   * @param array
+   */
+  public static function getBasicSearchFields() {
+    return [
+      'sort_name' => ['name' => 'sort_name', 'data_type' => 'String'],
+      'email' => ['name' => 'email', 'data_type' => 'String'],
+      'email_on_hold' => ['name' => 'email_on_hold', 'data_type' => 'CommaSeparatedIntegers'],
+      'contact_type' => ['name' => 'contact_type', 'data_type' => 'String'],
       'group' => [
         'name' => 'group',
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/group.tpl',
+        'data_type' => 'CommaSeparatedIntegers',
       ],
-      'contact_tags' => ['name' => 'contact_tags'],
-      'tag_types_text' => ['name' => 'tag_types_text'],
+      'contact_tags' => ['name' => 'contact_tags', 'data_type' => 'CommaSeparatedIntegers'],
+      'tag_types_text' => ['name' => 'tag_types_text', 'data_type' => 'String'],
       'tag_search' => [
         'name' => 'tag_search',
         'help' => ['id' => 'id-all-tags'],
+        'data_type' => 'String',
       ],
       'tag_set' => [
         'name' => 'tag_set',
         'is_custom' => TRUE,
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/tag_set.tpl',
+        'data_type' => 'CommaSeparatedIntegers',
       ],
       'all_tag_types' => [
         'name' => 'all_tag_types',
         'class' => 'search-field__span-3 search-field__checkbox',
         'help' => ['id' => 'id-all-tag-types'],
+        'data_type' => 'String',
       ],
       'phone_numeric' => [
         'name' => 'phone_numeric',
         'description' => ts('Punctuation and spaces are ignored.'),
+        'data_type' => 'String',
       ],
-      'phone_location_type_id' => ['name' => 'phone_location_type_id'],
-      'phone_phone_type_id' => ['name' => 'phone_phone_type_id'],
+      'phone_location_type_id' => ['name' => 'phone_location_type_id', 'data_type' => 'Integer'],
+      'phone_phone_type_id' => ['name' => 'phone_phone_type_id', 'data_type' => 'Integer'],
       'privacy_toggle' => [
         'name' => 'privacy_toggle',
         'class' => 'search-field__span-2',
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/privacy_toggle.tpl',
+        'data_type' => 'Integer',
       ],
       'preferred_communication_method' => [
         'name' => 'preferred_communication_method',
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl',
+        'data_type' => 'String',
       ],
       'contact_source' => [
         'name' => 'contact_source',
         'help' => ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact'],
+        'data_type' => 'String',
       ],
-      'job_title' => ['name' => 'job_title'],
-      'preferred_language' => ['name' => 'preferred_language'],
+      'job_title' => ['name' => 'job_title', 'data_type' => 'String'],
+      'preferred_language' => ['name' => 'preferred_language', 'data_type' => 'String'],
       'contact_id' => [
         'name' => 'contact_id',
         'help' => ['id' => 'id-contact-id', 'file' => 'CRM/Contact/Form/Contact'],
+        'data_type' => 'Integer',
       ],
       'external_identifier' => [
         'name' => 'external_identifier',
         'help' => ['id' => 'id-external-id', 'file' => 'CRM/Contact/Form/Contact'],
+        'data_type' => 'String',
       ],
       'uf_user' => [
         'name' => 'uf_user',
-        'description' => ts('Does the contact have a %1 Account?', [$userFramework]),
+        'description' => ts('Does the contact have a %1 Account?', [CRM_Core_Config::singleton()->userFramework]),
+        'data_type' => 'Positive',
       ],
-    ]);
+    ];
+  }
+
+  /**
+   * Return list of location fields that can be displayed for the Address search section.
+   *
+   * @param array
+   */
+  public static function getLocationSearchFields() {
+    return array(
+      'street_address' => ['title' => ts('Street Address'), 'data_type' => 'String'],
+      'supplemental_address_1' => ['title' => ts('Supplemental Address 1'), 'data_type' => 'String'],
+      'supplemental_address_2' => ['title' => ts('Supplemental Address 2'), 'data_type' => 'String'],
+      'supplemental_address_3' => ['title' => ts('Supplemental Address 3'), 'data_type' => 'String'],
+      'city' => ['title' => ts('City'), 'data_type' => 'String'],
+      'postal_code' => ['title' => ts('Postal Code'), 'data_type' => 'String'],
+      'country' => ['title' => ts('Country'), 'data_type' => 'Integer', 'select' => 'country'],
+      'state_province' => ['title' => ts('State/Province'), 'data_type' => 'Integer', 'select' => 'stateProvince'],
+      'county' => ['title' => ts('County'), 'data_type' => 'Integer', 'select' => 'county'],
+      'address_name' => ['title' => ts('Address Name'), 'data_type' => 'String'],
+      'street_number' => ['title' => ts('Street Number'), 'data_type' => 'String'],
+      'street_name' => ['title' => ts('Street Name'), 'data_type' => 'String'],
+      'street_unit' => ['title' => ts('Apt/Unit/Suite'), 'data_type' => 'String'],
+    );
+  }
+
+  /**
+   * Return list of demographic fields that can be displayed for the Demographics search section.
+   *
+   * @param array
+   */
+  public static function getDemographicsSearchFields() {
+    return [
+      'gender_id' => ['title' => ts('Gender'), 'data_type' => 'String'],
+      'age_low' => ['title' => ts('Min Age'), 'data_type' => 'String'],
+      'age_high' => ['title' => ts('Max Age'), 'data_type' => 'String'],
+      'birth_date' => ['data_type' => 'String'],
+      'deceased_date' => ['data_type' => 'String'],
+      'is_deceased' => ['title' => ts('Deceased'), 'data_type' => 'Positive'],
+    ];
+  }
+
+  public static function getChangeLogSearchFields() {
+    return [
+      'changed_by' => ['title' => ts('Modified By'), 'data_type' => 'String'],
+      'log_date' => ['title' => NULL, 'data_type' => 'Positive'],
+      'log_date_relative' => ['data_type' => 'String'],
+    ];
+  }
+
+  /**
+   * Return list of custom fields that can be displayed for the Custom Fields search section.
+   *
+   * @param array
+   */
+  public static function getCustomSearchFields() {
+    $extends = array_merge(array('Contact', 'Individual', 'Household', 'Organization', 'Address'),
+      CRM_Contact_BAO_ContactType::subTypes()
+    );
+    $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE,
+      $extends
+    );
+
+    $customFields = [];
+    foreach ($groupDetails as $key => $group) {
+      foreach ($group['fields'] as $field) {
+        $customFields['custom_' . $field['id']] = ['data_type' => $field['data_type']];
+      }
+    }
+
+    return $customFields;
   }
 
   /**
@@ -341,28 +430,19 @@ class CRM_Contact_Form_Search_Criteria {
       'address_options', TRUE, NULL, TRUE
     );
 
-    $attributes = CRM_Core_DAO::getAttribute('CRM_Core_DAO_Address');
-
-    $elements = [
-      'street_address' => [ts('Street Address'), $attributes['street_address'], NULL, NULL],
-      'supplemental_address_1' => [ts('Supplemental Address 1'), $attributes['supplemental_address_1'], NULL, NULL],
-      'supplemental_address_2' => [ts('Supplemental Address 2'), $attributes['supplemental_address_2'], NULL, NULL],
-      'supplemental_address_3' => [ts('Supplemental Address 3'), $attributes['supplemental_address_3'], NULL, NULL],
-      'city' => [ts('City'), $attributes['city'], NULL, NULL],
-      'postal_code' => [ts('Postal Code'), $attributes['postal_code'], NULL, NULL],
-      'country' => [ts('Country'), $attributes['country_id'], 'country', FALSE],
-      'state_province' => [ts('State/Province'), $attributes['state_province_id'], 'stateProvince', TRUE],
-      'county' => [ts('County'), $attributes['county_id'], 'county', TRUE],
-      'address_name' => [ts('Address Name'), $attributes['address_name'], NULL, NULL],
-      'street_number' => [ts('Street Number'), $attributes['street_number'], NULL, NULL],
-      'street_name' => [ts('Street Name'), $attributes['street_name'], NULL, NULL],
-      'street_unit' => [ts('Apt/Unit/Suite'), $attributes['street_unit'], NULL, NULL],
-    ];
-
     $parseStreetAddress = CRM_Utils_Array::value('street_address_parsing', $addressOptions, 0);
     $form->assign('parseStreetAddress', $parseStreetAddress);
-    foreach ($elements as $name => $v) {
-      list($title, $attributes, $select, $multiSelect) = $v;
+
+    $addressAttributes = CRM_Core_DAO::getAttribute('CRM_Core_DAO_Address');
+    foreach (self::getLocationSearchFields() as $name => $v) {
+      if (in_array($name, ['state_province', 'country'])) {
+        $attributes = $addressAttributes[$name . '_id'];
+      }
+      else {
+        $attributes = $addressAttributes[$name];
+      }
+      $title = $v['title'];
+      $select = CRM_Utils_Array::value('select', $v);
 
       if (in_array($name,
         ['street_number', 'street_name', 'street_unit']
@@ -387,7 +467,7 @@ class CRM_Contact_Form_Search_Criteria {
           $selectElements = ['' => ts('- any -')] + CRM_Core_PseudoConstant::$select();
           $element = $form->add('select', $name, $title, $selectElements, FALSE, ['class' => 'crm-select2']);
         }
-        if ($multiSelect) {
+        if (in_array($name, ['state_province', 'county'])) {
           $element->setMultiple(TRUE);
         }
       }
@@ -498,29 +578,33 @@ class CRM_Contact_Form_Search_Criteria {
    */
   public static function demographics(&$form) {
     $form->add('hidden', 'hidden_demographics', 1);
-    // radio button for gender
-    $genderOptions = [];
-    $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
-    foreach ($gender as $key => $var) {
-      $genderOptions[$key] = $form->createElement('radio', NULL,
-        ts('Gender'), $var, $key,
-        ['id' => "civicrm_gender_{$var}_{$key}"]
-      );
+
+    foreach (self::getDemographicsSearchFields() as $name => $attributes) {
+      if ($name == 'gender_id') {
+        // radio button for gender
+        $genderOptions = array();
+        $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
+        foreach ($gender as $key => $var) {
+          $genderOptions[$key] = $form->createElement('radio', NULL,
+            ts('Gender'), $var, $key,
+            array('id' => "civicrm_gender_{$var}_{$key}")
+          );
+        }
+        $form->addGroup($genderOptions, 'gender_id', $attributes['title'])->setAttribute('allowClear', TRUE);
+      }
+      elseif (strstr($name, 'age_')) {
+        $form->add('text', $name, $attributes['title'], array('size' => 6));
+        $form->addRule($name, ts('Please enter a positive integer'), 'positiveInteger');
+        $form->addDate('age_asof_date', ts('Age as of Date'), FALSE, array('formatType' => 'searchDate'));
+      }
+      elseif (in_array($name, ['birth_date', 'deceased_date'])) {
+        CRM_Core_Form_Date::buildDateRange($form, $name, 1, '_low', '_high', ts('From'), FALSE, FALSE, 'birth');
+      }
+      elseif ($name == 'is_deceased') {
+        // radio button for is_deceased
+        $form->addYesNo($name, $attributes['title'], TRUE);
+      }
     }
-    $form->addGroup($genderOptions, 'gender_id', ts('Gender'))->setAttribute('allowClear', TRUE);
-
-    $form->add('number', 'age_low', ts('Min Age'), ['class' => 'four', 'min' => 0]);
-    $form->addRule('age_low', ts('Please enter a positive integer'), 'positiveInteger');
-    $form->add('number', 'age_high', ts('Max Age'), ['class' => 'four', 'min' => 0]);
-    $form->addRule('age_high', ts('Please enter a positive integer'), 'positiveInteger');
-    $form->add('datepicker', 'age_asof_date', ts('As of'), NULL, FALSE, ['time' => FALSE]);
-
-    CRM_Core_Form_Date::buildDateRange($form, 'birth_date', 1, '_low', '_high', ts('From'), FALSE, FALSE, 'birth');
-
-    CRM_Core_Form_Date::buildDateRange($form, 'deceased_date', 1, '_low', '_high', ts('From'), FALSE, FALSE, 'birth');
-
-    // radio button for is_deceased
-    $form->addYesNo('is_deceased', ts('Deceased'), TRUE);
   }
 
   /**

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -205,6 +205,30 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   }
 
   /**
+   * Format some special form values including date fields
+   *
+   * @param string $name
+   * @param string $value
+   * @param string $dataType
+   *
+   * @return string|array
+   */
+  public function formatSpecialFormValue($name, $value, $dataType) {
+    if ($dataType == 'Date') {
+      // @todo we should pick up searchDate format here
+      $value = date('d/m/Y', strtotime($value));
+    }
+    elseif (in_array($name, [
+      'privacy_options',
+      'activity_tags',
+    ])) {
+      $value = explode(',', $value);
+    }
+
+    return $value;
+  }
+
+  /**
    * Get the validation rule to apply to a function.
    *
    * Alphanumeric is designed to always be safe & for now we just return
@@ -414,20 +438,24 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       return;
     }
 
-    $enabledComponents = CRM_Core_Component::getEnabledComponents();
+    $enabledComponents = array_merge(CRM_Core_Component::getEnabledComponents(), [
+      'CiviActivity' => ['namespace' => 'CRM_Activity'],
+    ]);
     if (!$this->_component) {
       if (method_exists('CRM_Contact_Form_Search', 'setSearchParamFromUrl')) {
         CRM_Contact_Form_Search::setSearchParamFromUrl($this);
       }
       foreach ($enabledComponents as $component) {
-        $searchClass = $component->namespace . '_Form_Search';
+        $component = (array) $component;
+        $searchClass = $component['namespace'] . '_Form_Search';
         if (method_exists($searchClass, 'setSearchParamFromUrl')) {
           $searchClass::setSearchParamFromUrl($this);
         }
       }
     }
     elseif (array_key_exists($this->_component, $enabledComponents)) {
-      $searchClass = $enabledComponents[$this->_component]->namespace . '_Form_Search';
+      $component = (array) $enabledComponents[$this->_component];
+      $searchClass = $component['namespace'] . '_Form_Search';
       if (method_exists($searchClass, 'setSearchParamFromUrl')) {
         $searchClass::setSearchParamFromUrl($this);
       }

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -90,6 +90,13 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   protected $entityReferenceFields = [];
 
   /**
+   * Indicates the Civi component overriden by respective search classes
+   *
+   * @var string
+   */
+  protected $_component;
+
+  /**
    * Builds the list of tasks or actions that a searcher can perform on a result set.
    *
    * To modify the task list, child classes should alter $this->_taskList,
@@ -396,6 +403,35 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
     $this->_ssID = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);
     $this->assign("context", $this->_context);
+  }
+
+  /**
+   * This function call setSearchParamFromUrl() of respective component's Search form and
+   *  is responsible to set search params found as url arguments
+   */
+  protected function loadSearchParamsFromUrl() {
+    if (!$this->_force && (!empty($_POST) || !empty($form->_ssID))) {
+      return;
+    }
+
+    $enabledComponents = CRM_Core_Component::getEnabledComponents();
+    if (!$this->_component) {
+      if (method_exists('CRM_Contact_Form_Search', 'setSearchParamFromUrl')) {
+        CRM_Contact_Form_Search::setSearchParamFromUrl($this);
+      }
+      foreach ($enabledComponents as $component) {
+        $searchClass = $component->namespace . '_Form_Search';
+        if (method_exists($searchClass, 'setSearchParamFromUrl')) {
+          $searchClass::setSearchParamFromUrl($this);
+        }
+      }
+    }
+    elseif (array_key_exists($this->_component, $enabledComponents)) {
+      $searchClass = $enabledComponents[$this->_component]->namespace . '_Form_Search';
+      if (method_exists($searchClass, 'setSearchParamFromUrl')) {
+        $searchClass::setSearchParamFromUrl($this);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is a sub-PR of https://github.com/civicrm/civicrm-core/pull/13651. This PR extends the fix and make all possible activity search filters to be used as a url arguments on forced search using 'Find Activity' or 'Advance Search'
 
Before
----------------------------------------
Search arguments didn't work

After
----------------------------------------
Behavior on advanced search and 'Find Activity' search form:
![after](https://user-images.githubusercontent.com/3735621/53472901-fc0d2e00-3a8e-11e9-8eab-029f6f1c3d63.gif)


Comments
----------------------------------------
ping @eileenmcnaughton @colemanw @lcdservices 