### PR TITLE
Mail accounts with " in the password were failing.

### DIFF
--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -57,12 +57,15 @@ class CRM_Mailing_MailStore {
       throw new Exception("Empty mail protocol");
     }
 
+    // Addcslashes here makes passwords with spaces, quotes, and backslashes work.
+    $password = addcslashes($dao->password, '"\ ');
+
     switch ($protocols[$dao->protocol]) {
       case 'IMAP':
-        return new CRM_Mailing_MailStore_Imap($dao->server, $dao->username, $dao->password, (bool) $dao->is_ssl, $dao->source);
+        return new CRM_Mailing_MailStore_Imap($dao->server, $dao->username, $password, (bool) $dao->is_ssl, $dao->source);
 
       case 'POP3':
-        return new CRM_Mailing_MailStore_Pop3($dao->server, $dao->username, $dao->password, (bool) $dao->is_ssl);
+        return new CRM_Mailing_MailStore_Pop3($dao->server, $dao->username, $password, (bool) $dao->is_ssl);
 
       case 'Maildir':
         return new CRM_Mailing_MailStore_Maildir($dao->source);


### PR DESCRIPTION
Mail accounts with " in the password were failing. Presumably the same for other special characters as well.

Comments added.

Much preferable to making changes in library - that would A) ensure that the change is lost when the 
 library is upgraded (or add overhead for the change to be migrated) B) take far longer to introduce C) risk re-introducing the bug if the library is ever switched.

Overview
----------------------------------------
CiviCRM provides the facility for email inboxes to be read, and their contents used in the CRM. Email login credentials are provided by the user to the CRM for this purpose. However, if the email account password includes a " then the process fails. This change allows special characters that are known to make passwords fail on the MailStore.

Before
----------------------------------------
Passwords on MailStore fail if they contain a " - they are not escaped, so the process fails. This is both for IMAP and Pop3. This is bug number 662 in gitlab.

After
----------------------------------------
Special characters in passwords work.

Technical Details
----------------------------------------
Escaping is provided for backslashes (\), inverted commas ("), and spaces ( ).

Comments
----------------------------------------
Comments provided according to feedback in previous PR (now closed, can't locate).