### PR TITLE
Add billingblock region to event registration thankyou to match contribution thankyou

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -281,10 +281,9 @@
           {/if}
         {else}
           <div class="crm-section no-label credit_card_details-section">
-            <div class="content">{$credit_card_type|escape}</div>
-            <div class="content">{$credit_card_number|escape}</div>
-            <div
-              class="content">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
+            <div class="content">{$credit_card_type}</div>
+            <div class="content">{$credit_card_number}</div>
+            <div class="content">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
             <div class="clear"></div>
           </div>
         {/if}

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -168,17 +168,19 @@
     {/if}
 
     {if $contributeMode eq 'direct' and ! $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+      {crmRegion name="event-confirm-billing-block"}
         <div class="crm-group credit_card-group">
-            <div class="header-dark">
-                {ts}Credit Card Information{/ts}
-            </div>
-            <div class="crm-section no-label credit_card_details-section">
-                <div class="content">{$credit_card_type}</div>
+          <div class="header-dark">
+            {ts}Credit Card Information{/ts}
+          </div>
+          <div class="crm-section no-label credit_card_details-section">
+            <div class="content">{$credit_card_type}</div>
             <div class="content">{$credit_card_number}</div>
-            <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+            <div class="content">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
             <div class="clear"></div>
           </div>
         </div>
+      {/crmRegion}
     {/if}
 
     {if $contributeMode NEQ 'notify'} {* In 'notify mode, contributor is taken to processor payment forms next *}

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -189,17 +189,19 @@
     {/if}
 
     {if $contributeMode eq 'direct' and $paidEvent and ! $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+      {crmRegion name="event-thankyou-billing-block"}
         <div class="crm-group credit_card-group">
-            <div class="header-dark">
-                {ts}Credit Card Information{/ts}
-            </div>
-            <div class="crm-section no-label credit_card_details-section">
-                <div class="content">{$credit_card_type}</div>
+          <div class="header-dark">
+            {ts}Credit Card Information{/ts}
+          </div>
+          <div class="crm-section no-label credit_card_details-section">
+            <div class="content">{$credit_card_type}</div>
             <div class="content">{$credit_card_number}</div>
-            <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+            <div class="content">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
             <div class="clear"></div>
           </div>
         </div>
+      {/crmRegion}
     {/if}
 
     {if $event.thankyou_footer_text}


### PR DESCRIPTION
Overview
----------------------------------------
This allows us to use the same code in payment processor extensions for the "confirm" and "thankyou" section of the payment process for both contributions and event registrations.

Before
----------------------------------------
If you want to alter/replace the billingblock on event registration confirm/thankyou pages you have to target it via jquery or alterContent hook.  But for contribution thankyou you just replace the region with one that displays billing information relevant to the payment processor.

After
----------------------------------------
Same method to replace billingblock for both event and contribution thankyou workflows.  Simpler code, more consistency...

Technical Details
----------------------------------------
Insert crmRegion into the smarty templates (I did consider different crmRegion names for the event pages but you can differentiate by the form class name if you need to and we need more consistency for payment processors so you can just write it once rather than write it differently for each workflow!

Comments
----------------------------------------
@seamuslee001 @jitendrapurohit Either of you able to take a look.  Most of the PR is just formatting (indenting), the only change is adding the crmRegion tags to the two event pages so should not break anything - and existing extensions that target those regions will not be affected as they still need to add event form class name to actually change the region.