### PR TITLE
(dev/mail#41) "Preview as HTML"  - Fix error with tracking urls

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1383,7 +1383,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       }
     }
     elseif ($type == 'url') {
-      if ($this->url_tracking) {
+      if ($this->url_tracking && !empty($this->id)) {
         // ensure that Google CSS and any .css files are not tracked.
         if (!(strpos($token, 'css?family') || strpos($token, '.css'))) {
           $data = CRM_Mailing_BAO_TrackableURL::getTrackerURL($token, $this->id, $event_queue_id);


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression in email preview. Use-case:

* Compose a "Mailing => New Mailing"
* Fill in basic in fields.
* In the body of the mailing, include a hyperlink
* Press the button "Preview as HTML"

This is an alternate version to https://github.com/civicrm/civicrm-core/pull/13813 based on Monish's comment at https://github.com/civicrm/civicrm-core/pull/13813#issuecomment-472682777 

Before
----------------------------------------
Fatal error generating trying to preview mailing

After
----------------------------------------
Preview works

ping @monishdeb @eileenmcnaughton @scardinius 