### PR TITLE
Flush ContributionRecur static cache when flushing processors

### DIFF
--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -134,6 +134,9 @@ class System {
    */
   public function flushProcessors() {
     $this->cache = [];
+    if (isset(\Civi::$statics['CRM_Contribute_BAO_ContributionRecur'])) {
+      unset(\Civi::$statics['CRM_Contribute_BAO_ContributionRecur']);
+    }
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors('all', TRUE);
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors('live', TRUE);
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors('test', TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Ensures a (new) static cache is flushed when creating a processor, mostly useful for unit testing

Before
----------------------------------------
Cache not flushed

After
----------------------------------------
Cache flushed

Technical Details
----------------------------------------
When creating a processor in a unit test it may not be available to use when creating
a recurring in the same test without flushing the static cache here

Comments
----------------------------------------
This hit our WMF unit tests 
