### PR TITLE
Convert activity_date_time field to datepicker and add support for url input

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -288,8 +288,10 @@ class CRM_Activity_BAO_Query {
       case 'activity_date':
       case 'activity_date_low':
       case 'activity_date_high':
+      case 'activity_date_time_low':
+      case 'activity_date_time_high':
         $query->dateQueryBuilder($values,
-          'civicrm_activity', 'activity_date', 'activity_date_time', ts('Activity Date')
+          'civicrm_activity', str_replace(['_high', '_low'], '', $name), 'activity_date_time', ts('Activity Date')
         );
         break;
 
@@ -440,7 +442,7 @@ class CRM_Activity_BAO_Query {
    * rather than a static function.
    */
   public static function getSearchFieldMetadata() {
-    $fields = ['activity_type_id'];
+    $fields = ['activity_type_id', 'activity_date_time'];
     $metadata = civicrm_api3('Activity', 'getfields', [])['values'];
     return array_intersect_key($metadata, array_flip($fields));
   }
@@ -453,10 +455,6 @@ class CRM_Activity_BAO_Query {
   public static function buildSearchForm(&$form) {
     $form->addSearchFieldMetadata(['Activity' => self::getSearchFieldMetadata()]);
     $form->addFormFieldsFromMetadata();
-
-    CRM_Core_Form_Date::buildDateRange($form, 'activity_date', 1, '_low', '_high', ts('From'), FALSE, FALSE);
-    $form->addElement('hidden', 'activity_date_range_error');
-    $form->addFormRule(array('CRM_Activity_BAO_Query', 'formRule'), $form);
 
     $followUpActivity = array(
       1 => ts('Yes'),
@@ -629,27 +627,6 @@ class CRM_Activity_BAO_Query {
     );
 
     return $properties;
-  }
-
-  /**
-   * Custom form rules.
-   *
-   * @param array $fields
-   * @param array $files
-   * @param CRM_Core_Form $form
-   *
-   * @return bool|array
-   */
-  public static function formRule($fields, $files, $form) {
-    $errors = array();
-
-    if (empty($fields['activity_date_low']) || empty($fields['activity_date_high'])) {
-      return TRUE;
-    }
-
-    CRM_Utils_Rule::validDateRange($fields, 'activity_date', $errors, ts('Activity Date'));
-
-    return empty($errors) ? TRUE : $errors;
   }
 
   /**

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -322,31 +322,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       }
     }
 
-    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'String');
-
-    if ($dateLow) {
-      $dateLow = date('m/d/Y', strtotime($dateLow));
-      $this->_formValues['activity_date_relative'] = 0;
-      $this->_defaults['activity_date_relative'] = 0;
-      $this->_formValues['activity_date_low'] = $dateLow;
-      $this->_defaults['activity_date_low'] = $dateLow;
-    }
-
-    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'String');
-
-    if ($dateHigh) {
-      // Activity date time assumes midnight at the beginning of the date
-      // This sets it to almost midnight at the end of the date
-      /*   if ($dateHigh <= 99999999) {
-      $dateHigh = 1000000 * $dateHigh + 235959;
-      } */
-      $dateHigh = date('m/d/Y', strtotime($dateHigh));
-      $this->_formValues['activity_date_relative'] = 0;
-      $this->_defaults['activity_date_relative'] = 0;
-      $this->_formValues['activity_date_high'] = $dateHigh;
-      $this->_defaults['activity_date_high'] = $dateHigh;
-    }
-
     // Enable search activity by custom value
     // @todo this is not good security practice. Instead define entity fields in metadata &
     // use getEntity Defaults

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1899,6 +1899,8 @@ class CRM_Contact_BAO_Query {
       case 'activity_date':
       case 'activity_date_low':
       case 'activity_date_high':
+      case 'activity_date_time_low':
+      case 'activity_date_time_high':
       case 'activity_role':
       case 'activity_status_id':
       case 'activity_status':

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -200,7 +200,7 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
    *
    * @return array|bool
    */
-  public static function formRule($fields) {
+  public static function formRule($fields, $files, $form) {
     // check actionName and if next, then do not repeat a search, since we are going to the next page
     if (array_key_exists('_qf_Search_next', $fields)) {
       if (empty($fields['task'])) {

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1295,11 +1295,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @param string $fieldName
    * @param string $label
+   * @param bool $isDateTime
+   *   Is this a date-time field (not just date).
    * @param bool $required
    * @param string $fromLabel
    * @param string $toLabel
    */
-  public function addDatePickerRange($fieldName, $label, $required = FALSE, $fromLabel = 'From', $toLabel = 'To') {
+  public function addDatePickerRange($fieldName, $label, $isDateTime = FALSE, $required = FALSE, $fromLabel = 'From', $toLabel = 'To') {
 
     $options = array(
       '' => ts('- any -'),
@@ -1314,7 +1316,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       NULL
     );
     $attributes = ['format' => 'searchDate'];
-    $extra = ['time' => FALSE];
+    $extra = ['time' => $isDateTime];
     $this->add('datepicker', $fieldName . '_low', ts($fromLabel), $attributes, $required, $extra);
     $this->add('datepicker', $fieldName . '_high', ts($toLabel), $attributes, $required, $extra);
   }

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -314,24 +314,6 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
-   * Global validation rules for the form.
-   *
-   * @param array $fields
-   *   Posted values of the form.
-   *
-   * @return array|bool
-   */
-  public static function formRule($fields) {
-    $errors = array();
-
-    if (!empty($errors)) {
-      return $errors;
-    }
-
-    return TRUE;
-  }
-
-  /**
    * Set the default form values.
    *
    *

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -112,6 +112,45 @@ class CRM_Upgrade_Incremental_SmartGroups {
   }
 
   /**
+   * Rename a smartgroup field.
+   *
+   * @param string $oldName
+   * @param string $newName
+   */
+  public function renameField($oldName, $newName) {
+    foreach ($this->getSearchesWithField($oldName) as $savedSearch) {
+      $formValues = $savedSearch['form_values'];
+      foreach ($formValues as $index => $formValue) {
+        if ($formValue[0] === $oldName) {
+          $formValues[$index][0] = $newName;
+        }
+      }
+
+      if ($formValues !== $savedSearch['form_values']) {
+        civicrm_api3('SavedSearch', 'create', ['id' => $savedSearch['id'], 'form_values' => $formValues]);
+      }
+    }
+  }
+
+  /**
+   * Rename pairs of fields
+   *
+   * @param array $pairs
+   *  Array or arrays of pairs - e.g
+   *  [
+   *    ['old' => 'activity_date', 'new' => 'activity_date_time'],
+   *    ['old' => 'activity_date_low', 'new' => 'activity_date_time_low'],
+   *    ['old' => 'activity_date_high', 'new' => 'activity_date_time_high'],
+   *    ['old' => 'activity_date_relative', 'new' => 'activity_date_time_relative'],
+   *  ]
+   */
+  public function renameFields($pairs) {
+    foreach ($pairs as $pair) {
+      $this->renameField($pair['old'], $pair['new']);
+    }
+  }
+
+  /**
    * @param $field
    * @return mixed
    */
@@ -121,6 +160,7 @@ class CRM_Upgrade_Incremental_SmartGroups {
       'form_values' => ['LIKE' => "%{$field}%"],
     ])['values'];
     return $savedSearches;
+
   }
 
 }

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -70,6 +70,10 @@ class CRM_Upgrade_Incremental_SmartGroups {
           }
         }
         foreach ($formValues as $index => $formValue) {
+          if (!isset($formValue[0])) {
+            // Any actual criteria will have this key set but skip any weird lines
+            continue;
+          }
           if (in_array($formValue[0], $fieldPossibilities)) {
             if ($isRelative) {
               unset($formValues[$index]);

--- a/CRM/Upgrade/Incremental/php/FiveTwelve.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwelve.php
@@ -73,10 +73,19 @@ class CRM_Upgrade_Incremental_php_FiveTwelve extends CRM_Upgrade_Incremental_Bas
    * @param string $rev
    */
   public function upgrade_5_12_alpha1($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Update smart groups to rename filters on activity_date to activity_date_time', 'updateSmartGroups', [
+      'renameFields' => [
+        ['old' => 'activity_date', 'new' => 'activity_date_time'],
+        ['old' => 'activity_date_low', 'new' => 'activity_date_time_low'],
+        ['old' => 'activity_date_high', 'new' => 'activity_date_time_high'],
+        ['old' => 'activity_date_relative', 'new' => 'activity_date_time_relative'],
+      ],
+    ]);
     $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
       'datepickerConversion' => [
         'age_asof_date',
+        'activity_date_time'
       ]
     ]);
   }

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -89,10 +89,9 @@
 </tr>
 
 <tr>
-  <td><label>{ts}Activity Dates{/ts}</label></td>
-</tr>
-<tr>
-  {include file="CRM/Core/DateRange.tpl" fieldName="activity_date" from='_low' to='_high'}
+  <td>
+    {include file="CRM/Core/DatePickerRange.tpl" fieldName="activity_date_time" from='_low' to='_high'}
+  </td>
 </tr>
 <tr>
   <td>

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -105,9 +105,16 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     ]);
     $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
     $this->assertEquals('grant_application_received_date_high', $savedSearch['form_values'][0][0]);
-    $this->assertEquals('2019-01-20 00:00:00', $savedSearch['form_values'][0][2]);
+    $this->assertEquals('2019-01-20 23:59:59', $savedSearch['form_values'][0][2]);
     $this->assertEquals('grant_due_date_low', $savedSearch['form_values'][1][0]);
     $this->assertEquals('2019-01-22 00:00:00', $savedSearch['form_values'][1][2]);
+    $hasRelative = FALSE;
+    foreach ($savedSearch['form_values'] as $form_value) {
+      if ($form_value[0] === 'grant_due_date_relative') {
+        $hasRelative = TRUE;
+      }
+    }
+    $this->assertEquals(TRUE, $hasRelative);
   }
 
   /**

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -124,6 +124,42 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
     $this->assertEquals('IN', $savedSearch['form_values'][0][1]);
     $this->assertEquals(['1'], $savedSearch['form_values'][0][2]);
+
+  }
+
+  /**
+   * Test renaming a field.
+   */
+  public function testRenameField() {
+    $this->callAPISuccess('SavedSearch', 'create', [
+      'form_values' => [
+        ['activity_date_low', '=', '01/22/2019'],
+      ]
+    ]);
+    $smartGroupConversionObject = new CRM_Upgrade_Incremental_SmartGroups();
+    $smartGroupConversionObject->renameField('activity_date_low', 'activity_date_time_low');
+    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
+    $this->assertEquals('activity_date_time_low', $savedSearch['form_values'][0][0]);
+  }
+
+  /**
+   * Test renaming multiple fields.
+   */
+  public function testRenameFields() {
+    $this->callAPISuccess('SavedSearch', 'create', [
+      'form_values' => [
+        ['activity_date_low', '=', '01/22/2019'],
+        ['activity_date_relative', '=', 0],
+      ]
+    ]);
+    $smartGroupConversionObject = new CRM_Upgrade_Incremental_SmartGroups();
+    $smartGroupConversionObject->renameFields([
+      ['old' => 'activity_date_low', 'new' => 'activity_date_time_low'],
+      ['old' => 'activity_date_relative', 'new' => 'activity_date_time_relative'],
+    ]);
+    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
+    $this->assertEquals('activity_date_time_low', $savedSearch['form_values'][0][0]);
+    $this->assertEquals('activity_date_time_relative', $savedSearch['form_values'][1][0]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Convert activity_date_time field on activity search page to use datepicker, add support for parameters to this in the url

Before
----------------------------------------
Deprecated jcalendar

After
----------------------------------------
Preferred datepicker & metadata approaches in use. Generic url support added with tight validation

![screenshot 2019-03-02 19 05 33](https://user-images.githubusercontent.com/336308/53678038-43f5b480-3d1e-11e9-9e2d-9d882ad1d56e.png)


Technical Details
----------------------------------------
This converts the form to being a metadata defined field & a date-picker field as well
as adding standardised url support for input.

The input format is
activity_date_time_high=20100101

I stripped out the complex and probably broken based on feedback  & not used in core
existing hard-coded url support.

Note that there are some outstanding items
1) I updated the check to ensure the high date is greater than the low date
-but it DOES display more than once if it fails - I think we could hone that later


Comments
----------------------------------------
@monishdeb @colemanw you both seem to be working on making search form changes that can be solved by adopting a generic approach - here is how I see it working for the activity date time field. We should be able to update similar fields like 'contribution receive date', membership start date , birth date etc with less code change as the Core_Form & Form_Search changes are to support time in datepicker ranges & url support for date fields (respectively)
