### PR TITLE
Convert activity tab to use datepicker

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2429,7 +2429,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
         $activityIcons[$type['value']] = $type['icon'];
       }
     }
-    CRM_Utils_Date::convertFormDateToApiFormat($params, 'activity_date_time', FALSE);
+    CRM_Utils_Date::convertFormDateToApiFormat($params, 'activity_date_time');
 
     // Get contact activities.
     $activities = CRM_Activity_BAO_Activity::getActivities($params);

--- a/CRM/Activity/Form/ActivityFilter.php
+++ b/CRM/Activity/Form/ActivityFilter.php
@@ -42,12 +42,7 @@ class CRM_Activity_Form_ActivityFilter extends CRM_Core_Form {
 
     $this->add('select', 'activity_type_filter_id', ts('Include'), array('' => ts('- all activity type(s) -')) + $activityOptions);
     $this->add('select', 'activity_type_exclude_filter_id', ts('Exclude'), array('' => ts('- select activity type -')) + $activityOptions);
-    CRM_Core_Form_Date::buildDateRange(
-      $this, 'activity_date_time', 1,
-      '_low', '_high', ts('From:'),
-      FALSE, array(), 'searchDate',
-      FALSE, array('class' => 'crm-select2 medium')
-    );
+    $this->addDatePickerRange('activity_date_time', ts('Date'));
     $this->addSelect('status_id',
       array('entity' => 'activity', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
     );

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -438,8 +438,8 @@ class CRM_Activity_Page_AJAX {
         }
         if (!empty($params[$searchField])) {
           $activityFilter[$formSearchField] = CRM_Utils_Type::escape($params[$searchField], $dataType);
-          if (in_array($searchField, array('activity_date_low', 'activity_date_high'))) {
-            $activityFilter['activity_date_relative'] = 0;
+          if (in_array($searchField, array('activity_date_time_low', 'activity_date_time_high'))) {
+            $activityFilter['activity_date_time_relative'] = 0;
           }
           elseif ($searchField == 'activity_status_id') {
             $activityFilter['status_id'] = explode(',', $activityFilter[$searchField]);

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -90,7 +90,7 @@
 
 <tr>
   <td>
-    {include file="CRM/Core/DatePickerRange.tpl" fieldName="activity_date_time" from='_low' to='_high'}
+    {include file="CRM/Core/DatePickerRange.tpl" fieldName="activity_date_time"}
   </td>
 </tr>
 <tr>

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -29,6 +29,7 @@
     {ts}Filter by Activity{/ts}</a>
     </div><!-- /.crm-accordion-header -->
     <div class="crm-accordion-body">
+      <form><!-- form element is here to fool the datepicker widget -->
       <table class="no-border form-layout-compressed activity-search-options">
         <tr>
           <td class="crm-contact-form-block-activity_type_filter_id crm-inline-edit-field">
@@ -37,12 +38,15 @@
           <td class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
             {$form.activity_type_exclude_filter_id.label}<br /> {$form.activity_type_exclude_filter_id.html|crmAddClass:medium}
           </td>
-          {include file="CRM/Core/DateRange.tpl" fieldName="activity_date_time" from='_low' to='_high' label='<label>Date</label>'}
+          <td>
+            {include file="CRM/Core/DatePickerRange.tpl" fieldName="activity_date_time"}
+          </td>
           <td class="crm-contact-form-block-activity_status_filter_id crm-inline-edit-field">
             <label>{ts}Status{/ts}</label><br /> {$form.status_id.html|crmAddClass:medium}
           </td>
         </tr>
       </table>
+      </form>
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
   <table class="contact-activity-selector-{$context} crm-ajax-table" style="width: 100%;">

--- a/templates/CRM/Core/DatePickerRange.tpl
+++ b/templates/CRM/Core/DatePickerRange.tpl
@@ -25,6 +25,8 @@
 *}
 {*this is included inside a table row*}
 {assign var=relativeName   value=$fieldName|cat:"_relative"}
+{assign var='from' value=$from|default:'_low'}
+{assign var='to' value=$to|default:'_high'}
 
   {$form.$relativeName.label}<br />
   {$form.$relativeName.html}<br />


### PR DESCRIPTION
Overview
----------------------------------------
Part of an ongoing conversion to datepicker

Before
----------------------------------------
uses jcalendar

![Screenshot 2019-03-21 19 10 34](https://user-images.githubusercontent.com/336308/54735828-1e691600-4c0d-11e9-84bd-46794e4a1919.png)



After
----------------------------------------
uses datepicker

There is no difference to the user. However, datepicker handles all the date formatting at the js layer whereas the old jcalendar method required php wrangling to convert between custom formats and mysql formats so our goal is to use datepicker everywhere & get rid of jcalendar

![Screenshot 2019-03-21 19 14 48](https://user-images.githubusercontent.com/336308/54735944-a0593f00-4c0d-11e9-8fb2-9f9954db99e9.png)


Technical Details
----------------------------------------
@colemanw this is actually giving me a validation error & I can't see why.

Also I think the include & exclude fields are not select 2? I know our users would prefer them to be multiple fields but they need conversion first?

Comments
----------------------------------------