### PR TITLE
Fixing formatting of contributors section

### DIFF
--- a/release-notes/5.11.0.md
+++ b/release-notes/5.11.0.md
@@ -714,8 +714,8 @@ J. Gómez; Fuzion - Jitendra Purohit; Greenpeace Central and Eastern Europe -
 Patrick Figel; iXiam - Luciano Spiegel; JMA Consulting - Monish Deb; Joinery -
 Allen Shaw; Ken West; Liquid Web, Inc. - Jason Gillman Jr.; Megaphone Technology
 Consulting - Jon Goldberg; MillerTech - Chamil Wijesooriya; MJW Consulting -
-Matthew Wire; Oxfam Germany - Thomas Schüttler; PeaceWorks Technology Solutions
-- Martin Hansen; Pradeep Nayak; Progressive Technology Project - Jamie
+Matthew Wire; Oxfam Germany - Thomas Schüttler; PeaceWorks Technology Solutions - 
+Martin Hansen; Pradeep Nayak; Progressive Technology Project - Jamie
 McClelland; Squiffle Consulting - Aidan Saunders; Wikimedia Foundation - Eileen
 McNaughton
 


### PR DESCRIPTION
Overview
----------------------------------------
The contributor section of the 5.11.0 release notes has a random bullet this fixes that formatting issue.

Before
--------------------------------------
![before](https://user-images.githubusercontent.com/11323624/54633651-02bc0f00-4a57-11e9-98bb-e11a06c1119f.png)

After
--------------------------------------
![after](https://user-images.githubusercontent.com/11323624/54633656-051e6900-4a57-11e9-8ec3-56638c1ed7fa.png)


