### PR TITLE
[REF] small cleanups on payment.create flow.

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -358,10 +358,6 @@ class CRM_Financial_BAO_Payment {
   public static function recordPayment($contributionId, $trxnData, $participantId) {
     list($contributionDAO, $params) = self::getContributionAndParamsInFormatForRecordFinancialTransaction($contributionId);
 
-    if (!$participantId) {
-      $participantId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $contributionId, 'participant_id', 'contribution_id');
-    }
-
     $trxnData['trxn_date'] = !empty($trxnData['trxn_date']) ? $trxnData['trxn_date'] : date('YmdHis');
     $params['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $trxnData, CRM_Utils_Array::value('payment_instrument_id', $params));
 
@@ -428,6 +424,9 @@ WHERE eft.entity_table = 'civicrm_contribution'
       // which in 'Partial Paid' => 'Completed' is not useful, instead specific financial record updates
       // are coded below i.e. just updating financial_item status to 'Paid'
 
+      if (!$participantId) {
+        $participantId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $contributionId, 'participant_id', 'contribution_id');
+      }
       if ($participantId) {
         // update participant status
         $participantStatuses = CRM_Event_PseudoConstant::participantStatus();


### PR DESCRIPTION
Overview
----------------------------------------
Small code tidy up

Before
----------------------------------------
Code less readable

After
----------------------------------------
Code more readable

Technical Details
----------------------------------------
In the interests of keeping some momentum I added this small cleanup which does 3 things

1) uses the preferred function to get 'from_financial_account_id', 2 moves a line of code to get participantID
& 3 removes the conditionals around is_payment. This probably needs the most double checking but
I believe recordPartialPaymet used to be called from places other than Payment.create so
it may not have always been handling a payment - however it I can't see a case for it not be
is_payment now

Comments
----------------------------------------
@pradpnayak you might recall some history here

@monishdeb I figured I'd add something small to keep moving on this
