### PR TITLE
Add in tests of purifying HTML output

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -642,6 +642,7 @@ class CRM_Utils_String {
     if (!$_filter) {
       $config = HTMLPurifier_Config::createDefault();
       $config->set('Core.Encoding', 'UTF-8');
+      $config->set('Attr.AllowedFrameTargets', ['_blank', '_self', '_parent', '_top']);
 
       // Disable the cache entirely
       $config->set('Cache.DefinitionImpl', NULL);

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -353,4 +353,21 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     );
   }
 
+  public function purifyHTMLProvider() {
+    $tests = [];
+    $tests[] = ['<span onmouseover=alert(0)>HOVER</span>', '<span>HOVER</span>'];
+    $tests[] = ['<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>', '<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>'];
+    return $tests;
+  }
+
+  /**
+   * Test ouput of purifyHTML
+   * @param string $testString
+   * @param string $expectedString
+   * @dataProvider purifyHTMLProvider
+   */
+  public function testPurifyHTML($testString, $expectedString) {
+    $this->assertEquals($expectedString, CRM_Utils_String::purifyHTML($testString));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This just adds in a couple of unit tests to test purifying html output which should assist in testing the upgrade of the html purifier library

Before
----------------------------------------
no tests

After
----------------------------------------
tests

ping @eileenmcnaughton 