### PR TITLE
dev/core/issues/743, Donot join relationship table when not required

### DIFF
--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -278,7 +278,10 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
     $ccc = $this->_aliases['civicrm_case_contact'];
 
     foreach ($this->_columns['civicrm_relationship']['filters'] as $fieldName => $field) {
-      if (!empty($this->_params[$fieldName . '_op']) && isset($this->_params[$fieldName . '_value'])) {
+      if (!empty($this->_params[$fieldName . '_op'])
+        && array_key_exists("{$fieldName}_value", $this->_params)
+        && !CRM_Utils_System::isNull($this->_params["{$fieldName}_value"])
+      ) {
         $this->_relField = TRUE;
         break;
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/743

Before
----------------------------------------
returned incorrect results

After
----------------------------------------
returned correct results

Technical Details
----------------------------------------
Used CRM_Utils_System::isNull() over isset() since all the fields in filters are always set and may be empty. isNull() functions handles isset and empty very well. 
