### PR TITLE
Convert dedupe select to select 2 and remove not-used var

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -113,22 +113,16 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     );
 
     $this->addField('used', ['label' => ts('Usage')], TRUE);
-    $disabled = [];
     $reserved = $this->addField('is_reserved', ['label' => ts('Reserved?')]);
     if (!empty($this->_defaults['is_reserved'])) {
       $reserved->freeze();
     }
 
     $attributes = ['class' => 'two'];
-    if (!empty($disabled)) {
-      $attributes = array_merge($attributes, $disabled);
-    }
 
     for ($count = 0; $count < self::RULES_COUNT; $count++) {
       $this->add('select', "where_$count", ts('Field'),
-        [
-          NULL => ts('- none -'),
-        ] + $this->_fields, FALSE, $disabled
+        $this->_fields, FALSE, ['class' => 'crm-select2', 'placeholder' => ts('Select Field')]
       );
       $this->addField("length_$count", ['entity' => 'Rule', 'name' => 'rule_length'] + $attributes);
       $this->addField("weight_$count", ['entity' => 'Rule', 'name' => 'rule_weight'] + $attributes);


### PR DESCRIPTION
Overview
----------------------------------------
Converts the field to select fields on dedupe rules form to select2

Before
----------------------------------------
![Screenshot 2019-04-30 17 05 17](https://user-images.githubusercontent.com/336308/56941685-2308de80-6b6a-11e9-82e2-cbb7fa8af8b2.png)


After
----------------------------------------
![Screenshot 2019-04-30 17 04 25](https://user-images.githubusercontent.com/336308/56941659-0b315a80-6b6a-11e9-9055-42456d94a9fd.png)


Technical Details
----------------------------------------
The $disabled var is empty & stays empty - it looks very very much like a typo

Comments
----------------------------------------
