### PR TITLE
Add unit test for api ContributionRecur.cancel, add support for cancel_reason

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -258,14 +258,19 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
   /**
    * Cancel Recurring contribution.
    *
-   * @param int $recurId
-   *   Recur contribution id.
+   * @param array $params
+   *   Recur contribution params
    *
    * @param array $activityParams
    *
    * @return bool
    */
-  public static function cancelRecurContribution($recurId, $activityParams = []) {
+  public static function cancelRecurContribution($params, $activityParams = []) {
+    if (is_int($params)) {
+      CRM_Core_Error::deprecatedFunctionWarning('You are using a BAO function whose signature has changed. Please use the ContributionRecur.cancel api');
+      $params = ['id' => $params];
+    }
+    $recurId = $params['id'];
     if (!$recurId) {
       return FALSE;
     }
@@ -282,6 +287,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $recur->start_date = CRM_Utils_Date::isoToMysql($recur->start_date);
       $recur->create_date = CRM_Utils_Date::isoToMysql($recur->create_date);
       $recur->modified_date = CRM_Utils_Date::isoToMysql($recur->modified_date);
+      $recur->cancel_reason = CRM_Utils_Array::value('cancel_reason', $params);
       $recur->cancel_date = date('YmdHis');
       $recur->save();
 

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -213,7 +213,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
           'details' => $message,
         ];
       $cancelStatus = CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(
-        $this->_subscriptionDetails->recur_id,
+        ['id' => $this->_subscriptionDetails->recur_id],
         $activityParams
       );
 

--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -84,8 +84,23 @@ function civicrm_api3_contribution_recur_get($params) {
  *   returns true is successfully cancelled
  */
 function civicrm_api3_contribution_recur_cancel($params) {
-  civicrm_api3_verify_one_mandatory($params, NULL, ['id']);
-  return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params['id']) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
+  return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
+}
+
+/**
+ * Adjust Metadata for Cancel action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_contribution_recur_cancel_spec(&$params) {
+  $params['id'] = [
+    'title' => ts('Contribution Recur ID'),
+    'api.required' => TRUE,
+    'type' => CRM_Utils_Type::T_INT,
+  ];
 }
 
 /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -90,7 +90,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    */
   public function testCancelRecur() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
-    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($contributionRecur['id']);
+    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(['id' => $contributionRecur['id']]);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -100,4 +100,16 @@ class api_v3_ContributionRecurTest extends CiviUnitTestCase {
     $this->assertEquals(12, $result['values']['start_date']['type']);
   }
 
+  /**
+   * Test that we can cancel a contribution and add a cancel_reason via the api.
+   */
+  public function testContributionRecurCancel() {
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
+    $this->callAPISuccess('ContributionRecur', 'cancel', ['id' => $result['id'], 'cancel_reason' => 'just cos']);
+    $cancelled = $this->callAPISuccess('ContributionRecur', 'getsingle', ['id' => $result['id']]);
+    $this->assertEquals('just cos', $cancelled['cancel_reason']);
+    $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Cancelled'), $cancelled['contribution_status_id']);
+    $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($cancelled['cancel_date'])));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Updates ContributionRecur.cancel to accept cancel_reason as a field. Starts process of tidy up and adding unit tests

Before
----------------------------------------
civicrm_api3('ContributionRecur', 'cancel', ['id' => 5, 'cancel_reason' => 'general annoyance']);

Does not result in reason being saved

After
----------------------------------------
civicrm_api3('ContributionRecur', 'cancel', ['id' => 5, 'cancel_reason' => 'general annoyance']);

Does t result in reason being saved

Technical Details
----------------------------------------
The cancelRecurContribution function is called from 2 places in the code - the api & a form. It needs a clean up since it bypasses hooks & I think the right answer is to switch over to using the api but until this there is no test on the api. I'm adding this & then I'll look to do some follow up cleanup

Comments
----------------------------------------

