### PR TITLE
Allow viewing of cancelled recurring contributions

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -243,9 +243,14 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
   private function buildRecurringContributionsArray($recurContributions) {
     $liveRecurringContributionCount = 0;
     foreach ($recurContributions as $recurId => $recurDetail) {
-      $action = array_sum(array_keys($this->recurLinks($recurId)));
-      // no action allowed if it's not active
-      $recurContributions[$recurId]['is_active'] = (!CRM_Contribute_BAO_Contribution::isContributionStatusNegative($recurDetail['contribution_status_id']));
+      // Is recurring contribution active?
+      $recurContributions[$recurId]['is_active'] = !in_array(CRM_Contribute_PseudoConstant::contributionStatus($recurDetail['contribution_status_id'], 'name'), CRM_Contribute_BAO_ContributionRecur::getInactiveStatuses());
+      if ($recurContributions[$recurId]['is_active']) {
+        $actionMask = array_sum(array_keys(self::recurLinks($recurId)));
+      }
+      else {
+        $actionMask = CRM_Core_Action::mask([CRM_Core_Permission::VIEW]);
+      }
 
       if (empty($recurDetail['is_test'])) {
         $liveRecurringContributionCount++;
@@ -260,20 +265,18 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         $recurContributions[$recurId]['contribution_status'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', $recurDetail['contribution_status_id']);
       }
 
-      if ($recurContributions[$recurId]['is_active']) {
-        $recurContributions[$recurId]['action'] = CRM_Core_Action::formLink(self::recurLinks($recurId), $action,
-          array(
-            'cid' => $this->_contactId,
-            'crid' => $recurId,
-            'cxt' => 'contribution',
-          ),
-          ts('more'),
-          FALSE,
-          'contribution.selector.recurring',
-          'Contribution',
-          $recurId
-        );
-      }
+      $recurContributions[$recurId]['action'] = CRM_Core_Action::formLink(self::recurLinks($recurId), $actionMask,
+        array(
+          'cid' => $this->_contactId,
+          'crid' => $recurId,
+          'cxt' => 'contribution',
+        ),
+        ts('more'),
+        FALSE,
+        'contribution.selector.recurring',
+        'Contribution',
+        $recurId
+      );
     }
 
     return [$recurContributions, $liveRecurringContributionCount];


### PR DESCRIPTION
Overview
----------------------------------------
When a recurring contribution is cancelled it is no longer possible to "view" that recurring contribution. The record holds useful information such as transaction ID, frequency and dates and it is often useful to be able to view the details.  I can't see any reason that you would not want to be able to view the details once cancelled?

Before
----------------------------------------
Can't view cancelled recurring contributions via UI

After
----------------------------------------
Can view cancelled recurring contributions via UI

Technical Details
----------------------------------------
Change the function used to get "active" recurring contribution statuses as they are slightly different for recurring contributions.  Change the "mask" so that links are always generated for the "VIEW" action.

Comments
----------------------------------------
