### PR TITLE
Fix Custom post outer div class on event registration form

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -145,7 +145,7 @@
       {include file='CRM/Core/BillingBlockWrapper.tpl'}
     {/if}
 
-    <div class="crm-public-form-item crm-section custom_pre-section">
+    <div class="crm-public-form-item crm-section custom_post-section">
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
     </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the class applied to the outer div around the custom profile in the post section of the form

Before
----------------------------------------
2 `custom_pre-section` classes in action

After
----------------------------------------
1 `custom_pre-section` 
1 `custom_post-section` 

ping @eileenmcnaughton @mattwire @monishdeb 