### PR TITLE
Make hook_civicrm_pre() and hook_civicrm_post() fire on CaseContacts

### DIFF
--- a/CRM/Case/BAO/CaseContact.php
+++ b/CRM/Case/BAO/CaseContact.php
@@ -45,9 +45,14 @@ class CRM_Case_BAO_CaseContact extends CRM_Case_DAO_CaseContact {
    * @return CRM_Case_BAO_CaseContact
    */
   public static function create($params) {
+    $hook = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($hook, 'CaseContact', CRM_Utils_Array::value('id', $params), $params);
+
     $caseContact = new self();
     $caseContact->copyValues($params);
     $caseContact->save();
+
+    CRM_Utils_Hook::post($hook, 'CaseContact', $caseContact->id, $caseContact);
 
     // add to recently viewed
     $caseType = CRM_Case_BAO_Case::getCaseType($caseContact->case_id);


### PR DESCRIPTION
Overview
----------------------------------------
Make hook_civicrm_pre() and hook_civicrm_post() fire on CaseContacts

Before
----------------------------------------
Modifications to CaseContacts do not trigger hook_civicrm_pre() or hook_civicrm_post()

After
----------------------------------------
Modifications to CaseContacts do trigger hook_civicrm_pre() or hook_civicrm_post()

Technical Details
----------------------------------------
Based on CRM_Core_BAO_Dashboard::create() as advised on https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_post/

Documentation PR will follow once code merged.
