### PR TITLE
Minor code cleanup - remove unnecessary ids declaration

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1017,19 +1017,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $contribParams['is_test'] = 1;
     }
 
-    $contribID = NULL;
     if (!empty($contribParams['invoice_id'])) {
-      $contribID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',
+      $contribParams['id'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',
         $contribParams['invoice_id'],
         'id',
         'invoice_id'
       );
-    }
-
-    $ids = array();
-    if ($contribID) {
-      $ids['contribution'] = $contribID;
-      $contribParams['id'] = $contribID;
     }
 
     if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {


### PR DESCRIPTION
Overview
----------------------------------------
Very minor code simplification

Before
----------------------------------------
Less readable

After
----------------------------------------
More readable

Technical Details
----------------------------------------
$ids  is not used  & $contribID is only used to set $contributionPaarams['id'] so this can be simplified


Comments
----------------------------------------

