### PR TITLE
Profiles with multi record fields - email and receipts use older values than latest

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -526,6 +526,8 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         }
 
         CRM_Core_BAO_UFGroup::getValues($cid, $fields, $values, FALSE, $params);
+        // update multirecord fields with latest values
+        CRM_Core_BAO_UFGroup::updateMultiRecordValuesWithLatest($gid, $cid, $fields, $values);
       }
     }
     return [$groupTitle, $values];

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1378,14 +1378,14 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     }
   }
 
-  /*
+  /**
    * Update $values populated by CRM_Core_BAO_UFGroup::getValues() with latest multi record values.
    * CRM_Core_BAO_UFGroup::getValues() uses search query with left joins with multi custom set tables,
-   * which won't fetch the latest record for multi custom set fields. And changing core search query 
+   * which won't fetch the latest record for multi custom set fields. And changing core search query
    * to use sub queries for multi set records is quite a big change and effort.
    *
-   * Use Cases: 
-   * 1. Use a profile with multi custom set fields for notification. Notifications would include oldest 
+   * Use Cases:
+   * 1. Use a profile with multi custom set fields for notification. Notifications would include oldest
    *    values.
    * 2. Use onbehalf of profile with multi custom set fields, for a contribution or membership page.
    *    The receipt include oldest values than the submitted latest values.
@@ -1419,14 +1419,14 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         $DTparams = array(
           'rowCount' => 1,
           'offset'   => 0,
-          'sort'     => 'id desc'
+          'sort'     => 'id desc',
         );
         $result = CRM_Core_BAO_CustomValueTable::getEntityValues($cid, NULL, $fieldIDs, TRUE, $DTparams);
         $ctIds  = array_keys($result['sortedResult']);
         $latestId = max($ctIds);
         if (!empty($result[$latestId])) {
           foreach ($fieldIDs as $fid) {
-            if (CRM_Core_BAO_CustomField::isMultiRecordField($fid) && 
+            if (CRM_Core_BAO_CustomField::isMultiRecordField($fid) &&
               CRM_Utils_Array::value($fid, $result[$latestId])
             ) {
               $display = CRM_Core_BAO_CustomField::displayValue($result[$latestId][$fid], $fid);

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -1315,21 +1315,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
     foreach ($ufGroups as $gId => $val) {
       if ($notify = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $gId, 'notify')) {
         $values = CRM_Core_BAO_UFGroup::checkFieldsEmptyValues($gId, $this->_id, NULL);
-        // for multi record fields, replace values with that of latest submitted values
-        if (CRM_Core_BAO_UFField::checkMultiRecordFieldExists($gId)) {
-          foreach ($params as $mkey => $mval) {
-            if (CRM_Core_BAO_CustomField::isMultiRecordField($mkey)) {
-              $mcfid = CRM_Core_BAO_CustomField::getKeyID($mkey);
-              if ($mcfid) {
-                $display = CRM_Core_BAO_CustomField::displayValue($mval, $mkey);
-                $label = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $mcfid, 'label');
-                if (array_key_exists($label, $values['values'])) {
-                  $values['values'][$label] = $display;
-                }
-              }
-            }
-          }
-        }
         CRM_Core_BAO_UFGroup::commonSendMail($this->_id, $values);
       }
     }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -1315,6 +1315,21 @@ class CRM_Profile_Form extends CRM_Core_Form {
     foreach ($ufGroups as $gId => $val) {
       if ($notify = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $gId, 'notify')) {
         $values = CRM_Core_BAO_UFGroup::checkFieldsEmptyValues($gId, $this->_id, NULL);
+        // for multi record fields, replace values with that of latest submitted values
+        if (CRM_Core_BAO_UFField::checkMultiRecordFieldExists($gId)) {
+          foreach ($params as $mkey => $mval) {
+            if (CRM_Core_BAO_CustomField::isMultiRecordField($mkey)) {
+              $mcfid = CRM_Core_BAO_CustomField::getKeyID($mkey);
+              if ($mcfid) {
+                $display = CRM_Core_BAO_CustomField::displayValue($mval, $mkey);
+                $label = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $mcfid, 'label');
+                if (array_key_exists($label, $values['values'])) {
+                  $values['values'][$label] = $display;
+                }
+              }
+            }
+          }
+        }
         CRM_Core_BAO_UFGroup::commonSendMail($this->_id, $values);
       }
     }

--- a/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
@@ -25,16 +25,16 @@ class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
       'group_type' => 'Contact',
       'name'       => 'test_profile_with_multi_records_cs',
       'title'      => 'Profile With Multi Record CS',
-      'api.uf_field.create' => array( 
+      'api.uf_field.create' => array(
         array(
           'field_name'  => "custom_{$customField['id']}",
           'is_required' => 1,
-          'visibility'  => 'Public Pages and Listings', 
-          'field_type'  => 'Contact',   
+          'visibility'  => 'Public Pages and Listings',
+          'field_type'  => 'Contact',
           'label'       => 'row text',
           'is_multi_summary' => 1,
         ),
-      )
+      ),
     );
     $profile = $this->callAPISuccess('uf_group', 'create', $ufGroupParams);
 
@@ -72,7 +72,7 @@ class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
     // getValues uses core search and fetches oldest value
     $this->assertEquals($values['row text'], 'First Row', 'Check for getValues() fetching oldest record.');
 
-    // test updateMultiRecordValuesWithLatest() which should update entries in $values with 
+    // test updateMultiRecordValuesWithLatest() which should update entries in $values with
     // that of latest record.
     CRM_Core_BAO_UFGroup::updateMultiRecordValuesWithLatest($profile['id'], $contactID, $fields, $values);
     $this->assertNotEmpty($values['row text']);
@@ -87,4 +87,5 @@ class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
     $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
+
 }

--- a/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Class CRM_Core_BAO_UFGroupTest
+ * @group headless
+ */
+class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function testUFGroupGetValuesForMultiRecordFields() {
+    // create multi record custom set
+    $customGroup = $this->customGroupCreate(array('is_multiple' => 1));
+    $fields = array(
+      'custom_group_id' => $customGroup['id'],
+      'dataType'        => 'String',
+      'htmlType'        => 'Text',
+    );
+    $customField = $this->customFieldCreate($fields);
+
+    // create profile with multi record custom fields
+    $ufGroupParams = array(
+      'group_type' => 'Contact',
+      'name'       => 'test_profile_with_multi_records_cs',
+      'title'      => 'Profile With Multi Record CS',
+      'api.uf_field.create' => array( 
+        array(
+          'field_name'  => "custom_{$customField['id']}",
+          'is_required' => 1,
+          'visibility'  => 'Public Pages and Listings', 
+          'field_type'  => 'Contact',   
+          'label'       => 'row text',
+          'is_multi_summary' => 1,
+        ),
+      )
+    );
+    $profile = $this->callAPISuccess('uf_group', 'create', $ufGroupParams);
+
+    // create first entry for multi record custom set
+    $contactID = $this->individualCreate();
+    $params = array(
+      'entityID' => $contactID,
+      "custom_{$customField['id']}_-1" => 'First Row',
+    );
+    CRM_Core_BAO_CustomValueTable::setValues($params);
+
+    // create second entry for multi record custom set
+    $params = array(
+      'entityID' => $contactID,
+      "custom_{$customField['id']}_-1" => 'Second Row',
+    );
+    CRM_Core_BAO_CustomValueTable::setValues($params);
+
+    // create third entry for multi record custom set
+    $params = array(
+      'entityID' => $contactID,
+      "custom_{$customField['id']}_-1" => 'Third Row',
+    );
+    CRM_Core_BAO_CustomValueTable::setValues($params);
+
+    // check number of fields in profile
+    $fields = CRM_Core_BAO_UFGroup::getFields($profile['id'], FALSE, CRM_Core_Action::VIEW);
+    $this->assertEquals(count($fields), 1, 'Check for number of fields in profile');
+
+    // test getValues() used to fetch profile field values, for display in receipts
+    // for e.g when profile submission is notified.
+    $values = array();
+    CRM_Core_BAO_UFGroup::getValues($contactID, $fields, $values, FALSE, NULL, TRUE);
+    $this->assertNotEmpty($values['row text']);
+    // getValues uses core search and fetches oldest value
+    $this->assertEquals($values['row text'], 'First Row', 'Check for getValues() fetching oldest record.');
+
+    // test updateMultiRecordValuesWithLatest() which should update entries in $values with 
+    // that of latest record.
+    CRM_Core_BAO_UFGroup::updateMultiRecordValuesWithLatest($profile['id'], $contactID, $fields, $values);
+    $this->assertNotEmpty($values['row text']);
+    $this->assertEquals($values['row text'], 'Third Row', 'Check for updateMultiRecordValuesWithLatest() fetching latest record.');
+
+    // delete profile
+    $params = array('id' => $profile['id']);
+    $profile = $this->callAPISuccess('uf_group', 'delete', $params);
+
+    // delete contact, custom field and set.
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
+    $this->contactDelete($contactID);
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
When using a profile with multi record fields for notification or on-behalf-of profile - emails and receipts end up showing oldest (first row of custom table) set of values than the latest submitted ones.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/33451769/56068348-5e3b9d00-5d76-11e9-84d2-6900530ae82c.png)

![image](https://user-images.githubusercontent.com/33451769/56068023-3435ab00-5d75-11e9-8249-47992f4e3bc6.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/33451769/56068076-5cbda500-5d75-11e9-955e-fd0c674f1838.png)

Technical Details
----------------------------------------
CRM_Core_BAO_UFGroup::getValues() uses search query with left joins with multi custom set tables, which won't fetch the latest record for multi record custom set fields. And changing core search query to use sub queries for multi set records is quite a big change and effort. Unless anyone already knows how to do it.

As an alternative - have added a new method to update $values populated by CRM_Core_BAO_UFGroup::getValues() with latest multi record values. The new method is based on CRM_Core_BAO_CustomValueTable::getEntityValues() which is used to display multi record values in contact tab (as a table). The trick used here is that it fetches only the latest record.

