### PR TITLE
dev/core/issues/823, fixed code to set contact type correctly

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -678,14 +678,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
       $this->removeFileRequiredRules('image_URL');
     }
 
-    if (array_key_exists('contact_sub_type', $this->_defaults) &&
-      !empty($this->_defaults['contact_sub_type'])
-    ) {
-      $this->_defaults['contact_sub_type'] = explode(CRM_Core_DAO::VALUE_SEPARATOR,
-        trim($this->_defaults['contact_sub_type'], CRM_Core_DAO::VALUE_SEPARATOR)
-      );
-    }
-
     $this->setDefaults($this->_defaults);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/823

Before
----------------------------------------
![Before](https://user-images.githubusercontent.com/2053075/55496984-2c209180-5638-11e9-93f2-eb27786ef3b2.gif)


After
----------------------------------------
![After](https://user-images.githubusercontent.com/2053075/55496991-32af0900-5638-11e9-9bd2-65802dc02eb2.gif)


Technical Details
----------------------------------------
Formatting of contact sub type is already handled in CRM_Core_BAO_UFGroup::setProfileDefaults() where default values for contact fields are build.
