### PR TITLE
CRM-21677 - sybunt report clean up

### DIFF
--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -587,25 +587,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
       }
 
       $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, 'contribute/detail', 'List all contribution(s)') ? TRUE : $entryFound;
-
-      //handle gender
-      if (array_key_exists('civicrm_contact_gender_id', $row)) {
-        if ($value = $row['civicrm_contact_gender_id']) {
-          $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
-          $rows[$rowNum]['civicrm_contact_gender_id'] = $gender[$value];
-        }
-        $entryFound = TRUE;
-      }
-
-      // display birthday in the configured custom format
-      if (array_key_exists('civicrm_contact_birth_date', $row)) {
-        $birthDate = $row['civicrm_contact_birth_date'];
-        if ($birthDate) {
-          $rows[$rowNum]['civicrm_contact_birth_date'] = CRM_Utils_Date::customFormat($birthDate, '%Y%m%d');
-        }
-        $entryFound = TRUE;
-      }
-
+      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, NULL, 'List all contribution(s)') ? TRUE : $entryFound;
       if (!empty($row['civicrm_financial_trxn_card_type_id'])) {
         $rows[$rowNum]['civicrm_financial_trxn_card_type_id'] = $this->getLabels($row['civicrm_financial_trxn_card_type_id'], 'CRM_Financial_DAO_FinancialTrxn', 'card_type_id');
         $entryFound = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
remove redundant birth date and gender evaluation code for sybunt report

Before
----------------------------------------
birth date and gender is evaluated properly
![sybunt_before](https://user-images.githubusercontent.com/3455173/54025256-fb2b7900-41bf-11e9-80e0-389f4287cffa.png)



After
----------------------------------------
birth date and gender is evaluated properly

![sybunt_after](https://user-images.githubusercontent.com/3455173/54025261-0088c380-41c0-11e9-9b33-920c22c20f12.png)


