### PR TITLE
report clean up - remove redundant code

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -732,19 +732,6 @@ ORDER BY  cv.label
         $entryFound = TRUE;
       }
 
-      // Handle employer id
-      if (array_key_exists('civicrm_contact_employer_id', $row)) {
-        $employerId = $row['civicrm_contact_employer_id'];
-        if ($employerId) {
-          $rows[$rowNum]['civicrm_contact_employer_id'] = CRM_Contact_BAO_Contact::displayName($employerId);
-          $url = CRM_Utils_System::url('civicrm/contact/view',
-            'reset=1&cid=' . $employerId, $this->_absoluteUrl
-          );
-          $rows[$rowNum]['civicrm_contact_employer_id_link'] = $url;
-          $rows[$rowNum]['civicrm_contact_employer_id_hover'] = ts('View Contact Summary for this Contact.');
-        }
-      }
-
       // Convert campaign_id to campaign title
       $this->_initBasicRow($rows, $entryFound, $row, 'civicrm_participant_campaign_id', $rowNum, $this->campaigns);
 


### PR DESCRIPTION
Overview
----------------------------------------
remove redundant employer calculation code

Before
----------------------------------------
employer is evaluated with link
![part_before](https://user-images.githubusercontent.com/3455173/53731634-65cb7480-3ea1-11e9-92ff-9678b31d20e2.png)

After
----------------------------------------
employer is evaluated with link
![part_after](https://user-images.githubusercontent.com/3455173/53731646-767bea80-3ea1-11e9-9a48-18b12c0d1c03.png)

Comments
----------------------------------------
the code has been centralised in _CRM/Report/Form.php_, so no need in to calculate in each report
