### PR TITLE
Do not cause a fatal error if no contact_id field for a note is fille…

### DIFF
--- a/CRM/Contact/Page/View/Note.php
+++ b/CRM/Contact/Page/View/Note.php
@@ -117,11 +117,13 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
           'Note',
           $note->id
         );
-        $contact = new CRM_Contact_DAO_Contact();
-        $contact->id = $note->contact_id;
-        $contact->find();
-        $contact->fetch();
-        $values[$note->id]['createdBy'] = $contact->display_name;
+        if (!empty($note->contact_id)) {
+          $contact = new CRM_Contact_DAO_Contact();
+          $contact->id = $note->contact_id;
+          $contact->find();
+          $contact->fetch();
+          $values[$note->id]['createdBy'] = $contact->display_name;
+        }
         $values[$note->id]['comment_count'] = CRM_Core_BAO_Note::getChildCount($note->id);
 
         // paper icon view for attachments part


### PR DESCRIPTION
…d in when viewing contact notes

Overview
----------------------------------------
Through direct SQL and DAO level statements it is possible to create a note without having the contact_id field filled in, this section of the code assumes that when you are viewing a contact the contact_id field of all the notes rendered will be there when that isn't necessarily the case in the DB, this just stops a fatal error.

Before
----------------------------------------
Fatal error generated when trying to view the contacts' notes tab if any notes don't have a contact_id set

After
----------------------------------------
no fatal error

ping @eileenmcnaughton 