### PR TITLE
Convert Pledge Calander Date and Start Date for pledges to use datepic…

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -339,7 +339,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       // @todo look to change to $defaults['start_date'] = date('Ymd His');
       // main settings form overrides this to implement above but this is left here
       // 'in case' another extending form uses start_date - for now
-      list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults();
+      $defaults['start_date'] = date('Y-m-d H:i:s');
     }
 
     if (!empty($defaults['recur_frequency_unit'])) {

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -179,7 +179,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
         $this->addElement('checkbox', 'adjust_recur_start_date', ts('Adjust Recurring Start Date'), NULL,
           ['onclick' => "showHideByValue('adjust_recur_start_date',true,'recurDefaults','table-row','radio',false);"]
         );
-        $this->addDate('pledge_calendar_date', ts('Specific Calendar Date'));
+        $this->add('datepicker', 'pledge_calendar_date', ts('Specific Calendar Date'), [], FALSE, ['time' => FALSE]);
         $month = CRM_Utils_Date::getCalendarDayOfMonth();
         $this->add('select', 'pledge_calendar_month', ts('Specific day of Month'), $month);
         $pledgeDefaults = [
@@ -512,7 +512,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
         'calendar_month' => 'pledge_calendar_month',
       ];
       if ($params['pledge_default_toggle'] == 'contribution_date') {
-        $fieldValue = json_encode(['contribution_date' => date('m/d/Y')]);
+        $fieldValue = json_encode(['contribution_date' => date('Y-m-d')]);
       }
       else {
         foreach ($pledgeDateFields as $key => $pledgeDateField) {

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -147,6 +147,14 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
+   * Supports altering future start dates
+   * @return bool
+   */
+  public function supportsFutureRecurStartDate() {
+    return TRUE;
+  }
+
+  /**
    * Submit a refund payment
    *
    * @throws \Civi\Payment\Exception\PaymentProcessorException

--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -308,15 +308,15 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
           foreach ($date as $field => $value) {
             switch ($field) {
               case 'contribution_date':
-                $form->addDate('start_date', ts('First installment payment'));
-                $paymentDate = $value = date('m/d/Y');
-                list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults(NULL);
+                $form->add('datepicker', 'start_date', ts('First installment payment'), [], FALSE, ['time' => FALSE]);
+                $paymentDate = $value = date('Y-m-d');
+                $defaults['start_date'] = $value;
                 $form->assign('is_date', TRUE);
                 break;
 
               case 'calendar_date':
-                $form->addDate('start_date', ts('First installment payment'));
-                list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults($value);
+                $form->add('datepicker', 'start_date', ts('First installment payment'), [], FALSE, ['time' => FALSE]);
+                $defaults['start_date'] = $value;
                 $form->assign('is_date', TRUE);
                 $paymentDate = $value;
                 break;
@@ -325,7 +325,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
                 $month = CRM_Utils_Date::getCalendarDayOfMonth();
                 $form->add('select', 'start_date', ts('Day of month installments paid'), $month);
                 $paymentDate = CRM_Pledge_BAO_Pledge::getPaymentDate($value);
-                list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults($paymentDate);
+                $defaults['start_date'] = $paymentDate;
                 break;
 
               default:

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -135,7 +135,7 @@
           <div class="clear"></div>
           {if $start_date_editable}
             {if $is_date}
-              <div class="label">{$form.start_date.label}</div><div class="content">{include file="CRM/common/jcalendar.tpl" elementName=start_date}</div>
+              <div class="label">{$form.start_date.label}</div><div class="content">{$form.start_date.html}</div>
             {else}
               <div class="label">{$form.start_date.label}</div><div class="content">{$form.start_date.html}</div>
             {/if}

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -121,7 +121,7 @@
         </table>
     </div>
 {if $futurePaymentProcessor}
-    <span id="pledge_calendar_date_field">&nbsp;&nbsp;{include file="CRM/common/jcalendar.tpl" elementName=pledge_calendar_date}</span>
+    <span id="pledge_calendar_date_field">&nbsp;&nbsp;{$form.pledge_calendar_date.html}</span>
     <span id="pledge_calendar_month_field">&nbsp;&nbsp;{$form.pledge_calendar_month.html}<br/><span class="description">{ts}Recurring payment will be processed this day of the month following submission of this contribution page.{/ts}</span></span>
 {/if}
 


### PR DESCRIPTION
…ker rather than jcalendar

Overview
----------------------------------------
This converts the pledge_calendar_date and start_date fields for pledges in association of Contribution Pages to using datepicker rather than jcalendar

Before
----------------------------------------
deprecated jcalendar used

After
----------------------------------------
using modern datepicker

ping @eileenmcnaughton @monishdeb @mattwire 