### PR TITLE
Ensure edit tooltip is always initially hidden in contact summary block

### DIFF
--- a/css/contactSummary.css
+++ b/css/contactSummary.css
@@ -49,7 +49,7 @@ div#crm-contact-thumbnail {
   min-height: 2.5em;
 }
 
-#crm-container div.crm-inline-edit .crm-edit-help {
+#crm-container div.crm-summary-block .crm-edit-help {
   display: none;
   position: absolute;
   right: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://github.com/eileenmcnaughton/org.wikimedia.relationshipblock/issues/19
When a user does not have permission to edit a contact summary block, the little "Edit" tooltip should be hidden.

Before
----------------------------------------
Edit tooltip appears and is not styled.

After
----------------------------------------
Edit tooltip hidden except when hovering over an editable block.

Comments
----------------------------------------
Core blocks do not need this because they hide the tooltip in the smarty template. That's fine but if an extension author forgets to do that, this will ensure it still looks right.
