### PR TITLE
Mutliple activity type filters on activity tab on contact records

### DIFF
--- a/CRM/Activity/Form/ActivityFilter.php
+++ b/CRM/Activity/Form/ActivityFilter.php
@@ -40,8 +40,8 @@ class CRM_Activity_Form_ActivityFilter extends CRM_Core_Form {
     $activityOptions = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE);
     asort($activityOptions);
 
-    $this->add('select', 'activity_type_filter_id', ts('Include'), array('' => ts('- all activity type(s) -')) + $activityOptions);
-    $this->add('select', 'activity_type_exclude_filter_id', ts('Exclude'), array('' => ts('- select activity type -')) + $activityOptions);
+    $this->add('select', 'activity_type_filter_id', ts('Include'), $activityOptions, FALSE, ['class' => 'crm-select2', 'multiple' => TRUE, 'placeholder' => ts('- all activity type(s) -')]);
+    $this->add('select', 'activity_type_exclude_filter_id', ts('Exclude'), $activityOptions, FALSE, ['class' => 'crm-select2', 'multiple' => TRUE, 'placeholder' => ts('- no types excluded -')]);
     $this->addDatePickerRange('activity_date_time', ts('Date'));
     $this->addSelect('status_id',
       array('entity' => 'activity', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -437,16 +437,13 @@ class CRM_Activity_Page_AJAX {
           $formSearchField = 'activity_type_exclude_filter_id';
         }
         if (!empty($params[$searchField])) {
-          $activityFilter[$formSearchField] = CRM_Utils_Type::escape($params[$searchField], $dataType);
+          $activityFilter[$formSearchField] = $params[$searchField];
           if (in_array($searchField, array('activity_date_time_low', 'activity_date_time_high'))) {
             $activityFilter['activity_date_time_relative'] = 0;
           }
           elseif ($searchField == 'activity_status_id') {
             $activityFilter['status_id'] = explode(',', $activityFilter[$searchField]);
           }
-        }
-        elseif (in_array($searchField, array('activity_type_id', 'activity_type_exclude_id'))) {
-          $activityFilter[$formSearchField] = '';
         }
       }
 

--- a/CRM/Core/Page/AJAX.php
+++ b/CRM/Core/Page/AJAX.php
@@ -270,7 +270,14 @@ class CRM_Core_Page_AJAX {
 
     foreach ($optionalParams as $param => $type) {
       if (CRM_Utils_Array::value($param, $_GET)) {
-        $params[$param] = CRM_Utils_Type::validate(CRM_Utils_Array::value($param, $_GET), $type);
+        if (!is_array($_GET[$param])) {
+          $params[$param] = CRM_Utils_Type::validate(CRM_Utils_Array::value($param, $_GET), $type);
+        }
+        else {
+          foreach ($_GET[$param] as $index => $value) {
+            $params[$param][$index] = CRM_Utils_Type::validate($value, $type);
+          }
+        }
       }
     }
 

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -403,7 +403,6 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     );
     $expectedFilters = array(
       'activity_type_filter_id' => 1,
-      'activity_type_exclude_filter_id' => '',
     );
 
     list($activities, $activityFilter) = CRM_Activity_Page_AJAX::getContactActivity();
@@ -414,11 +413,10 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       $this->assertContains('Meeting', $value['activity_type']);
     }
     unset($_GET['activity_type_id']);
-    $expectedFilters['activity_type_filter_id'] = '';
 
     $_GET['activity_type_exclude_id'] = $expectedFilters['activity_type_exclude_filter_id'] = 1;
     list($activities, $activityFilter) = CRM_Activity_Page_AJAX::getContactActivity();
-    $this->checkArrayEquals($expectedFilters, $activityFilter);
+    $this->assertEquals(['activity_type_exclude_filter_id' => 1], $activityFilter);
     // None of the activities should be of type Meeting.
     foreach ($activities['data'] as $value) {
       $this->assertNotContains('Meeting', $value['activity_type']);


### PR DESCRIPTION
Overview
----------------------------------------
Change include/exclude activity type filters to be multiple select 2 widgets rather than only permitting one select - old style.

Before
----------------------------------------
![Screenshot 2019-03-21 14 29 52](https://user-images.githubusercontent.com/336308/54729689-ccfb5f80-4be9-11e9-93c2-a42783e91bf7.png)

After
----------------------------------------
![Screenshot 2019-03-21 14 59 34](https://user-images.githubusercontent.com/336308/54729723-fc11d100-4be9-11e9-8f5d-118124953ddd.png)


Technical Details
----------------------------------------
This has a pre-requisite of #13855 - if reviewed separately I will rebase this.

I removed one call to validate because it was taking an already validated function - the next layer of functions were already 'array-ready' I just had to make the array get through validation & be stored correctly for sites with sticky activity filters saved (setting is under display preferences - 
![Screenshot 2019-03-21 15 02 25](https://user-images.githubusercontent.com/336308/54729799-5c087780-4bea-11e9-9bea-62ec22911a5d.png) ) & from my testing we don't need any upgrade handling. They might lose saved date filters but I think that's unlikely to be a concern since it sticks as soon as users re-filter.


Comments
----------------------------------------