### PR TITLE
Event Cart: fix start_date formatting in line items during checkout

### DIFF
--- a/templates/CRM/Event/Cart/Form/Checkout/Payment.tpl
+++ b/templates/CRM/Event/Cart/Form/Checkout/Payment.tpl
@@ -21,7 +21,7 @@
     {foreach from=$line_items item=line_item}
       <tr class="event-line-item {$line_item.class}">
   <td class="event-title">
-    {$line_item.event->title} ({$line_item.event->start_date})
+    {$line_item.event->title} ({$line_item.event->start_date|crmDate})
   </td>
   <td class="participants-column">
     {$line_item.num_participants}<br/>


### PR DESCRIPTION
Overview
----------------------------------------

During the Event Cart checkout process, the date/time is not shown in the site's localization preference. i.e. it defaults to the international date/time format:

![event-cart-date-format](https://user-images.githubusercontent.com/254741/57013583-2cca2a80-6bda-11e9-80ad-2ec3f29a6a22.png)

Before
----------------------------------------

24h time

After
----------------------------------------

Allows for legacy time formats. :-)
