### PR TITLE
refs issue 788 fix Warning: A non-numeric value encountered in ...

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -897,7 +897,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     // return if this is express mode
     $config = CRM_Core_Config::singleton();
     if ($self->_paymentProcessor &&
-      $self->_paymentProcessor['billing_mode'] & CRM_Core_Payment::BILLING_MODE_BUTTON
+      $self->_paymentProcessor['billing_mode'] && CRM_Core_Payment::BILLING_MODE_BUTTON
     ) {
       if (!empty($fields[$self->_expressButtonName . '_x']) || !empty($fields[$self->_expressButtonName . '_y']) ||
         CRM_Utils_Array::value($self->_expressButtonName, $fields)

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -897,7 +897,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     // return if this is express mode
     $config = CRM_Core_Config::singleton();
     if ($self->_paymentProcessor &&
-      $self->_paymentProcessor['billing_mode'] && CRM_Core_Payment::BILLING_MODE_BUTTON
+      (int) $self->_paymentProcessor['billing_mode'] & CRM_Core_Payment::BILLING_MODE_BUTTON
     ) {
       if (!empty($fields[$self->_expressButtonName . '_x']) || !empty($fields[$self->_expressButtonName . '_y']) ||
         CRM_Utils_Array::value($self->_expressButtonName, $fields)

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -1147,7 +1147,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $this->handlePreApproval($params);
       }
       elseif ($this->_paymentProcessor &&
-        $this->_paymentProcessor['billing_mode'] & CRM_Core_Payment::BILLING_MODE_NOTIFY
+        $this->_paymentProcessor['billing_mode'] && CRM_Core_Payment::BILLING_MODE_NOTIFY
       ) {
         // The concept of contributeMode is deprecated - but still needs removal from the message templates.
         $this->set('contributeMode', 'notify');

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -1147,7 +1147,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $this->handlePreApproval($params);
       }
       elseif ($this->_paymentProcessor &&
-        $this->_paymentProcessor['billing_mode'] && CRM_Core_Payment::BILLING_MODE_NOTIFY
+        (int) $this->_paymentProcessor['billing_mode'] & CRM_Core_Payment::BILLING_MODE_NOTIFY
       ) {
         // The concept of contributeMode is deprecated - but still needs removal from the message templates.
         $this->set('contributeMode', 'notify');


### PR DESCRIPTION
Overview
----------------------------------------
Warning: A non-numeric value encountered in ...

Before
----------------------------------------
Warning: A non-numeric value encountered in ... was thrown on contribution pages & event registrations

After
----------------------------------------
Warnings are gone

Technical Details
----------------------------------------
Added extra '&' sign

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/788
