### PR TITLE
(REF) CRM_Core_Resources - Move hook declaration from addCoreResources() to Container.php

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -582,7 +582,6 @@ class CRM_Core_Resources {
    * @return CRM_Core_Resources
    */
   public function addCoreResources($region = 'html-header') {
-    Civi::dispatcher()->addListener('hook_civicrm_buildAsset', [$this, 'renderMenubarStylesheet']);
     if (!isset($this->addedCoreResources[$region]) && !self::isAjaxMode()) {
       $this->addedCoreResources[$region] = TRUE;
       $config = CRM_Core_Config::singleton();

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -320,6 +320,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\Civi\Angular\Page\Modules', 'buildAngularModules']);
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Utils_VisualBundle', 'buildAssetJs']);
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Utils_VisualBundle', 'buildAssetCss']);
+    $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Core_Resources', 'renderMenubarStylesheet']);
     $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
     $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);
     $dispatcher->addListener('civi.dao.postDelete', ['\CRM_Core_BAO_RecurringEntity', 'triggerDelete']);


### PR DESCRIPTION
Overview
----------------------------------------
It's easier to declare `hook_civicrm_buildAsset` listeners at a high-level.

Before
----------------------------------------
Hook listener declared in-situ (near where it's *typically* used)

After
----------------------------------------
Hook listener declared in central way (so it's *always* defined).

Technical Details
----------------------------------------
Asset building can use two modes -- production mode writes a static file to disk upfront (when the file is being referenced).  Debug mode just generates a URL for a web-service (which in turn dynamically renders the content in a separate page-view).

If the only mode were production mode, then the previous code would be on pretty solid ground.  We could even simplify things a lot by changing the AssetBuilder contract to replace the hooks with callbacks, as in:

```php
Civi::service('asset_builder')->getUrl('crm-menu.css', function() {
  return '...the css code...';
});
```

Why have a hook?  Because hooks are generally context-free and always-available.  If we use debug-mode (or if we add a feature to warm-up the caches during deployment), then we'll want to fire that hook from a different context (e.g.  web-service or CLI), and the hook-listener needs to be available in those other contexts.

It would be nice if we could declare hooks generally without needing to edit the `Container.php` mega-file (e.g.  maybe some kind of annotation).  But, for the moment, I think this is the best spot that we have in `civicrm-core` for ensuring that hook listeners are fully/consistently registered.
