### PR TITLE
Create contribution before taking payment, per contribution page workflow

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1270,10 +1270,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       //add contribution record
       $contributions[] = $contribution = CRM_Event_Form_Registration_Confirm::processContribution(
-        $this, $this->_params,
-        $result, $contactID,
-        FALSE, FALSE,
-        $this->_paymentProcessor
+        $this, $this->_params, $contactID, FALSE, FALSE, $this->_paymentProcessor
       );
 
       // add participant record


### PR DESCRIPTION
Overview
----------------------------------------
When registering for an event the payment processor is called before the contribution is created.  This is inconsistent with the contribution page workflow which creates the contribution before calling the payment processor.

Before
----------------------------------------
No record of contribution if payment processor fails.

After
----------------------------------------
Contribution is created before payment processor is called, so there is always a contribution record even if payment fails.  Contribution ID is available to the payment processor and we can update it with our own parameters, rather than passing them back to the event handling code which subsequently saves them on the contribution.

Technical Details
----------------------------------------
"Simple" refactor that removes `$result` parameter which is not required, swaps two blocks of code around and stops the event code trying to do things with contributions that should be handled by the payment processor (eg. saving of trxn_id).

Comments
----------------------------------------
Further refactor could be to extract some of this code into separate functions but this seems like a logical first step as it puts things into the right order and variables are used later in the function.
