### PR TITLE
WIP More accurate wording for backend contribute buttons

### DIFF
--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -64,9 +64,9 @@
 
           {if $action eq 16 and $permission EQ 'edit'}
             <div class="action-link">
-              <a accesskey="N" href="{$newContribURL}" class="button"><span><i class="crm-i fa-plus-circle"></i> {ts}Record Contribution (Check, Cash, EFT ...){/ts}</span></a>
+              <a accesskey="N" href="{$newContribURL}" class="button"><span><i class="crm-i fa-plus-circle"></i> {ts}Record Contribution (Check, Cash ...){/ts}</span></a>
               {if $newCredit}
-                <a accesskey="N" href="{$newCreditURL}" class="button"><span><i class="crm-i fa-credit-card"></i> {ts}Submit Credit Card Contribution{/ts}</span></a>
+                <a accesskey="N" href="{$newCreditURL}" class="button"><span><i class="crm-i fa-credit-card"></i> {ts}Submit Contribution (Credit Card ...){/ts}</span></a>
               {/if}
               <br /><br />
             </div>


### PR DESCRIPTION
Overview
----------------------------------------
Submit credit card really means submit a live / online payment and it's confusing when not using a credit card processor.  Also, EFT can be submitted as well as recorded.  This just tweaks the wording in a small enough way that it should be clearer without opening up a big discussion on what the wording should be.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/56098809-83f2ae80-5efc-11e9-84c2-e9aa335f2618.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/56098814-9371f780-5efc-11e9-8ac9-a2164506eb60.png)


Technical Details
----------------------------------------
Just wording on template

Comments
----------------------------------------
@eileenmcnaughton Had a few clients using direct debit who don't like the "submit credit card" button. This should appease them
