### PR TITLE
Fix api bug whereby 0 & '0' are not accepted as range parameters for BETWEEN

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2542,7 +2542,7 @@ SELECT contact_id
           // ternary operators
           case 'BETWEEN':
           case 'NOT BETWEEN':
-            if (empty($criteria[0]) || empty($criteria[1])) {
+            if ((empty($criteria[0]) && !in_array($criteria[0], ['0', 0]))|| (empty($criteria[1]) &&  !in_array($criteria[1], ['0', 0]))) {
               throw new Exception("invalid criteria for $operator");
             }
             if (!$returnSanitisedArray) {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1017,7 +1017,26 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'last_name' => "O'Connor",
       'sequential' => 1,
     ));
-    $this->assertEquals("O'Connor", $result['last_name'], 'in line' . __LINE__);
+    $this->assertEquals("O'Connor", $result['last_name']);
+  }
+
+  /**
+   * Test between accepts zero.
+   *
+   * In the past it incorrectly required !empty.
+   */
+  public function testGetBetweenZeroWorks() {
+    $this->callAPISuccess($this->_entity, 'get', [
+      'contact_id' => ['BETWEEN' => [0, 9]],
+    ]);
+    $this->callAPISuccess($this->_entity, 'get', [
+      'contact_id' => [
+        'BETWEEN' => [
+          (0 - 9),
+          0,
+        ],
+      ],
+    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix api bug whereby 0 & '0' are not accepted as range parameters for BETWEEN

Before
----------------------------------------
These api calls are rejected
```
    civicrm_api3($this->_entity, 'get', [
      'contact_id' => ['BETWEEN' => [0, 9]],
    ]);
     civicrm_api3($this->_entity, 'get', [
      'contact_id' => ['BETWEEN' => [-9, 0]],
    ]);
```

After
----------------------------------------
Above calls succeed

Technical Details
----------------------------------------
In other news I'm not thrilled about the 0 casting to a string here but that is for another time

Comments
----------------------------------------

