### PR TITLE
Display test contributions when viewing contributions related to a test recurring contribution

### DIFF
--- a/CRM/Contribute/Page/ContributionRecurPayments.php
+++ b/CRM/Contribute/Page/ContributionRecurPayments.php
@@ -45,6 +45,7 @@ class CRM_Contribute_Page_ContributionRecurPayments extends CRM_Core_Page {
       'contribution_recur_id' => $this->id,
       'contact_id' => $this->contactId,
       'options' => array('limit' => 0),
+      'contribution_test' => '',
     ));
 
     foreach ($relatedContributionsResult['values'] as $contribution) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where you can view  a test recurring contribution but related contributions not displayed

Before
----------------------------------------
![screenshot 2019-03-07 18 47 04](https://user-images.githubusercontent.com/336308/53934932-6a926180-4109-11e9-81d6-114385689ea8.png)


After
----------------------------------------
![screenshot 2019-03-07 18 44 37](https://user-images.githubusercontent.com/336308/53934906-50f11a00-4109-11e9-8c7d-06613d9111cb.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
@mattwire this follows on from some changes you made