### PR TITLE
CRM-18011 improve lock handling for mysql 5.7.5+

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -177,7 +177,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    */
   public function acquire($timeout = NULL) {
     if (!$this->_hasLock) {
-      if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
+      if (!CRM_Utils_SQL::supportsMultipleLocks() && self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
         return $this->hackyHandleBrokenCode(self::$jobLog);
       }
 

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -78,7 +78,7 @@ class CRM_Utils_SQL {
    */
   public static function supportsFullGroupBy() {
     // CRM-21455 MariaDB 10.2 does not support ANY_VALUE
-    $version = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
+    $version = self::getDatabaseVersion();
 
     if (stripos($version, 'mariadb') !== FALSE) {
       return FALSE;
@@ -132,6 +132,44 @@ class CRM_Utils_SQL {
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Does the DB version support mutliple locks per
+   *
+   * https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
+   *
+   * As an interim measure we ALSO require CIVICRM_SUPPORT_MULTIPLE_LOCKS to be defined.
+   *
+   * This is a conservative measure to introduce the change which we expect to deprecate later.
+   *
+   * @todo we only check mariadb & mysql right now but maybe can add percona.
+   */
+  public static function supportsMultipleLocks() {
+    if (!defined('CIVICRM_SUPPORT_MULTIPLE_LOCKS')) {
+      return FALSE;
+    }
+    static $isSupportLocks = NULL;
+    if (!isset($isSupportLocks)) {
+      $version = self::getDatabaseVersion();
+      if (stripos($version, 'mariadb') !== FALSE) {
+        $isSupportLocks = version_compare($version, '10.0.2', '>=');
+      }
+      else {
+        $isSupportLocks = version_compare($version, '5.7.5', '>=');
+      }
+    }
+
+    return $isSupportLocks;
+  }
+
+  /**
+   * Get the version string for the database.
+   *
+   * @return string
+   */
+  public static function getDatabaseVersion() {
+    return CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
   }
 
 }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -448,6 +448,20 @@ if (!defined('CIVICRM_PSR16_STRICT')) {
 define('CIVICRM_DEADLOCK_RETRIES', 3);
 
 /**
+ * Enable support for multiple locks.
+ *
+ * This is a transitional setting. When enabled sites with mysql 5.7.5+ or equivalent
+ * MariaDB can improve their DB conflict management.
+ *
+ * There is no known or expected downside or enabling this (and definite upside).
+ * The setting only exists to allow sites to manage change in their environment
+ * conservatively for the first 3 months.
+ *
+ * See https://github.com/civicrm/civicrm-core/pull/13854
+ */
+ // define('CIVICRM_SUPPORT_MULTIPLE_LOCKS', TRUE);
+
+/**
  * Configure MySQL to throw more errors when encountering unusual SQL expressions.
  *
  * If undefined, the value is determined automatically. For CiviCRM tarballs, it defaults


### PR DESCRIPTION
Overview
----------------------------------------
Use mysql locks properly for sites on mysql or Maria DB versions that support them (mysql 5.7.5+ and MariaDB 10.0.2+)

https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
https://mariadb.com/kb/en/library/get_lock/

Before
----------------------------------------
Multiple are not supported - only one lock is respected at a time - giving us limited ability to prevent resource contention

After
----------------------------------------
Multiple mysql locks are supported on mysql 5.7.5+ and MariaDB 10.0.2+

Currently if a process uses multiple locks - e.g to start running mailing jobs and in the process to lock a cache the lock on the cache will be ignored & contention will still occur. With this both locks are respected


Technical Details
----------------------------------------
I don't personally think this has risk  - what it does is bypasses a hack that causes us to NOT ACTUALLY GET A LOCK if one has already been reserved & instead GET THE LOCK. This works on mysql versions that support it

UPDATE - this is currently opt in via a define - 
```
define('CIVICRM_SUPPORT_MULTIPLE_LOCKS', TRUE);
```

Comments
----------------------------------------
5.7.5+ supports multiple mysql threads in a process, provided civicrm.settings.php 
has the line

```
define('CIVICRM_SUPPORT_MULTIPLE_LOCKS', TRUE);
```
. We can be non-hacky once that is in play
