### PR TITLE
dev/membership#10 fix incorrect validation error saying Start date must be the same or later than Member since

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -417,7 +417,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
     //setting default join date if there is no join date
     if (empty($defaults['join_date'])) {
-      $defaults['join_date'] = date('Y-m-d H:i:s');
+      $defaults['join_date'] = date('Y-m-d');
     }
 
     if (!empty($defaults['membership_end_date'])) {


### PR DESCRIPTION
Overview
----------------------------------------
"Start date must be the same or later than Member since" triggered when dates are the same

Before
----------------------------------------
-> new membership
-> set start_date to match  join_date (don't change join_date field - problem is with default 'now'
-> validation error on save 

After
----------------------------------------
no error

Technical Details
----------------------------------------
This problem is because both dates exclude time but the default setting includes it - leading to a
comparison of a datetime with a date+midnight time

Comments
----------------------------------------

https://lab.civicrm.org/dev/membership/issues/10