### PR TITLE
Logging - attempt to fix tests

### DIFF
--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -412,6 +412,9 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
     $contactId = $this->individualCreate();
     $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
     CRM_Core_DAO::executeQuery("SET @uniqueID = 'wooty wop wop'");
+    // Perhaps if initialize & create are exactly the same time it can't cope.
+    // 1 second delay
+    sleep(1);
     $this->callAPISuccess('Contact', 'create', array(
         'id' => $contactId,
         'first_name' => 'Dopey',

--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -443,7 +443,7 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
         return TRUE;
       }
     }
-    throw new CRM_Core_Exception("No match found for key : $expectKey with value : $expectValue");
+    throw new CRM_Core_Exception("No match found for key : $expectKey with value : $expectValue" . print_r($diffs, 1));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Adding the 1 second delay appears to have helped in the other tests - try in this one

Before
----------------------------------------
More test fails

After
----------------------------------------
Hopefully less

Technical Details
----------------------------------------
Logging functions compare timestamps but are likely not able to cope with changed 'at the same time' - which is a test scenario rather than a real world scenario. Add a delay in the test.

Comments
----------------------------------------

