### PR TITLE
Add ID / Test ID for payment processors to list - makes setup of IPNs much easier!

### DIFF
--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -157,6 +157,7 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
         $dao->id
       );
       $paymentProcessor[$dao->id]['financialAccount'] = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($dao->id, NULL, 'civicrm_payment_processor', 'financial_account_id.name');
+      $paymentProcessor[$dao->id]['test_id'] = CRM_Financial_BAO_PaymentProcessor::getTestProcessorId($dao->id);
     }
 
     $this->assign('rows', $paymentProcessor);

--- a/templates/CRM/Admin/Page/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessor.tpl
@@ -39,22 +39,26 @@
    {include file="CRM/common/enableDisableApi.tpl"}
         <table class="selector row-highlight">
         <tr class="columnheader">
-            <th >{ts}Name{/ts}</th>
-            <th >{ts}Processor Type{/ts}</th>
-            <th >{ts}Description{/ts}</th>
-            <th >{ts}Financial Account{/ts}</th>
-            <th >{ts}Enabled?{/ts}</th>
-            <th >{ts}Default?{/ts}</th>
-            <th ></th>
+            <th>{ts}ID{/ts}</th>
+            <th>{ts}Test ID{/ts}</th>
+            <th>{ts}Name{/ts}</th>
+            <th>{ts}Processor Type{/ts}</th>
+            <th>{ts}Description{/ts}</th>
+            <th>{ts}Financial Account{/ts}</th>
+            <th>{ts}Enabled?{/ts}</th>
+            <th>{ts}Default?{/ts}</th>
+            <th></th>
         </tr>
         {foreach from=$rows item=row}
         <tr id="payment_processor-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+            <td class="crmf-id center">{$row.id}</td>
+            <td class="crmf-test_id center">{$row.test_id}</td>
             <td class="crmf-name">{$row.name}</td>
             <td class="crmf-payment_processor_type">{$row.payment_processor_type}</td>
             <td class="crmf-description">{$row.description}</td>
             <td class="crmf-financial_account_id">{$row.financialAccount}</td>
-            <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td class="crmf-is_default">
+            <td class="crmf-is_active center">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+            <td class="crmf-is_default center">
               {if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>{/if}&nbsp;
             </td>
             <td>{$row.action|replace:'xx':$row.id}</td>


### PR DESCRIPTION
Overview
----------------------------------------
We have rather long and convoluted instructions to find out the payment processor ID (and the test processor ID) when setting up IPNs and doing other work (eg. customisations on contribution pages).  There doesn't really seem to be any need for this when it could easily be displayed directly on the admin UI like this:
![image](https://user-images.githubusercontent.com/2052161/54685872-cbf5ff80-4b0f-11e9-9c05-352dee4d4f69.png)

Before
----------------------------------------
Complex instructions to get IDs for payment processors.

After
----------------------------------------
Much easier to get payment processor IDs!

Technical Details
----------------------------------------
Just expose the IDs on the template (and get the test ID via existing function).

Comments
----------------------------------------
@bgm @MegaphoneJon This would be a really quick review and I think you both might be interested?
