### PR TITLE
Fixed auto populate of contact refrence field on membership signup form

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1421,18 +1421,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         }
         break;
 
-      case 'Autocomplete-Select':
-        if ($customField->data_type == 'ContactReference') {
-          if (is_numeric($value)) {
-            $defaults[$elementName . '_id'] = $value;
-            $defaults[$elementName] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $value, 'sort_name');
-          }
-        }
-        else {
-          $defaults[$elementName] = $value;
-        }
-        break;
-
       default:
         $defaults[$elementName] = $value;
     }


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
![Before](https://user-images.githubusercontent.com/2053075/56290871-04432a80-611c-11e9-964e-b6afbbbbf128.gif)


After
----------------------------------------
![After](https://user-images.githubusercontent.com/2053075/56290877-073e1b00-611c-11e9-9bdd-c7a35727c87e.gif)


Technical Details
----------------------------------------
The code still used old method of setting contact reference field by default. When contact reference field was changed in core to use Select2 i guess we missed to remove the code from here.
