### PR TITLE
dev/core#338: Batch update membership type

### DIFF
--- a/templates/CRM/common/batchCopy.tpl
+++ b/templates/CRM/common/batchCopy.tpl
@@ -98,7 +98,7 @@
         });
       }
       else {
-        if (elementId.is('select') === true && firstElement.parent().find(':input').select().index() >= 1 && firstElement.parent().find('select').select().index < 1) {
+        if (elementId.is('select') === true && firstElement.parent().find(':input').select().index() >= 1 && firstElement.parent().find('select').select().length > 1) {
           // its a multiselect case
           firstElement.parent().find(':input').select().each( function(count) {
             var firstElementValue = $(this).val();


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Create a profile with a membership type field
2. Go to 'Find Membership' and search
3. Select one or more memberships and choose 'Update multiple memberships'
4. On next screen choose that profile

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/56211535-baa00480-6075-11e9-915d-58215cc04c0f.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/56211459-93e1ce00-6075-11e9-90b5-6ac7d238f93c.gif)


Technical Details
----------------------------------------
This is a regression due to https://github.com/civicrm/civicrm-core/commit/bd8af239d2ee51e71e46dd50217b4498f66f4a2d#diff-47cfdba4508ebec67c48710fd3b90cdf And this patch ensures that it doesn't revert the orginal fix for select custom field as shown in the __After__ screenshot.
