### PR TITLE
[REF] towards cleanup of update membership code

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -942,6 +942,30 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
   }
 
   /**
+   * Get memberships realted to the contribution.
+   *
+   * @param int $contributionID
+   *
+   * @return array
+   */
+  protected static function getRelatedMemberships($contributionID) {
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $contributionID;
+    $contribution->fetch(TRUE);
+    $contribution->loadRelatedMembershipObjects();
+    $result = CRM_Utils_Array::value('membership', $contribution->_relatedObjects, []);
+    $memberships = [];
+    foreach ($result as $membership) {
+      if (empty($membership)) {
+        continue;
+      }
+      // @todo - remove this again & just call api in the first place.
+      _civicrm_api3_object_to_array($membership, $memberships[$membership->id]);
+    }
+    return $memberships;
+  }
+
+  /**
    * @inheritDoc
    */
   public function addSelectWhereClause() {
@@ -5231,18 +5255,14 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
    * @throws \CiviCRM_API3_Exception
    */
   public static function updateMembershipBasedOnCompletionOfContribution($contribution, $primaryContributionID, $changeDate) {
-    $contribution->loadRelatedMembershipObjects();
-    if (empty($contribution->_relatedObjects['membership'])) {
-      return;
-    }
-    $memberships = $contribution->_relatedObjects['membership'];
-    foreach ($memberships as $membershipTypeIdKey => $membership) {
+    $memberships = self::getRelatedMemberships($contribution->id);
+    foreach ($memberships as $membership) {
       if ($membership) {
         $membershipParams = array(
-          'id' => $membership->id,
-          'contact_id' => $membership->contact_id,
-          'is_test' => $membership->is_test,
-          'membership_type_id' => $membership->membership_type_id,
+          'id' => $membership['id'],
+          'contact_id' => $membership['contact_id'],
+          'is_test' => $membership['is_test'],
+          'membership_type_id' => $membership['membership_type_id'],
           'membership_activity_status' => 'Completed',
         );
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup towards https://github.com/civicrm/civicrm-core/pull/12542

Before
----------------------------------------
less readable 

After
----------------------------------------
More readable

Technical Details
----------------------------------------
@mattwire I've pulled this out as I think breaking out the loading of the memberships would simplify changing that function

This PR limits itself to siphoning off how the memberships are fetched & having that function
- return as an array of arrays rather than an array of objects
- index the array by id rather than membership type

This is a step towards the changes in https://github.com/civicrm/civicrm-core/pull/12542

& it should allow a separation of concerns relating to the LOADING of memberships from the
processing.

I note that the PR I'm looking at changes what gets loaded & that should be it's own PR
but also that there is an extraneous if() here - I didn't alter that because
it is a big white space change & doing on it's own will make that easy to review

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
