### PR TITLE
dev/core#914 - avoid multiple submitOnce buttons until better way

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -640,9 +640,16 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public function addButtons($params) {
     $prevnext = $spacing = [];
+    $alreadyHaveSubmitOnce = FALSE;
     foreach ($params as $button) {
       if (!empty($button['submitOnce'])) {
-        $button['js']['onclick'] = "return submitOnce(this,'{$this->_name}','" . ts('Processing') . "');";
+        if ($alreadyHaveSubmitOnce) {
+          throw new Exception(ts("Multiple submitOnce buttons are not currently supported."));
+        }
+        else {
+          $alreadyHaveSubmitOnce = TRUE;
+          $button['js']['onclick'] = "return submitOnce(this,'{$this->_name}','" . ts('Processing') . "');";
+        }
       }
 
       $attrs = ['class' => 'crm-form-submit'] + (array) CRM_Utils_Array::value('js', $button);

--- a/tests/phpunit/CRM/Core/FormButtonsTest.php
+++ b/tests/phpunit/CRM/Core/FormButtonsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Tests for form buttons.
+ * @group headless
+ */
+class CRM_Core_FormButtonsTest extends CiviUnitTestCase {
+
+  /**
+   * Test multiple submitOnce buttons.
+   *
+   * This test can be removed/changed if the mechanism for preventing
+   * duplicate form submissions is improved in the future to work for
+   * multiple submitOnce buttons.
+   */
+  public function testSubmitOnceTwice() {
+    $form = new CRM_Core_Form();
+    try {
+      $form->addButtons([
+        [
+          'type' => 'upload',
+          'name' => ts('Save'),
+          'isDefault' => TRUE,
+          'submitOnce' => TRUE,
+        ],
+        [
+          'type' => 'upload',
+          'name' => ts('Save and New'),
+          'subName' => 'new',
+          'submitOnce' => TRUE,
+        ],
+        [
+          'type' => 'cancel',
+          'name' => ts('Cancel'),
+        ],
+      ]);
+    }
+    catch (Exception $e) {
+      $this->assertEquals(ts('Multiple submitOnce buttons are not currently supported.'), $e->getMessage());
+      return;
+    }
+    $this->fail('Exception should have been thrown for multiple submitOnce buttons.');
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
At the moment submitOnce buttons on a form bypass the normal processing so non-default buttons won't work as intended. See also PR 13333.

Before
----------------------------------------
Can break a button without realizing it.

After
----------------------------------------
Can still break a button if you try hard enough, but this will prevent adding multiple submitOnce buttons until a better way to prevent duplicate submissions is available.

Comments
----------------------------------------
This would be a bit difficult to test on the test sites. I think the easiest way to test this is to pretend you are writing some code and see another form that has `'submitOnce' => TRUE` already in the button definitions (e.g. https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/Form/Activity.php#L811) and you say "hey I can use that on this other form", and then go and add it to that other form for multiple buttons, e.g. the "Save" and "Save and New" buttons (an example might be https://github.com/civicrm/civicrm-core/blob/master/CRM/Member/Form.php#L290-L297). With the patch applied you should now get an error when you try to open that form (e.g. a new membership form if you used the example). So as a dev you'd notice right away.

Without the patch applied, the Save and New button would be a little broken and no longer take you to a new form afterwards because of the submitOnce, which you might not notice right away.
