### PR TITLE
Minor code cleanup

### DIFF
--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -107,13 +107,11 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     }
 
     $params = $this->_params;
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();
     // Make a copy of line items array to use for display only
     $tplLineItems = $this->_lineItem;
     if ($invoicing) {
       $getTaxDetails = FALSE;
-      $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
       foreach ($this->_lineItem as $key => $value) {
         foreach ($value as $k => $v) {
           if (isset($v['tax_rate'])) {
@@ -126,7 +124,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
         }
       }
       $this->assign('getTaxDetails', $getTaxDetails);
-      $this->assign('taxTerm', $taxTerm);
+      $this->assign('taxTerm', CRM_Invoicing_Utils::getTaxTerm());
       $this->assign('totalTaxAmount', $params['tax_amount']);
     }
 

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -96,9 +96,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     }
     $this->assignToTemplate();
 
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();
     $getTaxDetails = FALSE;
     $taxAmount = 0;
 
@@ -129,7 +127,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     if ($invoicing) {
       $this->assign('getTaxDetails', $getTaxDetails);
       $this->assign('totalTaxAmount', $taxAmount);
-      $this->assign('taxTerm', $taxTerm);
+      $this->assign('taxTerm', CRM_Invoicing_Utils::getTaxTerm());
     }
     $this->assign('totalAmount', $this->_totalAmount);
 

--- a/CRM/Invoicing/Utils.php
+++ b/CRM/Invoicing/Utils.php
@@ -94,4 +94,15 @@ class CRM_Invoicing_Utils {
     return CRM_Utils_Array::value('default_invoice_page', $invoiceSettings);
   }
 
+  /**
+   * Function to get the tax term.
+   *
+   * The value is nested in the contribution_invoice_settings setting - which
+   * is unsupported. Here we have a wrapper function to make later cleanup easier.
+   */
+  public static function getTaxTerm() {
+    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
+    return CRM_Utils_Array::value('tax_term', $invoiceSettings);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup 

Before
----------------------------------------
Less maintainable _

After
----------------------------------------
More readable

Technical Details
----------------------------------------
Invoicing code has been poorly integrated into CiviCRM with much copy & paste,
no following of settings spec and an awful lot of outright hacking.

This is a small step towards moving invoice logic to a centralised place -
specifically in this case the unpacking of the non-standard settings that have been
used. Perhaps once using these functions we can standardise them!

Ideally I'd like to see all the invoicing assigns in a function on this
class, better yet once which mimics the pre or buildForm hook & even
better one day to grow up & be a real hook

Comments
----------------------------------------
