### PR TITLE
Remove amavisd now that it is removed from the packages repository

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -96,7 +96,7 @@ function dm_install_packages() {
   local to="$2"
 
   local excludes_rsync=""
-  for exclude in .git .svn _ORIGINAL_ SeleniumRC PHPUnit PhpDocumentor SymfonyComponents amavisd-new git-footnote PHP/CodeCoverage ; do
+  for exclude in .git .svn _ORIGINAL_ SeleniumRC PHPUnit PhpDocumentor SymfonyComponents git-footnote PHP/CodeCoverage ; do
     excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
   done
 


### PR DESCRIPTION
Overview
----------------------------------------
now that https://github.com/civicrm/civicrm-packages/pull/243 has been merged we should remove the directory from within the distmaker as well

ping @colemanw 