### PR TITLE
Improve flushing after creating a processor so it can be used for a recurring in the same run

### DIFF
--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -137,6 +137,8 @@ class System {
     if (isset(\Civi::$statics['CRM_Contribute_BAO_ContributionRecur'])) {
       unset(\Civi::$statics['CRM_Contribute_BAO_ContributionRecur']);
     }
+    \CRM_Core_PseudoConstant::flush('paymentProcessor');
+    civicrm_api3('PaymentProcessor', 'getfields', ['cache_clear' => 1]);
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors('all', TRUE);
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors('live', TRUE);
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors('test', TRUE);

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -74,6 +74,15 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
     $params = $this->_params;
     $result = $this->callAPIAndDocument('payment_processor', 'create', $params, __FUNCTION__, __FILE__);
     $this->callAPISuccessGetSingle('EntityFinancialAccount', ['entity_table' => 'civicrm_payment_processor', 'entity_id' => $result['id']]);
+
+    // Test that the option values are flushed so ths can be used straight away.
+    $this->callAPISuccess('ContributionRecur', 'create', [
+      'contact_id' => $this->individualCreate(),
+      'amount' => 5,
+      'financial_type_id' => 'Donation',
+      'payment_processor_id' => 'API Test PP',
+      'frequency_interval' => 1,
+    ]);
     $this->getAndCheck($params, $result['id'], 'PaymentProcessor');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is mostly a test fix - new pseudoconstant info on recurring means there are more places payment processors can be cached. Flush on create

Before
----------------------------------------
Less caches flushed

After
----------------------------------------
More flushed

Technical Details
----------------------------------------
We needed this to get our own tests to pass

Comments
----------------------------------------

