### PR TITLE
Include lower level data when throwing an exception on payment processor.pay

### DIFF
--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -122,12 +122,23 @@ function _civicrm_api3_payment_processor_getlist_defaults(&$request) {
  *
  * @return array
  *   API result array.
- * @throws CiviCRM_API3_Exception
+ *
+ * @throws \API_Exception
  */
 function civicrm_api3_payment_processor_pay($params) {
   $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
   $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', ['id' => $params['payment_processor_id']]));
-  $result = $processor->doPayment($params);
+  try {
+    $result = $processor->doPayment($params);
+  }
+  catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+    $code = $e->getErrorCode();
+    $errorData = $e->getErrorData();
+    if (empty($code)) {
+      $code = 'EXTERNAL_FAILURE';
+    }
+    throw new API_Exception('Payment failed', $code, $errorData, $e);
+  }
   return civicrm_api3_create_success(array($result), $params);
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
5.13 includes PaymentProcessor.pay api  - it's been pointed out we can do a better job of passing errors back up the chain

Before
----------------------------------------
Error code & message swallowed

After
----------------------------------------
Error code & message set

Technical Details
----------------------------------------


Comments
----------------------------------------

