### PR TITLE
 Fix edge case issue with rendering multiple choice options

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1058,16 +1058,20 @@ class CRM_Utils_Array {
     if (!is_array($array)) {
       return;
     }
-    $keys = array_keys($array, 1);
-    if (count($keys) > 1 ||
-      (count($keys) == 1 &&
-        (current($keys) > 1 ||
-          is_string(current($keys)) ||
-          (current($keys) == 1 && $array[1] == 1) // handle (0 => 4), (1 => 1)
-        )
-      )
-    ) {
-      $array = $keys;
+
+    $hasSequentialKeysStartingWithZero = array_keys($array) === range(0, count($array) - 1);
+    $hasAllValuesAsNumberOne = array_unique(array_values($array)) === ['1'];
+    $hasMoreThanOneElement = count($array) > 1;
+    $isAssociative = !$hasSequentialKeysStartingWithZero || ($hasMoreThanOneElement && $hasAllValuesAsNumberOne);
+
+    if ($isAssociative) {
+      $tempArr = [];
+
+      foreach ($array as $key => $val) {
+        array_push($tempArr, (string)$key);
+      }
+
+      $array = $tempArr;
     }
   }
 

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -367,4 +367,52 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     $this->assertEquals($flat, $expected);
   }
 
+  public function testFormatArrayKeysTransformsAssociativeArrayToSequential() {
+    $tests = [
+      [
+        'object' => [
+          '5' => '1',
+          '1' => '1',
+          '4' => '1'
+        ],
+        'expectation' => ['5', '1', '4']
+      ],
+      [
+        'object' => ['5', '1', '4'],
+        'expectation' => ['5', '1', '4']
+      ],
+      [
+        'object' => ['0', '1'],
+        'expectation' => ['0', '1']
+      ],
+      [
+        'object' => [
+          '0' => '1',
+          '1' => '1'
+        ],
+        'expectation' => ['0', '1']
+      ],
+      [
+        'object' => 'not an array',
+        'expectation' => 'not an array'
+      ],
+      [
+        'object' => [
+          '5' => '1',
+          '1' => '1',
+          '4' => '1',
+          '1' => '1',
+          '4' => '1',
+          '5' => '1',
+          '1' => '1'
+        ],
+        'expectation' => ['5', '1', '4']
+      ],
+    ];
+
+    foreach ($tests as $test) {
+      CRM_Utils_Array::formatArrayKeys($test['object']);
+      $this->assertEquals($test['expectation'], $test['object']);
+    }
+  }
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes an issue with rendering multiple choice options in a comma-separated list. The issue is reproducible **only** in the scenario when:
1) there is an option with ID `1` and it is *not* ordered as the first one in the list.
2) the first option chosen is the one that goes *before* the one with ID `1`. It *must* be selected as a *second* option.
3) the second option chosen is the one with ID `1`.

It does not matter if you have other options chosen as well. Here is an example:

|   | Option name | ID | Order | Comment |
| ------------- | ------------- |------------- |------------- |------------- |
| ☑️ | France | 4 | 0 | One random option before ID = 1 |
|  | Belgium | 2 | 1 | |
| ☑️| England | 1 | 2 | ID = 1, must go second after previous one |
|  | Ireland | 3 | 3 | |
| ☑️| Italy | 5 | 4 | Does not really matter |


Before
----------------------------------------

*Setup (note, England North East has ID=1):*

![image](https://user-images.githubusercontent.com/3973243/55636054-f86d7500-57b9-11e9-83f2-25dede13e24c.png)

![image](https://user-images.githubusercontent.com/3973243/55636217-4edab380-57ba-11e9-9fe1-e6d4feaa6411.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/3973243/55636155-2e125e00-57ba-11e9-86ed-93ec8843746a.png)

Technical Details
----------------------------------------

The problem was inside `CRM/Utils/Array.php` inside `formatArrayKeys` function. It did not handle the following input properly:

```
[
  '5' => '1',
  '1' => '1',
  '4' => '1'
]
```

due to this line:

```
(current($keys) == 1 && $array[1] == 1) // handle (0 => 4), (1 => 1)
```
and returned just `['1']` hence it thought the object above is already a **sequential** array, **not associative** (took all `'1'` values and removed duplicates).

The new solution handles such a case:

```php
public static function formatArrayKeys(&$array) {
  ...

  // below is the logic determines if the array is associative or not
  $hasSequentialKeysStartingWithZero = array_keys($array) === range(0, count($array) - 1);
  $hasAllValuesAsNumberOne = array_unique(array_values($array)) === ['1'];
  $hasMoreThanOneElement = count($array) > 1;
  $isAssociative = !$hasSequentialKeysStartingWithZero || ($hasMoreThanOneElement && $hasAllValuesAsNumberOne);

  if ($isAssociative) {
    $tempArr = [];

    foreach ($array as $key => $val) {
      array_push($tempArr, (string)$key);
    }

    $array = $tempArr;
  }
}
```

Tests
----------------------------------------
New unit tests are added. The `formatArrayKeys` function is now covered. The new tests fail only one assertion with the previous implementation and pass all with the current one.

### Before

![image](https://user-images.githubusercontent.com/3973243/55636901-cceb8a00-57bb-11e9-9b35-063af2bdf95a.png)

### After

![image](https://user-images.githubusercontent.com/3973243/55637182-5f8c2900-57bc-11e9-9167-15b15caf86d5.png)

### Important

Some tests are currently failing on `master`:

```sh
➜  civicrm git:(master) env CIVICRM_UF=UnitTests phpunit4 ./tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
PHPUnit 4.8.21 by Sebastian Bergmann and contributors.

.
Installing civiclean2_bkq2u database
.........F.F.EF.

Time: 10.17 seconds, Memory: 61.75Mb

There was 1 error:

1) CRM_Core_BAO_SchemaHandlerTest::testReconcileMissingIndices
Exception: PEAR_Exception: "DB Error: not found"
 * ERROR TYPE: DB_Error
 * ERROR CODE: -4
 * ERROR MESSAGE: DB Error: not found
 * ERROR MODE: 16
 * ERROR USERINFO: ALTER TABLE civicrm_contact DROP INDEX index_sort_name [nativecode=1091 ** Can't DROP 'index_sort_name'; check that column/key exists]
 * ERROR DEBUGINFO: ALTER TABLE civicrm_contact DROP INDEX index_sort_name [nativecode=1091 ** Can't DROP 'index_sort_name'; check that column/key exists]
#0 [internal function](): CRM_Core_Error::exceptionHandler(Object(DB_Error))
```

