### PR TITLE
dev/core#766 fix loss of custom fields when creating an event from template

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1669,6 +1669,9 @@ FROM   civicrm_domain
         }
       }
       $newObject->save();
+      if (!empty($newData['custom'])) {
+        CRM_Core_BAO_CustomValueTable::store($newData['custom'], $newObject::getTableName(), $newObject->id);
+      }
       CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getBriefName($daoName), $newObject->id, $newObject);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes 5.9 regression whereby creating an event from template does not save custom field data

Before
----------------------------------------
Custom data entered in the event not retained when creating event from template

After
----------------------------------------
Data saved

Technical Details
----------------------------------------
A while back the code was updated to use the copyGeneric function, handling of custom data was not addressed then

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/766#note_14381

@mattwire @seamuslee001 I think we should get this in 5.11
