### PR TITLE
Test fix

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -336,6 +336,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     //flush component settings
     CRM_Core_Component::getEnabledComponents(TRUE);
 
+    $_REQUEST = $_GET = $_POST = [];
     error_reporting(E_ALL);
 
     $this->_sethtmlGlobals();


### PR DESCRIPTION
Overview
----------------------------------------
Fix for intermittent test fails

Before
----------------------------------------
More intermittent test fails

After
----------------------------------------
Less intermittent test fails

Technical Details
----------------------------------------
I've been noticing tests failing on lines which indicate they were getting variables from one of these globals - this seems like a safe place to ensure they are set to empty

- e.g

CRM_Member_Form_MembershipTest::testSubmitUpdateMembershipFromPartiallyPaid
CiviCRM_API3_Exception: Expected one Contact but found 0

/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/api/api.php:45
/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/CRM/Contribute/Form/AbstractEditPayment.php:757
/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/CRM/Contribute/Form/AbstractEditPayment.php:256
/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/CRM/Member/Form.php:153
/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/CRM/Member/Form/Membership.php:224
/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/tests/phpunit/CRM/Member/Form/MembershipTest.php:832
/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/tests/phpunit/CRM/Member/Form/MembershipTest.php:895
/home/jenkins/bknix-dfl/build/core-13854-7x4fu/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:196
/home/jenkins/bknix-dfl/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
