### PR TITLE
Speed up contribution results by removing join on civicrm_financial_type table when rendering search results.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -804,7 +804,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           ]
         );
       }
-      $typeField = CRM_Financial_DAO_FinancialType::export();
+
       $financialAccount = CRM_Financial_DAO_FinancialAccount::export();
 
       $contributionPage = array(
@@ -872,7 +872,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         ),
       );
 
-      $fields = array_merge($fields, $typeField, $contributionPage,
+      $fields = array_merge($fields, $contributionPage,
         $contributionNote, $extraFields, $softCreditFields, $financialAccount, $campaignTitle,
         CRM_Core_BAO_CustomField::getFieldsForImport('Contribution', FALSE, FALSE, FALSE, $checkPermission)
       );

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -173,8 +173,12 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       'contribution_payment_instrument' => 'contribution_payment_instrument_id',
       'contribution_status' => 'contribution_status_id',
     );
+
     $name = isset($fieldAliases[$name]) ? $fieldAliases[$name] : $name;
     $qillName = $name;
+    if (in_array($name, $fieldAliases)) {
+      $qillName = array_search($name, $fieldAliases);
+    }
     $pseudoExtraParam = array();
 
     switch ($name) {

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -69,14 +69,6 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
     }
 
-    // get financial_type
-    if (!empty($query->_returnProperties['financial_type'])) {
-      $query->_select['financial_type'] = "civicrm_financial_type.name as financial_type";
-      $query->_element['financial_type'] = 1;
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_financial_type'] = 1;
-    }
-
     // get accounting code
     if (!empty($query->_returnProperties['accounting_code'])) {
       $query->_select['accounting_code'] = "civicrm_financial_account.accounting_code as accounting_code";

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -2579,7 +2579,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'world_region' => 'world_region varchar(128)',
       'url' => 'url varchar(128)',
       'phone_type_id' => 'phone_type_id varchar(16)',
-      'financial_type' => 'financial_type varchar(64)',
+      'financial_type' => 'financial_type varchar(255)',
       'contribution_source' => 'contribution_source varchar(255)',
       'receive_date' => 'receive_date varchar(32)',
       'thankyou_date' => 'thankyou_date varchar(32)',


### PR DESCRIPTION
Overview
----------------------------------------
Speed up contribution results by removing join on civicrm_financial_type table when rendering search results.



Before
----------------------------------------
Join on civicrm_financial_type used to get financial type name = slower

After
----------------------------------------
Pseudoconstant used - faster

Technical Details
----------------------------------------
This can be done much more efficiently through the pseudoconstant mechanism.

Although it is an indexed join it is chosen at the expense of another index - so
your search on payment_instrument_id may not use an index on the filter field
due to this join.

Comments
----------------------------------------

Note that there are multiple unit tests covering filtering by & returning of financial type. Last time I worked in this part of the code I added the function api_v3_ContactTest::testPseudoFields to cover the pseudofields handled at that time. We hit some regressions around order by in search builder so this time I added 

CRM_Contribute_BAO_QueryTest::testSearchPseudoReturnProperties

in preparation for this change