### PR TITLE
Fix decimal places for tax rate on registration confirm/thankyou

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -516,12 +516,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
       foreach ($this->_lineItem as $key => $value) {
         foreach ($value as $k => $v) {
-          if (isset($v['tax_rate'])) {
-            if ($v['tax_rate'] != '') {
-              $getTaxDetails = TRUE;
-              // Cast to float to display without trailing zero decimals
-              $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
-            }
+          if (!empty($v['tax_rate'])) {
+            $getTaxDetails = TRUE;
+            // Cast to float to display without trailing zero decimals
+            $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
           }
         }
       }

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -116,12 +116,10 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
       $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
       foreach ($this->_lineItem as $key => $value) {
         foreach ($value as $k => $v) {
-          if (isset($v['tax_rate'])) {
-            if ($v['tax_rate'] != '') {
-              $getTaxDetails = TRUE;
-              // Cast to float to display without trailing zero decimals
-              $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
-            }
+          if (!empty($v['tax_rate'])) {
+            $getTaxDetails = TRUE;
+            // Cast to float to display without trailing zero decimals
+            $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
           }
         }
       }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -285,24 +285,26 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     }
 
     if ($this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config')) {
-      $lineItemForTemplate = array();
+      $tplLineItems = array();
       $getTaxDetails = FALSE;
       if (!empty($this->_lineItem) && is_array($this->_lineItem)) {
         foreach ($this->_lineItem as $key => $value) {
           if (!empty($value)) {
-            $lineItemForTemplate[$key] = $value;
+            $tplLineItems[$key] = $value;
           }
           if ($invoicing) {
-            foreach ($value as $v) {
-              if (isset($v['tax_rate'])) {
+            foreach ($value as $k => $v) {
+              if (!empty($v['tax_rate'])) {
                 $getTaxDetails = TRUE;
+                // Cast to float to display without trailing zero decimals
+                $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
               }
             }
           }
         }
       }
-      if (!empty($lineItemForTemplate)) {
-        $this->assign('lineItem', $lineItemForTemplate);
+      if (!empty($tplLineItems)) {
+        $this->assign('lineItem', $tplLineItems);
       }
       $this->assign('getTaxDetails', $getTaxDetails);
     }

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -100,18 +100,18 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
     $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
     $getTaxDetails = FALSE;
-    $taxAmount = 0;
 
-    $lineItemForTemplate = array();
+    $tplLineItems = array();
     if (!empty($this->_lineItem) && is_array($this->_lineItem)) {
       foreach ($this->_lineItem as $key => $value) {
         if (!empty($value) && $value != 'skip') {
-          $lineItemForTemplate[$key] = $value;
+          $tplLineItems[$key] = $value;
           if ($invoicing) {
-            foreach ($value as $v) {
-              if (isset($v['tax_amount']) || isset($v['tax_rate'])) {
-                $taxAmount += $v['tax_amount'];
+            foreach ($value as $k => $v) {
+              if (!empty($v['tax_rate'])) {
                 $getTaxDetails = TRUE;
+                // Cast to float to display without trailing zero decimals
+                $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
               }
             }
           }
@@ -121,14 +121,14 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
 
     if ($this->_priceSetId &&
       !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config') &&
-      !empty($lineItemForTemplate)
+      !empty($tplLineItems)
     ) {
-      $this->assign('lineItem', $lineItemForTemplate);
+      $this->assign('lineItem', $tplLineItems);
     }
 
     if ($invoicing) {
       $this->assign('getTaxDetails', $getTaxDetails);
-      $this->assign('totalTaxAmount', $taxAmount);
+      $this->assign('totalTaxAmount', $this->_params['tax_amount']);
       $this->assign('taxTerm', $taxTerm);
     }
     $this->assign('totalAmount', $this->_totalAmount);


### PR DESCRIPTION
Overview
----------------------------------------
This is the same change as https://github.com/civicrm/civicrm-core/pull/10856 but for the event confirm/thankyou pages.

Before
----------------------------------------
Tax rates shown with 8 decimal places for line items on event confirm/thankyou pages.
Examples: 20.00000000%; 8.90000000%

After
----------------------------------------
Tax rates shown with no trailing zeros for line items on event confirm/thankyou pages.

Examples: 20%, 8.9%

Technical Details
----------------------------------------
Cast to float per contribution page changes.
Also minor cleanup to make the code more consistent between the 4 pages (contribution/event confirm/thankyou) to allow for future consolidation.

Comments
----------------------------------------
@highfalutin @JoeMurray @kcristiano Could one of you please review?  Noting the reference to the related PR that was merged in 2017