### PR TITLE
Upgrade htmlpurifier to 4.10 to support PHP7.2 and install via composer

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -190,7 +190,7 @@ class CRM_Core_ClassLoader {
     // we do this to prevent a autoloader errors with joomla / 3rd party packages
     // Use absolute path, since we don't know the content of include_path yet.
     // CRM-11304
-    $file = dirname(__FILE__) . '/../../packages/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php';
+    $file = dirname(__FILE__) . '/../../vendor/ezyang/htmlpurifier/library/HTMLPurifier/Bootstrap.php';
     if (file_exists($file)) {
       return $file;
     }

--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -125,7 +125,7 @@ class CRM_Core_IDS {
         'filter_type' => 'xml',
         'filter_path' => "{$civicrm_root}/packages/IDS/default_filter.xml",
         'tmp_path' => $tmpDir,
-        'HTML_Purifier_Path' => 'IDS/vendors/htmlpurifier/HTMLPurifier.auto.php',
+        'HTML_Purifier_Path' => $civicrm_root . '/vendor/ezyang/htmlpurifier/library/HTMLPurifier.auto.php',
         'HTML_Purifier_Cache' => $tmpDir,
         'scan_keys' => '',
         'exceptions' => array('__utmz', '__utmc'),

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     "guzzlehttp/guzzle": "^6.3",
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",
-    "pear/log": "1.13.1"
+    "pear/log": "1.13.1",
+    "ezyang/htmlpurifier": "4.10"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17e71aacd764675ceb9e0cfc31eb2725",
+    "content-hash": "bf8e79e6741fa30ccbc5bd59416f9f16",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -225,6 +225,53 @@
             "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
             "homepage": "http://code.google.com/p/phpquery/",
             "time": "2013-03-21T12:39:33+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/d85d39da4576a6934b72480be6978fb10c860021",
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "time": "2018-02-23T01:58:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -356,7 +356,7 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
   public function purifyHTMLProvider() {
     $tests = [];
     $tests[] = ['<span onmouseover=alert(0)>HOVER</span>', '<span>HOVER</span>'];
-    $tests[] = ['<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>', '<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>'];
+    $tests[] = ['<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>', '<a href="https://civicrm.org" target="_blank" class="button-purple" rel="noreferrer noopener">hello</a>'];
     return $tests;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This upgrades the HTML Purifier library to be version 4.10 to support PHP7.2 and installs it via composer

ping @mfb @totten 