### PR TITLE
(dev/mail#41) "Preview as HTML" - Fix error with tracking urls

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1366,7 +1366,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       }
     }
     elseif ($type == 'url') {
-      if ($this->url_tracking) {
+      if ($this->url_tracking && !empty($this->id)) {
         $data = CRM_Mailing_BAO_TrackableURL::getTrackerURL($token, $this->id, $event_queue_id);
         if (!empty($html)) {
           $data = htmlentities($data, ENT_NOQUOTES);


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression in email preview. Use-case:

* Compose a "Mailing => New Mailing"
* Fill in basic in fields.
* In the body of the mailing, include a hyperlink
* Press the button "Preview as HTML"

5.12 port of https://github.com/civicrm/civicrm-core/pull/13956

ping @colemanw @eileenmcnaughton @monishdeb @mattwire 