### PR TITLE
Fix unrelased regression where activity date relative filters are ingnored in the rc

### DIFF
--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -9,14 +9,17 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
     $this->individualID = $this->individualCreate();
-    $this->contributionCreate(array('contact_id' => $this->individualID, 'receive_date' => '2017-01-30'));
+    $this->contributionCreate([
+      'contact_id' => $this->individualID,
+      'receive_date' => '2017-01-30',
+    ]);
   }
 
   public function tearDown() {
-    $tablesToTruncate = array(
+    $tablesToTruncate = [
       'civicrm_activity',
       'civicrm_activity_contact',
-    );
+    ];
     $this->quickCleanup($tablesToTruncate);
   }
 
@@ -32,7 +35,8 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
     $form->postProcess();
     $qfKey = $form->controller->_key;
     $rows = $form->controller->get('rows');
-    $this->assertEquals(array(array(
+    $this->assertEquals([
+      [
         'contact_id' => '3',
         'contact_type' => '<a href="/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4" class="crm-summary-link"><div class="icon crm-icon Individual-icon"></div></a>',
         'sort_name' => 'Anderson, Anthony',
@@ -46,8 +50,8 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
         'activity_type_id' => '6',
         'activity_type' => 'Contribution',
         'activity_is_test' => '0',
-        'target_contact_name' => array(),
-        'assignee_contact_name' => array(),
+        'target_contact_name' => [],
+        'assignee_contact_name' => [],
         'source_contact_id' => '3',
         'source_contact_name' => 'Anderson, Anthony',
         'checkbox' => 'mark_x_1',
@@ -56,7 +60,8 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
         'campaign' => NULL,
         'campaign_id' => NULL,
         'repeat' => '',
-    )), $rows);
+      ],
+    ], $rows);
   }
 
 }

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -64,4 +64,63 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
     ], $rows);
   }
 
+  /**
+   * Test the Qill for activity Date time.
+   *
+   * @dataProvider getSearchCriteria
+   *
+   * @param array $searchCriteria
+   * @param array $expectedQill
+   */
+  public function testQill($searchCriteria, $expectedQill) {
+    $selector = new CRM_Activity_Selector_Search($searchCriteria);
+    $this->assertEquals($expectedQill, $selector->getQILL());
+  }
+
+  /**
+   * Get criteria for activity testing.
+   */
+  public function getSearchCriteria() {
+
+    // We have to define format because tests crash trying to access the config param from the dataProvider
+    // perhaps because there is no property on config?
+    $format = '%B %E%f, %Y %l:%M %P';
+    $dates['ending_60.day'] = CRM_Utils_Date::getFromTo('ending_60.day', NULL, NULL);
+    $dates['earlier.year'] = CRM_Utils_Date::getFromTo('earlier.year', NULL, NULL);
+    $dates['greater.year'] = CRM_Utils_Date::getFromTo('greater.year', NULL, NULL);
+    return [
+      [
+        'search_criteria' => [
+          ['activity_date_time_relative', '=', 'ending_60.day', 0, 0],
+        ],
+        'expected_qill' => [['Activity Date is Last 60 days including today (between ' . CRM_Utils_Date::customFormat($dates['ending_60.day'][0], $format) . ' and ' . CRM_Utils_Date::customFormat($dates['ending_60.day'][1], $format) . ')']],
+      ],
+      [
+        'search_criteria' => [
+          ['activity_date_time_relative', '=', 'earlier.year', 0, 0],
+        ],
+        'expected_qill' => [['Activity Date is To end of previous calendar year (to ' . CRM_Utils_Date::customFormat($dates['earlier.year'][1], $format) . ')']],
+      ],
+      [
+        'search_criteria' => [
+          ['activity_date_time_relative', '=', 'greater.year', 0, 0],
+        ],
+        'expected_qill' => [['Activity Date is From start of current calendar year (from ' . CRM_Utils_Date::customFormat($dates['greater.year'][0], $format) . ')']],
+      ],
+      [
+        'search_criteria' => [
+          ['activity_date_time_low', '=', '2019-03-05', 0, 0],
+          ['activity_date_time_high', '=', '2019-03-27', 0, 0],
+        ],
+        'expected_qill' => [['Activity Date - greater than or equal to "March 5th, 2019 12:00 AM" AND less than or equal to "March 27th, 2019 11:59 PM"']],
+      ],
+      [
+        'search_criteria' => [
+          ['activity_status_id', '=', ['IN' => ['1', '2']], 0, 0]
+        ],
+        'expected_qill' => [['Activity Status In Scheduled, Completed']],
+      ],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
In testing I found that there is an unreleased regression relating to our date conversion
on activity_date_time in activity search. This fixes and adds tests. (regression was it
was being ignored).

Note that the option value is capitalised which makes the capitalisation slightly odd but
I think accepting that is the least bad option

Before
----------------------------------------
Relative filters on activity_date_time ignored

After
----------------------------------------
filter respected, tests added, qill indicates the resolved field dates as well as the name of the fitler used

![Screenshot 2019-03-12 13 43 41](https://user-images.githubusercontent.com/336308/54167049-db9c9500-44cc-11e9-8d36-4f994bf1f439.png)


Technical Details
----------------------------------------
Note that the option value is capitalised which makes the capitalisation slightly odd but
I think accepting that is the least bad option

Comments
----------------------------------------
_