### PR TITLE
Hook to alter menubar css variables & fix breakpoint in WP

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -859,7 +859,7 @@ class CRM_Core_Resources {
       'breakMin' => $e->params['breakpoint'] . 'px',
       'breakMax' => ($e->params['breakpoint'] - 1) . 'px',
       'menubarColor' => $color,
-      'semiTransparentMenuColor' => 'rgba(' . implode(', ', CRM_Utils_Color::getRgb($color)) . ", {$e->params['opacity']})",
+      'menuItemColor' => 'rgba(' . implode(', ', CRM_Utils_Color::getRgb($color)) . ", {$e->params['opacity']})",
       'highlightColor' => CRM_Utils_Color::getHighlight($color),
       'textColor' => CRM_Utils_Color::getContrast($color, '#333', '#ddd'),
     ];

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -853,6 +853,8 @@ class CRM_Core_Resources {
     $vars = [
       'resourceBase' => rtrim($config->resourceBase, '/'),
       'menubarHeight' => '40px',
+      'breakMin' => '768px',
+      'breakMax' => '767px',
       'menubarColor' => $color,
       'semiTransparentMenuColor' => 'rgba(' . implode(', ', CRM_Utils_Color::getRgb($color)) . ', .85)',
       'highlightColor' => CRM_Utils_Color::getHighlight($color),

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -767,6 +767,9 @@ class CRM_Core_Resources {
       $items[] = 'js/crm.menubar.js';
       $items[] = Civi::service('asset_builder')->getUrl('crm-menubar.css', [
         'color' => Civi::settings()->get('menubar_color'),
+        'height' => 40,
+        'breakpoint' => 768,
+        'opacity' => .88,
       ]);
       $items[] = [
         'menubar' => [
@@ -852,11 +855,11 @@ class CRM_Core_Resources {
     }
     $vars = [
       'resourceBase' => rtrim($config->resourceBase, '/'),
-      'menubarHeight' => '40px',
-      'breakMin' => '768px',
-      'breakMax' => '767px',
+      'menubarHeight' => $e->params['height'] . 'px',
+      'breakMin' => $e->params['breakpoint'] . 'px',
+      'breakMax' => ($e->params['breakpoint'] - 1) . 'px',
       'menubarColor' => $color,
-      'semiTransparentMenuColor' => 'rgba(' . implode(', ', CRM_Utils_Color::getRgb($color)) . ', .85)',
+      'semiTransparentMenuColor' => 'rgba(' . implode(', ', CRM_Utils_Color::getRgb($color)) . ", {$e->params['opacity']})",
       'highlightColor' => CRM_Utils_Color::getHighlight($color),
       'textColor' => CRM_Utils_Color::getContrast($color, '#333', '#ddd'),
     ];

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2218,6 +2218,24 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called when building a link to a semi-static asset.
+   *
+   * @param string $asset
+   *   The name of the asset.
+   *   Ex: 'angular.json'
+   * @param array $params
+   *   List of optional arguments which influence the content.
+   * @return null
+   *   the return value is ignored
+   */
+  public static function getAssetUrl(&$asset, &$params) {
+    return self::singleton()->invoke(['asset', 'params'],
+      $asset, $params, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_getAssetUrl'
+    );
+  }
+
+  /**
    * This hook is called whenever the system builds a new copy of
    * semi-static asset.
    *

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -52,6 +52,7 @@
  * @method static setHttpHeader(string $name, string $value) Set http header.
  * @method static array synchronizeUsers() Create CRM contacts for all existing CMS users.
  * @method static appendCoreResources(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_coreResourceList.
+ * @method static alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_getAssetUrl.
  */
 class CRM_Utils_System {
 

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -920,6 +920,14 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Modify dynamic assets.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public function alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) {
+  }
+
+  /**
    * @param string $name
    * @param string $value
    */

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -810,6 +810,16 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
+  public function alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) {
+    // Set menubar breakpoint to match WP admin theme
+    if ($e->asset == 'crm-menubar.css') {
+      $e->params['breakpoint'] = 783;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function synchronizeUsers() {
     $config = CRM_Core_Config::singleton();
     if (PHP_SAPI != 'cli') {

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -125,6 +125,8 @@ class AssetBuilder {
    *   Ex: 'http://example.org/files/civicrm/dyn/angular.abcd1234abcd1234.json'.
    */
   public function getUrl($name, $params = []) {
+    \CRM_Utils_Hook::getAssetUrl($name, $params);
+
     if (!$this->isValidName($name)) {
       throw new \RuntimeException("Invalid dynamic asset name");
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -322,6 +322,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Utils_VisualBundle', 'buildAssetCss']);
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Core_Resources', 'renderMenubarStylesheet']);
     $dispatcher->addListener('hook_civicrm_coreResourceList', ['\CRM_Utils_System', 'appendCoreResources']);
+    $dispatcher->addListener('hook_civicrm_getAssetUrl', ['\CRM_Utils_System', 'alterAssetUrl']);
     $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
     $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);
     $dispatcher->addListener('civi.dao.postDelete', ['\CRM_Core_BAO_RecurringEntity', 'triggerDelete']);

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -219,7 +219,7 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   }
 
   #civicrm-menu li a {
-    background-color: $semiTransparentMenuColor;
+    background-color: $menuItemColor;
     color: $textColor;
   }
 

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -183,7 +183,7 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   transform: rotate(180deg);
 }
 
-@media (min-width: 768px) {
+@media (min-width: $breakMin) {
 
   /* Switch to desktop layout
   -----------------------------------------------
@@ -263,7 +263,7 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: $breakMax) {
   /* hide the menu in mobile view */
   #crm-menubar-state:not(:checked) ~ #civicrm-menu {
     display: none;

--- a/css/menubar-backdrop.css
+++ b/css/menubar-backdrop.css
@@ -1,4 +1,4 @@
-@media (min-width: 768px) {
+@media (min-width: $breakMin) {
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu {
     border-top: 0 none !important;
@@ -28,7 +28,7 @@
   }
 
 }
-@media (max-width: 768px) {
+@media (max-width: $breakMax) {
 
   body.backdrop-admin-bar-position-absolute #civicrm-menu-nav {
     position: absolute;

--- a/css/menubar-drupal7.css
+++ b/css/menubar-drupal7.css
@@ -1,4 +1,4 @@
-@media (min-width: 768px) {
+@media (min-width: $breakMin) {
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar {
     display: none;
@@ -67,7 +67,7 @@
 }
 
 /* For adminimal_admin_menu */
-@media (min-width: 768px) and (max-width: 1024px) {
+@media (min-width: $breakMin) and (max-width: 1024px) {
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu.admin-menu.adminimal-menu > .slicknav_menu {
     display: none;
@@ -80,7 +80,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: $breakMax) {
 
   body.toolbar.crm-menubar-visible #toolbar-home {
     visibility: hidden;

--- a/css/menubar-drupal8.css
+++ b/css/menubar-drupal8.css
@@ -24,7 +24,7 @@ nav#civicrm-menu-nav .crm-menubar-toggle-btn-icon {
   left: 44px;
 }
 
-@media (min-width: 768px) {
+@media (min-width: $breakMin) {
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-administration {
     display: none;

--- a/css/menubar-joomla.css
+++ b/css/menubar-joomla.css
@@ -1,4 +1,4 @@
-@media (min-width: 768px) {
+@media (min-width: $breakMin) {
 
   body.crm-menubar-over-cms-menu.crm-menubar-visible {
     padding-top: $menubarHeight;
@@ -15,7 +15,7 @@
   }
 
 }
-@media (max-width: 768px) {
+@media (max-width: $breakMax) {
 
   body #civicrm-menu-nav {
     position: absolute;

--- a/css/menubar-wordpress.css
+++ b/css/menubar-wordpress.css
@@ -1,4 +1,4 @@
-@media (min-width: 768px) {
+@media (min-width: $breakMin) {
 
   body.crm-menubar-over-cms-menu.crm-menubar-visible #wpbody {
     padding-top: 8px;
@@ -33,7 +33,7 @@
   }
 
 }
-@media (min-width: 768px) and (max-width: 960px) {
+@media (min-width: $breakMin) and (max-width: 960px) {
 
   /* For the auto-fold toolbar */
   .wp-toolbar body.crm-menubar-below-cms-menu.auto-fold > #civicrm-menu-nav #civicrm-menu {
@@ -42,7 +42,7 @@
   }
 
 }
-@media (max-width: 768px) {
+@media (max-width: $breakMax) {
 
   body #civicrm-menu-nav .crm-menubar-toggle-btn {
     position: absolute;


### PR DESCRIPTION
Overview
----------------------------------------
Makes the menubar more flexible and configurable; fixes a couple issues with breakpoints.

Before
----------------------------------------
- Menubar breakpoint hardcoded at `768px` which works for Drupal & Joomla but causes weird problems on WP with screen widths between 768 - 783px.

After
----------------------------------------
- Generic hook added to allow altering of dynamic asset params
- Several menubar variables exposed to the hook
- Implemented hook internally to modify breakpoint to match WP admin theme

