### PR TITLE
Event Cart: Fix PHP 7.2 fatal error (pass by ref)

### DIFF
--- a/CRM/Event/Cart/Form/Cart.php
+++ b/CRM/Event/Cart/Form/Cart.php
@@ -152,7 +152,7 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
     $no_fields = array();
     $contact_id = CRM_Contact_BAO_Contact::createProfileContact($contact_params, $no_fields, NULL);
     if (!$contact_id) {
-      CRM_Core_Error::displaySessionError("Could not create or match a contact with that email address.  Please contact the webmaster.");
+      CRM_Core_Session::setStatus(ts("Could not create or match a contact with that email address. Please contact the webmaster."), '', 'error');
     }
     return $contact_id;
   }


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

* Use PHP 7.2
* Enable the Event Cart
* Create an Event, add it to the cart, then head to the cart checkout (`/civicrm/event/cart_checkout`).

Result: blank page / fatal error.

Technical Details
----------------------------------------

```
PHP Fatal error:  Only variables can be passed by reference
in [...] CRM/Event/Cart/Form/Cart.php on line 155
```

I'm not a fan of this function, and this seems like an incorrect usage, but I couldn't figure out how to trigger the error (for some reason, the PHP fatals, even if the code does not run on that line).