### PR TITLE
 Improve function to get financial account relationships - improved

### DIFF
--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -293,6 +293,11 @@ WHERE cft.id = %1
       'Sales Tax Account is' => 'Liability',
       'Deferred Revenue Account is' => 'Liability',
     );
+    foreach ($Links as $defaultAccountRelation => $defaultAccountType) {
+      if (!isset(Civi::$statics[__CLASS__]['account_relationships'][$defaultAccountRelation])) {
+        Civi::$statics[__CLASS__]['account_relationships'][$defaultAccountRelation] = $defaultAccountType;
+      }
+    }
     if (!$flip) {
       foreach ($Links as $accountRelation => $accountType) {
         $financialAccountLinks[array_search($accountRelation, $accountRelationships)] = array_search($accountType, $financialAccountType);


### PR DESCRIPTION
Overview
----------------------------------------
PR #13472 adds the ability to modify the financial account relationships in an extension.  While the merits of the approach are still being debated, there's a logic error in the PR itself.  Since I've been running this in production, I just developed a fix.  If the approach is approved, I think this PR should be merged instead.

Before
----------------------------------------
Can't modify financial account relationship types.

After
----------------------------------------
You can modify financial account relationship types (without breaking existing relationship types).

Technical Details
----------------------------------------
See PR #13472 for background.