### PR TITLE
CiviMail - Restore support for preview of "mailing"/"action" tokens via TokenProcessor/Flexmailer

### DIFF
--- a/CRM/Mailing/ActionTokens.php
+++ b/CRM/Mailing/ActionTokens.php
@@ -65,7 +65,8 @@ class CRM_Mailing_ActionTokens extends \Civi\Token\AbstractTokenSubscriber {
    * @inheritDoc
    */
   public function checkActive(\Civi\Token\TokenProcessor $processor) {
-    return !empty($processor->context['mailingId']) || !empty($processor->context['mailing']);
+    return !empty($processor->context['mailingId']) || !empty($processor->context['mailing'])
+      || in_array('mailingId', $processor->context['schema']) || in_array('mailing', $processor->context['schema']);
   }
 
   /**
@@ -85,7 +86,9 @@ class CRM_Mailing_ActionTokens extends \Civi\Token\AbstractTokenSubscriber {
     // replaceSubscribeInviteTokens().
 
     if (empty($row->context['mailingJobId']) || empty($row->context['mailingActionTarget']['hash'])) {
-      throw new \CRM_Core_Exception("Error: Cannot use action tokens unless context defines mailingJobId and mailingActionTarget.");
+      // Strictly speaking, it doesn't make much sense to generate action-tokens when there's no job ID, but traditional CiviMail
+      // does this in v5.6+ for "Preview" functionality. Relaxing this strictness check ensures parity between newer+older styles.
+      // throw new \CRM_Core_Exception("Error: Cannot use action tokens unless context defines mailingJobId and mailingActionTarget.");
     }
 
     if ($field === 'eventQueueId') {

--- a/CRM/Mailing/Tokens.php
+++ b/CRM/Mailing/Tokens.php
@@ -61,7 +61,8 @@ class CRM_Mailing_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    * @inheritDoc
    */
   public function checkActive(\Civi\Token\TokenProcessor $processor) {
-    return !empty($processor->context['mailingId']) || !empty($processor->context['mailing']);
+    return !empty($processor->context['mailingId']) || !empty($processor->context['mailing'])
+      || in_array('mailingId', $processor->context['schema']) || in_array('mailing', $processor->context['schema']);
   }
 
   /**

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -102,16 +102,25 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     $this->assertEquals(1, $count);
   }
 
-  /**
-   * Check the behavior in the erroneous situation where someone uses
-   * a mailing-related token without providing a mailing ID.
-   */
-  public function testTokensWithoutMailing() {
-    // We only need one case to see that the mailing-object works as
-    // an alternative to the mailing-id.
-    $inputTemplateFormat = 'text/plain';
-    $inputTemplate = 'To optout: {action.optOutUrl}!';
+  public function getExampleTokensForUseWithoutMailingJob() {
+    $cases = [];
+    $cases[] = ['text/plain', 'To opt out: {action.optOutUrl}!', '@To opt out: .*civicrm/mailing/optout.*&jid=&qid=@'];
+    $cases[] = ['text/html', 'To opt out: <a href="{action.optOutUrl}">click here</a>!', '@To opt out: <a href=".*civicrm/mailing/optout.*&amp;jid=&amp;qid=.*">click@'];
+    return $cases;
+  }
 
+  /**
+   * When previewing a mailing, there is no active mailing job, so one cannot
+   * generate fully formed URLs which reference the job. The current behavior
+   * is to link to a placeholder URL which has blank values for key fields
+   * like `jid` and `qid`.
+   *
+   * This current behavior may be wise or unwise - either way, having ensures
+   * that changes are intentional.
+   *
+   * @dataProvider getExampleTokensForUseWithoutMailingJob
+   */
+  public function testTokensWithoutMailingJob($inputTemplateFormat, $inputTemplateText, $expectRegex) {
     $mailing = CRM_Core_DAO::createTestObject('CRM_Mailing_DAO_Mailing', array(
       'name' => 'Example Name',
     ));
@@ -120,17 +129,23 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     $p = new \Civi\Token\TokenProcessor(Civi::service('dispatcher'), array(
       'mailing' => $mailing,
     ));
-    $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
+    $p->addMessage('example', $inputTemplateText, $inputTemplateFormat);
     $p->addRow()->context(array(
       'contactId' => $contact->id,
     ));
-    try {
-      $p->evaluate();
-      $this->fail('TokenProcessor::evaluate() should have thrown an exception');
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertRegExp(';Cannot use action tokens unless context defines mailingJobId and mailingActionTarget;', $e->getMessage());
-    }
+    //    try {
+    //      $p->evaluate();
+    //      $this->fail('TokenProcessor::evaluate() should have thrown an exception');
+    //    }
+    //    catch (CRM_Core_Exception $e) {
+    //      $this->assertRegExp(';Cannot use action tokens unless context defines mailingJobId and mailingActionTarget;', $e->getMessage());
+    //    }
+
+    $p->evaluate();
+
+    // FIXME: For compatibility with
+    $actual = $p->getRow(0)->render('example');
+    $this->assertRegExp($expectRegex, $actual);
   }
 
 }


### PR DESCRIPTION
Overview
--------

When using `TokenProcessor` to generate a mailing (e.g.  as with Flexmailer/Mosaico), the mailing/action-tokens (e.g. `{mailing.subject}` and `{action.optOutUrl}`) are generated via `CRM_Mailing_Tokens` and `CRM_Mailing_ActionTokens`.  To properly generate them, `CRM_Mailing_Tokens` and `CRM_Mailing_ActionTokens` check the mailing/job ID.  However, that information is no longer available when performing a "Preview" -- leading to misbehavior in previews.  In combination with https://github.com/civicrm/org.civicrm.flexmailer/pull/38, this restores parity for token/preview support.

Before (Pre-5.6; OK)
----------------

* When a user begins composing a mailing, CiviMail creates a draft mailing with a concrete ID (e.g. `mailing #123`). 
* To preview the mailing, the UI calls `Mailing.preview` API with the ID of the mailing. 
* Flexmailer/Mosaico generates the preview by calling `TokenProcessor` and therefore `CRM_Mailing_ActionTokens`.
* `CRM_Mailing_ActionTokens` has strictness checks. These pass because the ID is available.

Before (5.6-5.12; Not OK)
----------------

As a performance enhancement, CiviCRM 5.6 (PR #12509; [dev/mail#20](https://lab.civicrm.org/dev/mail/issues/20)) revised the signature for `Mailing.preview` API to allow previews *without* having a specific mailing record/job/ID. Consequently:

* When a user begins composing a mailing, CiviMail creates a draft mailing with a concrete ID (e.g.  `mailing #123`). 
* To preview the mailing, the UI calls `Mailing.preview` API ~~with~~ **without** the ID of the mailing.
* Flexmailer/Mosaico generates the preview by calling `TokenProcessor` and therefore `CRM_Mailing_ActionTokens`.
* `CRM_Mailing_ActionTokens` has strictness checks. These ~~pass~~ **fail** because the ID is ~~available~~ **unavailable**.

After (OK)
----------------

* When a user begins composing a mailing, CiviMail creates a draft mailing with a concrete ID (e.g.  `mailing #123`). 
* To preview the mailing, the UI calls `Mailing.preview` API ~~with~~ **without** the ID of the mailing.
* Flexmailer/Mosaico generates the preview by calling `TokenProcessor` and therefore `CRM_Mailing_ActionTokens`.
* `CRM_Mailing_ActionTokens` has ~~strictness~~ **less strict** checks. These **pass** because the `context[schema]` hints that a mailing ID *will be available* when it's really needed. 

Comments
----------------

The change in contract for `Mailing.preview` API has produced multiple overlapping issues -- including this issue in `civicrm-core` and some other issues in `flexmailer`.  The `flexmailer` issues generally involve getting the wrong information about a previewed mailing because the `id` is unavailable.  Unfortunately, because of the overlapping issues, it can be hard to produce a clear/singular symptom.  (Ex: The symptoms change significantly depending on the `template_type` of the *first* mailing in the DB and/or depending on whether you enable the hidden setting `experimentalFlexMailerEngine`.)

With regard to QA for this PR, some important mitigating circumstances to note:

* CiviMail's BAO-based delivery engine (in `civicrm-core`) doesn't use `TokenProcessor` or `CRM_*_Tokens`. That change was done as "leap by extension" (`flexmailer`). 
* `civicrm-core` does use `TokenProcessor` for scheduled reminders - but they don't involve mailings.
* For some other/overlapping issues in, there's https://github.com/civicrm/org.civicrm.flexmailer/pull/38. That patch also expands test-coverage, and it will be included in the `CiviCRM-Ext-Matrix` once it's merged. (However, that PR currently fails because it depends on having this change!)
