### PR TITLE
Fixed double protocol being added in link by CKEditor.

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1346,6 +1346,10 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $numSlices = count($embed_data);
       $url = '';
       for ($i = 0; $i < $numSlices; $i++) {
+        $embed_url_data = parse_url($embed_data[$i]);
+        if (!empty($embed_url_data['scheme'])) {
+          $token_a['embed_parts'][$i] = preg_replace("/href=\"(https*:\/\/)/", "href=\"", $token_a['embed_parts'][$i]);
+        }
         $url .= "{$token_a['embed_parts'][$i]}{$embed_data[$i]}";
       }
       if (isset($token_a['embed_parts'][$numSlices])) {


### PR DESCRIPTION
Overview
----------------------------------------
Adding action tokens using the CKEditor link interface can easily cause double protocols
Before

**Steps to reproduce:**

1. Create a mailing.
2. Add a link using the CKEditor link button
3. The "protocol" should be http:// (if it isn't set to this already, change it, but this has come up because http:// was the default)
4. Set the URL to `{action.forward}`
5. Add some text, e.g. "Forward"
6. Preview the mailing, and inspect the link; note that it has an href starting with http://https:// or http://http://

Before
----------------------------------------
Links are added with double protocols, http://https:// or http://http://

After
----------------------------------------
Links have only a single protocol.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-1143_