### PR TITLE
dev/core#502 fix bug on sorting by address fields when viewing search results by profile

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1228,11 +1228,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
         $queryOperator
       );
     }
-    $value = $query->searchQuery(0, 0, $sort,
-      FALSE, FALSE, FALSE,
-      FALSE, FALSE
-    );
-    return $value;
+    return $query->searchQuery(0, 0, $sort);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -712,6 +712,31 @@ civicrm_relationship.is_active = 1 AND
     $selector->contactIDQuery([], $sortOrder);
   }
 
+  /**
+   * Test the sorting on the contact ID query works with a profile search.
+   *
+   * Checking for lack of fatal.
+   */
+  public function testContactIDQueryProfileSearchResults() {
+    $profile = $this->callAPISuccess('UFGroup', 'create', ['group_type' => 'Contact', 'name' => 'search', 'title' => 'search']);
+    $this->callAPISuccess('UFField', 'create', [
+      'uf_group_id' => $profile['id'],
+      'field_name' => 'postal_code',
+      'field_type' => 'Contact',
+      'in_selector' => TRUE,
+      'is_searchable' => TRUE,
+      'label' => 'postal code',
+      'visibility' => 'Public Pages and Listings',
+    ]);
+    $selector = new CRM_Contact_Selector(NULL, ['radio_ts' => 'ts_all', 'uf_group_id' => $profile['id']], NULL, ['sort_name' => 1]);
+    $selector->contactIDQuery([], '2_d');
+  }
+
+  /**
+   * Get search options to reflect how a UI search would look.
+   *
+   * @return array
+   */
   public function getSortOptions() {
     return [
       ['1_d'],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby a fatal error occurs if you attempt to export contacts after sorting by postal_code from a search profile

Before
----------------------------------------
Steps to reproduce:

Create a profile with e.g. the postal code field of the primary address
Perform a contact search using this profile for displaying the results
Sort the result by the postal code field
Tick the "all # records" radio button
Choose any action to perform on the result (e.g. "Print PDF document")

- fatal error

After
----------------------------------------
works

Technical Details
----------------------------------------
@mattwire @jitendrapurohit I figured I'd fix this related bug before closing out this cleanup / fix up round. I note that there is still some obvious cleanup in the function to be done (consolidate orderBy & orderByArray, get rid of the switch) but I think those are also soooo obvious they could be left until next time someone touches that code

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/502