### PR TITLE
Remove mcrypt system status check

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -121,35 +121,6 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
-   * @return array
-   */
-  public function checkPhpEcrypt() {
-    $messages = array();
-    $mailingBackend = Civi::settings()->get('mailing_backend');
-    if (!is_array($mailingBackend)
-      || !isset($mailingBackend['outBound_option'])
-      || $mailingBackend['outBound_option'] != CRM_Mailing_Config::OUTBOUND_OPTION_SMTP
-      || !CRM_Utils_Array::value('smtpAuth', $mailingBackend)
-    ) {
-      return $messages;
-    }
-
-    $test_pass = 'iAmARandomString';
-    $encrypted_test_pass = CRM_Utils_Crypt::encrypt($test_pass);
-    if ($encrypted_test_pass == base64_encode($test_pass)) {
-      $messages[] = new CRM_Utils_Check_Message(
-        __FUNCTION__,
-        ts('Your PHP does not include the mcrypt encryption functions. Your SMTP password will not be stored encrypted, and if you have recently upgraded from a PHP that stored it with encryption, it will not be decrypted correctly.'
-        ),
-        ts('PHP Missing Extension "mcrypt"'),
-        \Psr\Log\LogLevel::WARNING,
-        'fa-server'
-      );
-    }
-    return $messages;
-  }
-
-  /**
    * Check that the MySQL time settings match the PHP time settings.
    *
    * @return array<CRM_Utils_Check_Message> an empty array, or a list of warnings


### PR DESCRIPTION
Overview
----------------------------------------
Remove status check for mcrypt

Before
----------------------------------------
Status check error is mcrypt not present & smtp encryption in place

After
----------------------------------------
Error gone

Technical Details
----------------------------------------
Php 7.2 doesn't support this & it is being deprecated so having this here causes
sites to try to install it - creating a migration problem they wouldn't otherwise have

The situation here is unresolved but this check doesn't solve more confusion than it creates or help more than it hinders

Comments
----------------------------------------
Arose from this user-confusion discussion https://chat.civicrm.org/civicrm/pl/765mcnydrtfru8h8ixz9od3p3w
