### PR TITLE
[REF] Move the qfbug handling to it's own function (towards dev/core#723)

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1609,14 +1609,11 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       return FALSE;
     }
 
-    $qfZeroBug = 'e8cddb72-a257-11dc-b9cc-0016d3330ee9';
     $relTables = CRM_Dedupe_Merger::relTables();
     $submittedCustomFields = $moveTables = $locationMigrationInfo = $tableOperations = $removeTables = [];
 
+    self::swapOutFieldsAffectedByQFZeroBug($migrationInfo);
     foreach ($migrationInfo as $key => $value) {
-      if ($value == $qfZeroBug) {
-        $value = '0';
-      }
 
       if (substr($key, 0, 12) == 'move_custom_' && $value != NULL) {
         $submitted[substr($key, 5)] = $value;
@@ -2405,6 +2402,25 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       // delete entry from PrevNextCache table so we don't consider the pair next time
       // pair may have been flipped, so make sure we delete using both orders
       CRM_Core_BAO_PrevNextCache::deletePair($mainId, $otherId, $cacheKeyString, TRUE);
+    }
+  }
+
+  /**
+   * Replace the pseudo QFKey with zero if it is present.
+   *
+   * @todo - on the slim chance this is still relevant it should be moved to the form layer.
+   *
+   * Details about this bug are somewhat obscured by the move from svn but perhaps JIRA
+   * can still help.
+   *
+   * @param array $migrationInfo
+   */
+  protected static function swapOutFieldsAffectedByQFZeroBug(&$migrationInfo) {
+    $qfZeroBug = 'e8cddb72-a257-11dc-b9cc-0016d3330ee9';
+    foreach ($migrationInfo as $key => &$value) {
+      if ($value == $qfZeroBug) {
+        $value = '0';
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Less readable

After
----------------------------------------
More readable

Technical Details
----------------------------------------
This is a really toxci function. In order to save the pain or iterating multiple times through a small array
we are dealing with an awful lot of complexity. I'm changing this to iterate through it multiple
times in order to rationalise the code - I think performance is minimal & being able to read the code....

Comments
----------------------------------------

