### PR TITLE
PHP warnings on Case Dashboard and Find Cases

### DIFF
--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -301,7 +301,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
    *
    * @return array|bool
    */
-  public static function formRule($fields) {
+  public static function formRule($fields, $files, $form) {
     $errors = [];
 
     if (!empty($errors)) {


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/13746 adds a formRule() to CRM_Core_Form_Search, but CRM_Case_Form_Search is derived from that class and already has one that doesn't match.

Before
----------------------------------------
Warning: Declaration of CRM_Case_Form_Search::formRule($fields) should be compatible with CRM_Core_Form_Search::formRule($fields, $files, $form) in require_once() (line 37 of CRM\Case\Form\Search.php).

After
----------------------------------------
All good.
