### PR TITLE
dev/core#918 Enotice fix

### DIFF
--- a/CRM/Utils/Check/Component/FinancialTypeAcls.php
+++ b/CRM/Utils/Check/Component/FinancialTypeAcls.php
@@ -36,7 +36,7 @@ class CRM_Utils_Check_Component_FinancialTypeAcls extends CRM_Utils_Check_Compon
     $messages = [];
     $ftAclSetting = Civi::settings()->get('acl_financial_type');
     $financialAclExtension = civicrm_api3('extension', 'get', ['key' => 'biz.jmaconsulting.financialaclreport']);
-    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['status'] != 'Installed') || $financialAclExtension['count'] !== 1)) {
+    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['values'][0]['status'] != 'Installed') || $financialAclExtension['count'] !== 1)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('CiviCRM will in the future require the extension %1 for CiviCRM Reports to work correctly with the Financial Type ACLs. The extension can be downloaded <a href="%2">here</a>', [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a notice / fail in the Financial type acl check - The check is looking for status at the wrong level in the array


Before
----------------------------------------
Error randomly appearing when Financial type ACL is enanled
Notice: Undefined index: status in CRM_Utils_Check_Component_FinancialTypeAcls::checkFinancialAclReport() (line 39 of /home/webadmin/public_html/cmm-uat/sites/all/modules/civicrm/CRM/Utils/Check/Component/FinancialTypeAcls.php).

Also, in system status keep saying Extension missing, although its installed.

After
----------------------------------------
Error gone, extension correctly identified as installed

Technical Details
----------------------------------------


Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/918