### PR TITLE
Cron Status Check - Better hyperlinks

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -303,17 +303,16 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       );
     }
     else {
+      $cronLink = 'target="_blank" href="' . htmlentities(CRM_Utils_System::docURL2('sysadmin/setup/jobs/', TRUE)) . '""';
+      $msg .= '<p>' . ts('To enable scheduling support, please <a %1>set up the cron job</a>.', [
+        1 => $cronLink,
+      ]) . '</p>';
       $message = new CRM_Utils_Check_Message(
         __FUNCTION__,
         $msg,
         ts('Cron Not Running'),
         ($lastCron > gmdate('U') - 86400) ? \Psr\Log\LogLevel::WARNING : \Psr\Log\LogLevel::ERROR,
         'fa-clock-o'
-      );
-      $docUrl = 'target="_blank" href="' . CRM_Utils_System::docURL(['resource' => 'wiki', 'page' => 'Managing Scheduled Jobs', 'URLonly' => TRUE]) . '""';
-      $message->addHelp(
-        ts('Configuring cron on your server is necessary for running scheduled jobs such as sending mail and scheduled reminders.') . '<br />' .
-        ts("Learn more in the <a %1>online documentation</a>.", [1 => $docUrl])
       );
       $messages[] = $message;
     }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1385,7 +1385,7 @@ class CRM_Utils_System {
    * @return mixed
    */
   public static function formatDocUrl($url) {
-    return preg_replace('#^user/#', 'user/en/stable/', $url);
+    return preg_replace('#^(user|sysadmin|dev)/#', '\1/en/stable/', $url);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Improve placement and content of help

Before
----------------------------------------
For a new admin, the actual help is buried behind two clicks, and it points to a wiki page with poor styling.

<img width="746" alt="Screen Shot 2019-04-18 at 10 53 42 AM" src="https://user-images.githubusercontent.com/1336047/56380914-4a55c800-61c8-11e9-8c60-6ec21468089f.png">

&nbsp;

&nbsp;

After
----------------------------------------
For a new admin, the actual help is buried behind one click, and it points to the current Sysadmin Guide.

<img width="705" alt="Screen Shot 2019-04-18 at 10 53 21 AM" src="https://user-images.githubusercontent.com/1336047/56380913-4a55c800-61c8-11e9-9ce5-2597dfe1cbc3.png">
