### PR TITLE
Fix placeholder font in Quicksearch

### DIFF
--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -143,16 +143,16 @@ a.highlighted #crm-qsearch-input,
   width: 130px;
 }
 input#crm-qsearch-input:-ms-input-placeholder {
-  font-family: 'FontAwesome';
+  font-family: 'FontAwesome', sans-serif;
 }
 input#crm-qsearch-input::-webkit-input-placeholder {
-  font-family: 'FontAwesome';
+  font-family: 'FontAwesome', sans-serif;
 }
 input#crm-qsearch-input::-moz-placeholder {
-  font-family: 'FontAwesome';
+  font-family: 'FontAwesome', sans-serif;
 }
 input#crm-qsearch-input::placeholder {
-  font-family: 'FontAwesome';
+  font-family: 'FontAwesome', sans-serif;
 }
 
 ul.crm-quickSearch-results {


### PR DESCRIPTION
Overview
----------------------------------------
This is a fairly trivial change to ensure the placeholder text shown in the Quicksearch input uses the same font as the rest of the menu.

Before
----------------------------------------
The Quicksearch placeholder font is set to "FontAwesome", causing it to fall back to the default UA font for regular text:

![image](https://user-images.githubusercontent.com/277794/56909466-9518ef00-6aa8-11e9-9e7f-f40659a1376a.png)


After
----------------------------------------
Civi's default font is used:

![image](https://user-images.githubusercontent.com/277794/56909509-ac57dc80-6aa8-11e9-81b9-17e4b3d0cd2a.png)
