### PR TITLE
[unreleased regression] Add error handling for when no test procesor row exists.

### DIFF
--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -158,7 +158,13 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
         $dao->id
       );
       $paymentProcessor[$dao->id]['financialAccount'] = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($dao->id, NULL, 'civicrm_payment_processor', 'financial_account_id.name');
-      $paymentProcessor[$dao->id]['test_id'] = CRM_Financial_BAO_PaymentProcessor::getTestProcessorId($dao->id);
+
+      try {
+        $paymentProcessor[$dao->id]['test_id'] = CRM_Financial_BAO_PaymentProcessor::getTestProcessorId($dao->id);
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        CRM_Core_Session::setStatus(ts('No test processor entry exists for %1. Not having a test entry for each processor could cause problems', [$dao->name]));
+      }
     }
 
     $this->assign('rows', $paymentProcessor);


### PR DESCRIPTION
Overview
----------------------------------------
Avoid hard fails when no test row in processor table

This is not really a valid config but for sites that have processors without test rows recent changes
will make that problematic. We can be nice


Before
----------------------------------------
![Screenshot 2019-04-04 11 13 11](https://user-images.githubusercontent.com/336308/55516758-b4e80d80-56ca-11e9-958a-c6fa1c140ef0.png)


After
----------------------------------------
![Screenshot 2019-04-04 11 14 24](https://user-images.githubusercontent.com/336308/55516786-d2b57280-56ca-11e9-9fb0-1823b3094d2e.png)


Technical Details
----------------------------------------


Comments
----------------------------------------

