### PR TITLE
dev/core#913 - update autogenerated .htaccess for apache 2.4

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -526,8 +526,16 @@ class CRM_Utils_File {
     if (!empty($dir) && is_dir($dir)) {
       $htaccess = <<<HTACCESS
 <Files "*">
-  Order allow,deny
-  Deny from all
+# Apache 2.2
+  <IfModule !authz_core_module>
+    Order allow,deny
+    Deny from all
+  </IfModule>
+
+# Apache 2.4+
+  <IfModule authz_core_module>
+    Require all denied
+  </IfModule>
 </Files>
 
 HTACCESS;


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/913

Before
----------------------------------------
The current autogenerated .htaccess is for apache 2.2. It happens to work on apache 2.4 because it gives an internal error, but that's obviously not what was intended. It may also happen to work on apache 2.4 if mod_access_compat happens to be installed.

After
----------------------------------------
Works on apache 2.4 with no log errors. Falls back to current behavior if it can't tell if it's apache 2.4 or higher.
