### PR TITLE
dev/financial#38 : Support refund payment using payment processor

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -337,6 +337,15 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Does this payment processor support refund?
+   *
+   * @return bool
+   */
+  public function supportsRefund() {
+    return FALSE;
+  }
+
+  /**
    * Should the first payment date be configurable when setting up back office recurring payments.
    *
    * We set this to false for historical consistency but in fact most new processors use tokens for recurring and can support this
@@ -1257,6 +1266,17 @@ abstract class CRM_Core_Payment {
     }
     return $result;
   }
+
+  /**
+   * Refunds payment
+   *
+   * Payment processors should set payment_status_id if it set the status to Refunded in case the transaction is successful
+   *
+   * @param array $params
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function doRefund(&$params) {}
 
   /**
    * Query payment processor for details about a transaction.

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -138,6 +138,25 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
+   * Does this payment processor support refund?
+   *
+   * @return bool
+   */
+  public function supportsRefund() {
+    return TRUE;
+  }
+
+  /**
+   * Submit a refund payment
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   *
+   * @param array $params
+   *   Assoc array of input parameters for this transaction.
+   */
+  public function doRefund(&$params) {}
+
+  /**
    * Generate error object.
    *
    * Throwing exceptions is preferred over this.

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -115,3 +115,41 @@ function _civicrm_api3_payment_processor_getlist_defaults(&$request) {
     ],
   ];
 }
+
+/**
+ * Action refund.
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result array.
+ * @throws CiviCRM_API3_Exception
+ */
+function civicrm_api3_payment_processor_refund($params) {
+  $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
+  $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', array('id' => $params['payment_processor_id'])));
+  if (!$processor->supportsRefund()) {
+    throw API_Exception('Payment Processor does not support refund');
+  }
+  $result = $processor->doRefund($params);
+  return civicrm_api3_create_success(array($result), $params);
+}
+
+/**
+ * Action Refund.
+ *
+ * @param array $params
+ *
+ */
+function _civicrm_api3_payment_processor_refund_spec(&$params) {
+  $params['payment_processor_id'] = [
+    'api.required' => 1,
+    'title' => ts('Payment processor'),
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+  $params['amount'] = [
+    'api.required' => TRUE,
+    'title' => ts('Amount to refund'),
+    'type' => CRM_Utils_Type::T_MONEY,
+  ];
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add PaymentProcessor.refund api

Before
----------------------------------------
No api

After
----------------------------------------
api - processors need to implement doRefund & supportsRefund functions

Technical Details
----------------------------------------
This is a reviewer's commit of https://github.com/civicrm/civicrm-core/pull/13794 - it adds the simplest portion of the change & leaves things that need more discussion / tests to future prs

Comments
----------------------------------------

