### PR TITLE
[nfc] Attempt to improve false negatives on Logging test

### DIFF
--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -295,6 +295,9 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
   public function testRevertNoDate() {
     $contactId = $this->individualCreate();
     $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
+    // Pause for one second here to ensure the timestamps between the first create action
+    // and the second differ.
+    sleep(1);
     CRM_Core_DAO::executeQuery("SET @uniqueID = 'Wot woot'");
     $this->callAPISuccess('Contact', 'create', array(
         'id' => $contactId,


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to reduce false test fails on logging

Before
----------------------------------------
no change

After
----------------------------------------
no change - maybe less false fails

Technical Details
----------------------------------------
The theory is the test box is flying so fast that there is no difference in timestamp on the 2 writes - making 'revert to previous' un-doable.

It might be significant that the one I added sleep(1) to before wasn't a fail in this one...

https://test.civicrm.org/job/CiviCRM-Core-PR/25137/

Comments
----------------------------------------
