### PR TITLE
[ref] Move copyCustomFields function from Event to Core_DAO for re-usability

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1680,6 +1680,61 @@ FROM   civicrm_domain
   }
 
   /**
+   * Method that copies custom fields values from an old event to a new one. Fixes bug CRM-19302,
+   * where if a custom field of File type was present, left both events using the same file,
+   * breaking download URL's for the old event.
+   *
+   * @todo the goal here is to clean this up so that it works for any entity. Copy Generic already DOES some custom field stuff
+   * so it's not clear why this is needed - best guess is the custom fields are not handled - this is ALSO the
+   * situation with the dedupe.
+   *
+   * @param int $oldEventID
+   * @param int $newCopyID
+   */
+  public function copyCustomFields($oldEventID, $newCopyID) {
+    // Obtain custom values for old event
+    $customParams = $htmlType = [];
+    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($oldEventID, 'Event');
+
+    // If custom values present, we copy them
+    if (!empty($customValues)) {
+      // Get Field ID's and identify File type attributes, to handle file copying.
+      $fieldIds = implode(', ', array_keys($customValues));
+      $sql = "SELECT id FROM civicrm_custom_field WHERE html_type = 'File' AND id IN ( {$fieldIds} )";
+      $result = CRM_Core_DAO::executeQuery($sql);
+
+      // Build array of File type fields
+      while ($result->fetch()) {
+        $htmlType[] = $result->id;
+      }
+
+      // Build params array of custom values
+      foreach ($customValues as $field => $value) {
+        if ($value !== NULL) {
+          // Handle File type attributes
+          if (in_array($field, $htmlType)) {
+            $fileValues = CRM_Core_BAO_File::path($value, $oldEventID);
+            $customParams["custom_{$field}_-1"] = [
+              'name' => CRM_Utils_File::duplicate($fileValues[0]),
+              'type' => $fileValues[1],
+            ];
+          }
+          // Handle other types
+          else {
+            $customParams["custom_{$field}_-1"] = $value;
+          }
+        }
+      }
+
+      // Save Custom Fields for new Event
+      CRM_Core_BAO_CustomValueTable::postProcess($customParams, 'civicrm_event', $newCopyID, 'Event');
+    }
+
+    // copy activity attachments ( if any )
+    CRM_Core_BAO_File::copyEntityFile('civicrm_event', $oldEventID, 'civicrm_event', $newCopyID);
+  }
+
+  /**
    * Cascade update through related entities.
    *
    * @param string $daoName


### PR DESCRIPTION
Overview
----------------------------------------
Minor refactor - move function per https://github.com/civicrm/civicrm-core/pull/13470

Before
----------------------------------------
Less readable

After
----------------------------------------
More readable

Technical Details
----------------------------------------
Note this is JUST a file move to keep it reviewable - I think the function should not be static & some genericisation should happen

Comments
----------------------------------------
