### PR TITLE
dev/core#880: Fix typo in DROP table query.

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -613,6 +613,7 @@ class Requirements {
       return $results;
     }
 
+    mysqli_query($conn, 'DROP TABLE IF EXISTS civicrm_utf8mb4_test');
     $r = mysqli_query($conn, 'CREATE TABLE civicrm_utf8mb4_test (id VARCHAR(255), PRIMARY KEY(id(255))) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC ENGINE=INNODB');
     if (!$r) {
       $results['severity'] = $this::REQUIREMENT_WARNING;
@@ -620,7 +621,7 @@ class Requirements {
       mysqli_close($conn);
       return $results;
     }
-    mysqli_query('DROP TABLE civicrm_utf8mb4_test');
+    mysqli_query($conn, 'DROP TABLE civicrm_utf8mb4_test');
 
     // Ensure that the MySQL driver supports utf8mb4 encoding.
     $version = mysqli_get_client_info($conn);


### PR DESCRIPTION
Overview
----------------------------------------
The DROP table query in the utf8mb4 is missing its $conn argument. Hat tip johnk: https://lab.civicrm.org/dev/core/issues/880#note_16365

Before
----------------------------------------
utf8mb4 test fails if run again because table already exists.

After
----------------------------------------
Drop table if it exists; properly drop table after running test.