### PR TITLE
Fix REST on WordPress

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -472,9 +472,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
     $name = CRM_Utils_Array::value('name', $params);
     $pass = CRM_Utils_Array::value('pass', $params);
-    if (isset($params['uid'])) {
-      throw new \RuntimeException("Not implemented WordPress::loadBootStrap([uid=>\$num]))");
-    }
 
     if (!defined('WP_USE_THEMES')) {
       define('WP_USE_THEMES', FALSE);
@@ -500,7 +497,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
     }
     require_once $cmsRootPath . DIRECTORY_SEPARATOR . 'wp-includes/pluggable.php';
-    $uid = CRM_Utils_Array::value('uid', $name);
+    $uid = CRM_Utils_Array::value('uid', $params);
     if (!$uid) {
       $name = $name ? $name : trim(CRM_Utils_Array::value('name', $_REQUEST));
       $pass = $pass ? $pass : trim(CRM_Utils_Array::value('pass', $_REQUEST));


### PR DESCRIPTION
Overview
----------------------------------------
Civi 5.13.0 broke the REST endpoint on WordPress.

Before
----------------------------------------
A call like: http://wpmaster.localhost/wp-content/plugins/civicrm/civicrm/extern/rest.php?entity=system&action=check&key=cTJjAAadwbEB2n5w&api_key=54321

results in a 500 error with stack trace:
```
#0 /var/www/9to5.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Utils/System.php(1474): CRM_Utils_System_WordPress->loadBootStrap(Array, true, false, NULL)
#1 /var/www/9to5.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Utils/REST.php(640): CRM_Utils_System::loadBootStrap(Array, true, false)
#2 /var/www/9to5.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Utils/REST.php(114): CRM_Utils_REST->loadCMSBootstrap()
#3 /var/www/9to5.org/htdocs/wp-content/plugins/civicrm/civicrm/extern/rest.php(42): CRM_Utils_REST->bootAndRun()
#4 {main}
  thrown in /var/www/9to5.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Utils/System/WordPress.php on line 476
```

After
----------------------------------------
REST endpoint works as expected.

Technical Details
----------------------------------------
[This commit](https://github.com/civicrm/civicrm-core/commit/9ba02e3e25fe10e8d1eb46c07b77b7fa407eda0d#diff-0761b448ddeed621a369a6e6e9ac2129) declared an exception when loading the CMS bootstrap by uid as "not implemented".  So I implemented it and removed the exception :)