### PR TITLE
dev/core#832 CiviCase: rebuild case activity views during upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFourteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveFourteen.php
@@ -67,21 +67,40 @@ class CRM_Upgrade_Incremental_php_FiveFourteen extends CRM_Upgrade_Incremental_B
    * (change the x in the function name):
    */
 
-  //  /**
-  //   * Upgrade function.
-  //   *
-  //   * @param string $rev
-  //   */
-  //  public function upgrade_5_0_x($rev) {
-  //    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
-  //    $this->addTask('Do the foo change', 'taskFoo', ...);
-  //    // Additional tasks here...
-  //    // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
-  //    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
-  //  }
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_14_alpha1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
 
-  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
-  //   return TRUE;
-  // }
+    // Only need to rebuild view if CiviCase is enabled: otherwise will be
+    // rebuilt when component is enabled
+    $config = CRM_Core_Config::singleton();
+    if (in_array('CiviCase', $config->enableComponents)) {
+      $this->addTask('Rebuild case activity views', 'rebuildCaseActivityView', $rev);
+    }
+    // Additional tasks here...
+    // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
+    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
+  }
+
+  /**
+   * Rebuild the view of recent and upcoming case activities
+   *
+   * See https://github.com/civicrm/civicrm-core/pull/14086 and
+   * https://lab.civicrm.org/dev/core/issues/832
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @return bool
+   */
+  public static function rebuildCaseActivityView($ctx) {
+    if (!CRM_Case_BAO_Case::createCaseViews()) {
+      CRM_Core_Error::debug_log_message(ts("Could not create the MySQL views for CiviCase. Your mysql user needs to have the 'CREATE VIEW' permission"));
+      return FALSE;
+    }
+    return TRUE;
+  }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This triggers a rebuild of the case activity SQL views during upgrade since they were edited in #14086.

Before
----------------------------------------
The definition of the `civicrm_view_case_activity_upcoming` and `civicrm_view_case_activity_recent` views has changed for 5.14, but they won't get updated unless someone turns CiviCase off and on again.

After
----------------------------------------
Upgrading to 5.14 will upgrade the views.

Technical Details
----------------------------------------
Here are the views: https://github.com/civicrm/civicrm-core/blob/b632d5ee03738bb8e81fac0175bff93e5c2f124a/CRM/Case/BAO/Case.php#L2966-L2997

#14086 updated the views so that they pull the activity with the *id* matching the earliest upcoming scheduled activity (or most recent activity that isn't scheduled) on each case.  Before, it would pull activities matching that activity's date--potentially yielding multiple activities per case in each view if they have the same date.

Comments
----------------------------------------
See [dev/core#832](https://lab.civicrm.org/dev/core/issues/832)