### PR TITLE
Event Cart: add support for the Credit Card type icons

### DIFF
--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -175,6 +175,10 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
       );
       $this->assign('pay_later_instructions', $this->pay_later_receipt);
     }
+
+    // Event Cart does not support multiple payment processors
+    // so we cannot call $this->preProcessPaymentOptions();
+    CRM_Financial_Form_Payment::addCreditCardJs($this->_paymentProcessor['id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

The Event Cart Checkout page was not showing the credit card type icons as do other payment forms in CiviCRM.

It's kind of annoying, because the field shows as optional, but if left empty CiviCRM will say that the card number is invalid (with the dummy processor).

Before
----------------------------------------

![Capture d’écran de 2019-05-01 12-08-57](https://user-images.githubusercontent.com/254741/57027264-f0aebe00-6c09-11e9-97a1-c2c9568fa60d.png)


After
----------------------------------------

![Capture d’écran de 2019-05-01 12-08-43](https://user-images.githubusercontent.com/254741/57027266-f60c0880-6c09-11e9-917d-23ecb4b06825.png)

Comments
----------------------------------------

The Cart Checkout does not allow a choice of payment processor, but this is a bit too much work for now and I feel that very few people would use it.