### PR TITLE
Core/725 - Get state_province_id given non numeric country_id or country parameter

### DIFF
--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -436,4 +436,43 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->assertEquals('3497', $address2['values'][0]['state_province_id']);
   }
 
+  public function getSymbolicCountryStateExamples() {
+    return [
+      // [mixed $inputCountry, mixed $inputState, int $expectCountry, int $expectState]
+      [1228, 1004, 1228, 1004],
+      //['US', 'CA', 1228, 1004],
+      //['US', 'TX', 1228, 1042],
+      ['US', 'California', 1228, 1004],
+      [1228, 'Texas', 1228, 1042],
+      // Don't think these have been supported?
+      // ['United States', 1004, 1228, 1004] ,
+      // ['United States', 'TX', 1228, 1042],
+    ];
+  }
+
+  /**
+   * @param mixed $inputCountry
+   *   Ex: 1228 or 'US'
+   * @param mixed $inputState
+   *   Ex: 1004 or 'CA'
+   * @param int $expectCountry
+   * @param int $expectState
+   * @dataProvider getSymbolicCountryStateExamples
+   */
+  public function testCreateAddressSymbolicCountryAndState($inputCountry, $inputState, $expectCountry, $expectState) {
+    $cid = $this->individualCreate();
+    $r = $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $cid,
+      'location_type_id' => 1,
+      'street_address' => '123 Some St',
+      'city' => 'Hereville',
+      'country_id' => $inputCountry, //'US',
+      'state_province_id' => $inputState, // 'California',
+      'postal_code' => '94100',
+    ]);
+    $created = CRM_Utils_Array::first($r['values']);
+    $this->assertEquals($expectCountry, $created['country_id']);
+    $this->assertEquals($expectState, $created['state_province_id']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Part Duex for https://lab.civicrm.org/dev/core/issues/725

ping @totten and @eileenmcnaughton 

Before
----------------------------------------
Address API create failure when country_id parameter is abbreviation instead of numeric id

After
----------------------------------------
Address API create success when country_id parameter is abbreviation instead of numeric id
Fixes regression documented by Tim here: https://lab.civicrm.org/dev/core/issues/725#note_15384

Technical Details
----------------------------------------
See regression found by Tim before release: https://lab.civicrm.org/dev/core/issues/725#note_15384

Adding function _civicrm_api3_resolve_country_id() to api/v3/utils.php for the resolving of the country_id or country parameter to a numeric id for the country

Test provided by Tim included, we can close https://github.com/civicrm/civicrm-core/pull/13932/files after this passes.
Comments
----------------------------------------
Trying to make this work for the 'country' parameter, as well as supporting full country names as well as abbreviations if passed into the Address API create, so maybe more edge case regressions can be caught now, instead of reported later.
