### PR TITLE
[WIP] Improve consistency of getOptions context handling

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -411,7 +411,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         FALSE,
         FALSE,
         FALSE,
-        'label',
+        $context == 'validate' ? 'value' : 'label',
         !($context == 'validate' || $context == 'get')
       );
     }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -245,7 +245,10 @@ class CRM_Core_PseudoConstant {
 
       // if callback is specified..
       if (!empty($pseudoconstant['callback'])) {
-        $fieldOptions = call_user_func(Civi\Core\Resolver::singleton()->get($pseudoconstant['callback']), $context);
+        $fieldOptions = call_user_func(Civi\Core\Resolver::singleton()->get($pseudoconstant['callback']));
+        if ($context === 'validate') {
+          $fieldOptions = array_combine(array_keys($fieldOptions), array_keys($fieldOptions));
+        }
         //CRM-18223: Allow additions to field options via hook.
         CRM_Utils_Hook::fieldOptions($entity, $fieldName, $fieldOptions, $params);
         return $fieldOptions;
@@ -331,6 +334,9 @@ class CRM_Core_PseudoConstant {
             }
             elseif (in_array('name', $availableFields)) {
               $params[$nameField] = 'name';
+            }
+            else {
+              $params[$nameField] = $params['keyColumn'];
             }
           }
           // Condition param can be passed as an sql clause string or an array of clauses

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -894,7 +894,7 @@ class CRM_Core_SelectValues {
    *
    * @return array
    */
-  public static function getSearchBuilderOperators($fieldType = NULL) {
+  public static function getSearchBuilderOperators() {
     return [
       '=' => '=',
       '!=' => '≠',

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -1058,6 +1058,18 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
         // Ensure count of optionValues is not extraordinarily high.
         $max = CRM_Utils_Array::value('max', $field, 20);
         $this->assertLessThanOrEqual($max, count($optionValues), $message);
+
+        // Test validate and match contexts
+        $validateContext = $daoName::buildOptions($field['fieldName'], 'validate');
+        $this->assertNotEmpty($validateContext, $message);
+        $matchContext = $daoName::buildOptions($field['fieldName'], 'match');
+        $this->assertNotEmpty($matchContext, $message);
+        // Check that "match" options key == "validate" options value
+        foreach ($matchContext as $name => $label) {
+          $id = array_search($name, $validateContext);
+          $this->assertNotFalse($id, $message);
+          $this->assertEquals($label, $optionValues[$id], $message);
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up the inconsistent handling of some getOptions contexts and adds a test.

Before
----------------------------------------
GetOptions contexts that index or label by the "name" column had inconsistent/unpredictable behavior for option groups that lacked a "name" column.

After
----------------------------------------
The "id" column is used in place of the "name" column when it doesn't exist.
