### PR TITLE
dev/core#731 Add upgrade routine to convert on_hold to an array for sites with

### DIFF
--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -100,11 +100,7 @@ class CRM_Upgrade_Incremental_SmartGroups {
     }
 
     foreach ($fields as $field) {
-      $savedSearches = civicrm_api3('SavedSearch', 'get', [
-        'options' => ['limit' => 0],
-        'form_values' => ['LIKE' => "%{$field}%"],
-      ])['values'];
-      foreach ($savedSearches as $savedSearch) {
+      foreach ($this->getSearchesWithField($field) as $savedSearch) {
         $formValues = $savedSearch['form_values'];
         foreach ($formValues as $index => $formValue) {
           if (in_array($formValue[0], $fieldPossibilities)) {
@@ -114,6 +110,30 @@ class CRM_Upgrade_Incremental_SmartGroups {
         if ($formValues !== $savedSearch['form_values']) {
           civicrm_api3('SavedSearch', 'create', ['id' => $savedSearch['id'], 'form_values' => $formValues]);
         }
+      }
+    }
+  }
+
+  /**
+   * Conversion routine for a form change change from = string to IN array.
+   *
+   * For example a checkbox expected [$fieldName, '=', 1]
+   * whereas select expects [$fieldName, 'IN', [1]]
+   *
+   * @param string $field
+   */
+  public function convertEqualsStringToInArray($field) {
+    foreach ($this->getSearchesWithField($field) as $savedSearch) {
+      $formValues = $savedSearch['form_values'];
+      foreach ($formValues as $index => $formValue) {
+        if ($formValue[0] === $field && !is_array($formValue[2]) && $formValue[1] === '=') {
+          $formValues[$index][1] = 'IN';
+          $formValues[$index][2] = [$formValue[2]];
+        }
+      }
+
+      if ($formValues !== $savedSearch['form_values']) {
+        civicrm_api3('SavedSearch', 'create', ['id' => $savedSearch['id'], 'form_values' => $formValues]);
       }
     }
   }
@@ -160,6 +180,18 @@ class CRM_Upgrade_Incremental_SmartGroups {
       $dateValue = date('Y-m-d H:i:s', strtotime(CRM_Utils_Date::processDate($dateValue)));
     }
     return $dateValue;
+  }
+
+  /**
+   * @param $field
+   * @return mixed
+   */
+  protected function getSearchesWithField($field) {
+    $savedSearches = civicrm_api3('SavedSearch', 'get', [
+      'options' => ['limit' => 0],
+      'form_values' => ['LIKE' => "%{$field}%"],
+    ])['values'];
+    return $savedSearches;
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/FiveEleven.php
+++ b/CRM/Upgrade/Incremental/php/FiveEleven.php
@@ -75,6 +75,29 @@ class CRM_Upgrade_Incremental_php_FiveEleven extends CRM_Upgrade_Incremental_Bas
   public function upgrade_5_11_alpha1($rev) {
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', $rev);
+    if (Civi::settings()->get('civimail_multiple_bulk_emails')) {
+      $this->addTask('Update any on hold groups to reflect field change', 'updateOnHold', $rev);
+    }
+  }
+
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_11_beta1($rev) {
+    if (Civi::settings()->get('civimail_multiple_bulk_emails')) {
+      $this->addTask('Update any on hold groups to reflect field change', 'updateOnHold', $rev);
+    }
+  }
+
+  /**
+   * Update on hold groups -note the core function layout for this sort of upgrade changed in 5.12 - don't copy this.
+   */
+  public function updateOnHold($ctx, $version) {
+    $groupUpdateObject = new CRM_Upgrade_Incremental_SmartGroups($version);
+    $groupUpdateObject->convertEqualsStringToInArray('on_hold');
+    return TRUE;
   }
 
 }

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -6,6 +6,10 @@
  */
 class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
 
+  public function tearDown() {
+    $this->quickCleanup(['civicrm_saved_search']);
+  }
+
   /**
    * Test message upgrade process.
    */
@@ -97,6 +101,22 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     $this->assertEquals('2019-01-20 00:00:00', $savedSearch['form_values'][0][2]);
     $this->assertEquals('grant_due_date_low', $savedSearch['form_values'][1][0]);
     $this->assertEquals('2019-01-22 00:00:00', $savedSearch['form_values'][1][2]);
+  }
+
+  /**
+   * Test conversion of on hold group.
+   */
+  public function testOnHoldConversion() {
+    $this->callAPISuccess('SavedSearch', 'create', [
+      'form_values' => [
+        ['on_hold', '=', '1'],
+      ]
+    ]);
+    $smartGroupConversionObject = new CRM_Upgrade_Incremental_SmartGroups('5.11.alpha1');
+    $smartGroupConversionObject->convertEqualsStringToInArray('on_hold');
+    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
+    $this->assertEquals('IN', $savedSearch['form_values'][0][1]);
+    $this->assertEquals(['1'], $savedSearch['form_values'][0][2]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds an upgrade routine for smart groups affected by the change of field type for on_hold emails 
where civimail_multiple_bulk_emails is enabled

Before
----------------------------------------
Smart groups need to be manually resaved

To replicate create a smart group for contacts with email on hold with the setting civimail_multiple_bulk_emails enabled on 5.8 codebase, then switch to 5.11 & create one - note the format differences ie email_on_hold is a string in the 5.8 group & an array in the 5.11 group

After
----------------------------------------
Upgrading to 5.11 updates the groups

Run the upgrade - both groups should be the same

Technical Details
----------------------------------------
For sites with civimail_multiple_bulk_emails set we get a select box which needs an array rather than a checkbox, the saved groups need to reflect that.

    // preferred communication method
    if (Civi::settings()->get('civimail_multiple_bulk_emails')) {
      ->addSelect('email_on_hold',
        array('entity' => 'email', 'multiple' => 'multiple', 'label' => ts('Email On Hold'), 'options' => CRM_Core_PseudoConstant::emailOnHoldOptions()));
    }
    else {
      ->add('advcheckbox', 'email_on_hold', ts('Email On Hold')

Comments
----------------------------------------

Note from my testing there is problem loading the defaults on an existing saved search due to the field name having a discrepancy 
wrong - this aligns groups created before & after the 5.9 upgrade but does not resolve that.

@twomice ping

https://lab.civicrm.org/dev/core/issues/731
