### PR TITLE
Update test to reflect recently merged PR lower permission to access dedupecheck

### DIFF
--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -883,7 +883,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
       'check_permissions' => 0,
     ]);
     $this->assertEquals(2, $dupes['count']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM'];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
 
     $dupes = $this->callAPISuccess('Contact', 'duplicatecheck', [
       'match' => [


### PR DESCRIPTION
Overview
----------------------------------------
Test fix following #13398 

Before
----------------------------------------
tests fail

After
----------------------------------------
tests pass

Technical Details
----------------------------------------
A test on permissions was added after #13398 tests ran & merging that PR caused the test to fail as they were assuming 'administer CiviCRM' but it's now 'access CiviCRM'

Comments
----------------------------------------
I thought about making it either/or but the other permissions only give access & not both so it's assumed you will have access I guess 
