### PR TITLE
Fix status type (error, not fail) for CRM_Core_Session::setStatus

### DIFF
--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -113,12 +113,11 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     }
     elseif ($result == FALSE) {
       // Email address not verified
-
       $statusMsg = ts('The email address: %1 you have entered does not match the email associated with this opt out request.',
         array(1 => $values['email_confirm'])
       );
 
-      CRM_Core_Session::setStatus($statusMsg, '', 'fail');
+      CRM_Core_Session::setStatus($statusMsg, '', 'error');
     }
 
   }

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -72,7 +72,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
       $statusMsg = ts('Email: %1 has been successfully unsubscribed from this Mailing List/Group.',
         array(1 => $email)
       );
-      CRM_Core_Session::setStatus($statusMsg, '', 'fail');
+      CRM_Core_Session::setStatus($statusMsg, '', 'error');
     }
     $this->assign('groupExist', $groupExist);
 
@@ -116,8 +116,8 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
 
     if ($result == TRUE) {
       // Email address verified
-
       $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($job_id, $queue_id, $hash);
+
       if (count($groups)) {
         CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($queue_id, $groups, FALSE, $job_id);
       }
@@ -130,12 +130,11 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     }
     elseif ($result == FALSE) {
       // Email address not verified
-
       $statusMsg = ts('The email address: %1 you have entered does not match the email associated with this unsubscribe request.',
         array(1 => $values['email_confirm'])
       );
 
-      CRM_Core_Session::setStatus($statusMsg, '', 'fail');
+      CRM_Core_Session::setStatus($statusMsg, '', 'error');
 
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fixes an incorrect status for `setMessage`. It was using 'fail' instead of 'error'. Fail is not a valid status.

https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Session.php#L451