### PR TITLE
dev/core#787 Auto-complete search results fixes

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3449,7 +3449,8 @@ WHERE  $smartGroupClause
     }
     // Replace spaces with wildcards for a LIKE operation
     // UNLESS string contains a comma (this exception is a tiny bit questionable)
-    elseif ($op == 'LIKE' && strpos($value, ',') === FALSE) {
+    // Also need to check if there is space in between sort name.
+    elseif ($op == 'LIKE' && strpos($value, ',') === FALSE && strpos($value, ' ') === TRUE) {
       $value = str_replace(' ', '%', $value);
     }
     $value = CRM_Core_DAO::escapeString(trim($value));


### PR DESCRIPTION
Overview
----------------------------------------
Auto-complete search results not consistent with other searches.

Before
----------------------------------------
Auto-complete (custom data on contacts) search results not consistent with other searches if the searched string has a space.
![before-search-results](https://user-images.githubusercontent.com/445545/54257345-09ddab80-4585-11e9-95c8-67ab42aa1bd4.png)


After
----------------------------------------
All search are consistent.
![after-search-results](https://user-images.githubusercontent.com/445545/54257359-14984080-4585-11e9-8b24-722eb66a29e6.png)



Comments
----------------------------------------
Here is the issue details https://lab.civicrm.org/dev/core/issues/787