### PR TITLE
Add FrontEndPaymentFormTrait to start to share functionality between Event and Contribution forms

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -35,6 +35,7 @@
  * form to process actions on the group aspect of Custom Data
  */
 class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_ContributionBase {
+  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * The id of the contact associated with this contribution.
@@ -514,17 +515,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if ($invoicing) {
       $getTaxDetails = FALSE;
       $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
-      foreach ($this->_lineItem as $key => $value) {
-        foreach ($value as $k => $v) {
-          if (isset($v['tax_rate'])) {
-            if ($v['tax_rate'] != '') {
-              $getTaxDetails = TRUE;
-              // Cast to float to display without trailing zero decimals
-              $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
-            }
-          }
-        }
-      }
+      list($getTaxDetails, $tplLineItems) = $this->alterLineItemsForTemplate($tplLineItems);
       $this->assign('getTaxDetails', $getTaxDetails);
       $this->assign('taxTerm', $taxTerm);
       $this->assign('totalTaxAmount', $params['tax_amount']);

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ */
+
+/**
+ * This class holds functionality shared between various front end forms.
+ */
+trait CRM_Financial_Form_FrontEndPaymentFormTrait {
+
+  /**
+   * Alter line items for template.
+   *
+   * This is an early cut of what will ideally eventually be a hooklike call to the
+   * CRM_Invoicing_Utils class with a potential end goal of moving this handling to an extension.
+   *
+   * @param $tplLineItems
+   *
+   * @return array
+   */
+  protected function alterLineItemsForTemplate($tplLineItems) {
+    $getTaxDetails = FALSE;
+    foreach ($tplLineItems as $key => $value) {
+      foreach ($value as $k => $v) {
+        if (isset($v['tax_rate'])) {
+          if ($v['tax_rate'] != '') {
+            $getTaxDetails = TRUE;
+            // Cast to float to display without trailing zero decimals
+            $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
+          }
+        }
+      }
+    }
+    // @todo fix this to only return $tplLineItems. Calling function can check for tax rate and
+    // do all invoicing related assigns
+    // another discrete function (it's just one more iteration through a an array with only a handful of
+    // lines so the separation of concerns is more important than 'efficiency'
+    return [$getTaxDetails, $tplLineItems];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Internal code restructuring - start to share functionality between event & Contribution forms in a Trait (does not add functionality to extension writers)

Before
----------------------------------------
Only CRM_Core_Form in common

After
----------------------------------------
Opportunity to share functionality in FrontEndPaymentFormTrait. I've added one small function to it....

Technical Details
----------------------------------------


Comments
----------------------------------------
This arose out of reviewing https://github.com/civicrm/civicrm-core/pull/13827 & thinking about how we could cleanup these functions
