### PR TITLE
CRM-21677 - report clean up

### DIFF
--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -709,23 +709,6 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
 
       $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, NULL, 'List all contribution(s)') ? TRUE : $entryFound;
       $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, NULL, 'List all contribution(s)') ? TRUE : $entryFound;
-      //handle gender
-      if (array_key_exists('civicrm_contact_gender_id', $row)) {
-        if ($value = $row['civicrm_contact_gender_id']) {
-          $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
-          $rows[$rowNum]['civicrm_contact_gender_id'] = $gender[$value];
-        }
-        $entryFound = TRUE;
-      }
-
-      // display birthday in the configured custom format
-      if (array_key_exists('civicrm_contact_birth_date', $row)) {
-        $birthDate = $row['civicrm_contact_birth_date'];
-        if ($birthDate) {
-          $rows[$rowNum]['civicrm_contact_birth_date'] = CRM_Utils_Date::customFormat($birthDate, '%Y%m%d');
-        }
-        $entryFound = TRUE;
-      }
 
       if (!empty($row['civicrm_financial_trxn_card_type_id'])) {
         $rows[$rowNum]['civicrm_financial_trxn_card_type_id'] = $this->getLabels($row['civicrm_financial_trxn_card_type_id'], 'CRM_Financial_DAO_FinancialTrxn', 'card_type_id');


### PR DESCRIPTION
Overview
----------------------------------------
remove redundant birth date and gender evaluation code for lybunt report

Before
----------------------------------------
birth date and gender is evaluated properly
![lybunt_before](https://user-images.githubusercontent.com/3455173/54011797-d02e2e80-4199-11e9-8a3b-dc7c31499b08.png)


After
----------------------------------------
birth date and gender is evaluated properly
![lybunt_after](https://user-images.githubusercontent.com/3455173/54011806-d4f2e280-4199-11e9-86e3-32eabfe0c8ff.png)


