### PR TITLE
dev/core#561 Remove last free jcalendar

### DIFF
--- a/CRM/Campaign/Form/Search/Campaign.php
+++ b/CRM/Campaign/Form/Search/Campaign.php
@@ -37,6 +37,15 @@
 class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
 
   /**
+   * Explicitly declare the entity api name.
+   *
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'Campaign';
+  }
+
+  /**
    * Are we forced to run a search.
    *
    * @var int
@@ -78,11 +87,8 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
     //campaign description.
     $this->add('text', 'description', ts('Description'), $attributes['description']);
 
-    //campaign start date.
-    $this->addDate('start_date', ts('From'), FALSE, ['formatType' => 'searchDate']);
-
-    //campaign end date.
-    $this->addDate('end_date', ts('To'), FALSE, ['formatType' => 'searchDate']);
+    $this->add('datepicker', 'start_date', ts('Campaign Start Date'), [], FALSE, ['time' => FALSE]);
+    $this->add('datepicker', 'end_date', ts('Campaign End Date'), [], FALSE, ['time' => FALSE]);
 
     //campaign type.
     $campaignTypes = CRM_Campaign_PseudoConstant::campaignType();

--- a/templates/CRM/Campaign/Form/Search/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Search/Campaign.tpl
@@ -99,10 +99,10 @@
 
             <tr>
               <td>{$form.start_date.label}<br/>
-                {include file="CRM/common/jcalendar.tpl" elementName=start_date}
+                {$form.start_date.html}
               </td>
               <td>{$form.end_date.label}<br/>
-                {include file="CRM/common/jcalendar.tpl" elementName=end_date}
+                {$form.end_date.html}
               </td>
             </tr>
 


### PR DESCRIPTION
Overview
----------------------------------------
This is the last jcalendar outside of buildDateRange instances.

It turns out to be 'just a form' and pretty straight forward

Before
----------------------------------------
jcalendar

After
----------------------------------------
datepicker - no user change

![Screenshot 2019-04-27 19 33 07](https://user-images.githubusercontent.com/336308/56846460-c0260600-6923-11e9-83cd-ab2bc806da04.png)


Technical Details
----------------------------------------


Comments
----------------------------------------

