### PR TITLE
Case Manager is not shown for closed cases (Gitlab issue 542)

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -868,7 +868,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
        AND con.is_deleted = 0';
 
     if ($activeOnly) {
-      $query .= ' AND rel.is_active = 1 AND (rel.end_date IS NULL OR rel.end_date > NOW())';
+      $query .= ' AND rel.is_active = 1';
     }
 
     $params = array(

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -408,7 +408,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $activeCaseRelationships = CRM_Case_BAO_Case::getCaseRoles($this->_params['contact_id'], $case['id'], NULL, FALSE);
     $this->assertEquals(count($activeCaseRelationships), 3, "Checking for empty array");
 
-    // But -1 if only active relationships are selected makes total 3
+    // But -1 if only active relationships are selected makes total 2
     $activeCaseRelationships = CRM_Case_BAO_Case::getCaseRoles($this->_params['contact_id'], $case['id'], NULL, TRUE);
     $this->assertEquals(count($activeCaseRelationships), 2, "Checking for empty array");
   }

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -181,14 +181,6 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     foreach ($relationships['values'] as $key => $values) {
       $this->assertEquals($values['end_date'], date('Y-m-d'));
     }
-
-    //Verify there are no active relationships.
-    $activeCaseRelationships = CRM_Case_BAO_Case::getCaseRoles($result['values'][$id]['client_id'][1], $id);
-    $this->assertEquals(count($activeCaseRelationships), 0, "Checking for empty array");
-
-    //Check if getCaseRoles() is able to return inactive relationships.
-    $caseRelationships = CRM_Case_BAO_Case::getCaseRoles($result['values'][$id]['client_id'][1], $id, NULL, FALSE);
-    $this->assertEquals(count($caseRelationships), 1);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When a case is closed the case manager is not shown anymore in the case view. So when a returning client arrives at the desk, and his old cases are looked into, the name of the case manager is not shown. So she (the manager of the old case) cannot be contacted for context. 

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/14834891/54441643-78fe0000-473d-11e9-9d49-ef37df1b7244.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/14834891/54442053-3852b680-473e-11e9-84fb-0832fb2578e6.png)

Some User Story Background
----------------------------------------
When a case is closed all the roles (including the case manager) get the enddate of the case. This is done in `CRM_Case_Form_Activity_ChangeCaseStatus`. It makes sense, a closed case means, no more actions, and the relationship comes in some also to an end. 

However, the relationship is still active (means the field is_active=1). That makes also makes sense. The case still shows up in your case dashboard, so you can browse in your historical cases. It even shows the future planned activities for the case. These should not be there and present a choice. The user must cancel the activity or reopen the case. 

Technical Details
----------------------------------------
However, the code `CRM_Case_BAO_Case::getCaseRoles` that retrieves the active roles, also selects on end_date. But I think and end_date in the past does not mean an inactive relationship
```
if ($activeOnly) {
      $query .= ' AND rel.is_active = 1 AND (rel.end_date IS NULL OR rel.end_date > NOW())';
    }
```

Comments
----------------------------------------
This issue is reported on gitlab at https://lab.civicrm.org/dev/core/issues/542
This issue has another PR https://github.com/civicrm/civicrm-core/pull/13510 . This PR gives the user the choice to see al the inactive relationships with a checkbox. This complicates the screen and also shows former (in_active) managers, that contact much less relevant information. If the user is interested in the former case roles he can look into the Assign Case Role activities. 
