### PR TITLE
Allow columns in relationship table to be modified by searchColumns hook

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -44,6 +44,12 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   const NONE = 0, EDIT = 1, VIEW = 2;
 
   /**
+   * The list of column headers
+   * @var array
+   */
+  private static $columnHeaders;
+
+  /**
    * Create function - use the API instead.
    *
    * Note that the previous create function has been renamed 'legacyCreateMultiple'
@@ -2200,12 +2206,69 @@ AND cc.sort_name LIKE '%$name%'";
       }
     }
 
+    $columnHeaders = self::getColumnHeaders();
+    $selector = NULL;
+    CRM_Utils_Hook::searchColumns('relationship.rows', $columnHeaders, $contactRelationships, $selector);
+
     $relationshipsDT = [];
     $relationshipsDT['data'] = $contactRelationships;
     $relationshipsDT['recordsTotal'] = $params['total'];
     $relationshipsDT['recordsFiltered'] = $params['total'];
 
     return $relationshipsDT;
+  }
+
+  /**
+   * @return array
+   */
+  public static function getColumnHeaders() {
+    return [
+      'relation' => [
+        'name' => ts('Relationship'),
+        'sort' => 'relation',
+        'direction' => CRM_Utils_Sort::ASCENDING,
+      ],
+      'sort_name' => [
+        'name' => '',
+        'sort' => 'sort_name',
+        'direction' => CRM_Utils_Sort::ASCENDING,
+      ],
+      'start_date' => [
+        'name' => ts('Start'),
+        'sort' => 'start_date',
+        'direction' => CRM_Utils_Sort::DONTCARE,
+      ],
+      'end_date' => [
+        'name' => ts('End'),
+        'sort' => 'end_date',
+        'direction' => CRM_Utils_Sort::DONTCARE,
+      ],
+      'city' => [
+        'name' => ts('City'),
+        'sort' => 'city',
+        'direction' => CRM_Utils_Sort::DONTCARE,
+      ],
+      'state' => [
+        'name' => ts('State/Prov'),
+        'sort' => 'state',
+        'direction' => CRM_Utils_Sort::DONTCARE,
+      ],
+      'email' => [
+        'name' => ts('Email'),
+        'sort' => 'email',
+        'direction' => CRM_Utils_Sort::DONTCARE,
+      ],
+      'phone' => [
+        'name' => ts('Phone'),
+        'sort' => 'phone',
+        'direction' => CRM_Utils_Sort::DONTCARE,
+      ],
+      'links' => [
+        'name' => '',
+        'sort' => 'links',
+        'direction' => CRM_Utils_Sort::DONTCARE,
+      ],
+    ];
   }
 
   /**

--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -158,6 +158,10 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
    */
   public function browse() {
     // do nothing :) we are using datatable for rendering relationship selectors
+    $columnHeaders = CRM_Contact_BAO_Relationship::getColumnHeaders();
+    $contactRelationships = $selector = NULL;
+    CRM_Utils_Hook::searchColumns('relationship.columns', $columnHeaders, $contactRelationships, $selector);
+    $this->assign('columnHeaders', $columnHeaders);
   }
 
   /**

--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -144,6 +144,10 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
 
     // CRM-16512 - Hide related contact table if user lacks permission to view self
     if (!empty($dashboardOptions['Permissioned Orgs']) && CRM_Core_Permission::check('view my contact')) {
+      $columnHeaders = CRM_Contact_BAO_Relationship::getColumnHeaders();
+      $contactRelationships = $selector = NULL;
+      CRM_Utils_Hook::searchColumns('relationship.columns', $columnHeaders, $contactRelationships, $selector);
+      $this->assign('columnHeaders', $columnHeaders);
       $dashboardElements[] = [
         'class' => 'crm-dashboard-permissionedOrgs',
         'templatePath' => 'CRM/Contact/Page/View/RelationshipSelector.tpl',

--- a/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
@@ -23,24 +23,25 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* relationship selector *}
+{* entity selector *}
 {crmRegion name="crm-contact-relationshipselector-pre"}
 {/crmRegion}
-<div class="crm-contact-relationship-{$context}">
+<div class="crm-contact-{$entityInClassFormat}-{$context}">
   <table
-    class="crm-contact-relationship-selector-{$context} crm-ajax-table"
-    data-ajax="{crmURL p="civicrm/ajax/contactrelationships" q="context=$context&cid=$contactId"}" style="width: 100%;">
+    class="crm-contact-{$entityInClassFormat}-selector-{$context} crm-ajax-table"
+    data-ajax="{crmURL p="civicrm/ajax/contactrelationships" q="context=$context&cid=$contactId"}"
+    data-order='[[0,"asc"],[1,"asc"]]'
+    style="width: 100%;">
     <thead>
     <tr>
-      <th data-data="relation" class='crm-contact-relationship-type'>{ts}Relationship{/ts}</th>
-      <th data-data="sort_name" class='crm-contact-relationship-contact_name'>&nbsp;</th>
-      <th data-data="start_date" class='crm-contact-relationship-start_date'>{ts}Start{/ts}</th>
-      <th data-data="end_date" class='crm-contact-relationship-end_date'>{ts}End{/ts}</th>
-      <th data-data="city" class='crm-contact-relationship-city'>{ts}City{/ts}</th>
-      <th data-data="state" class='crm-contact-relationship-state'>{ts}State/Prov{/ts}</th>
-      <th data-data="email" class='crm-contact-relationship-email'>{ts}Email{/ts}</th>
-      <th data-data="phone" class='crm-contact-relationship-phone'>{ts}Phone{/ts}</th>
-      <th data-data="links" data-orderable="false" class='crm-contact-relationship-links'></th>
+      {foreach from=$columnHeaders key=headerkey item=header}
+        {if $header.sort}
+          <th data-data="{$header.sort}" class="crm-contact-{$entityInClassFormat}-{$header.sort}">{$header.name}</th>
+        {else}
+          <th data-data="{$headerkey}" data-orderable="false" class="crm-contact-{$entityInClassFormat}-{$headerkey}">{$header.name}</th>
+        {/if}
+
+      {/foreach}
     </tr>
     </thead>
   </table>


### PR DESCRIPTION
Overview
----------------------------------------
Allow columns in relationship table to be modified by searchColumns hook.  This allows us to modify the columns that are shown to the user on the Contact relationships tab.

Before
----------------------------------------
Not possible to modify relationship tab columns without changing templates/php.

After
----------------------------------------
Can modify columns by implementing searchColumns hook.

Technical Details
----------------------------------------
Implemented in standard way as done by other entities

Comments
----------------------------------------
@eileenmcnaughton There's a couple of bits in here that would probably be good to take further into an EntityPageTrait or similar.  I've done a bit of work towards that here.
