### PR TITLE
Support button elements in ajax popups

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -456,7 +456,7 @@
         var buttonContainers = '.crm-submit-buttons, .action-link',
           buttons = [],
           added = [];
-        $(buttonContainers, $el).find('input.crm-form-submit, a.button').each(function() {
+        $(buttonContainers, $el).find('input.crm-form-submit, a.button, button').each(function() {
           var $el = $(this),
             label = $el.is('input') ? $el.attr('value') : $el.text(),
             identifier = $el.attr('name') || $el.attr('href');


### PR DESCRIPTION
Overview
----------------------------------------
This adds support for "button" elements in CiviCRM ajax popup forms in addition to the input type=button/submit and the "a class=button".

Related to https://lab.civicrm.org/dev/core/issues/347

This is a first step towards cleaning up button handling from a theming perspective as currently the ajax popups require buttons to be in the two specific formats and the "span" with an icon + link is notoriously difficult to theme.

This change opens up the possibility to replace "all" form buttons, for example by modifying "formButtons.tpl" like this: https://github.com/civicrm/civicrm-core/commit/9a05a2aa49537ba1a72b4f89babf95fb10a6af62 - that part *is* trivial to do via an extension.

Before
----------------------------------------
Button types tightly coupled to ajax popups

After
----------------------------------------
Slightly more *standard* button types allowed for ajax popups.  More flexibility for themes.

Technical Details
----------------------------------------
It is nearly impossible to sensible override crm.ajax.js via extension as it is tied to a specific order of loading here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Resources.php#L724 and things break if loaded later (eg. via extension hook).

Comments
----------------------------------------
@colemanw I would appreciate a review on this if you have time - hopefully you can see my intention.  @vingle @christianwach @aka84 feedback/endorsement welcome :-)
