### PR TITLE
dev/core#890 - Multiple line item shown on view contribution if parti…

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -377,11 +377,13 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     //copy line items to new participant
     $line_items = CRM_Price_BAO_LineItem::getLineItems($this->_from_participant_id);
-    foreach ($line_items as $item) {
+    foreach ($line_items as $id => $item) {
+      //Remove contribution id from older participant line item.
+      CRM_Core_DAO::singleValueQuery("UPDATE civicrm_line_item SET contribution_id = NULL WHERE id = %1", [1 => [$id, 'Integer']]);
       $item['entity_id'] = $participant->id;
       $item['id'] = NULL;
       $item['entity_table'] = "civicrm_participant";
-      $new_item = CRM_Price_BAO_LineItem::create($item);
+      CRM_Price_BAO_LineItem::create($item);
     }
     //now cancel the from participant record, leaving the original line-item(s)
     $value_from = [];


### PR DESCRIPTION
…cipant is transferred to another contact

Overview
----------------------------------------
Multiple line item shown on view contribution if participant is transferred to another contact

Before
----------------------------------------
To replicate -

- Create a priceset for an event with `Text / Numeric Quantity` field type. Amount = $10.
- Register contact A to the event using the above price option.
- Transfer the event participation to another contact B.
- View contribution on the main contact, it displays double line items for the participation. 

![image](https://user-images.githubusercontent.com/5929648/56482564-8d72ac80-64e2-11e9-8cf4-384a77f49bfc.png)

I think the older participant status is set to "transferred" so it should remove the contribution link from the line item table?

After
----------------------------------------

Line item is displayed correctly.

![image](https://user-images.githubusercontent.com/5929648/56482624-b2671f80-64e2-11e9-8966-296a824b11a9.png)


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/890