### PR TITLE
dev/core#768 - Fix fatal error on group search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3027,10 +3027,13 @@ class CRM_Contact_BAO_Query {
       if (count($regularGroupIDs) > 1) {
         $op = strpos($op, 'IN') ? $op : ($op == '!=') ? 'NOT IN' : 'IN';
       }
-      $groupIds = CRM_Utils_Type::validate(
-        implode(',', (array) $regularGroupIDs),
-        'CommaSeparatedIntegers'
-      );
+      $groupIds = '';
+      if (!empty($regularGroupIDs)) {
+        $groupIds = CRM_Utils_Type::validate(
+          implode(',', (array) $regularGroupIDs),
+          'CommaSeparatedIntegers'
+        );
+      }
       $gcTable = "`civicrm_group_contact-" . uniqid() . "`";
       $joinClause = array("contact_a.id = {$gcTable}.contact_id");
 
@@ -6546,7 +6549,7 @@ AND   displayRelType.is_active = 1
         FROM (
       SELECT civicrm_contribution.total_amount, civicrm_contribution.currency
       $from
-      $where  AND civicrm_contribution.cancel_date IS NOT NULL 
+      $where  AND civicrm_contribution.cancel_date IS NOT NULL
       GROUP BY civicrm_contribution.id
     ) as conts
     GROUP BY currency";


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on group search

Before
----------------------------------------
- Navigate to Search builder
- Search for Contact => Groups => IS NULL. On submit, you'll get the following error.

![image](https://user-images.githubusercontent.com/5929648/53560783-2df7c080-3b73-11e9-87a3-4f1e6e86202f.png)

We've also seen this error on contact summary page => Groups tab on one of the client site, but not sure what exact cases need to be true to see the error.

![image](https://user-images.githubusercontent.com/5929648/53560803-3ea83680-3b73-11e9-80c7-de3b36e98216.png)

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
`CommaSeparatedIntegers` does not validate empty values. Either we can avoid its call(as done in this PR) OR maybe, modify CommaSeparatedIntegers rule to also return TRUE for empty string? @eileenmcnaughton 

Comments
----------------------------------------
Seems related to changes made in https://github.com/civicrm/civicrm-core/commit/0cf0a3f39283cac6b7c45a059ffba09621e813e3

Gitlab - https://lab.civicrm.org/dev/core/issues/768