### PR TITLE
Alternate fix for various crashes on upgrades with native extensions

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -271,13 +271,22 @@ class CRM_Extension_Mapper {
    *
    * @param bool $fresh
    *   whether to forcibly reload extensions list from canonical store.
+   * @param bool $ignoreUpgradeMode
+   *   Should we load all, regardless of whether the site is in upgrade mode?.
+   *   For native extensions we don't load them into the list during upgrade. For historical reasons native CMS
+   *   modules ARE loaded. During the last part of the upgrade we desperately need extensions to be enabled (and
+   *   the CMS modules).
+   *   to ensure settings keep working and triggers and log tables are rebuild correctly.
+   *   This allows us to force it to reload the extension list after upgrade.
+   *   For more discussion see https://github.com/civicrm/civicrm-core/pull/13551.
+   *
    * @return array
    *   array(array('prefix' => $, 'file' => $))
    */
-  public function getActiveModuleFiles($fresh = FALSE) {
+  public function getActiveModuleFiles($fresh = FALSE, $ignoreUpgradeMode = FALSE) {
     $config = CRM_Core_Config::singleton();
-    if ($config->isUpgradeMode() || !defined('CIVICRM_DSN')) {
-      return []; // hmm, ok
+    if (($config->isUpgradeMode() && !$ignoreUpgradeMode)|| !defined('CIVICRM_DSN')) {
+      return [];
     }
 
     $moduleExtensions = NULL;

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -765,6 +765,9 @@ SET    version = '$version'
   }
 
   public static function doFinish() {
+    // Reload extensions as native extensions are excluded during upgrade mode.
+    $mapper = CRM_Extension_System::singleton()->getMapper();
+    $mapper->getActiveModuleFiles(TRUE, TRUE);
     $upgrade = new CRM_Upgrade_Form();
     list($ignore, $latestVer) = $upgrade->getUpgradeVersions();
     // Seems extraneous in context, but we'll preserve old behavior


### PR DESCRIPTION
Overview
----------------------------------------
This is an alternate fix for this https://github.com/civicrm/civicrm-core/pull/13551
intended to prevent crashes on upgrade due to alterLogTables not being run or bugs after
upgrade due to settings data being wrong or triggers being missing.

Before
----------------------------------------
CMS module hooks respected on upgrade but extension hooks ignored - leading to various problems

After
----------------------------------------
CMS hooks respected during upgrade. Extension hooks ALSO respected during the final doFinish - which is the source of known hook related upgrade issues

Technical Details
----------------------------------------
@totten this is an alternative to 
https://github.com/civicrm/civicrm-core/pull/13551

My instincts are still in favour of #13551 but this is more conservative I guess

Comments
----------------------------------------

