### PR TITLE
Fix ts() usage in CRM_SMS_Form_Schedule

### DIFF
--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -67,8 +67,8 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
     $this->setAttribute('autocomplete', 'off');
 
     $sendOptions = [
-      $this->createElement('radio', NULL, NULL, 'Send immediately', 'send_immediate', ['id' => 'send_immediate', 'style' => 'margin-bottom: 10px;']),
-      $this->createElement('radio', NULL, NULL, 'Send at:', 'send_later', ['id' => 'send_later']),
+      $this->createElement('radio', NULL, NULL, ts('Send immediately'), 'send_immediate', ['id' => 'send_immediate', 'style' => 'margin-bottom: 10px;']),
+      $this->createElement('radio', NULL, NULL, ts('Send at:'), 'send_later', ['id' => 'send_later']),
     ];
     $this->addGroup($sendOptions, 'send_option', '', '<br>');
 


### PR DESCRIPTION
Overview
----------------------------------------

Fixes the ts() usage of strings on the "Send Mass SMS" form, so that strings can be correctly translated.

Before
--------------

![Capture d’écran de 2019-04-22 09-24-44](https://user-images.githubusercontent.com/254741/56502511-8b0f5300-64e0-11e9-9de3-951619e5488e.png)



After
------------

![Capture d’écran de 2019-04-22 09-24-58](https://user-images.githubusercontent.com/254741/56502506-88acf900-64e0-11e9-8e1f-667eccec9c55.png)

