### PR TITLE
Skip adding core resources when building assets

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -821,8 +821,8 @@ class CRM_Core_Resources {
     ) {
       return TRUE;
     }
-    $url = CRM_Utils_System::getUrlPath();
-    return (strpos($url, 'civicrm/ajax') === 0) || (strpos($url, 'civicrm/angular') === 0);
+    list($arg0, $arg1) = array_pad(explode('/', CRM_Utils_System::getUrlPath()), 2, '');
+    return ($arg0 === 'civicrm' && in_array($arg1, ['ajax', 'angularprofiles', 'asset']));
   }
 
   /**

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -350,6 +350,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     return array(
       array(array('q' => 'civicrm/ajax/foo'), TRUE),
       array(array('q' => 'civicrm/angularprofiles/template'), TRUE),
+      array(array('q' => 'civicrm/asset/builder'), TRUE),
       array(array('q' => 'civicrm/test/page'), FALSE),
       array(array('q' => 'civicrm/test/page', 'snippet' => 'json'), TRUE),
       array(array('q' => 'civicrm/test/page', 'snippet' => 'foo'), FALSE),


### PR DESCRIPTION
Overview
----------------------------------------
Adds asset builder url to the whitelist of ajax paths in which we skip adding core resources.

Before
----------------------------------------
Core resources get processed for no reason on assetbuilder callbacks.

After
----------------------------------------
Core resources get skipped on assetbuilder callbacks.
