### PR TITLE
(NFC) SchemaStructure.php - Fix up mismatch between stored+generated code

### DIFF
--- a/CRM/Core/CodeGen/I18n.php
+++ b/CRM/Core/CodeGen/I18n.php
@@ -50,7 +50,7 @@ class CRM_Core_CodeGen_I18n extends CRM_Core_CodeGen_BaseTask {
       }
     }
 
-    $template = new CRM_Core_CodeGen_Util_Template('php');
+    $template = new CRM_Core_CodeGen_Util_Template('php', FALSE);
 
     $template->assign('columns', $columns);
     $template->assign('indices', $indices);

--- a/xml/templates/schema_structure.tpl
+++ b/xml/templates/schema_structure.tpl
@@ -1,30 +1,29 @@
 <?php
-
 /*
- +--------------------------------------------------------------------+
- | CiviCRM version 5                                                  |
- +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2019                                |
- +--------------------------------------------------------------------+
- | This file is a part of CiviCRM.                                    |
- |                                                                    |
- | CiviCRM is free software; you can copy, modify, and distribute it  |
- | under the terms of the GNU Affero General Public License           |
- | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
- |                                                                    |
- | CiviCRM is distributed in the hope that it will be useful, but     |
- | WITHOUT ANY WARRANTY; without even the implied warranty of         |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
- | See the GNU Affero General Public License for more details.        |
- |                                                                    |
- | You should have received a copy of the GNU Affero General Public   |
- | License and the CiviCRM Licensing Exception along                  |
- | with this program; if not, contact CiviCRM LLC                     |
- | at info[AT]civicrm[DOT]org. If you have questions about the        |
- | GNU Affero General Public License or the licensing of CiviCRM,     |
- | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
- +--------------------------------------------------------------------+
-*/
++--------------------------------------------------------------------+
+| CiviCRM version 5                                                  |
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC (c) 2004-2019                                |
++--------------------------------------------------------------------+
+| This file is a part of CiviCRM.                                    |
+|                                                                    |
+| CiviCRM is free software; you can copy, modify, and distribute it  |
+| under the terms of the GNU Affero General Public License           |
+| Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+|                                                                    |
+| CiviCRM is distributed in the hope that it will be useful, but     |
+| WITHOUT ANY WARRANTY; without even the implied warranty of         |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+| See the GNU Affero General Public License for more details.        |
+|                                                                    |
+| You should have received a copy of the GNU Affero General Public   |
+| License and the CiviCRM Licensing Exception along                  |
+| with this program; if not, contact CiviCRM LLC                     |
+| at info[AT]civicrm[DOT]org. If you have questions about the        |
+| GNU Affero General Public License or the licensing of CiviCRM,     |
+| see the CiviCRM license FAQ at http://civicrm.org/licensing        |
++--------------------------------------------------------------------+
+ */
 
 /**
  *
@@ -34,102 +33,99 @@
  * Generated from {$smarty.template}
  * {$generated}
  */
-class CRM_Core_I18n_SchemaStructure
-{ldelim}
+class CRM_Core_I18n_SchemaStructure {ldelim}
 
-    /**
-     * Get translatable columns.
-     *
-     * @return array
-     *   A table-indexed array of translatable columns.
-     */
-    public static function &columns()
-    {ldelim}
-        static $result = null;
-        if (!$result) {ldelim}
-          $result = array(
-            {foreach from=$columns key=table item=types}
-              '{$table}' => array(
-                {foreach from=$types key=column item=type}
-                  '{$column}' => "{$type}",
-                {/foreach}
-              ),
-            {/foreach}
-          );
-        {rdelim}
-        return $result;
+  /**
+   * Get translatable columns.
+   *
+   * @return array
+   *   A table-indexed array of translatable columns.
+   */
+  public static function &columns() {ldelim}
+    static $result = NULL;
+    if (!$result) {ldelim}
+      $result = [
+{foreach from=$columns key=table item=types}
+        '{$table}' => [
+{foreach from=$types key=column item=type}
+          '{$column}' => "{$type}",
+{/foreach}{* /foreach from=$types item=type *}
+        ],
+{/foreach}{* /foreach from=$columns item=types *}
+      ];
     {rdelim}
+    return $result;
+  {rdelim}
 
-    /**
-     * Get a table indexed array of the indices for translatable fields.
-     *
-     * @return array
-     *   Indices for translatable fields.
-     */
-    public static function &indices()
-    {ldelim}
-        static $result = null;
-        if (!$result) {ldelim}
-          $result = array(
-            {foreach from=$indices key=table item=tableIndices}
-              '{$table}' => array(
-                {foreach from=$tableIndices key=name item=info}
-                  '{$name}' => array(
-                      'name' => '{$info.name}',
-                      'field' => array(
-                        {foreach from=$info.field item=field}
-                          '{$field}',
-                        {/foreach}
-                      ),
-                      {if $info.unique}'unique' => 1,{/if}
-                  ),
-                {/foreach}
-              ),
-            {/foreach}
-          );
-        {rdelim}
-        return $result;
-    {rdelim}
+  /**
+   * Get a table indexed array of the indices for translatable fields.
+   *
+   * @return array
+   *   Indices for translatable fields.
+   */
+  public static function &indices() {ldelim}
+    static $result = NULL;
+    if (!$result) {ldelim}
+      $result = [
+{foreach from=$indices key=table item=tableIndices}
+        '{$table}' => [
+{foreach from=$tableIndices key=name item=info}
+          '{$name}' => [
+            'name' => '{$info.name}',
+            'field' => [
+{foreach from=$info.field item=field}
+              '{$field}',
+{/foreach}{* foreach from=$info.field item=field *}
+            ],
+            {if $info.unique}'unique' => 1,{/if}
 
-    /**
-     * Get tables with translatable fields.
-     *
-     * @return array
-     *   Array of names of tables with fields that can be translated.
-     */
-    static function &tables()
-    {ldelim}
-        static $result = null;
-        if (!$result) {ldelim}
-            $result = array_keys(self::columns());
-        {rdelim}
-        return $result;
+          ],
+{/foreach}{* /foreach from=$tableIndices item=info *}
+        ],
+{/foreach}{* /foreach from=$indices item=tableIndices *}
+      ];
     {rdelim}
+    return $result;
+  {rdelim}
 
-    /**
-     * Get a list of widgets for editing translatable fields.
-     *
-     * @return array
-     *   Array of the widgets for editing translatable fields.
-     */
-    static function &widgets()
-    {ldelim}
-        static $result = null;
-        if (!$result) {ldelim}
-          $result = array(
-            {foreach from=$widgets key=table item=columns}
-              '{$table}' => array(
-                {foreach from=$columns key=column item=widget}
-                  '{$column}' => array(
-                    {foreach from=$widget key=name item=value}
-                      '{$name}' => "{$value}",
-                    {/foreach}
-                  ),
-                {/foreach}
-              ),
-            {/foreach}
-          );
-        {rdelim}
-        return $result;
+  /**
+   * Get tables with translatable fields.
+   *
+   * @return array
+   *   Array of names of tables with fields that can be translated.
+   */
+  public static function &tables() {ldelim}
+    static $result = NULL;
+    if (!$result) {ldelim}
+      $result = array_keys(self::columns());
     {rdelim}
+    return $result;
+  {rdelim}
+
+  /**
+   * Get a list of widgets for editing translatable fields.
+   *
+   * @return array
+   *   Array of the widgets for editing translatable fields.
+   */
+  public static function &widgets() {ldelim}
+    static $result = NULL;
+    if (!$result) {ldelim}
+      $result = [
+{foreach from=$widgets key=table item=columns}
+        '{$table}' => [
+{foreach from=$columns key=column item=widget}
+          '{$column}' => [
+{foreach from=$widget key=name item=value}
+            '{$name}' => "{$value}",
+{/foreach}{* /foreach from=$widget item=value *}
+          ],
+{/foreach}{* /foreach from=$columns item=widget *}
+        ],
+{/foreach}{* /foreach from=$widgets item=columns *}
+      ];
+    {rdelim}
+    return $result;
+  {rdelim}
+
 {rdelim}


### PR DESCRIPTION
Overview
--------

The class `CRM_Core_I18n_SchemaStructure` is autogenerated via `GenCode`, and it is also commited to git. The two forms don't match because of the recent code-style cleanup.

Before
------

After running `GenCode`, there appears to be uncommitted changes in `CRM_Core_I18n_SchemaStructure`. The changes indicate a reversion in code-style (e.g. `null` vs `NULL`; some whitespace).

After
-----

`GenCode` produces output which matches the recent cleanup.

Comments
--------

Fixing `null` / `NULL` was easy. However, the whitespace mismatch was more subtle -- because the `PHP_Beautifier` was messing it up. To resolve, I disabled `PHP_Beautifier` for this file, and fixed the underlying templates to generate well-formed code.

The output of the process matches the existing code; therefore, the change have no functional impact (NFC).  You can see this by running `setup.sh` and checking the `git status`.
