### PR TITLE
Fix mis-formatting of Email greeting id, Address greeting id etc

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1277,6 +1277,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
                 // Set this value as the default against the 'other' contact value
                 $rows["move_location_{$blockName}_{$count}"]['main'] = $mainValueCheck[$blockInfo['displayField']];
                 $rows["move_location_{$blockName}_{$count}"]['main_is_primary'] = $mainValueCheck['is_primary'];
+                $rows["move_location_{$blockName}_{$count}"]['location_entity'] = $blockName;
                 $mainContactBlockId = $mainValueCheck['id'];
                 break;
               }

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -114,8 +114,8 @@
 
           <td>
             {* @TODO check if this is ever an array or a fileName? *}
-            {if $row.title|substr:0:5 == "Email"   OR
-                $row.title|substr:0:7 == "Address"}
+            {if $row.location_entity == "email"   OR
+                $row.location_entity == "address"}
               <span style="white-space: pre">
             {else}
               <span>
@@ -135,16 +135,12 @@
           </td>
 
           {* For location blocks *}
-          {if $row.title|substr:0:5 == "Email"   OR
-              $row.title|substr:0:7 == "Address" OR
-              $row.title|substr:0:2 == "IM"      OR
-              $row.title|substr:0:7 == "Website" OR
-              $row.title|substr:0:5 == "Phone"}
+          {if $row.location_entity}
 
             <td>
               {strip}
-                {if $row.title|substr:0:5 == "Email"   OR
-                    $row.title|substr:0:7 == "Address"}
+                {if $row.location_entity == "email"   OR
+                    $row.location_entity == "address"}
                   <span style="white-space: pre" id="main_{$blockName|escape}_{$blockId|escape}">
                 {else}
                   <span id="main_{$blockName|escape}_{$blockId|escape}">


### PR DESCRIPTION
Overview
----------------------------------------
Fix bad formatting of greeting fields on the merge screen for Email greeting id and Address greeting id

1) it says 'overwrite' when they are the same
2) wonky alignment on '


Before
----------------------------------------
![Screenshot 2019-03-27 14 59 09](https://user-images.githubusercontent.com/336308/55045390-7e930880-50a2-11e9-97b8-7cf3b2ed71f1.png)



After
----------------------------------------
![Screenshot 2019-03-27 15 11 49](https://user-images.githubusercontent.com/336308/55045443-aaae8980-50a2-11e9-8d15-c31b8f3937d8.png)


Technical Details
----------------------------------------
The formatting was inappropriately relying on the field's title in the IF clause. I added the location_entity so the row so it would no longer have to guess

Comments
----------------------------------------
@JKingsnorth perhaps you could check this?
