### PR TITLE
Do not load membership contribution as updateMembershipBasedOnCompletionOfContribution loads it within the function

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -358,10 +358,6 @@ class CRM_Financial_BAO_Payment {
    */
   public static function recordPayment($contributionId, $trxnData, $participantId) {
     list($contributionDAO, $params) = self::getContributionAndParamsInFormatForRecordFinancialTransaction($contributionId);
-    // load related memberships on basis of $contributionDAO object
-    // @todo - this is done in the function that completes payments so it's being done twice.
-    // test & remove.
-    $contributionDAO->loadRelatedMembershipObjects();
 
     if (!$participantId) {
       $participantId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $contributionId, 'participant_id', 'contribution_id');


### PR DESCRIPTION
Overview
----------------------------------------
Remove lines of code previously identified as duplicates

Before
----------------------------------------
loadMembershipStatus called once before the membership update fn & once during

After
----------------------------------------
loadMembershipStatus called once

Technical Details
----------------------------------------
Let's see if tests have any concerns but I'm pretty comfortable this is just extraneous

Comments
----------------------------------------

