### PR TITLE
dev/core#856 - update case role on editing rel type name

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -630,6 +630,31 @@ AND        a.is_deleted = 0
   }
 
   /**
+   * Update role name after relationship is edited.
+   *
+   * @param string $prevName
+   * @param string $updatedName
+   */
+  public function updateCaseRoleNames($prevName, $updatedName) {
+    $repo = new CRM_Case_XMLRepository();
+    foreach ($repo->getAllCaseTypes() as $caseId => $caseTypeName) {
+      $caseTypeXML = $repo->retrieve($caseTypeName);
+      if (in_array($prevName, $this->getDeclaredRelationshipTypes($caseTypeXML))) {
+        foreach ($caseTypeXML->CaseRoles->RelationshipType as $relType) {
+          if ($relType->name == $prevName) {
+            $relType->name = $updatedName;
+          }
+        }
+        $updateParams = [
+          'id' => $caseId,
+          'definition' => CRM_Case_BAO_CaseType::convertXmlToDefinition($caseTypeXML),
+        ];
+        CRM_Case_BAO_CaseType::create($updateParams);
+      }
+    }
+  }
+
+  /**
    * Returns the default assignee for the activity by searching for the target's
    * contact relationship type defined in the activity's details.
    *

--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -100,6 +100,9 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
         $params['name_b_a'] = $params['label_b_a'];
       }
     }
+    else {
+      $previousLabelBA = CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', $params['id'], 'label_b_a');
+    }
 
     // action is taken depending upon the mode
     $relationshipType = new CRM_Contact_DAO_RelationshipType();
@@ -109,6 +112,12 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
 
     $relationshipType->copyValues($params);
     $relationshipType->save();
+
+    //Update case roles definition if label is changed.
+    if (!empty($previousLabelBA) && !empty($params['label_b_a']) && $previousLabelBA != $params['label_b_a']) {
+      $xmlProcessor = new CRM_Case_XMLProcessor_Process();
+      $xmlProcessor->updateCaseRoleNames($previousLabelBA, $params['label_b_a']);
+    }
 
     CRM_Utils_Hook::post($hook, 'RelationshipType', $relationshipType->id, $relationshipType);
 

--- a/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
@@ -144,6 +144,41 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
 
   /**
    * @param string $fixtureName
+   * @param string $expectedJson
+   * @param string $inputXml
+   * @dataProvider definitionProvider
+   */
+  public function testUpdateCaseRoleName($fixtureName, $expectedJson, $inputXml) {
+    if ($fixtureName == 'one-item-in-each') {
+      $xml = simplexml_load_string($inputXml);
+      $actualDefinition = CRM_Case_BAO_CaseType::convertXmlToDefinition($xml);
+      $relType = $this->callAPISuccess('RelationshipType', 'create', [
+        'name_a_b' => "First role",
+        'name_b_a' => "First role",
+      ]);
+
+      //Add case type with the definition.
+      $this->callAPISuccess('CaseType', 'create', [
+        'name' => "test_case",
+        'title' => "Test Case",
+        'is_active' => 1,
+        'definition' => $actualDefinition,
+      ]);
+
+      //Update relationship type name.
+      $this->callAPISuccess('RelationshipType', 'create', [
+        'id' => $relType['id'],
+        'label_b_a' => "Edited First role",
+      ]);
+
+      //Check if rel type is correctly updated on case role.
+      $caseTypeDef = CRM_Case_XMLRepository::singleton()->retrieve('test_case');
+      $this->assertEquals("Edited First role", $caseTypeDef->CaseRoles->RelationshipType->name);
+    }
+  }
+
+  /**
+   * @param string $fixtureName
    * @param string $inputJson
    * @param string $expectedXml
    * @dataProvider definitionProvider


### PR DESCRIPTION
Overview
----------------------------------------
update case role on editing relationship type name

Before
----------------------------------------
If a rel type name is updated through UI, the name is not reflected in case type screen.

To reproduce -
- Create a case type with some roles.
- Edit the rel type name b_a from inline edit or from relationship edit form.

![image](https://user-images.githubusercontent.com/5929648/55726337-30c8b980-5a2d-11e9-8a52-a55158895291.png)

- Save.

![image](https://user-images.githubusercontent.com/5929648/55726354-3aeab800-5a2d-11e9-8431-04bfbd4ad4f1.png)

Case type screen still shows the previous name in roles tab.

After
----------------------------------------
Case Role name is updated.

![image](https://user-images.githubusercontent.com/5929648/55726401-5786f000-5a2d-11e9-90e5-f6c05ac2edc0.png)

Comments
----------------------------------------

Added unit test

Gitlab - https://lab.civicrm.org/dev/core/issues/856