### PR TITLE
dev/core#553: Creating new event takes value from default value not from saved template for custom fields

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -48,10 +48,11 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     parent::preProcess();
     $this->assign('selectedChild', 'settings');
 
-    if ($this->_id) {
-      $this->assign('entityID', $this->_id);
+    $entityID = $this->_id ?: $this->_templateId;
+    if ($entityID) {
+      $this->assign('entityID', $entityID);
       $eventType = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event',
-        $this->_id,
+        $entityID,
         'event_type_id'
       );
     }
@@ -127,7 +128,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     if ($this->_eventType) {
       $this->assign('customDataSubType', $this->_eventType);
     }
-    $this->assign('entityId', $this->_id);
 
     $this->_first = TRUE;
     $this->applyFilter('__ALL__', 'trim');


### PR DESCRIPTION
Overview
----------------------------------------
When creating a new event using a template the new event screen is taking the default values directly from the custom fields, and not from what's saved in the event template.

Steps to replicate:
1. Create a custom field for Events
2. Set default value say 'abc' for that custom field
3. Create/Edit an event template and save with custom field value say 'def'
4. Now create a new event using that event template

Issue - Custom field is set to default value 'abc' instead of 'def'

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/56207119-97705780-606b-11e9-8f79-05a9413af6bd.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/56207131-a0612900-606b-11e9-8ef7-c45556d22ed4.gif)


