### PR TITLE
Fixed visibility logic on Price field options.

### DIFF
--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -314,10 +314,10 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
         $publicCount++;
       }
     }
-    if ($visibilityOptions[$priceField->visibility_id] == 'public' && $publicCount == 0) {
+    if ($visibilityOptions[$priceField->visibility_id] == 'public' && $publicCount == 0 && $visibilityOptions[$fields['visibility_id']] == 'admin') {
       $errors['visibility_id'] = ts('All other options for this \'Public\' field have \'Admin\' visibility. There should at least be one \'Public\' option, or make the field \'Admin\' only.');
     }
-    elseif ($visibilityOptions[$priceField->visibility_id] == 'admin' && $publicCount > 0) {
+    elseif ($visibilityOptions[$priceField->visibility_id] == 'admin' && $visibilityOptions[$fields['visibility_id']] == 'public') {
       $errors['visibility_id'] = ts('You must choose \'Admin\' visibility for this price option, as it belongs to a field with \'Admin\' visibility.');
     }
 


### PR DESCRIPTION
Steps to reproduce the issue
----------------------------------------

1. Create a new Price Set
2. Add a Price field (Radio) with Visibility: Admin and 2 options.
3. Edit one of the options and change its visibility to Public
4. Add one option to that field with Visibility: Admin

Error is displayed: "You must choose 'Admin' visibility for this price option, as it belongs to a field with 'Admin' visibility.

Expected Behavior
----------------------------------------

1. Public Price field should at  least have one public option.
2. Admin Price field must contain only admin options.

Before
----------------------------------------
The current implementation was doing above checks without considering the new option which is being added. 

After
----------------------------------------
Fixed the implementation and it is now working as expected. 

Comments
----------------------------------------
_Agileware Ref: CIVICRM-1168_
