### PR TITLE
CRM-21677 - report clean up

### DIFF
--- a/CRM/Report/Form/Contact/Summary.php
+++ b/CRM/Report/Form/Contact/Summary.php
@@ -210,15 +210,6 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
       // Handle ID to label conversion for contact fields
       $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'contact/summary', 'View Contact Summary') ? TRUE : $entryFound;
 
-      // display birthday in the configured custom format
-      if (array_key_exists('civicrm_contact_birth_date', $row)) {
-        $birthDate = $row['civicrm_contact_birth_date'];
-        if ($birthDate) {
-          $rows[$rowNum]['civicrm_contact_birth_date'] = CRM_Utils_Date::customFormat($birthDate, '%Y%m%d');
-        }
-        $entryFound = TRUE;
-      }
-
       // skip looking further in rows, if first row itself doesn't
       // have the column we need
       if (!$entryFound) {


### PR DESCRIPTION
Overview
----------------------------------------
remove redundant birth date evaluation code

Before
----------------------------------------
birth date is evaluated properly
![summ_before](https://user-images.githubusercontent.com/3455173/53941017-16718800-40dd-11e9-8383-bac656415f71.png)


After
----------------------------------------
birth date is evaluated properly
![summ_after](https://user-images.githubusercontent.com/3455173/53941022-196c7880-40dd-11e9-8a33-4bb1d94549c6.png)


