### PR TITLE
dev/core#852 Provide wysiwyg editor for confirmation email text

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -465,7 +465,7 @@ SELECT  id, html_type
 
     $form->add('select', 'from_email_address', ts('Receipt From'), $form->_fromEmails['from_email_id']);
 
-    $form->add('textarea', 'receipt_text', ts('Confirmation Message'));
+    $form->add('wysiwyg', 'receipt_text', ts('Confirmation Message'));
 
     // Retrieve the name and email of the contact - form will be the TO for receipt email ( only if context is not standalone)
     if ($form->_context != 'standalone') {

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -411,7 +411,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $form->registerRule('emailList', 'callback', 'emailList', 'CRM_Utils_Rule');
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
     $form->addYesNo('is_email_confirm', ts('Send Confirmation Email?'), NULL, NULL, ['onclick' => "return showHideByValue('is_email_confirm','','confirmEmail','block','radio',false);"]);
-    $form->add('textarea', 'confirm_email_text', ts('Text'), $attributes['confirm_email_text']);
+    $form->add('wysiwyg', 'confirm_email_text', ts('Text'), $attributes['confirm_email_text'] + array('class' => 'collapsed', 'preset' => 'civievent'));
     $form->add('text', 'cc_confirm', ts('CC Confirmation To'), CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'cc_confirm'));
     $form->addRule('cc_confirm', ts('Please enter a valid list of comma delimited email addresses'), 'emailList');
     $form->add('text', 'bcc_confirm', ts('BCC Confirmation To'), CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'bcc_confirm'));

--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -97,6 +97,7 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         'honor_block_text',
         'pay_later_text',
         'pay_later_receipt',
+        'receipt_text',
         // This is needed for FROM Email Address configuration. dgg
         'label',
         // This is needed for navigation items urls


### PR DESCRIPTION
Overview
----------------------------------------
Provide wysiwyg editor for confirmation email text for online and offline event registrations
https://civicrm.stackexchange.com/questions/21255/confirmation-email-providing-a-wysiwyg-so-users-can-add-html-ified-content

Before
----------------------------------------
online
![online_before](https://user-images.githubusercontent.com/3455173/55629749-99b3f580-57d1-11e9-85a2-53508641f41f.png)

offline
![offline_before](https://user-images.githubusercontent.com/3455173/55629752-9caee600-57d1-11e9-9d2f-fd63d645b1ae.png)

After
----------------------------------------
online
![online_after](https://user-images.githubusercontent.com/3455173/55629671-62454900-57d1-11e9-8a5b-856a5da386b4.png)

offline
![offline_after](https://user-images.githubusercontent.com/3455173/55629677-65d8d000-57d1-11e9-87fa-21d025acae01.png)

