### PR TITLE
dev/core#859 - Dedupe fails on address field in 5.12

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -107,8 +107,8 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
       case 'civicrm_address':
         $id = 'contact_id';
         $on[] = 't1.location_type_id = t2.location_type_id';
-        $innerJoinClauses[] = ['t1.location_type_id = t2.location_type_id'];
-        if ($this->params['civicrm_address']['location_type_id']) {
+        $innerJoinClauses[] = 't1.location_type_id = t2.location_type_id';
+        if (!empty($this->params['civicrm_address']['location_type_id'])) {
           $locTypeId = CRM_Utils_Type::escape($this->params['civicrm_address']['location_type_id'], 'Integer', FALSE);
           if ($locTypeId) {
             $where[] = "t1.location_type_id = $locTypeId";


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/859

The $innerJoinClauses array has various strings added to it throughout the function. For the line in question there's a typo that adds a nested array to it instead of a string. When the array gets imploded later this nested array comes out as the literal "Array" which of course is not valid SQL.

The second part is a notice warning that is just because the params array may or may not have the member element being evaluated.

Before
----------------------------------------
Deduping on an address field gives a fatal error with this in the log
`INSERT INTO civicrm_tmp_e_dedupe_99e668b27bc1a5343d9c39a58a400ffb  (id1, id2, weight) SELECT t1.contact_id id1, t2.contact_id id2, 1 weight FROM civicrm_address t1 INNER JOIN civicrm_address t2 ON (t1.postal_code IS NOT NULL AND t2.postal_code IS NOT NULL AND t1.postal_code = t2.postal_code AND t1.postal_code <> '' AND t2.postal_code <> '' AND Array) WHERE t1.contact_id < t2.contact_id GROUP BY id1, id2, weight ON DUPLICATE KEY UPDATE weight = weight + VALUES(weight) [nativecode=1054 ** Unknown column 'Array' in 'on clause']`

Then after fixing that you get this notice:
`Notice: Undefined index: civicrm_address in CRM_Dedupe_BAO_Rule->sql() (line 111`

After
----------------------------------------
No error, no notice.
