### PR TITLE
Don't break loop if address fields not found while formatting rows in Reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4493,8 +4493,8 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
             $rows[$rowNum]["{$fieldName}_link"] = $url;
             $rows[$rowNum]["{$fieldName}_hover"] = ts("%1 for this %2.", array(1 => $linkText, 2 => $addressField));
           }
-          $entryFound = TRUE;
         }
+        $entryFound = TRUE;
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
There is a regression caught on https://github.com/civicrm/civicrm-core/pull/11660 at [here](https://github.com/civicrm/civicrm-core/pull/11660/files#diff-d355cdb00cea3915a3cf306c6c08f6a6L4232). Where earlier we don't break the loop if the column name is found in the rows. But as per the previous fix, we break the loop if the value of any of the three address fields is empty.    

Before
----------------------------------------
On CSV Export state_province, country or county are not translated into name.

After
----------------------------------------
On CSV Export state_province, country or county are translated into name.


Comments
----------------------------------------
ping @eileenmcnaughton @seamuslee001 