### PR TITLE
Test fix

### DIFF
--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -414,6 +414,8 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
     $contactId = $this->individualCreate();
     $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
     CRM_Core_DAO::executeQuery("SET @uniqueID = 'wooty woot'");
+    // Add delay so the update is actually enough after the create that the timestamps differ
+    sleep(1);
     $timeStamp = date('Y-m-d H:i:s');
     $this->callAPISuccess('Contact', 'create', array(
         'id' => $contactId,


### PR DESCRIPTION
Overview
----------------------------------------
Test fix on logging test

Before
----------------------------------------
More false fails

After
----------------------------------------
Less false fails

Technical Details
----------------------------------------
Logging requires our servers to be slow enough that the actions happen at least one second apart. Performance improvements broke the test

Comments
----------------------------------------

