### PR TITLE
(REF) Fix unnecessary required param in contact BAO update

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -272,6 +272,10 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       return $contact;
     }
 
+    if (!empty($params['contact_id']) && empty($params['contact_type'])) {
+      $params['contact_type'] = self::getContactType($params['contact_id']);
+    }
+
     $isEdit = TRUE;
     if ($invokeHooks) {
       if (!empty($params['contact_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Normally a BAO should require an id and nothing else for an update op.
But the contact BAO also required contact_type for no good reason.

Before
----------------------------------------
Contact BAO required contact_type even for update ops.

After
----------------------------------------
 `contact_type` is optional for update ops.

Notes
----------------
Originally this PR also fixed the oddity that `contact_id` is used in place of `id` but that caused test failures and revealed some underlying problems that make fixing that unfeasible. See https://github.com/civicrm/civicrm-core/pull/14075#issuecomment-484253219