### PR TITLE
Event Cart: pass the contactID to fix payment on Stripe

### DIFF
--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -502,6 +502,8 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
         $ctype,
         TRUE
       );
+
+      $params['contact_id'] = $this->payer_contact_id;
     }
 
     $params['now'] = date('YmdHis');


### PR DESCRIPTION
Overview
----------------------------------------

When using the Stripe payment processor with the Event Cart, it was not possible to complete the checkout process. When submitting the payment form, it would just loop back to the main form, without any visible error.

Technical Details
----------------------------------------

I eventually managed to find an exception : `Stripe Customer (find): contact_id is required`.

And related issue: https://lab.civicrm.org/extensions/stripe/issues/16

The Cart Checkout does not do the same trick as the Event Payment does, so I figured it was simpler to fix it this way.
