### PR TITLE
Standardise setTitle method on forms

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -472,15 +472,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       CRM_Utils_Array::value('cancelSubscriptionUrl', $this->_values)
     );
 
-    // assigning title to template in case someone wants to use it, also setting CMS page title
-    if ($this->_pcpId) {
-      $this->assign('title', $this->_pcpInfo['title']);
-      CRM_Utils_System::setTitle($this->_pcpInfo['title']);
-    }
-    else {
-      $this->assign('title', $this->_values['title']);
-      CRM_Utils_System::setTitle($this->_values['title']);
-    }
+    $this->setTitle(($this->_pcpId ? $this->_pcpInfo['title'] : $this->_values['title']));
     $this->_defaults = array();
 
     $this->_amount = $this->get('amount');

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -752,6 +752,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public function setTitle($title) {
     $this->_title = $title;
+    CRM_Utils_System::setTitle($title);
   }
 
   /**

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -391,9 +391,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $this->_contributeMode = $this->get('contributeMode');
     $this->assign('contributeMode', $this->_contributeMode);
 
-    // setting CMS page title
-    CRM_Utils_System::setTitle($this->_values['event']['title']);
-    $this->assign('title', $this->_values['event']['title']);
+    $this->setTitle($this->_values['event']['title']);
 
     $this->assign('paidEvent', $this->_values['event']['is_monetary']);
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup, also makes the title of a form available in the buildForm hook

Before
----------------------------------------
Code less sensible, form title obtainable in the buildForm hook but in a way that feels a bit round-about

After
----------------------------------------
Code more consistent. ContributionPage & Form titles retrievable with 'getTitle' in buildForm hooks

Technical Details
----------------------------------------
We have inconsistent methodology for setting the title. This is a minor simplification and
consistency improvement. It also means hooks can call 'getTitle' - ideally all forms would call thi
s & title handling would be consistent.... one day


Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/1058