### PR TITLE
fix getAddressColumns() to respect tableAlias

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5627,7 +5627,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'type' => CRM_Utils_Type::T_INT,
         'no_display' => TRUE,
         'required' => TRUE,
-        'dbAlias' => '(address_civireport.street_number % 2)',
+        'dbAlias' => "({$tableAlias}_civireport.street_number % 2)",
         'is_fields' => TRUE,
         'is_order_bys' => TRUE,
       ],

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1226,4 +1226,18 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->assertEquals(2, $values['civicrm_contribution_soft_soft_id_count'], "Total donors should be 2");
   }
 
+  /**
+   * Test a report that uses getAddressColumns();
+   */
+  public function testGetAddressColumns() {
+    $template = 'event/participantlisting';
+    $rows = $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => $template,
+      'fields' => [
+        'sort_name' => '1',
+        'street_address' => '1',
+      ],
+    ]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
The `getAddressColumns()` function is intended to reduce copy/paste in CiviReport.  It supports passing a prefix if you want to call it on two different contacts in the same query.  However, the prefix isn't respected in one instance.

Before
----------------------------------------
`getAddressColumns()` returns an error when used twice.

After
----------------------------------------
No error.

Technical Details
----------------------------------------
I'm just substituting a variable that's defined a few lines above for a string of the same type.  In the instance that no prefix is passed, there is no change.  A grep of the codebase shows that "prefix" is never passed (and if it were, it would break that report without this fix).