### PR TITLE
dev/core#846 Add shared parent for ContributionRecur forms

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -34,7 +34,7 @@
 /**
  * This class provides support for canceling recurring subscriptions.
  */
-class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
+class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_ContributionRecur {
   protected $_paymentProcessorObj = NULL;
 
   protected $_userContext = NULL;
@@ -42,10 +42,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
   protected $_mode = NULL;
 
   protected $_mid = NULL;
-
-  protected $_coid = NULL;
-
-  protected $_crid = NULL;
 
   protected $_selfService = FALSE;
 

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be usefusul, but   |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ */
+
+/**
+ * Shared parent class for recurring contribution forms.
+ */
+class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
+
+  /**
+   * @var int Contribution ID
+   */
+  protected $_coid = NULL;
+
+  /**
+   * @var int Contribution Recur ID
+   */
+  protected $_crid = NULL;
+
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'ContributionRecur';
+  }
+
+  /**
+   * Explicitly declare the form context.
+   */
+  public function getDefaultContext() {
+    return 'create';
+  }
+
+}

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -34,9 +34,7 @@
 /**
  * This class generates form components for processing a contribution.
  */
-class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
-  protected $_crid = NULL;
-  protected $_coid = NULL;
+class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_ContributionRecur {
   protected $_mode = NULL;
 
   protected $_subscriptionDetails = NULL;

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -37,7 +37,7 @@
  * back in. It also uses a lot of functionality with the CRM API's, so any change
  * made here could potentially affect the API etc. Be careful, be aware, use unit tests.
  */
-class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
+class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_ContributionRecur {
 
   /**
    * The recurring contribution id, used when editing the recurring contribution.
@@ -45,8 +45,6 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
    * @var int
    */
   protected $contributionRecurID = NULL;
-
-  protected $_coid = NULL;
 
   protected $_subscriptionDetails = NULL;
 
@@ -380,13 +378,6 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
       return CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contribute/subscriptionstatus',
         "reset=1&task=update&result=1"));
     }
-  }
-
-  /**
-   * Explicitly declare the form context.
-   */
-  public function getDefaultContext() {
-    return 'create';
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is a non-functional change that adds a shared parent for 3 linked forms so we can consolidate functionality

Before
----------------------------------------
No shared parent

After
----------------------------------------
shared parent

Technical Details
----------------------------------------
Ties into https://github.com/civicrm/civicrm-core/pull/13285

Comments
----------------------------------------
@mattwire any chance you can check this - I kept it very small in the hope of  a quick merge so we can look at other related issues


Note my working branch with my thoughts about follow ons is here 
https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:recur_fixes?expand=1