### PR TITLE
Unfork Zetacomponents mail and use patch to apply differences

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "tecnickcom/tcpdf" : "6.2.*",
     "totten/ca-config": "~17.05",
     "zetacomponents/base": "1.9.*",
-    "zetacomponents/mail": "dev-1.8-civi",
+    "zetacomponents/mail": "dev-master",
     "marcj/topsort": "~1.1",
     "phpoffice/phpword": "^0.15.0",
     "pear/validate_finance_creditcard": "dev-master",
@@ -63,12 +63,6 @@
     "pear/log": "1.13.1",
     "ezyang/htmlpurifier": "4.10"
   },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/civicrm/zetacomponents-mail.git"
-    }
-  ],
   "scripts": {
     "post-install-cmd": [
       "bash tools/scripts/composer/dompdf-cleanup.sh",
@@ -94,6 +88,9 @@
       },
       "phpoffice/phpword": {
         "Fix handling of libxml_disable_entity_loader": "tools/scripts/composer/patches/phpword-libxml-fix-global-handling.patch"
+      },
+      "zetacomponents/mail": {
+        "CiviCRM Custom Patches for ZetaCompoents mail": "tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch"
       }
     }
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf8e79e6741fa30ccbc5bd59416f9f16",
+    "content-hash": "93a9f686f7eb00fb9d766d262eedb09b",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -2308,11 +2308,17 @@
         },
         {
             "name": "zetacomponents/mail",
-            "version": "dev-1.8-civi",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/civicrm/zetacomponents-mail.git",
-                "reference": "7286a167a4ec3199ab3c69a361967d853ffbcd90"
+                "url": "https://github.com/zetacomponents/Mail.git",
+                "reference": "b60e9a543f6c3d9a9ec74452d4ff5736a1c63a77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/b60e9a543f6c3d9a9ec74452d4ff5736a1c63a77",
+                "reference": "b60e9a543f6c3d9a9ec74452d4ff5736a1c63a77",
+                "shasum": ""
             },
             "require": {
                 "zetacomponents/base": "~1.8"
@@ -2321,11 +2327,17 @@
                 "zetacomponents/unit-test": "*"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "CiviCRM Custom Patches for ZetaCompoents mail": "tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
@@ -2361,18 +2373,18 @@
                     "name": "Alexandru Stanoi"
                 },
                 {
+                    "name": "Christian Michel"
+                },
+                {
                     "name": "Sinisa Dukaric"
                 },
                 {
                     "name": "Mikko Koppanen"
-                },
-                {
-                    "name": "Christian Michel"
                 }
             ],
             "description": "The component allows you construct and/or parse Mail messages conforming to  the mail standard. It has support for attachments, multipart messages and HTML  mail. It also interfaces with SMTP to send mail or IMAP, POP3 or mbox to  retrieve e-mail.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2019-03-14T11:29:52+00:00"
+            "time": "2019-02-13T11:33:09+00:00"
         }
     ],
     "packages-dev": [],

--- a/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch
+++ b/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch
@@ -1,0 +1,25 @@
+diff --git a/src/transports/imap/imap_transport.php b/src/transports/imap/imap_transport.php
+index 94837cd..1542673 100644
+--- a/src/transports/imap/imap_transport.php
++++ b/src/transports/imap/imap_transport.php
+@@ -1012,7 +1012,9 @@ class ezcMailImapTransport
+         {
+             // get the sizes of the messages
+             $tag = $this->getNextTag();
+-            $query = trim( implode( ',', $messageList ) );
++            $mailBatchSize = defined('MAIL_BATCH_SIZE') ? MAIL_BATCH_SIZE : 1000;
++            $truncatedMessageList = array_slice($messageList, 0, $mailBatchSize);
++            $query = trim( implode( ',', $truncatedMessageList ) );
+             $this->connection->sendData( "{$tag} FETCH {$query} RFC822.SIZE" );
+             $response = $this->getResponse( 'FETCH (' );
+             $currentMessage = trim( reset( $messageList ) );
+diff --git a/tests/tutorial_examples.php b/tests/tutorial_examples.php
+index 3acadc3..06f1e71 100644
+--- a/tests/tutorial_examples.php
++++ b/tests/tutorial_examples.php
+@@ -1,5 +1,4 @@
+ <?php
+-declare(encoding="latin1");
+ /**
+  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+  * @version //autogentag//


### PR DESCRIPTION
Overview
----------------------------------------
This aims to unfork from the upstream zetacomponents/mail by applying the local civicrm patches using a patch file instead

Before
----------------------------------------
Uses forked repo

After
----------------------------------------
non forked

ping @mfb @totten @mlutfy 