### PR TITLE
REF Extract case action links into a separate function to facilitate refactoring

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1062,48 +1062,22 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
 
     $activityTypes = CRM_Case_PseudoConstant::caseActivityType(FALSE, TRUE);
 
-    $url = CRM_Utils_System::url("civicrm/case/activity",
-      "reset=1&cid={$contactID}&caseid={$caseID}", FALSE, NULL, FALSE
-    );
-
-    $contextUrl = '';
-    if ($context == 'fulltext') {
-      $contextUrl = "&context={$context}";
-    }
-    $editUrl = "{$url}&action=update{$contextUrl}";
-    $deleteUrl = "{$url}&action=delete{$contextUrl}";
-    $restoreUrl = "{$url}&action=renew{$contextUrl}";
-    $viewTitle = ts('View activity');
-
-    $emailActivityTypeIDs = array(
-      'Email' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email'),
-      'Inbound Email' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound Email'),
-    );
-
-    $caseDeleted = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $caseID, 'is_deleted');
-
     $compStatusValues = array_keys(
       CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED) +
       CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::CANCELLED)
     );
 
     if (!$userID) {
-      $session = CRM_Core_Session::singleton();
-      $userID = $session->get('userID');
+      $userID = CRM_Core_Session::getLoggedInContactID();
     }
 
-    $caseActivities = array();
+    $caseActivities = [];
 
     while ($dao->fetch()) {
       $caseActivityId = $dao->id;
 
-      $allowView = self::checkPermission($caseActivityId, 'view', $dao->activity_type_id, $userID);
-      $allowEdit = self::checkPermission($caseActivityId, 'edit', $dao->activity_type_id, $userID);
-      $allowDelete = self::checkPermission($caseActivityId, 'delete', $dao->activity_type_id, $userID);
-
-      //do not have sufficient permission
-      //to access given case activity record.
-      if (!$allowView && !$allowEdit && !$allowDelete) {
+      //Do we have permission to access given case activity record.
+      if (!self::checkPermission($caseActivityId, 'view', $dao->activity_type_id, $userID)) {
         continue;
       }
 
@@ -1176,46 +1150,8 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
       // Activity Status Label for Case activities list
       $caseActivities[$caseActivityId]['status_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_status_id', $dao->status);
 
-      // FIXME: Why are we not using CRM_Core_Action for these links? This is too much manual work and likely to get out-of-sync with core markup.
-      $url = "";
-      $css = 'class="action-item crm-hover-button"';
-      if ($allowView) {
-        $viewUrl = CRM_Utils_System::url('civicrm/case/activity/view', array('cid' => $contactID, 'aid' => $caseActivityId));
-        $url = '<a ' . str_replace('action-item', 'action-item medium-pop-up', $css) . 'href="' . $viewUrl . '" title="' . $viewTitle . '">' . ts('View') . '</a>';
-      }
-      $additionalUrl = "&id={$caseActivityId}";
-      if (!$dao->deleted) {
-        //hide edit link of activity type email.CRM-4530.
-        if (!in_array($dao->type, $emailActivityTypeIDs)) {
-          //hide Edit link if activity type is NOT editable (special case activities).CRM-5871
-          if ($allowEdit) {
-            $url .= '<a ' . $css . ' href="' . $editUrl . $additionalUrl . '">' . ts('Edit') . '</a> ';
-          }
-        }
-        if ($allowDelete) {
-          $url .= ' <a ' . str_replace('action-item', 'action-item small-popup', $css) . ' href="' . $deleteUrl . $additionalUrl . '">' . ts('Delete') . '</a>';
-        }
-      }
-      elseif (!$caseDeleted) {
-        $url = ' <a ' . $css . ' href="' . $restoreUrl . $additionalUrl . '">' . ts('Restore') . '</a>';
-        $caseActivities[$caseActivityId]['status_id'] = $caseActivities[$caseActivityId]['status_id'] . '<br /> (deleted)';
-      }
-
-      //check for operations.
-      if (self::checkPermission($caseActivityId, 'Move To Case', $dao->activity_type_id)) {
-        $url .= ' <a ' . $css . ' href="#" onClick="Javascript:fileOnCase( \'move\',' . $caseActivityId . ', ' . $caseID . ', this ); return false;">' . ts('Move To Case') . '</a> ';
-      }
-      if (self::checkPermission($caseActivityId, 'Copy To Case', $dao->activity_type_id)) {
-        $url .= ' <a ' . $css . ' href="#" onClick="Javascript:fileOnCase( \'copy\',' . $caseActivityId . ',' . $caseID . ', this ); return false;">' . ts('Copy To Case') . '</a> ';
-      }
-      // if there are file attachments we will return how many and, if only one, add a link to it
-      if (!empty($dao->attachment_ids)) {
-        $attachmentIDs = array_unique(explode(',', $dao->attachment_ids));
-        $caseActivities[$caseActivityId]['no_attachments'] = count($attachmentIDs);
-        $url .= implode(' ', CRM_Core_BAO_File::paperIconAttachment('civicrm_activity', $caseActivityId));
-      }
-
-      $caseActivities[$caseActivityId]['links'] = $url;
+      $caseActivities[$caseActivityId]
+        = self::addCaseActivityLinks($caseID, $contactID, $userID, $context, $dao, $caseActivities[$caseActivityId]);
     }
 
     $caseActivitiesDT = array();
@@ -1224,6 +1160,83 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
     $caseActivitiesDT['recordsFiltered'] = $caseCount;
 
     return $caseActivitiesDT;
+  }
+
+  /**
+   * FIXME: This is a transitional function to facilitate a refactor of this to use CRM_Core_Action and actionLinks
+   * Add the set of "actionLinks" to the case activity
+   *
+   * @param int $caseID
+   * @param int $contactID
+   * @param int $userID
+   * @param string $context
+   * @param \CRM_Core_DAO $dao
+   * @param array $caseActivity
+   *
+   * @return array caseActivity
+   */
+  public static function addCaseActivityLinks($caseID, $contactID, $userID, $context, $dao, $caseActivity) {
+    // FIXME: Why are we not using CRM_Core_Action for these links? This is too much manual work and likely to get out-of-sync with core markup.
+    $caseActivityId = $dao->id;
+    $allowView = self::checkPermission($caseActivityId, 'view', $dao->activity_type_id, $userID);
+    $allowEdit = self::checkPermission($caseActivityId, 'edit', $dao->activity_type_id, $userID);
+    $allowDelete = self::checkPermission($caseActivityId, 'delete', $dao->activity_type_id, $userID);
+    $emailActivityTypeIDs = [
+      'Email' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email'),
+      'Inbound Email' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound Email'),
+    ];
+    $url = CRM_Utils_System::url("civicrm/case/activity",
+      "reset=1&cid={$contactID}&caseid={$caseID}", FALSE, NULL, FALSE
+    );
+    $contextUrl = '';
+    if ($context == 'fulltext') {
+      $contextUrl = "&context={$context}";
+    }
+    $editUrl = "{$url}&action=update{$contextUrl}";
+    $deleteUrl = "{$url}&action=delete{$contextUrl}";
+    $restoreUrl = "{$url}&action=renew{$contextUrl}";
+    $viewTitle = ts('View activity');
+    $caseDeleted = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $caseID, 'is_deleted');
+
+    $url = "";
+    $css = 'class="action-item crm-hover-button"';
+    if ($allowView) {
+      $viewUrl = CRM_Utils_System::url('civicrm/case/activity/view', array('cid' => $contactID, 'aid' => $caseActivityId));
+      $url = '<a ' . str_replace('action-item', 'action-item medium-pop-up', $css) . 'href="' . $viewUrl . '" title="' . $viewTitle . '">' . ts('View') . '</a>';
+    }
+    $additionalUrl = "&id={$caseActivityId}";
+    if (!$dao->deleted) {
+      //hide edit link of activity type email.CRM-4530.
+      if (!in_array($dao->type, $emailActivityTypeIDs)) {
+        //hide Edit link if activity type is NOT editable (special case activities).CRM-5871
+        if ($allowEdit) {
+          $url .= '<a ' . $css . ' href="' . $editUrl . $additionalUrl . '">' . ts('Edit') . '</a> ';
+        }
+      }
+      if ($allowDelete) {
+        $url .= ' <a ' . str_replace('action-item', 'action-item small-popup', $css) . ' href="' . $deleteUrl . $additionalUrl . '">' . ts('Delete') . '</a>';
+      }
+    }
+    elseif (!$caseDeleted) {
+      $url = ' <a ' . $css . ' href="' . $restoreUrl . $additionalUrl . '">' . ts('Restore') . '</a>';
+      $caseActivity['status_id'] = $caseActivity['status_id'] . '<br /> (deleted)';
+    }
+
+    //check for operations.
+    if (self::checkPermission($caseActivityId, 'Move To Case', $dao->activity_type_id)) {
+      $url .= ' <a ' . $css . ' href="#" onClick="Javascript:fileOnCase( \'move\',' . $caseActivityId . ', ' . $caseID . ', this ); return false;">' . ts('Move To Case') . '</a> ';
+    }
+    if (self::checkPermission($caseActivityId, 'Copy To Case', $dao->activity_type_id)) {
+      $url .= ' <a ' . $css . ' href="#" onClick="Javascript:fileOnCase( \'copy\',' . $caseActivityId . ',' . $caseID . ', this ); return false;">' . ts('Copy To Case') . '</a> ';
+    }
+    // if there are file attachments we will return how many and, if only one, add a link to it
+    if (!empty($dao->attachment_ids)) {
+      $attachmentIDs = array_unique(explode(',', $dao->attachment_ids));
+      $caseActivity['no_attachments'] = count($attachmentIDs);
+      $url .= implode(' ', CRM_Core_BAO_File::paperIconAttachment('civicrm_activity', $caseActivityId));
+    }
+    $caseActivity['links'] = $url;
+    return $caseActivity;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is a simple refactor to extract the code that generates the case activity links.

They should be generated using CRM_Core_Action so they use standard CiviCRM markup and pass through hooks etc. but we need to disentangle the code first.

Before
----------------------------------------
Link generation in shared function

After
----------------------------------------
Link generation in it's own function, variables specific to generating links are moved to this function.  There are a couple of extra things being conditionally set that should be moved out of this function (status_id and no_attachments) but that's for the next round.

Technical Details
----------------------------------------
Simple function extraction.

Comments
----------------------------------------
@colemanw As it's case related are you able to take a look?  I know there's a lot of improvements that could be made here but I'd like to start with the simple extraction if that's ok and make improvements to the code in subsequent PRs.
