### PR TITLE
dev/core#562 Remove more DAO->free() calls

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -463,7 +463,6 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
     // we need to set this on the form so that hooks can identify the created entity
     $this->set('id', $bao->id);
-    $bao->free();
 
     $status = ts("Your new Reminder titled %1 has been saved.",
       [1 => "<strong>{$values['title']}</strong>"]

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2945,7 +2945,6 @@ AND       civicrm_openid.is_primary = 1";
       while ($blockDAO->fetch()) {
         $locBlockIds[$name][] = $blockDAO->id;
       }
-      $blockDAO->free();
     }
 
     return $locBlockIds;
@@ -3556,7 +3555,6 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
       }
     }
     CRM_Utils_Hook::post('delete', $type, $id, $obj);
-    $obj->free();
     return TRUE;
   }
 

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -374,7 +374,6 @@ UNION
         $ids['relationship'] = $relationship->id;
         CRM_Contact_BAO_Relationship::setIsActive($relationship->id, TRUE);
       }
-      $relationship->free();
     }
 
     //need to handle related meberships. CRM-3792
@@ -457,7 +456,6 @@ WHERE id={$contactId}; ";
             CRM_Core_Action::DELETE
           );
         }
-        $relationship->free();
       }
     }
   }
@@ -799,7 +797,6 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
           $contactDetails[$contact->componentId][$property] = $contact->$property;
         }
       }
-      $contact->free();
     }
 
     return $contactDetails;

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -785,7 +785,6 @@ WHERE name = %1";
 
       $customDataCount = CRM_Core_DAO::singleValueQuery($sql);
       if (!empty($customDataCount)) {
-        $dao->free();
         return TRUE;
       }
     }

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1112,7 +1112,6 @@ WHERE  id IN $groupIdString
         ];
       }
     }
-    $dao->free();
 
     $hierarchy = [];
     for ($i = 0; $i < count($roots); $i++) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -344,8 +344,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_relationship', $relationship->id);
     }
 
-    $relationship->free();
-
     CRM_Utils_Hook::post($hook, 'Relationship', $relationship->id, $relationship);
 
     return $relationship;
@@ -959,11 +957,9 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
       // Check whether the custom field values are identical.
       $result = self::checkDuplicateCustomFields($params, $relationship->id);
       if ($result) {
-        $relationship->free();
         return TRUE;
       }
     }
-    $relationship->free();
     return FALSE;
   }
 
@@ -1450,7 +1446,6 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         }
       }
 
-      $relationship->free();
       return $values;
     }
   }

--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -54,7 +54,6 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
     $relationshipType->copyValues($params);
     if ($relationshipType->find(TRUE)) {
       CRM_Core_DAO::storeValues($relationshipType, $defaults);
-      $relationshipType->free();
       return $relationshipType;
     }
     return NULL;

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -245,8 +245,6 @@ UPDATE civicrm_dedupe_rule_group
     $ruleDao = new CRM_Dedupe_DAO_Rule();
     $ruleDao->dedupe_rule_group_id = $rgDao->id;
     $ruleDao->delete();
-    $ruleDao->free();
-
     $substrLenghts = [];
 
     $tables = [];
@@ -267,7 +265,6 @@ UPDATE civicrm_dedupe_rule_group
         $ruleDao->rule_length = $length;
         $ruleDao->rule_weight = $weight;
         $ruleDao->save();
-        $ruleDao->free();
 
         if (!array_key_exists($table, $tables)) {
           $tables[$table] = [];

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -453,7 +453,6 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
           $this->_contactIds[] = $householdsDAO->household_id;
         }
       }
-      $householdsDAO->free();
     }
 
     // If contact list has changed, households will probably be at the end of

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -820,7 +820,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
               $formatting['contact_sub_type'] = $relationType->$direction;
             }
           }
-          $relationType->free();
 
           $contactFields = NULL;
           $contactFields = CRM_Contact_DAO_Contact::import();
@@ -1353,7 +1352,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
               $params[$key]['contact_sub_type'] = $relationshipType->$direction;
             }
           }
-          $relationshipType->free();
         }
 
         self::isErrorInCustomData($params[$key], $errorMessage, $csType, $relationships);

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -343,7 +343,6 @@ WHERE  contribution_id = {$id}
       $this->_premiumID = $dao->id;
       $this->_productDAO = $dao;
     }
-    $dao->free();
   }
 
   /**

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -137,7 +137,6 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
           $contributionContactIds["{$result->contact_id}-{$result->contribution_id}"] = $result->contribution_id;
         }
       }
-      $result->free();
       $form->assign('totalSelectedContributions', $form->get('rowCount'));
     }
 

--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -247,7 +247,6 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
             // get prepared to search within already found dupes if $searchWithinDupes flag is set
             $dao->query("DROP TEMPORARY TABLE IF EXISTS dedupe_copy");
             $dao->query("CREATE TEMPORARY TABLE dedupe_copy SELECT * FROM {$this->temporaryTables['dedupe']} WHERE weight >= {$weightSum}");
-            $dao->free();
 
             preg_match($patternColumn, $query, $matches);
             $query = str_replace(' WHERE ', str_replace('column', $matches[1], $dupeCopyJoin), $query);
@@ -258,7 +257,6 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
               // Make a second temp table:
               $dao->query("DROP TEMPORARY TABLE IF EXISTS dedupe_copy_2");
               $dao->query("CREATE TEMPORARY TABLE dedupe_copy_2 SELECT * FROM {$this->temporaryTables['dedupe']} WHERE weight >= {$weightSum}");
-              $dao->free();
               // After the union, use that new temp table:
               $part1 = substr($query, 0, $matches[1][1]);
               $query = $part1 . str_replace('dedupe_copy', 'dedupe_copy_2', substr($query, $matches[1][1]));
@@ -273,7 +271,6 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
           // FIXME: we need to be more acurate with affected rows, especially for insert vs duplicate insert.
           // And that will help optimize further.
           $affectedRows = $dao->affectedRows();
-          $dao->free();
 
           // In an inclusive situation, failure of any query means no further processing -
           if ($affectedRows == 0) {

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1830,7 +1830,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           CRM_Core_BAO_File::deleteFileReferences($fileIds[$mainId], $mainId, $customId);
         }
       }
-      $dao->free();
 
       // move the other contact's file to main contact
       //NYSS need to INSERT or UPDATE depending on whether main contact has an existing record

--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -88,7 +88,6 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
         $tracker->save();
       }
       $id = $tracker->id;
-      $tracker->free();
 
       $redirect = $config->userFrameworkResourceURL . "extern/url.php?u=$id";
       $urlCache[$mailing_id . $url] = $redirect;

--- a/CRM/Mailing/Event/BAO/Delivered.php
+++ b/CRM/Mailing/Event/BAO/Delivered.php
@@ -56,7 +56,6 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
     if (!$q) {
       return NULL;
     }
-    $q->free();
 
     $delivered = new CRM_Mailing_Event_BAO_Delivered();
     $delivered->time_stamp = date('YmdHis');

--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -97,7 +97,6 @@ LEFT JOIN civicrm_email      ON contact_a.id = civicrm_email.contact_id
       if ($dao->fetch()) {
         $contact_id = $dao->contact_id;
       }
-      $dao->free();
     }
 
     $transaction = new CRM_Core_Transaction();
@@ -343,7 +342,6 @@ SELECT     civicrm_email.id as email_id
       ];
     }
 
-    $dao->free();
     return $groups;
   }
 

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2237,7 +2237,6 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     while ($dao->fetch()) {
       $customFields[$dao->table_name . '_custom_' . $dao->id] = $dao->id;
     }
-    $dao->free();
 
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {

--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -617,7 +617,6 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
     while ($dao->fetch()) {
       $contactIds[] = $dao->cid;
     }
-    $dao->free();
     $this->setPager();
 
     $relationshipRows = [];
@@ -732,7 +731,6 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
       }
       $rows[$dao->civicrm_contact_id]['aggregate_amount'] += $dao->civicrm_contribution_total_amount;
     }
-    $dao->free();
     return $rows;
   }
 
@@ -776,7 +774,6 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
         $relatedContactIds[$dao->contact_id_a] = $dao->contact_id_a;
       }
     }
-    $dao->free();
     return [$relationshipRows, $relatedContactIds];
   }
 

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -392,7 +392,6 @@ class SettingsBag {
       // to save the field `group_name`, which is required in older schema.
       \CRM_Core_DAO::executeQuery(\CRM_Utils_SQL_Insert::dao($dao)->toSQL());
     }
-    $dao->free();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup 

Before
----------------------------------------
More obsolete code

After
----------------------------------------
Less obsolete code

Technical Details
----------------------------------------
We have been removing a few of these each release. They no longer provide any benefit
as the resources are released in the deconstructor. OTOH they can in rare circumstances cause bugs.

Previous removals have not caused any issues so the slow approach is starting to
look overly cautious now

Comments

