### PR TITLE
dev/core#770 - View Case Activity page displays disabled custom fields

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -581,10 +581,11 @@ WHERE      a.id = %1
   /**
    * @param int $activityTypeID
    * @param null $dateFormat
+   * @param bool $onlyActive
    *
    * @return mixed
    */
-  public function getActivityTypeCustomSQL($activityTypeID, $dateFormat = NULL) {
+  public function getActivityTypeCustomSQL($activityTypeID, $dateFormat = NULL, $onlyActive = TRUE) {
     static $cache = array();
 
     if (is_null($activityTypeID)) {
@@ -608,6 +609,9 @@ WHERE  cf.custom_group_id = cg.id
 AND    cg.extends = 'Activity'
 AND " . CRM_Core_Permission::customGroupClause(CRM_Core_Permission::VIEW, 'cg.');
 
+      if ($onlyActive) {
+        $query .= " AND cf.is_active = 1 ";
+      }
       if ($activityTypeID) {
         $query .= "AND ( cg.extends_entity_column_value IS NULL OR cg.extends_entity_column_value LIKE '%" . CRM_Core_DAO::VALUE_SEPARATOR . "%1" . CRM_Core_DAO::VALUE_SEPARATOR . "%' )";
       }


### PR DESCRIPTION
Overview
----------------------------------------
View Case Activity page displays disabled custom fields

Before
----------------------------------------
Replicate it by -

- Creating a custom group for case activity
- Add 2 fields to the set - active and disabled.

![image](https://user-images.githubusercontent.com/5929648/53622263-47564680-3c1f-11e9-8b7b-a722545df91c.png)

- Create a case activity and enter value in the active custom field.
- Click `View` link in the activity row and notice the disabled field shown on the page.

![image](https://user-images.githubusercontent.com/5929648/53622273-4de4be00-3c1f-11e9-9a0e-8afc1e62ba21.png)

After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/5929648/53622301-5d640700-3c1f-11e9-8fce-c3ac65051862.png)

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/770