### PR TITLE
Pass the RFC 3164 severity level thru to drupal watchdog.

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -617,7 +617,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     if (!empty(\Civi::$statics[__CLASS__]['userFrameworkLogging'])) {
       // should call $config->userSystem->logger($message) here - but I got a situation where userSystem was not an object - not sure why
       if ($config->userSystem->is_drupal and function_exists('watchdog')) {
-        watchdog('civicrm', '%message', ['%message' => $message], WATCHDOG_DEBUG);
+        watchdog('civicrm', '%message', ['%message' => $message], isset($priority) ? $priority : WATCHDOG_DEBUG);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
When passing log messages thru to Drupal watchdog(), CRM_Core_Error::debug_log_message() logs everything at debug level.  However, Pear Log and Drupal both use the same RFC 3164 numeric severity levels. Therefore, we could pass the severity level thru to watchdog().

Before
----------------------------------------
Everything is logged at debug level.

After
----------------------------------------
Errors, warnings, notices, info, etc. can be logged appropriately.