### PR TITLE
dev/core#887 Fix fatal error on pledge search

### DIFF
--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -178,6 +178,11 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    */
   public static function formRule($fields, $files, $form) {
     $errors = [];
+    if (!is_a($form, 'CRM_Core_Form_Search')) {
+      // So this gets hit with a form object when doing an activity date search from
+      // advanced search, but a NULL object when doing a pledge search.
+      return $errors;
+    }
     foreach ($form->getSearchFieldMetadata() as $entity => $spec) {
       foreach ($spec as $fieldName => $fieldSpec) {
         if ($fieldSpec['type'] === CRM_Utils_Type::T_DATE || $fieldSpec['type'] === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)) {

--- a/CRM/Grant/BAO/Query.php
+++ b/CRM/Grant/BAO/Query.php
@@ -297,7 +297,7 @@ class CRM_Grant_BAO_Query extends CRM_Core_BAO_Query {
   }
 
   /**
-   * Get the metadata for fields to be included on the activity search form.
+   * Get the metadata for fields to be included on the grant search form.
    */
   public static function getSearchFieldMetadata() {
     $fields = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal error regression when doing pledge search

Before
----------------------------------------
Search fails with fatal error 

```Result: Error: Call to a member function getSearchFieldMetadata() on null in CRM_Core_Form_Search::formRule() (line 181 of /srv/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Form/Search.php).
```

After
----------------------------------------
Search succeeds

Technical Details
----------------------------------------
Ug

Comments
----------------------------------------

