### PR TITLE
PHP Error on Grant Detail Report

### DIFF
--- a/CRM/Report/Form/Grant/Detail.php
+++ b/CRM/Report/Form/Grant/Detail.php
@@ -281,32 +281,6 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
     }
   }
 
-  public function groupBy() {
-    // @todo this function appears to do nothing more than parent, test & remove
-    $this->_groupBy = "";
-    if (!empty($this->_params['group_bys']) &&
-      is_array($this->_params['group_bys']) &&
-      !empty($this->_params['group_bys'])
-    ) {
-      foreach ($this->_columns as $tableName => $table) {
-        if (array_key_exists('group_bys', $table)) {
-          foreach ($table['group_bys'] as $fieldName => $field) {
-            if (!empty($this->_params['group_bys'][$fieldName])) {
-              $this->_groupBy[] = $field['dbAlias'];
-            }
-          }
-        }
-      }
-    }
-    if (!empty($this->_groupBy)) {
-      $this->_groupBy = "ORDER BY " . implode(', ', $this->_groupBy) .
-        ", {$this->_aliases['civicrm_contact']}.sort_name";
-    }
-    else {
-      $this->_groupBy = "ORDER BY {$this->_aliases['civicrm_contact']}.sort_name";
-    }
-  }
-
   /**
    * Alter display of rows.
    *

--- a/CRM/Report/Form/Grant/Detail.php
+++ b/CRM/Report/Form/Grant/Detail.php
@@ -210,30 +210,6 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
     parent::__construct();
   }
 
-  public function select() {
-    // @todo remove this override - seems to do nothing parent doesn't.
-    $select = array();
-
-    $this->_columnHeaders = array();
-    foreach ($this->_columns as $tableName => $table) {
-      if (array_key_exists('fields', $table)) {
-        foreach ($table['fields'] as $fieldName => $field) {
-          if (!empty($field['required']) ||
-            !empty($this->_params['fields'][$fieldName])
-          ) {
-
-            $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-          }
-        }
-      }
-    }
-
-    $this->_select = "SELECT " . implode(', ', $select) . " ";
-  }
-
   public function from() {
     $this->setFromBase('civicrm_contact');
     $this->_from .= <<<HERESQL
@@ -244,46 +220,6 @@ HERESQL;
     $this->joinEmailFromContact();
     $this->joinPhoneFromContact();
     $this->joinAddressFromContact();
-  }
-
-  public function where() {
-    // @todo this function appears to do nothing more than parent, test & remove
-    $clauses = array();
-    $this->_where = '';
-    foreach ($this->_columns as $tableName => $table) {
-      if (array_key_exists('filters', $table)) {
-        foreach ($table['filters'] as $fieldName => $field) {
-
-          $clause = NULL;
-          if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
-
-            if ($relative || $from || $to) {
-              $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
-            }
-          }
-          else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
-            if ($op) {
-              $clause = $this->whereClause($field,
-                $op,
-                CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
-              );
-            }
-          }
-          if (!empty($clause)) {
-            $clauses[] = $clause;
-          }
-        }
-      }
-    }
-    if (!empty($clauses)) {
-      $this->_where = "WHERE " . implode(' AND ', $clauses);
-    }
   }
 
   /**

--- a/CRM/Report/Form/Grant/Detail.php
+++ b/CRM/Report/Form/Grant/Detail.php
@@ -47,6 +47,8 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
     $contactCols = $this->getColumns('Contact', array(
       'order_bys_defaults' => array('sort_name' => 'ASC '),
       'fields_defaults' => ['sort_name'],
+      'fields_excluded' => ['id'],
+      'fields_required' => ['id'],
       'filters_defaults' => array('is_deleted' => 0),
       'no_field_disambiguation' => TRUE,
     ));
@@ -243,7 +245,7 @@ HERESQL;
           $this->_absoluteUrl
         );
         $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("View contact details for this record.");
+        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("View Contact Summary for this Contact.");
         $entryFound = TRUE;
       }
 
@@ -256,18 +258,6 @@ HERESQL;
       if (array_key_exists('civicrm_grant_status_id', $row)) {
         if ($value = $row['civicrm_grant_status_id']) {
           $rows[$rowNum]['civicrm_grant_status_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Grant_DAO_Grant', 'status_id', $value);
-        }
-        $entryFound = TRUE;
-      }
-      if (array_key_exists('civicrm_grant_grant_report_received', $row)) {
-        if ($value = $row['civicrm_grant_grant_report_received']) {
-          if ($value == 1) {
-            $value = 'Yes';
-          }
-          else {
-            $value = 'No';
-          }
-          $rows[$rowNum]['civicrm_grant_grant_report_received'] = $value;
         }
         $entryFound = TRUE;
       }

--- a/CRM/Report/Form/Grant/Detail.php
+++ b/CRM/Report/Form/Grant/Detail.php
@@ -33,6 +33,10 @@
 class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
 
   protected $_customGroupExtends = array(
+    'Contact',
+    'Individual',
+    'Household',
+    'Organization',
     'Grant',
   );
 
@@ -47,6 +51,24 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
       'no_field_disambiguation' => TRUE,
     ));
     $specificCols = array(
+      'civicrm_email' => array(
+        'dao' => 'CRM_Core_DAO_Email',
+        'fields' => array(
+          'email' => array(
+            'title' => ts('Email'),
+          ),
+        ),
+        'grouping' => 'contact-fields',
+      ),
+      'civicrm_phone' => array(
+        'dao' => 'CRM_Core_DAO_Phone',
+        'fields' => array(
+          'phone' => array(
+            'title' => ts('Phone'),
+          ),
+        ),
+        'grouping' => 'contact-fields',
+      ),
       'civicrm_grant' => array(
         'dao' => 'CRM_Grant_DAO_Grant',
         'fields' => array(
@@ -213,10 +235,14 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
   }
 
   public function from() {
-    $this->_from = "
-        FROM civicrm_grant {$this->_aliases['civicrm_grant']}
-                        LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
-                    ON ({$this->_aliases['civicrm_grant']}.contact_id  = {$this->_aliases['civicrm_contact']}.id  ) ";
+    $this->setFromBase('civicrm_contact');
+    $this->_from .= <<<HERESQL
+    INNER JOIN civicrm_grant {$this->_aliases['civicrm_grant']}
+      ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_grant']}.contact_id
+HERESQL;
+
+    $this->joinEmailFromContact();
+    $this->joinPhoneFromContact();
     $this->joinAddressFromContact();
   }
 

--- a/CRM/Report/Form/Grant/Detail.php
+++ b/CRM/Report/Form/Grant/Detail.php
@@ -40,54 +40,13 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
    * Class constructor.
    */
   public function __construct() {
-    $this->_columns = array(
-      'civicrm_contact' => array(
-        'dao' => 'CRM_Contact_DAO_Contact',
-        'fields' => array(
-          'sort_name' => array(
-            'title' => ts('Contact Name'),
-            'required' => TRUE,
-            'no_repeat' => TRUE,
-          ),
-          'id' => array(
-            'no_display' => TRUE,
-            'required' => TRUE,
-          ),
-        ),
-        'grouping' => 'contact-fields',
-        'filters' => array(
-          'sort_name' => array(
-            'title' => ts('Contact Name'),
-            'operator' => 'like',
-          ),
-          'gender_id' => array(
-            'title' => ts('Gender'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id'),
-          ),
-          'id' => array(
-            'title' => ts('Contact ID'),
-            'no_display' => TRUE,
-          ),
-        ),
-      ),
-      'civicrm_address' => array(
-        'dao' => 'CRM_Core_DAO_Address',
-        'filters' => array(
-          'country_id' => array(
-            'title' => ts('Country'),
-            'type' => CRM_Utils_Type::T_INT,
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::country(),
-          ),
-          'state_province_id' => array(
-            'title' => ts('State/Province'),
-            'type' => CRM_Utils_Type::T_INT,
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::stateProvince(),
-          ),
-        ),
-      ),
+    $contactCols = $this->getColumns('Contact', array(
+      'order_bys_defaults' => array('sort_name' => 'ASC '),
+      'fields_defaults' => ['sort_name'],
+      'filters_defaults' => array('is_deleted' => 0),
+      'no_field_disambiguation' => TRUE,
+    ));
+    $specificCols = array(
       'civicrm_grant' => array(
         'dao' => 'CRM_Grant_DAO_Grant',
         'fields' => array(
@@ -112,6 +71,7 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
             'name' => 'application_received_date',
             'title' => ts('Application Received'),
             'default' => TRUE,
+            'type' => CRM_Utils_Type::T_DATE,
           ),
           'money_transfer_date' => array(
             'name' => 'money_transfer_date',
@@ -187,6 +147,23 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
           'status_id' => array(
             'title' => ts('Grant Status'),
           ),
+          'application_received_date' => array(
+            'title' => ts('Application Received Date'),
+          ),
+          'money_transfer_date' => array(
+            'title' => ts('Money Transfer Date'),
+          ),
+          'decision_date' => array(
+            'title' => ts('Grant Decision Date'),
+          ),
+        ),
+        'order_bys' => array(
+          'grant_type_id' => array(
+            'title' => ts('Grant Type'),
+          ),
+          'status_id' => array(
+            'title' => ts('Grant Status'),
+          ),
           'amount_total' => array(
             'title' => ts('Amount Requested'),
           ),
@@ -205,6 +182,8 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
         ),
       ),
     );
+
+    $this->_columns = array_merge($contactCols, $specificCols, $this->addAddressFields(FALSE));
 
     parent::__construct();
   }


### PR DESCRIPTION
Overview
----------------------------------------
The Grant Detail Report would not work on upgrade to PHP 7.2 because it attempted to add array items to a string.  In the process of fixing that, I modernized it and removed redundant method overrides.

Before
----------------------------------------
You'd get the PHP error when viewing the Grant Detail Report.

> Error: [] operator not supported for strings in CRM_Report_Form_Grant_Detail->groupBy() (line 295 of /path/to/civi/civicrm/CRM/Report/Form/Grant/Detail.php).

The report has an *ad hoc*, limited set of contact fields.

Selecting columns for Grouping in the report settings would cause the report to set the `ORDER BY` with those fields.

After
----------------------------------------
The report works.  Checking a box for Grouping will `GROUP BY` the field.  The Sorting tab is available for setting the `ORDER BY`.  The `select()`, `where()`, and `groupBy()` method overrides are gone, and a lot of the newer helpers from `CRM_Report_Form` are used instead of mostly-repeated but somewhat unique code.

Technical Details
----------------------------------------
The offending line is here: https://github.com/civicrm/civicrm-core/blob/6b83d5bdd0f2ca546924feae6aa42aeddb1d40cf/CRM/Report/Form/Grant/Detail.php#L295