### PR TITLE
Deprecate creating recipients from MailingJob.create.

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -72,7 +72,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     $jobDAO = new CRM_Mailing_BAO_MailingJob();
     $jobDAO->copyValues($params, TRUE);
     $jobDAO->save();
-    if (!empty($params['mailing_id'])) {
+    if (!empty($params['mailing_id']) && empty('is_calling_function_updated_to_reflect_deprecation')) {
       CRM_Mailing_BAO_Mailing::getRecipients($params['mailing_id']);
     }
     CRM_Utils_Hook::post($op, 'MailingJob', $jobDAO->id, $jobDAO);

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -631,7 +631,9 @@ function civicrm_api3_mailing_send_test($params) {
   $testEmailParams['is_test'] = 1;
   $testEmailParams['status'] = 'Scheduled';
   $testEmailParams['scheduled_date'] = CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s'));
+  $testEmailParams['is_calling_function_updated_to_reflect_deprecation'] = TRUE;
   $job = civicrm_api3('MailingJob', 'create', $testEmailParams);
+  CRM_Mailing_BAO_Mailing::getRecipients($testEmailParams['mailing_id']);
   $testEmailParams['job_id'] = $job['id'];
   $testEmailParams['emails'] = array_key_exists('test_email', $testEmailParams) ? explode(',', strtolower($testEmailParams['test_email'])) : NULL;
   if (!empty($params['test_email'])) {


### PR DESCRIPTION
Overview
----------------------------------------
deprecate code path towards code clean up

Before
----------------------------------------
not deprecated

After
----------------------------------------
deprecated

Technical Details
----------------------------------------
It is done in mailing create & then has to bypass MailingJob.create in order to not do it twice.

This ALSO bypasses hooks

Comments
----------------------------------------

