### PR TITLE
dev/core#785 Differentiate smart group from regular group using icon in select2 field

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1082,7 +1082,7 @@ WHERE  id IN $groupIdString
           'visibility' => $dao->visibility,
           'description' => $dao->description,
           'icon' => empty($dao->saved_search_id) ? NULL : 'fa-lightbulb-o',
-        );
+        ];
       }
       else {
         $roots[] = [
@@ -1091,7 +1091,7 @@ WHERE  id IN $groupIdString
           'visibility' => $dao->visibility,
           'description' => $dao->description,
           'icon' => empty($dao->saved_search_id) ? NULL : 'fa-lightbulb-o',
-        );
+        ];
       }
     }
 
@@ -1119,7 +1119,8 @@ WHERE  id IN $groupIdString
     $spaces = str_repeat($spacer, $level);
 
     if ($titleOnly) {
-      $hierarchy[$group['id']] = $spaces . $group['title'];
+      $icon = $group['icon'] ? '* ' : '';
+      $hierarchy[$group['id']] = $icon . $spaces . $group['title'];
     }
     else {
       $hierarchy[] = array(

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1052,7 +1052,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $groups = [];
     $args = [1 => [$groupIdString, 'String']];
     $query = "
-SELECT id, title, description, visibility, parents
+SELECT id, title, description, visibility, parents, saved_search_id
 FROM   civicrm_group
 WHERE  id IN $groupIdString
 ";
@@ -1081,7 +1081,8 @@ WHERE  id IN $groupIdString
           'title' => $dao->title,
           'visibility' => $dao->visibility,
           'description' => $dao->description,
-        ];
+          'icon' => empty($dao->saved_search_id) ? NULL : 'fa-lightbulb-o',
+        );
       }
       else {
         $roots[] = [
@@ -1089,7 +1090,8 @@ WHERE  id IN $groupIdString
           'title' => $dao->title,
           'visibility' => $dao->visibility,
           'description' => $dao->description,
-        ];
+          'icon' => empty($dao->saved_search_id) ? NULL : 'fa-lightbulb-o',
+        );
       }
     }
 
@@ -1097,6 +1099,7 @@ WHERE  id IN $groupIdString
     for ($i = 0; $i < count($roots); $i++) {
       self::buildGroupHierarchy($hierarchy, $roots[$i], $tree, $titleOnly, $spacer, 0);
     }
+
     return $hierarchy;
   }
 
@@ -1119,11 +1122,13 @@ WHERE  id IN $groupIdString
       $hierarchy[$group['id']] = $spaces . $group['title'];
     }
     else {
-      $hierarchy[$group['id']] = [
-        'title' => $spaces . $group['title'],
+      $hierarchy[] = array(
+        'id' => $group['id'],
+        'text' => $spaces . $group['title'],
         'description' => $group['description'],
         'visibility' => $group['visibility'],
-      ];
+        'icon' => $group['icon'],
+      );
     }
 
     // For performance reasons we use a for loop rather than a foreach.

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1078,19 +1078,17 @@ WHERE  id IN $groupIdString
         $parent = self::filterActiveGroups($parentArray);
         $tree[$parent][] = [
           'id' => $dao->id,
-          'title' => $dao->title,
+          'title' => empty($dao->saved_search_id) ? $dao->title : '* ' . $dao->title,
           'visibility' => $dao->visibility,
           'description' => $dao->description,
-          'icon' => empty($dao->saved_search_id) ? NULL : 'fa-lightbulb-o',
         ];
       }
       else {
         $roots[] = [
           'id' => $dao->id,
-          'title' => $dao->title,
+          'title' => empty($dao->saved_search_id) ? $dao->title : '* ' . $dao->title,
           'visibility' => $dao->visibility,
           'description' => $dao->description,
-          'icon' => empty($dao->saved_search_id) ? NULL : 'fa-lightbulb-o',
         ];
       }
     }
@@ -1119,8 +1117,7 @@ WHERE  id IN $groupIdString
     $spaces = str_repeat($spacer, $level);
 
     if ($titleOnly) {
-      $icon = $group['icon'] ? '* ' : '';
-      $hierarchy[$group['id']] = $icon . $spaces . $group['title'];
+      $hierarchy[$group['id']] = $spaces . $group['title'];
     }
     else {
       $hierarchy[] = array(
@@ -1128,7 +1125,6 @@ WHERE  id IN $groupIdString
         'text' => $spaces . $group['title'],
         'description' => $group['description'],
         'visibility' => $group['visibility'],
-        'icon' => $group['icon'],
       );
     }
 

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -869,8 +869,9 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $params['preferred_communication_method'] = 'null';
     }
 
-    $group = $params['group'] ?? NULL;
-    if (!empty($group) && is_array($group)) {
+    $group = CRM_Utils_Array::value('group', $params);
+    if (!empty($group)) {
+      $group = is_array($group) ? $group : explode(',', $group);
       unset($params['group']);
       foreach ($group as $key => $value) {
         $params['group'][$value] = 1;

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -102,7 +102,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
           }
 
           if ($groupElementType == 'select') {
-            $groupsOptions[$id] = $group['title'];
+            $groupsOptions[$id] = $group;
           }
           else {
             $form->_tagGroup[$fName][$id]['description'] = $group['description'];
@@ -111,8 +111,8 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
         }
 
         if ($groupElementType == 'select' && !empty($groupsOptions)) {
-          $form->add('select', $fName, $groupName, $groupsOptions, FALSE,
-            ['id' => $fName, 'multiple' => 'multiple', 'class' => 'crm-select2 twenty']
+          $form->add('select2', $fName, $groupName, $groupsOptions, FALSE,
+            ['placeholder' => '- select -', 'multiple' => TRUE, 'class' => 'twenty']
           );
           $form->assign('groupCount', count($groupsOptions));
         }

--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -73,7 +73,7 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
         if ($onlyPublicGroups && $group['visibility'] == 'User and User Admin Only') {
           continue;
         }
-        $allGroups[$id] = $group;
+        $allGroups[$group['id']] = $group;
       }
     }
     else {

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -49,14 +49,15 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
 
     // add select for groups
     // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
-    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;', TRUE);
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;');
     if (!empty($searchOptions['groups'])) {
-      $this->addField('group', [
-        'entity' => 'group_contact',
-        'label' => ts('in'),
-        'placeholder' => ts('- any group -'),
-        'options' => $groupHierarchy,
-      ]);
+      $this->addField('group', array[
+          'entity' => 'group_contact',
+          'label' => ts('in'),
+          'placeholder' => ts('- any group -'),
+          'options' => $groupHierarchy,
+          'type' => 'Select2',
+        ]);
     }
 
     if (!empty($searchOptions['tags'])) {

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -51,13 +51,13 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
     // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
     $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;');
     if (!empty($searchOptions['groups'])) {
-      $this->addField('group', array[
-          'entity' => 'group_contact',
-          'label' => ts('in'),
-          'placeholder' => ts('- any group -'),
-          'options' => $groupHierarchy,
-          'type' => 'Select2',
-        ]);
+      $this->addField('group', [
+        'entity' => 'group_contact',
+        'label' => ts('in'),
+        'placeholder' => ts('- any group -'),
+        'options' => $groupHierarchy,
+        'type' => 'Select2',
+      ]);
     }
 
     if (!empty($searchOptions['tags'])) {

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -45,7 +45,7 @@ class CRM_Contact_Form_Search_Criteria {
         $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '&nbsp;&nbsp;');
 
         $form->add('select2', 'group', ts('Groups'), $groupHierarchy, FALSE,
-          ['placeholder' => '- select -', 'multiple' => TRUE, 'class' => 'twenty']
+          ['placeholder' => ts('- select -'), 'multiple' => TRUE, 'class' => 'twenty']
         );
         $groupOptions = CRM_Core_BAO_OptionValue::getOptionValuesAssocArrayFromName('group_type');
         $form->add('select', 'group_type', ts('Group Types'), $groupOptions, FALSE,

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -42,10 +42,10 @@ class CRM_Contact_Form_Search_Criteria {
       // multiselect for groups
       if ($form->_group) {
         // Arrange groups into hierarchical listing (child groups follow their parents and have indentation spacing in title)
-        $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '&nbsp;&nbsp;', TRUE);
+        $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '&nbsp;&nbsp;');
 
-        $form->add('select', 'group', ts('Groups'), $groupHierarchy, FALSE,
-          ['id' => 'group', 'multiple' => 'multiple', 'class' => 'crm-select2']
+        $form->add('select2', 'group', ts('Groups'), $groupHierarchy, FALSE,
+          ['placeholder' => '- select -', 'multiple' => TRUE, 'class' => 'twenty']
         );
         $groupOptions = CRM_Core_BAO_OptionValue::getOptionValuesAssocArrayFromName('group_type');
         $form->add('select', 'group_type', ts('Group Types'), $groupOptions, FALSE,

--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -94,7 +94,7 @@
             return item.text;
           }
           var option = convertValueToObj(item.id);
-          var icon = (option.entity_type === 'civicrm_mailing') ? 'fa-envelope' : 'fa-users';
+          var icon = (option.entity_type === 'civicrm_mailing') ? 'fa-envelope' : item.is_smart ? 'fa-lightbulb-o' : 'fa-users';
           var spanClass = (option.mode == 'exclude') ? 'crmMailing-exclude' : 'crmMailing-include';
           if (option.entity_type != 'civicrm_mailing' && isMandatory(option.entity_id)) {
             spanClass = 'crmMailing-mandatory';
@@ -154,7 +154,7 @@
               mids.push(0);
             }
 
-            CRM.api3('Group', 'getlist', { params: { id: { IN: gids }, options: { limit: 0 } }, extra: ["is_hidden"] } ).then(
+            CRM.api3('Group', 'getlist', { params: { id: { IN: gids }, options: { limit: 0 } }, extra: ["is_hidden"] }).then(
               function(glist) {
                 CRM.api3('Mailing', 'getlist', { params: { id: { IN: mids }, options: { limit: 0 } } }).then(
                   function(mlist) {
@@ -165,8 +165,8 @@
 
                     $(glist.values).each(function (idx, group) {
                       var key = group.id + ' civicrm_group include';
-                      groupNames.push({id: parseInt(group.id), title: group.label, is_hidden: group.extra.is_hidden});
 
+                      groupNames.push({id: parseInt(group.id), title: group.label, is_hidden: group.extra.is_hidden});
                       if (values.indexOf(key) >= 0) {
                         datamap.push({id: key, text: group.label});
                       }
@@ -239,7 +239,7 @@
             transport: function(params) {
               switch(rcpAjaxState.entity) {
               case 'civicrm_group':
-                CRM.api3('Group', 'getlist', params.data).then(params.success, params.error);
+                CRM.api3('Group', 'get', params.data).then(params.success, params.error);
                 break;
 
               case 'civicrm_mailing':
@@ -255,9 +255,8 @@
                     return obj["api.MailingRecipients.getcount"] > 0 ? {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
                                text: obj.label } : '';
                   }
-                  else {
-                    return {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
-                               text: obj.label };
+                  else if (obj.is_hidden == 0) {
+                    return { id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type, text: obj.title, is_smart: (!_.isEmpty(obj.saved_search_id)) };
                   }
                 })
               };

--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -94,12 +94,13 @@
             return item.text;
           }
           var option = convertValueToObj(item.id);
-          var icon = (option.entity_type === 'civicrm_mailing') ? 'fa-envelope' : item.is_smart ? 'fa-lightbulb-o' : 'fa-users';
+          var icon = (option.entity_type === 'civicrm_mailing') ? 'fa-envelope' : 'fa-users';
+          var smartGroupMarker = item.is_smart ? '* ' : '';
           var spanClass = (option.mode == 'exclude') ? 'crmMailing-exclude' : 'crmMailing-include';
           if (option.entity_type != 'civicrm_mailing' && isMandatory(option.entity_id)) {
             spanClass = 'crmMailing-mandatory';
           }
-          return '<i class="crm-i '+icon+'" aria-hidden="true"></i> <span class="' + spanClass + '">' + item.text + '</span>';
+          return '<i class="crm-i '+icon+'"></i> <span class="' + spanClass + '">' + smartGroupMarker + item.text + '</span>';
         }
 
         function validate() {
@@ -233,13 +234,16 @@
               if('civicrm_mailing' === rcpAjaxState.entity) {
                 params["api.MailingRecipients.getcount"] = {};
               }
+              else if ('civicrm_group' === rcpAjaxState.entity) {
+                params.extra = ["saved_search_id"];
+              }
 
               return params;
             },
             transport: function(params) {
               switch(rcpAjaxState.entity) {
               case 'civicrm_group':
-                CRM.api3('Group', 'get', params.data).then(params.success, params.error);
+                CRM.api3('Group', 'getlist', params.data).then(params.success, params.error);
                 break;
 
               case 'civicrm_mailing':
@@ -255,8 +259,9 @@
                     return obj["api.MailingRecipients.getcount"] > 0 ? {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
                                text: obj.label } : '';
                   }
-                  else if (obj.is_hidden == 0) {
-                    return { id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type, text: obj.title, is_smart: (!_.isEmpty(obj.saved_search_id)) };
+                  else {
+                    return {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type, text: obj.label,
+                              is_smart: (!_.isEmpty(obj.extra.saved_search_id)) };
                   }
                 })
               };

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
@@ -177,7 +177,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
     $group_id_field_html = $form['group_id']['html'];
     $this->assertContains($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should be in listed available groups, but is not.");
     $this->assertContains($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should be in listed available groups, but is not.");
-    $this->assertNotContains($adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains('* ' . $adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
     $this->assertNotContains($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
 
     // Add current user to the test groups.
@@ -199,9 +199,9 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
 
     $form = CRM_Core_Smarty::singleton()->get_template_vars('form');
     $group_id_field_html = $form['group_id']['html'];
-    $this->assertNotContains($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains('* ' . $publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should not be in listed available groups, but is.");
     $this->assertNotContains($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should not be in listed available groups, but is.");
-    $this->assertNotContains($adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains('* ' . $adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
     $this->assertNotContains($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently, there is no way to tell which group is smart or regular group from UI. It would be ideal to use icon against such smart group options to differentiate them from regular ones. This patch appends an icon against smart group option of the select2 widget 

https://lab.civicrm.org/dev/core/-/issues/785

Before
----------------------------------------
<img width="250" alt="Screen Shot 2019-04-04 at 5 54 08 PM" src="https://user-images.githubusercontent.com/3735621/55555351-b6352c80-5702-11e9-83ba-fbb7ced8cd58.png">

<img width="268" alt="Screen Shot 2019-04-04 at 5 46 34 PM" src="https://user-images.githubusercontent.com/3735621/55555423-e250ad80-5702-11e9-9290-15f387db713c.png">



After
----------------------------------------
<img width="219" alt="Screen Shot 2019-04-04 at 5 42 38 PM" src="https://user-images.githubusercontent.com/3735621/55554749-3064b180-5701-11e9-8325-61099940f39e.png">
<img width="239" alt="Screen Shot 2019-04-04 at 5 43 13 PM" src="https://user-images.githubusercontent.com/3735621/55555774-a79b4500-5703-11e9-9944-41137c5f7032.png">




Comments
----------------------------------------
ping @colemanw @lcdservices 