### PR TITLE
Add minimal PaymentProcessor.pay api

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -337,6 +337,15 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Does this payment processor support refund?
+   *
+   * @return bool
+   */
+  public function supportsRefund() {
+    return FALSE;
+  }
+
+  /**
    * Should the first payment date be configurable when setting up back office recurring payments.
    *
    * We set this to false for historical consistency but in fact most new processors use tokens for recurring and can support this
@@ -1257,6 +1266,17 @@ abstract class CRM_Core_Payment {
     }
     return $result;
   }
+
+  /**
+   * Refunds payment
+   *
+   * Payment processors should set payment_status_id if it set the status to Refunded in case the transaction is successful
+   *
+   * @param array $params
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function doRefund(&$params) {}
 
   /**
    * Query payment processor for details about a transaction.

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -138,6 +138,25 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
+   * Does this payment processor support refund?
+   *
+   * @return bool
+   */
+  public function supportsRefund() {
+    return TRUE;
+  }
+
+  /**
+   * Submit a refund payment
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   *
+   * @param array $params
+   *   Assoc array of input parameters for this transaction.
+   */
+  public function doRefund(&$params) {}
+
+  /**
    * Generate error object.
    *
    * Throwing exceptions is preferred over this.

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -117,6 +117,40 @@ function _civicrm_api3_payment_processor_getlist_defaults(&$request) {
 }
 
 /**
+ * Action payment.
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result array.
+ * @throws CiviCRM_API3_Exception
+ */
+function civicrm_api3_payment_processor_pay($params) {
+  $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
+  $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', ['id' => $params['payment_processor_id']]));
+  $result = $processor->doPayment($params);
+  return civicrm_api3_create_success(array($result), $params);
+}
+
+/**
+ * Action payment.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_payment_processor_pay_spec(&$params) {
+  $params['payment_processor_id'] = [
+    'api.required' => 1,
+    'title' => ts('Payment processor'),
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+  $params['amount'] = [
+    'api.required' => TRUE,
+    'title' => ts('Amount to refund'),
+    'type' => CRM_Utils_Type::T_MONEY,
+  ];
+}
+
+/**
  * Action refund.
  *
  * @param array $params

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -115,3 +115,41 @@ function _civicrm_api3_payment_processor_getlist_defaults(&$request) {
     ],
   ];
 }
+
+/**
+ * Action refund.
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result array.
+ * @throws CiviCRM_API3_Exception
+ */
+function civicrm_api3_payment_processor_refund($params) {
+  $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
+  $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', array('id' => $params['payment_processor_id'])));
+  if (!$processor->supportsRefund()) {
+    throw API_Exception('Payment Processor does not support refund');
+  }
+  $result = $processor->doRefund($params);
+  return civicrm_api3_create_success(array($result), $params);
+}
+
+/**
+ * Action Refund.
+ *
+ * @param array $params
+ *
+ */
+function _civicrm_api3_payment_processor_refund_spec(&$params) {
+  $params['payment_processor_id'] = [
+    'api.required' => 1,
+    'title' => ts('Payment processor'),
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+  $params['amount'] = [
+    'api.required' => TRUE,
+    'title' => ts('Amount to refund'),
+    'type' => CRM_Utils_Type::T_MONEY,
+  ];
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds api for PaymentProcessor.pay

Before
----------------------------------------
Doesn't exist

After
----------------------------------------
Does exist

Technical Details
----------------------------------------
This is immature at the moment but it makes sense to add it at the same time as https://github.com/civicrm/civicrm-core/pull/13952 (this might require some fixes to Omnipay which already implements but I will look at that)


Comments
----------------------------------------

