### PR TITLE
Menu config screen improvements

### DIFF
--- a/CRM/Admin/Form/Navigation.php
+++ b/CRM/Admin/Form/Navigation.php
@@ -73,10 +73,10 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
 
     $permissions = [];
     foreach (CRM_Core_Permission::basicPermissions(TRUE, TRUE) as $id => $vals) {
-      $permissions[] = ['id' => $id, 'label' => $vals[0], 'description' => (array) CRM_Utils_Array::value(1, $vals)];
+      $permissions[] = ['id' => $id, 'text' => $vals[0], 'description' => (array) CRM_Utils_Array::value(1, $vals)];
     }
-    $this->add('text', 'permission', ts('Permission'),
-      ['placeholder' => ts('Unrestricted'), 'class' => 'huge', 'data-select-params' => json_encode(['data' => ['results' => $permissions, 'text' => 'label']])]
+    $this->add('select2', 'permission', ts('Permission'), $permissions, FALSE,
+      ['placeholder' => ts('Unrestricted'), 'class' => 'huge', 'multiple' => TRUE]
     );
 
     $operators = ['AND' => ts('AND'), 'OR' => ts('OR')];
@@ -122,6 +122,10 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
 
     // its ok if there is no element called is_active
     $defaults['is_active'] = ($this->_id) ? $this->_defaults['is_active'] : 1;
+
+    if (!empty($defaults['icon'])) {
+      $defaults['icon'] = trim(str_replace('crm-i', '', $defaults['icon']));
+    }
 
     return $defaults;
   }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -389,7 +389,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if ($inputType == 'select2') {
       $type = 'text';
       $options = $attributes;
-      $attributes = $attributes = ($extra ? $extra : []) + ['class' => ''];
+      $attributes = ($extra ? $extra : []) + ['class' => ''];
       $attributes['class'] = ltrim($attributes['class'] . " crm-select2 crm-form-select2");
       $attributes['data-select-params'] = json_encode(['data' => $options, 'multiple' => !empty($attributes['multiple'])]);
       unset($attributes['multiple']);

--- a/templates/CRM/Admin/Form/Navigation.tpl
+++ b/templates/CRM/Admin/Form/Navigation.tpl
@@ -66,12 +66,7 @@
       .on('change', function() {
         $('span.permission_operator_wrapper').toggle(CRM._.includes($(this).val(), ','));
       })
-      .change()
-      .crmSelect2({
-        formatResult: CRM.utils.formatSelect2Result,
-        formatSelection: function(row) {return row.label},
-        multiple: true
-      });
+      .change();
   });
 </script>
 {/literal}

--- a/templates/CRM/Admin/Page/Navigation.hlp
+++ b/templates/CRM/Admin/Page/Navigation.hlp
@@ -40,5 +40,5 @@
   <li>{ts}Change the permissions for a menu item. Right-click and select 'Edit'.{/ts}</li>
   <li>{ts}Re-order menu items (including moving them from one branch of the menu 'tree' to another. Simply use your mouse to 'drag and drop' the menu item to the new location.{/ts}</li>
 </ul>
-<p><em>{ts}Changes you make to the menu are saved immediately. However, you will need reload this page to see your changes in the menu bar above.{/ts}</em></p>
+<p><em>{ts}Changes you make to the menu are saved immediately.{/ts}</em></p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Live-updates to the menubar when adding/editing menu items on the admin screen.
Adds links to related settings pages to reduce confusion about how to configure various aspects of the menubar.
Fixes broken icon picker and missing Civi icon.

Before
----------------------------------------
- Missing Civi icon
- Broken icon picker for menu items.
- Yellow alert appears with a "refresh page" link.
- No links to related menu settings.

![image](https://user-images.githubusercontent.com/2874912/55754159-f86bb000-5a19-11e9-8920-fdcc03756a2d.png)


After
----------------------------------------
- Fixed Civi icon
- Fixed menu item icon picker
- Live refresh of menubar, no need for yellow alert.
- Added some links to related settings.

![image](https://user-images.githubusercontent.com/2874912/55754006-b2165100-5a19-11e9-97e4-85764654c9bb.png)
