### PR TITLE
membership#9 - show user a notification on back-office renewals

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -129,6 +129,21 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
    *
    * @throws \Exception
    */
+
+  /**
+   * Set the renewal notification status message.
+   */
+  public function setRenewalMessage() {
+    $statusMsg = ts('%1 membership for %2 has been renewed.', array(1 => $this->membershipTypeName, 2 => $this->_memberDisplayName));
+
+    if ($this->isMailSent) {
+      $statusMsg .= ' ' . ts('A renewal confirmation and receipt has been sent to %1.', array(
+        1 => $this->_contributorEmail,
+      ));
+    }
+    CRM_Core_Session::setStatus($statusMsg, ts('Complete'), 'success');
+  }
+
   public function preProcess() {
 
     // This string makes up part of the class names, differentiating them (not sure why) from the membership fields.
@@ -459,21 +474,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     try {
       $this->submit();
-      $statusMsg = ts('%1 membership for %2 has been renewed.', [1 => $this->membershipTypeName, 2 => $this->_memberDisplayName]);
-
-      if ($this->endDate) {
-        $statusMsg .= ' ' . ts('The new membership End Date is %1.', [
-          1 => CRM_Utils_Date::customFormat(substr($this->endDate, 0, 8)),
-        ]);
-      }
-
-      if ($this->isMailSent) {
-        $statusMsg .= ' ' . ts('A renewal confirmation and receipt has been sent to %1.', [
-          1 => $this->_contributorEmail,
-        ]);
-        return $statusMsg;
-      }
-      return $statusMsg;
+      $this->setRenewalMessage();
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
       CRM_Core_Session::singleton()->setStatus($e->getMessage());
@@ -481,8 +482,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         "reset=1&action=renew&cid={$this->_contactID}&id={$this->_id}&context=membership&mode={$this->_mode}"
       ));
     }
-
-    CRM_Core_Session::setStatus($statusMsg, ts('Complete'), 'success');
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -182,6 +182,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $form->_contactID = $this->_individualId;
 
     $form->testSubmit($params);
+    $form->setRenewalMessage();
     $membership = $this->callAPISuccessGetSingle('Membership', array('contact_id' => $this->_individualId));
     $this->callAPISuccessGetCount('ContributionRecur', array('contact_id' => $this->_individualId), 0);
     $contribution = $this->callAPISuccess('Contribution', 'get', array(
@@ -203,6 +204,14 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
         'return' => 'payment_instrument_id',
       )),
     ), 'online');
+    $this->assertEquals([
+      [
+        'text' => 'AnnualFixed membership for Mr. Anthony Anderson II has been renewed.',
+        'title' => 'Complete',
+        'type' => 'success',
+        'options' => NULL,
+      ],
+    ], CRM_Core_Session::singleton()->getStatus());
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When renewing a membership via the back-office form, no on-screen notification appears.  This is technically a regression but appears to be quite old, so no need for urgency.

Before
----------------------------------------
No notification appears.

After
----------------------------------------
Notification appears.
![selection_791](https://user-images.githubusercontent.com/1796012/52441750-88ab7880-2aef-11e9-8a7f-35333b20c353.png)


Technical Details
----------------------------------------
The only functional change is removing the two `return` statements and removing the sentence about the end date (per Eileen's request to align with PR #12583).  I additionally extracted the renewal message into its own method so that I could extend the tests to cover it.

Comments
----------------------------------------
The screenshot above is from before I removed the sentence about the end date.  This is also a redo of PR #13553.

https://lab.civicrm.org/dev/membership/issues/9