### PR TITLE
Update Default Sort Orders For Manage Events Screen

### DIFF
--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -81,6 +81,13 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     $contactDetails = CRM_Contact_BAO_Contact_Utils::contactDetails($this->_participantIds,
       'CiviEvent', $returnProperties
     );
+
+    // Sort participants by sort_name
+    uasort($contactDetails, function ($a, $b) {
+      return strcasecmp($a['sort_name'], $b['sort_name']);
+    });
+    $this->_participantIds = array_keys($contactDetails);
+
     $this->assign('contactDetails', $contactDetails);
     $this->assign('readOnlyFields', $readOnlyFields);
   }

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -332,7 +332,7 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
   SELECT *
     FROM civicrm_event
    WHERE $whereClause
-ORDER BY start_date desc
+ORDER BY start_date asc
    LIMIT $offset, $rowCount";
 
     $dao = CRM_Core_DAO::executeQuery($query, $params, TRUE, 'CRM_Event_DAO_Event');


### PR DESCRIPTION
Overview
----------------------------------------
This PR updates the default sort order of the following
1. When you go to the 'manage events' screen, we would like to have the default sort order (for all events, not just those on the current screen) to be:
*Event start date (earliest/upcoming to latest/furthest): current behaviour displays the latest/furthest event first
![408-1](https://user-images.githubusercontent.com/36624620/54984099-2261b300-4fd4-11e9-8853-642dcf340cc7.png)

2. When on the update multiple participants page (Events -> Manage Events -> Participants -> Registered, Attended, Pending, etc -> Select all participants -> Actions -> Update Multiple Participants -> Select Profile -> Participant Status -> Continue), the order of the participants is not alphabetical, which makes it difficult to locate a participant quickly
![408-2](https://user-images.githubusercontent.com/36624620/54984290-8c7a5800-4fd4-11e9-8286-c1e9d488611d.png)

This PR updates the sort order of the above 2 cases.