### PR TITLE
Fix duplicate households on 'Merge same household' exports

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -330,8 +330,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       if (empty($returnProperties['id'])) {
         $returnProperties['id'] = 1;
       }
-
-      $processor->setHouseholdMergeReturnProperties(array_diff_key($returnProperties, array_fill_keys(['location_type', 'im_provider'], 1)));
+      $processor->setHouseholdMergeReturnProperties($returnProperties);
     }
 
     self::buildRelatedContactArray($selectAll, $ids, $processor, $componentTable);
@@ -464,7 +463,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         $componentDetails[] = $row;
 
         // output every $tempRowCount rows
-        if ($count % $tempRowCount == 0) {
+        if (($count > 0) && ($count % $tempRowCount == 0)) {
           self::writeDetailsToTable($exportTempTable, $componentDetails, $sqlColumns);
           $componentDetails = [];
         }
@@ -1334,6 +1333,7 @@ LIMIT $offset, $limit
             $processor->setRelationshipValue($relationshipKey, $allRelContactDAO->refContact, $property, $row[$relationshipKey . '_' . $property]);
           }
         }
+        $processor->setHouseholdHasRelationships($allRelContactDAO->contact_id);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Merge same household was creating duplicate rows for each household, one for the "merged individuals" and one being the explicit household directly exported.

Before
----------------------------------------
* Duplicate households on "merge same household" contact export.

After
----------------------------------------
* No duplicate households on "merge same household" contact export.

Technical Details
----------------------------------------
When exporting contacts with "Merge same household" a household record is created by merging the individual record.  However, that household is also exported directly leading to two records for the same household.
If a household has no relationships then we do need to directly export.

Comments
----------------------------------------
Reported on two sites running 5.11 and 5.12.  I don't think this is a regression as "Merge same household" was completely broken until recently.