### PR TITLE
dev/core#830 Expose cancel_reason field by cleaning up the cancel template to use entity field template

### DIFF
--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -108,6 +108,15 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   }
 
   /**
+   * Get the entity id being edited.
+   *
+   * @return int|null
+   */
+  public function getEntityId() {
+    return $this->contributionRecurID;
+  }
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -88,6 +88,15 @@ trait CRM_Core_Form_EntityFormTrait {
   }
 
   /**
+   * Should custom data be suppressed on this form.
+   *
+   * @return bool
+   */
+  protected function isSuppressCustomData() {
+    return FALSE;
+  }
+
+  /**
    * Get the entity subtype ID being edited
    *
    * @param $subTypeId
@@ -105,6 +114,9 @@ trait CRM_Core_Form_EntityFormTrait {
    * If the custom data is in the submitted data (eg. added via ajax loaded form) add to form.
    */
   public function addCustomDataToForm() {
+    if ($this->isSuppressCustomData()) {
+      return TRUE;
+    }
     $customisableEntities = CRM_Core_SelectValues::customGroupExtends();
     if (isset($customisableEntities[$this->getDefaultEntity()])) {
       CRM_Custom_Form_CustomData::addToForm($this);

--- a/templates/CRM/Contribute/Form/CancelSubscription.tpl
+++ b/templates/CRM/Contribute/Form/CancelSubscription.tpl
@@ -42,17 +42,5 @@
     </div>
   {/if}
 </div>
-{if !$self_service}
-<table class="form-layout">
-   <tr>
-      <td class="label">{$form.send_cancel_request.label}</td>
-      <td class="html-adjust">{$form.send_cancel_request.html}</td>
-   </tr>
-   <tr>
-      <td class="label">{$form.is_notify.label}</td>
-      <td class="html-adjust">{$form.is_notify.html}</td>
-   </tr>
-</table>
-{/if}
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+  {include file="CRM/Core/Form/EntityForm.tpl"}
 </div>

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -47,6 +47,7 @@
             <tr><td class="label">{ts}Created Date{/ts}</td><td>{$recur.create_date|crmDate}</td></tr>
             {if $recur.modified_date}<tr><td class="label">{ts}Modified Date{/ts}</td><td>{$recur.modified_date|crmDate}</td></tr>{/if}
             {if $recur.cancel_date}<tr><td class="label">{ts}Cancelled Date{/ts}</td><td>{$recur.cancel_date|crmDate}</td></tr>{/if}
+            {if $recur.cancel_reason}<tr><td class="label">{ts}Cancel Reason{/ts}</td><td>{$recur.cancel_reason}</td></tr>{/if}
             {if $recur.end_date}<tr><td class="label">{ts}End Date{/ts}</td><td>{$recur.end_date|crmDate}</td></tr>{/if}
             {if $recur.processor_id}<tr><td class="label">{ts}Processor ID{/ts}</td><td>{$recur.processor_id}</td></tr>{/if}
             <tr><td class="label">{ts}Transaction ID{/ts}</td><td>{$recur.trxn_id}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
Add cancel reason field to form to cancel recurring contributions

Before
----------------------------------------
![Screenshot 2019-04-08 14 18 11](https://user-images.githubusercontent.com/336308/55694641-285e8780-5a09-11e9-90d8-8c5983cc0e79.png)

As seen by a back-office user
![Screen Shot 2019-04-25 at 4 17 13 PM](https://user-images.githubusercontent.com/336308/56709483-ae9efb80-6775-11e9-83ac-c137794c1a89.png)


After
----------------------------------------
As seen by a back-office user
![Screen Shot 2019-04-25 at 4 03 25 PM](https://user-images.githubusercontent.com/336308/56709112-b52c7380-6773-11e9-9cc7-439faeebbb07.png)



As seen by a 'self service' user - ie someone without edit contributions permission
![Screen Shot 2019-04-25 at 4 01 06 PM](https://user-images.githubusercontent.com/336308/56709065-6f6fab00-6773-11e9-9357-a03c75237b85.png)

Exposed on view form
![Screen Shot 2019-04-25 at 4 13 51 PM](https://user-images.githubusercontent.com/336308/56709489-b5c60980-6775-11e9-89f8-e30fcfbdbf86.png)




Technical Details
----------------------------------------
Needed https://github.com/civicrm/civicrm-core/pull/13993 to be merged first

----------------------------------------

@mattwire I think this will conclude this round of cleanup on the recurring forms for me - we now have a shared parent for the 3 forms using the entity form. Ideally more of that subscription wrangling would be moved to the shared parent in a later round but this takes us forwards in terms of code quality / use of metadata. 

I'm going to look a bit more at the search side of it though before closing this piece of work