### PR TITLE
User dashboard: show most recent contributions, not earliest

### DIFF
--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -37,7 +37,10 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
    */
   public function listContribution() {
     $rows = civicrm_api3('Contribution', 'get', [
-      'options' => ['limit' => 12],
+      'options' => [
+        'limit' => 12,
+        'sort' => 'receive_date DESC',
+      ],
       'sequential' => 1,
       'contact_id' => $this->_contactId,
       'return' => [
@@ -53,6 +56,9 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
         'contribution_source',
       ],
     ])['values'];
+
+    // We want oldest first, just among the most recent contributions
+    $rows = array_reverse($rows);
 
     foreach ($rows as $index => $row) {
       // This is required for tpl logic. We should move away from hard-code this to adding an array of actions to the row


### PR DESCRIPTION
Overview
----------------------------------------
A recent change in how contributions are listed in the User Dashboard has caused a regression where it displays the 12 contributions with the lowest IDs (generally the earliest) rather than the most recent ones.

Before
----------------------------------------
A test user makes 15 contributions, one on each day in March.  The first 12 appear.

![Screenshot_2019-03-27 Dashboard - demo example com grantdetailreport(1)](https://user-images.githubusercontent.com/1682375/55090908-48e02680-5086-11e9-96a6-5b87f8c17c51.png)

After
----------------------------------------
Same scenario: 15 contributions, one on each day in March.  The most recent 12 appear.

![Screenshot_2019-03-27 Dashboard - demo example com grantdetailreport](https://user-images.githubusercontent.com/1682375/55090958-5f867d80-5086-11e9-943d-b61139f8d391.png)

Technical Details
----------------------------------------
The listing was switched to use the API in #13584.  There isn't a good way in APIv3 to list the most recent things starting with the oldest.  In this case, I had to sort by most recent and then reverse the array.

Comments
----------------------------------------
I might wonder whether the header should say "Your Most Recent Contribution(s)", but that's a bit outside scope, and the user dash appears to have always just been the dozen most recent contributions.