### PR TITLE
dev/translation#26 Fix Notice errors caused by l10n rewriting of quer…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -936,7 +936,7 @@ class CRM_Core_DAO extends DB_DataObject {
 
     if (!array_key_exists($tableName, $show)) {
       $query = "SHOW CREATE TABLE $tableName";
-      $dao = CRM_Core_DAO::executeQuery($query);
+      $dao = CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
 
       if (!$dao->fetch()) {
         CRM_Core_Error::fatal();
@@ -963,7 +963,7 @@ class CRM_Core_DAO extends DB_DataObject {
     foreach ($tables as $tableName) {
       if (!array_key_exists($tableName, $show)) {
         $query = "SHOW CREATE TABLE $tableName";
-        $dao = CRM_Core_DAO::executeQuery($query);
+        $dao = CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
 
         if (!$dao->fetch()) {
           CRM_Core_Error::fatal();


### PR DESCRIPTION
…y so query outputed create view rather than the create table

Overview
----------------------------------------
This fixes a undefined property notice error because the query was returning the CREATE View statement rather than the create table statement because the query was being re-written

Before
----------------------------------------
Undefined property notice shows

After
----------------------------------------
No notice

ping @JoeMurray @mlutfy @monishdeb 
