### PR TITLE
Attempted test fix

### DIFF
--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -273,6 +273,9 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
   public function testRevert() {
     $contactId = $this->individualCreate();
     $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
+    // Pause for one second here to ensure the timestamps between the first create action
+    // and the second differ.
+    sleep(1);
     CRM_Core_DAO::executeQuery("SET @uniqueID = 'woot'");
     $timeStamp = date('Y-m-d H:i:s');
     $this->callAPISuccess('Contact', 'create', array(


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to fix false negative test fail

Before
----------------------------------------
inappropriate intermittent fails

After
----------------------------------------
Maybe not?

Technical Details
----------------------------------------
This revert test has started failing frequently. It's possible the reason is performance
Improvements, resulting ineffectively no change in time between the entries.

I's also possible the issue is with the timestamp being used but I think that has
a permitted variance

Comments
----------------------------------------

