### PR TITLE
(REF; dev/core#873) MailingAB - Migrate "copy winner" logic from JS to PHP

### DIFF
--- a/ang/crmMailingAB/WinnerDialogCtrl.js
+++ b/ang/crmMailingAB/WinnerDialogCtrl.js
@@ -17,20 +17,11 @@
           text: ts('Submit final mailing'),
           icons: {primary: 'fa-paper-plane'},
           click: function() {
-            crmMailingMgr.mergeInto(abtest.mailings.c, abtest.mailings[mailingName], [
-              'name',
-              'recipients',
-              'scheduled_date'
-            ]);
-            crmStatus({start: ts('Saving...'), success: ''}, abtest.save())
-              .then(function() {
-                return crmStatus({start: ts('Submitting...'), success: ts('Submitted')},
-                  abtest.submitFinal().then(function(r) {
-                    delete abtest.$CrmMailingABReportCnt;
-                    return r;
-                  }));
-              })
-              .then(function() {
+            crmStatus({start: ts('Submitting...'), success: ts('Submitted')},
+              abtest.submitFinal(abtest.mailings[mailingName].id).then(function (r) {
+                delete abtest.$CrmMailingABReportCnt;
+              }))
+              .then(function () {
                 dialogService.close('selectWinnerDialog', abtest);
               });
           }

--- a/ang/crmMailingAB/services.js
+++ b/ang/crmMailingAB/services.js
@@ -147,11 +147,12 @@
       // Schedule the final mailing
       // @return Promise CrmMailingAB
       // Note: Submission may cause the server state to change. Consider abtest.submit().then(...abtest.load()...)
-      submitFinal: function submitFinal() {
+      submitFinal: function submitFinal(winner_id) {
         var crmMailingAB = this;
         var params = {
           id: this.ab.id,
           status: 'Final',
+          winner_id: winner_id,
           approval_date: 'now',
           scheduled_date: this.mailings.c.scheduled_date ? this.mailings.c.scheduled_date : 'now'
         };

--- a/tests/phpunit/api/v3/MailingABTest.php
+++ b/tests/phpunit/api/v3/MailingABTest.php
@@ -42,9 +42,18 @@ class api_v3_MailingABTest extends CiviUnitTestCase {
     parent::setUp();
     $this->useTransaction(TRUE);
     $this->createLoggedInUser();
-    $this->_mailingID_A = $this->createMailing();
-    $this->_mailingID_B = $this->createMailing();
-    $this->_mailingID_C = $this->createMailing();
+    $this->_mailingID_A = $this->createMailing([
+      'subject' => 'subject a ' . time(),
+      'body_text' => 'body_text a ' . time(),
+    ]);
+    $this->_mailingID_B = $this->createMailing([
+      'subject' => 'subject b ' . time(),
+      'body_text' => 'body_text b ' . time(),
+    ]);
+    $this->_mailingID_C = $this->createMailing([
+      'subject' => 'not yet ' . time(),
+      'body_text' => 'not yet ' . time(),
+    ]);
     $this->_groupID = $this->groupCreate();
 
     $this->_params = array(
@@ -152,6 +161,65 @@ class api_v3_MailingABTest extends CiviUnitTestCase {
     ));
     $this->assertRecipientCounts($expectedCountA, $expectedCountB, $expectedCountC);
     $this->assertJobCounts(1, 1, 1);
+  }
+
+  /**
+   * Create a test. Declare the second mailing a winner. Ensure that key
+   * fields propagate to the final mailing.
+   */
+  public function testSubmitWinnderId() {
+    $checkSyncFields = ['subject', 'body_text'];
+
+    $result = $this->groupContactCreate($this->_groupID, 20, TRUE);
+    $this->assertEquals(20, $result['added'], "in line " . __LINE__);
+
+    $params = $this->_params;
+    $params['group_percentage'] = 10;
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
+
+    $this->callAPISuccess('Mailing', 'create', [
+      'id' => $this->_mailingID_A,
+      'groups' => ['include' => [$this->_groupID]],
+    ]);
+    $this->assertJobCounts(0, 0, 0);
+
+    $this->callAPISuccess('MailingAB', 'submit', [
+      'id' => $result['id'],
+      'status' => 'Testing',
+      'scheduled_date' => 'now',
+      'approval_date' => 'now',
+    ]);
+    $this->assertJobCounts(1, 1, 0);
+
+    $b = $this->getApiValues('Mailing', ['id' => $this->_mailingID_B], $checkSyncFields);
+    $c = $this->getApiValues('Mailing', ['id' => $this->_mailingID_C], $checkSyncFields);
+    $this->assertNotEquals($b, $c);
+
+    $this->callAPISuccess('MailingAB', 'submit', [
+      'id' => $result['id'],
+      'status' => 'Final',
+      'winner_id' => $this->_mailingID_B,
+      'scheduled_date' => 'now',
+      'approval_date' => 'now',
+    ]);
+    $this->assertJobCounts(1, 1, 1);
+
+    $b = $this->getApiValues('Mailing', ['id' => $this->_mailingID_B], $checkSyncFields);
+    $c = $this->getApiValues('Mailing', ['id' => $this->_mailingID_C], $checkSyncFields);
+    $this->assertEquals($b, $c);
+  }
+
+  /**
+   * Lookup a record via API. Return *only* the expected values.
+   *
+   * @param $entity
+   * @param $filter
+   * @param $return
+   * @return array
+   */
+  protected function getApiValues($entity, $filter, $return) {
+    $rec = $this->callAPISuccess($entity, 'getsingle', $filter + ['return' => $return]);
+    return CRM_Utils_Array::subset($rec, $return);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In CiviMail, a user may run an A/B test, compare the performance of each variant, and choose a "winner". The mailing details (`subject`, `body_text`, etc) are copied from the winner to the full, final mailing.

This refactoring does not seek to change the usage or behavior. It just moves the "copy winner" logic from in-situ JS to a PHP API. It aims to allow better unit-testing and to allow more alternative workflows.

Before
----------------------------------------
* After the user chooses a winner, the details are copied via JS (`crmMailingMgr.mergeInto(finalMailing, winnerMailing...)`).

After
----------------------------------------
* After the user chooses a winner, the details are copied via PHP API (`MailingAB.submit winner_id=...`)
* Side benefit: Slightly reduces the number of AJAX calls. (Since the mailing details aren't changed on client-side, we don't need to send a `Mailing.create` to save any changes. But the client-side still winds up with the right data because it reloads after submission.)

Comments
----------------------------------------

The new test-coverage is for the new API parameter. To show that it has the overall intended effect (e.g. old code and new code produce similar outcomes for user), I used this procedure:

* Make a test site
* Setup a fake mail service (e.g. `mailcatcher` or `fakesmtp`)
* Add all the sample contacts to the newsletter group
* Compose a new A/B test (based on full email content -- different subject and different body). Target the newsletter group. Run `Job.process_mailings`. Check that a subset of people receive both mailings.
* Save a DB snapshot
* In different configurations (with patch; without patch; with "A" as winner; with "B" as winner; etc), do these steps and compare outcome:
    * Restore DB snapshot
    * Navigate to review A/B test results
    * Choose a winner (A or B)
    * Observe that the web UI refreshes (filling the winner/C column)
    * Run `Job.process_mailings`
    * Check that the remaining people receive the designated subject+body.
