### PR TITLE
Upgrader: Don't abort if state_province already exists

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.30.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.30.mysql.tpl
@@ -12,5 +12,5 @@ INSERT INTO civicrm_mailing_bounce_pattern (bounce_type_id, pattern) VALUES (@bo
 
 -- CRM-21532 Add French state/departments
 SELECT @country_id := id from civicrm_country where name = 'France' AND iso_code = 'FR';
-INSERT INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
+INSERT IGNORE INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
 (NULL, @country_id, "52", "Haute-Marne");

--- a/CRM/Upgrade/Incremental/sql/4.7.32.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.32.mysql.tpl
@@ -2,7 +2,7 @@
 
 -- CRM-21837 - Missing states for Gabon
 SELECT @country_id := id from civicrm_country where name = 'Gabon' AND iso_code = 'GA';
-INSERT INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
+INSERT IGNORE INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
 (NULL, @country_id, "01", "Estuaire"),
 (NULL, @country_id, "02", "Haut-Ogooué"),
 (NULL, @country_id, "03", "Moyen-Ogooué"),


### PR DESCRIPTION
Overview
----------------------------------------

When upgrading a client site from 4.7.27 to the latest security release I hit two fatal errors during upgrade.  As I've only just started working with this client I don't know why they were already added but the SQL change is "safe".

Before
----------------------------------------
Fatal error if state_province values already exist during upgrade to 4.7.30 and 4.7.32

After
----------------------------------------
Upgrade continues if state_province values already exist during upgrade to 4.7.30 and 4.7.32

Technical Details
----------------------------------------
Change from INSERT INTO to INSERT IGNORE INTO

Comments
----------------------------------------
Hopefully this will save someone else a little pain if they have to upgrade and hit this.