### PR TITLE
Decommision getPartialPaymentTrxn function

### DIFF
--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -507,26 +507,6 @@ WHERE ceft.entity_id = %1";
   }
 
   /**
-   * Function records partial payment, complete's contribution if payment is fully paid
-   * and returns latest payment ie financial trxn
-   *
-   * @param array $contribution
-   * @param array $params
-   *
-   * @return \CRM_Financial_DAO_FinancialTrxn
-   */
-  public static function getPartialPaymentTrxn($contribution, $params) {
-    $trxn = CRM_Contribute_BAO_Contribution::recordPartialPayment($contribution, $params);
-    $paid = CRM_Core_BAO_FinancialTrxn::getTotalPayments($params['contribution_id']);
-    $total = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution_id'], 'total_amount');
-    $cmp = bccomp($total, $paid, 5);
-    if ($cmp == 0 || $cmp == -1) {// If paid amount is greater or equal to total amount
-      civicrm_api3('Contribution', 'completetransaction', array('id' => $contribution['id']));
-    }
-    return $trxn;
-  }
-
-  /**
    * Get revenue amount for membership.
    *
    * @param array $lineItem

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -79,7 +79,14 @@ class CRM_Financial_BAO_Payment {
       }
     }
     if (!$fullyPaidPayLater) {
-      $trxn = CRM_Core_BAO_FinancialTrxn::getPartialPaymentTrxn($contribution, $params);
+      $trxn = CRM_Contribute_BAO_Contribution::recordPartialPayment($contribution, $params);
+      $paid = CRM_Core_BAO_FinancialTrxn::getTotalPayments($params['contribution_id']);
+      $total = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution_id'], 'total_amount');
+      $cmp = bccomp($total, $paid, 5);
+      if ($cmp == 0 || $cmp == -1) {// If paid amount is greater or equal to total amount
+        civicrm_api3('Contribution', 'completetransaction', array('id' => $contribution['id']));
+      }
+
       if (CRM_Utils_Array::value('line_item', $params) && !empty($trxn)) {
         foreach ($params['line_item'] as $values) {
           foreach ($values as $id => $amount) {

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -106,9 +106,9 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test getPartialPaymentTrxn function.
+   * Tests the lines of code that used to be in the getPartialPaymentTrxn fn.
    */
-  public function testGetPartialPaymentTrxn() {
+  public function testGetExPartialPaymentTrxn() {
     $contributionTest = new CRM_Contribute_BAO_ContributionTest();
     list($lineItems, $contribution) = $contributionTest->addParticipantWithContribution();
     $contribution = (array) $contribution;
@@ -116,7 +116,13 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
       'contribution_id' => $contribution['id'],
       'total_amount' => 100.00,
     );
-    $trxn = CRM_Core_BAO_FinancialTrxn::getPartialPaymentTrxn($contribution, $params);
+    $trxn = CRM_Contribute_BAO_Contribution::recordPartialPayment($contribution, $params);
+    $paid = CRM_Core_BAO_FinancialTrxn::getTotalPayments($params['contribution_id']);
+    $total = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution_id'], 'total_amount');
+    $cmp = bccomp($total, $paid, 5);
+    if ($cmp == 0 || $cmp == -1) {// If paid amount is greater or equal to total amount
+      civicrm_api3('Contribution', 'completetransaction', array('id' => $contribution['id']));
+    }
 
     $this->assertEquals('100.00', $trxn->total_amount, 'Amount does not match.');
 


### PR DESCRIPTION
Overview
----------------------------------------
Readability fix - remove internal function

Before
----------------------------------------
getPartialPaymentTrxn called in order to do updates

After
----------------------------------------
Misleading function removed

Technical Details
----------------------------------------
This function is only called from one place in the code & also from a test.

It is misleading as it implies a 'get' when it actually does an update
and it groups functionality in a way that doesn't make sense from the calling code pov

In this commit the function is removed and the lines are directly copied to the calling
function, as preparation for cleaning up the calling function

Comments
----------------------------------------
@monishdeb this is reduced from https://github.com/civicrm/civicrm-core/pull/13690 - just moving code lines - I realise now there is some more scariness in the handling in that fn - test cover has been really good!