### PR TITLE
dev/financial#49 Pass 'related contact' to template when giving on behalf of an organization

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -423,6 +423,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         // reset primary-email in the template
         $tplParams['email'] = $ccEmail;
 
+        $tplParams['related_contact'] = $values['related_contact'];
         $tplParams['onBehalfName'] = $displayName;
         $tplParams['onBehalfEmail'] = $email;
 

--- a/tests/phpunit/CRM/Utils/System/DrupalBaseTest.php
+++ b/tests/phpunit/CRM/Utils/System/DrupalBaseTest.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Class CRM_Utils_DrupalBaseTest
+ * @group headless
+ */
+class CRM_Utils_DrupalBaseTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function testFormatResourceUrl() {
+    global $base_url;
+    $url = $base_url . "/sites/all/modules/civicrm/js/crm.menubar.js";
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3049,7 +3049,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    * @param int $contributionPageID
    * @param string $module
    */
-  protected function addProfile($name, $contributionPageID, $module = 'CiviContribute') {
+  protected function addProfile($name, $contributionPageID, $module = 'CiviContribute', $moduleData = []) {
     $params = [
       'uf_group_id' => $name,
       'module' => $module,
@@ -3058,7 +3058,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'weight' => 1,
     ];
     if ($module !== 'CiviContribute') {
-      $params['module_data'] = [$module => []];
+      $params['module_data'] = [$module => $moduleData];
     }
     $this->callAPISuccess('UFJoin', 'create', $params);
   }

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -62,6 +62,7 @@
   customPre_grouptitle:::{$customPre_grouptitle}
   customPost_grouptitle:::{$customPost_grouptitle}
   contributionStatus:::{$contributionStatus}
+  related_contact:::{$related_contact}
  {foreach from=$lineItem item=value key=priceset}
   {foreach from=$value item=line}
      line.html_type:::{$line.html_type}


### PR DESCRIPTION
Overview
----------------------------------------
When giving "on behalf of an organization" (via a public contribution page), there's no way to pull in information about the individual who entered the contribution to the receipt template.

https://lab.civicrm.org/dev/financial/issues/49

Before
----------------------------------------
As above.

After
----------------------------------------
We pass the contact's ID in `$tplParams`.

Technical Details
----------------------------------------
This should be extremely safe, and should have zero impact on folks who don't choose to take advantage of the functionality this provides.