### PR TITLE
dev/core#926  Fixes bug on searching for removed members of smartgroups

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2962,6 +2962,8 @@ class CRM_Contact_BAO_Query {
    * Where / qill clause for groups.
    *
    * @param $values
+   *
+   * @throws \CRM_Core_Exception
    */
   public function group($values) {
     list($name, $op, $value, $grouping, $wildcard) = $values;
@@ -3008,8 +3010,10 @@ class CRM_Contact_BAO_Query {
     $isNotOp = ($op == 'NOT IN' || $op == '!=');
 
     $statusJoinClause = $this->getGroupStatusClause($grouping);
+    // If we are searching for 'Removed' contacts then despite it being a smart group we only care about the group_contact table.
+    $isGroupStatusSearch = (!empty($this->getSelectedGroupStatuses($grouping)) && $this->getSelectedGroupStatuses($grouping) !== ["'Added'"]);
     $groupClause = [];
-    if ($hasNonSmartGroups || empty($value)) {
+    if ($hasNonSmartGroups || empty($value) || $isGroupStatusSearch) {
       // include child groups IDs if any
       $childGroupIds = (array) CRM_Contact_BAO_Group::getChildGroupIds($regularGroupIDs);
       foreach ($childGroupIds as $key => $id) {
@@ -3023,7 +3027,13 @@ class CRM_Contact_BAO_Query {
       }
 
       if (empty($regularGroupIDs)) {
-        $regularGroupIDs = [0];
+        if ($isGroupStatusSearch) {
+          $regularGroupIDs = $smartGroupIDs;
+        }
+        // If it is still empty we want a filter that blocks all results.
+        if (empty($regularGroupIDs)) {
+          $regularGroupIDs = [0];
+        }
       }
 
       // if $regularGroupIDs is populated with regular child group IDs
@@ -3059,8 +3069,9 @@ class CRM_Contact_BAO_Query {
     }
 
     //CRM-19589: contact(s) removed from a Smart Group, resides in civicrm_group_contact table
-    $groupContactCacheClause = '';
-    if (count($smartGroupIDs) || empty($value)) {
+    // If we are only searching for Removed or Pending contacts we don't need to resolve the smart group
+    // as that info is in the group_contact table.
+    if ((count($smartGroupIDs) || empty($value)) && !$isGroupStatusSearch) {
       $this->_groupUniqueKey = uniqid();
       $this->_groupKeys[] = $this->_groupUniqueKey;
       $gccTableAlias = "civicrm_group_contact_cache_{$this->_groupUniqueKey}";

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -732,11 +732,30 @@ civicrm_relationship.is_active = 1 AND
   }
 
   /**
+   * Test we can narrow a group get by status.
+   *
+   * @throws \Exception
+   */
+  public function testGetByGroupWithStatusSmartGroup() {
+    $groupID = $this->smartGroupCreate();
+    // This means they are actually all hard-added, which is fine for this purpose.
+    $this->groupContactCreate($groupID, 3);
+    $groupContactID = $this->callAPISuccessGetSingle('GroupContact', ['group_id' => $groupID, 'options' => ['limit' => 1]])['id'];
+    $this->callAPISuccess('GroupContact', 'create', ['id' => $groupContactID, 'status' => 'Removed']);
+
+    $queryObj = new CRM_Contact_BAO_Query([['group', '=', $groupID, 0, 0], ['group_contact_status', 'IN', ['Removed' => 1], 0, 0]]);
+    $resultDAO = $queryObj->searchQuery();
+    $this->assertEquals(1, $resultDAO->N);
+  }
+
+  /**
    * Test the group contact clause does not contain an OR.
    *
    * The search should return 3 contacts - 2 households in the smart group of
    * Contact Type = Household and one Individual hard-added to it. The
    * Household that meets both criteria should be returned once.
+   *
+   * @throws \Exception
    */
   public function testGroupClause() {
     $this->householdCreate();

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1246,13 +1246,15 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @param array $smartGroupParams
    * @param array $groupParams
+   * @param string $contactType
+   *
    * @return int
    */
-  public function smartGroupCreate($smartGroupParams = array(), $groupParams = array()) {
-    $smartGroupParams = array_merge(array(
-      'formValues' => array('contact_type' => array('IN' => array('Household'))),
-    ),
-    $smartGroupParams);
+  public function smartGroupCreate($smartGroupParams = [], $groupParams = [], $contactType = 'Household') {
+    $smartGroupParams = array_merge([
+      'formValues' => ['contact_type' => ['IN' => [$contactType]]],
+    ],
+      $smartGroupParams);
     $savedSearch = CRM_Contact_BAO_SavedSearch::create($smartGroupParams);
 
     $groupParams['saved_search_id'] = $savedSearch->id;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby it's not possible to search for contacts who have been removed from a smart group (although it works with regular groups)

Before
----------------------------------------
![Screenshot 2019-05-02 17 12 39](https://user-images.githubusercontent.com/336308/57060090-3358bf00-6d0c-11e9-81e9-f87f17b2bb0c.png)


After
----------------------------------------
![Screenshot 2019-05-02 19 05 25](https://user-images.githubusercontent.com/336308/57060359-428c3c80-6d0d-11e9-8c16-4aee5a1c1e06.png)


Technical Details
----------------------------------------
This is an imperfect fix - code is still hard to read & I feel like there is still a logic gap in the code (unchanged) but it 
1) adds testing
2) does some code cleanup - which will probably be merged in https://github.com/civicrm/civicrm-core/pull/14181 & rebased out of this PR
3) improves in code comments (with doc blocks)
3) fixes a replicable bug in a pretty safe way - in some ways the least important of these things


Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/926
