### PR TITLE
Improve ContributionPage.validate api

### DIFF
--- a/api/v3/ContributionPage.php
+++ b/api/v3/ContributionPage.php
@@ -117,6 +117,7 @@ function civicrm_api3_contribution_page_validate($params) {
   // If we are calling this as a result of a POST action (e.g validating a form submission before first getting payment
   // authorization from a payment processor like Paypal checkout) the lack of a qfKey will not result in a valid
   // one being generated so we generate one first.
+  $originalRequest = $_REQUEST;
   $qfKey = CRM_Utils_Array::value('qfKey', $_REQUEST);
   if (!$qfKey) {
     $_REQUEST['qfKey'] = CRM_Core_Key::get('CRM_Core_Controller', TRUE);
@@ -129,6 +130,7 @@ function civicrm_api3_contribution_page_validate($params) {
   if ($errors === TRUE) {
     $errors = [];
   }
+  $_REQUEST = $originalRequest;
   return civicrm_api3_create_success($errors, $params, 'ContributionPage', 'validate');
 }
 

--- a/api/v3/ContributionPage.php
+++ b/api/v3/ContributionPage.php
@@ -114,6 +114,13 @@ function civicrm_api3_contribution_page_submit($params) {
  *   API result array
  */
 function civicrm_api3_contribution_page_validate($params) {
+  // If we are calling this as a result of a POST action (e.g validating a form submission before first getting payment
+  // authorization from a payment processor like Paypal checkout) the lack of a qfKey will not result in a valid
+  // one being generated so we generate one first.
+  $qfKey = CRM_Utils_Array::value('qfKey', $_REQUEST);
+  if (!$qfKey) {
+    $_REQUEST['qfKey'] = CRM_Core_Key::get('CRM_Core_Controller', TRUE);
+  }
   $form = new CRM_Contribute_Form_Contribution_Main();
   $form->controller = new CRM_Core_Controller();
   $form->set('id', $params['id']);
@@ -123,6 +130,19 @@ function civicrm_api3_contribution_page_validate($params) {
     $errors = [];
   }
   return civicrm_api3_create_success($errors, $params, 'ContributionPage', 'validate');
+}
+
+/**
+ * Metadata for validate action.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_contribution_page_validate_spec(&$params) {
+  $params['id'] = [
+    'title' => ts('Contribution Page ID'),
+    'api.required' => TRUE,
+    'type' => CRM_Utils_Type::T_INT,
+  ];
 }
 
 /**

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1923,6 +1923,22 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test validating a contribution page submit in POST context.
+   *
+   * A likely use case for the validation is when the is being submitted and some handling is
+   * to be done before processing but the validity of input needs to be checked first.
+   *
+   * For example Paypal Checkout will replace the confirm button with it's own but we are able to validate
+   * before paypal launches it's modal. In this case the $_REQUEST is post but we need validation to succeed.
+   */
+  public function testValidatePost() {
+    $_SERVER['REQUEST_METHOD'] = 'POST';
+    $this->setUpContributionPage();
+    $errors = $this->callAPISuccess('ContributionPage', 'validate', array_merge($this->getBasicSubmitParams(), ['action' => 'submit']))['values'];
+    $this->assertEmpty($errors);
+  }
+
+  /**
    * Implements hook_civicrm_alterPaymentProcessorParams().
    *
    * @throws \Exception

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1936,6 +1936,21 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->setUpContributionPage();
     $errors = $this->callAPISuccess('ContributionPage', 'validate', array_merge($this->getBasicSubmitParams(), ['action' => 'submit']))['values'];
     $this->assertEmpty($errors);
+    unset($_SERVER['REQUEST_METHOD']);
+  }
+
+  /**
+   * Test that an error is generated if required fields are not submitted.
+   */
+  public function testValidateOutputOnMissingRecurFields() {
+    $this->params['is_recur_interval'] = 1;
+    $this->setUpContributionPage(TRUE);
+    $submitParams = array_merge($this->getBasicSubmitParams(), ['action' => 'submit']);
+    $submitParams['is_recur'] = 1;
+    $submitParams['frequency_interval'] = '';
+    $submitParams['frequency_unit'] = '';
+    $errors = $this->callAPISuccess('ContributionPage', 'validate', $submitParams)['values'];
+    $this->assertEquals('Please enter a number for how often you want to make this recurring contribution (EXAMPLE: Every 3 months).', $errors['frequency_interval']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This api mostly exists to support payment processors that take an action via js on the Main page during the submit process. Generally they like to abort if the page has not been correctly filled in. 

The PR fixes it so the validate api can be called during POST (which would be the case with something like Paypal Checkout which calls a Promise we provide to determine whether to proceed after their button is pushed

Before
----------------------------------------
Funny key weird handling means in POST request the api cannot be called

After
----------------------------------------
POST request api validation supported, test added

Technical Details
----------------------------------------

Comments
----------------------------------------
I also marked 'id' as required