### PR TITLE
Import date test

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1691,6 +1691,10 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
   /**
    * Build error-message containing error-fields
    *
+   * Once upon a time there was a dev who hadn't heard of implode. That dev wrote this function.
+   *
+   * @todo just say no!
+   *
    * @param string $errorName
    *   A string containing error-field name.
    * @param string $errorMessage

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -177,7 +177,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
     $errorMessage = NULL;
 
     //for date-Formats
-    $errorMessage = $this->formatDateFields($params);
+    $errorMessage = implode('; ', $this->formatDateFields($params));
     //date-Format part ends
 
     $params['contact_type'] = 'Contribution';
@@ -539,7 +539,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
    *   Error messages, if any.
    */
   public function formatDateFields(&$params) {
-    $errorMessage = NULL;
+    $errorMessage = [];
     $dateType = CRM_Core_Session::singleton()->get('dateTypes');
     foreach ($params as $key => $val) {
       if ($val) {
@@ -549,7 +549,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
               $params[$key] = $dateValue;
             }
             else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Receive Date', $errorMessage);
+              $errorMessage[] = ts('Receive Date');
             }
             break;
 
@@ -558,7 +558,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
               $params[$key] = $dateValue;
             }
             else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Cancel Date', $errorMessage);
+              $errorMessage[] = ts('Cancel Date');
             }
             break;
 
@@ -567,7 +567,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
               $params[$key] = $dateValue;
             }
             else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Receipt date', $errorMessage);
+              $errorMessage[] = ts('Receipt date');
             }
             break;
 
@@ -576,7 +576,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
               $params[$key] = $dateValue;
             }
             else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Thankyou Date', $errorMessage);
+              $errorMessage[] = ts('Thankyou Date');
             }
             break;
         }

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -177,49 +177,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
     $errorMessage = NULL;
 
     //for date-Formats
-    $session = CRM_Core_Session::singleton();
-    $dateType = $session->get('dateTypes');
-    foreach ($params as $key => $val) {
-      if ($val) {
-        switch ($key) {
-          case 'receive_date':
-            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
-              $params[$key] = $dateValue;
-            }
-            else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Receive Date', $errorMessage);
-            }
-            break;
-
-          case 'cancel_date':
-            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
-              $params[$key] = $dateValue;
-            }
-            else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Cancel Date', $errorMessage);
-            }
-            break;
-
-          case 'receipt_date':
-            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
-              $params[$key] = $dateValue;
-            }
-            else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Receipt date', $errorMessage);
-            }
-            break;
-
-          case 'thankyou_date':
-            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
-              $params[$key] = $dateValue;
-            }
-            else {
-              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Thankyou Date', $errorMessage);
-            }
-            break;
-        }
-      }
-    }
+    $errorMessage = $this->formatDateFields($params);
     //date-Format part ends
 
     $params['contact_type'] = 'Contribution';
@@ -257,42 +215,12 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
 
     $params = &$this->getActiveFieldParams();
     $formatted = ['version' => 3, 'skipRecentView' => TRUE, 'skipCleanMoney' => FALSE];
-    $dateType = CRM_Core_Session::singleton()->get('dateTypes');
-
-    $customDataType = !empty($params['contact_type']) ? $params['contact_type'] : 'Contribution';
-    $customFields = CRM_Core_BAO_CustomField::getFields($customDataType);
 
     //CRM-10994
     if (isset($params['total_amount']) && $params['total_amount'] == 0) {
       $params['total_amount'] = '0.00';
     }
-    foreach ($params as $key => $val) {
-      if ($val) {
-        switch ($key) {
-          case 'receive_date':
-          case 'cancel_date':
-          case 'receipt_date':
-          case 'thankyou_date':
-            $params[$key] = CRM_Utils_Date::formatDate($params[$key], $dateType);
-            break;
-
-          case 'pledge_payment':
-            $params[$key] = CRM_Utils_String::strtobool($val);
-            break;
-
-        }
-        if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-          if ($customFields[$customFieldID]['data_type'] == 'Date') {
-            CRM_Contact_Import_Parser_Contact::formatCustomDate($params, $formatted, $dateType, $key);
-            unset($params[$key]);
-          }
-          elseif ($customFields[$customFieldID]['data_type'] == 'Boolean') {
-            $params[$key] = CRM_Utils_String::strtoboolstr($val);
-          }
-        }
-      }
-    }
-    //date-Format part ends
+    $this->formatInput($params);
 
     static $indieFields = NULL;
     if ($indieFields == NULL) {
@@ -600,6 +528,107 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
    * The initializer code, called before the processing.
    */
   public function fini() {
+  }
+
+  /**
+   * Format date fields from input to mysql.
+   *
+   * @param array $params
+   *
+   * @return array
+   *   Error messages, if any.
+   */
+  public function formatDateFields(&$params) {
+    $errorMessage = NULL;
+    $dateType = CRM_Core_Session::singleton()->get('dateTypes');
+    foreach ($params as $key => $val) {
+      if ($val) {
+        switch ($key) {
+          case 'receive_date':
+            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
+              $params[$key] = $dateValue;
+            }
+            else {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Receive Date', $errorMessage);
+            }
+            break;
+
+          case 'cancel_date':
+            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
+              $params[$key] = $dateValue;
+            }
+            else {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Cancel Date', $errorMessage);
+            }
+            break;
+
+          case 'receipt_date':
+            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
+              $params[$key] = $dateValue;
+            }
+            else {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Receipt date', $errorMessage);
+            }
+            break;
+
+          case 'thankyou_date':
+            if ($dateValue = CRM_Utils_Date::formatDate($params[$key], $dateType)) {
+              $params[$key] = $dateValue;
+            }
+            else {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Thankyou Date', $errorMessage);
+            }
+            break;
+        }
+      }
+    }
+    return $errorMessage;
+  }
+
+  /**
+   * Format input params to suit api handling.
+   *
+   * Over time all the parts of  _civicrm_api3_deprecated_formatted_param
+   * and all the parts of the import function on this class that relate to
+   * reformatting input should be moved here and tests should be added in
+   * CRM_Contribute_Import_Parser_ContributionTest.
+   *
+   * @param array $params
+   */
+  public function formatInput(&$params) {
+    $dateType = CRM_Core_Session::singleton()->get('dateTypes');
+    $customDataType = !empty($params['contact_type']) ? $params['contact_type'] : 'Contribution';
+    $customFields = CRM_Core_BAO_CustomField::getFields($customDataType);
+    // @todo call formatDateFields & move custom data handling there.
+    // Also note error handling for dates is currently in  _civicrm_api3_deprecated_formatted_param
+    // we should use the error handling in formatDateFields.
+    foreach ($params as $key => $val) {
+      // @todo - call formatDateFields instead.
+      if ($val) {
+        switch ($key) {
+          case 'receive_date':
+          case 'cancel_date':
+          case 'receipt_date':
+          case 'thankyou_date':
+            $params[$key] = CRM_Utils_Date::formatDate($params[$key], $dateType);
+            break;
+
+          case 'pledge_payment':
+            $params[$key] = CRM_Utils_String::strtobool($val);
+            break;
+
+        }
+        if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
+          if ($customFields[$customFieldID]['data_type'] == 'Date') {
+            CRM_Contact_Import_Parser_Contact::formatCustomDate($params, $params, $dateType, $key);
+            unset($params[$key]);
+          }
+          elseif ($customFields[$customFieldID]['data_type'] == 'Boolean') {
+            $params[$key] = CRM_Utils_String::strtoboolstr($val);
+          }
+        }
+      }
+    }
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -69,6 +69,24 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->callAPISuccess('ContributionSoft', 'Delete', ['id' => $contributionsOfSoftContact->id]);
     $this->callAPISuccess('Contribution', 'Delete', ['id' => $contributionsOfMainContact->id]);
   }
+
+  /**
+   * Test dates are parsed
+   */
+  public function testParsedDates() {
+    $mapperKeys = [];
+    $form = new CRM_Contribute_Import_Parser_Contribution($mapperKeys);
+    $params = ['receive_date' => '20/10/2019'];
+    CRM_Core_Session::singleton()->set('dateTypes', 32);
+    $form->formatDateFields($params);
+    $this->assertEquals('20191020', $params['receive_date']);
+
+    $params = ['receive_date' => '20/10/2019'];
+    CRM_Core_Session::singleton()->set('dateTypes', 32);
+    $form->formatInput($params);
+    $this->assertEquals('20191020', $params['receive_date']);
+  }
+
   /**
    * Run the import parser.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test to date parsing on import (including extraction to support it)

This is primarily as a demo of how to test this class.

Before
----------------------------------------
No model for how to test formatting on input

After
----------------------------------------
Model created

Technical Details
----------------------------------------

Basically to add testing -  extract the parts that we want to check the formatting of into manageable
functions. I made the name on the second one pretty generic so slowly all formatting can
be moved into it, with testing.

This would include moving the various bits of work done in
_civicrm_api3_deprecated_formatted_param
into this function - that code really does just belong on this class as it
is not called from anywhere else.

It also does the checking, but not the formatting, for these date fields - sigh

I would have liked to have made the method protected but the mucking around that required
in the test classes didn't seem to justify it

Comments
----------------------------------------
Created in response to questions asked on #13464 on how to add a test
