### PR TITLE
Fix contact.merge api to pass check_permissions parameter through to the deeper layer

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1195,12 +1195,14 @@ function _civicrm_api3_contact_deprecation() {
  * @throws API_Exception
  */
 function civicrm_api3_contact_merge($params) {
-  if (($result = CRM_Dedupe_Merger::merge([
-      [
-        'srcID' => $params['to_remove_id'],
-        'dstID' => $params['to_keep_id'],
-      ],
-    ], [], $params['mode'])) != FALSE) {
+  if (($result = CRM_Dedupe_Merger::merge(
+    [['srcID' => $params['to_remove_id'], 'dstID' => $params['to_keep_id']]],
+    [],
+    $params['mode'],
+    FALSE,
+    CRM_Utils_Array::value('check_permissions', $params)
+    )) != FALSE) {
+
     return civicrm_api3_create_success($result, $params);
   }
   throw new API_Exception('Merge failed');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where calling Contact.merge from php will leave the merged contact unmerged if the logged in user does not have the delete contacts permission

Before
----------------------------------------
check_permissions flag not passed to BAO layer

After
----------------------------------------
flag passed

Technical Details
----------------------------------------
 Pass 'check permissions' flag through to merge function
    
The inner function will only delete the merged contact if checkPermissions is false or the logged in user has permission to delete. Our api model expects check_permissions to be respected at the BAO level.

The reason this was a problem for me was actually in the context of a unit test - however, our general principle is that when check_permissions is passed into the api it is respected throughout the action that is taken

Comments
----------------------------------------
Can clean this up once the preliminary code cleanup( #13806)  is merged