### PR TITLE
Deploy PEAR Log package and upgrade to latest version in the process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
     "civicrm/civicrm-setup": "~0.2.0",
     "guzzlehttp/guzzle": "^6.3",
     "psr/simple-cache": "~1.0.1",
-    "cweagans/composer-patches": "~1.0"
+    "cweagans/composer-patches": "~1.0",
+    "pear/log": "1.13.1"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f9eab6b0bf1c120dace5cf229223605",
+    "content-hash": "17588dc1a1e09a5f449c38e1169c4209",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -590,6 +590,59 @@
             ],
             "description": "More info available on: http://pear.php.net/package/Console_Getopt",
             "time": "2015-07-20T20:28:12+00:00"
+        },
+        {
+            "name": "pear/log",
+            "version": "1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Log.git",
+                "reference": "c4be9ded2353c7c231d4c35cc3da75b209453803"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Log/zipball/c4be9ded2353c7c231d4c35cc3da75b209453803",
+                "reference": "c4be9ded2353c7c231d4c35cc3da75b209453803",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear_exception": "1.0.0",
+                "php": ">5.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "pear/db": "Install optionally via your project's composer.json"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Log": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jon Parise",
+                    "email": "jon@php.net",
+                    "homepage": "http://www.indelible.org",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PEAR Logging Framework",
+            "homepage": "http://pear.github.io/Log/",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "time": "2016-04-16T00:49:33+00:00"
         },
         {
             "name": "pear/mail",


### PR DESCRIPTION
Overview
----------------------------------------
This aims to upgrade our version of the PEAR Log package and deploy it via composer now

Before
----------------------------------------
Old version of Pear Log package used and deployed using civicrm-packages

After
----------------------------------------
Latest version deployed and deployed via compsoer

Technical Details
----------------------------------------
this is a diff between the two package installs https://gist.github.com/seamuslee001/4cae97df85c25c32264f4f5c53929e49 

ping @totten @eileenmcnaughton @mfb 
