### PR TITLE
dev/core#771 - Smart group with uf_group_id does not load contacts wi…

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -467,6 +467,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
       'operator',
       'component_mode',
       'display_relationship_type',
+      'uf_group_id',
     );
     foreach ($specialElements as $element) {
       if (!empty($formValues[$element])) {

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -143,6 +143,37 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     $this->assertEquals('01/01/2009', $result['participant_register_date_low']);
     $this->assertEquals('01/01/2018', $result['participant_register_date_high']);
   }
+
+  /**
+   * Test if skipped elements are correctly
+   * stored and retrieved as formvalues.
+   */
+  public function testSkippedElements() {
+    $relTypeID = $this->relationshipTypeCreate();
+    $savedSearch = new CRM_Contact_BAO_SavedSearch();
+    $formValues = array(
+      'operator' => 'AND',
+      'title' => 'testsmart',
+      'radio_ts' => 'ts_all',
+      'component_mode' => CRM_Contact_BAO_Query::MODE_CONTACTS,
+      'display_relationship_type' => "{$relTypeID}_a_b",
+      'uf_group_id' => 1,
+    );
+    $queryParams = array();
+    CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
+    $savedSearch->form_values = serialize($queryParams);
+    $savedSearch->save();
+
+    $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
+    $expectedResult = array(
+      'operator' => 'AND',
+      'component_mode' => CRM_Contact_BAO_Query::MODE_CONTACTS,
+      'display_relationship_type' => "{$relTypeID}_a_b",
+      'uf_group_id' => 1,
+    );
+    $this->checkArrayEquals($result, $expectedResult);
+  }
+
   /**
    * Test if relative dates are stored correctly
    * in civicrm_saved_search table.


### PR DESCRIPTION
…th same search profile

Overview
----------------------------------------
Smart group with uf_group_id does not load contacts with same search profile

Before
----------------------------------------
Steps to reproduce -

- Create a search profile adding some basic fields `first name`, last name and email.
- Open Advanced Search form, select this profile and add some filters.
- create a smart group of the resulted contacts.
- When you come back from the process after clicking the `Done` button on the last screen, the profile is not pre-selected by default.
- `uf_group_id` is not stored as a formvalue in `civicrm_saved_search` table.

After
----------------------------------------
Fixed. `uf_group_id` is correctly stored and retrieved from civicrm_saved_search table.


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/771