### PR TITLE
dev/core#898: use user.login route for D8 login URL instead of user.page

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -185,7 +185,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    */
   public function getLoginURL($destination = '') {
     $query = $destination ? ['destination' => $destination] : [];
-    return \Drupal::url('user.page', [], ['query' => $query]);
+    return \Drupal::url('user.login', [], ['query' => $query]);
   }
 
   /**

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -657,6 +657,10 @@
 - github      : joels341
   name        : Joel Stevens
 
+- github      : johncronan
+  name        : John Kyle Cronan
+  jira        : johnk
+
 - github      : johntwyman
   name        : John Twyman
   organization: Australian Greens


### PR DESCRIPTION
Overview
----------------------------------------
If you create a public contribution page on a Drupal 8 site, it will include a login link for unauthenticated users, with parameters ?destination=... to direct back to the contribution page after login. This link is broken with recent Drupal versions, because it needs to go to /user/login instead of just /user.

Before
----------------------------------------
404 after following login link with parameters, such as from contribution form.

After
----------------------------------------
Link is working.

Technical Details
----------------------------------------
user.page resolves to '/user', which does present a login form to an unauthenticated user. The problem is that in recent Drupal versions it will not work when passed parameters, such as `?destination=...`. Instead you have to use '/user/login', which is the 'user.login' route.
