### PR TITLE
Event Cart: fix sending of email receipts

### DIFF
--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -351,7 +351,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     $send_template_params = [
       'table' => 'civicrm_msg_template',
       'contactId' => $this->payer_contact_id,
-      'from' => CRM_Core_BAO_Domain::getNameAndEmail(TRUE, TRUE),
+      'from' => current(CRM_Core_BAO_Domain::getNameAndEmail(TRUE, TRUE)),
       'groupName' => 'msg_tpl_workflow_event',
       'isTest' => FALSE,
       'toEmail' => $contact_details[1],


### PR DESCRIPTION
Overview
----------------------------------------

When using the Event Cart, the configuration emails would cause a fatal error.

To reproduce, one needs to enable the Event Cart (Administer > CiviEvent > Event component settings), setup an event, add to cart and checkout.

Technical Details
----------------------------------------

This looks like a terrible solution, but it's what `CRM/Contact/Form/Task/EmailCommon.php` does.
