### PR TITLE
dev/core#801 Fix from email on PDF Letters, such as Thank You Letters.

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -39,6 +39,9 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         'subject' => CRM_Utils_Array::value('subject', $formValues),
         'from' => CRM_Utils_Array::value('from_email_address', $formValues),
       );
+
+      $emailParams['from'] = CRM_Utils_Mail::formatFromAddress($emailParams['from']);
+
       // We need display_name for emailLetter() so add to returnProperties here
       $returnProperties['display_name'] = 1;
       if (stristr($formValues['email_options'], 'pdfemail')) {


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/issues/801

To reproduce:

* Record a contribution for a contact
* Find Contributions, select the contribution, Send Thank You Letters
* Select the option to send emails
* Use the default from of the contact, which should be the email on their contact record.

When sending the emails, CiviCRM will throw an error that there is no 'from' in the email, which sounds like this SE question: https://civicrm.stackexchange.com/questions/21780/civicontribute-thank-you-letter-not-emailed-using-cividesk-sparkpost/24948

Inspecting the form html reveal's this:

![Capture d’écran de 2019-03-14 12-45-04](https://user-images.githubusercontent.com/254741/54375456-73c68580-4657-11e9-8fb3-1ecd280252b3.png)

It seems very familiar to issue #357

Before
----------------------------------------

Error message while trying to send Thank You letters by email.

After
----------------------------------------

Fixed.

Technical Details
----------------------------------------

It was setting "from = 122", where 122 is the Email ID.

Comments
----------------------------------------

Related issue: https://lab.civicrm.org/dev/core/issues/357
