### PR TITLE
dev/core/issues/806, Fixed DB error already exist when recording recurring payment having tax

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -901,7 +901,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    */
   protected static function isComplete($recurringContributionID, $installments) {
     $paidInstallments = CRM_Core_DAO::singleValueQuery(
-      'SELECT count(*) FROM civicrm_contribution 
+      'SELECT count(*) FROM civicrm_contribution
         WHERE contribution_recur_id = %1
         AND contribution_status_id = ' . CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
       array(1 => array($recurringContributionID, 'Integer'))
@@ -949,13 +949,13 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
         $priceField = new CRM_Price_DAO_PriceField();
         $priceField->id = $lineItem['price_field_id'];
         $priceField->find(TRUE);
-        $lineSets[$priceField->price_set_id][] = $lineItem;
+        $lineSets[$priceField->price_set_id][$lineItem['price_field_id']] = $lineItem;
       }
     }
     // CRM-19309 if more than one then just pass them through:
     elseif (count($lineItems) > 1) {
       foreach ($lineItems as $index => $lineItem) {
-        $lineSets[$index][] = $lineItem;
+        $lineSets[$index][$lineItem['price_field_id']] = $lineItem;
       }
     }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4299,4 +4299,31 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals(array('invoice_id'), $result['values']['UI_contrib_invoice_id']);
   }
 
+  /**
+   * Test Repeat Transaction Contribution with Tax amount.
+   * https://lab.civicrm.org/dev/core/issues/806
+   */
+  public function testRepeatContributionWithTaxAmount() {
+    $this->enableTaxAndInvoicing();
+    $financialType = $this->callAPISuccess('financial_type', 'create', [
+      'name' => 'Test taxable financial Type',
+      'is_reserved' => 0,
+      'is_active' => 1,
+    ]);
+    $this->relationForFinancialTypeWithFinancialAccount($financialType['id']);
+    $contribution = $this->setUpRepeatTransaction(
+      [],
+      'single',
+      [
+        'financial_type_id' => $financialType['id'],
+      ]
+    );
+    $this->callAPISuccess('contribution', 'repeattransaction', array(
+      'original_contribution_id' => $contribution['id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => uniqid(),
+    ));
+    $this->callAPISuccessGetCount('Contribution', [], 2);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/806

Before
----------------------------------------
DB Error:: Already Exists

After
----------------------------------------
No DB Error

Technical Details
----------------------------------------
The line item build in CRM_Contribute_BAO_Contribution::repeatTransaction() is not in a format that is expected by CRM_Contribute_BAO_Contribution::add(); Hence always new item is added in $params['line_item'] with duplicate values which causes DB error when inserting into civicrm_line_item table.