### PR TITLE
dev/core#562 remove more instances of ->free()

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1652,7 +1652,6 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         strpos($dao->source, $source) !== FALSE
       ) {
         $contributionId = $dao->contribution_id;
-        $dao->free();
       }
     }
 
@@ -1928,8 +1927,6 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
               }
             }
             // else fall back to using current membership type
-            $dao->free();
-
             // Figure out number of terms
             $numterms = 1;
             $lineitems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contributionId);
@@ -3102,7 +3099,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             'amount' => $additional->fee_amount,
           );
           $additional->save();
-          $additional->free();
           $template->assign('amount', $amount);
           CRM_Event_BAO_Event::sendMail($cId, $values, $pId, $isTest, $returnMessageText);
         }
@@ -4697,7 +4693,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $membership->start_date = CRM_Utils_Date::isoToMysql($membership->start_date);
           $membership->end_date = CRM_Utils_Date::isoToMysql($membership->end_date);
           $this->_relatedObjects['membership'][$membership->membership_type_id] = $membership;
-          $membership->free();
         }
       }
     }
@@ -5287,7 +5282,6 @@ LIMIT 1;";
           $membershipParams['membership_type_id'] = $dao->membership_type_id;
         }
       }
-      $dao->free();
 
       $membershipParams['num_terms'] = $contribution->getNumTermsByContributionAndMembershipType(
         $membershipParams['membership_type_id'],

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -132,7 +132,6 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
         while ($dao->fetch()) {
           $result[$dao->path] = self::decode($dao->data);
         }
-        $dao->free();
 
         self::$_cache[$argString] = $result;
         $cache->set($cleanKey, self::$_cache[$argString]);
@@ -201,8 +200,6 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
     }
 
     $lock->release();
-
-    $dao->free();
 
     // cache coherency - refresh or remove dependent caches
 

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -67,8 +67,7 @@ class CRM_Core_BAO_SchemaHandler {
   public static function createTable(&$params) {
     $sql = self::buildTableSQL($params);
     // do not i18n-rewrite
-    $dao = CRM_Core_DAO::executeQuery($sql, array(), TRUE, NULL, FALSE, FALSE);
-    $dao->free();
+    CRM_Core_DAO::executeQuery($sql, array(), TRUE, NULL, FALSE, FALSE);
 
     $config = CRM_Core_Config::singleton();
     if ($config->logging) {
@@ -253,15 +252,13 @@ class CRM_Core_BAO_SchemaHandler {
 ALTER TABLE {$tableName}
       DROP FOREIGN KEY `FK_{$fkName}`;";
 
-    $dao = CRM_Core_DAO::executeQuery($dropFKSql);
-    $dao->free();
+    CRM_Core_DAO::executeQuery($dropFKSql);
 
     $addFKSql = "
 ALTER TABLE {$tableName}
       ADD CONSTRAINT `FK_{$fkName}` FOREIGN KEY (`entity_id`) REFERENCES {$fkTableName} (`id`) ON DELETE CASCADE;";
     // CRM-7007: do not i18n-rewrite this query
-    $dao = CRM_Core_DAO::executeQuery($addFKSql, array(), TRUE, NULL, FALSE, FALSE);
-    $dao->free();
+    CRM_Core_DAO::executeQuery($addFKSql, array(), TRUE, NULL, FALSE, FALSE);
 
     return TRUE;
   }
@@ -336,8 +333,7 @@ ALTER TABLE {$tableName}
     }
 
     // CRM-7007: do not i18n-rewrite this query
-    $dao = CRM_Core_DAO::executeQuery($sql, array(), TRUE, NULL, FALSE, FALSE);
-    $dao->free();
+    CRM_Core_DAO::executeQuery($sql, array(), TRUE, NULL, FALSE, FALSE);
 
     $config = CRM_Core_Config::singleton();
     if ($config->logging) {
@@ -529,7 +525,6 @@ ADD UNIQUE INDEX `unique_entity_id` ( `entity_id` )";
         $tableIndexes[$dao->Key_name]['unique'] = ($dao->Non_unique == 0 ? 1 : 0);
       }
       $indexes[$table] = $tableIndexes;
-      $dao->free();
     }
     return $indexes;
   }
@@ -636,7 +631,6 @@ MODIFY      {$columnName} varchar( $length )
     $query = "SHOW COLUMNS FROM $tableName LIKE '%1'";
     $dao = CRM_Core_DAO::executeQuery($query, [1 => [$columnName, 'Alphanumeric']], TRUE, NULL, FALSE, $i18nRewrite);
     $result = $dao->fetch() ? TRUE : FALSE;
-    $dao->free();
     return $result;
   }
 
@@ -783,7 +777,6 @@ MODIFY      {$columnName} varchar( $length )
     foreach ($queries as $query) {
       $dao->query($query, FALSE);
     }
-    $dao->free();
   }
 
 }

--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -76,7 +76,6 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
       $this->redis->hSet($dataKey, $entity_id, $data);
     }
 
-    $dao->free();
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Unnecessary code / deprecated code pattern more present 

After
----------------------------------------
Less unnecessary code / deprecated code pattern present

Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/562 we have been incrementally removing these as
1) we free resources on DAO->_destruct now and
2) in some edge cases freeing resources in an 'inner loop' can free outer loop
resources - resulting in a hard-to-analyse bug

Comments
----------------------------------------

