### PR TITLE
dev/core#812 - Fix null display of contribution row on …

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -273,7 +273,9 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
 
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution.$name", $op, $value, $dataType);
         list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_Contribution', $name, $value, $op, $pseudoExtraParam);
-        $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$qillName]['title'], 2 => $op, 3 => $value));
+        if (!($name == 'id' && $value == 0)) {
+          $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$qillName]['title'], 2 => $op, 3 => $value));
+        }
         $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
         return;
 

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -181,6 +181,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
     $this->_action = $action;
     $returnProperties = CRM_Contribute_BAO_Query::selectorReturnProperties($this->_queryParams);
     $this->_includeSoftCredits = CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled($this->_queryParams);
+    $this->_queryParams[] = ['contribution_id', '!=', 0, 0, 0];
     $this->_query = new CRM_Contact_BAO_Query(
       $this->_queryParams,
       $returnProperties,

--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -373,6 +373,34 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
   }
 
   /**
+   *  Test contact contributions.
+   */
+  public function testContributionSearchWithContactID() {
+    $contactID = $this->individualCreate([], 1);
+    $fv = ['contact_id' => $contactID];
+    $queryParams = CRM_Contact_BAO_Query::convertFormValues($fv);
+    $selector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::ADD);
+    list($select, $from, $where) = $selector->getQuery()->query();
+
+    // get and assert contribution count
+    $contributions = CRM_Core_DAO::executeQuery("{$select} {$from} {$where}")->fetchAll();
+    $this->assertEquals(count($contributions), 0);
+
+    $this->callAPISuccess('Contribution', 'create', [
+      'financial_type_id' => "Donation",
+      'receive_date' => date('Y-m-d'),
+      'total_amount' => 10,
+      'contact_id' => $contactID,
+    ]);
+    $selector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::ADD);
+    list($select, $from, $where) = $selector->getQuery()->query();
+
+    // get and assert contribution count
+    $contributions = CRM_Core_DAO::executeQuery("{$select} {$from} {$where}")->fetchAll();
+    $this->assertEquals(count($contributions), 1);
+  }
+
+  /**
    *  Test CRM_Contribute_Form_Search Recurring Contribution Status Id filters
    */
   public function testContributionRecurStatusFilter() {


### PR DESCRIPTION
…y page

Overview
----------------------------------------
RC fix for https://github.com/civicrm/civicrm-core/pull/13868. Null row is displayed on contact summary page if contact has 0 contribution.

Before
----------------------------------------
Screenshot from dmaster -

![image](https://user-images.githubusercontent.com/5929648/54676903-c73d4580-4b27-11e9-9587-573084027ce4.png)

If any of the link is clicked on the row, it results into an error -

![image](https://user-images.githubusercontent.com/5929648/54676924-d7552500-4b27-11e9-89e3-b67c1d4b9912.png)


After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/5929648/54676958-e9cf5e80-4b27-11e9-9ce5-d416259612de.png)


Technical Details
----------------------------------------
We removed the unnecessary financial type join from the contribution table in https://github.com/civicrm/civicrm-core/pull/13720

Before the above fix, the query included the financial type which unintentionally avoided the null row to be returned as output -

    SELECT  civicrm_contribution.id, .......... 
    FROM civicrm_contact contact_a 
        LEFT JOIN civicrm_contribution ON civicrm_contribution.contact_id = contact_a.id  
        INNER JOIN civicrm_financial_type ON civicrm_contribution.financial_type_id = civicrm_financial_type.id  
        LEFT  JOIN civicrm_contribution_product ON civicrm_contribution_product.contribution_id = civicrm_contribution.id 
        LEFT  JOIN civicrm_product ON civicrm_contribution_product.product_id =civicrm_product.id 
    WHERE  ( contact_a.id = '202' )  AND (contact_a.is_deleted = 0)   
      GROUP BY civicrm_contribution.id  ORDER BY `receive_date` desc, `contact_a`.`id`  LIMIT 0, 50 

After the removal of financial type join, the query is -

    SELECT  civicrm_contribution.id, ......
    FROM civicrm_contact contact_a 
        LEFT JOIN civicrm_contribution   ON civicrm_contribution.contact_id = contact_a.id
    WHERE  ( contact_a.id = '202' )  AND (contact_a.is_deleted = 0)   
    GROUP BY civicrm_contribution.id  ORDER BY `receive_date` desc, `contact_a`.`id`  
    LIMIT 0, 50 

As it is a left join and no other field, the contact null row gets returned and is displayed on the contribution tab. @eileenmcnaughton 

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/812