### PR TITLE
Mark de.systopia.recentitems obsolete

### DIFF
--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -5,6 +5,9 @@
   "com.aghstrategies.slicknav": {
     "obsolete": "5.12"
   },
+  "de.systopia.recentitems": {
+    "obsolete": "5.12"
+  },
   "com.ixiam.modules.quicksearch": {
     "obsolete": "5.8"
   }


### PR DESCRIPTION
Fixes https://github.com/systopia/de.systopia.recentitems/issues/3

This extension is now deprecated in favor of https://github.com/civicrm/org.civicrm.recentmenu/