### PR TITLE
dev/core#748 Move UPPER() from sql to php domain

### DIFF
--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -431,7 +431,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
    * @return mixed
    */
   public function alphabetQuery() {
-    return $this->_query->searchQuery(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+    return $this->_query->alphabetQuery();
   }
 
   /**

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -456,7 +456,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
    * @return mixed
    */
   public function alphabetQuery() {
-    return $this->_query->searchQuery(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+    return $this->_query->alphabetQuery();
   }
 
   /**

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1384,7 +1384,7 @@ class CRM_Contact_BAO_Query {
       }
     }
     elseif ($sortByChar) {
-      $select = 'SELECT DISTINCT UPPER(LEFT(contact_a.sort_name, 1)) as sort_name';
+      $select = 'SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name';
       $from = $this->_simpleFromClause;
     }
     elseif ($groupContacts) {
@@ -4897,6 +4897,22 @@ civicrm_relationship.start_date > {$today}
   }
 
   /**
+   * Create and query the db for a contact search.
+   *
+   * @return CRM_Core_DAO
+   */
+  public function alphabetQuery() {
+    $query = $this->getSearchSQL(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+
+    $dao = CRM_Core_DAO::executeQuery($query);
+
+    // We can always call this - it will only re-enable if it was originally enabled.
+    CRM_Core_DAO::reenableFullGroupByMode();
+
+    return $dao;
+  }
+
+  /**
    * Fetch a list of contacts for displaying a search results page
    *
    * @param array $cids
@@ -6249,25 +6265,19 @@ AND   displayRelType.is_active = 1
         }
       }
       elseif ($sortByChar) {
-        $orderByArray = array("UPPER(LEFT(contact_a.sort_name, 1)) asc");
+        $orderBy = " sort_name asc";
       }
       else {
         $orderBy = " contact_a.sort_name ASC, contact_a.id";
       }
     }
-    if (!$orderBy && empty($orderByArray)) {
+    if (!$orderBy) {
       return [NULL, $additionalFromClause];
     }
     // Remove this here & add it at the end for simplicity.
     $order = trim($orderBy);
+    $orderByArray = explode(',', $order);
 
-    // hack for order clause
-    if (!empty($orderByArray)) {
-      $order = implode(', ', $orderByArray);
-    }
-    else {
-      $orderByArray = explode(',', $order);
-    }
     foreach ($orderByArray as $orderByClause) {
       $orderByClauseParts = explode(' ', trim($orderByClause));
       $field = $orderByClauseParts[0];

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1192,7 +1192,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    * @return CRM_Contact_DAO_Contact
    */
   public function alphabetQuery() {
-    return $this->_query->searchQuery(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+    return $this->_query->alphabetQuery();
   }
 
   /**

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -619,7 +619,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
    * @return mixed
    */
   public function alphabetQuery() {
-    return $this->_query->searchQuery(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+    return $this->_query->alphabetQuery();
   }
 
   /**

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -530,7 +530,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
    * @return mixed
    */
   public function alphabetQuery() {
-    return $this->_query->searchQuery(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+    return $this->_query->alphabetQuery();
   }
 
   /**

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -389,7 +389,7 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
    * @return mixed
    */
   public function alphabetQuery() {
-    return $this->_query->searchQuery(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+    return $this->_query->alphabetQuery();
   }
 
   /**

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -543,7 +543,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
    * @return mixed
    */
   public function alphabetQuery() {
-    return $this->_query->searchQuery(NULL, NULL, NULL, FALSE, FALSE, TRUE);
+    return $this->_query->alphabetQuery();
   }
 
   /**

--- a/CRM/Utils/PagerAToZ.php
+++ b/CRM/Utils/PagerAToZ.php
@@ -113,7 +113,7 @@ class CRM_Utils_PagerAToZ {
 
     $dynamicAlphabets = array();
     while ($result->fetch()) {
-      $dynamicAlphabets[] = $result->sort_name;
+      $dynamicAlphabets[] = strtoupper($result->sort_name);
     }
     return $dynamicAlphabets;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Extracted from #13713 

Using UPPER()/LOWER() in SQL queries causes the query to stop using indexes.  The query for the 
the first, slowest, query when doing a search is just to generate any extended characters for the alphabet pager across the top of the search results!

Before
----------------------------------------
Very slow query for complex smartgroups / larger datasets.

After
----------------------------------------
Removed both "UPPER()" functions from the "alphabet" query (as that stops it using indexes) and moved that to the PHP level.  Query much faster and no functional change.

Technical Details
----------------------------------------
Combined with further work in #13713 to reduce left joins this reduced a number of queries from infinity to < 1 second on a site with a number of complex smartgroups.

Comments
----------------------------------------
There is precedent for removing UPPER/LOWER from SQL as it is known to cause performance issues.

@eileenmcnaughton I've extracted `alphabetQuery()` in this too.
