### PR TITLE
Fix up e-notice error when using a user from email address same issue…

### DIFF
--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -200,8 +200,12 @@ AND    {$this->_componentClause}";
 
       $values = array();
       if (isset($params['from_email_address']) && !$elements['createPdf']) {
+        // If a logged in user from email is used rather than a domain wide from email address
+        // the from_email_address params key will be numerical and we need to convert it to be
+        // in normal from email format
+        $from = CRM_Utils_Mail::formatFromAddress($params['from_email_address']);
         // CRM-19129 Allow useres the choice of From Email to send the receipt from.
-        $fromDetails = explode(' <', $params['from_email_address']);
+        $fromDetails = explode(' <', $from);
         $input['receipt_from_email'] = substr(trim($fromDetails[1]), 0, -1);
         $input['receipt_from_name'] = str_replace('"', '', $fromDetails[0]);
       }


### PR DESCRIPTION
… as dev/core#644

Overview
----------------------------------------
This fixes an e-notice issue which is actually the same bug as shown in dev/core#644 but this time is exposed when re-sending a receipt. 

Before
----------------------------------------
Using a user driven from email address generates e-notice when re-sending a receipt

After
----------------------------------------
no e-notice and from email address is correct

ping @MegaphoneJon @eileenmcnaughton 
