### PR TITLE
dev/core#248 - Fixes advanced search mailings results headers

### DIFF
--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -343,9 +343,7 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
   public function &getColumnHeaders($action = NULL, $output = NULL) {
 
     if (!isset(self::$_columnHeaders)) {
-      $enabledLanguages = CRM_Core_I18n::languages(TRUE);
-      $isMultiLingual = (count($enabledLanguages) > 1);
-
+      $isMultiLingual = CRM_Core_I18n::isMultiLingual();
       $headers = [
         ['desc' => ts('Contact Type')],
         [

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -367,7 +367,7 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
 
       // Check to see if languages column should be displayed.
       if ($isMultiLingual) {
-        $headers[] =  [
+        $headers[] = [
           'name' => ts('Language'),
           'sort' => 'language',
           'direction' => CRM_Utils_Sort::DONTCARE,

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -341,8 +341,12 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
    *   the column headers that need to be displayed
    */
   public function &getColumnHeaders($action = NULL, $output = NULL) {
+
     if (!isset(self::$_columnHeaders)) {
-      self::$_columnHeaders = [
+      $enabledLanguages = CRM_Core_I18n::languages(TRUE);
+      $isMultiLingual = (count($enabledLanguages) > 1);
+
+      $headers = [
         ['desc' => ts('Contact Type')],
         [
           'name' => ts('Name'),
@@ -359,11 +363,17 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
           'sort' => 'mailing_name',
           'direction' => CRM_Utils_Sort::DONTCARE,
         ],
-        [
+      ];
+
+      // Check to see if languages column should be displayed.
+      if ($isMultiLingual) {
+        $headers[] =  [
           'name' => ts('Language'),
           'sort' => 'language',
           'direction' => CRM_Utils_Sort::DONTCARE,
-        ],
+        ];
+      }
+      self::$_columnHeaders = array_merge($headers, [
         [
           'name' => ts('Mailing Subject'),
           'sort' => 'mailing_subject',
@@ -380,7 +390,7 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
           'direction' => CRM_Utils_Sort::DONTCARE,
         ],
         ['desc' => ts('Actions')],
-      ];
+      ]);
     }
     return self::$_columnHeaders;
   }


### PR DESCRIPTION
Removes language from advanced search results mailings column
headers for non-multilingual sites.

Overview
----------------------------------------
Fixes a misalignment of headers for advanced search results when displaying results as mailing.

https://lab.civicrm.org/dev/core/issues/248

Before
----------------------------------------
On sites that are not multilingual the language column is included as a header but not as a result meaning the results and the headers are out of alignment.

After
----------------------------------------
Results are back in alignment with headers.
