### PR TITLE
dev/mail#41 - Fix preview as HTML does not open window at all

### DIFF
--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -276,7 +276,6 @@
         }
         else {
           var params = angular.extend({}, mailing);
-          delete params.id;
           return backend('Mailing', 'preview', params).then(function(result) {
             // changes rolled back, so we don't care about updating mailing
             return result.values;


### PR DESCRIPTION
Overview
----------------------------------------
When you click on "Preview as HTML" button on mailing form nothing happen, only error in api rest call to Mailing.preview:

{"error_code":"unknown error","tip":"add debug=1 to your API call to have more info about the error","is_error":1,"error_message":"DB Error: unknown error"}

more info here https://lab.civicrm.org/dev/mail/issues/41

Before
----------------------------------------
https://lab.civicrm.org/dev/mail/issues/20 removes id param

After
----------------------------------------
https://lab.civicrm.org/dev/mail/issues/20 restore id param (remains if it exists in param object)

Technical Details
----------------------------------------
CRM_Mailing_BAO_TrackableURL::getTrackerURL() requires id of mailing but after https://lab.civicrm.org/dev/mail/issues/20 (closed) mailing_id is removed from params to Mailing.preview