### PR TITLE
CiviCRM Membership Detail report, add column to display if membership is Primary or Inherited

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -104,6 +104,10 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
             'title' => ts('End Date'),
             'default' => TRUE,
           ),
+          'owner_membership_id' => array(
+            'title' => ts('Primary/Inherited?'),
+            'default' => TRUE,
+          ),
           'join_date' => array(
             'title' => ts('Join Date'),
             'default' => TRUE,
@@ -360,6 +364,12 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
       }
       if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
+        $entryFound = TRUE;
+      }
+
+      if (array_key_exists('civicrm_membership_owner_membership_id', $row)) {
+        $value = $row['civicrm_membership_owner_membership_id'];
+        $rows[$rowNum]['civicrm_membership_owner_membership_id'] = ($value != '') ? 'Inherited' : 'Primary';
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Membership Detail report does lists all memberships but has no way of differentiating between those memberships which are primary and those that are inherited from another contact.

Before
----------------------------------------
No ability to show Primary or Inherited membership.

After
----------------------------------------
Adds a new column to the report "Primary/Inherited?" which shows "Primary" or "Inherited" based on the membership being with the contact or inherited from another contact.

Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.

Agileware Ref: CIVICRM-1149
