### PR TITLE
[REF] extract buildClause from CRM_Report_Form_Event_Income

### DIFF
--- a/CRM/Report/Form/Event/Income.php
+++ b/CRM/Report/Form/Event/Income.php
@@ -37,6 +37,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
 
   protected $_summary = NULL;
   protected $_noFields = TRUE;
+  protected $eventIDs = [];
 
   protected $_add2groupSupported = FALSE;
 
@@ -75,47 +76,13 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
   public function buildEventReport($eventIDs) {
 
     $this->assign('events', $eventIDs);
-
-    $eventID = implode(',', $eventIDs);
-
+    $this->eventIDs = $eventIDs;
+    $eventID = implode(',', $this->eventIDs);
     $participantRole = CRM_Event_PseudoConstant::participantRole();
     $paymentInstruments = CRM_Contribute_PseudoConstant::paymentInstrument();
 
     $rows = $eventSummary = $roleRows = $statusRows = $instrumentRows = $count = [];
-
-    $optionGroupDAO = new CRM_Core_DAO_OptionGroup();
-    $optionGroupDAO->name = 'event_type';
-    $optionGroupId = NULL;
-    if ($optionGroupDAO->find(TRUE)) {
-      $optionGroupId = $optionGroupDAO->id;
-    }
-
-    $activeParticipantClause = " AND civicrm_participant.status_id IN ( " . implode(',', array_keys($this->getActiveParticipantStatuses())) . " ) ";
-    $select = [
-      "civicrm_event.id as event_id",
-      "civicrm_event.title as event_title",
-      "civicrm_event.max_participants as max_participants",
-      "civicrm_event.start_date as start_date",
-      "civicrm_event.end_date as end_date",
-      "civicrm_option_value.label as event_type",
-      "civicrm_participant.fee_currency as currency",
-    ];
-
-    $groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($select, 'civicrm_event.id');
-    $sql = "
-            SELECT  " . implode(', ', $select) . ",
-                    SUM(civicrm_participant.fee_amount) as total,
-                    COUNT(civicrm_participant.id)       as participant
-
-            FROM       civicrm_event
-            LEFT JOIN  civicrm_option_value
-                   ON  ( civicrm_event.event_type_id = civicrm_option_value.value AND
-                         civicrm_option_value.option_group_id = {$optionGroupId} )
-            LEFT JOIN  civicrm_participant ON ( civicrm_event.id = civicrm_participant.event_id
-                       {$activeParticipantClause} AND civicrm_participant.is_test  = 0 )
-
-            WHERE      civicrm_event.id IN( {$eventID}) {$groupBy}";
-
+    $sql = $this->buildQuery();
     $eventDAO = $this->executeReportQuery($sql);
     $currency = [];
     while ($eventDAO->fetch()) {
@@ -130,6 +97,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
     }
     $this->assign_by_ref('summary', $eventSummary);
 
+    $activeParticipantClause = " AND civicrm_participant.status_id IN ( " . implode(',', array_keys($this->getActiveParticipantStatuses())) . " ) ";
     //Total Participant Registerd for the Event
     $pariticipantCount = "
             SELECT COUNT(civicrm_participant.id ) as count, civicrm_participant.event_id as event_id
@@ -382,6 +350,52 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
    */
   protected function getActiveParticipantStatuses() {
     return CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1", "label");
+  }
+
+  /**
+   * Build main report sql query.
+   *
+   * @param bool $applyLimit
+   *
+   * @return string
+   */
+  public function buildQuery($applyLimit = FALSE) {
+    $eventID = implode(',', $this->eventIDs);
+
+    $optionGroupDAO = new CRM_Core_DAO_OptionGroup();
+    $optionGroupDAO->name = 'event_type';
+    $optionGroupId = NULL;
+    if ($optionGroupDAO->find(TRUE)) {
+      $optionGroupId = $optionGroupDAO->id;
+    }
+
+    $activeParticipantClause = " AND civicrm_participant.status_id IN ( " . implode(',', array_keys($this->getActiveParticipantStatuses())) . " ) ";
+    $select = [
+      "civicrm_event.id as event_id",
+      "civicrm_event.title as event_title",
+      "civicrm_event.max_participants as max_participants",
+      "civicrm_event.start_date as start_date",
+      "civicrm_event.end_date as end_date",
+      "civicrm_option_value.label as event_type",
+      "civicrm_participant.fee_currency as currency",
+    ];
+
+    $groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($select, 'civicrm_event.id');
+    $sql = "
+            SELECT  " . implode(', ', $select) . ",
+                    SUM(civicrm_participant.fee_amount) as total,
+                    COUNT(civicrm_participant.id)       as participant
+
+            FROM       civicrm_event
+            LEFT JOIN  civicrm_option_value
+                   ON  ( civicrm_event.event_type_id = civicrm_option_value.value AND
+                         civicrm_option_value.option_group_id = {$optionGroupId} )
+            LEFT JOIN  civicrm_participant ON ( civicrm_event.id = civicrm_participant.event_id
+                       {$activeParticipantClause} AND civicrm_participant.is_test  = 0 )
+
+            WHERE      civicrm_event.id IN( {$eventID}) {$groupBy}";
+
+    return $sql;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Function extraction towards bringing the event income details report under unit testing

Before
----------------------------------------
Report less stdised

After
----------------------------------------
Report more stdisied

Technical Details
----------------------------------------
This report is currently excluded from unit tests by virtue of it being declared as skipped in
api_v3_ReportTemplateTest

We have a PR https://github.com/civicrm/civicrm-core/pull/13928 to alter test logic.

I'm really not comfortable making any logic changes to the report until
it is under testing. Extracting buildQuery removes one of the blockers to
bringing it under testing (remaining are moving most / all logic from
postProcess to beginPostProcessCommon and fixing up the setPager function -
which probably just means removing it

Comments
----------------------------------------

