### PR TITLE
dev/core#889 - Refund throws a fatal error if the main contribution a…

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -332,7 +332,10 @@ class CRM_Financial_BAO_Payment {
         if ($lineItemValue['qty'] == 0) {
           continue;
         }
-        $paid = $lineItemValue['line_total'] * ($financialTrxn->total_amount / $contributionDAO->total_amount);
+        $paid = $financialTrxn->total_amount;
+        if (!empty(floatval($contributionDAO->total_amount))) {
+          $paid = $lineItemValue['line_total'] * ($financialTrxn->total_amount / $contributionDAO->total_amount);
+        }
         $addFinancialEntry = [
           'transaction_date' => $financialTrxn->trxn_date,
           'contact_id' => $contributionDAO->contact_id,


### PR DESCRIPTION
…mount is 0

Overview
----------------------------------------
Refund throws a fatal error if the main contribution amount is 0

Before
----------------------------------------
To replicate -

- Create an event with fee amount options = $0, $50, $100.
- Register contact A for an event with price $50.
- Change selection to $0. Main contribution amount updates to $0.
- Record refund of $50 -> Submit.
- Payment is refunded but the ajax form is stuck with an Error.

![image](https://user-images.githubusercontent.com/5929648/56481960-459e5600-64df-11e9-9761-0fdfa9ffe61e.png)


After
----------------------------------------
Refund form is submitted correctly.

Technical Details
----------------------------------------
As main contribution amount `$contributionDAO->total_amount ` is 0, there is a division by zero error assignment to $paid var which throws an error when it is tried to insert as a row in financial item table.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/889