### PR TITLE
dev/core#745 do not filter on 'on_hold' if it is an empty string

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1638,8 +1638,15 @@ class CRM_Contact_BAO_Query {
       }
       elseif ($id == 'email_on_hold') {
         if ($onHoldValue = CRM_Utils_Array::value('email_on_hold', $formValues)) {
-          $onHoldValue = (array) $onHoldValue;
-          $params[] = array('on_hold', 'IN', $onHoldValue, 0, 0);
+          // onHoldValue should be 0 or 1 or an array. Some legacy groups may hold ''
+          // so in 5.11 we have an extra if that should become redundant over time.
+          // https://lab.civicrm.org/dev/core/issues/745
+          // @todo this renaming of email_on_hold to on_hold needs revisiting
+          // it preceeds recent changes but causes the default not to reload.
+          if (is_numeric($onHoldValue) || is_array($onHoldValue)) {
+            $onHoldValue = (array) $onHoldValue;
+            $params[] = ['on_hold', 'IN', $onHoldValue, 0, 0];
+          }
         }
       }
       elseif (substr($id, 0, 7) == 'custom_'


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression on smart groups where an on-hold filter is added to some legacy groups

Before
----------------------------------------
Legacy groups in correctly filter for on-hold

After
----------------------------------------
Filter shouldn't happen

Technical Details
----------------------------------------
Although I couldn't find a way to create a group on an earlier version with the format that causes this; that doesn't mean there aren't systems with those groups.

 We only care about number (0 or 1) or arrays (from the select widget)
so add an extra check before filtering

Comments
----------------------------------------
@scardinius this is slightly different to yours as I see it as a temporary hack & tried to make it look like one - can you check

https://lab.civicrm.org/dev/core/issues/745