### PR TITLE
Don't call session_start() before CMS bootstrap (PHP 7.2 compat)

### DIFF
--- a/extern/rest.php
+++ b/extern/rest.php
@@ -31,7 +31,6 @@ $config = CRM_Core_Config::singleton();
 if (defined('PANTHEON_ENVIRONMENT')) {
   ini_set('session.save_handler', 'files');
 }
-session_start();
 $rest = new CRM_Utils_REST();
 
 // Json-appropriate header will be set by CRM_Utils_Rest


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM's extern/rest.php calls session_start() before bootstrapping the CMS.  However, configuring the session is one of the bootstrap steps for Drupal (and perhaps other CMS), and on PHP ≥ 7.2, you cannot configure the session after starting it.  In addition, generally speaking, Drupal does not want anything besides itself to start the session.  This is presumably why there is some logic in CRM_Core_Session::initialize() for starting the session differently on Drupal.

Before
----------------------------------------
When sending a request to extern/rest.php on PHP ≥ 7.2, the following error is logged: Warning: ini_set(): A session is active. You cannot change the session module's ini settings at this time in drupal_environment_initialize() (line 695 of includes/bootstrap.inc).  In addition, other errors/notices in Drupal modules may be logged.

After
----------------------------------------
We no longer call session_start() in extern/rest.php.  I believe this should work because commit f320e5cd2fd5ec881b613d4afb9c4839839dcac3 should result in a session being initialized during CRM_Utils_REST::loadCMSBootstrap().  If not.. then more work is needed here :)