### PR TITLE
Allow payment processor to determine the text around 'continue'

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -598,6 +598,15 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $contribButton = ts('Make Contribution');
     }
     $this->assign('button', $contribButton);
+
+    $this->assign('continueText',
+      $this->getPaymentProcessorObject()->getText('contributionPageContinueText', [
+        'is_payment_to_existing' => !empty($this->_ccid),
+        'amount' => $this->_amount,
+        ]
+      )
+    );
+
     $this->addButtons(array(
         array(
           'type' => 'next',

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1390,4 +1390,17 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
   }
 
+
+  /**
+   * Get the payment processor object for the submission, returning the manual one for offline payments.
+   *
+   * @return CRM_Core_Payment
+   */
+  protected function getPaymentProcessorObject() {
+    if (!empty($this->_paymentProcessor)) {
+      return $this->_paymentProcessor['object'];
+    }
+    return new CRM_Core_Payment_Manual();
+  }
+
 }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -522,9 +522,23 @@ abstract class CRM_Core_Payment {
             $gotText .= ' ' . ts('You will receive an email receipt for each recurring contribution.');
           }
         }
-        break;
+        return $gotText;
+
+      case 'contributionPageContinueText':
+        if ($params['amount'] <= 0) {
+          return ts('To complete this transaction, click the <strong>Continue</strong> button below.');
+        }
+        if ($this->_paymentProcessor['billing_mode'] == 4) {
+          return ts('Click the <strong>Continue</strong> button to go to %1, where you will select your payment method and complete the contribution.', [$this->_paymentProcessor['payment_processor_type']]);
+        }
+        if ($params['is_payment_to_existing']) {
+          return ts('To complete this transaction, click the <strong>Make Payment</strong> button below.');
+        }
+        return ts('To complete your contribution, click the <strong>Continue</strong> button below.');
+
     }
-    return $gotText;
+    CRM_Core_Error::deprecatedFunctionWarning('Calls to getText must use a supported method');
+    return '';
   }
 
   /**

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -231,4 +231,30 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
     return TRUE;
   }
 
+  /**
+   * Get help text information (help, description, etc.) about this payment,
+   * to display to the user.
+   *
+   * @param string $context
+   *   Context of the text.
+   *   Only explicitly supported contexts are handled without error.
+   *   Currently supported:
+   *   - contributionPageRecurringHelp (params: is_recur_installments, is_email_receipt)
+   *
+   * @param array $params
+   *   Parameters for the field, context specific.
+   *
+   * @return string
+   */
+  public function getText($context, $params) {
+    switch ($context) {
+      case 'contributionPageContinueText':
+        if ($params['amount'] <= 0) {
+          return ts('To complete this transaction, click the <strong>Continue</strong> button below.');
+        }
+        return ts('To complete your contribution, click the <strong>Continue</strong> button below.');
+
+    }
+  }
+
 }

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -31,16 +31,8 @@
 
 <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-confirm-form-block">
   <div class="help">
-    <p>{ts}Please verify the information below carefully. Click<strong>Go Back</strong>if you need to make changes.{/ts}
-      {if $contributeMode EQ 'notify' and ! $is_pay_later}
-        {ts 1=$paymentProcessor.name 2=$button}Click the
-          <strong>%2</strong>
-          button to go to %1, where you will select your payment method and complete the contribution.{/ts}
-      {elseif ! $is_monetary or $amount LE 0.0 or $is_pay_later}
-        {ts 1=$button}To complete this transaction, click the<strong>%1</strong>button below.{/ts}
-      {else}
-        {ts 1=$button}To complete your contribution, click the<strong>%1</strong>button below.{/ts}
-      {/if}
+    <p>{ts}Please verify the information below carefully. Click <strong>Go Back</strong> if you need to make changes.{/ts}
+      {$continueText}
     </p>
   </div>
   <div id="crm-submit-buttons" class="crm-submit-buttons">


### PR DESCRIPTION
Overview
----------------------------------------
Make text on 'confirm' page more appropriate to processors in use today


Before
----------------------------------------
![screenshot 2019-03-08 02 05 45](https://user-images.githubusercontent.com/336308/53999463-55204480-41a8-11e9-92c9-0de2c2eb0329.png)


After
----------------------------------------
![screenshot 2019-03-08 13 52 06](https://user-images.githubusercontent.com/336308/53999723-63bb2b80-41a9-11e9-926f-b3546ffeea35.png)


Technical Details
----------------------------------------
This text traditionally depends on the outdated payment processor 'mode' concept. Since the 'right' text depends
on what the payment processor plans to do moving it out to the processor classes makes sense

We could also do the same with 'button'

Comments
----------------------------------------
As a general rule any code that refers to 'contributeMode' is deprecated. We could change it so the handling of $0 is in the calling class - on the fence about that. Not sure if processsors intervene there sometimes (perhaps to create tokens)

Update - I looked at what text I would actually use and it's pretty generic

![screenshot 2019-03-08 16 30 28](https://user-images.githubusercontent.com/336308/54006077-c835b500-41c0-11e9-87c1-8c846182cd8c.png)
