### PR TITLE
Expose sort_name as a dedupe-matchable field

### DIFF
--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -74,7 +74,7 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
    * @return array
    *   a table-keyed array of field-keyed arrays holding supported fields' titles
    */
-  public static function &supportedFields($requestedType) {
+  public static function supportedFields($requestedType) {
     static $fields = NULL;
     if (!$fields) {
       // this is needed, as we're piggy-backing importableFields() below
@@ -116,6 +116,13 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
             $fields[$ctype][$table][$field] = $iField['title'];
           }
         }
+        // Note that most of the fields available come from 'importable fields' -
+        // I thought about making this field 'importable' but it felt like there might be unknown consequences
+        // so I opted for just adding it in & securing it with a unit test.
+        // Example usage of sort_name - It is possible to alter sort name via hook so 2 organization names might differ as in
+        // Justice League vs The Justice League but these could have the same sort_name if 'the the'
+        // exension is installed (https://github.com/eileenmcnaughton/org.wikimedia.thethe)
+        $fields[$ctype]['civicrm_contact']['sort_name'] = ts('Sort Name');
         // add custom data fields
         foreach (CRM_Core_BAO_CustomGroup::getTree($ctype, NULL, NULL, -1) as $key => $cg) {
           if (!is_int($key)) {
@@ -128,7 +135,7 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
       }
     }
     CRM_Utils_Hook::dupeQuery(CRM_Core_DAO::$_nullObject, 'supportedFields', $fields);
-    return $fields[$requestedType];
+    return !empty($fields[$requestedType]) ? $fields[$requestedType] : [];
   }
 
   /**

--- a/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
+++ b/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Class CRM_Dedupe_BAO_RuleGroupTest
+ * @group headless
+ */
+class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
+
+  /**
+   * Test that sort_name is included in supported fields.
+   *
+   * This feels like kind of a brittle test but since I debated actually making it
+   * importable in the schema & bottled out at least some degree of test support
+   * to ensure the field remains 'hacked in' seems important.
+   *
+   * This will at least surface any changes that affect this function.
+   *
+   * In general we do have a bit of a problem with having overloaded the meaning of
+   * importable & exportable fields.
+   */
+  public function testSupportedFields() {
+    $fields = CRM_Dedupe_BAO_RuleGroup::supportedFields('Organization');
+
+    $this->assertEquals([
+      'civicrm_address' =>
+        [
+          'name' => 'Address Name',
+          'city' => 'City',
+          'country_id' => 'Country',
+          'county_id' => 'County',
+          'geo_code_1' => 'Latitude',
+          'geo_code_2' => 'Longitude',
+          'master_id' => 'Master Address Belongs To',
+          'postal_code' => 'Postal Code',
+          'postal_code_suffix' => 'Postal Code Suffix',
+          'state_province_id' => 'State',
+          'street_address' => 'Street Address',
+          'supplemental_address_1' => 'Supplemental Address 1',
+          'supplemental_address_2' => 'Supplemental Address 2',
+          'supplemental_address_3' => 'Supplemental Address 3',
+        ],
+      'civicrm_contact' =>
+        [
+          'addressee_id' => 'Addressee',
+          'addressee_custom' => 'Addressee Custom',
+          'id' => 'Contact ID',
+          'source' => 'Contact Source',
+          'contact_sub_type' => 'Contact Subtype',
+          'do_not_email' => 'Do Not Email',
+          'do_not_mail' => 'Do Not Mail',
+          'do_not_phone' => 'Do Not Phone',
+          'do_not_sms' => 'Do Not Sms',
+          'do_not_trade' => 'Do Not Trade',
+          'email_greeting_id' => 'Email Greeting',
+          'email_greeting_custom' => 'Email Greeting Custom',
+          'external_identifier' => 'External Identifier',
+          'image_URL' => 'Image Url',
+          'legal_identifier' => 'Legal Identifier',
+          'legal_name' => 'Legal Name',
+          'nick_name' => 'Nickname',
+          'is_opt_out' => 'No Bulk Emails (User Opt Out)',
+          'organization_name' => 'Organization Name',
+          'postal_greeting_id' => 'Postal Greeting',
+          'postal_greeting_custom' => 'Postal Greeting Custom',
+          'preferred_communication_method' => 'Preferred Communication Method',
+          'preferred_language' => 'Preferred Language',
+          'preferred_mail_format' => 'Preferred Mail Format',
+          'sic_code' => 'Sic Code',
+          'user_unique_id' => 'Unique ID (OpenID)',
+          'sort_name' => 'Sort Name',
+        ],
+      'civicrm_email' =>
+        [
+          'email' => 'Email',
+          'signature_html' => 'Signature Html',
+          'signature_text' => 'Signature Text',
+        ],
+      'civicrm_im' =>
+        [
+          'name' => 'IM Screen Name',
+        ],
+      'civicrm_note' =>
+        [
+          'note' => 'Note',
+        ],
+      'civicrm_openid' =>
+        [
+          'openid' => 'OpenID',
+        ],
+      'civicrm_phone' =>
+        [
+          'phone_numeric' => 'Phone',
+          'phone_ext' => 'Phone Extension',
+        ],
+    ], $fields);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Allow sort_name to be used in dedupe rules

Before
----------------------------------------
sort_name not available

After
----------------------------------------
sort_name available, test

Technical Details
----------------------------------------
This opens up the option of us using a hook to do some standardisation - e.g getting rid of 'The'
in the sort name or perhaps trailing suffixes like 'Ltd' & it helping with both sorting and with deduping

Note that most of the fields available come from 'importable fields' - I thought about making this field 'importable' but it felt like there might be unknown consequences so I opted for just adding it in & securing it with a unit test (IMHO the test qualifies as the 'additional code improvement' required to justify it)


Comments
----------------------------------------

