### PR TITLE
dev/core#824 Render contact type icons in std way on merge screen

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -87,7 +87,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
       $contacts = civicrm_api3('Contact', 'get', [
         'id' => ['IN' => [$this->_cid, $this->_oid]],
-        'return' => ['contact_type', 'modified_date', 'created_date'],
+        'return' => ['contact_type', 'modified_date', 'created_date', 'contact_sub_type'],
       ])['values'];
 
       $this->_contactType = $contacts[$this->_cid]['contact_type'];
@@ -183,6 +183,22 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
       $this->assign('mainLocBlock', json_encode($rowsElementsAndInfo['main_details']['location_blocks']));
       $this->assign('locationBlockInfo', json_encode(CRM_Dedupe_Merger::getLocationBlockInfo()));
+      $this->assign('mainContactTypeIcon', CRM_Contact_BAO_Contact_Utils::getImage($contacts[$this->_cid]['contact_sub_type'] ? $contacts[$this->_cid]['contact_sub_type'] : $contacts[$this->_cid]['contact_type'],
+        FALSE,
+        $this->_cid
+      ));
+      $this->assign('otherContactTypeIcon', CRM_Contact_BAO_Contact_Utils::getImage($contacts[$this->_oid]['contact_sub_type'] ? $contacts[$this->_oid]['contact_sub_type'] : $contacts[$this->_oid]['contact_type'],
+        FALSE,
+        $this->_oid
+      ));
+
+      if (isset($rowsElementsAndInfo['rows']['move_contact_type'])) {
+        // We don't permit merging contacts of different types so this is just clutter - putting
+        // the icon next to the contact name is consistent with elsewhere and permits hover-info
+        // https://lab.civicrm.org/dev/core/issues/824
+        unset($rowsElementsAndInfo['rows']['move_contact_type']);
+      }
+
       $this->assign('rows', $rowsElementsAndInfo['rows']);
 
       // add elements

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -85,10 +85,12 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
       $this->bounceIfInvalid($this->_cid, $this->_oid);
 
-      $this->_contactType = civicrm_api3('Contact', 'getvalue', array(
-        'id' => $this->_cid,
-        'return' => 'contact_type',
-      ));
+      $contacts = civicrm_api3('Contact', 'get', [
+        'id' => ['IN' => [$this->_cid, $this->_oid]],
+        'return' => ['contact_type', 'modified_date', 'created_date'],
+      ])['values'];
+
+      $this->_contactType = $contacts[$this->_cid]['contact_type'];
 
       $browseUrl = CRM_Utils_System::url('civicrm/contact/dedupefind', array_merge($urlParams, ['action' => 'browse']));
 
@@ -175,6 +177,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $this->assign('main_cid', $main['contact_id']);
       $this->assign('other_cid', $other['contact_id']);
       $this->assign('rgid', $this->_rgid);
+      $this->assignSummaryRowsToTemplate($contacts);
 
       $this->addElement('checkbox', 'toggleSelect', NULL, NULL, array('class' => 'select-rows'));
 
@@ -363,6 +366,36 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       );
       CRM_Core_Error::statusBounce($message);
     }
+  }
+
+  /**
+   * Assign the summary_rows variable to the tpl.
+   *
+   * This adds rows to the beginning of the block that will help in making merge choices.
+   *
+   * It can be modified by a hook by altering what is assigned. Although not technically supported this
+   * is an easy tweak with no earth-shattering impacts if later changes stop if from working.
+   *
+   * https://lab.civicrm.org/dev/core/issues/824
+   *
+   * @param array $contacts
+   */
+  protected function assignSummaryRowsToTemplate($contacts) {
+    $mostRecent = ($contacts[$this->_cid]['modified_date'] < $contacts[$this->_oid]['modified_date']) ? $this->_oid : $this->_cid;
+    $this->assign('summary_rows', [
+      [
+        'name' => 'created_date',
+        'label' => ts('Created'),
+        'main_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_cid]['created_date']),
+        'other_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_oid]['created_date']),
+      ],
+      [
+        'name' => 'modified_date',
+        'label' => ts('Last Modified'),
+        'main_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_cid]['modified_date']) . ($mostRecent == $this->_cid ? ' (' . ts('Most Recent') . ')' : ''),
+        'other_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_oid]['modified_date']) . ($mostRecent == $this->_oid ? ' (' . ts('Most Recent') . ')' : ''),
+      ],
+    ]);
   }
 
 }

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -78,17 +78,16 @@
       <th width="300">Add/overwrite?</th>
     </tr>
 
-    {crmAPI var='other_result' entity='Contact' action='get' return="modified_date" id=$other_cid}
 
-    {crmAPI var='main_result' entity='Contact' action='get' return="modified_date" id=$main_cid}
-
-    <tr>
-      <td>Last modified</td>
-      <td>{$other_result.values.0.modified_date|crmDate} {if $other_result.values.0.modified_date gt $main_result.values.0.modified_date} (Most recent) {/if}</td>
-      <td></td>
-      <td>{$main_result.values.0.modified_date|crmDate} {if $main_result.values.0.modified_date gt $other_result.values.0.modified_date} (Most recent) {/if}</td>
-      <td></td>
-    </tr>
+    {foreach from=$summary_rows item=summaryRow}
+      <tr>
+        <td>{$summaryRow.label}</td>
+        <td>{$summaryRow.other_contact_value}</td>
+        <td></td>
+        <td>{$summaryRow.main_contact_value}</td>
+        <td></td>
+      </tr>
+    {/foreach}
 
     {foreach from=$rows item=row key=field}
 

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -72,9 +72,9 @@
   <table class="row-highlight">
     <tr class="columnheader">
       <th>&nbsp;</th>
-      <th><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$other_cid"}">{$other_name|escape}</a> ({ts}duplicate{/ts})</th>
+      <th>{$otherContactTypeIcon} <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$other_cid"}">{$other_name|escape}</a> ({ts}duplicate{/ts})</th>
       <th>{ts}Mark All{/ts}<br />=={$form.toggleSelect.html} ==&gt;</th>
-      <th><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$main_cid"}">{$main_name|escape}</a></th>
+      <th>{$mainContactTypeIcon}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$main_cid"}">{$main_name|escape}</a></th>
       <th width="300">Add/overwrite?</th>
     </tr>
 


### PR DESCRIPTION
Overview
----------------------------------------
Reduces clutter & increases available info & consistency by removing contact type from comparison table & putting icons next to the names

Before
----------------------------------------
    The merge screen currently shows contact types as a row but that is meaningless as we don't currently
    permit them to be changed when merging.
![Screenshot 2019-03-27 17 44 59](https://user-images.githubusercontent.com/336308/55051011-53b3af00-50b8-11e9-8ab4-718d2ec9edb9.png)


After
----------------------------------------
 Rendering as an icon is more consistent with elsewhere
    and potentially the hover makes it easy to see salient information about the contact.
![Screenshot 2019-03-27 17 44 21](https://user-images.githubusercontent.com/336308/55051021-59a99000-50b8-11e9-9e00-386c4318a862.png)


Technical Details
----------------------------------------
Note this depends on related PR #13897

Comments
----------------------------------------

