### PR TITLE
dev/core#795 Fix PHP warning when updating a multiselect country field.

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -124,7 +124,6 @@ class CRM_Core_BAO_CustomValueTable {
 
             case 'Country':
               $type = 'Integer';
-              $mulValues = explode(',', $value);
               if (is_array($value)) {
                 $value = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $value) . CRM_Core_DAO::VALUE_SEPARATOR;
                 $type = 'String';


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/issues/795

Steps to reproduce:

* Create a new custom field for Contacts of type Country - Multiselect.
* Run the following test script:

```
<?php

\Drupal::service('civicrm')->initialize();

error_reporting(E_ALL);
$result = civicrm_api3( 'Contact', 'create', [
  'id' => 131,
  'custom_33' => [1039, 1041],
]);
```

Resulting warning:

```
explode() expects parameter 2 to be string, array given CustomValueTable.php:127
```

Before
----------------------------------------

warning

After
----------------------------------------

no warning

Technical Details
----------------------------------------

Seems like a pretty obvious error in the code. Mostly harmless, but warnings are annoying. According to the git blame, it's been like that forever (pre-2013).

The warning was not visible when using the API explorer or when updating a contact record through the normal CiviCRM interface.