### PR TITLE
CRM/Contact - Fix fatal error on tag search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3259,11 +3259,14 @@ WHERE  $smartGroupClause
       }
     }
 
-    // implode array, then remove all spaces and validate CommaSeparatedIntegers
-    $value = CRM_Utils_Type::validate(
-      str_replace(' ', '', implode(',', (array) $value)),
-      'CommaSeparatedIntegers'
-    );
+    // implode array, then remove all spaces
+    $value = str_replace(' ', '', implode(',', (array) $value));
+    if (!empty($value)) {
+      $value = CRM_Utils_Type::validate(
+        $value,
+        'CommaSeparatedIntegers'
+      );
+    }
 
     $useAllTagTypes = $this->getWhereValues('all_tag_types', $grouping);
     $tagTypesText = $this->getWhereValues('tag_types_text', $grouping);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in search builder when "Tag(s) IS NULL" is used.

Before
----------------------------------------
Searching for "Tag(s) IS NULL" triggers a fatal error because the CommaSeparatedIntegers does not accept empty strings.

After
----------------------------------------
Searching for "Tag(s) IS NULL" works because the validation is only performed if the value is not empty.

Comments
----------------------------------------
This is basically the same as https://github.com/civicrm/civicrm-core/pull/13738, only for tags.
