### PR TITLE
Fix bug preventing affecting `cv --user` on Joomla

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -454,6 +454,12 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       $instance->login($params);
     }
 
+    // Save details in Joomla session
+    $user = JFactory::getUser($uid);
+    $jsession = JFactory::getSession();
+    $jsession->set('user', $user);
+
+    // Save details in Civi session
     $session = CRM_Core_Session::singleton();
     $session->set('ufID', $uid);
     $session->set('userID', $contactID);


### PR DESCRIPTION
See https://lab.civicrm.org/dev/joomla/issues/6

Overview
----------------------------------------
Fix problem in Joomla bootstrap that prevent the `--user` option of `cv` working.

Before
----------------------------------------
On a Joomla install: `cv --user=cron ev 'print_r(JFactory::getUser())'` prints the anonymous user

After
----------------------------------------
On a Joomla install: `cv --user=cron ev 'print_r(JFactory::getUser())'` prints the cron user (assuming you have a cron user ...)


Technical Details
----------------------------------------
`CRM_Utils_System_Joomla::loadUser()` saves the logged in user details in the Civi session, but did not save in the Joomla session

Comments
----------------------------------------
Only affects Joomla.  
