### PR TITLE
(dev/core#794) expose address name in the template

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -443,6 +443,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         'domain_country' => $countryDomain,
         'domain_email' => CRM_Utils_Array::value('email', CRM_Utils_Array::value('1', $locationDefaults['email'])),
         'domain_phone' => CRM_Utils_Array::value('phone', CRM_Utils_Array::value('1', $locationDefaults['phone'])),
+        'domain_address_name' => CRM_Utils_Array::value('address_name', CRM_Utils_Array::value('1', $locationDefaults['address'])),
       );
 
       if (isset($creditNoteId)) {


### PR DESCRIPTION
Overview
----------------------------------------
Allow *domain_address_name* to be used as address name in invoice template.

Before
----------------------------------------
Address name is not available in template.

After
----------------------------------------
Address name is available in template.

