### PR TITLE
(flexmailer#29) civicrm/mailing/view - Use Mailing.preview API. Fix compatibility with Flexmailer.

### DIFF
--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -35,6 +35,12 @@
  * A page for mailing preview.
  */
 class CRM_Mailing_Page_View extends CRM_Core_Page {
+
+  /**
+   * @var Signal to Flexmailer that this version of the class is usable.
+   */
+  const USES_MAILING_PREVIEW_API = 1;
+
   protected $_mailingID;
   protected $_mailing;
   protected $_contactID;
@@ -132,59 +138,27 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       return NULL;
     }
 
-    CRM_Mailing_BAO_Mailing::tokenReplace($this->_mailing);
+    $contactId = isset($this->_contactID) ? $this->_contactID : 0;
 
-    // get and format attachments
-    $attachments = CRM_Core_BAO_File::getEntityFile('civicrm_mailing',
-      $this->_mailing->id
-    );
-
-    // get contact detail and compose if contact id exists
-    $returnProperties = $this->_mailing->getReturnProperties();
-    if (isset($this->_contactID)) {
-      // get details of contact with token value including Custom Field Token Values.CRM-3734
-      $params = ['contact_id' => $this->_contactID];
-      $details = CRM_Utils_Token::getTokenDetails($params,
-        $returnProperties,
-        FALSE, TRUE, NULL,
-        $this->_mailing->getFlattenedTokens(),
-        get_class($this)
-      );
-      $details = $details[0][$this->_contactID];
-      $contactId = $this->_contactID;
-    }
-    else {
-      // get tokens that are not contact specific resolved
-      $params = ['contact_id' => 0];
-      $details = CRM_Utils_Token::getAnonymousTokenDetails($params,
-        $returnProperties,
-        TRUE, TRUE, NULL,
-        $this->_mailing->getFlattenedTokens(),
-        get_class($this)
-      );
-
-      $details = CRM_Utils_Array::value(0, $details[0]);
-      $contactId = 0;
-    }
-    $mime = $this->_mailing->compose(NULL, NULL, NULL, $contactId,
-      $this->_mailing->from_email,
-      $this->_mailing->from_email,
-      TRUE, $details, $attachments
-    );
+    $result = civicrm_api3('Mailing', 'preview', [
+      'id' => $this->_mailingID,
+      'contact_id' => $contactId,
+    ]);
+    $mailing = \CRM_Utils_Array::value('values', $result);
 
     $title = NULL;
-    if (isset($this->_mailing->body_html) && empty($_GET['text'])) {
+    if (isset($mailing['body_html']) && empty($_GET['text'])) {
       $header = 'text/html; charset=utf-8';
-      $content = $mime->getHTMLBody();
+      $content = $mailing['body_html'];
       if (strpos($content, '<head>') === FALSE && strpos($content, '<title>') === FALSE) {
-        $title = '<head><title>' . $this->_mailing->subject . '</title></head>';
+        $title = '<head><title>' . $mailing['subject'] . '</title></head>';
       }
     }
     else {
       $header = 'text/plain; charset=utf-8';
-      $content = $mime->getTXTBody();
+      $content = $mailing['body_text'];
     }
-    CRM_Utils_System::setTitle($this->_mailing->subject);
+    CRM_Utils_System::setTitle($mailing['subject']);
 
     if (CRM_Utils_Array::value('snippet', $_GET) === 'json') {
       CRM_Core_Page_AJAX::returnJsonResponse($content);

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -592,7 +592,7 @@ function civicrm_api3_mailing_preview($params) {
   );
 
   return civicrm_api3_create_success([
-    'id' => $params['id'],
+    'id' => $mailingID,
     'contact_id' => $contactID,
     'subject' => $mime->headers()['Subject'],
     'body_html' => $mime->getHTMLBody(),

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -573,13 +573,20 @@ function civicrm_api3_mailing_preview($params) {
   $returnProperties = $mailing->getReturnProperties();
   $contactID = CRM_Utils_Array::value('contact_id', $params);
   if (!$contactID) {
-    $contactID = $session->get('userID');
+    // If we still don't have a userID in a session because we are annon then set contactID to be 0
+    $contactID = empty($session->get('userID')) ? 0 : $session->get('userID');
   }
   $mailingParams = ['contact_id' => $contactID];
 
-  $details = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+  // if $contactID is zero we are dealing with annon user so call separate function for annon users
+  if (!$contactID) {
+    $details = CRM_Utils_Token::getAnonymousTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+  }
+  else {
+    $details = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+  }
 
-  $mime = $mailing->compose(NULL, NULL, NULL, $session->get('userID'), $fromEmail, $fromEmail,
+  $mime = $mailing->compose(NULL, NULL, NULL, $contactID, $fromEmail, $fromEmail,
     TRUE, $details[0][$contactID], $attachments
   );
 

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -578,16 +578,17 @@ function civicrm_api3_mailing_preview($params) {
   }
   $mailingParams = ['contact_id' => $contactID];
 
-  // if $contactID is zero we are dealing with annon user so call separate function for annon users
   if (!$contactID) {
     $details = CRM_Utils_Token::getAnonymousTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+    $details = CRM_Utils_Array::value(0, $details[0]);
   }
   else {
     $details = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+    $details = $details[0][$contactID];
   }
 
   $mime = $mailing->compose(NULL, NULL, NULL, $contactID, $fromEmail, $fromEmail,
-    TRUE, $details[0][$contactID], $attachments
+    TRUE, $details, $attachments
   );
 
   return civicrm_api3_create_success([

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -276,6 +276,23 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $this->assertContains("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
   }
 
+  public function testMailerPreviewUnknownContact() {
+    $params = $this->_params;
+    $params['api.Mailing.preview'] = array(
+      'id' => '$value.id',
+    );
+
+    $result = $this->callAPISuccess('mailing', 'create', $params);
+
+    // NOTE: It's highly debatable what's best to do with contact-tokens for an
+    // unknown-contact. However, changes should be purposeful, so we'll test
+    // for the current behavior (i.e. returning blanks).
+    $previewResult = $result['values'][$result['id']]['api.Mailing.preview'];
+    $this->assertEquals("Hello ", $previewResult['values']['subject']);
+    $this->assertContains("This is .", $previewResult['values']['body_text']);
+    $this->assertContains("<p>This is .</p>", $previewResult['values']['body_html']);
+  }
+
   public function testMailerPreviewRecipients() {
     // BEGIN SAMPLE DATA
     $groupIDs['inc'] = $this->groupCreate(array('name' => 'Example include group', 'title' => 'Example include group'));


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue when an anonymous user views a mailing in the web browser (`civicrm/mailing/view`). It accomplishes this by updating the `Mailing.preview` API (which is required by Flexmailer's implementation of `civicrm/mailing/view`).

Moreover, to prevent such problems in the future, it also improves test-coverage of the API and updates `civicrm/mailing/view` (s.t. the implementations in `civicrm-core` and `flexmailer` using the same API and s.t. the `flexmailer` variant can be phased-out).

See also: https://github.com/civicrm/org.civicrm.flexmailer/issues/29

Before
----------------------------------------
* If you install Flexmailer, send a `traditional` mail-blast, and anonymously view the mailing in a web-browser (via `civicrm/mailing/view`), then it fails (*with an error regarding validating a contact_id which is not positive*)
* Core's implementation of `civicrm/mailing/view` renders mailing content by calling various token+BAO functions.

After
----------------------------------------
* If you install Flexmailer, send a `traditional` mail-blast, and anonymously view the mailing in a web-browser (via `civicrm/mailing/view`),  then it works.
* Core's implementation of `civicrm/mailing/view` renders mailing content by calling the `Mailing.preview` API.