### PR TITLE
Use data provider to test both api versions

### DIFF
--- a/Civi/Test/Api3DocTrait.php
+++ b/Civi/Test/Api3DocTrait.php
@@ -68,7 +68,7 @@ trait Api3DocTrait {
    *   Name for this example file (CamelCase) - if omitted the action name will be substituted.
    */
   private function documentMe($entity, $action, $params, $result, $testFunction, $testFile, $description = "", $exampleName = NULL) {
-    if (defined('DONT_DOCUMENT_TEST_CONFIG') && DONT_DOCUMENT_TEST_CONFIG) {
+    if ($params['version'] != 3 || (defined('DONT_DOCUMENT_TEST_CONFIG') && DONT_DOCUMENT_TEST_CONFIG)) {
       return;
     }
     $entity = _civicrm_api_get_camel_name($entity);

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -14,8 +14,6 @@ namespace Civi\Test;
  */
 trait ContactTestTrait {
 
-  abstract public function callAPISuccess($entity, $action, $params, $checkAgainst = NULL);
-
   /**
    * Emulate a logged in user since certain functions use that.
    * value to store a record in the DB (like activity)

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -257,6 +257,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that address custom fields can be imported
+   * FIXME: Api4
    */
   public function testAddressWithCustomData() {
     $ids = $this->entityCustomGroupWithSingleFieldCreate('Address', 'AddressTest.php');

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -305,6 +305,8 @@ class CiviUnitTestCase extends PHPUnit_Framework_TestCase {
     $session = CRM_Core_Session::singleton();
     $session->set('userID', NULL);
 
+    $this->_apiversion = 3;
+
     // REVERT
     $this->errorScope = CRM_Core_TemporaryErrorScope::useException();
     //  Use a temporary file for STDIN
@@ -451,6 +453,8 @@ class CiviUnitTestCase extends PHPUnit_Framework_TestCase {
    *  Common teardown functions for all unit tests.
    */
   protected function tearDown() {
+    $this->_apiversion = 3;
+
     error_reporting(E_ALL & ~E_NOTICE);
     CRM_Utils_Hook::singleton()->reset();
     if ($this->hookClass) {
@@ -1372,7 +1376,7 @@ class CiviUnitTestCase extends PHPUnit_Framework_TestCase {
       $params['assignee_contact_id'] = $params['target_contact_id'];
     }
 
-    $result = $this->callAPISuccess('Activity', 'create', $params);
+    $result = civicrm_api3('Activity', 'create', $params);
 
     $result['target_contact_id'] = $params['target_contact_id'];
     $result['assignee_contact_id'] = $params['assignee_contact_id'];

--- a/tests/phpunit/api/v3/ACLCachingTest.php
+++ b/tests/phpunit/api/v3/ACLCachingTest.php
@@ -33,7 +33,6 @@
  * @group headless
  */
 class api_v3_ACLCachingTest extends CiviUnitTestCase {
-  protected $_apiversion = 3;
   protected $_params;
 
   public $DBResetRequired = FALSE;
@@ -53,7 +52,12 @@ class api_v3_ACLCachingTest extends CiviUnitTestCase {
     $this->quickCleanup($tablesToTruncate, TRUE);
   }
 
-  public function testActivityCreateCustomBefore() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testActivityCreateCustomBefore($version) {
+    $this->_apiversion = $version;
     $values = $this->callAPISuccess('custom_field', 'getoptions', array('field' => 'custom_group_id'));
     $this->assertTrue($values['count'] == 0);
     $this->CustomGroupCreate(array('extends' => 'Activity'));

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -36,7 +36,6 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   use CRMTraits_ACL_PermissionTrait;
 
-  protected $_apiversion = 3;
   public $DBResetRequired = FALSE;
   protected $_entity;
 
@@ -76,8 +75,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Function tests that an empty where hook returns no results.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetNoResultsHook() {
+  public function testContactGetNoResultsHook($version) {
+    $this->_apiversion = $version;
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
       'aclWhereHookNoResults',
@@ -93,8 +95,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    * Function tests that an empty where hook returns exactly 1 result with "view my contact".
    *
    * CRM-16512 caused contacts with Edit my contact to be able to view all records.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetOneResultHookWithViewMyContact() {
+  public function testContactGetOneResultHookWithViewMyContact($version) {
+    $this->_apiversion = $version;
     $this->createLoggedInUser();
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
@@ -113,8 +118,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Function tests that a user with "edit my contact" can edit themselves.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactEditHookWithEditMyContact() {
+  public function testContactEditHookWithEditMyContact($version) {
+    $this->_apiversion = $version;
     $cid = $this->createLoggedInUser();
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
@@ -127,13 +135,17 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     $this->callAPISuccess('contact', 'create', [
       'check_permissions' => 1,
       'id' => $cid,
+      'first_name' => 'NewName',
     ]);
   }
 
   /**
    * Ensure contact permissions do not block contact-less location entities.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testAddressWithoutContactIDAccess() {
+  public function testAddressWithoutContactIDAccess($version) {
+    $this->_apiversion = $version;
     $ownID = $this->createLoggedInUser();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'access CiviCRM',
@@ -163,8 +175,12 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Ensure contact permissions extend to related entities like email
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   * FIXME: Finish api4 part
    */
-  public function testRelatedEntityPermissions() {
+  public function testRelatedEntityPermissions($version) {
+    $this->_apiversion = $version;
     $this->createLoggedInUser();
     $disallowedContact = $this->individualCreate([], 0);
     $this->allowedContactId = $this->individualCreate([], 1);
@@ -206,6 +222,9 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
       ]);
       $this->assertGreaterThan(0, $results['count']);
     }
+    if ($version == 4) {
+      $this->markTestIncomplete('Skipping entity_id related perms in api4 for now.');
+    }
     $newTag = civicrm_api3('Tag', 'create', [
       'name' => 'Foo123',
     ]);
@@ -243,8 +262,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Function tests all results are returned.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetAllResultsHook() {
+  public function testContactGetAllResultsHook($version) {
+    $this->_apiversion = $version;
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
       'aclWhereHookAllResults',
@@ -259,8 +281,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Function tests that deleted contacts are not returned.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetPermissionHookNoDeleted() {
+  public function testContactGetPermissionHookNoDeleted($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('contact', 'create', ['id' => 2, 'is_deleted' => 1]);
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
@@ -275,8 +300,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Test permissions limited by hook.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetHookLimitingHook() {
+  public function testContactGetHookLimitingHook($version) {
+    $this->_apiversion = $version;
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
       'aclWhereOnlySecond',
@@ -291,8 +319,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Confirm that without check permissions we still get 2 contacts returned.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetHookLimitingHookDontCheck() {
+  public function testContactGetHookLimitingHookDontCheck($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('contact', 'get', [
       'check_permissions' => 0,
       'return' => 'display_name',
@@ -302,8 +333,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Check that id works as a filter.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetIDFilter() {
+  public function testContactGetIDFilter($version) {
+    $this->_apiversion = $version;
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
       'aclWhereHookAllResults',
@@ -357,8 +391,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Check that pledge IS not returned.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetPledgeIDNotReturned() {
+  public function testContactGetPledgeIDNotReturned($version) {
+    $this->_apiversion = $version;
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
       'aclWhereHookAllResults',
@@ -395,8 +432,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Check that chaining doesn't bypass permissions
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetPledgeNotChainable() {
+  public function testContactGetPledgeNotChainable($version) {
+    $this->_apiversion = $version;
     $this->hookClass->setHook('civicrm_aclWhereClause', [
       $this,
       'aclWhereOnlySecond',
@@ -531,8 +571,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Basic check that an unpermissioned call keeps working and permissioned call fails.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityNoPermissions() {
+  public function testGetActivityNoPermissions($version) {
+    $this->_apiversion = $version;
     $this->setPermissions([]);
     $this->callAPISuccess('Activity', 'get', []);
     $this->callAPIFailure('Activity', 'get', ['check_permissions' => 1]);
@@ -540,8 +583,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * View all activities is enough regardless of contact ACLs.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityViewAllActivitiesDoesntCutItAnymore() {
+  public function testGetActivityViewAllActivitiesDoesntCutItAnymore($version) {
+    $this->_apiversion = $version;
     $activity = $this->activityCreate();
     $this->setPermissions(['view all activities', 'access CiviCRM']);
     $this->callAPISuccessGetCount('Activity', [
@@ -552,16 +598,22 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * View all activities is required unless id is passed in.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityViewAllContactsEnoughWithoutID() {
+  public function testGetActivityViewAllContactsEnoughWithoutID($version) {
+    $this->_apiversion = $version;
     $this->setPermissions(['view all contacts', 'access CiviCRM']);
     $this->callAPISuccess('Activity', 'get', ['check_permissions' => 1]);
   }
 
   /**
    * Without view all activities contact level acls are used.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityViewAllContactsEnoughWIthID() {
+  public function testGetActivityViewAllContactsEnoughWIthID($version) {
+    $this->_apiversion = $version;
     $activity = $this->activityCreate();
     $this->setPermissions(['view all contacts', 'access CiviCRM']);
     $this->callAPISuccess('Activity', 'getsingle', [
@@ -572,8 +624,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Check the error message is not a permission error.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityAccessCiviCRMEnough() {
+  public function testGetActivityAccessCiviCRMEnough($version) {
+    $this->_apiversion = $version;
     $activity = $this->activityCreate();
     $this->setPermissions(['access CiviCRM']);
     $this->callAPIFailure('Activity', 'getsingle', [
@@ -594,8 +649,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    *
    * (logically the same component limit should apply when they have access to view all too but....
    * adding test for 'how it is at the moment.)
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityCheckPermissionsByComponent() {
+  public function testGetActivityCheckPermissionsByComponent($version) {
+    $this->_apiversion = $version;
     $activity = $this->activityCreate(['activity_type_id' => 'Contribution']);
     $activity2 = $this->activityCreate(['activity_type_id' => 'Pledge Reminder']);
     $this->hookClass->setHook('civicrm_aclWhereClause', [
@@ -616,8 +674,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Check that component related activity filtering works for CiviCase.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityCheckPermissionsByCaseComponent() {
+  public function testGetActivityCheckPermissionsByCaseComponent($version) {
+    $this->_apiversion = $version;
     CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
     $activity = $this->activityCreate(['activity_type_id' => 'Open Case']);
     $activity2 = $this->activityCreate(['activity_type_id' => 'Pledge Reminder']);
@@ -645,8 +706,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    *
    * The activities api applies ACLs in a very limited circumstance, if id is passed in.
    * Otherwise it sticks with the blunt original permissions.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityByACL() {
+  public function testGetActivityByACL($version) {
+    $this->_apiversion = $version;
     $this->setPermissions(['access CiviCRM']);
     $activity = $this->activityCreate();
 
@@ -666,6 +730,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * To leverage ACL permission to view an activity you must be able to see any of the contacts.
+   * FIXME: Api4
    */
   public function testGetActivityByAclCannotViewAllContacts() {
     $activity = $this->activityCreate(['assignee_contact_id' => $this->individualCreate()]);
@@ -707,8 +772,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * To leverage ACL permission to view an activity you must be able to see any of the contacts.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityByAclCannotViewAnyContacts() {
+  public function testGetActivityByAclCannotViewAnyContacts($version) {
+    $this->_apiversion = $version;
     $activity = $this->activityCreate();
     $contacts = $this->getActivityContacts($activity);
     $this->setPermissions(['access CiviCRM']);
@@ -727,8 +795,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    * CRM-18409.
    *
    * @throws \CRM_Core_Exception
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivityACLSourceContactDeleted() {
+  public function testGetActivityACLSourceContactDeleted($version) {
+    $this->_apiversion = $version;
     $this->setPermissions(['access CiviCRM', 'delete contacts']);
     $activity = $this->activityCreate();
     $contacts = $this->getActivityContacts($activity);
@@ -747,8 +818,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   /**
    * Test get activities multiple ids with check permissions
    * CRM-20441
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActivitiesGetMultipleIdsCheckPermissions() {
+  public function testActivitiesGetMultipleIdsCheckPermissions($version) {
+    $this->_apiversion = $version;
     $this->createLoggedInUser();
     $activity = $this->activityCreate();
     $activity2 = $this->activityCreate();
@@ -770,8 +844,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    * Test get activities multiple ids with check permissions
    * Limit access to One contact
    * CRM-20441
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActivitiesGetMultipleIdsCheckPermissionsLimitedACL() {
+  public function testActivitiesGetMultipleIdsCheckPermissionsLimitedACL($version) {
+    $this->_apiversion = $version;
     $this->createLoggedInUser();
     $activity = $this->activityCreate();
     $contacts = $this->getActivityContacts($activity);
@@ -792,7 +869,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     ];
     $result = $this->callAPISuccess('activity', 'get', $params);
     $this->assertEquals(1, $result['count']);
-    $this->callAPIFailure('activity', 'get', array_merge($params, [
+    $this->callAPIFailure('activity', 'getsingle', array_merge($params, [
       'id' => [
         'IN',
         [$activity2['id']],
@@ -803,8 +880,11 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   /**
    * Test get activities multiple ids with check permissions
    * CRM-20441
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActivitiesGetMultipleIdsCheckPermissionsNotIN() {
+  public function testActivitiesGetMultipleIdsCheckPermissionsNotIN($version) {
+    $this->_apiversion = $version;
     $this->createLoggedInUser();
     $activity = $this->activityCreate();
     $activity2 = $this->activityCreate();
@@ -860,6 +940,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * Test that the 'everyone' group can be given access to a contact.
+   * FIXME: Api4
    */
   public function testGetACLEveryonePermittedEntity() {
     $this->setupScenarioCoreACLEveryonePermittedToGroup();

--- a/tests/phpunit/api/v3/ActionScheduleTest.php
+++ b/tests/phpunit/api/v3/ActionScheduleTest.php
@@ -35,7 +35,6 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
   protected $_params;
   protected $_params2;
   protected $_entity = 'action_schedule';
-  protected $_apiversion = 3;
 
   /**
    * Test setup for every test.
@@ -47,8 +46,11 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
 
   /**
    * Test simple create action schedule.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSimpleActionScheduleCreate() {
+  public function testSimpleActionScheduleCreate($version) {
+    $this->_apiversion = $version;
     $oldCount = CRM_Core_DAO::singleValueQuery('select count(*) from civicrm_action_schedule');
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
@@ -73,8 +75,11 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
 
   /**
    * Check if required fields are not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActionScheduleCreateWithoutRequired() {
+  public function testActionScheduleCreateWithoutRequired($version) {
+    $this->_apiversion = $version;
     $params = array(
       'subject' => 'this case should fail',
       'scheduled_date_time' => date('Ymd'),
@@ -84,8 +89,11 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
 
   /**
    * Test create with scheduled dates.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActionScheduleWithScheduledDatesCreate() {
+  public function testActionScheduleWithScheduledDatesCreate($version) {
+    $this->_apiversion = $version;
     $oldCount = CRM_Core_DAO::singleValueQuery('select count(*) from civicrm_action_schedule');
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
@@ -116,7 +124,7 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
     $actionSchedule = $this->callAPISuccess('action_schedule', 'create', $params);
     $this->assertTrue(is_numeric($actionSchedule['id']));
     $this->assertTrue($actionSchedule['id'] > 0);
-    $this->assertEquals($actionSchedule['values'][$actionSchedule['id']]['start_action_offset'][0], $params['start_action_offset']);
+    $this->assertEquals($actionSchedule['values'][$actionSchedule['id']]['start_action_offset'], $params['start_action_offset']);
     $newCount = CRM_Core_DAO::singleValueQuery('select count(*) from civicrm_action_schedule');
     $this->assertEquals($oldCount + 1, $newCount);
 

--- a/tests/phpunit/api/v3/ActivityContactTest.php
+++ b/tests/phpunit/api/v3/ActivityContactTest.php
@@ -40,7 +40,6 @@ class api_v3_ActivityContactTest extends CiviUnitTestCase {
   protected $_params;
 
   public function setUp() {
-    $this->_apiversion = 3;
     parent::setUp();
     $this->useTransaction(TRUE);
 
@@ -55,7 +54,12 @@ class api_v3_ActivityContactTest extends CiviUnitTestCase {
     );
   }
 
-  public function testCreateActivityContact() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateActivityContact($version) {
+    $this->_apiversion = $version;
 
     $result = $this->callAPIAndDocument('activity_contact', 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
@@ -64,7 +68,12 @@ class api_v3_ActivityContactTest extends CiviUnitTestCase {
     $this->callAPISuccess('activity_contact', 'delete', array('id' => $result['id']));
   }
 
-  public function testDeleteActivityContact() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteActivityContact($version) {
+    $this->_apiversion = $version;
     //create one
     $create = $this->callAPISuccess('activity_contact', 'create', $this->_params);
 
@@ -77,25 +86,36 @@ class api_v3_ActivityContactTest extends CiviUnitTestCase {
   }
 
   /**
-   *
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetActivitiesByContact() {
+  public function testGetActivitiesByContact($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('ActivityContact', 'Get', array('contact_id' => $this->_contactID));
   }
 
-  public function testGetActivitiesByActivity() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetActivitiesByActivity($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('ActivityContact', 'Get', array('activity_id' => $this->_activityID));
   }
 
   /**
    * Test civicrm_activity_contact_get with empty params.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetEmptyParams() {
+  public function testGetEmptyParams($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('ActivityContact', 'Get', array());
   }
 
   /**
    * Test civicrm_activity_contact_get with wrong params.
+   * FIXME: Api4
    */
   public function testGetWrongParams() {
     $this->callAPIFailure('ActivityContact', 'Get', array('contact_id' => 'abc'));

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -44,7 +44,6 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   protected $_params;
   protected $_params2;
   protected $_entity = 'activity';
-  protected $_apiversion = 3;
   protected $test_activity_type_value;
   protected $_contactID;
   /**
@@ -121,15 +120,21 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Check fails with empty array.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActivityCreateEmpty() {
+  public function testActivityCreateEmpty($version) {
+    $this->_apiversion = $version;
     $this->callAPIFailure('activity', 'create', array());
   }
 
   /**
    * Check if required fields are not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActivityCreateWithoutRequired() {
+  public function testActivityCreateWithoutRequired($version) {
+    $this->_apiversion = $version;
     $params = array(
       'subject' => 'this case should fail',
       'scheduled_date_time' => date('Ymd'),
@@ -197,8 +202,11 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_activity_id() with non-numeric source_contact_id.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActivityCreateWithNonNumericContactId() {
+  public function testActivityCreateWithNonNumericContactId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'source_contact_id' => 'fubar',
       'subject' => 'Make-it-Happen Meeting',
@@ -326,8 +334,11 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_activity_create() with valid parameters - use type_id.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testActivityCreateCampaignTypeID() {
+  public function testActivityCreateCampaignTypeID($version) {
+    $this->_apiversion = $version;
     $this->enableCiviCampaign();
 
     $params = array(

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -37,7 +37,6 @@
  * @group headless
  */
 class api_v3_AddressTest extends CiviUnitTestCase {
-  protected $_apiversion = 3;
   protected $_contactID;
   protected $_locationType;
   protected $_params;
@@ -71,14 +70,24 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->quickCleanup(array('civicrm_address', 'civicrm_relationship'));
   }
 
-  public function testCreateAddress() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateAddress($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument('address', 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->_params, $result['id'], 'address');
   }
 
-  public function testCreateAddressParsing() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateAddressParsing($version) {
+    $this->_apiversion = $version;
     $params = array(
       'street_parsing' => 1,
       'street_address' => '54A Excelsior Ave. Apt 1C',
@@ -98,8 +107,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Is_primary should be set as a default.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressTestDefaults() {
+  public function testCreateAddressTestDefaults($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['is_primary']);
     $result = $this->callAPISuccess('address', 'create', $params);
@@ -108,6 +120,9 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->getAndCheck($this->_params, $result['id'], 'address');
   }
 
+  /**
+   * FIXME: Api4
+   */
   public function testCreateAddressTooLongSuffix() {
     $params = $this->_params;
     $params['street_number_suffix'] = 'really long string';
@@ -116,8 +131,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Create an address with a master ID and ensure that a relationship is created.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressWithMasterRelationshipHousehold() {
+  public function testCreateAddressWithMasterRelationshipHousehold($version) {
+    $this->_apiversion = $version;
     $householdID = $this->householdCreate();
     $address = $this->callAPISuccess('address', 'create', array_merge($this->_params, $this->_params, array('contact_id' => $householdID)));
     $individualID = $this->individualCreate();
@@ -134,8 +152,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Create an address with a master ID and ensure that a relationship is created.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressWithMasterRelationshipOrganization() {
+  public function testCreateAddressWithMasterRelationshipOrganization($version) {
+    $this->_apiversion = $version;
     $address = $this->callAPISuccess('address', 'create', $this->_params);
     $individualID = $this->individualCreate();
     $individualParams = array(
@@ -151,8 +172,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Create an address with a master ID and relationship creation disabled.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressWithoutMasterRelationshipOrganization() {
+  public function testCreateAddressWithoutMasterRelationshipOrganization($version) {
+    $this->_apiversion = $version;
     $address = $this->callAPISuccess('address', 'create', $this->_params);
     $individualID = $this->individualCreate();
     $individualParams = array(
@@ -169,8 +193,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Create an address with a master ID and ensure that a relationship is created.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressWithMasterRelationshipChangingOrganization() {
+  public function testCreateAddressWithMasterRelationshipChangingOrganization($version) {
+    $this->_apiversion = $version;
     $address = $this->callAPISuccess('address', 'create', $this->_params);
     $organisation2ID = $this->organizationCreate();
     $address2 = $this->callAPISuccess('address', 'create', array_merge($this->_params, array('contact_id' => $organisation2ID)));
@@ -200,15 +227,18 @@ class api_v3_AddressTest extends CiviUnitTestCase {
    * ie. create the address, unset the params & recreate.
    * is_primary should be 0 before & after the update. ie - having no other address
    * is_primary is invalid.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressTestDefaultWithID() {
+  public function testCreateAddressTestDefaultWithID($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     $params['is_primary'] = 0;
     $result = $this->callAPISuccess('address', 'create', $params);
     unset($params['is_primary']);
     $params['id'] = $result['id'];
-    $result = $this->callAPISuccess('address', 'create', $params);
-    $this->callAPISuccess('address', 'get', array('contact_id' => $params['contact_id']));
+    $this->callAPISuccess('address', 'create', $params);
+    $result = $this->callAPISuccess('address', 'get', array('contact_id' => $params['contact_id']));
     $this->assertEquals(1, $result['count']);
     $this->assertEquals(1, $result['values'][$result['id']]['is_primary']);
     $this->getAndCheck($params, $result['id'], 'address', __FUNCTION__);
@@ -216,8 +246,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * test address deletion.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDeleteAddress() {
+  public function testDeleteAddress($version) {
+    $this->_apiversion = $version;
     //check there are no address to start with
     $get = $this->callAPISuccess('address', 'get', array(
       'location_type_id' => $this->_locationType->id,
@@ -237,8 +270,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_address_get - success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetAddress() {
+  public function testGetAddress($version) {
+    $this->_apiversion = $version;
     $address = $this->callAPISuccess('address', 'create', $this->_params);
 
     $params = array(
@@ -254,8 +290,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_address_get - success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetSingleAddress() {
+  public function testGetSingleAddress($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('address', 'create', $this->_params);
     $params = array(
       'contact_id' => $this->_contactID,
@@ -267,8 +306,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_address_get with sort option- success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetAddressSort() {
+  public function testGetAddressSort($version) {
+    $this->_apiversion = $version;
     $create = $this->callAPISuccess('address', 'create', $this->_params);
     $this->callAPISuccess('address', 'create', array_merge($this->_params, array('street_address' => 'yzy')));
     $subfile = "AddressSort";
@@ -288,8 +330,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_address_get with sort option- success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetAddressLikeSuccess() {
+  public function testGetAddressLikeSuccess($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('address', 'create', $this->_params);
     $subfile = "AddressLike";
     $description = "Demonstrates Use of Like.";
@@ -305,8 +350,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_address_get with sort option- success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetAddressLikeFail() {
+  public function testGetAddressLikeFail($version) {
+    $this->_apiversion = $version;
     $create = $this->callAPISuccess('address', 'create', $this->_params);
     $params = array(
       'street_address' => array('LIKE' => "'%xy%'"),
@@ -318,6 +366,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   }
 
   /**
+   * FIXME: Api4 custom address fields broken?
    */
   public function testGetWithCustom() {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
@@ -338,8 +387,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   }
 
   /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressPrimaryHandlingChangeToPrimary() {
+  public function testCreateAddressPrimaryHandlingChangeToPrimary($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['is_primary']);
     $address1 = $this->callAPISuccess('address', 'create', $params);
@@ -354,8 +406,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   }
 
   /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAddressPrimaryHandlingChangeExisting() {
+  public function testCreateAddressPrimaryHandlingChangeExisting($version) {
+    $this->_apiversion = $version;
     $address1 = $this->callAPISuccess('address', 'create', $this->_params);
     $this->callAPISuccess('address', 'create', $this->_params);
     $check = $this->callAPISuccess('address', 'getcount', array(
@@ -371,7 +426,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
    * This is legacy API v3 behaviour and not correct behaviour
    * however we are too far down the path wiwth v3 to fix this
    * @link https://chat.civicrm.org/civicrm/pl/zcq3jkg69jdt5g4aqze6bbe9pc
-   * @todo vis this in v4 api
+   * FIXME: Api4
    */
   public function testCreateDuplicateLocationTypes() {
     $address1 = $this->callAPISuccess('address', 'create', $this->_params);
@@ -479,31 +534,41 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->assertEquals($expectState, $created['state_province_id']);
   }
 
-  public function testBuildStateProvinceOptionsWithDodgyProvinceLimit() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testBuildStateProvinceOptionsWithDodgyProvinceLimit($version) {
+    $this->_apiversion = $version;
     $provinceLimit = [1228, "abcd;ef"];
     $this->callAPISuccess('setting', 'create', [
-     'provinceLimit' => $provinceLimit,
+      'provinceLimit' => $provinceLimit,
     ]);
     $result = $this->callAPIFailure('address', 'getoptions', ['field' => 'state_province_id']);
     // confirm that we hit our error not a SQLI.
     $this->assertEquals('Province limit or default country setting is incorrect', $result['error_message']);
     $this->callAPISuccess('setting', 'create', [
-     'provinceLimit' => [1228],
+      'provinceLimit' => [1228],
     ]);
     // Now confirm with a correct province setting it works fine
     $this->callAPISuccess('address', 'getoptions', ['field' => 'state_province_id']);
   }
 
-  public function testBuildCountryWithDodgyCountryLimitSetting() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testBuildCountryWithDodgyCountryLimitSetting($version) {
+    $this->_apiversion = $version;
     $countryLimit = [1228, "abcd;ef"];
     $this->callAPISuccess('setting', 'create', [
-     'countryLimit' => $countryLimit,
+      'countryLimit' => $countryLimit,
     ]);
     $result = $this->callAPIFailure('address', 'getoptions', ['field' => 'country_id']);
     // confirm that we hit our error not a SQLI.
     $this->assertEquals('Available Country setting is incorrect', $result['error_message']);
     $this->callAPISuccess('setting', 'create', [
-     'countryLimit' => [1228],
+      'countryLimit' => [1228],
     ]);
     // Now confirm with a correct province setting it works fine
     $this->callAPISuccess('address', 'getoptions', ['field' => 'country_id']);

--- a/tests/phpunit/api/v3/CampaignTest.php
+++ b/tests/phpunit/api/v3/CampaignTest.php
@@ -30,14 +30,12 @@
  * @group headless
  */
 class api_v3_CampaignTest extends CiviUnitTestCase {
-  protected $_apiversion;
   protected $params;
   protected $id;
 
   public $DBResetRequired = FALSE;
 
   public function setUp() {
-    $this->_apiversion = 3;
     $this->params = array(
       'title' => "campaign title",
       'description' => "Call people, ask for money",
@@ -47,7 +45,12 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
     $this->useTransaction(TRUE);
   }
 
-  public function testCreateCampaign() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateCampaign($version) {
+    $this->_apiversion = $version;
     $description = "Create a campaign - Note use of relative dates here:
       @link http://www.php.net/manual/en/datetime.formats.relative.php.";
     $result = $this->callAPIAndDocument('campaign', 'create', $this->params, __FUNCTION__, __FILE__, $description);
@@ -56,14 +59,24 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
     $this->getAndCheck(array_merge($this->params, array('created_date' => '2008-07-05 00:00:00')), $result['id'], 'campaign', TRUE);
   }
 
-  public function testGetCampaign() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetCampaign($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('campaign', 'create', $this->params);
     $result = $this->callAPIAndDocument('campaign', 'get', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
 
-  public function testDeleteCampaign() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteCampaign($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('campaign', 'create', $this->params);
     $entity = $this->callAPISuccess('campaign', 'get', ($this->params));
     $delete = array('id' => $entity['id']);

--- a/tests/phpunit/api/v3/ConstantTest.php
+++ b/tests/phpunit/api/v3/ConstantTest.php
@@ -37,7 +37,6 @@
  * @group headless
  */
 class api_v3_ConstantTest extends CiviUnitTestCase {
-  protected $_apiversion = 3;
 
   /**
    * Test setup for every test.
@@ -48,7 +47,6 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
   public function setUp() {
     //  Connect to the database
     parent::setUp();
-    $this->_apiversion = 3;
   }
 
   /**
@@ -89,8 +87,11 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_address_getoptions( 'location_type_id' )
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testLocationTypeGet() {
+  public function testLocationTypeGet($version) {
+    $this->_apiversion = $version;
     // needed to get rid of cached values from previous tests
     CRM_Core_PseudoConstant::flush();
 
@@ -107,8 +108,11 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_phone_getoptions( 'phone_type_id' )
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testPhoneType() {
+  public function testPhoneType($version) {
+    $this->_apiversion = $version;
     $params = array(
       'field' => 'phone_type_id',
     );
@@ -124,8 +128,11 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_constant_get( 'mailProtocol' )
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testmailProtocol() {
+  public function testmailProtocol($version) {
+    $this->_apiversion = $version;
     $params = array(
       'field' => 'protocol',
     );

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -64,7 +64,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   public function setUp() {
     // Connect to the database.
     parent::setUp();
-    $this->_apiversion = 3;
     $this->_entity = 'contact';
     $this->_params = array(
       'first_name' => 'abc1',
@@ -79,6 +78,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function tearDown() {
+    $this->_apiversion = 3;
     $this->callAPISuccess('Setting', 'create', array('includeOrderByClause' => TRUE));
     // truncate a few tables
     $tablesToTruncate = array(
@@ -108,8 +108,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * Verify that attempt to create individual contact with only
    * first and last names succeeds
+   *
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testAddCreateIndividual() {
+  public function testAddCreateIndividual($version) {
+    $this->_apiversion = $version;
     $oldCount = CRM_Core_DAO::singleValueQuery('select count(*) from civicrm_contact');
     $params = array(
       'first_name' => 'abc1',
@@ -200,8 +204,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test civicrm_contact_create.
    *
    * Verify that preferred language can be set.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testAddCreateIndividualWithPreferredLanguage() {
+  public function testAddCreateIndividualWithPreferredLanguage($version) {
+    $this->_apiversion = $version;
     $params = array(
       'first_name' => 'abc1',
       'contact_type' => 'Individual',
@@ -217,6 +224,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test civicrm_contact_create with sub-types.
    *
    * Verify that sub-types are created successfully and not deleted by subsequent updates.
+   *
+   * v3 only - uses nonstandard syntax
    */
   public function testIndividualSubType() {
     $params = array(
@@ -242,8 +251,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Verify that we can retreive contacts of different sub types
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetMultipleContactSubTypes() {
+  public function testGetMultipleContactSubTypes($version) {
+    $this->_apiversion = $version;
 
     // This test presumes that there are no parents or students in the dataset
 
@@ -375,8 +387,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test creating individual by name.
    *
    * Verify create individual contact with only first and last names succeeds.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateNameIndividual() {
+  public function testCreateNameIndividual($version) {
+    $this->_apiversion = $version;
     $params = array(
       'first_name' => 'abc1',
       'contact_type' => 'Individual',
@@ -390,8 +405,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test creating individual by display_name.
    *
    * Display name & sort name should be set.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateDisplayNameIndividual() {
+  public function testCreateDisplayNameIndividual($version) {
+    $this->_apiversion = $version;
     $params = array(
       'display_name' => 'abc1',
       'contact_type' => 'Individual',
@@ -404,8 +422,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that name searches are case insensitive.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetNameVariantsCaseInsensitive() {
+  public function testGetNameVariantsCaseInsensitive($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('contact', 'create', [
       'display_name' => 'Abc1',
       'contact_type' => 'Individual',
@@ -413,7 +434,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccessGetSingle('Contact', ['display_name' => 'aBc1']);
     $this->callAPISuccessGetSingle('Contact', ['sort_name' => 'aBc1']);
     Civi::settings()->set('includeNickNameInName', TRUE);
-    $this->callAPISuccessGetSingle('Contact', ['display_name' => 'aBc1']);
+    $result = $this->callAPISuccessGetSingle('Contact', ['display_name' => 'aBc1']);
     $this->callAPISuccessGetSingle('Contact', ['sort_name' => 'aBc1']);
     Civi::settings()->set('includeNickNameInName', FALSE);
   }
@@ -474,8 +495,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * Verify that attempt to create household contact with only
    * household name succeeds
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateNameHousehold() {
+  public function testCreateNameHousehold($version) {
+    $this->_apiversion = $version;
     $params = array(
       'household_name' => 'The abc Household',
       'contact_type' => 'Household',
@@ -488,8 +512,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * Verify that attempt to create organization contact with only
    * organization name succeeds.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateNameOrganization() {
+  public function testCreateNameOrganization($version) {
+    $this->_apiversion = $version;
     $params = array(
       'organization_name' => 'The abc Organization',
       'contact_type' => 'Organization',
@@ -510,8 +537,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Check that permissions on API key are restricted (CRM-18112).
+   *
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateApiKey() {
+  public function testCreateApiKey($version) {
+    $this->_apiversion = $version;
     $config = CRM_Core_Config::singleton();
     $contactId = $this->individualCreate(array(
       'first_name' => 'A',
@@ -583,8 +614,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Note that the test is written on purpose without any
    * variables specific to participant so it can be replicated into other entities
    * and / or moved to the automated test suite
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateWithCustom() {
+  public function testCreateWithCustom($version) {
+    $this->_apiversion = $version;
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
     $params = $this->_params;
@@ -616,8 +650,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-14232 test preferred language set to site default if not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreatePreferredLanguageUnset() {
+  public function testCreatePreferredLanguageUnset($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('Contact', 'create', array(
       'first_name' => 'Snoop',
       'last_name' => 'Dog',
@@ -629,8 +666,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-14232 test preferred language returns setting if not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreatePreferredLanguageSet() {
+  public function testCreatePreferredLanguageSet($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('Setting', 'create', array('contact_default_language' => 'fr_FR'));
     $this->callAPISuccess('Contact', 'create', array(
       'first_name' => 'Snoop',
@@ -643,6 +683,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-14232 test preferred language returns setting if not passed where setting is NULL.
+   * TODO: Api4
    */
   public function testCreatePreferredLanguageNull() {
     $this->callAPISuccess('Setting', 'create', array('contact_default_language' => 'null'));
@@ -657,8 +698,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-14232 test preferred language returns setting if not passed where setting is NULL.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreatePreferredLanguagePassed() {
+  public function testCreatePreferredLanguagePassed($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('Setting', 'create', array('contact_default_language' => 'null'));
     $this->callAPISuccess('Contact', 'create', array(
       'first_name' => 'Snoop',
@@ -811,8 +855,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Check deceased contacts are not retrieved.
    *
    * Note at time of writing the default is to return default. This should possibly be changed & test added.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetDeceasedRetrieved() {
+  public function testGetDeceasedRetrieved($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $c2 = $this->callAPISuccess($this->_entity, 'create', array(
       'first_name' => 'bb',
@@ -859,8 +906,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test that we can retrieve contacts using array syntax.
    *
    * I.e 'id' => array('IN' => array('3,4')).
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetINIDArray() {
+  public function testGetINIDArray($version) {
+    $this->_apiversion = $version;
     $c1 = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $c2 = $this->callAPISuccess($this->_entity, 'create', array(
       'first_name' => 'bb',
@@ -916,8 +966,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that sort works - new syntax.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetSortNewSyntax() {
+  public function testGetSortNewSyntax($version) {
+    $this->_apiversion = $version;
     $c1 = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $c2 = $this->callAPISuccess($this->_entity, 'create', array(
       'first_name' => 'bb',
@@ -952,8 +1005,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test sort and limit for chained relationship get.
    *
    * https://issues.civicrm.org/jira/browse/CRM-15983
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSortLimitChainedRelationshipGetCRM15983() {
+  public function testSortLimitChainedRelationshipGetCRM15983($version) {
+    $this->_apiversion = $version;
     // Some contact
     $create_result_1 = $this->callAPISuccess('contact', 'create', array(
       'first_name' => 'Jules',
@@ -1015,8 +1071,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test apostrophe works in get & create.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetApostropheCRM10857() {
+  public function testGetApostropheCRM10857($version) {
+    $this->_apiversion = $version;
     $params = array_merge($this->_params, array('last_name' => "O'Connor"));
     $this->callAPISuccess($this->_entity, 'create', $params);
     $result = $this->callAPISuccess($this->_entity, 'getsingle', array(
@@ -1030,8 +1089,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test between accepts zero.
    *
    * In the past it incorrectly required !empty.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetBetweenZeroWorks() {
+  public function testGetBetweenZeroWorks($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess($this->_entity, 'get', [
       'contact_id' => ['BETWEEN' => [0, 9]],
     ]);
@@ -1047,6 +1109,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test retrieval by addressee id.
+   * V3 only - the "skip_greeting_processing" param is not currently in v4
    */
   public function testGetByAddresseeID() {
     $individual1ID = $this->individualCreate([
@@ -1301,8 +1364,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test for direction when chaining relationships.
    *
    * https://issues.civicrm.org/jira/browse/CRM-16084
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDirectionChainingRelationshipsCRM16084() {
+  public function testDirectionChainingRelationshipsCRM16084($version) {
+    $this->_apiversion = $version;
     // Some contact, called Jules.
     $create_result_1 = $this->callAPISuccess('contact', 'create', array(
       'first_name' => 'Jules',
@@ -1356,9 +1422,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     // Clean up first.
     $this->callAPISuccess('contact', 'delete', array(
       'id' => $create_result_1['id'],
-    ));
-    $this->callAPISuccess('contact', 'delete', array(
-      'id' => $create_result_2['id'],
     ));
     $this->callAPISuccess('contact', 'delete', array(
       'id' => $create_result_2['id'],
@@ -1608,8 +1671,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Verify successful update of household contact.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUpdateHouseholdWithAll() {
+  public function testUpdateHouseholdWithAll($version) {
+    $this->_apiversion = $version;
     $contactID = $this->householdCreate();
 
     $params = [
@@ -1637,8 +1703,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Deliberately exclude contact_type as it should still cope using civicrm_api.
    *
    * CRM-7645.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUpdateCreateWithID() {
+  public function testUpdateCreateWithID($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate();
     $this->callAPISuccess('Contact', 'Update', [
       'id' => $contactID,
@@ -1649,8 +1718,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_contact_delete() with no contact ID.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactDeleteNoID() {
+  public function testContactDeleteNoID($version) {
+    $this->_apiversion = $version;
     $params = array(
       'foo' => 'bar',
     );
@@ -1659,16 +1731,22 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_contact_delete() with error.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactDeleteError() {
+  public function testContactDeleteError($version) {
+    $this->_apiversion = $version;
     $params = array('contact_id' => 999);
     $this->callAPIFailure('contact', 'delete', $params);
   }
 
   /**
    * Test civicrm_contact_delete().
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactDelete() {
+  public function testContactDelete($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate();
     $params = array(
       'id' => $contactID,
@@ -1678,8 +1756,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_contact_get() return only first name.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetRetFirst() {
+  public function testContactGetRetFirst($version) {
+    $this->_apiversion = $version;
     $contact = $this->callAPISuccess('contact', 'create', $this->_params);
     $params = array(
       'contact_id' => $contact['id'],
@@ -1696,8 +1777,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test civicrm_contact_get() return only first name & last name.
    *
    * Use comma separated string return with a space.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetReturnFirstLast() {
+  public function testContactGetReturnFirstLast($version) {
+    $this->_apiversion = $version;
     $contact = $this->callAPISuccess('contact', 'create', $this->_params);
     $params = array(
       'contact_id' => $contact['id'],
@@ -1723,8 +1807,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test civicrm_contact_get() return only first name & last name.
    *
    * Use comma separated string return without a space
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetReturnFirstLastNoComma() {
+  public function testContactGetReturnFirstLastNoComma($version) {
+    $this->_apiversion = $version;
     $contact = $this->callAPISuccess('contact', 'create', $this->_params);
     $params = array(
       'contact_id' => $contact['id'],
@@ -1769,15 +1856,21 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_contact_get) with empty params.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetEmptyParams() {
+  public function testContactGetEmptyParams($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('contact', 'get', []);
   }
 
   /**
    * Test civicrm_contact_get(,true) with no matches.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetOldParamsNoMatches() {
+  public function testContactGetOldParamsNoMatches($version) {
+    $this->_apiversion = $version;
     $this->individualCreate();
     $result = $this->callAPISuccess('contact', 'get', ['first_name' => 'Fred']);
     $this->assertEquals(0, $result['count']);
@@ -1817,8 +1910,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Ensure consistent return format for option group fields.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSetPreferredCommunicationNull() {
+  public function testSetPreferredCommunicationNull($version) {
+    $this->_apiversion = $version;
     $contact = $this->callAPISuccess('contact', 'create', array_merge($this->_params, array(
       'preferred_communication_method' => array('Phone', 'SMS'),
     )));
@@ -2054,8 +2150,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test creating multiple phones using chaining.
    *
    * @throws \Exception
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCRM13252MultipleChainedPhones() {
+  public function testCRM13252MultipleChainedPhones($version) {
+    $this->_apiversion = $version;
     $contactID = $this->householdCreate();
     $this->callAPISuccessGetCount('phone', array('contact_id' => $contactID), 0);
     $params = array(
@@ -2102,8 +2201,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Verify attempt to create individual with chained arrays and sequential.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetIndividualWithChainedArraysAndSequential() {
+  public function testGetIndividualWithChainedArraysAndSequential($version) {
+    $this->_apiversion = $version;
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
     $params['custom_' . $ids['custom_field_id']] = "custom string";
 
@@ -2205,9 +2307,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   /**
    * Verify attempt to create individual with chained arrays and sequential.
    *
-   *  See https://issues.civicrm.org/jira/browse/CRM-15815
+   * @see https://issues.civicrm.org/jira/browse/CRM-15815
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateIndividualWithChainedArrayAndSequential() {
+  public function testCreateIndividualWithChainedArrayAndSequential($version) {
+    $this->_apiversion = $version;
     $params = array(
       'sequential' => 1,
       'first_name' => 'abc5',
@@ -2392,6 +2497,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test checks usage of $values to pick & choose inputs.
+   *
+   * Api3 Only - chaining syntax is too funky for v4 (assuming entityTag "entity_id" field will be filled by magic)
    */
   public function testChainingValuesCreate() {
     $description = "This demonstrates the usage of chained api functions.  Specifically it has one 'parent function' &
@@ -2421,8 +2528,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test TrueFalse format - I couldn't come up with an easy way to get an error on Get.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetFormatIsSuccessTrue() {
+  public function testContactGetFormatIsSuccessTrue($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
     $description = "This demonstrates use of the 'format.is_success' param.
     This param causes only the success or otherwise of the function to be returned as BOOLEAN";
@@ -2435,8 +2545,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test TrueFalse format.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactCreateFormatIsSuccessFalse() {
+  public function testContactCreateFormatIsSuccessFalse($version) {
+    $this->_apiversion = $version;
 
     $description = "This demonstrates use of the 'format.is_success' param.
     This param causes only the success or otherwise of the function to be returned as BOOLEAN";
@@ -2450,8 +2563,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test long display names.
    *
    * CRM-21258
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactCreateLongDisplayName() {
+  public function testContactCreateLongDisplayName($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('Contact', 'Create', array(
       'first_name' => str_pad('a', 64, 'a'),
       'last_name' => str_pad('a', 64, 'a'),
@@ -2465,8 +2581,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test that we can set the sort name via the api or alter it via a hook.
    *
    * As of writing this is being fixed for Organization & Household but it makes sense to do for individuals too.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateAlterSortName() {
+  public function testCreateAlterSortName($version) {
+    $this->_apiversion = $version;
     $organizationID = $this->organizationCreate(['organization_name' => 'The Justice League', 'sort_name' => 'Justice League, The']);
     $organization = $this->callAPISuccessGetSingle('Contact', ['return' => ['sort_name', 'display_name'], 'id' => $organizationID]);
     $this->assertEquals('Justice League, The', $organization['sort_name']);
@@ -2495,8 +2614,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test Single Entity format.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetSingleEntityArray() {
+  public function testContactGetSingleEntityArray($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
     $description = "This demonstrates use of the 'format.single_entity_array' param.
       This param causes the only contact to be returned as an array without the other levels.
@@ -2509,8 +2631,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test Single Entity format.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetFormatCountOnly() {
+  public function testContactGetFormatCountOnly($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
     $description = "This demonstrates use of the 'getCount' action.
       This param causes the count of the only function to be returned as an integer.";
@@ -2523,8 +2648,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test id only format.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetFormatIDOnly() {
+  public function testContactGetFormatIDOnly($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
     $description = "This demonstrates use of the 'format.id_only' param.
       This param causes the id of the only entity to be returned as an integer.
@@ -2538,8 +2666,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test id only format.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactGetFormatSingleValue() {
+  public function testContactGetFormatSingleValue($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
     $description = "This demonstrates use of the 'format.single_value' param.
       This param causes only a single value of the only entity to be returned as an string.
@@ -2553,8 +2684,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that permissions are respected when creating contacts.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactCreationPermissions() {
+  public function testContactCreationPermissions($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_type' => 'Individual',
       'first_name' => 'Foo',
@@ -2564,7 +2698,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $config = CRM_Core_Config::singleton();
     $config->userPermissionClass->permissions = array('access CiviCRM');
     $result = $this->callAPIFailure('contact', 'create', $params);
-    $this->assertEquals('API permission check failed for Contact/create call; insufficient permission: require access CiviCRM and add contacts', $result['error_message'], 'lacking permissions should not be enough to create a contact');
+    $this->assertContains('failed', $result['error_message'], 'lacking permissions should not be enough to create a contact');
 
     $config->userPermissionClass->permissions = array('access CiviCRM', 'add contacts', 'import contacts');
     $this->callAPISuccess('contact', 'create', $params);
@@ -2572,6 +2706,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that delete with skip undelete respects permissions.
+   * TODO: Api4
    */
   public function testContactDeletePermissions() {
     $contactID = $this->individualCreate();
@@ -2590,8 +2725,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test update with check permissions set.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactUpdatePermissions() {
+  public function testContactUpdatePermissions($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_type' => 'Individual',
       'first_name' => 'Foo',
@@ -3104,8 +3242,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test the use of sql operators.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSQLOperatorsOnContactAPI() {
+  public function testSQLOperatorsOnContactAPI($version) {
+    $this->_apiversion = $version;
     $this->individualCreate();
     $this->organizationCreate();
     $this->householdCreate();
@@ -3117,8 +3258,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-14743 - test api respects search operators.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetModifiedDateByOperators() {
+  public function testGetModifiedDateByOperators($version) {
+    $this->_apiversion = $version;
     $preExistingContactCount = CRM_Core_DAO::singleValueQuery('select count(*) FROM civicrm_contact');
     $contact1 = $this->individualCreate();
     $sql = "UPDATE civicrm_contact SET created_date = '2012-01-01', modified_date = '2013-01-01' WHERE id = " . $contact1;
@@ -3137,8 +3281,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-14743 - test api respects search operators.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetCreatedDateByOperators() {
+  public function testGetCreatedDateByOperators($version) {
+    $this->_apiversion = $version;
     $preExistingContactCount = CRM_Core_DAO::singleValueQuery('select count(*) FROM civicrm_contact');
     $contact1 = $this->individualCreate();
     $sql = "UPDATE civicrm_contact SET created_date = '2012-01-01' WHERE id = " . $contact1;
@@ -3768,8 +3915,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-21041 Test if 'communication style' is set to site default if not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateCommunicationStyleUnset() {
+  public function testCreateCommunicationStyleUnset($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('Contact', 'create', array(
       'first_name' => 'John',
       'last_name' => 'Doe',
@@ -3803,6 +3953,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that creating a contact with various contact greetings works.
+   * V3 Only.
    */
   public function testContactGreetingsCreate() {
     $contact = $this->callAPISuccess('Contact', 'create', array('first_name' => 'Alan', 'last_name' => 'MouseMouse', 'contact_type' => 'Individual'));

--- a/tests/phpunit/api/v3/ContactTypeTest.php
+++ b/tests/phpunit/api/v3/ContactTypeTest.php
@@ -35,7 +35,6 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
     $this->useTransaction(TRUE);
-    $this->_apiversion = 3;
     $params = array(
       'label' => 'sub_individual',
       'name' => 'sub_individual',
@@ -70,8 +69,11 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
   /**
    * Test add methods with valid data.
    * success expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactCreate() {
+  public function testContactCreate($version) {
+    $this->_apiversion = $version;
 
     // check for Type:Individual Subtype:sub_individual
     $contactParams = array(
@@ -112,8 +114,11 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
 
   /**
    * Test add with invalid data.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactAddInvalidData() {
+  public function testContactAddInvalidData($version) {
+    $this->_apiversion = $version;
 
     // check for Type:Individual Subtype:sub_household
     $contactParams = array(
@@ -136,8 +141,11 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
   /**
    * Test update with no subtype to valid subtype.
    * success expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactUpdateNoSubtypeValid() {
+  public function testContactUpdateNoSubtypeValid($version) {
+    $this->_apiversion = $version;
 
     // check for Type:Individual
     $contactParams = array(
@@ -200,8 +208,11 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
 
   /**
    * Test update with no subtype to invalid subtype.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactUpdateNoSubtypeInvalid() {
+  public function testContactUpdateNoSubtypeInvalid($version) {
+    $this->_apiversion = $version;
 
     // check for Type:Individual
     $contactParams = array(
@@ -248,8 +259,11 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
   /**
    * Test update with no subtype to valid subtype.
    * success expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactUpdateSubtypeValid() {
+  public function testContactUpdateSubtypeValid($version) {
+    $this->_apiversion = $version;
 
     $params = array(
       'label' => 'sub2_individual',
@@ -336,8 +350,11 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
 
   /**
    * Test update with no subtype to invalid subtype.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactUpdateSubtypeInvalid() {
+  public function testContactUpdateSubtypeInvalid($version) {
+    $this->_apiversion = $version;
 
     // check for Type:Individual subtype:sub_individual
     $contactParams = array(

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -33,7 +33,6 @@
  * @group headless
  */
 class api_v3_ContributionPageTest extends CiviUnitTestCase {
-  protected $_apiversion = 3;
   protected $testAmount = 34567;
   protected $params;
   protected $id = 0;
@@ -90,14 +89,24 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->quickCleanUpFinancialEntities();
   }
 
-  public function testCreateContributionPage() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateContributionPage($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
   }
 
-  public function testGetBasicContributionPage() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetBasicContributionPage($version) {
+    $this->_apiversion = $version;
     $createResult = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $this->id = $createResult['id'];
     $getParams = array(
@@ -121,7 +130,12 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->assertEquals(1, $getResult['count']);
   }
 
-  public function testDeleteContributionPage() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteContributionPage($version) {
+    $this->_apiversion = $version;
     $createResult = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = array('id' => $createResult['id']);
     $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -41,7 +41,6 @@ class api_v3_DomainTest extends CiviUnitTestCase {
    */
   public $DBResetRequired = FALSE;
 
-  protected $_apiversion = 3;
   protected $params;
 
   /**
@@ -149,8 +148,11 @@ class api_v3_DomainTest extends CiviUnitTestCase {
    * This test checks for a memory leak.
    *
    * The leak was observed when doing 2 gets on current domain.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetCurrentDomainTwice() {
+  public function testGetCurrentDomainTwice($version) {
+    $this->_apiversion = $version;
     $domain = $this->callAPISuccess('domain', 'getvalue', array(
       'current_domain' => 1,
       'return' => 'name',
@@ -178,8 +180,11 @@ class api_v3_DomainTest extends CiviUnitTestCase {
    * Test if Domain.create does not touch the version of the domain.
    *
    * See CRM-17430.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUpdateDomainName() {
+  public function testUpdateDomainName($version) {
+    $this->_apiversion = $version;
     // First create a domain.
     $domain_result = $this->callAPISuccess('domain', 'create', $this->params);
     $domain_before = $this->callAPISuccess('Domain', 'getsingle', array('id' => $domain_result['id']));
@@ -215,8 +220,11 @@ class api_v3_DomainTest extends CiviUnitTestCase {
    * Test civicrm_domain_create with empty params.
    *
    * Error expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateWithEmptyParams() {
+  public function testCreateWithEmptyParams($version) {
+    $this->_apiversion = $version;
     $this->callAPIFailure('domain', 'create', array());
   }
 

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -30,14 +30,12 @@
  * @group headless
  */
 class api_v3_EmailTest extends CiviUnitTestCase {
-  protected $_apiversion;
   protected $_contactID;
   protected $_locationType;
   protected $_entity;
   protected $_params;
 
   public function setUp() {
-    $this->_apiversion = 3;
     $this->_entity = 'Email';
     parent::setUp();
     $this->useTransaction(TRUE);
@@ -60,7 +58,12 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     );
   }
 
-  public function testCreateEmail() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEmail($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     //check there are no emails to start with
     $get = $this->callAPISuccess('email', 'get', array(
@@ -79,8 +82,11 @@ class api_v3_EmailTest extends CiviUnitTestCase {
    * If a new email is set to is_primary the prev should no longer be.
    *
    * If is_primary is not set then it should become is_primary is no others exist
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateEmailPrimaryHandlingChangeToPrimary() {
+  public function testCreateEmailPrimaryHandlingChangeToPrimary($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['is_primary']);
     $email1 = $this->callAPISuccess('email', 'create', $params);
@@ -94,7 +100,12 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     );
   }
 
-  public function testCreateEmailPrimaryHandlingChangeExisting() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEmailPrimaryHandlingChangeExisting($version) {
+    $this->_apiversion = $version;
     $email1 = $this->callAPISuccess('email', 'create', $this->_params);
     $email2 = $this->callAPISuccess('email', 'create', $this->_params);
     $check = $this->callAPISuccess('email', 'getcount', array(
@@ -104,13 +115,23 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->assertEquals(1, $check);
   }
 
-  public function testCreateEmailWithoutEmail() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEmailWithoutEmail($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIFailure('Email', 'Create', array('contact_id' => 4));
     $this->assertContains('missing', $result['error_message']);
     $this->assertContains('email', $result['error_message']);
   }
 
-  public function testGetEmail() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetEmail($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('email', 'create', $this->_params);
     $get = $this->callAPISuccess('email', 'create', $this->_params);
     $this->assertEquals($get['count'], 1);
@@ -121,7 +142,12 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $delresult = $this->callAPISuccess('email', 'delete', array('id' => $result['id']));
   }
 
-  public function testDeleteEmail() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteEmail($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id' => $this->_contactID,
       'location_type_id' => $this->_locationType->id,
@@ -147,7 +173,12 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->assertEquals(0, $get['count'], 'Contact not successfully deleted In line ' . __LINE__);
   }
 
-  public function testReplaceEmail() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testReplaceEmail($version) {
+    $this->_apiversion = $version;
     // check there are no emails to start with
     $get = $this->callAPISuccess('email', 'get', array(
       'contact_id' => $this->_contactID,
@@ -240,7 +271,12 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->assertEquals(0, $get['count'], 'Incorrect email count at ' . __LINE__);
   }
 
-  public function testReplaceEmailsInChain() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testReplaceEmailsInChain($version) {
+    $this->_apiversion = $version;
     // check there are no emails to start with
     $get = $this->callAPISuccess('email', 'get', array(
 
@@ -326,7 +362,12 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->assertEquals(2, $get['count'], 'Incorrect email count at ' . __LINE__);
   }
 
-  public function testReplaceEmailWithId() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testReplaceEmailWithId($version) {
+    $this->_apiversion = $version;
     // check there are no emails to start with
     $get = $this->callAPISuccess('email', 'get', array(
       'contact_id' => $this->_contactID,

--- a/tests/phpunit/api/v3/EntityTagTest.php
+++ b/tests/phpunit/api/v3/EntityTagTest.php
@@ -69,7 +69,7 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
     $this->_householdID = $this->houseHoldCreate();
     $this->_organizationID = $this->organizationCreate();
     $this->_params = array(
-      'contact_id' => $this->_individualID,
+      'entity_id' => $this->_individualID,
       'tag_id' => $this->_tagID,
     );
   }
@@ -90,10 +90,12 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Test basic create.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testContactEntityTagCreate() {
+  public function testContactEntityTagCreate($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('entity_tag', 'create', $this->_params);
-    $this->assertEquals($result['added'], 1);
   }
 
   /**
@@ -128,15 +130,19 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Basic get functionality test.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testIndividualEntityTagGet() {
+  public function testIndividualEntityTagGet($version) {
+    $this->_apiversion = $version;
     $individualEntity = $this->callAPISuccess('entity_tag', 'create', $this->_params);
-    $this->assertEquals($individualEntity['added'], 1);
 
     $paramsEntity = array(
       'contact_id' => $this->_individualID,
     );
-    $this->callAPIAndDocument('entity_tag', 'get', $paramsEntity, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument('entity_tag', 'get', $paramsEntity, __FUNCTION__, __FILE__);
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals($this->_tagID, $result['values'][$result['id']]['tag_id']);
   }
 
   /**
@@ -167,18 +173,22 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Test tag can be added to an organization.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testOrganizationEntityGet() {
+  public function testOrganizationEntityGet($version) {
+    $this->_apiversion = $version;
 
     $params = array(
-      'contact_id' => $this->_organizationID,
+      'entity_id' => $this->_organizationID,
       'tag_id' => $this->_tagID,
     );
 
-    $organizationEntity = $this->callAPISuccess('entity_tag', 'create', $params);
-    $this->assertEquals($organizationEntity['added'], 1);
+    $this->callAPISuccess('entity_tag', 'create', $params);
 
-    $this->callAPISuccess('entity_tag', 'getsingle', array('contact_id' => $this->_organizationID));
+    $tag = $this->callAPISuccess('entity_tag', 'getsingle', array('contact_id' => $this->_organizationID));
+    $this->assertEquals($this->_organizationID, $tag['entity_id']);
+    $this->assertEquals($this->_tagID, $tag['tag_id']);
   }
 
   /**

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -157,7 +157,12 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals($result['values'][0]['id'], $this->_eventIds[0]);
   }
 
-  public function testGetEventByWrongTitle() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetEventByWrongTitle($version) {
+    $this->_apiversion = $version;
     $params = array(
       'title' => 'No event with that title',
     );
@@ -165,6 +170,9 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals(0, $result['count']);
   }
 
+  /**
+   * Skip api4 - this api uses deprecated query syntax
+   */
   public function testGetEventByIdSort() {
     $params = array(
       'return.sort' => 'id ASC',
@@ -210,6 +218,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Test 'is.Current' option. Existing event is 'old' so only current should be returned
+   * FIXME: Api4
    */
   public function testGetIsCurrent() {
     $params = array(
@@ -233,6 +242,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * There has been a schema change & the api needs to buffer developers from it
+   * FIXME: Api4
    */
   public function testGetPaymentProcessorId() {
     $params = $this->_params[0];
@@ -244,7 +254,12 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals($result['values'][0]['payment_processor_id'], 1, "handing get payment processor compatibility");
   }
 
-  public function testInvalidData() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testInvalidData($version) {
+    $this->_apiversion = $version;
     $params = $this->_params[0];
     $params['sequential'] = 1;
     $params['loc_block_id'] = 100;
@@ -253,7 +268,8 @@ class api_v3_EventTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test 'is.Current' option. Existing event is 'old' so only current should be returned
+   * Test 'is_full' option.
+   * FIXME: Api4
    */
   public function testGetSingleReturnIsFull() {
     $contactID = $this->individualCreate();
@@ -306,8 +322,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Chaining get event and loc block.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testChainingGetLocBlock() {
+  public function testChainingGetLocBlock($version) {
+    $this->_apiversion = $version;
     // create a loc block and an event for that loc block.
     $eventParams = $this->_params[0];
     $eventParams['loc_bloc_id'] = '$value.id';
@@ -368,8 +387,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Note that the test is written on purpose without any
    * variables specific to participant so it can be replicated into other entities
    * and / or moved to the automated test suite.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateWithCustom() {
+  public function testCreateWithCustom($version) {
+    $this->_apiversion = $version;
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
     $params = $this->_params[0];
@@ -392,8 +414,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Check searching on custom fields.
    *
    * https://issues.civicrm.org/jira/browse/CRM-16036
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSearchCustomField() {
+  public function testSearchCustomField($version) {
+    $this->_apiversion = $version;
     // create custom group with custom field on event
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
@@ -413,8 +438,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Check searching on custom fields with IS NULL.
    *
    * https://issues.civicrm.org/jira/browse/CRM-20740
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSearchCustomFieldIsNull() {
+  public function testSearchCustomFieldIsNull($version) {
+    $this->_apiversion = $version;
     // create custom group with custom field on event
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
@@ -434,6 +462,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Test searching on custom fields returning a contact reference.
    *
    * https://issues.civicrm.org/jira/browse/CRM-16036
+   * FIXME: Api4
    */
   public function testEventGetCustomContactRefFieldCRM16036() {
     // Create some contact.
@@ -497,8 +526,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Test searching on custom fields with less than or equal.
    *
    * See CRM-17101.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testEventGetCustomFieldLte() {
+  public function testEventGetCustomFieldLte($version) {
+    $this->_apiversion = $version;
     // create custom group with custom field on event
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
@@ -567,6 +599,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Test that an event with a price set can be created.
+   * FIXME: Api4
    */
   public function testCreatePaidEvent() {
     //@todo alter API so that an integer is converted to an array
@@ -576,33 +609,53 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertArrayKeyExists('price_set_id', $event);
   }
 
-  public function testCreateEventParamsNotArray() {
-    $params = NULL;
-    $result = $this->callAPIFailure('event', 'create', $params);
-  }
-
-  public function testCreateEventEmptyParams() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEventEmptyParams($version) {
+    $this->_apiversion = $version;
     $params = array();
     $result = $this->callAPIFailure('event', 'create', $params);
   }
 
-  public function testCreateEventParamsWithoutTitle() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEventParamsWithoutTitle($version) {
+    $this->_apiversion = $version;
     unset($this->_params['title']);
     $result = $this->callAPIFailure('event', 'create', $this->_params);
     $this->assertAPIFailure($result);
   }
 
-  public function testCreateEventParamsWithoutEventTypeId() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEventParamsWithoutEventTypeId($version) {
+    $this->_apiversion = $version;
     unset($this->_params['event_type_id']);
     $result = $this->callAPIFailure('event', 'create', $this->_params);
   }
 
-  public function testCreateEventParamsWithoutStartDate() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEventParamsWithoutStartDate($version) {
+    $this->_apiversion = $version;
     unset($this->_params['start_date']);
-    $result = $this->callAPIFailure('event', 'create', $this->_params);
+    $result = $this->callAPIFailure('event', 'create', $this->_params, 'start_date');
   }
 
-  public function testCreateEventSuccess() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateEventSuccess($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument('Event', 'Create', $this->_params[0], __FUNCTION__, __FILE__);
     $this->assertArrayHasKey('id', $result['values'][$result['id']]);
     $result = $this->callAPISuccess($this->_entity, 'Get', array('id' => $result['id']));
@@ -615,6 +668,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Test that passing in Unique field names works.
+   * Skip api4 which doesn't use unique names
    */
   public function testCreateEventSuccessUniqueFieldNames() {
     $this->_params[0]['event_start_date'] = $this->_params[0]['start_date'];
@@ -634,7 +688,12 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals($this->_params[0]['event_title'], $result['values'][$result['id']]['title'], 'end date is not set in line ' . __LINE__);
   }
 
-  public function testUpdateEvent() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUpdateEvent($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('event', 'create', $this->_params[1]);
 
     $params = array(
@@ -648,11 +707,21 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->callAPISuccess($this->_entity, 'Delete', array('id' => $result['id']));
   }
 
-  public function testDeleteEmptyParams() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteEmptyParams($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIFailure('Event', 'Delete', array());
   }
 
-  public function testDelete() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDelete($version) {
+    $this->_apiversion = $version;
     $params = array(
       'id' => $this->_eventIds[0],
     );
@@ -661,8 +730,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Check event_id still supported for delete.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDeleteWithEventId() {
+  public function testDeleteWithEventId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'event_id' => $this->_eventIds[0],
     );
@@ -672,8 +744,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Trying to delete an event with participants should return error.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDeleteWithExistingParticipant() {
+  public function testDeleteWithExistingParticipant($version) {
+    $this->_apiversion = $version;
     $contactID = $this->individualCreate();
     $this->participantCreate(
       array(
@@ -684,7 +759,12 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->callAPISuccess('Event', 'Delete', array('id' => $this->_eventIds[0]));
   }
 
-  public function testDeleteWithWrongEventId() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteWithWrongEventId($version) {
+    $this->_apiversion = $version;
     $params = array('event_id' => $this->_eventIds[0]);
     $result = $this->callAPISuccess('Event', 'Delete', $params);
     // try to delete again - there's no such event anymore
@@ -694,16 +774,22 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_event_search with wrong params type.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSearchWrongParamsType() {
+  public function testSearchWrongParamsType($version) {
+    $this->_apiversion = $version;
     $params = 'a string';
     $result = $this->callAPIFailure('event', 'get', $params);
   }
 
   /**
    * Test civicrm_event_search with empty params.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSearchEmptyParams() {
+  public function testSearchEmptyParams($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('event', 'create', $this->_params[1]);
 
     $getParams = array(
@@ -718,8 +804,11 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_event_search. Success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSearch() {
+  public function testSearch($version) {
+    $this->_apiversion = $version;
     $params = array(
       'event_type_id' => 1,
       'return.title' => 1,
@@ -764,7 +853,12 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals(2, $result['count'], ' 2 results returned In line ' . __LINE__);
   }
 
-  public function testEventCreationPermissions() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testEventCreationPermissions($version) {
+    $this->_apiversion = $version;
     $params = array(
       'event_type_id' => 1,
       'start_date' => '2010-10-03',
@@ -773,8 +867,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
     );
     $config = CRM_Core_Config::singleton();
     $config->userPermissionClass->permissions = array('access CiviCRM');
-    $result = $this->callAPIFailure('event', 'create', $params);
-    $this->assertEquals('API permission check failed for Event/create call; insufficient permission: require access CiviCRM and access CiviEvent and edit all events', $result['error_message'], 'lacking permissions should not be enough to create an event');
+    $result = $this->callAPIFailure('event', 'create', $params, 'failed');
 
     $config->userPermissionClass->permissions = array(
       'access CiviEvent',
@@ -784,11 +877,16 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('event', 'create', $params);
   }
 
-  public function testgetfields() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testgetfields($version) {
+    $this->_apiversion = $version;
     $description = "Demonstrate use of getfields to interrogate api.";
     $params = array('action' => 'create');
     $result = $this->callAPISuccess('event', 'getfields', $params);
-    $this->assertEquals(1, $result['values']['is_active']['api.default']);
+    $this->assertEquals('is_active', $result['values']['is_active']['name']);
   }
 
   /**
@@ -801,6 +899,9 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['values']['is_active']['api.default']);
   }
 
+  /**
+   * Skip api4 - output is different
+   */
   public function testgetfieldsGet() {
     $description = "Demonstrate use of getfields to interrogate api.";
     $params = array('action' => 'get');
@@ -808,6 +909,9 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals('title', $result['values']['event_title']['name']);
   }
 
+  /**
+   * Skip api4 - output is different
+   */
   public function testgetfieldsDelete() {
     $description = "Demonstrate use of getfields to interrogate api.";
     $params = array('action' => 'delete');
@@ -815,7 +919,12 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['values']['id']['api.required']);
   }
 
-  public function testCreateFromTemplate() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateFromTemplate($version) {
+    $this->_apiversion = $version;
     $templateParams = array(
       'summary' => 'Sign up now to learn the results of this unit test',
       'description' => 'This event is created from a template, so all the values should be the same as the original ones.',

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -32,7 +32,6 @@
  * @group headless
  */
 class api_v3_GroupTest extends CiviUnitTestCase {
-  protected $_apiversion = 3;
   protected $_groupID;
 
   /**
@@ -57,8 +56,11 @@ class api_v3_GroupTest extends CiviUnitTestCase {
 
   /**
    * Test missing required title parameter results in an error.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGroupCreateNoTitle() {
+  public function testGroupCreateNoTitle($version) {
+    $this->_apiversion = $version;
     $params = array(
       'name' => 'Test Group No title ',
       'domain_id' => 1,
@@ -71,10 +73,15 @@ class api_v3_GroupTest extends CiviUnitTestCase {
       ),
     );
 
-    $this->callAPIFailure('group', 'create', $params, 'Mandatory key(s) missing from params array: title');
+    $this->callAPIFailure('group', 'create', $params, 'title');
   }
 
-  public function testGetGroupWithEmptyParams() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetGroupWithEmptyParams($version) {
+    $this->_apiversion = $version;
     $group = $this->callAPISuccess('group', 'get', array());
 
     $group = $group["values"];
@@ -88,14 +95,22 @@ class api_v3_GroupTest extends CiviUnitTestCase {
    * Test ability to get active, inactive and both.
    *
    * Default is active only.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetGroupActiveAndInactive() {
+  public function testGetGroupActiveAndInactive($version) {
+    $this->_apiversion = $version;
     $this->groupCreate(['is_active' => 0, 'name' => 'group_2', 'title' => 2]);
     $group1 = $this->callAPISuccessGetSingle('Group', ['is_active' => 1]);
     $this->callAPISuccessGetCount('Group', [], 2);
   }
 
-  public function testGetGroupParamsWithGroupId() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetGroupParamsWithGroupId($version) {
+    $this->_apiversion = $version;
     $params = array('id' => $this->_groupID);
     $group = $this->callAPISuccess('group', 'get', $params);
 
@@ -108,7 +123,12 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     }
   }
 
-  public function testGetGroupParamsWithGroupName() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetGroupParamsWithGroupName($version) {
+    $this->_apiversion = $version;
     $params = array(
       'name' => "Test Group 1",
     );
@@ -124,7 +144,12 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     }
   }
 
-  public function testGetGroupParamsWithReturnName() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetGroupParamsWithReturnName($version) {
+    $this->_apiversion = $version;
     $params = array();
     $params['id'] = $this->_groupID;
     $params['return.name'] = 1;
@@ -134,7 +159,12 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     );
   }
 
-  public function testGetGroupParamsWithGroupTitle() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetGroupParamsWithGroupTitle($version) {
+    $this->_apiversion = $version;
     $params = array();
     $params['title'] = 'New Test Group Created';
     $group = $this->callAPISuccess('group', 'get', $params);
@@ -150,6 +180,7 @@ class api_v3_GroupTest extends CiviUnitTestCase {
 
   /**
    * Test Group create with Group Type and Parent
+   * FIXME: Api4
    */
   public function testGroupCreateWithTypeAndParent() {
     $params = array(
@@ -214,6 +245,7 @@ class api_v3_GroupTest extends CiviUnitTestCase {
 
   /**
    * Test that an array of valid values works for group_type field.
+   * FIXME: Api4
    */
   public function testGroupTypeWithPseudoconstantArray() {
     $params = [
@@ -228,22 +260,37 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     $this->assertAPIArrayComparison([2, 1], $groupType);
   }
 
-  public function testGetNonExistingGroup() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetNonExistingGroup($version) {
+    $this->_apiversion = $version;
     $params = array();
     $params['title'] = 'No such group Exist';
     $group = $this->callAPISuccess('group', 'get', $params);
     $this->assertEquals(0, $group['count']);
   }
 
-  public function testgroupdeleteParamsnoId() {
-    $group = $this->callAPIFailure('group', 'delete', array(), 'Mandatory key(s) missing from params array: id');
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testgroupdeleteParamsnoId($version) {
+    $this->_apiversion = $version;
+    $group = $this->callAPIFailure('group', 'delete', array());
   }
 
-  public function testgetfields() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testgetfields($version) {
+    $this->_apiversion = $version;
     $description = "Demonstrate use of getfields to interrogate api.";
     $params = array('action' => 'create');
     $result = $this->callAPIAndDocument('group', 'getfields', $params, __FUNCTION__, __FILE__, $description);
-    $this->assertEquals(1, $result['values']['is_active']['api.default']);
+    $this->assertEquals('is_active', $result['values']['is_active']['name']);
   }
 
   public function testIllegalParentsParams() {
@@ -273,6 +320,7 @@ class api_v3_GroupTest extends CiviUnitTestCase {
 
   /**
    * Test that ACLs are applied to group.get calls.
+   * FIXME: Api4
    */
   public function testGroupGetACLs() {
     $this->createLoggedInUser();

--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -33,7 +33,6 @@
  * @group headless
  */
 class api_v3_ImTest extends CiviUnitTestCase {
-  protected $_apiversion = 3;
   protected $params;
   protected $id;
   protected $_entity;
@@ -54,14 +53,24 @@ class api_v3_ImTest extends CiviUnitTestCase {
     );
   }
 
-  public function testCreateIm() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateIm($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
 
-  public function testGetIm() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetIm($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
@@ -69,7 +78,12 @@ class api_v3_ImTest extends CiviUnitTestCase {
     $this->callAPISuccess($this->_entity, 'delete', array('id' => $result['id']));
   }
 
-  public function testDeleteIm() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteIm($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = array('id' => $result['id']);
     $result = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
@@ -77,6 +91,9 @@ class api_v3_ImTest extends CiviUnitTestCase {
     $this->assertEquals(0, $checkDeleted['count']);
   }
 
+  /**
+   * Skip api4 test - delete behaves differently
+   */
   public function testDeleteImInvalid() {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = array('id' => 600);

--- a/tests/phpunit/api/v3/MailSettingsTest.php
+++ b/tests/phpunit/api/v3/MailSettingsTest.php
@@ -40,7 +40,7 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
       'domain_id' => 1,
       'name' => "my mail setting",
       'domain' => 'setting.com',
-      'local_part' => 'civicrm+',
+      'localpart' => 'civicrm+',
       'server' => "localhost",
       'username' => 'sue',
       'password' => 'pass',
@@ -52,8 +52,11 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
 
   /**
    * Test creation.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateMailSettings() {
+  public function testCreateMailSettings($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccessGetCount('mail_settings', array(), 1);
     $result = $this->callAPIAndDocument('MailSettings', 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
@@ -64,8 +67,11 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
 
   /**
    * Test caches cleared adequately.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateUpdateMailSettings() {
+  public function testCreateUpdateMailSettings($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('MailSettings', 'create', $this->params);
     $this->assertEquals('setting.com', CRM_Core_BAO_MailSettings::defaultDomain());
     $this->callAPISuccess('mail_settings', 'create', array('id' => $result['id'], 'domain' => 'updated.com'));
@@ -76,8 +82,11 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
 
   /**
    * Test get method.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetMailSettings() {
+  public function testGetMailSettings($version) {
+    $this->_apiversion = $version;
     $this->callAPIAndDocument('MailSettings', 'create', $this->params, __FUNCTION__, __FILE__);
     $result = $this->callAPIAndDocument('MailSettings', 'get', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
@@ -86,7 +95,12 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
     $this->callAPISuccessGetCount('mail_settings', array(), 1);
   }
 
-  public function testDeleteMailSettings() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteMailSettings($version) {
+    $this->_apiversion = $version;
     $this->callAPIAndDocument('MailSettings', 'create', $this->params, __FUNCTION__, __FILE__);
     $entity = $this->callAPISuccess('MailSettings', 'get', $this->params);
     $this->assertEquals('setting.com', $entity['values'][$entity['id']]['domain']);
@@ -97,17 +111,20 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
 
   /**
    * Test chained delete.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetMailSettingsChainDelete() {
+  public function testGetMailSettingsChainDelete($version) {
+    $this->_apiversion = $version;
     $description = "Demonstrates get + delete in the same call.";
     $subFile = 'ChainedGetDelete';
     $params = array(
-      'title' => "MailSettings title",
+      'name' => "delete this setting",
       'api.MailSettings.delete' => 1,
     );
-    $this->callAPISuccess('MailSettings', 'create', $this->params);
-    $this->callAPIAndDocument('MailSettings', 'get', $params, __FUNCTION__, __FILE__, $description, $subFile);
-    $this->assertEquals(0, $this->callAPISuccess('MailSettings', 'getcount', array()));
+    $this->callAPISuccess('MailSettings', 'create', ['name' => "delete this setting"] + $this->params);
+    $result = $this->callAPIAndDocument('MailSettings', 'get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $this->assertEquals(0, $this->callAPISuccess('MailSettings', 'getcount', ['name' => "delete this setting"]));
   }
 
 }

--- a/tests/phpunit/api/v3/NavigationTest.php
+++ b/tests/phpunit/api/v3/NavigationTest.php
@@ -37,13 +37,17 @@ class api_v3_NavigationTest extends CiviUnitTestCase {
 
   /**
    * Test get function.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGet() {
+  public function testGet($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess($this->_entity, 'getsingle', array('label' => 'Manage Groups', 'domain_id' => 1));
   }
 
   /**
    * Test get specifying parent
+   * FIXME: Api4
    */
   public function testGetByParent() {
     // get by name
@@ -61,8 +65,11 @@ class api_v3_NavigationTest extends CiviUnitTestCase {
 
   /**
    * Test create function.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreate() {
+  public function testCreate($version) {
+    $this->_apiversion = $version;
     $params = array('label' => 'Feed the Goats', 'domain_id' => 1);
     $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $this->getAndCheck($params, $result['id'], $this->_entity, TRUE);
@@ -70,8 +77,11 @@ class api_v3_NavigationTest extends CiviUnitTestCase {
 
   /**
    * Test create function.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDefaultDomain() {
+  public function testDefaultDomain($version) {
+    $this->_apiversion = $version;
     $params = array('label' => 'Herd the Cats');
     $result = $this->callAPISuccess($this->_entity, 'create', $params);
     // Check domain_id has been set per default
@@ -81,8 +91,11 @@ class api_v3_NavigationTest extends CiviUnitTestCase {
 
   /**
    * Test delete function.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDelete() {
+  public function testDelete($version) {
+    $this->_apiversion = $version;
     $getParams = array(
       'return' => 'id',
       'options' => array('limit' => 1),

--- a/tests/phpunit/api/v3/NoteTest.php
+++ b/tests/phpunit/api/v3/NoteTest.php
@@ -31,7 +31,6 @@
  */
 class api_v3_NoteTest extends CiviUnitTestCase {
 
-  protected $_apiversion;
   protected $_contactID;
   protected $_params;
   protected $_noteID;
@@ -39,7 +38,6 @@ class api_v3_NoteTest extends CiviUnitTestCase {
 
   public function setUp() {
 
-    $this->_apiversion = 3;
     // Connect to the database.
     parent::setUp();
     $this->useTransaction(TRUE);
@@ -64,8 +62,11 @@ class api_v3_NoteTest extends CiviUnitTestCase {
    * Check retrieve note with empty parameter array.
    *
    * Error expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetWithEmptyParams() {
+  public function testGetWithEmptyParams($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('note', 'get', array());
   }
 
@@ -73,8 +74,11 @@ class api_v3_NoteTest extends CiviUnitTestCase {
    * Check retrieve note with missing parameters.
    *
    * Error expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetWithoutEntityId() {
+  public function testGetWithoutEntityId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'entity_table' => 'civicrm_contact',
     );
@@ -83,8 +87,11 @@ class api_v3_NoteTest extends CiviUnitTestCase {
 
   /**
    * Check civicrm_note get.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGet() {
+  public function testGet($version) {
+    $this->_apiversion = $version;
     $entityId = $this->_noteID;
     $params = array(
       'entity_table' => 'civicrm_contact',
@@ -97,11 +104,14 @@ class api_v3_NoteTest extends CiviUnitTestCase {
    * Check create with empty parameter array.
    *
    * Error Expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateWithEmptyNoteField() {
+  public function testCreateWithEmptyNoteField($version) {
+    $this->_apiversion = $version;
     $this->_params['note'] = "";
     $this->callAPIFailure('note', 'create', $this->_params,
-      'Mandatory key(s) missing from params array: note'
+      'missing'
     );
   }
 
@@ -109,28 +119,37 @@ class api_v3_NoteTest extends CiviUnitTestCase {
    * Check create with partial params.
    *
    * Error expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateWithoutEntityId() {
+  public function testCreateWithoutEntityId($version) {
+    $this->_apiversion = $version;
     unset($this->_params['entity_id']);
     $this->callAPIFailure('note', 'create', $this->_params,
-      'Mandatory key(s) missing from params array: entity_id');
+      'entity_id');
   }
 
   /**
    * Check create with partially empty params.
    *
    * Error expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateWithEmptyEntityId() {
+  public function testCreateWithEmptyEntityId($version) {
+    $this->_apiversion = $version;
     $this->_params['entity_id'] = "";
     $this->callAPIFailure('note', 'create', $this->_params,
-      'Mandatory key(s) missing from params array: entity_id');
+      'entity_id');
   }
 
   /**
    * Check civicrm note create.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreate() {
+  public function testCreate($version) {
+    $this->_apiversion = $version;
 
     $result = $this->callAPIAndDocument('note', 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals($result['values'][$result['id']]['note'], 'Hello!!! m testing Note');
@@ -139,7 +158,12 @@ class api_v3_NoteTest extends CiviUnitTestCase {
     $this->assertArrayHasKey('id', $result);
   }
 
-  public function testCreateWithApostropheInString() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateWithApostropheInString($version) {
+    $this->_apiversion = $version;
     $params = array(
       'entity_table' => 'civicrm_contact',
       'entity_id' => $this->_contactID,
@@ -158,8 +182,11 @@ class api_v3_NoteTest extends CiviUnitTestCase {
 
   /**
    * Check civicrm_note_create - tests used of default set to .
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateWithoutModifiedDate() {
+  public function testCreateWithoutModifiedDate($version) {
+    $this->_apiversion = $version;
     unset($this->_params['modified_date']);
     $apiResult = $this->callAPISuccess('note', 'create', $this->_params);
     $this->assertAPISuccess($apiResult);
@@ -171,8 +198,11 @@ class api_v3_NoteTest extends CiviUnitTestCase {
    *
    * Please don't copy & paste this - is of marginal value
    * better to put time into the function on Syntax Conformance class that tests this
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUpdateWithEmptyParams() {
+  public function testUpdateWithEmptyParams($version) {
+    $this->_apiversion = $version;
     $this->callAPIFailure('note', 'create', array());
   }
 
@@ -180,21 +210,27 @@ class api_v3_NoteTest extends CiviUnitTestCase {
    * Check update with missing parameter (contact id).
    *
    * Error expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUpdateWithoutContactId() {
+  public function testUpdateWithoutContactId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'entity_id' => $this->_contactID,
       'entity_table' => 'civicrm_contact',
     );
     $this->callAPIFailure('note', 'create', $params,
-      'Mandatory key(s) missing from params array: note'
+      'missing'
     );
   }
 
   /**
    * Check civicrm_note update.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUpdate() {
+  public function testUpdate($version) {
+    $this->_apiversion = $version;
     $params = array(
       'id' => $this->_noteID,
       'contact_id' => $this->_contactID,
@@ -225,18 +261,24 @@ class api_v3_NoteTest extends CiviUnitTestCase {
    * Check delete with wrong id.
    *
    * Error expected
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDeleteWithWrongID() {
+  public function testDeleteWithWrongID($version) {
+    $this->_apiversion = $version;
     $params = array(
       'id' => 99999,
     );
-    $this->callAPIFailure('note', 'delete', $params, 'Error while deleting Note');
+    $this->callAPIFailure('note', 'delete', $params, 'Note');
   }
 
   /**
    * Check civicrm_note delete.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDelete() {
+  public function testDelete($version) {
+    $this->_apiversion = $version;
     $additionalNote = $this->noteCreate($this->_contactID);
 
     $params = array(

--- a/tests/phpunit/api/v3/OpenIDTest.php
+++ b/tests/phpunit/api/v3/OpenIDTest.php
@@ -54,14 +54,24 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
     );
   }
 
-  public function testCreateOpenID() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateOpenID($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id'], 'In line ' . __LINE__);
   }
 
-  public function testGetOpenID() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetOpenID($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
@@ -69,7 +79,12 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
     $this->callAPISuccess($this->_entity, 'delete', array('id' => $result['id']));
   }
 
-  public function testDeleteOpenID() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteOpenID($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = array('id' => $result['id']);
     $result = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
@@ -77,7 +92,12 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
     $this->assertEquals(0, $checkDeleted['count'], 'In line ' . __LINE__);
   }
 
-  public function testDeleteOpenIDInvalid() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteOpenIDInvalid($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = array('id' => 600);
     $result = $this->callAPIFailure($this->_entity, 'delete', $deleteParams);

--- a/tests/phpunit/api/v3/PhoneTest.php
+++ b/tests/phpunit/api/v3/PhoneTest.php
@@ -33,13 +33,11 @@
  * @group headless
  */
 class api_v3_PhoneTest extends CiviUnitTestCase {
-  protected $_apiversion;
   protected $_contactID;
   protected $_locationType;
   protected $_params;
 
   public function setUp() {
-    $this->_apiversion = 3;
     parent::setUp();
     $this->useTransaction();
 
@@ -56,7 +54,12 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
     );
   }
 
-  public function testCreatePhone() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreatePhone($version) {
+    $this->_apiversion = $version;
 
     $result = $this->callAPIAndDocument('phone', 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
@@ -65,7 +68,12 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
     $this->callAPISuccess('phone', 'delete', array('id' => $result['id']));
   }
 
-  public function testDeletePhone() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeletePhone($version) {
+    $this->_apiversion = $version;
     //create one
     $create = $this->callAPISuccess('phone', 'create', $this->_params);
 
@@ -80,8 +88,11 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_phone_get with empty params.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetEmptyParams() {
+  public function testGetEmptyParams($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('Phone', 'Get', array());
   }
 
@@ -96,8 +107,11 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_phone_get - success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGet() {
+  public function testGet($version) {
+    $this->_apiversion = $version;
     $phone = $this->callAPISuccess('phone', 'create', $this->_params);
     $params = array(
       'contact_id' => $this->_params['contact_id'],
@@ -114,8 +128,11 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
 
   /**
    * Ensure numeric_phone field is correctly populated (this happens via sql trigger)
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testNumericPhone() {
+  public function testNumericPhone($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('phone', 'create', $this->_params);
     $id = $result['id'];
     $params = array('id' => $id, 'return.phone_numeric' => 1);
@@ -127,8 +144,11 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
    * If a new phone is set to is_primary the prev should no longer be.
    *
    * If is_primary is not set then it should become is_primary is no others exist
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreatePhonePrimaryHandlingChangeToPrimary() {
+  public function testCreatePhonePrimaryHandlingChangeToPrimary($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['is_primary']);
     $phone1 = $this->callAPISuccess('phone', 'create', $params);
@@ -140,7 +160,12 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
     $this->assertEquals(1, $check);
   }
 
-  public function testCreatePhonePrimaryHandlingChangeExisting() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreatePhonePrimaryHandlingChangeExisting($version) {
+    $this->_apiversion = $version;
     $phone1 = $this->callAPISuccess('phone', 'create', $this->_params);
     $phone2 = $this->callAPISuccess('phone', 'create', $this->_params);
     $check = $this->callAPISuccess('phone', 'getcount', array(

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -33,7 +33,6 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   use CRMTraits_Custom_CustomDataTrait;
 
-  protected $_apiversion = 3;
   protected $_cId_a;
   /**
    * Second individual.
@@ -107,8 +106,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check with empty array.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateEmpty() {
+  public function testRelationshipCreateEmpty($version) {
+    $this->_apiversion = $version;
     $this->callAPIFailure('relationship', 'create', array());
   }
 
@@ -154,8 +156,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check if required fields are not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateWithoutRequired() {
+  public function testRelationshipCreateWithoutRequired($version) {
+    $this->_apiversion = $version;
     $params = array(
       'start_date' => array('d' => '10', 'M' => '1', 'Y' => '2008'),
       'end_date' => array('d' => '10', 'M' => '1', 'Y' => '2009'),
@@ -167,8 +172,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check with incorrect required fields.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateWithIncorrectData() {
+  public function testRelationshipCreateWithIncorrectData($version) {
+    $this->_apiversion = $version;
 
     $params = array(
       'contact_id_a' => $this->_cId_a,
@@ -200,8 +208,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship creation with invalid Relationship.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateInvalidRelationship() {
+  public function testRelationshipCreateInvalidRelationship($version) {
+    $this->_apiversion = $version;
     // Both have the contact type Individual.
     $params = array(
       'contact_id_a' => $this->_cId_a,
@@ -227,8 +238,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship already exists.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateAlreadyExists() {
+  public function testRelationshipCreateAlreadyExists($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -254,8 +268,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship already exists.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateUpdateAlreadyExists() {
+  public function testRelationshipCreateUpdateAlreadyExists($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -279,8 +296,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check update doesn't reset stuff badly - CRM-11789.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateUpdateDoesNotMangle() {
+  public function testRelationshipCreateUpdateDoesNotMangle($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -305,8 +325,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship creation.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreate() {
+  public function testRelationshipCreate($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -339,8 +362,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Ensure disabling works.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipUpdate() {
+  public function testRelationshipUpdate($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('relationship', 'create', $this->_params);
     $relID = $result['id'];
     $result = $this->callAPISuccess('relationship', 'create', array('id' => $relID, 'description' => 'blah'));
@@ -359,8 +385,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship creation.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateEmptyEndDate() {
+  public function testRelationshipCreateEmptyEndDate($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -397,6 +426,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship creation with custom data.
+   * FIXME: Api4
    */
   public function testRelationshipCreateEditWithCustomData() {
     $this->createCustomGroupWithFieldsOfAllTypes();
@@ -446,6 +476,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * Note that the test is written on purpose without any
    * variables specific to participant so it can be replicated into other entities
    * and / or moved to the automated test suite
+   * FIXME: Api4
    */
   public function testGetWithCustom() {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
@@ -465,23 +496,19 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with empty array.
-   */
-  public function testRelationshipDeleteEmpty() {
-    $this->callAPIFailure('relationship', 'delete', array(), 'Mandatory key(s) missing from params array: id');
-  }
-
-  /**
    * Check if required fields are not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipDeleteWithoutRequired() {
+  public function testRelationshipDeleteWithoutRequired($version) {
+    $this->_apiversion = $version;
     $params = array(
       'start_date' => '2008-12-20',
       'end_date' => '2009-12-20',
       'is_active' => 1,
     );
 
-    $this->callAPIFailure('relationship', 'delete', $params, 'Mandatory key(s) missing from params array: id');
+    $this->callAPIFailure('relationship', 'delete', $params);
   }
 
   /**
@@ -502,8 +529,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship creation.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipDelete() {
+  public function testRelationshipDelete($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -522,10 +552,13 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check with empty array.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipUpdateEmpty() {
+  public function testRelationshipUpdateEmpty($version) {
+    $this->_apiversion = $version;
     $this->callAPIFailure('relationship', 'create', array(),
-      'Mandatory key(s) missing from params array: contact_id_a, contact_id_b, relationship_type_id');
+      'contact_id_a, contact_id_b, relationship_type_id');
   }
 
   /**
@@ -534,8 +567,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check relationship update.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipCreateDuplicate() {
+  public function testRelationshipCreateDuplicate($version) {
+    $this->_apiversion = $version;
     $relParams = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -567,6 +603,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
   /**
    * CRM-13725 - Two relationships of same type with same start and end date
    * should be OK if the custom field values differ.
+   * FIXME: Api4
    */
   public function testRelationshipCreateDuplicateWithCustomFields() {
     $this->createCustomGroupWithFieldsOfAllTypes();
@@ -610,6 +647,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * should be OK if the custom field values differ. In this case, the
    * existing relationship does not have custom values, but the new one
    * does.
+   * FIXME: Api4
    */
   public function testRelationshipCreateDuplicateWithCustomFields2() {
     $this->createCustomGroupWithFieldsOfAllTypes();
@@ -645,6 +683,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * should be OK if the custom field values differ. In this case, the
    * existing relationship does have custom values, but the new one
    * does not.
+   * FIXME: Api4
    */
   public function testRelationshipCreateDuplicateWithCustomFields3() {
     $this->createCustomGroupWithFieldsOfAllTypes();
@@ -711,8 +750,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Chain Relationship.get and to Contact.get.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipGetWithChainedCall() {
+  public function testRelationshipGetWithChainedCall($version) {
+    $this->_apiversion = $version;
     // Create a relationship.
     $createResult = $this->callAPISuccess('relationship', 'create', $this->_params);
     $id = $createResult['id'];
@@ -737,8 +779,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Chain Contact.get to Relationship.get and again to Contact.get.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipGetInChainedCall() {
+  public function testRelationshipGetInChainedCall($version) {
+    $this->_apiversion = $version;
     // Create a relationship.
     $this->callAPISuccess('relationship', 'create', $this->_params);
 
@@ -767,8 +812,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
   /**
    * Check with valid params array.
    * (The get function will behave differently without 'contact_id' passed
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipsGetGeneric() {
+  public function testRelationshipsGetGeneric($version) {
+    $this->_apiversion = $version;
     $relParams = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b,
@@ -789,8 +837,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Test retrieving only current relationships.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetIsCurrent() {
+  public function testGetIsCurrent($version) {
+    $this->_apiversion = $version;
     $rel2Params = array(
       'contact_id_a' => $this->_cId_a,
       'contact_id_b' => $this->_cId_b2,
@@ -798,15 +849,12 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       'start_date' => '2008-12-20',
       'is_active' => 0,
     );
-    $this->callAPISuccess('relationship', 'create', $rel2Params);
+    $rel0 = $this->callAPISuccess('relationship', 'create', $rel2Params);
     $rel1 = $this->callAPISuccess('relationship', 'create', $this->_params);
 
-    $getParams = array(
-      'filters' => array('is_current' => 1),
-    );
+    $getParams = ['filters' => ['is_current' => 1]];
     $description = "Demonstrates is_current filter.";
     $subfile = 'filterIsCurrent';
-    //no relationship has been created
     $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
     $this->assertEquals($result['count'], 1);
     $this->AssertEquals($rel1['id'], $result['id']);
@@ -814,22 +862,29 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     // now try not started
     $rel2Params['is_active'] = 1;
     $rel2Params['start_date'] = 'tomorrow';
-    $this->callAPISuccess('relationship', 'create', $rel2Params);
+    $rel2 = $this->callAPISuccess('relationship', 'create', $rel2Params);
+
+    // now try finished
+    $rel2Params['start_date'] = 'last week';
+    $rel2Params['end_date'] = 'yesterday';
+    $rel3 = $this->callAPISuccess('relationship', 'create', $rel2Params);
+
     $result = $this->callAPISuccess('relationship', 'get', $getParams);
     $this->assertEquals($result['count'], 1);
     $this->AssertEquals($rel1['id'], $result['id']);
 
-    // now try finished
-    $rel2Params['is_active'] = 1;
-    $rel2Params['start_date'] = 'last week';
-    $rel2Params['end_date'] = 'yesterday';
-    $this->callAPISuccess('relationship', 'create', $rel2Params);
+    foreach ([$rel0, $rel1, $rel2, $rel3] as $rel) {
+      $this->callAPISuccess('Relationship', 'delete', $rel);
+    }
   }
 
   /**
    * Test using various operators.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetTypeOperators() {
+  public function testGetTypeOperators($version) {
+    $this->_apiversion = $version;
     $relTypeParams = array(
       'name_a_b' => 'Relation 3 for delete',
       'name_b_a' => 'Relation 6 for delete',
@@ -908,6 +963,9 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->assertEquals($result['count'], 1);
     $this->AssertEquals(array($rel1['id']), array_keys($result['values']));
 
+    foreach ([$relationType2, $relationType3, $relationType4] as $id) {
+      $this->callAPISuccess('RelationshipType', 'delete', ['id' => $id]);
+    }
   }
 
   /**
@@ -1009,8 +1067,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    *
    * We should get 1 result without or with correct relationship type id & 0 with
    * an incorrect one
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetRelationshipByTypeDAO() {
+  public function testGetRelationshipByTypeDAO($version) {
+    $this->_apiversion = $version;
     $this->_ids['relationship'] = $this->callAPISuccess($this->entity, 'create', array('format.only_id' => TRUE) +
       $this->_params);
     $this->callAPISuccess($this->entity, 'getcount', array(
@@ -1034,8 +1095,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    *
    * We should get 1 result without or with correct relationship type id & 0 with
    * an incorrect one
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetRelationshipByTypeArrayDAO() {
+  public function testGetRelationshipByTypeArrayDAO($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess($this->entity, 'create', $this->_params);
     $org3 = $this->organizationCreate();
     // lets just assume built in ones aren't being messed with!
@@ -1119,8 +1183,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    *
    * We should get 1 result without or with correct relationship type id & 0 with
    * an incorrect one
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetRelationshipByMembershipTypeDAO() {
+  public function testGetRelationshipByMembershipTypeDAO($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess($this->entity, 'create', $this->_params);
     $org3 = $this->organizationCreate();
 
@@ -1176,8 +1243,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    *
    * We should get 1 result without or with correct relationship type id & 0 with
    * an incorrect one
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetRelationshipByMembershipTypeReciprocal() {
+  public function testGetRelationshipByMembershipTypeReciprocal($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess($this->entity, 'create', $this->_params);
     $org3 = $this->organizationCreate();
 
@@ -1229,8 +1299,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check for e-notices on enable & disable as reported in CRM-14350
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSetActive() {
+  public function testSetActive($version) {
+    $this->_apiversion = $version;
     $relationship = $this->callAPISuccess($this->entity, 'create', $this->_params);
     $this->callAPISuccess($this->entity, 'create', array('id' => $relationship['id'], 'is_active' => 0));
     $this->callAPISuccess($this->entity, 'create', array('id' => $relationship['id'], 'is_active' => 1));
@@ -1238,8 +1311,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Test creating related memberships.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateRelatedMembership() {
+  public function testCreateRelatedMembership($version) {
+    $this->_apiversion = $version;
     $relatedMembershipType = $this->callAPISuccess('MembershipType', 'create', array(
       'name' => 'Membership with Related',
       'member_of_contact_id' => 1,

--- a/tests/phpunit/api/v3/RelationshipTypeTest.php
+++ b/tests/phpunit/api/v3/RelationshipTypeTest.php
@@ -82,21 +82,25 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with no name.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeCreateWithoutName() {
+  public function testRelationshipTypeCreateWithoutName($version) {
+    $this->_apiversion = $version;
     $relTypeParams = array(
       'contact_type_a' => 'Individual',
       'contact_type_b' => 'Organization',
     );
-    $result = $this->callAPIFailure('relationship_type', 'create', $relTypeParams,
-      'Mandatory key(s) missing from params array: name_a_b, name_b_a'
-    );
+    $result = $this->callAPIFailure('relationship_type', 'create', $relTypeParams);
   }
 
   /**
    * Create relationship type.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeCreate() {
+  public function testRelationshipTypeCreate($version) {
+    $this->_apiversion = $version;
     $params = array(
       'name_a_b' => 'Relation 1 for relationship type create',
       'name_b_a' => 'Relation 2 for relationship type create',
@@ -115,8 +119,11 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Test  using example code.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeCreateExample() {
+  public function testRelationshipTypeCreateExample($version) {
+    $this->_apiversion = $version;
     require_once 'api/v3/examples/RelationshipType/Create.php';
     $result = relationship_type_create_example();
     $expectedResult = relationship_type_create_expectedresult();
@@ -125,8 +132,11 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Check if required fields are not passed.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeDeleteWithoutRequired() {
+  public function testRelationshipTypeDeleteWithoutRequired($version) {
+    $this->_apiversion = $version;
     $params = array(
       'name_b_a' => 'Relation 2 delete without required',
       'contact_type_b' => 'Individual',
@@ -135,7 +145,12 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
     );
 
     $result = $this->callAPIFailure('relationship_type', 'delete', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: id');
+    if ($version == 3) {
+      $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: id');
+    }
+    else {
+      $this->assertEquals($result['error_message'], 'Parameter "where" is required.');
+    }
   }
 
   /**
@@ -158,8 +173,11 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Check relationship type delete.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeDelete() {
+  public function testRelationshipTypeDelete($version) {
+    $this->_apiversion = $version;
     $id = $this->_relationshipTypeCreate();
     // create sample relationship type.
     $params = array(
@@ -173,17 +191,24 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with empty array.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeUpdateEmpty() {
+  public function testRelationshipTypeUpdateEmpty($version) {
+    $this->_apiversion = $version;
     $params = array();
     $result = $this->callAPIFailure('relationship_type', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: name_a_b, name_b_a');
+    $this->assertContains('name_a_b', $result['error_message']);
+    $this->assertContains('name_b_a', $result['error_message']);
   }
 
   /**
    * Check with no contact type.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeUpdateWithoutContactType() {
+  public function testRelationshipTypeUpdateWithoutContactType($version) {
+    $this->_apiversion = $version;
     // create sample relationship type.
     $this->_relTypeID = $this->_relationshipTypeCreate();
 
@@ -204,8 +229,11 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with all parameters.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypeUpdate() {
+  public function testRelationshipTypeUpdate($version) {
+    $this->_apiversion = $version;
     // create sample relationship type.
     $this->_relTypeID = $this->_relationshipTypeCreate();
 
@@ -231,8 +259,11 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with empty array.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypesGetEmptyParams() {
+  public function testRelationshipTypesGetEmptyParams($version) {
+    $this->_apiversion = $version;
     $firstRelTypeParams = array(
       'name_a_b' => 'Relation 27 for create',
       'name_b_a' => 'Relation 28 for create',
@@ -262,16 +293,22 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with params Not Array.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypesGetParamsNotArray() {
+  public function testRelationshipTypesGetParamsNotArray($version) {
+    $this->_apiversion = $version;
 
     $results = $this->callAPIFailure('relationship_type', 'get', 'string');
   }
 
   /**
    * Check with valid params array.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testRelationshipTypesGet() {
+  public function testRelationshipTypesGet($version) {
+    $this->_apiversion = $version;
     $firstRelTypeParams = array(
       'name_a_b' => 'Relation 30 for create',
       'name_b_a' => 'Relation 31 for create',

--- a/tests/phpunit/api/v3/SystemCheckTest.php
+++ b/tests/phpunit/api/v3/SystemCheckTest.php
@@ -36,22 +36,22 @@
  * @group headless
  */
 class api_v3_SystemCheckTest extends CiviUnitTestCase {
-  protected $_apiversion;
   protected $_contactID;
   protected $_locationType;
   protected $_params;
 
   public function setUp() {
-    $this->_apiversion = 3;
     parent::setUp();
     $this->useTransaction(TRUE);
   }
 
   /**
-   * Ensure that without any StatusPreference set, checkDefaultMailbox shows
-   * up.
+   * Ensure that without any StatusPreference set, checkDefaultMailbox shows up.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckBasic() {
+  public function testSystemCheckBasic($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('System', 'check', array());
     foreach ($result['values'] as $check) {
       if ($check['name'] == 'checkDefaultMailbox') {
@@ -64,8 +64,11 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
   /**
    * Permanently hushed items should never show up.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckHushForever() {
+  public function testSystemCheckHushForever($version) {
+    $this->_apiversion = $version;
     $this->_params = array(
       'name' => 'checkDefaultMailbox',
       'ignore_severity' => 7,
@@ -86,8 +89,11 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
   /**
    * Items hushed through tomorrow shouldn't show up.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckHushFuture() {
+  public function testSystemCheckHushFuture($version) {
+    $this->_apiversion = $version;
     $tomorrow = new DateTime('tomorrow');
     $this->_params = array(
       'name' => 'checkDefaultMailbox',
@@ -110,8 +116,11 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
   /**
    * Items hushed through today should show up.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckHushToday() {
+  public function testSystemCheckHushToday($version) {
+    $this->_apiversion = $version;
     $today = new DateTime('today');
     $this->_params = array(
       'name' => 'checkDefaultMailbox',
@@ -134,8 +143,11 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
   /**
    * Items hushed through yesterday should show up.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckHushYesterday() {
+  public function testSystemCheckHushYesterday($version) {
+    $this->_apiversion = $version;
     $yesterday = new DateTime('yesterday');
     $this->_params = array(
       'name' => 'checkDefaultMailbox',
@@ -158,8 +170,11 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
   /**
    * Items hushed above current severity should be hidden.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckHushAboveSeverity() {
+  public function testSystemCheckHushAboveSeverity($version) {
+    $this->_apiversion = $version;
     $this->_params = array(
       'name' => 'checkDefaultMailbox',
       'ignore_severity' => 4,
@@ -180,14 +195,17 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
   /**
    * Items hushed at current severity should be hidden.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckHushAtSeverity() {
+  public function testSystemCheckHushAtSeverity($version) {
+    $this->_apiversion = $version;
     $this->_params = array(
       'name' => 'checkDefaultMailbox',
       'ignore_severity' => 3,
     );
-    $statusPreference = $this->callAPISuccess('StatusPreference', 'create', $this->_params);
-    $result = $this->callAPISuccess('System', 'check', array());
+    $this->callAPISuccess('StatusPreference', 'create', $this->_params);
+    $result = $this->callAPISuccess('System', 'check');
     foreach ($result['values'] as $check) {
       if ($check['name'] == 'checkDefaultMailbox') {
         $testedCheck = $check;
@@ -202,8 +220,11 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
   /**
    * Items hushed below current severity should be shown.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testSystemCheckHushBelowSeverity() {
+  public function testSystemCheckHushBelowSeverity($version) {
+    $this->_apiversion = $version;
     $this->_params = array(
       'name' => 'checkDefaultMailbox',
       'ignore_severity' => 2,

--- a/tests/phpunit/api/v3/TagTest.php
+++ b/tests/phpunit/api/v3/TagTest.php
@@ -59,8 +59,11 @@ class api_v3_TagTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_tag_get with wrong params.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetWrongParams() {
+  public function testGetWrongParams($version) {
+    $this->_apiversion = $version;
     $params = array('name' => 'Wrong Tag Name');
     $result = $this->callAPISuccess('tag', 'get', $params);
     $this->assertEquals(0, $result['count']);
@@ -68,8 +71,11 @@ class api_v3_TagTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_tag_get - success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGet() {
+  public function testGet($version) {
+    $this->_apiversion = $version;
     $params = array(
       'id' => $this->tagID,
       'name' => $this->tag['name'],
@@ -81,8 +87,11 @@ class api_v3_TagTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_tag_get - success expected.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetReturnArray() {
+  public function testGetReturnArray($version) {
+    $this->_apiversion = $version;
     $description = "Demonstrates use of Return as an array.";
     $subfile = "GetReturnArray";
 
@@ -100,15 +109,21 @@ class api_v3_TagTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_tag_create with empty params.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateEmptyParams() {
-    $result = $this->callAPIFailure('tag', 'create', array(), 'Mandatory key(s) missing from params array: name');
+  public function testCreateEmptyParams($version) {
+    $this->_apiversion = $version;
+    $result = $this->callAPIFailure('tag', 'create', array(), 'name');
   }
 
   /**
    * Test civicrm_tag_create.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreatePasstagInParams() {
+  public function testCreatePasstagInParams($version) {
+    $this->_apiversion = $version;
     $params = array(
       'tag' => 10,
       'name' => 'New Tag23',
@@ -120,6 +135,7 @@ class api_v3_TagTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_tag_create - success expected.
+   * Skipping v4 because used_for is an array
    */
   public function testCreate() {
     $params = array(
@@ -136,6 +152,8 @@ class api_v3_TagTest extends CiviUnitTestCase {
    * Test civicrm_tag_create activity tag- success expected.
    *
    * Test checks that used_for is set and not over-written by default on update.
+   *
+   * Skipping v4 because used_for is an array
    */
   public function testCreateEntitySpecificTag() {
     $params = array(
@@ -157,15 +175,21 @@ class api_v3_TagTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_tag_delete without tag id.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDeleteWithoutTagId() {
-    $result = $this->callAPIFailure('tag', 'delete', array(), 'Mandatory key(s) missing from params array: id');
+  public function testDeleteWithoutTagId($version) {
+    $this->_apiversion = $version;
+    $result = $this->callAPIFailure('tag', 'delete', array());
   }
 
   /**
    * Test civicrm_tag_delete .
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testTagDeleteOldSyntax() {
+  public function testTagDeleteOldSyntax($version) {
+    $this->_apiversion = $version;
     $params = array(
       'tag_id' => $this->tagID,
     );
@@ -175,8 +199,11 @@ class api_v3_TagTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_tag_delete = $params['id'] is correct
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testTagDeleteCorrectSyntax() {
+  public function testTagDeleteCorrectSyntax($version) {
+    $this->_apiversion = $version;
     $params = array(
       'id' => $this->tagID,
     );

--- a/tests/phpunit/api/v3/UFFieldTest.php
+++ b/tests/phpunit/api/v3/UFFieldTest.php
@@ -26,9 +26,7 @@
  */
 
 /**
- * Test class for UFGroup API - civicrm_uf_*
- *
- * @todo Split UFGroup and UFJoin tests
+ * Test class for UFField API
  *
  * @package   CiviCRM
  * @group headless
@@ -105,8 +103,11 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
 
   /**
    * Create / updating field.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateUFField() {
+  public function testCreateUFField($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     $ufField = $this->callAPIAndDocument('uf_field', 'create', $params, __FUNCTION__, __FILE__);
     unset($params['uf_group_id']);
@@ -118,8 +119,11 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
 
   /**
    * Failure test for field_name.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateUFFieldWithBadFieldName() {
+  public function testCreateUFFieldWithBadFieldName($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     $params['field_name'] = 'custom_98789';
     $this->callAPIFailure('uf_field', 'create', $params);
@@ -127,8 +131,11 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
 
   /**
    * Failure test for bad parameters.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateUFFieldWithWrongParams() {
+  public function testCreateUFFieldWithWrongParams($version) {
+    $this->_apiversion = $version;
     $this->callAPIFailure('uf_field', 'create', ['field_name' => 'test field']);
     $this->callAPIFailure('uf_field', 'create', ['label' => 'name-less field']);
   }
@@ -137,8 +144,11 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
    * Create a field with 'weight=1' and then a second with 'weight=1'.
    *
    * The second field winds up with weight=1, and the first field gets bumped to 'weight=2'.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateUFFieldWithDefaultAutoWeight() {
+  public function testCreateUFFieldWithDefaultAutoWeight($version) {
+    $this->_apiversion = $version;
     $params1 = $this->_params;
     $ufField1 = $this->callAPISuccess('uf_field', 'create', $params1);
     $this->assertEquals(1, $ufField1['values'][$ufField1['id']]['weight']);
@@ -161,8 +171,11 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
 
   /**
    * Deleting field.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testDeleteUFField() {
+  public function testDeleteUFField($version) {
+    $this->_apiversion = $version;
     $ufField = $this->callAPISuccess('uf_field', 'create', $this->_params);
     $params = [
       'field_id' => $ufField['id'],
@@ -172,8 +185,11 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
 
   /**
    * Test getting ufField.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetUFFieldSuccess() {
+  public function testGetUFFieldSuccess($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $result = $this->callAPIAndDocument($this->_entity, 'get', [], __FUNCTION__, __FILE__);
     $this->getAndCheck($this->_params, $result['id'], $this->_entity);
@@ -243,8 +259,11 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
 
   /**
    * Check Profile API permission without ACL.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testProfilesWithoutACL() {
+  public function testProfilesWithoutACL($version) {
+    $this->_apiversion = $version;
     $this->createLoggedInUser();
     $baseFields[] = [
       'field_name' => 'first_name',

--- a/tests/phpunit/api/v3/UFGroupTest.php
+++ b/tests/phpunit/api/v3/UFGroupTest.php
@@ -41,7 +41,6 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
   protected $_ufFieldId;
   protected $_contactId;
   protected $_groupId;
-  protected $_apiversion = 3;
   protected $params;
 
   protected function setUp() {
@@ -99,9 +98,11 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Updating group.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUpdateUFGroup() {
+  public function testUpdateUFGroup($version) {
+    $this->_apiversion = $version;
     $params = array(
       'title' => 'Edited Test Profile',
       'help_post' => 'Profile Pro help text.',
@@ -115,8 +116,12 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
     }
   }
 
-  public function testUFGroupCreate() {
-
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFGroupCreate($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument('uf_group', 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertAPISuccess($result);
     $this->assertEquals($result['values'][$result['id']]['add_to_group_id'], $this->params['add_contact_to_group']);
@@ -132,11 +137,21 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
     }
   }
 
-  public function testUFGroupCreateWithWrongParams() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFGroupCreateWithWrongParams($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIFailure('uf_group', 'create', array('name' => 'A title-less group'));
   }
 
-  public function testUFGroupUpdate() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFGroupUpdate($version) {
+    $this->_apiversion = $version;
     $params = array(
       'id' => $this->_ufGroupId,
       'add_captcha' => 1,
@@ -173,7 +188,12 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
     $this->assertEquals($result['values'][$result['id']]['limit_listings_group_id'], $params['group']);
   }
 
-  public function testUFGroupGet() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFGroupGet($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('uf_group', 'create', $this->params);
     $params = array('id' => $result['id']);
     $result = $this->callAPIAndDocument('uf_group', 'get', $params, __FUNCTION__, __FILE__);
@@ -186,15 +206,29 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
       }
       $expected = $this->params[$key];
       $received = $result['values'][$result['id']][$key];
+      // Api4 auto-splits serialized fields, v3 sometimes does but not in this case
+      if ($version == 4 && is_array($received)) {
+        $received = implode(',', $received);
+      }
       $this->assertEquals($expected, $received, "The string '$received' does not equal '$expected' for key '$key' in line " . __LINE__);
     }
   }
 
-  public function testUFGroupUpdateWithEmptyParams() {
-    $result = $this->callAPIFailure('uf_group', 'create', array(), 'Mandatory key(s) missing from params array: title');
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFGroupUpdateWithEmptyParams($version) {
+    $this->_apiversion = $version;
+    $result = $this->callAPIFailure('uf_group', 'create', [], 'title');
   }
 
-  public function testUFGroupDelete() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFGroupDelete($version) {
+    $this->_apiversion = $version;
     $ufGroup = $this->callAPISuccess('uf_group', 'create', $this->params);
     $params = array('id' => $ufGroup['id']);
     $this->assertEquals(1, $this->callAPISuccess('uf_group', 'getcount', $params), "in line " . __LINE__);

--- a/tests/phpunit/api/v3/UFJoinTest.php
+++ b/tests/phpunit/api/v3/UFJoinTest.php
@@ -71,8 +71,11 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
 
   /**
    * Find uf join group id.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testFindUFGroupId() {
+  public function testFindUFGroupId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'module' => 'CiviContribute',
       'entity_table' => 'civicrm_contribution_page',
@@ -94,19 +97,23 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
     }
   }
 
-  public function testUFJoinEditWrongParamsType() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFJoinEditWrongParamsType($version) {
+    $this->_apiversion = $version;
     $params = 'a string';
     $result = $this->callAPIFailure('uf_join', 'create', $params);
     $this->assertEquals($result['error_message'], 'Input variable `params` is not an array');
   }
 
-  public function testUFJoinEditEmptyParams() {
-    $params = array();
-    $result = $this->callAPIFailure('uf_join', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: module, weight, uf_group_id');
-  }
-
-  public function testUFJoinEditWithoutUFGroupId() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUFJoinEditWithoutUFGroupId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'module' => 'CiviContribute',
       'entity_table' => 'civicrm_contribution_page',
@@ -115,13 +122,18 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
     $result = $this->callAPIFailure('uf_join', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: uf_group_id');
+    $this->assertContains('Mandatory', $result['error_message']);
+    $this->assertContains('missing', $result['error_message']);
+    $this->assertContains('uf_group_id', $result['error_message']);
   }
 
   /**
    * Create/update uf join
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateUFJoin() {
+  public function testCreateUFJoin($version) {
+    $this->_apiversion = $version;
     $params = array(
       'module' => 'CiviContribute',
       'entity_table' => 'civicrm_contribution_page',
@@ -155,8 +167,11 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
   /**
    * Ensure we can create a survey join which is less common than event or contribution
    * joins.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateSurveyUFJoin() {
+  public function testCreateSurveyUFJoin($version) {
+    $this->_apiversion = $version;
     $params = array(
       'module' => 'CiviCampaign',
       'entity_table' => 'civicrm_survey',
@@ -172,18 +187,25 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
     $this->assertEquals($ufJoin['values'][0]['is_active'], $params['is_active']);
   }
 
-  public function testFindUFJoinWrongParamsType() {
-    $params = 'a string';
-    $result = $this->callAPIFailure('uf_join', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Input variable `params` is not an array');
-  }
-
-  public function testFindUFJoinEmptyParams() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testFindUFJoinEmptyParams($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIFailure('uf_join', 'create', array());
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: module, weight, uf_group_id');
+    $this->assertContains('Mandatory', $result['error_message']);
+    $this->assertContains('missing', $result['error_message']);
+    $this->assertContains('module', $result['error_message']);
+    $this->assertContains('uf_group_id', $result['error_message']);
   }
 
-  public function testFindUFJoinWithoutUFGroupId() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateUFJoinWithoutUFGroupId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'module' => 'CiviContribute',
       'entity_table' => 'civicrm_contribution_page',
@@ -192,13 +214,18 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
     $result = $this->callAPIFailure('uf_join', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: uf_group_id');
+    $this->assertContains('Mandatory', $result['error_message']);
+    $this->assertContains('missing', $result['error_message']);
+    $this->assertContains('uf_group_id', $result['error_message']);
   }
 
   /**
    * Find uf join id.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetUFJoinId() {
+  public function testGetUFJoinId($version) {
+    $this->_apiversion = $version;
     $params = array(
       'module' => 'CiviContribute',
       'entity_table' => 'civicrm_contribution_page',
@@ -223,8 +250,11 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_activity_create() using example code.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUFJoinCreateExample() {
+  public function testUFJoinCreateExample($version) {
+    $this->_apiversion = $version;
     require_once 'api/v3/examples/UFJoin/Create.php';
     $result = UF_join_create_example();
     $expectedResult = UF_join_create_expectedresult();

--- a/tests/phpunit/api/v3/UFMatchTest.php
+++ b/tests/phpunit/api/v3/UFMatchTest.php
@@ -79,8 +79,11 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
 
   /**
    * Fetch contact id by uf id.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetUFMatchID() {
+  public function testGetUFMatchID($version) {
+    $this->_apiversion = $version;
     $params = array(
       'uf_id' => 42,
     );
@@ -88,15 +91,23 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
     $this->assertEquals($result['values'][$result['id']]['contact_id'], 69);
   }
 
-  public function testGetUFMatchIDWrongParam() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetUFMatchIDWrongParam($version) {
+    $this->_apiversion = $version;
     $params = 'a string';
     $result = $this->callAPIFailure('uf_match', 'get', $params);
   }
 
   /**
    * Fetch uf id by contact id.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetUFID() {
+  public function testGetUFID($version) {
+    $this->_apiversion = $version;
     $params = array(
       'contact_id' => 69,
     );
@@ -104,30 +115,46 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
     $this->assertEquals($result['values'][$result['id']]['uf_id'], 42);
   }
 
-  public function testGetUFIDWrongParam() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetUFIDWrongParam($version) {
+    $this->_apiversion = $version;
     $params = 'a string';
     $result = $this->callAPIFailure('uf_match', 'get', $params);
   }
 
   /**
    * Test civicrm_activity_create() using example code
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUFMatchGetExample() {
+  public function testUFMatchGetExample($version) {
+    $this->_apiversion = $version;
     require_once 'api/v3/examples/UFMatch/Get.php';
     $result = UF_match_get_example();
     $expectedResult = UF_match_get_expectedresult();
     $this->assertEquals($result, $expectedResult);
   }
 
-  public function testCreate() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreate($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('uf_match', 'create', $this->_params);
     $this->getAndCheck($this->_params, $result['id'], 'uf_match');
   }
 
   /**
    * Test Civi to CMS email sync optional
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testUFNameMatchSync() {
+  public function testUFNameMatchSync($version) {
+    $this->_apiversion = $version;
     $this->callAPISuccess('uf_match', 'create', $this->_params);
     $email1 = substr(sha1(rand()), 0, 7) . '@test.com';
     $email2 = substr(sha1(rand()), 0, 7) . '@test.com';
@@ -160,7 +187,12 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
     $this->assertEquals($email1, $ufName);
   }
 
-  public function testDelete() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDelete($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('uf_match', 'create', $this->_params);
     $this->assertEquals(1, $this->callAPISuccess('uf_match', 'getcount', array(
       'id' => $result['id'],

--- a/tests/phpunit/api/v3/WebsiteTest.php
+++ b/tests/phpunit/api/v3/WebsiteTest.php
@@ -53,14 +53,24 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
     );
   }
 
-  public function testCreateWebsite() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateWebsite($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
 
-  public function testGetWebsite() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testGetWebsite($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
@@ -68,7 +78,12 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
     $this->callAPISuccess('website', 'delete', array('id' => $result['id']));
   }
 
-  public function testDeleteWebsite() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteWebsite($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = array('id' => $result['id']);
     $result = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
@@ -76,7 +91,12 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
     $this->assertEquals(0, $checkDeleted['count']);
   }
 
-  public function testDeleteWebsiteInvalid() {
+  /**
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteWebsiteInvalid($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = array('id' => 600);
     $result = $this->callAPIFailure($this->_entity, 'delete', $deleteParams);
@@ -97,9 +117,11 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test retrieval of label metadata.
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetFields() {
+  public function testGetFields($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument($this->_entity, 'getfields', array('action' => 'get'), __FUNCTION__, __FILE__);
     $this->assertArrayKeyExists('url', $result['values']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Adds a compatibility layer and converts some api3 tests to also run on api v4.

Before
----------------------------------------
Core api tests covered v3 only.

After
----------------------------------------
311 v3 tests converted to also test v4.

Technical Details
----------------------------------------
Uses `@dataProvider` annotation to feed 2 version numbers to each test.

Comments
----------------------------------------
The key issue with apiv4 is that it doesn't do enough - ie it does the metadata crud stuff but not enough of the other stuff that makes apiv3 useful - all the different actions. 

In order to add the actions to apiv4 we need to figure out how to make the tests test apiv4  -since the tests, rather than the code, are the main asset and we shouldn't even be adding actions without test parity to api v4.

One idea is that we run all our apiv3 tests using apiv4 as well - with some obvious opt outs - goodbye ConstantTest....

This would cause quite a few fails but we can work through them & decide which represent missing v4 features and which should not be ported.

If we do this the question becomes how we mark which tests should run on both versions - ideally we would follow an opt out - ie. by manually doing this or some other method add the dataprovider to all tests & then edit it back with a comment as to why for all the ones we don't port. e.g 'no v4 test as this function is deprecated in v3 & deliberately not ported' or 'no v4 test as we have written a separate test for v4'
