### PR TITLE
dev/core#934 Fix regression on sorting activity tab by 'Added by'

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -300,6 +300,7 @@ function _civicrm_api3_activity_get_spec(&$params) {
 function civicrm_api3_activity_get($params) {
   $options = _civicrm_api3_get_options_from_params($params, FALSE, 'Activity', 'get');
   $sql = CRM_Utils_SQL_Select::fragment();
+  _civicrm_activity_get_handleSourceContactNameOrderBy($params, $options, $sql);
 
   _civicrm_api3_activity_get_extraFilters($params, $sql);
 
@@ -334,6 +335,40 @@ function civicrm_api3_activity_get($params) {
   $activities = _civicrm_api3_activity_get_formatResult($params, $activities, $options);
   //legacy custom data get - so previous formatted response is still returned too
   return civicrm_api3_create_success($activities, $params, 'Activity', 'get');
+}
+
+/**
+ * Handle source_contact_name as a sort parameter.
+ *
+ * This is passed from the activity selector - e.g search results or contact tab.
+ *
+ * It's a non-standard handling but this api already handles variations on handling source_contact
+ * as a filter & as a field so it's in keeping with that. Source contact has a one-one relationship
+ * with activity table.
+ *
+ * Test coverage in CRM_Activity_BAO_ActivtiyTest::testGetActivitiesforContactSummaryWithSortOptions
+ *
+ * @param array $params
+ * @param array $options
+ * @param CRM_Utils_SQL_Select $sql
+ */
+function _civicrm_activity_get_handleSourceContactNameOrderBy(&$params, &$options, $sql) {
+  $sourceContactID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Source');
+  if (!empty($options['sort']) && in_array($options['sort'], [
+      'source_contact_name',
+      'source_contact_name desc',
+      'source_contact_name asc'
+    ])) {
+    $order = substr($options['sort'], -4) === 'desc' ? 'desc' : 'asc';
+    $sql->join(
+      'source_contact',
+      "LEFT JOIN
+      civicrm_activity_contact ac ON (ac.activity_id = a.id AND record_type_id = $sourceContactID )
+       LEFT JOIN civicrm_contact c ON c.id = ac.contact_id"
+    );
+    $sql->orderBy("c.display_name $order");
+    unset($options['sort'], $params['options']['sort']);
+  }
 }
 
 /**

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -331,12 +331,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Test getActivities BAO method for getting count
    */
   public function testGetActivitiesCountforNonAdminDashboard() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     $params = array(
       'contact_id' => 9,
@@ -360,12 +355,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Test getActivities BAO method for getting count
    */
   public function testGetActivitiesCountforContactSummary() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     $params = array(
       'contact_id' => 9,
@@ -387,12 +377,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * CRM-18706 - Test Include/Exclude Activity Filters
    */
   public function testActivityFilters() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
     Civi::settings()->set('preserve_activity_tab_filter', 1);
     $this->createLoggedInUser();
 
@@ -429,12 +414,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Test getActivities BAO method for getting count
    */
   public function testGetActivitiesCountforContactSummaryWithNoActivities() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     $params = array(
       'contact_id' => 17,
@@ -501,12 +481,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Test getActivities BAO method.
    */
   public function testGetActivitiesforNonAdminDashboard() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     $contactID = 9;
     $params = array(
@@ -575,13 +550,32 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   /**
    * Test getActivities BAO method.
    */
+  public function testGetActivitiesforContactSummaryWithSortOptions() {
+    $this->createTestActivities();
+    $params = [
+      'contact_id' => 9,
+      'admin' => FALSE,
+      'caseId' => NULL,
+      'context' => 'activity',
+      'activity_type_id' => NULL,
+      'offset' => 0,
+      'rowCount' => 0,
+      'sort' => 'source_contact_name desc',
+    ];
+
+    $activities = CRM_Activity_BAO_Activity::getActivities($params);
+    $alphaOrder = ['Test Contact 11', 'Test Contact 12', 'Test Contact 3', 'Test Contact 4', 'Test Contact 9'];
+    foreach ($activities as $activity) {
+      $this->assertEquals(array_pop($alphaOrder), $activity['source_contact_name']);
+    }
+
+  }
+
+  /**
+   * Test getActivities BAO method.
+   */
   public function testGetActivitiesforContactSummary() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     $contactID = 9;
     $params = array(
@@ -592,7 +586,6 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'activity_type_id' => NULL,
       'offset' => 0,
       'rowCount' => 0,
-      'sort' => NULL,
     );
 
     //since we are loading activities from dataset, we know total number of activities for this contact
@@ -633,12 +626,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Test getActivities BAO method.
    */
   public function testGetActivitiesforContactSummaryWithActivities() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     // parameters for different test cases, check each array key for the specific test-case
     $testCases = array(
@@ -763,12 +751,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    */
   public function testByActivityDateAndStatus() {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view all contacts', 'access CiviCRM'];
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     // activity IDs catagorised by date
     $lastWeekActivities = array(1, 2, 3);
@@ -1030,12 +1013,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Set up for testing activity queries.
    */
   protected function setUpForActivityDashboardTests() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createFlatXMLDataSet(
-        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
-      )
-    );
+    $this->createTestActivities();
 
     $this->_params = array(
       'contact_id' => NULL,
@@ -1333,6 +1311,15 @@ $text
     );
 
     return array($sent, $activityId, $success);
+  }
+
+  protected function createTestActivities() {
+    $op = new PHPUnit_Extensions_Database_Operation_Insert();
+    $op->execute($this->_dbconn,
+      $this->createFlatXMLDataSet(
+        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
+      )
+    );
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression whereby source_name no longer sorts due to api not supporting it (yet)

Before
----------------------------------------
![Screenshot 2019-05-03 13 32 15](https://user-images.githubusercontent.com/336308/57117583-63a66900-6db1-11e9-8767-1ca771766200.png)

After
----------------------------------------
works

Technical Details
----------------------------------------
Note that handling target_name or assignee_name introduces a tonne of complexity due the 1->N relationship - ug. In the UI sort_name & target_name are sortable

Comments
----------------------------------------
Actually the PR doesn't even fix it yet :-(