### PR TITLE
dev/drupal#63 Drupal8: override setMessage(), because drupal_set_message is deprecated

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -635,6 +635,16 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function setMessage($message) {
+    // CiviCRM sometimes includes markup in messages (ex: Event Cart)
+    // it needs to be rendered before being displayed.
+    $message = \Drupal\Core\Render\Markup::create($message);
+    \Drupal::messenger()->addMessage($message);
+  }
+
+  /**
    * Drupal 8 has a different function to get current path, hence
    * overriding the postURL function
    *


### PR DESCRIPTION
When using the CiviCRM Event Cart in Drupal8, some status messages display HTML to the user.

This PR fixes two things:

- It renders the markup before displaying it.
- it uses the Messenger service, because `drupal_set_message` is deprecated since Drupal 8.5.x (2017) https://www.drupal.org/node/2774931

ping @dsnopek @MegaphoneJon 

https://lab.civicrm.org/dev/drupal/issues/63