### PR TITLE
dev/core#891 condition on id existence when retrieving mailing hash

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1775,7 +1775,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    */
   public static function getMailingHash($id) {
     $hash = NULL;
-    if (Civi::settings()->get('hash_mailing_url')) {
+    if (Civi::settings()->get('hash_mailing_url') && !empty($id)) {
       $hash = CRM_Core_DAO::getFieldValue('CRM_Mailing_BAO_Mailing', $id, 'hash', 'id');
     }
     return $hash;


### PR DESCRIPTION
Overview
----------------------------------------
The presence of the mailing.viewUrl token with the mailing hash setting enabled expects the Mailing ID, which is not passed with the preview action (for performance reasons).

Before
----------------------------------------
With mailing hash enabled, the presence of the mailing.viewUrl token in a mailing would cause the mailing preview to hang and fail to open.

After
----------------------------------------
Preview opens as expected. 

Technical Details
----------------------------------------
Same underlying issue as detailed in: https://github.com/civicrm/civicrm-core/pull/13956