### PR TITLE
Drupal#56 - fix quicksearch text color on D8

### DIFF
--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -134,6 +134,7 @@ input#crm-qsearch-input {
   height: 30px;
   width: 30px;
   transition: width .5s .05s, background-color .3s .05s;
+  color: black;
 }
 a.highlighted #crm-qsearch-input,
 #crm-qsearch-input:focus,


### PR DESCRIPTION
Overview
----------------------------------------
The color of the Quicksearch box on 5.12.1 is almost unreadable, it's RGB (221, 221, 221).

Before
----------------------------------------
![Selection_853](https://user-images.githubusercontent.com/1796012/56317416-b386fe00-612a-11e9-8a3b-1f610137b9f3.png)

After
----------------------------------------
![Selection_854](https://user-images.githubusercontent.com/1796012/56317483-ddd8bb80-612a-11e9-9c02-cddb8a538c7c.png)


Technical Details
----------------------------------------
The problem is `normalize.css`, which ships as part of D8.2+.