### PR TITLE
Add unit testing for activity creation when cancelling a recurring, related cleanup

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -207,15 +207,8 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
       CRM_Core_Error::displaySessionError($cancelSubscription);
     }
     elseif ($cancelSubscription) {
-      $activityParams
-        = [
-          'subject' => $this->_mid ? ts('Auto-renewal membership cancelled') : ts('Recurring contribution cancelled'),
-          'details' => $message,
-        ];
       $cancelStatus = CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(
-        ['id' => $this->_subscriptionDetails->recur_id],
-        $activityParams
-      );
+        ['id' => $this->_subscriptionDetails->recur_id, 'membership_id' => $this->_mid, 'processor_message' => $message]);
 
       if ($cancelStatus) {
         $tplParams = [];


### PR DESCRIPTION
Overview
----------------------------------------
Unit testing & cleanup around cancelling a recurring contribution 

Before
----------------------------------------
Less testing

After
----------------------------------------
More testing

Technical Details
----------------------------------------
This is preliminary cleanup on supporting the new cancel_reason field on the form

Comments
----------------------------------------
