### PR TITLE
core#798 - fix rendering of public-facing prefix/suffix select2

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3597,7 +3597,6 @@ span.crm-status-icon {
 }
 .crm-container.crm-public .select2-container .select2-choice {
   padding: 5px 5px 5px 8px;
-  height: auto;
 }
 .crm-container.crm-public .select2-container-multi .select2-choices {
   padding: 4px;


### PR DESCRIPTION
Overview
----------------------------------------
Prefix and suffix fields in contribution/event profiles render incorrectly on public-facing pages.

Before
----------------------------------------
![Selection_824](https://user-images.githubusercontent.com/1796012/54295488-78bd0380-4589-11e9-970b-cc841ea9a384.png)


After
----------------------------------------
![Selection_825](https://user-images.githubusercontent.com/1796012/54295497-7ce92100-4589-11e9-9c38-cdb8ff1c79f3.png)


Comments
----------------------------------------
I don't know why `civicrm.css` overrides `select2.css` on the front end - the backend uses `select2.css` to set select2 height and it's fine.  Other select2 widgets are unaffected because they have placeholder text.  I could also add placeholder text to the default rendering of this widget, but I think the CSS fix makes more sense.

https://lab.civicrm.org/dev/core/issues/798