### PR TITLE
dev/core#824 Rationalise summary part of the merge screen.

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -85,10 +85,12 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
       $this->bounceIfInvalid($this->_cid, $this->_oid);
 
-      $this->_contactType = civicrm_api3('Contact', 'getvalue', array(
-        'id' => $this->_cid,
-        'return' => 'contact_type',
-      ));
+      $contacts = civicrm_api3('Contact', 'get', [
+        'id' => ['IN' => [$this->_cid, $this->_oid]],
+        'return' => ['contact_type', 'modified_date', 'created_date'],
+      ])['values'];
+
+      $this->_contactType = $contacts[$this->_cid]['contact_type'];
 
       $browseUrl = CRM_Utils_System::url('civicrm/contact/dedupefind', array_merge($urlParams, ['action' => 'browse']));
 
@@ -175,6 +177,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $this->assign('main_cid', $main['contact_id']);
       $this->assign('other_cid', $other['contact_id']);
       $this->assign('rgid', $this->_rgid);
+      $this->assignSummaryRowsToTemplate($contacts);
 
       $this->addElement('checkbox', 'toggleSelect', NULL, NULL, array('class' => 'select-rows'));
 
@@ -363,6 +366,36 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       );
       CRM_Core_Error::statusBounce($message);
     }
+  }
+
+  /**
+   * Assign the summary_rows variable to the tpl.
+   *
+   * This adds rows to the beginning of the block that will help in making merge choices.
+   *
+   * It can be modified by a hook by altering what is assigned. Although not technically supported this
+   * is an easy tweak with no earth-shattering impacts if later changes stop if from working.
+   *
+   * https://lab.civicrm.org/dev/core/issues/824
+   *
+   * @param array $contacts
+   */
+  protected function assignSummaryRowsToTemplate($contacts) {
+    $mostRecent = ($contacts[$this->_cid]['modified_date'] < $contacts[$this->_oid]['modified_date']) ? $this->_oid : $this->_cid;
+    $this->assign('summary_rows', [
+      [
+        'name' => 'created_date',
+        'label' => ts('Created'),
+        'main_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_cid]['created_date']),
+        'other_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_oid]['created_date']),
+      ],
+      [
+        'name' => 'modified_date',
+        'label' => ts('Last Modified'),
+        'main_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_cid]['modified_date']) . ($mostRecent == $this->_cid ? ' (' . ts('Most Recent') . ')' : ''),
+        'other_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_oid]['modified_date']) . ($mostRecent == $this->_oid ? ' (' . ts('Most Recent') . ')' : ''),
+      ],
+    ]);
   }
 
 }

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -78,17 +78,16 @@
       <th width="300">Add/overwrite?</th>
     </tr>
 
-    {crmAPI var='other_result' entity='Contact' action='get' return="modified_date" id=$other_cid}
 
-    {crmAPI var='main_result' entity='Contact' action='get' return="modified_date" id=$main_cid}
-
-    <tr>
-      <td>Last modified</td>
-      <td>{$other_result.values.0.modified_date|crmDate} {if $other_result.values.0.modified_date gt $main_result.values.0.modified_date} (Most recent) {/if}</td>
-      <td></td>
-      <td>{$main_result.values.0.modified_date|crmDate} {if $main_result.values.0.modified_date gt $other_result.values.0.modified_date} (Most recent) {/if}</td>
-      <td></td>
-    </tr>
+    {foreach from=$summary_rows item=summaryRow}
+      <tr>
+        <td>{$summaryRow.label}</td>
+        <td>{$summaryRow.other_contact_value}</td>
+        <td></td>
+        <td>{$summaryRow.main_contact_value}</td>
+        <td></td>
+      </tr>
+    {/foreach}
 
     {foreach from=$rows item=row key=field}
 


### PR DESCRIPTION
Overview
----------------------------------------
This does 3 things
1) reduces contact get queries from 3 to 1 since the 2 in the tpl layer are removed
2) adds created date to the merge summary information
3) makes it easier for extensions to replace/ extend this data (although core makes no
commitment to the tpl remaining unchanged so extension writers need to carry that risk)

Before
----------------------------------------
![Screenshot 2019-03-27 16 58 26](https://user-images.githubusercontent.com/336308/55049547-8efeaf80-50b1-11e9-912f-94e890943eec.png)


After
----------------------------------------
Created date also present - last modified date is not that useful when geocode jobs or other jobs are updating contacts - what we WOULD find useful is last donation date but I can't make a case for that as a core feature

![Screenshot 2019-03-27 16 56 53](https://user-images.githubusercontent.com/336308/55049505-64145b80-50b1-11e9-9a1e-943584ad34f9.png)



Technical Details
----------------------------------------


Comments
----------------------------------------

