### PR TITLE
Event Cart: honor the allow_same_participant_emails setting

### DIFF
--- a/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
+++ b/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
@@ -151,6 +151,11 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
         }
       }
 
+      // Validate if participant is already registered
+      if ($event_in_cart->event->allow_same_participant_emails) {
+        continue;
+      }
+
       foreach ($event_in_cart->participants as $mer_participant) {
         $participant_fields = $fields['event'][$event_in_cart->event_id]['participant'][$mer_participant->id];
         //TODO what to do when profile responses differ for the same contact?


### PR DESCRIPTION
Overview
----------------------------------------

When using the Event Cart, the Checkout process does not honor the "allow participants with the same email address".

This copies the same check as the normal Event registration.

Comments
----------------------------------------

This should be my last Event Cart PR! Thank you :-)