### PR TITLE
dev/core#784 - On civicase case type editing screen creating a new relationship type on the fly inserts a blank row

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -436,8 +436,10 @@
         } else {
           CRM.loadForm(CRM.url('civicrm/admin/reltype', {action: 'add', reset: 1, label_a_b: roleName, label_b_a: roleName}))
             .on('crmFormSuccess', function(e, data) {
-              roles.push({name: data.relationshipType[REL_TYPE_CNAME]});
-              $scope.relationshipTypeOptions.push({id: data.relationshipType[REL_TYPE_CNAME], text: data.relationshipType.label_b_a});
+              var newTypes = _.values(data.relationshipType);
+              var newType = newTypes[0];
+              roles.push({name: newType[REL_TYPE_CNAME]});
+              $scope.relationshipTypeOptions.push({id: newType[REL_TYPE_CNAME], text: newType.label_b_a});
               $scope.$digest();
             });
         }

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -436,8 +436,7 @@
         } else {
           CRM.loadForm(CRM.url('civicrm/admin/reltype', {action: 'add', reset: 1, label_a_b: roleName, label_b_a: roleName}))
             .on('crmFormSuccess', function(e, data) {
-              var newTypes = _.values(data.relationshipType);
-              var newType = newTypes[0];
+              var newType = _.values(data.relationshipType)[0];
               roles.push({name: newType[REL_TYPE_CNAME]});
               $scope.relationshipTypeOptions.push({id: newType[REL_TYPE_CNAME], text: newType.label_b_a});
               $scope.$digest();


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/784

Before
----------------------------------------
Adding a new relationship type on the fly during case type roles editing would insert a blank row.

After
----------------------------------------
Inserted row is not blank.
