### PR TITLE
dev/core#560 Update Cancel Billing & update billing to use status bounce rather than fatal

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -107,7 +107,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
 
     if (!CRM_Core_Permission::check('edit contributions')) {
       if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
-        CRM_Core_Error::fatal(ts('You do not have permission to cancel this recurring contribution.'));
+        CRM_Core_Error::statusBounce(ts('You do not have permission to cancel this recurring contribution.'));
       }
       $this->_selfService = TRUE;
     }

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -89,7 +89,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
     }
     if (!CRM_Core_Permission::check('edit contributions')) {
       if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
-        CRM_Core_Error::fatal(ts('You do not have permission to cancel subscription.'));
+        CRM_Core_Error::statusBounce(ts('You do not have permission to cancel subscription.'));
       }
       $this->_selfService = TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Minor stdisation on error handling

Before
----------------------------------------
![Screenshot 2019-03-18 14 06 29](https://user-images.githubusercontent.com/336308/54501266-40eafd00-4989-11e9-8a58-836745b637ca.png)


After
----------------------------------------
![Screenshot 2019-03-18 14 24 32](https://user-images.githubusercontent.com/336308/54501335-98896880-4989-11e9-90b6-0c1b3724be0c.png)

(It's slightly weird that the box starts to open & then closes & the error msg pops up but IMHO it's still better)


Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/560 we have resolved to get rid of fatal & move
to throwing Exceptions.

However, I'm leaning towards making statusBounces the rules for when we just deem a form inaccessible.

In this case we have 3 parallel forms - cancel, update & a similar update but slightly different just cos.

One does a status bounce - 2 spit out fatals when access not available.

Just looking at Cancel these are the places that still have fatal

- The recurring contribution looks to have been cancelled already
- Required information missing

I'm not sure the value of a fatal as opposed to the gentler statusBounces in either of those cases.

Throwing an exception looks very much like a fatal except
1) it doesn't hurt tests or cli tools as much
2) IF display backtrace is enabled THEN the back trace displays - ie 

![Screenshot 2019-03-18 14 06 49](https://user-images.githubusercontent.com/336308/54501271-48aaa180-4989-11e9-86fa-4467b37d879b.png)


so, it's generally better BUT I kinda feel like the only time when it's actually better than a status
bounce is when a bug has occurred (eg. an unexpectedly failed api call) - anything we anticipate
seems like a bounce to me....

Comments
----------------------------------------

@colemanw @seamuslee001 @monishdeb @mattwire @jitendrapurohit @pradpnayak @totten 
I feel like it would be good to have a generalised agreement on when to use statusBounce as opposed to throwing an exception. Per above I would say almost always at the form layer