### PR TITLE
dev/core#814 Fix menu restore link

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -115,15 +115,13 @@
         .addClass('crm-menubar-hidden')
         .removeClass('crm-menubar-visible');
       if (showMessage === true && $('#crm-notification-container').length && initialized) {
-        var alert = CRM.alert('<a href="#" id="crm-restore-menu" style="text-align: center; margin-top: -8px;">' + _.escape(ts('Restore CiviCRM Menu')) + '</a>', '', 'none', {expires: 10000});
+        var alert = CRM.alert('<a href="#" id="crm-restore-menu" >' + _.escape(ts('Restore CiviCRM Menu')) + '</a>', ts('Menu hidden'), 'none', {expires: 10000});
         $('#crm-restore-menu')
-          .button({icons: {primary: 'fa-undo'}})
           .click(function(e) {
             e.preventDefault();
             alert.close();
             CRM.menubar.show(speed);
-          })
-          .parent().css('text-align', 'center').find('.ui-button-text').css({'padding-top': '4px', 'padding-bottom': '4px'});
+          });
       }
     },
     open: function(itemName) {


### PR DESCRIPTION
Overview
-----
@agh1 noticed this issue. Somewhere along the line the text color got screwed up for the menu restore button.
Now that we have KAM the "hide" menu feature is going to be used a lot less since we now have a quick toggle to get it out of the way, so I just turned it into a text link for the simplest solution.

Before
-------
![image](https://user-images.githubusercontent.com/2874912/54768639-f4e0c800-4bd5-11e9-829e-6f9b8f4627ac.png)

After
--------
![image](https://user-images.githubusercontent.com/2874912/54768577-d4b10900-4bd5-11e9-93fb-a76d440c5826.png)

See https://lab.civicrm.org/dev/core/issues/814