### PR TITLE
(ops#878) (Fast)ArrayDecorator - Emit expected exception when using WP and strict PSR-16

### DIFF
--- a/CRM/Utils/Cache/ArrayDecorator.php
+++ b/CRM/Utils/Cache/ArrayDecorator.php
@@ -94,6 +94,7 @@ class CRM_Utils_Cache_ArrayDecorator implements CRM_Utils_Cache_Interface {
   }
 
   public function get($key, $default = NULL) {
+    CRM_Utils_Cache::assertValidKey($key);
     if (array_key_exists($key, $this->values) && $this->expires[$key] > CRM_Utils_Time::getTimeRaw()) {
       return $this->reobjectify($this->values[$key]);
     }
@@ -110,6 +111,7 @@ class CRM_Utils_Cache_ArrayDecorator implements CRM_Utils_Cache_Interface {
   }
 
   public function delete($key) {
+    CRM_Utils_Cache::assertValidKey($key);
     unset($this->values[$key]);
     unset($this->expires[$key]);
     return $this->delegate->delete($key);
@@ -126,6 +128,7 @@ class CRM_Utils_Cache_ArrayDecorator implements CRM_Utils_Cache_Interface {
   }
 
   public function has($key) {
+    CRM_Utils_Cache::assertValidKey($key);
     if (array_key_exists($key, $this->values) && $this->expires[$key] > CRM_Utils_Time::getTimeRaw()) {
       return TRUE;
     }

--- a/CRM/Utils/Cache/FastArrayDecorator.php
+++ b/CRM/Utils/Cache/FastArrayDecorator.php
@@ -99,6 +99,7 @@ class CRM_Utils_Cache_FastArrayDecorator implements CRM_Utils_Cache_Interface {
   }
 
   public function get($key, $default = NULL) {
+    CRM_Utils_Cache::assertValidKey($key);
     if (array_key_exists($key, $this->values)) {
       return $this->values[$key];
     }
@@ -114,6 +115,7 @@ class CRM_Utils_Cache_FastArrayDecorator implements CRM_Utils_Cache_Interface {
   }
 
   public function delete($key) {
+    CRM_Utils_Cache::assertValidKey($key);
     unset($this->values[$key]);
     return $this->delegate->delete($key);
   }


### PR DESCRIPTION
Overview
-------

Suppose someone calls `CRM_Utils_Cache_ArrayDecorator::get()` or `FastArrayDecorator::get()` with an invalid key (e.g.  passing `float` or an `array` instead of a `string`).  This patch improves error-reporting for that scenario.

This is primarily about fixing multiple test failures in `E2E_Cache_(Fast)ArrayDecoratorTest` reported on `wp-demo`. These generally look like:

```
1) E2E_Cache_FastArrayDecoratorTest::testGetInvalidKeys with data set #1 (true)
array_key_exists(): The first argument should be either a string or an integer

/Users/totten/bknix/build/wpmaster/wp-content/plugins/civicrm/civicrm/CRM/Utils/Cache/FastArrayDecorator.php:102
/Users/totten/bknix/build/wpmaster/wp-content/plugins/civicrm/civicrm/packages/Cache/IntegrationTests/LegacySimpleCacheTest.php:409
/Users/totten/bknix/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598
```

Before
------

The (Fast)ArrayDecorator first checks its front cache (`array_key_exists`) to see if the key is defined.  In the `wp-demo` environment, this produces a warning and causes the test to fail.

The condition *is* erroneous, but PSR-16 specifies that the error should be reported as exception.

After
-----

The condition is reported as the expected exception.

The corresponding E2E tests pass on `wp-demo`.

Comment
-------

This brings the code in `(Fast)ArrayDecorator.php` into alignment with most of the other `CRM/Utils/Cache/*.php` drivers; in most drivers, it is typical to validate the key at the start of most functions.

Note to reviewer: you should be generally OK with this, but you may have trouble reproducing the specific environment for running E2E tests on WP. That's OK. We've also got https://test.civicrm.org/job/CiviCRM-E2E-Matrix/ (which will kick in after merging).

The PR currently targets `5.12` because I'd prefer that the E2E matrix be passing on the RC. However, I'm not gonna push the point hard -- if y'all are more comfortable, we can merge to `master` (and just ignore E2E matrix for this cycle).