### PR TITLE
[REF][Test] Remove call to CRM_Contribute_BAO_Contribution::recordAdditionalPayment in favour of payment create

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3591,8 +3591,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     ) {
       return;
     }
-    if ((($previousContributionStatus == 'Partially paid'
-      && $currentContributionStatus == 'Completed')
+    // The 'right' way to add payments or refunds is through the Payment.create api. That api
+    // then updates the contribution but this process shoud not also record another financial trxn.
+    if ((($previousContributionStatus == 'Partially paid' && $currentContributionStatus == 'Completed')
+      || ($previousContributionStatus == 'Pending refund' && $currentContributionStatus == 'Completed')
+      // This concept of pay_later as different to any other sort of pending is deprecated & it's unclear
+      // why it is here or where it is handled instead.
       || ($previousContributionStatus == 'Pending' && $params['prevContribution']->is_pay_later == TRUE
       && $currentContributionStatus == 'Partially paid'))
       && $context == 'changedStatus'

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -308,12 +308,12 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $contributionBalance = ($this->_cheapFee - $actualPaidAmount);
     $this->assertEquals($contributionBalance, CRM_Contribute_BAO_Contribution::getContributionBalance($this->_contributionId));
 
-    //Complete the refund payment.
-    $submittedValues = array(
-      'total_amount' => 120,
+    $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $this->_contributionId,
+      'total_amount' => -120,
       'payment_instrument_id' => 3,
-    );
-    CRM_Contribute_BAO_Contribution::recordAdditionalPayment($this->_contributionId, $submittedValues, 'refund', $this->_participantId);
+      'participant_id' => $this->_participantId,
+    ]);
     $contributionBalance += 120;
     $this->assertEquals($contributionBalance, CRM_Contribute_BAO_Contribution::getContributionBalance($this->_contributionId));
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove call to CRM_Contribute_BAO_Contribution::recordAdditionalPayment in favour of using Payment.create api. This exposes that the Payment.create api currently adds an extra transaction for refunds where the status is changed to completetransaction & handles that

Before
----------------------------------------
Less tests. Extra financial trxn created when adding a refund payment through the Payment.create api

After
----------------------------------------
More tests. Extra financial trxn not created when adding a refund payment through the Payment.create api

Technical Details
----------------------------------------
The goal here is to remove recordAdditionalPayment and call the Payment.create api instead. In order to do this we have been working to ensure the functionality is equivalent and tested. 

With this merged I still see 2 gaps
1) creating an activity from Payment.create api - should be pretty simple
2) currently when you record a refund payment (of any amount) with a participant id ALL related participant records are set to 'Registered' - this seems kinda odd but we could probably transfer into the payment.create BAO & retain for now.

Comments
----------------------------------------
FYI @pradpnayak @jitendrapurohit @monishdeb 
