### PR TITLE
(dev/core#876) Allow url to set IS NULL/ NOT NULL in report for opera…

### DIFF
--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -178,6 +178,11 @@ class CRM_Report_Utils_Get {
         }
         break;
 
+      case 'nll':
+      case 'nnll':
+        $defaults["{$fieldName}_op"] = $fieldOP;
+        break;
+
       case 'in':
       case 'notin':
         // send the type as string so that multiple values can also be retrieved from url.


### PR DESCRIPTION
…tions

Overview
----------------------------------------
This depends on #14028 
Now that we allow IS NULL/ NOT NULL for filters like campaign, we should also allow the params to be passed via url.

Before
----------------------------------------
Operator not respected

![op_before](https://user-images.githubusercontent.com/3455173/56109839-de792280-5f6f-11e9-8573-0cc8f3bac4a9.png)


After
----------------------------------------
Operator is respected
![op_after](https://user-images.githubusercontent.com/3455173/56109844-e5a03080-5f6f-11e9-8f6f-b2d3cfb86cd9.png)



Comments
----------------------------------------
Filters can be passes via url for is null/is not null for fields like campaigns, etc


