### PR TITLE
[cleanup] Remove deprecated pattern &CRM_Core_Config::singleton()

### DIFF
--- a/CRM/Activity/BAO/ICalendar.php
+++ b/CRM/Activity/BAO/ICalendar.php
@@ -67,8 +67,7 @@ class CRM_Activity_BAO_ICalendar {
   public function addAttachment(&$attachments, $contacts) {
     // Check preferences setting
     if (Civi::settings()->get('activity_assignee_notification_ics')) {
-      $config = &CRM_Core_Config::singleton();
-      $this->icsfile = tempnam($config->customFileUploadDir, 'ics');
+      $this->icsfile = tempnam(CRM_Core_Config::singleton()->customFileUploadDir, 'ics');
       if ($this->icsfile !== FALSE) {
         rename($this->icsfile, $this->icsfile . '.ics');
         $this->icsfile .= '.ics';

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -215,8 +215,7 @@ class CRM_Utils_System {
     $print = FALSE,
     $maintenance = FALSE
   ) {
-    $config = &CRM_Core_Config::singleton();
-    return $config->userSystem->theme($content, $print, $maintenance);
+    return CRM_Core_Config::singleton()->userSystem->theme($content, $print, $maintenance);
   }
 
   /**
@@ -1613,8 +1612,7 @@ class CRM_Utils_System {
     $addLanguagePart = TRUE,
     $removeLanguagePart = FALSE
   ) {
-    $config = &CRM_Core_Config::singleton();
-    return $config->userSystem->languageNegotiationURL($url, $addLanguagePart, $removeLanguagePart);
+    return CRM_Core_Config::singleton()->userSystem->languageNegotiationURL($url, $addLanguagePart, $removeLanguagePart);
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -254,10 +254,9 @@ abstract class CRM_Utils_System_Base {
     }
     $out = $content;
 
-    $config = &CRM_Core_Config::singleton();
     if (
       !$print &&
-      $config->userFramework == 'WordPress'
+      CRM_Core_Config::singleton()->userFramework == 'WordPress'
     ) {
       if (!function_exists('is_admin')) {
         throw new \Exception('Function "is_admin()" is missing, even though WordPress is the user framework.');

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1163,8 +1163,7 @@ $text
   public function testSendSMSWithoutPermission() {
     $dummy = NULL;
     $session = CRM_Core_Session::singleton();
-    $config = &CRM_Core_Config::singleton();
-    $config->userPermissionClass->permissions = array('access CiviCRM');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM');
 
     CRM_Activity_BAO_Activity::sendSMS(
       $dummy,

--- a/tools/bin/scripts/cli.php
+++ b/tools/bin/scripts/cli.php
@@ -88,8 +88,8 @@ class civicrm_CLI {
   function authenticate($user, $pass) {
     session_start();
     require_once 'CRM/Core/Config.php';
-
-    $config = &CRM_Core_Config::singleton();
+    // Does calling this do anything here?
+    CRM_Core_Config::singleton();
 
     // this does not return on failure
     // require_once 'CRM/Utils/System.php';

--- a/tools/bin/scripts/memcache.php
+++ b/tools/bin/scripts/memcache.php
@@ -5,8 +5,8 @@ require_once 'CRM/Utils/Cache.php';
 
 define('CIVICRM_USE_MEMCACHE', 1);
 
-$config = &CRM_Core_Config::singleton();
-$cache = &CRM_Utils_Cache::singleton();
+$config = CRM_Core_Config::singleton();
+$cache = CRM_Utils_Cache::singleton();
 
 $cache->set('CRM_Core_Config' .CRM_Core_Config::domainID(), $config);
 CRM_Core_Error::debug('get', $cache->get('CRM_Core_Config' . CRM_Core_Config::domainID()));

--- a/tools/scripts/civimail-spooler/civimail-spooler.php
+++ b/tools/scripts/civimail-spooler/civimail-spooler.php
@@ -17,7 +17,7 @@ require_once "$config_file";
 require_once "CRM/Core/Config.php";
 ');
 
-$config = &CRM_Core_Config::singleton();
+$config = CRM_Core_Config::singleton();
 
 /* Temporary permissioning hack for now */
 

--- a/tools/scripts/solr/createSolrJSON.php
+++ b/tools/scripts/solr/createSolrJSON.php
@@ -373,7 +373,7 @@ function run(&$contactIDs) {
   }
 }
 
-$config = &CRM_Core_Config::singleton();
+$config = CRM_Core_Config::singleton();
 $config->userFramework = 'Soap';
 $config->userFrameworkClass = 'CRM_Utils_System_Soap';
 $config->userHookClass = 'CRM_Utils_Hook_Soap';

--- a/tools/scripts/solr/createSolrXML.php
+++ b/tools/scripts/solr/createSolrXML.php
@@ -244,7 +244,7 @@ function run(&$contactIDs) {
   }
 }
 
-$config = &CRM_Core_Config::singleton();
+$config = CRM_Core_Config::singleton();
 $config->userFramework = 'Soap';
 $config->userFrameworkClass = 'CRM_Utils_System_Soap';
 $config->userHookClass = 'CRM_Utils_Hook_Soap';

--- a/tools/scripts/solr/createSyncJSON.php
+++ b/tools/scripts/solr/createSyncJSON.php
@@ -526,7 +526,7 @@ function run(&$values, &$contactIDs, &$allContactIDs) {
   }
 }
 
-$config = &CRM_Core_Config::singleton();
+$config = CRM_Core_Config::singleton();
 $config->userFramework = 'Soap';
 $config->userFrameworkClass = 'CRM_Utils_System_Soap';
 $config->userHookClass = 'CRM_Utils_Hook_Soap';


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup  - leading & on CRM_Core_Config::singleton()

Before
----------------------------------------
Deprecated 
```&CRM_Core_Config::singleton()```

used

After
----------------------------------------
```CRM_Core_Config::singleton()``` used, compressed to one line where straightforward

Technical Details
----------------------------------------
I was actually looking to another round of dao->free() removals but it made sense to clean out some of these too

Comments
----------------------------------------

