### PR TITLE
dev/core#932 Fix dedupe contacts flip selection

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -938,7 +938,10 @@ LIMIT {$offset}, {$rowCount}
   public static function flipDupePairs($prevNextId = NULL) {
     if (!$prevNextId) {
       // @todo figure out if this is always POST & specify that rather than inexact GET
-      $prevNextId = CRM_Utils_Request::retrieve('pnid', 'Integer');
+
+      // We cannot use CRM_Utils_Request::retrieve() because it might be an array.
+      // It later gets validated in escapeAll below.
+      $prevNextId = $_REQUEST['pnid'];
     }
 
     $onlySelected = FALSE;

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -282,6 +282,7 @@
       });
 
       $(".crm-dedupe-flip-selections").on('click', function(e) {
+        e.preventDefault();
         var ids = [];
         $('.crm-row-selected').each(function() {
           var ele = CRM.$('input.crm-dedupe-select', this);
@@ -289,7 +290,8 @@
         });
         if (ids.length > 0) {
           var dataUrl = {/literal}"{crmURL p='civicrm/ajax/flipDupePairs' h=0 q='snippet=4'}"{literal};
-          CRM.$.post(dataUrl, {pnid: ids}, function (response) {
+          var request = $.post(dataUrl, {pnid: ids});
+          request.done(function(dt) {
             var mapper = {1:3, 2:4, 5:6, 7:8, 9:10}
             $('.crm-row-selected').each(function() {
               var idx = $('table#dupePairs').DataTable().row(this).index();
@@ -302,7 +304,7 @@
               // keep the checkbox checked if needed
               $('input.crm-dedupe-select', this).prop('checked', $(this).hasClass('crm-row-selected'));
             });
-          }, 'json');
+          });
         }
       });
     });


### PR DESCRIPTION
Overview
----------------------------------------

How to reproduce on dmaster:

* Go to: Contacts > Find and merge duplicates
* Select the "Name and address" rule, which brings you here: https://dmaster.demo.civicrm.org/civicrm/contact/dedupefind?reset=1&action=update&rgid=7#

Then notice that)

* when we click on "flip" for a single entry, it seems to flip, but the "merge" link is the same, so doing the actual merge does not flip the direction.
* if we click the checkbox for the result, then click the "Flip selected duplicates", nothing happens.

![civicrm-dedupe-flip](https://user-images.githubusercontent.com/254741/57139462-4f4b7780-6d83-11e9-897b-07d4060a53f9.jpg)

Before
----------------------------------------

Flipping had no visual effect, and multi-flipping had no effect at all (did not update the dupes in the prevnext cache).

After
----------------------------------------

Works as expected.

Technical Details
----------------------------------------

I had to partially revert a change that was done a long time ago regarding `$prevNextId = $_REQUEST['pnid'];`. Is there a way to use `CRM_Utils_Request::retrieveValue` on an URL param that can sometimes be an array? (it would be better to have two different AJAX endpoints for this, imho)

https://lab.civicrm.org/dev/core/issues/932
