### PR TITLE
dev/core#849 Replace get_headers functions call with Guzzle HTTP request.

### DIFF
--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -66,7 +66,7 @@ abstract class CRM_Utils_Check_Component {
    * @return bool
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function fileExists($url, $timeout = 0.25) {
+  public function fileExists($url, $timeout = 0.50) {
     $fileExists = FALSE;
     try {
       $guzzleClient = new GuzzleHttp\Client();

--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -25,6 +25,8 @@
  +--------------------------------------------------------------------+
  */
 
+use GuzzleHttp\Client;
+
 /**
  *
  * @package CRM
@@ -55,6 +57,28 @@ abstract class CRM_Utils_Check_Component {
       }
     }
     return $messages;
+  }
+
+  /**
+   * Check if file exists on given URL.
+   *
+   * @param $url
+   * @return bool
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   */
+  public function fileExists($url, $timeout = 0.25) {
+    $fileExists = FALSE;
+    try {
+      $guzzleClient = new GuzzleHttp\Client();
+      $guzzleResponse = $guzzleClient->request('GET', $url, array(
+        'timeout' => $timeout,
+      ));
+      $fileExists = ($guzzleResponse->getStatusCode() == 200);
+    }
+    catch (Exception $e) {
+      echo $e->getMessage();
+    }
+    return $fileExists;
   }
 
 }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -47,9 +47,9 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
             1 => $phpVersion,
             2 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
-        ts('PHP Up-to-Date'),
-        \Psr\Log\LogLevel::INFO,
-        'fa-server'
+          ts('PHP Up-to-Date'),
+          \Psr\Log\LogLevel::INFO,
+          'fa-server'
       );
     }
     elseif (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) >= 0) {
@@ -60,9 +60,9 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
             1 => $phpVersion,
             2 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
-        ts('PHP Out-of-Date'),
-        \Psr\Log\LogLevel::NOTICE,
-        'fa-server'
+          ts('PHP Out-of-Date'),
+          \Psr\Log\LogLevel::NOTICE,
+          'fa-server'
       );
     }
     elseif (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) >= 0) {
@@ -74,9 +74,9 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
             2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
             3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
-        ts('PHP Out-of-Date'),
-        \Psr\Log\LogLevel::WARNING,
-        'fa-server'
+          ts('PHP Out-of-Date'),
+          \Psr\Log\LogLevel::WARNING,
+          'fa-server'
       );
     }
     else {
@@ -88,9 +88,9 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
             2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
             3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
-        ts('PHP Out-of-Date'),
-        \Psr\Log\LogLevel::ERROR,
-        'fa-server'
+          ts('PHP Out-of-Date'),
+          \Psr\Log\LogLevel::ERROR,
+          'fa-server'
       );
     }
 
@@ -111,9 +111,9 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
             1 => 'https://civicrm.org/blog/totten/psa-please-verify-php-extension-mysqli',
             2 => 'mysqli',
           )),
-        ts('Forward Compatibility: Enable "mysqli"'),
-        \Psr\Log\LogLevel::WARNING,
-        'fa-server'
+          ts('Forward Compatibility: Enable "mysqli"'),
+          \Psr\Log\LogLevel::WARNING,
+          'fa-server'
       );
     }
 
@@ -883,9 +883,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
 
     // Does arrow.png exist where we expect it?
     $arrowUrl = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'packages/jquery/css/images/arrow.png';
-    $headers = get_headers($arrowUrl);
-    $fileExists = stripos($headers[0], "200 OK") ? 1 : 0;
-    if ($fileExists === FALSE) {
+    if ($this->fileExists($arrowUrl) === FALSE) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('The Resource URL is not set correctly. Please set the <a href="%1">CiviCRM Resource URL</a>.',

--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -86,8 +86,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
         if (count($log_path) > 1) {
           $url[] = $log_path[1];
           $log_url = implode($filePathMarker, $url);
-          $headers = @get_headers($log_url);
-          if (stripos($headers[0], '200')) {
+          if ($this->fileExists($log_url)) {
             $docs_url = $this->createDocUrl('checkLogFileIsNotAccessible');
             $msg = 'The <a href="%1">CiviCRM debug log</a> should not be downloadable.'
               . '<br />' .
@@ -145,9 +144,9 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
               2 => $privateDir,
               3 => $heuristicUrl,
             )),
-          ts('Private Files Readable'),
-          \Psr\Log\LogLevel::WARNING,
-          'fa-lock'
+            ts('Private Files Readable'),
+            \Psr\Log\LogLevel::WARNING,
+            'fa-lock'
         );
       }
     }
@@ -365,8 +364,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
       return FALSE;
     }
 
-    $headers = @get_headers("$url/$file");
-    if (stripos($headers[0], '200')) {
+    if ($this->fileExists("$url/$file")) {
       $content = @file_get_contents("$url/$file");
       if (preg_match('/delete me/', $content)) {
         $result = TRUE;

--- a/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Class CRM_Utils_Check_Component_EnvTest
+ * @package CiviCRM
+ * @subpackage CRM_Utils_Type
+ * @group headless
+ */
+class CRM_Utils_Check_Component_EnvTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * File check test should fail if reached maximum timeout.
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   */
+  public function testResourceUrlCheck() {
+    $check = new \CRM_Utils_Check_Component_Env();
+    $failRequest = $check->fileExists('https://civicrm.org', 0.001);
+    $successRequest = $check->fileExists('https://civicrm.org', 0);
+
+    $this->assertEquals(FALSE, $failRequest, 'Request should fail for minimum timeout.');
+    $this->assertEquals(TRUE, $successRequest, 'Request should not fail for infinite timeout.');
+
+  }
+
+}


### PR DESCRIPTION
Base PR: #12938 (New implementation replaces cURL with Guzzle)

Overview
----------------------------------------
The existing get_headers function call has no explicit timeout and will execute until PHP timeout is reached. This can be problematic in some hosting environments where a PHP request can block further PHP execution - preventing the website from loading at all. A blocking request will eventually time out, causing a HTTP 504 error for the website and all visitors.

This problem most commonly occurs where the internal request is to a resource which cannot be resolved, usually relating to local DNS issue but can also be due to front-end proxy services.

Before
----------------------------------------
CiviCRM's internal request will execute until PHP timeout is reached and cause HTTP 504 error.

After
----------------------------------------
CiviCRM uses the Guzzle library to perform the request and now has a timeout of 250ms which will be sufficient for those requests which have no issues and in the event that the request cannot be resolved, will cancel execution earlier than the PHP timeout.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-1163_