### PR TITLE
dev/core#745 Further on_hold fix - it has been suggested the value might be an array like ['']

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1643,8 +1643,8 @@ class CRM_Contact_BAO_Query {
           // https://lab.civicrm.org/dev/core/issues/745
           // @todo this renaming of email_on_hold to on_hold needs revisiting
           // it preceeds recent changes but causes the default not to reload.
-          if (is_numeric($onHoldValue) || is_array($onHoldValue)) {
-            $onHoldValue = (array) $onHoldValue;
+          $onHoldValue = array_filter((array) $onHoldValue, 'is_numeric');
+          if (!empty($onHoldValue)) {
             $params[] = ['on_hold', 'IN', $onHoldValue, 0, 0];
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
This extends the fix to prevent us winding up with a query like on_hold IN ('') or on_hold IN (NULL)

Before
----------------------------------------
Potential inappropriate filtering on legacy smart groups

After
----------------------------------------
on_hold filter only applied for numeric values - either as a value or in an array

Technical Details
----------------------------------------
We seem to have some legacy group variants hitting problems - the data about what they might be is a bit unclear but this would see to ensure that only a non-empty array of numeric values gets to the if clause

Comments
----------------------------------------
@agileware-fj @seamuslee001  - Seamus felt we were missing some possible variants in https://github.com/civicrm/civicrm-core/pull/13754 so this should be tighter & still pretty sage