### PR TITLE
Fix Contact.create calls to respect passed in variables & variables set via hook for sort_name & display_name

### DIFF
--- a/api/v3/Generic/Update.php
+++ b/api/v3/Generic/Update.php
@@ -77,6 +77,12 @@ function civicrm_api3_generic_update($apiRequest) {
   }
 
   $existing = array_pop($existing['values']);
+  // Per Unit test testUpdateHouseholdWithAll we don't want to load these from the DB
+  // if they are not passed in then we'd rather they are calculated.
+  // Note update is not recomended anyway...
+  foreach (['sort_name', 'display_name'] as $fieldToNotSet) {
+    unset($existing[$fieldToNotSet]);
+  }
   $p = array_merge($existing, $apiRequest['params']);
   return civicrm_api($apiRequest['entity'], 'create', $p);
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby Contact.create does not respect attempts to set sort_name & display_name via hook or as passed by the parameters

Before
----------------------------------------
sort_name set by hook is ignored

After
----------------------------------------
sort_name set by hook is respected

Technical Details
----------------------------------------
This has been applied to Organizations & Households, not Individuals at this stage as that is more complex.

Use case is saving organizations with The so that The is at the end of their sort_name, making it easier to
deal with data entry variations

Comments
----------------------------------------
