### PR TITLE
(dev/core#861) Mail job stuck after contact marked deceased

### DIFF
--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -86,8 +86,8 @@ WHERE  mailing_id = %1
     }
 
     $sql = "
-SELECT contact_id, email_id, phone_id
-FROM   civicrm_mailing_recipients
+SELECT r.contact_id, r.email_id, r.phone_id
+FROM   civicrm_mailing_recipients r
 {$additionalJoin}
 WHERE  mailing_id = %1
        $limitString

--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -73,12 +73,11 @@ WHERE  mailing_id = %1
       $limitString = "LIMIT $offset, $limit";
     }
 
-
     $isSMSmode = CRM_Core_DAO::getFieldValue('CRM_Mailing_BAO_Mailing', $mailingID, 'sms_provider_id', 'id');
     $additionalJoin = '';
     if (!$isSMSmode) {
       // mailing_recipients added when mailing is submitted in UI by user.
-      // if any email is marked on_hold =1 or contact is deceased after mailing is submitted 
+      // if any email is marked on_hold =1 or contact is deceased after mailing is submitted
       // then it should be get skipped while preparing event_queue
       // event_queue list is prepared when mailing job gets started.
       $additionalJoin = " INNER JOIN civicrm_email e ON (r.email_id = e.id AND e.on_hold = 0 AND e.is_primary = 1)


### PR DESCRIPTION
Overview
----------------------------------------
Mail job gets stuck when a contact's email was placed on hold after draft creation - an additional condition needs to be added in order to skip deceased contacts if they are included in the mail group.

This is same for deceased contact, his preference changes or if contact's email is no longer primary.

Steps to replicate:
------------------------
* Create a mailing with contacts and schedule it.
* Edit one of the contact to make it deceased.
* Run the scheduled job, it get stuck and no mailing goes out.


Before
----------------------------------------
![mailing](https://user-images.githubusercontent.com/3455173/55878301-c5f8b900-5bb9-11e9-9f6f-ff85e1242d07.png)


After
----------------------------------------
![mailing_after](https://user-images.githubusercontent.com/3455173/55878354-e0cb2d80-5bb9-11e9-80a5-3a2249680135.png)

