### PR TITLE
dev/core#877 Export Multi-Value custom field result in DB error when label length is greater than 255 char

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1149,6 +1149,10 @@ class CRM_Export_BAO_ExportProcessor {
           if (isset($queryFields[$columnName]['maxlength'])) {
             return "$fieldName varchar({$queryFields[$columnName]['maxlength']})";
           }
+          elseif (isset($queryFields[$columnName]['text_length'])) {
+            $length = max(512, CRM_Utils_Array::value('text_length', $queryFields[$columnName]));
+            return "$fieldName varchar($length)";
+          }
           else {
             return "$fieldName varchar(255)";
           }


### PR DESCRIPTION
Export Multi-Value custom field result in DB error when label length is greater than 255 char

Overview
----------------------------------------
custom field id xx is of multi-select (Alphanumeric) and having field length 255 char in DB.
If we choose multiple option in select field (assuming total label length is greater than 255 char).
(all multi-select option value length sum come under 255 charter but label length goes beyond that.)
When we export the data, label get stored in temporary table and same get exported.
During the Export process temporary table get created in database and column data length get decided on field length of custom field. in our case it was 255 charter but label goes around 300 character. When Data length is greater than size, query get failed.

Before
----------------------------------------
Query Failed :  Data length is greater than size

After
----------------------------------------
Column length get adjusted as per custom field size.
