### PR TITLE
Fix deprecation handling [intra-rc-follow up] on #13999]

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -263,7 +263,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    * @return bool
    */
   public static function cancelRecurContribution($params) {
-    if (is_int($params)) {
+    if (is_numeric($params)) {
       CRM_Core_Error::deprecatedFunctionWarning('You are using a BAO function whose signature has changed. Please use the ContributionRecur.cancel api');
       $params = ['id' => $params];
     }


### PR DESCRIPTION
Overview
----------------------------------------
The signature for  CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution was altered in 5.13 ( https://github.com/civicrm/civicrm-core/commit/9cfc631e6750cc743981f36152e894c03aa59f68) to expect an array. Out of concern for sites calling the BAO directly from extensions we added deprecation handle to make it succeed naughtily

Turns out we were one of the sites naughtily using the BAO directly who needed this handling
to work - but because we passed a number in quote it didn't - this fixes

Before
----------------------------------------
Deprecation handling works for 5 but not '5'

After
----------------------------------------
Deprecation handling works for 5 and '5'

Technical Details
----------------------------------------



Comments
----------------------------------------
We don't support calling the BAO directly but somethings we kinda try to be helpful anyway