### PR TITLE
Promise Polyfill for older browsers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,8 @@
     "angular-bootstrap": "^2.5.0",
     "angular-sanitize": "~1.5.0",
     "smartmenus": "~1.1",
-    "phantomjs-polyfill": "^0.0.2"
+    "phantomjs-polyfill": "^0.0.2",
+    "es6-promise": "^4.2.4"
   },
   "resolutions": {
     "angular": "~1.5.11"

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -128,5 +128,11 @@
     params: {},
     functions: []
   };
+
+  // Load polyfill
+  if (!('Promise' in window)) {
+    CRM.loadScript(CRM.config.resourceBase + 'bower_components/es6-promise/es6-promise.auto.min.js');
+  }
+
 })(jQuery);
 {/literal}


### PR DESCRIPTION
Overview
-----
Loads a polyfill for IE and other outdated browsers so we can use native js Promises in our code.

Before
-----
Code using native js promises will bomb in older browsers.

After
---
Should work, but I don't have an old browser to test it on.

Notes
-----
The new Paypal Smart Buttons SDK needs this.

To Test
-----
Using IE or another [older browser that does not support Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Browser_compatibility), visit a civicrm demo site and type `window.Promise` in your console. It should return `undefined`. Now visit the demo site for this PR and do the same thing from any CiviCRM page. It should return a function.