### PR TITLE
REF Don't pass activity object to addCaseActivityLinks

### DIFF
--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -322,7 +322,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
       $isDeleted = FALSE;
       if ($result->case_deleted) {
         $isDeleted = TRUE;
-        $row['case_status_id'] = empty($row['case_status_id']) ? "" : $row['case_status_id'] . '<br />(deleted)';
+        $row['case_status_id'] = empty($row['case_status_id']) ? "" : $row['case_status_id'] . '<br />' . ts('(deleted)');
       }
 
       $scheduledInfo['case_id'][] = $result->case_id;


### PR DESCRIPTION
Overview
----------------------------------------
Simplifies the transitional addCaseActivityLinks function by removing one of the passed parameters.

Before
----------------------------------------
Less refactorable

After
----------------------------------------
More refactorable

Technical Details
----------------------------------------
We switch addCaseActivityLinks to private as it should not be called from elsewhere (it was only added recently so this should not be an issue).  Once the refactor is "complete" the function will disappear and be replace by actionLinks.

Comments
----------------------------------------
Partial from https://github.com/civicrm/civicrm-core/compare/master...mattwire:case_links_refactor_part2