### PR TITLE
dev/core#859 - Dedupe fails on address field in 5.12

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -109,8 +109,8 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
       case 'civicrm_address':
         $id = 'contact_id';
         $on[] = 't1.location_type_id = t2.location_type_id';
-        $innerJoinClauses[] = ['t1.location_type_id = t2.location_type_id'];
-        if ($this->params['civicrm_address']['location_type_id']) {
+        $innerJoinClauses[] = 't1.location_type_id = t2.location_type_id';
+        if (!empty($this->params['civicrm_address']['location_type_id'])) {
           $locTypeId = CRM_Utils_Type::escape($this->params['civicrm_address']['location_type_id'], 'Integer', FALSE);
           if ($locTypeId) {
             $where[] = "t1.location_type_id = $locTypeId";

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -90,6 +90,35 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test a custom rule with a non-default field.
+   */
+  public function testCustomRuleWithAddress() {
+    $this->setupForGroupDedupe();
+
+    $ruleGroup = $this->callAPISuccess('RuleGroup', 'create', array(
+      'contact_type' => 'Individual',
+      'threshold' => 10,
+      'used' => 'General',
+      'name' => 'TestRule',
+      'title' => 'TestRule',
+      'is_reserved' => 0,
+    ));
+    $rules = [];
+    foreach (array('postal_code') as $field) {
+      $rules[$field] = $this->callAPISuccess('Rule', 'create', [
+        'dedupe_rule_group_id' => $ruleGroup['id'],
+        'rule_table' => 'civicrm_address',
+        'rule_weight' => 10,
+        'rule_field' => $field,
+      ]);
+    }
+    $foundDupes = CRM_Dedupe_Finder::dupesInGroup($ruleGroup['id'], $this->groupID);
+    $this->assertEquals(count($foundDupes), 1);
+    CRM_Dedupe_Finder::dupes($ruleGroup['id']);
+
+  }
+
+  /**
    * Test the supervised dedupe rule against a group.
    *
    * @throws \Exception
@@ -260,6 +289,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
         'email' => 'robin@example.com',
         'contact_type' => 'Individual',
         'birth_date' => '2016-01-01',
+        'api.Address.create' => ['location_type_id' => 'Billing', 'postal_code' => '99999'],
       ),
       array(
         'first_name' => 'robin',
@@ -267,6 +297,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
         'email' => 'hood@example.com',
         'contact_type' => 'Individual',
         'birth_date' => '2016-01-01',
+        'api.Address.create' => ['location_type_id' => 'Billing', 'postal_code' => '99999'],
       ),
       array(
         'first_name' => 'robin',


### PR DESCRIPTION
Adds https://github.com/civicrm/civicrm-core/pull/14013 to 5.13 (it should have gone to 5.13 & been ported back to 5.12 but I didn't spot that when I merged to 5.12)