### PR TITLE
dev/core#769 - Fix for ZipArchive->open() PHP bug

### DIFF
--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -251,7 +251,7 @@ abstract class CRM_Financial_BAO_ExportFormat {
     }
     if (count($validFiles)) {
       $zip = new ZipArchive();
-      if ($zip->open($destination, $overwrite ? ZIPARCHIVE::OVERWRITE : ZIPARCHIVE::CREATE) !== TRUE) {
+      if ($zip->open($destination, $overwrite ? ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE : ZIPARCHIVE::CREATE) !== TRUE) {
         return FALSE;
       }
       foreach ($validFiles as $file) {


### PR DESCRIPTION
Overview
----------------------------------------
There is an issue with the ZipArchive class' open() method. In previous versions of PHP when the only flag passed to the method was the ZipArchive::OVERWRITE, the method also created non-existing archives.
Since PHP 5.6 the OVERWRITE flag alone cannot create new archives which breaks compatibility.

Before
----------------------------------------
Zip files were created if they did not exist by simply specifying the ZIPARCHIVE::OVERWRITE flag.

After
----------------------------------------
ZipArchive::ER_OPEN error code is returned (cannot open zip file).

Technical Details
----------------------------------------
Bug report: https://bugs.php.net/bug.php?id=71064
