### PR TITLE
dev/core#888 - Backoffice participant transfer form does not populate…

### DIFF
--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -283,7 +283,6 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
    * return @void
    */
   public function transferParticipant($params) {
-    $isBackOfficeArg = $this->isBackoffice ? '&is_backoffice=1' : '';
     CRM_Utils_System::redirect(CRM_Utils_System::url(
       'civicrm/event/selfsvctransfer',
       [
@@ -291,6 +290,7 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
         'action' => 'add',
         'pid' => $this->_participant_id,
         'cs' => $this->_userChecksum,
+        'is_backoffice' => $this->isBackoffice,
       ]
     ));
   }


### PR DESCRIPTION
… contact reference field

Overview
----------------------------------------
Backoffice participant transfer form does not populate contact reference field

Before
----------------------------------------
To replicate -

- Register contact A for an event.
- Click on more -> `Transfer or cancel` link
- Select transfer as an action on the form loaded.
- On the next page, a contact reference field should be populated to select contact B for the transfer. Instead a normal first/last name and email field is shown - 

![image](https://user-images.githubusercontent.com/5929648/56481079-d161b380-64da-11e9-8cd2-bfa638bf1e8f.png)

After
----------------------------------------
Contact ref field is displayed correctly -

![image](https://user-images.githubusercontent.com/5929648/56481090-de7ea280-64da-11e9-82c2-7fcb2701a30b.png)


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/888