### PR TITLE
(dev/core#865) Result filter criteria doesn't show IS NULL/IS NOT NUL…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1301,7 +1301,7 @@ class CRM_Report_Form extends CRM_Core_Form {
             if (!empty($field['options']) ||
               $fieldName == 'state_province_id' || $fieldName == 'county_id'
             ) {
-              $this->addElement('select', "{$fieldName}_op", ts('Operator:'), $operations,
+              $element = $this->addElement('select', "{$fieldName}_op", ts('Operator:'), $operations,
                 array('onchange' => "return showHideMaxMinVal( '$fieldName', this.value );")
               );
 

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1301,7 +1301,10 @@ class CRM_Report_Form extends CRM_Core_Form {
             if (!empty($field['options']) ||
               $fieldName == 'state_province_id' || $fieldName == 'county_id'
             ) {
-              $element = $this->addElement('select', "{$fieldName}_op", ts('Operator:'), $operations);
+              $this->addElement('select', "{$fieldName}_op", ts('Operator:'), $operations,
+                array('onchange' => "return showHideMaxMinVal( '$fieldName', this.value );")
+              );
+
               if (count($operations) <= 1) {
                 $element->freeze();
               }
@@ -1776,6 +1779,8 @@ class CRM_Report_Form extends CRM_Core_Form {
         $result = [
           'in' => ts('Is one of'),
           'notin' => ts('Is not one of'),
+          'nll' => ts('Is empty (Null)'),
+          'nnll' => ts('Is not empty (Null)'),
         ];
         return $result;
 


### PR DESCRIPTION
…L for operations

Overview
----------------------------------------
We can not search all contributions that are not associated with a campaign currently in report. We should expose IS NULL/IS NOT NULL for other operators as well

Before
----------------------------------------
![rep_befre](https://user-images.githubusercontent.com/3455173/55943250-da918b80-5c63-11e9-9556-94c3dbf2f8b4.png)


After
----------------------------------------
![rep_after](https://user-images.githubusercontent.com/3455173/55942992-4aebdd00-5c63-11e9-855c-a0d35707c95a.png)

