### PR TITLE
financial#46 - clean money format at form layer

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -589,9 +589,10 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
             if (isset($values[$i]) &&
               (strlen(trim($values[$i])) > 0)
             ) {
+              $values[$i] = $params['value'][$i] = CRM_Utils_Rule::cleanMoney(trim($values[$i]));
               $options[] = array(
                 'label' => trim($labels[$i]),
-                'value' => CRM_Utils_Rule::cleanMoney(trim($values[$i])),
+                'value' => $values[$i],
                 'weight' => $i,
                 'is_active' => 1,
                 'is_default' => $default == $i,


### PR DESCRIPTION
Overview
----------------------------------------
When specifying a donation amount of $1000 or more (on a monolingual en_US site), the amount is saved as $1,000.00.
When you press save again, the comma is treated as a decimal separator, and so it's resaved as $1.

Before
----------------------------------------
19 second screencast showing the issue:
https://lab.civicrm.org/dev/financial/uploads/3efa6a65f2585256b3792f512ce29416/thousandseparatorbug-2019-02-27_16.07.04.mkv

After
----------------------------------------
Amount saves correctly.

Technical Details
----------------------------------------
The "Amounts" tab of contribution page configuration doesn't clean the money format at the form level.  Since cleaning at the BAO level was removed in 5.9.0, we need to clean the money at the form level.