### PR TITLE
Remove CIVICRM_TEMP_FORCE_UTF8; deprecate TempTable::setUtf8()

### DIFF
--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -147,7 +147,7 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
   }
 
   public function buildTempTable() {
-    $table = CRM_Utils_SQL_TempTable::build()->setCategory('custom')->setMemory()->setUtf8();
+    $table = CRM_Utils_SQL_TempTable::build()->setCategory('custom')->setMemory();
     $this->_tableName = $table->getName();
 
     $this->_tableFields = [
@@ -211,7 +211,7 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
 ";
     $table->createWithColumns($sql);
 
-    $entityIdTable = CRM_Utils_SQL_TempTable::build()->setCategory('custom')->setMemory()->setUtf8();
+    $entityIdTable = CRM_Utils_SQL_TempTable::build()->setCategory('custom')->setMemory();
     $this->_entityIDTableName = $entityIdTable->getName();
     $sql = "
   id int unsigned NOT NULL AUTO_INCREMENT,

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -153,7 +153,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     $form->assign('taskName', CRM_Utils_Array::value($form->_task, $crmContactTaskTasks));
 
     if ($useTable) {
-      $tempTable = CRM_Utils_SQL_TempTable::build()->setCategory('tskact')->setDurable()->setId($qfKey)->setUtf8();
+      $tempTable = CRM_Utils_SQL_TempTable::build()->setCategory('tskact')->setDurable()->setId($qfKey);
       $form->_componentTable = $tempTable->getName();
       $tempTable->drop();
       $tempTable->createWithColumns('contact_id int primary key');

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -652,7 +652,7 @@ VALUES $sqlValueString
    */
   public static function createTempTable($sqlColumns) {
     //creating a temporary table for the search result that need be exported
-    $exportTempTable = CRM_Utils_SQL_TempTable::build()->setDurable()->setCategory('export')->setUtf8();
+    $exportTempTable = CRM_Utils_SQL_TempTable::build()->setDurable()->setCategory('export');
 
     // also create the sql table
     $exportTempTable->drop();

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1164,7 +1164,7 @@ class CRM_Report_Form extends CRM_Core_Form {
    * @return string
    */
   public function createTemporaryTable($identifier, $sql, $isColumns = FALSE, $isMemory = FALSE) {
-    $tempTable = CRM_Utils_SQL_TempTable::build()->setUtf8();
+    $tempTable = CRM_Utils_SQL_TempTable::build();
     if ($isMemory) {
       $tempTable->setMemory();
     }

--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -54,7 +54,7 @@
  *
  * Example 3: Create an empty temp table with list of columns.
  *
- * $tmpTbl = CRM_Utils_SQL_TempTable::build()->setDurable()->setUtf8()->createWithColumns('id int(10, name varchar(64)');
+ * $tmpTbl = CRM_Utils_SQL_TempTable::build()->setDurable()->createWithColumns('id int(10, name varchar(64)');
  *
  * Example 4: Drop a table that you previously created.
  *
@@ -105,8 +105,7 @@ class CRM_Utils_SQL_TempTable {
     $t->id = md5(uniqid('', TRUE));
     // The constant CIVICRM_TEMP_FORCE_DURABLE is for local debugging.
     $t->durable = CRM_Utils_Constant::value('CIVICRM_TEMP_FORCE_DURABLE', FALSE);
-    // @deprecated This constant is deprecated and will be removed.
-    $t->utf8 = CRM_Utils_Constant::value('CIVICRM_TEMP_FORCE_UTF8', TRUE);
+    $t->utf8 = TRUE;
     $t->autodrop = FALSE;
     $t->memory = FALSE;
     return $t;
@@ -319,7 +318,9 @@ class CRM_Utils_SQL_TempTable {
   /**
    * Set table collation to UTF8.
    *
-   * This would make sense as a default but cautiousness during phasing in has made it opt-in.
+   * @deprecated This method is deprecated as tables should be assumed to have
+   * UTF-8 as the default character set and collation; some other character set
+   * or collation may be specified in the column definition.
    *
    * @param bool $value
    *


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup for #13658 to
- Remove the CIVICRM_TEMP_FORCE_UTF8 constant; and
- Deprecate the TempTable::setUtf8() method as tables should be assumed to use UTF-8 as default character set and collation (but may define columns to use some other character set and/or collation).

After
----------------------------------------
- Setting CIVICRM_TEMP_FORCE_UTF8 would have no effect. All instances would be assumed to have UTF-8 as the default character set and collation for temporary tables.
- TempTable::setUtf8(FALSE) could still be called, but this would be deprecated / discouraged, because the resulting default character set and collation is undefined (depends on the database default character set and collation).  Tables that need to use a specific character set or collation should specify this in the column definition.