### PR TITLE
Allow extensions to enable validate.tpl

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -415,5 +415,9 @@
 {/if}
 
 {* jQuery validate *}
-{* disabled because more work needs to be done to conditionally require credit card fields *}
-{*include file="CRM/Form/validate.tpl"*}
+{* disabled because originally this caused problems with some credit cards.
+Likely it no longer has an problems but allowing conditional
+ inclusion by extensions / payment processors for now in order to add in a conservative way *}
+{if $isJsValidate}
+  {include file="CRM/Form/validate.tpl"}
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Makes it possible for extensions to cause validate to be added.

Validate.tpl provides front end javascript validation. This is a better user experience because the feedback to the user does not involve a slow form refresh. It was added & enabled in the past but caused some processor validation issues. I strongly suspect these would not recur as we handle required processor fields differently now but this provides a conservative way to make it available again. 

Hopefully this is the predecessor to always enabling it.

Before
----------------------------------------
Cannot be enabled via an extension.

After
----------------------------------------
Can be enabled via an extesnion

Technical Details
----------------------------------------
From https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/106
I found that I couldn't enable our validation from the payment processor currently.

It's a bit immature in that our front end presentation is poor,but this allows us to
start improving that

Comments
----------------------------------------
