### PR TITLE
Menubar z-index fixes

### DIFF
--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -240,6 +240,10 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
     z-index: 99999;
   }
 
+  body.crm-menubar-above-crm-container #civicrm-menu {
+    z-index: 100;
+  }
+
   body.crm-menubar-hidden #civicrm-menu {
     display: none;
   }

--- a/js/Common.js
+++ b/js/Common.js
@@ -923,6 +923,7 @@ if (!CRM.vars) CRM.vars = {};
     })
     .on('dialogopen', function(e) {
       var $el = $(e.target);
+      $('body').addClass('ui-dialog-open');
       // Modal dialogs should disable scrollbars
       if ($el.dialog('option', 'modal')) {
         $el.addClass('modal-dialog');
@@ -956,6 +957,9 @@ if (!CRM.vars) CRM.vars = {};
       // Restore scrollbars when closing modal
       if ($('.ui-dialog .modal-dialog:visible').not(e.target).length < 1) {
         $('body').css({overflow: ''});
+      }
+      if ($('.ui-dialog-content:visible').not(e.target).length < 1) {
+        $('body').removeClass('ui-dialog-open');
       }
     })
     .on('submit', function(e) {

--- a/js/Common.js
+++ b/js/Common.js
@@ -940,6 +940,9 @@ if (!CRM.vars) CRM.vars = {};
             $(this).button('option', 'icons', {primary: 'fa-expand'});
           } else {
             var menuHeight = $('#civicrm-menu').outerHeight();
+            if ($('body').hasClass('crm-menubar-below-cms-menu')) {
+              menuHeight += $('#civicrm-menu').offset().top;
+            }
             $el.data('origSize', {
               position: {my: 'center', at: 'center center+' + (menuHeight / 2), of: window},
               width: $el.dialog('option', 'width'),

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -572,8 +572,11 @@
           var currentHeight = $wrapper.outerHeight(),
             padding = currentHeight - $dialog.height(),
             newHeight = $dialog.prop('scrollHeight') + padding,
-            menuHeight = $('#civicrm-menu').outerHeight(),
-            maxHeight = $(window).height() - menuHeight;
+            menuHeight = $('#civicrm-menu').outerHeight();
+          if ($('body').hasClass('crm-menubar-below-cms-menu')) {
+            menuHeight += $('#civicrm-menu').offset().top;
+          }
+          var maxHeight = $(window).height() - menuHeight;
           newHeight = newHeight > maxHeight ? maxHeight : newHeight;
           if (newHeight > (currentHeight + 15)) {
             $dialog.dialog('option', {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue where modal dialogs can be obscured by the CiviCRM menu.

Before
----------------------------------------
Dialog opens behind menubar

After
----------------------------------------
Dialog stays below the menubar

Technical Details
----------------------------------------
Also introduces a new css body class `ui-dialog-open` to make it easier to move things out of the way of open dialogs.
