### PR TITLE
dev/core#891 condition on id existenced when retrieving mailing hash

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1750,7 +1750,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    */
   public static function getMailingHash($id) {
     $hash = NULL;
-    if (Civi::settings()->get('hash_mailing_url')) {
+    if (Civi::settings()->get('hash_mailing_url') && !empty($id)) {
       $hash = CRM_Core_DAO::getFieldValue('CRM_Mailing_BAO_Mailing', $id, 'hash', 'id');
     }
     return $hash;


### PR DESCRIPTION
Overview
----------------------------------------
backport of https://github.com/civicrm/civicrm-core/pull/14114

Preview fails when the token {mailing.viewUrl} is included in a mailing

Before
----------------------------------------
Preview breaks

After
----------------------------------------
preview works

ping @totten @eileenmcnaughton 