### PR TITLE
 civicrm/admin/setting/uf - Fix advice about Backdrop Views ($database_prefix)

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -82,6 +82,9 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
       $dsnArray = DB::parseDSN($config->dsn);
       $tableNames = CRM_Core_DAO::getTableNames();
       $tablePrefixes = '$databases[\'default\'][\'default\'][\'prefix\']= array(';
+      if ($config->userFramework === 'Backdrop') {
+        $tablePrefixes = '$database_prefix = array(';
+      }
       $tablePrefixes .= "\n  'default' => '$drupal_prefix',"; // add default prefix: the drupal database prefix
       $prefix = "";
       if ($config->dsn != $config->userFrameworkDSN) {

--- a/templates/CRM/Admin/Form/Setting/UF.tpl
+++ b/templates/CRM/Admin/Form/Setting/UF.tpl
@@ -52,7 +52,7 @@
 <div class="form-item">
 <fieldset>
     <legend>{ts}Views integration settings{/ts}</legend>
-    <div>{ts}To enable CiviCRM Views integration, add the following to the site <code>settings.php</code> file:{/ts}</div>
+    <div>{ts}To enable CiviCRM Views integration, add or update the following item in the <code>settings.php</code> file:{/ts}</div>
     <pre>{$tablePrefixes}</pre>
 </fieldset>
 </div>


### PR DESCRIPTION
Overview
--------

The screen "*Administer => System Settings => CMS Database Integration*" (`civicrm/admin/setting/uf`) provides advice about enabling Views on multi-DB deployments. We would like the advice to work.

NOTE: This is a simpler alternative to #13788. It assigns tables to `$database_prefix` rather than trying to manage `$databases`.

Before
------

The screen `civicrm/admin/setting/uf` provides advice on configuring Views. It specifically suggests editing `settings.php` to update `array $databases` with a list of table-prefixes.

<img width="848" alt="screen shot 2019-03-07 at 5 46 34 pm" src="https://user-images.githubusercontent.com/1336047/54001674-ff449180-4100-11e9-9eb8-b17d19f23d0c.png">

However, in a stock deployment of Backdrop, these prefixes are not used. Why not? *After* evaluating the `settings.php`, Backdrop reads `string $database` and generates a new version of `array $databases` -- but this overwrites any table-prefixes that the admin has put into `array $databases`.

After
-----

The screen `civicrm/admin/setting/uf` provides advice on configuring Views. It sets `mixed $database_prefix` instead of `array $databases`. (Later during bootstrap, Backdrop merges the `$database_prefix` into `$databases`.)

![Screenshot from 2019-03-12 00-41-13](https://user-images.githubusercontent.com/1071483/54175293-b3774c80-4460-11e9-81fe-0d280d868853.png)

(Edited by totten 2019-03-12)


