### PR TITLE
Add a class to handle test entities consistently

### DIFF
--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -310,7 +310,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
       $accessMailingReport = FALSE;
       $activityTypeId = $row['activity_type_id'];
       if ($row['activity_is_test']) {
-        $row['activity_type'] = $row['activity_type'] . " (test)";
+        $row['activity_type'] = CRM_Core_TestEntity::appendTestText($row['activity_type']);
       }
       $row['mailingId'] = '';
       if (

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -520,7 +520,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $result[$cs->id]['links'] = CRM_Core_Action::formLink($links, NULL, $replace);
 
       if ($isTest) {
-        $result[$cs->id]['contribution_status'] = $result[$cs->id]['contribution_status'] . '<br /> (test)';
+        $result[$cs->id]['contribution_status'] = CRM_Core_TestEntity::appendTestText($result[$cs->id]['contribution_status']);
       }
     }
     return $result;

--- a/CRM/Contribute/Page/ContributionRecurPayments.php
+++ b/CRM/Contribute/Page/ContributionRecurPayments.php
@@ -53,6 +53,9 @@ class CRM_Contribute_Page_ContributionRecurPayments extends CRM_Core_Page {
       $this->insertStatusLabels($contribution);
       $this->insertContributionActions($contribution);
 
+      if ($contribution['is_test']) {
+        $contribution['financial_type'] = CRM_Core_TestEntity::appendTestText($contribution['financial_type']);
+      }
       $relatedContributions[] = $contribution;
     }
 

--- a/CRM/Core/TestEntity.php
+++ b/CRM/Core/TestEntity.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * This file contains various support functions for test entities in CiviCRM.
+ * Historically there is a lot of inconsistency as to how test entities are displayed.
+ * This class helps resolve that.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ */
+
+/**
+ * Class CRM_Core_TestEntity.
+ */
+class CRM_Core_TestEntity {
+
+  // @todo extend this class to include functions that control when/where test entities are displayed
+  //  and then use those functions everywhere we can display test transactions.
+  // Ideally the display of test transactions would be a per-user setting or permission
+  //  so it can be toggled on/off as required and does not affect "day-to-day" usage.
+
+  /**
+   * Append "test" text to a string. eg. Member Dues (test) or My registration (test)
+   *
+   * @param string $text
+   *
+   * @return string
+   */
+  public static function appendTestText($text) {
+    return $text . ' ' . ts('(test)');
+  }
+
+}

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -118,7 +118,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     }
 
     if ($values[$participantID]['is_test']) {
-      $values[$participantID]['status'] .= ' (test) ';
+      $values[$participantID]['status'] = CRM_Core_TestEntity::appendTestText($values[$participantID]['status']);
     }
 
     // Get Note

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -363,7 +363,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
       $row['showConfirmUrl'] = ($statusClass == 'Pending') ? TRUE : FALSE;
 
       if (!empty($row['participant_is_test'])) {
-        $row['participant_status'] .= ' (' . ts('test') . ')';
+        $row['participant_status'] = CRM_Core_TestEntity::appendTestText($row['participant_status']);
       }
 
       $row['checkbox'] = CRM_Core_Form::CB_PREFIX . $result->participant_id;

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -398,7 +398,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
     }
 
     if (!empty($values['is_test'])) {
-      $values['membership_type'] .= ' (test) ';
+      $values['membership_type'] = CRM_Core_TestEntity::appendTestText($values['membership_type']);
     }
 
     $subscriptionCancelled = CRM_Member_BAO_Membership::isSubscriptionCancelled($this->membershipID);

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -377,7 +377,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
       $row['campaign_id'] = $result->member_campaign_id;
 
       if (!empty($row['member_is_test'])) {
-        $row['membership_type'] = $row['membership_type'] . " (test)";
+        $row['membership_type'] = CRM_Core_TestEntity::appendTestText($row['membership_type']);
       }
 
       $row['checkbox'] = CRM_Core_Form::CB_PREFIX . $result->membership_id;

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -326,7 +326,7 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
       }
       // append (test) to status label
       if (!empty($row['pledge_is_test'])) {
-        $row['pledge_status'] .= ' (test)';
+        $row['pledge_status'] = CRM_Core_TestEntity::appendTestText($row['pledge_status']);
       }
 
       $hideOption = array();

--- a/tests/phpunit/WebTest/Event/AddParticipationTest.php
+++ b/tests/phpunit/WebTest/Event/AddParticipationTest.php
@@ -342,7 +342,7 @@ class WebTest_Event_AddParticipationTest extends CiviSeleniumTestCase {
     $this->clickLink("_qf_Search_refresh", "participantSearch");
 
     //verifying the registered participants
-    $status = "Registered (test)";
+    $status = CRM_Core_TestEntity::appendTestText("Registered");
 
     foreach ($contacts as $contact) {
       $this->verifyText("xpath=//div[@id='participantSearch']//table//tbody//tr/td[@class='crm-participant-sort_name']/a[text()='{$contact['sort_name']}']/../../td[9]", preg_quote($status));


### PR DESCRIPTION
Overview
----------------------------------------
Test entities are handled pretty inconsistently throughout CiviCRM.  From when they are displayed, the order they are displayed in, which entities they are shown on etc.  I have a "sprint" topic to work on this at some point but this is a first tiny step.

Before
----------------------------------------
No consistency about how an entity shows "test".

After
----------------------------------------
Consistent function to handle the display of "test".

Technical Details
----------------------------------------
We add a new class CRM_Core_TestEntity to provide a central class for handling display of test entities.

Comments
----------------------------------------
@eileenmcnaughton related to #13779
