### PR TITLE
dev/core#846 Rationalise loading of payment processor across the 3 update forms

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -35,7 +35,6 @@
  * This class provides support for canceling recurring subscriptions.
  */
 class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_ContributionRecur {
-  protected $_paymentProcessorObj = NULL;
 
   protected $_userContext = NULL;
 
@@ -49,7 +48,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
   public function preProcess() {
     parent::preProcess();
     if ($this->_crid) {
-      $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_crid, 'recur', 'obj');
       $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_crid);
       $this->assign('frequency_unit', $this->_subscriptionDetails->frequency_unit);
       $this->assign('frequency_interval', $this->_subscriptionDetails->frequency_interval);

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -62,6 +62,21 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   protected $_mid = NULL;
 
   /**
+   * Payment processor object.
+   *
+   * @var \CRM_Core_Payment
+   */
+  protected $_paymentProcessorObj = NULL;
+
+  /**
+   * @var array
+   *
+   * Current payment processor including a copy of the object in 'object' key for
+   * legacy reasons.
+   */
+  public $_paymentProcessor = [];
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -83,6 +98,23 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
     $this->_crid = CRM_Utils_Request::retrieve('crid', 'Integer', $this, FALSE);
     $this->contributionRecurID = $this->_crid;
     $this->_coid = CRM_Utils_Request::retrieve('coid', 'Integer', $this, FALSE);
+    $this->setPaymentProcessor();
+  }
+
+  /**
+   * Set the payment processor object up.
+   *
+   * This is a function that needs to be better consolidated between the inheriting forms
+   * but this is good choice of function to call.
+   */
+  protected function setPaymentProcessor() {
+    if ($this->_crid) {
+      $this->_paymentProcessor = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessor($this->contributionRecurID);
+      if (!$this->_paymentProcessor) {
+        CRM_Core_Error::statusBounce(ts('There is no valid processor for this subscription so it cannot be updated'));
+      }
+      $this->_paymentProcessorObj = $this->_paymentProcessor['object'];
+    }
   }
 
 }

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -44,18 +44,11 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
   public $_bltID = NULL;
 
   /**
-   * @var array current payment processor including a copy of the object in 'object' key
-   */
-  public $_paymentProcessor = array();
-
-  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
     parent::preProcess();
     if ($this->_crid) {
-      $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_crid, 'recur', 'info');
-      $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_crid, 'recur', 'obj');
       $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_crid);
 
       // Are we cancelling a recurring contribution that is linked to an auto-renew membership?

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -72,15 +72,6 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     $this->setAction(CRM_Core_Action::UPDATE);
 
     if ($this->contributionRecurID) {
-      try {
-        $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($this->contributionRecurID);
-      }
-      catch (CRM_Core_Exception $e) {
-        CRM_Core_Error::statusBounce(ts('There is no valid processor for this subscription so it cannot be edited.'));
-      }
-      catch (CiviCRM_API3_Exception $e) {
-        CRM_Core_Error::statusBounce(ts('There is no valid processor for this subscription so it cannot be edited.'));
-      }
       $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->contributionRecurID);
     }
 

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -632,6 +632,7 @@ abstract class CRM_Core_Payment {
     if ($this->supports('changeSubscriptionAmount')) {
       return ['amount'];
     }
+    return [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Standardise the way in which the payment processor is loaded in the 3 forms that update subscriptions

Before
----------------------------------------
3 different ways, using function we are looking to deprecate

After
----------------------------------------
Stdised way

Technical Details
----------------------------------------
This only covers when the crid is in the URL since we have an existing better fn for that
& it's easy to test.

Comments
----------------------------------------
@mattwire ping
