### PR TITLE
WIP Fix display of membership renew checkbox on contribution pages

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1158,7 +1158,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $membershipTypeIds = $membershipTypes = $radio = array();
       $membershipPriceset = (!empty($this->_priceSetId) && $this->_useForMember) ? TRUE : FALSE;
 
-      $allowAutoRenewMembership = $autoRenewOption = FALSE;
+      $autoRenewOption = FALSE;
       $autoRenewMembershipTypeOptions = array();
 
       $separateMembershipPayment = CRM_Utils_Array::value('is_separate_payment', $this->_membershipBlock);
@@ -1231,16 +1231,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             }
           }
           elseif ($memType['is_active']) {
-
-            if ($allowAutoRenewOpt) {
-              $javascriptMethod = array('onclick' => "return showHideAutoRenew( this.value );");
-              $allowAutoRenewMembership = TRUE;
-              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = $memType['auto_renew'];
-            }
-            else {
-              $javascriptMethod = NULL;
-              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = 0;
-            }
+            $javascriptMethod = ['onclick' => "return showHideAutoRenew( this.value );"];
+            $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"]
+              = CRM_Utils_Array::value($value, CRM_Utils_Array::value('auto_renew', $this->_membershipBlock));
 
             //add membership type.
             $radio[$memType['id']] = $this->createElement('radio', NULL, NULL, NULL,
@@ -1289,7 +1282,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->assign('membershipBlock', $this->_membershipBlock);
       $this->assign('showRadio', $isContributionMainPage);
       $this->assign('membershipTypes', $membershipTypes);
-      $this->assign('allowAutoRenewMembership', $allowAutoRenewMembership);
+      $this->assign('allowAutoRenewMembership', TRUE);
       $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
       //give preference to user submitted auto_renew value.
       $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted()) ? TRUE : FALSE;
@@ -1326,7 +1319,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           $this->addRule('selectMembership', ts('Please select one of the memberships.'), 'required');
         }
 
-        if ((!$this->_values['is_pay_later'] || is_array($this->_paymentProcessors)) && ($allowAutoRenewMembership || $autoRenewOption)) {
+        if ((!$this->_values['is_pay_later'] || is_array($this->_paymentProcessors)) && $autoRenewOption) {
           if ($autoRenewOption == 2) {
             $this->addElement('hidden', 'auto_renew', ts('Please renew my membership automatically.'));
           }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1207,6 +1207,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             }
           }
         }
+
+        // Loop through each membership type on the contribution page and assign details to the form
         foreach ($membershipTypeIds as $value) {
           $memType = $membershipTypeValues[$value];
           if ($selectedMembershipTypeID != NULL) {
@@ -1232,8 +1234,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
             if ($allowAutoRenewOpt) {
               $javascriptMethod = array('onclick' => "return showHideAutoRenew( this.value );");
-              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = (int) $memType['auto_renew'] * CRM_Utils_Array::value($value, CRM_Utils_Array::value('auto_renew', $this->_membershipBlock));
               $allowAutoRenewMembership = TRUE;
+              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = $memType['auto_renew'];
             }
             else {
               $javascriptMethod = NULL;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -121,6 +121,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   protected $_paymentProcessorID;
 
   /**
+   * @return int
+   */
+  public function getPaymentProcessorID() {
+    return $this->_paymentProcessorID;
+  }
+
+  /**
    * Is pay later enabled for the form.
    *
    * As part of trying to consolidate various payment pages we store processors here & have functions
@@ -878,9 +885,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       else {
         $this->_paymentProcessor = array();
       }
-      CRM_Financial_Form_Payment::addCreditCardJs($this->_paymentProcessorID);
     }
-    $this->assign('paymentProcessorID', $this->_paymentProcessorID);
     // We save the fact that the profile 'billing' is required on the payment form.
     // Currently pay-later is the only 'processor' that takes notice of this - but ideally
     // 1) it would be possible to select the minimum_billing_profile_id for the contribution form

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -72,6 +72,13 @@ class CRM_Core_Payment_ProcessorForm {
 
     $form->assign('suppressSubmitButton', $form->_paymentObject->isSuppressSubmitButtons());
 
+    CRM_Financial_Form_Payment::addCreditCardJs($form->getPaymentProcessorID());
+
+    $paymentProcessorCapabilities = [
+      'isrecur' => $form->_paymentProcessor['is_recur'],
+    ];
+    $form->assign('paymentProcessorCapabilities', $paymentProcessorCapabilities);
+    $form->assign('paymentProcessorID', $form->getPaymentProcessorID());
     $form->assign('currency', $form->getCurrency());
 
     // also set cancel subscription url

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -81,6 +81,10 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
 
     self::addCreditCardJs($this->_paymentProcessorID);
 
+    $paymentProcessorCapabilities = [
+      'isrecur' => $this->_paymentProcessor['is_recur'],
+    ];
+    $this->assign('paymentProcessorCapabilities', $paymentProcessorCapabilities);
     $this->assign('paymentProcessorID', $this->_paymentProcessorID);
     $this->assign('currency', $this->currency);
 

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -35,7 +35,6 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
   /**
    * @var int
    */
-  protected $_paymentProcessorID;
   protected $currency;
 
   public $_values = array();
@@ -78,15 +77,6 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
     $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($this->_paymentProcessorID);
 
     CRM_Core_Payment_ProcessorForm::preProcess($this);
-
-    self::addCreditCardJs($this->_paymentProcessorID);
-
-    $paymentProcessorCapabilities = [
-      'isrecur' => $this->_paymentProcessor['is_recur'],
-    ];
-    $this->assign('paymentProcessorCapabilities', $paymentProcessorCapabilities);
-    $this->assign('paymentProcessorID', $this->_paymentProcessorID);
-    $this->assign('currency', $this->currency);
 
     $this->assign('suppressForm', TRUE);
     $this->controller->_generateQFKey = FALSE;

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -135,10 +135,10 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         $this->_id, 'payment_processor'
       );
       $paymentProcessorId = explode(CRM_Core_DAO::VALUE_SEPARATOR, $paymentProcessorIds);
-      $isRecur = TRUE;
+      $isRecur = FALSE;
       foreach ($paymentProcessorId as $dontCare => $id) {
-        if (!array_key_exists($id, $paymentProcessor)) {
-          $isRecur = FALSE;
+        if (array_key_exists($id, $paymentProcessor)) {
+          $isRecur = TRUE;
           continue;
         }
       }

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -255,7 +255,7 @@
 
       var readOnly = false;
       var isChecked  = false;
-      if ( currentOption == 0 ) {
+      if ( currentOption == 0 || (typeof currentOption === "undefined")) {
         isChecked = false;
         forceRenew.hide();
         autoRenew.hide();

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -79,27 +79,6 @@
       </div>
     {/if}
   </div>
-{literal}
-  <script type="text/javascript">
-    CRM.$(function($) {
-      //if price set is set we use below below code to show for showing auto renew
-      var autoRenewOption =  {/literal}'{$autoRenewOption}'{literal};
-      var autoRenew = $("#auto_renew_section");
-      var autoRenewCheckbox = $("#auto_renew");
-      var forceRenew = $("#force_renew");
-      autoRenew.hide();
-      forceRenew.hide();
-      if ( autoRenewOption == 1 ) {
-        autoRenew.show();
-      } else if ( autoRenewOption == 2 ) {
-        autoRenewCheckbox.prop('checked',  true );
-        autoRenewCheckbox.attr( 'readonly', true );
-        autoRenew.hide();
-        forceRenew.show();
-      }
-    });
-  </script>
-{/literal}
 {elseif $membershipBlock AND !$is_quick_config}
   <div id="membership" class="crm-group membership-group">
     {if $context EQ "makeContribution"}
@@ -285,6 +264,9 @@
 
       autoRenewC.attr( 'readonly', readOnly );
       autoRenewC.prop('checked',  isChecked );
+
+      // We need to trigger the change handler as it won't by default when the element is hidden
+      autoRenewC.trigger('change');
     }
 
     {/literal}{if $allowAutoRenewMembership}{literal}

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -36,7 +36,7 @@
 
       // Display a warning to the user if the selected payment processor does not support recurring payments
       function showHidePaymentProcessorCapabilities() {
-        var isAutoRenew = $('input#auto_renew:checked').prop('checked');
+        var isAutoRenew = $('input[name="auto_renew"]').prop('checked');
         var isRecurSupported = {/literal}{if $paymentProcessorCapabilities.isrecur}true{else}false{/if}{literal}
         var isPaymentProcessorSelected = $('input[name="payment_processor_id"]:checked').length;
         $('div#payment_processor_capabilities_warning').remove();

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -24,6 +24,30 @@
  +--------------------------------------------------------------------+
 *}
 {crmRegion name="billing-block"}
+{literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      // Unbind first so we don't add another handler every time we switch payment processors
+      $('input[name="payment_processor_id"]').on('change', function() { $('input#auto_renew').unbind(showHidePaymentProcessorCapabilities()); });
+
+      // Trigger check for capabilities every time we change the payment processor
+      $('input#auto_renew').on('change', showHidePaymentProcessorCapabilities);
+      showHidePaymentProcessorCapabilities();
+
+      // Display a warning to the user if the selected payment processor does not support recurring payments
+      function showHidePaymentProcessorCapabilities() {
+        var isAutoRenew = $('input#auto_renew:checked').prop('checked');
+        var isRecurSupported = {/literal}{if $paymentProcessorCapabilities.isrecur}true{else}false{/if}{literal}
+        var isPaymentProcessorSelected = $('input[name="payment_processor_id"]:checked').length;
+        $('div#payment_processor_capabilities_warning').remove();
+        if (isAutoRenew && !isRecurSupported && isPaymentProcessorSelected) {
+          $('div#billing-payment-block:first').prepend(
+            '<div id="payment_processor_capabilities_warning" class="messages status crm-warning">This payment method does not support automatic renewals</div>');
+        }
+      }
+    });
+  </script>
+{/literal}
 <div id="payment_information">
   {if $paymentFields|@count}
     <fieldset class="billing_mode-group {$paymentTypeName}_info-group">


### PR DESCRIPTION
Overview
----------------------------------------
Requires rebase after #13830 is merged.
Also need to extract https://github.com/civicrm/civicrm-core/pull/13815/commits/3d0078a1163436b40a9f6114a2769192a5fbff22

To reproduce:
Create a contribution page with membership options only and no priceset.  Do not set a default membership.

Before
----------------------------------------
* "Renew my membership automatically" checkbox is displayed on initial load.
* No auto-renew options if any of the payment processors don't support auto-renew.


After
----------------------------------------
![contribution_noautorenewwarn](https://user-images.githubusercontent.com/2052161/54427537-b4cfa000-4712-11e9-94ee-385837c87f86.png)

* "Renew my membership automatically" checkbox is displayed on initial load.
* Always show auto-renew options if available.  If the payment processor doesn't support it it won't get shown on the confirm/thankyou pages as auto-renew.  But if the processor does support it we can actually setup a recurring contribution that will auto-renew.  It's impossible to (sensibly) combine direct debit processors on the same page as eg. pay later otherwise as you can't actually submit a recurring payment.

Technical Details
----------------------------------------
* javascript needs to check for undefined as well as 0.
* Remove an additional function that gets run on form load and does (nearly) the same thing as the one lower down.

Comments
----------------------------------------
