### PR TITLE
[nfc] Reset entire session object between tests

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -413,8 +413,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     if ($this->hookClass) {
       $this->hookClass->reset();
     }
-    $session = CRM_Core_Session::singleton();
-    $session->set('userID', NULL);
+    CRM_Core_Session::singleton()->reset(1);
 
     if ($this->tx) {
       $this->tx->rollback()->commit();


### PR DESCRIPTION
Overview
----------------------------------------
Improve test clean up

Before
----------------------------------------
Session object partially reset

After
----------------------------------------
Session object fully reset

Technical Details
----------------------------------------
#13553 has been struggling with bugs that seem to be leakage of the session object between
tests - this seems like a good place to flush it

Comments
----------------------------------------

