### PR TITLE
(NFC, infra/ops#878) AssetBuilderTest - Relax getUrl() assertion for WP compat

### DIFF
--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -150,7 +150,8 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
     \Civi::service('asset_builder')->setCacheEnabled(FALSE);
     $url = \Civi::service('asset_builder')->getUrl($asset, $params);
     $this->assertEquals(0, $this->fired['hook_civicrm_buildAsset']);
-    $this->assertRegExp(';^https?:.*civicrm/asset/builder.*square.(txt|js);', $url);
+    // Ex: Traditional URLs on D7 have "/". Traditional URLs on WP have "%2F".
+    $this->assertRegExp(';^https?:.*civicrm(/|%2F)asset(/|%2F)builder.*square.(txt|js);', $url);
 
     // Simulate a request. Our fake hook won't fire in a real request.
     parse_str(parse_url($url, PHP_URL_QUERY), $get);


### PR DESCRIPTION
The test ensures that AssetBuilder produces plausible URLs when caching is disabled.

Generated URLs look different in the default `drupal-clean` and `wp-demo` configurations, e.g.

* D7 (drupal-clean): `http://dmaster.bknix:8001/civicrm/asset/builder?an=square.js&ap=...`
* WP (wp-demo): `http://wpmaster.bknix:8001/?page=CiviCRM&q=civicrm%2Fasset%2Fbuilder&an=square.js&ap=...

The assertion in `AssetBuilderTest` was coded in a way that fails on working URLs.

Before
------

The test fails on WP.

After
-----

The test passes on WP.
