### PR TITLE
Convert trxn_date field in the Update Pending Status task option from…

### DIFF
--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -140,9 +140,7 @@ AND    co.id IN ( $contribIDs )";
       $this->addRule("fee_amount_{$row['contribution_id']}", ts('Please enter a valid amount.'), 'money');
       $defaults["fee_amount_{$row['contribution_id']}"] = 0.0;
 
-      $row['trxn_date'] = $this->add('datepicker', "trxn_date_{$row['contribution_id']}", [], FALSE,
-        ts('Receipt Date'), array('time' => FALSE)
-      );
+      $row['trxn_date'] = $this->add('datepicker', "trxn_date_{$row['contribution_id']}", ts('Transaction Date'), [], FALSE, ['time' => FALSE]);
       $defaults["trxn_date_{$row['contribution_id']}"] = $now;
 
       $this->add("text", "check_number_{$row['contribution_id']}", ts('Check Number'));
@@ -294,7 +292,7 @@ AND    co.id IN ( $contribIDs )";
       else {
         $input['trxn_id'] = $contribution->invoice_id;
       }
-      $input['trxn_date'] = CRM_Utils_Date::processDate($params["trxn_date_{$row['contribution_id']}"], date('H:i:s'));
+      $input['trxn_date'] = $params["trxn_date_{$row['contribution_id']}"] . ' ' .  date('H:i:s');
 
       // @todo calling baseIPN like this is a pattern in it's last gasps. Call contribute.completetransaction api.
       $baseIPN->completeTransaction($input, $ids, $objects, $transaction, FALSE);

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -118,7 +118,7 @@ AND    co.id IN ( $contribIDs )";
     $this->_rows = array();
     $attributes = CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_Contribution');
     $defaults = array();
-    $now = date("m/d/Y");
+    $now = date("Y-m-d");
     $paidByOptions = array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::paymentInstrument();
 
     while ($dao->fetch()) {
@@ -140,8 +140,8 @@ AND    co.id IN ( $contribIDs )";
       $this->addRule("fee_amount_{$row['contribution_id']}", ts('Please enter a valid amount.'), 'money');
       $defaults["fee_amount_{$row['contribution_id']}"] = 0.0;
 
-      $row['trxn_date'] = $this->addDate("trxn_date_{$row['contribution_id']}", FALSE,
-        ts('Receipt Date'), array('formatType' => 'activityDate')
+      $row['trxn_date'] = $this->add('datepicker', "trxn_date_{$row['contribution_id']}", [], FALSE,
+        ts('Receipt Date'), array('time' => FALSE)
       );
       $defaults["trxn_date_{$row['contribution_id']}"] = $now;
 

--- a/templates/CRM/Contribute/Form/Task/Status.tpl
+++ b/templates/CRM/Contribute/Form/Task/Status.tpl
@@ -59,7 +59,7 @@
     {assign var="element_name" value="trxn_id_"|cat:$row.contribution_id}
     <td>{$form.$element_name.html|crmAddClass:eight}</td>
     {assign var="element_name" value="trxn_date_"|cat:$row.contribution_id}
-    <td>{include file="CRM/common/jcalendar.tpl" elementName=$element_name}</td>
+    <td>{$form.$element_name.html}</td>
 </tr>
 {/foreach}
 </table>


### PR DESCRIPTION
… find contributions to datepicker from jcalendar

Overview
----------------------------------------
This converts the transaction date field on the update pending status task from being done using jcalendar to being a datepicker

Before
----------------------------------------
Legacy jcalendar used
![Screenshot 2019-04-01 14 17 07](https://user-images.githubusercontent.com/336308/55298216-effafe80-5488-11e9-9a4b-3e20659118f8.png)


After
----------------------------------------
Modern Datepicker used

![Screenshot 2019-04-01 14 17 07](https://user-images.githubusercontent.com/336308/55298225-01dca180-5489-11e9-817f-70b9326ee7ae.png)

ping @eileenmcnaughton @monishdeb @mattwire 