### PR TITLE
wip - Record refund from paypal payment processor

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -259,6 +259,19 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       );
       $this->addRule('net_amount', ts('Please enter a valid monetary value for Net Amount.'), 'money');
     }
+    $ft = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($this->_contributionId);
+    if (!empty($ft['financialTrxnId'])) {
+      $defaults = [];
+      $ftParams = ['id' => $ft['financialTrxnId']];
+      $financialTrxn = CRM_Core_BAO_FinancialTrxn::retrieve($ftParams, $defaults);
+      if (!empty($financialTrxn->payment_processor_id)) {
+        $processor = Civi\Payment\System::singleton()->getById($financialTrxn->payment_processor_id);
+        if ($processor->supports('Refund')) {
+          $this->addElement('checkbox', 'processor_refund', ts('Record refund from the payment processor?'));
+          $this->assign('processorRefund', TRUE);
+        }
+      }
+    }
 
     $buttonName = $this->_refund ? 'Record Refund' : 'Record Payment';
     $this->addButtons([

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -112,6 +112,12 @@
             <span class="description">{ts}Processing fee for this transaction (if applicable).{/ts}</span></td></tr>
            <tr class="crm-payment-form-block-net_amount"><td class="label">{$form.net_amount.label}</td><td>{$form.net_amount.html|crmMoney:$currency:'':1}<br />
             <span class="description">{ts}Net value of the payment (Total Amount minus Fee).{/ts}</span></td></tr>
+          {if $processorRefund}
+            <tr class="crm-payment-form-block-processor_refund">
+              <td class="label">{$form.processor_refund.label}</td>
+              <td>{$form.processor_refund.html}</td>
+            </tr>
+          {/if}
         </table>
       </div>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Record refund from the paypal payment processor.

Before
----------------------------------------
Payment Refund could not be processed from the main transaction in paypal.

After
----------------------------------------
Refund from the Paypal processor is optionally available.

If main contribution is attached to any payment processor supporting refund, a checkbox is displayed on the form. If enabled, refund will be processed directly from the paypal transaction.

![image](https://user-images.githubusercontent.com/5929648/56495861-aeec8c00-6514-11e9-9575-62d4fd02ae95.png)

tagging wip since the final patch needs to be tested on production and it might need a unit test as well?
