### PR TITLE
Switch to using ContributionRecur.cancel api from CancelSubscription form

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -207,10 +207,13 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
       CRM_Core_Error::displaySessionError($cancelSubscription);
     }
     elseif ($cancelSubscription) {
-      $cancelStatus = CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(
-        ['id' => $this->_subscriptionDetails->recur_id, 'membership_id' => $this->_mid, 'processor_message' => $message]);
+      try {
+        civicrm_api3('ContributionRecur', 'cancel', [
+          'id' => $this->_subscriptionDetails->recur_id,
+          'membership_id' => $this->_mid,
+          'processor_message' => $message,
+        ]);
 
-      if ($cancelStatus) {
         $tplParams = [];
         if ($this->_mid) {
           $inputParams = ['id' => $this->_mid];
@@ -276,7 +279,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
           list($sent) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         }
       }
-      else {
+      catch (CiviCRM_API3_Exception $e) {
         $msgType = 'error';
         $msgTitle = ts('Error');
         if ($params['send_cancel_request'] == 1) {


### PR DESCRIPTION
Overview
----------------------------------------
This makes it so the form uses the api, which we have started to add unit testing to. Following this we can use the api for transaction handling and move more of the form logic into
the api, making it available to others & allowing us to better move to a new form layer later
without as much logic in the forms

Before
----------------------------------------
No noticeable change - code consolidation only

After
----------------------------------------
No noticeable change - code consolidation only

Technical Details
----------------------------------------
The function cancelRecurContribution is only called from the form and from the api.

I did some preliminary cleanup on the api & added a unit test in a previous PR to prepare for this


Comments
----------------------------------------

