### PR TITLE
Enotice fix on creating a smart group

### DIFF
--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -67,7 +67,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     }
 
     // Get Task name
-    $modeValue = CRM_Contact_Form_Search::getModeValue($values['component_mode']);
+    $modeValue = CRM_Contact_Form_Search::getModeValue(CRM_Utils_Array::value('component_mode', $values, CRM_Contact_BAO_Query::MODE_CONTACTS));
     $className = $modeValue['taskClassName'];
     $taskList = $className::taskTitles();
     $this->_task = CRM_Utils_Array::value('task', $values);


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix  - To recreate do a first name search & create a smart group from it

Before
----------------------------------------
![Screenshot 2019-05-02 17 07 01](https://user-images.githubusercontent.com/336308/57057430-b6721900-6cfc-11e9-946b-0937758b7972.png)


After
----------------------------------------
fixed 

Technical Details
----------------------------------------
Dates back to https://github.com/civicrm/civicrm-core/commit/eda34f9b15c494715e8fc54f09b5ea4308d16b17#diff-8041069091a94b730ff8ad60bdd24042R70 (or earlier)
(Mar 2018).


Comments
----------------------------------------
