### PR TITLE
Extract getSearchSQLParts function

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -273,17 +273,17 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
       $cacheKey = "civicrm search {$this->_key}";
       Civi::service('prevnext')->deleteItem(NULL, $cacheKey, 'civicrm_contact');
 
-      $sql = $this->_query->getSearchSQL(0, 0, $sort,
+      $sql = $this->_query->getSearchSQLParts(0, 0, $sort,
         FALSE, FALSE,
         FALSE, FALSE,
         $this->_campaignWhereClause,
         NULL,
         $this->_campaignFromClause
       );
-      list($select, $from) = explode(' FROM ', $sql);
+
       $selectSQL = "
       SELECT %1, contact_a.id, contact_a.display_name
-FROM {$from}
+FROM {$sql['from']}
 ";
 
       try {

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -555,15 +555,12 @@ WHERE  id IN ( $groupIDs )
           );
         $query->_useDistinct = FALSE;
         $query->_useGroupBy = FALSE;
-        $searchSQL
-          = $query->searchQuery(
+        $sqlParts = $query->getSearchSQLParts(
             0, 0, NULL,
             FALSE, FALSE,
-            FALSE, TRUE,
-            TRUE,
-            NULL, NULL, NULL,
-            TRUE
+            FALSE, TRUE
           );
+        $searchSQL = "{$sqlParts['select']} {$sqlParts['from']} {$sqlParts['where']} {$sqlParts['having']} {$sqlParts['group_by']}";
       }
       $groupID = CRM_Utils_Type::escape($groupID, 'Integer');
       $sql = $searchSQL . " AND contact_a.id NOT IN (


### PR DESCRIPTION
Overview
----------------------------------------
Code extraction - separate out code to return the query parts - return as an array

Before
----------------------------------------
code less readable

After
----------------------------------------
Code more readable

Technical Details
----------------------------------------
We have many cases where this function is called in order to get sql which is then wrangled to extract the 'select' or 'from' - instead allow the parts to be returned as an array

Comments
----------------------------------------
@mattwire this is where I was imagining going with this function - ie trying to get rid of some of those silly params & having the calling function do things like add additional where clauses or ditch the limit clause
