### PR TITLE
WIP: dev/core#723: fatal error merging contacts with custom file fields.

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -561,8 +561,17 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           $preOperationSqls = self::operationSql($mainId, $otherId, $table, $tableOperations);
           $sqls = array_merge($sqls, $preOperationSqls);
 
-          $sqls[] = "DELETE FROM $table WHERE $field = $mainId";
-          $sqls[] = "UPDATE $table SET $field = $mainId WHERE $field = $otherId";
+          if (stripos($table, 'civicrm_value_') === 0) {
+            $sqls[] = "DELETE FROM $table WHERE $field = $mainId";
+            $sqls[] = "UPDATE $table SET $field = $mainId WHERE $field = $otherId";
+          }
+          else {
+            if ($customTableToCopyFrom !== NULL && in_array($table, $customTableToCopyFrom) && !self::customRecordExists($mainId, $table, $field)) {
+              $sqls[] = "INSERT INTO $table ($field) VALUES ($mainId)";
+            }
+            $sqls[] = "UPDATE IGNORE $table SET $field = $mainId WHERE $field = $otherId";
+            $sqls[] = "DELETE FROM $table WHERE $field = $otherId";
+          }
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Simplified and corrected code for merging custom file fields in "merge contacts" operation (hopefully without obliterating some edge case support) 

Before
----------------------------------------
As described in https://lab.civicrm.org/dev/core/issues/723:

- Fatal errors appeared
- Contacts were not merged
- Data loss: Custom file field values were dissociated from the contacts

After
----------------------------------------

- No fatal errors
- Contacts are merged
- File data is retained (merged or not, depending on user selection in Merge form.

Technical Details
----------------------------------------
The problem was in how the code was merging data in two places:

1. Tables named like `civicrm_value_%`: The query `update ignore civicrm_value_% set entity_id = '$mainId' where entity_id = '$otherId'` was essentially doing nothing in these cases, because a) $mainId already has a record, and b)there's a unique index on entity_id.  Then the next query was `delete from  civicrm_value_% where entity_id = '$otherId'`, which just deletes the very data we (might) want to retain.
1. Table `civicrm_entity_file`: The code that writes queries to update this table was hitting problems when the $otherId contact has no file. This code seemed to be making effort to handle cases in which the table doesn't have a record and thus would need an insert query, but since this is a merge, we should be able to assume that the data is there. So this PR just does an update and leaves it at that.

Comments
----------------------------------------
Manually tested in these situations:

- Main contact has a file, and Other contact doesn't
- Other contact has a file, and Main contact doesn't.
- Both contacts have a file.

If this approach looks reasonable, I'll add some tests for these 3 cases. Are there other cases we should consider?