### PR TITLE
Possible paypal fix to avoid sending 500 errors from ipn triggerred b…

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -426,7 +426,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
     CRM_Core_Error::debug_var('POST', $_POST, TRUE, TRUE);
     if ($this->_isPaymentExpress) {
       $this->handlePaymentExpress();
-      return FALSE;
+      return;
     }
     $objects = $ids = $input = array();
     $this->_component = $input['component'] = self::getValue('m');
@@ -557,6 +557,9 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
     $objects = $ids = $input = array();
     $isFirst = FALSE;
     $input['invoice'] = self::getValue('i', FALSE);
+    if (empty($input['invoice'])) {
+      return;
+    }
     $input['txnType'] = $this->retrieve('txn_type', 'String');
     $contributionRecur = civicrm_api3('contribution_recur', 'getsingle', array(
       'return' => 'contact_id, id, payment_processor_id',

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -557,7 +557,8 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
     $objects = $ids = $input = array();
     $isFirst = FALSE;
     $input['invoice'] = self::getValue('i', FALSE);
-    if (empty($input['invoice'])) {
+    //Avoid return in case of unit test.
+    if (empty($input['invoice']) && empty($this->_inputParameters['is_unit_test'])) {
       return;
     }
     $input['txnType'] = $this->retrieve('txn_type', 'String');

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -250,6 +250,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'payment_gross' => '200.00',
       'shipping' => '0.00',
       'ipn_track_id' => '5r27c2e31rl7c',
+      'is_unit_test' => TRUE,
     );
   }
 


### PR DESCRIPTION
…y one-off payment

Overview
----------------------------------------
Possible paypal fix to avoid sending 500 errors from ipn triggerred by non-recurring payment.

Before
----------------------------------------
Paypal system send us a warning email re failed IPN calls.

After
----------------------------------------
Should be fixed.

Technical Details
----------------------------------------
All the processing in `handlePaymentExpress` method is done based on the `invoice` text received from the $_GET parameters. 

This change adds an early return statement if we don't get this input param from paypal to avoid any error while retrieving the recur contribution or updating any record in civi.

Comments
----------------------------------------
@Stoob @eileenmcnaughton Does this makes sense?