### PR TITLE
dev/core#704 Fix loss of links for recurrings with no payment_processor_id

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -167,18 +167,28 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    * Get the payment processor (array) for a recurring processor.
    *
    * @param int $id
-   * @param string $mode
-   *   - Test or NULL - all other variants are ignored.
    *
    * @return array|null
    */
-  public static function getPaymentProcessor($id, $mode = NULL) {
+  public static function getPaymentProcessor($id) {
     $paymentProcessorID = self::getPaymentProcessorID($id);
-    if (!$paymentProcessorID) {
-      return NULL;
-    }
+    return CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID);
+  }
 
-    return CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID, $mode);
+
+  /**
+   * Get the processor object for the recurring contribution record.
+   *
+   * @param int $id
+   *
+   * @return CRM_Core_Payment|NULL
+   *   Returns a processor object or NULL if the processor is disabled.
+   *   Note this returns the 'Manual' processor object if no processor is attached
+   *   (since it still makes sense to update / cancel
+   */
+  public static function getPaymentProcessorObject($id) {
+    $processor = self::getPaymentProcessor($id);
+    return is_array($processor) ? $processor['object'] : NULL;
   }
 
   /**

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -80,8 +80,8 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
 
     if ($recurID) {
       $links = self::$_links;
-      $paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($recurID, 'recur', 'obj');
-      if (!is_object($paymentProcessorObj)) {
+      $paymentProcessorObj = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorObject($recurID);
+      if (!$paymentProcessorObj) {
         unset($links[CRM_Core_Action::DISABLE]);
         unset($links[CRM_Core_Action::UPDATE]);
         return $links;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes 5.8 regression where the cancel link became unavailable on recurring contributions with no attached payment processor id

In 5.8 changes were made that remove the cancel links from recurring payments where the payment processor object doesn't load. 

This is appropriate for cases where there IS a processor but it's disabled. However, it is not
unknown for sites to import contribution_recur records from elsewhere as data records rather than 'functional records' & it is appropriate to be able to edit those.

Before
----------------------------------------
![Screenshot 2019-04-02 15 13 09](https://user-images.githubusercontent.com/336308/55371206-da093e80-5559-11e9-8f09-2a3efa5567a8.png)


After
----------------------------------------
![Screenshot 2019-04-02 15 09 36](https://user-images.githubusercontent.com/336308/55371151-a6c6af80-5559-11e9-86d8-319de8ebc43e.png)


Technical Details
----------------------------------------
We already have a relevant pattern - loading payment processor 0 loads the manual processor
(class is CRM_Core_Manual) which has functionality appropriate to non-automated flows
(also known as the paylater processor).

This PR switches to the function CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorObject
which is a skinny wrapper on CRM_Contribute_BAO_ContributionRecur::getPaymentProcessor - which itself
was not actually called from core prior to this change (we didn't remove it as it was better than
functions in play & hence intended to start using it again). No processor is loaded
for an inactive processor so links do not appear there.

Comments
----------------------------------------
