### PR TITLE
dev/core#927 [ref] Extract contribution.cancel function

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -971,6 +971,92 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
   }
 
   /**
+   * Cancel contribution.
+   *
+   * This function should only be called from transitioncomponents - it is an interim step in refactoring.
+   *
+   * @param $processContributionObject
+   * @param $memberships
+   * @param $contributionId
+   * @param $membershipStatuses
+   * @param $updateResult
+   * @param $participant
+   * @param $oldStatus
+   * @param $pledgePayment
+   * @param $pledgeID
+   * @param $pledgePaymentIDs
+   * @param $contributionStatusId
+   * @return array
+   */
+  protected static function cancel($processContributionObject, $memberships, $contributionId, $membershipStatuses, $updateResult, $participant, $oldStatus, $pledgePayment, $pledgeID, $pledgePaymentIDs, $contributionStatusId) {
+    $processContribution = FALSE;
+    $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
+    if (is_array($memberships)) {
+      foreach ($memberships as $membership) {
+        $update = TRUE;
+        //Update Membership status if there is no other completed contribution associated with the membership.
+        $relatedContributions = CRM_Member_BAO_Membership::getMembershipContributionId($membership->id, TRUE);
+        foreach ($relatedContributions as $contriId) {
+          if ($contriId == $contributionId) {
+            continue;
+          }
+          $statusId = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $contriId, 'contribution_status_id');
+          if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $statusId) === 'Completed') {
+            $update = FALSE;
+          }
+        }
+        if ($membership && $update) {
+          $newStatus = array_search('Cancelled', $membershipStatuses);
+
+          // Create activity
+          $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
+          $activityParam = [
+            'subject' => "Status changed from {$allStatus[$membership->status_id]} to {$allStatus[$newStatus]}",
+            'source_contact_id' => CRM_Core_Session::singleton()->get('userID'),
+            'target_contact_id' => $membership->contact_id,
+            'source_record_id' => $membership->id,
+            'activity_type_id' => 'Change Membership Status',
+            'status_id' => 'Completed',
+            'priority_id' => 'Normal',
+            'activity_date_time' => 'now',
+          ];
+
+          $membership->status_id = $newStatus;
+          $membership->is_override = TRUE;
+          $membership->status_override_end_date = 'null';
+          $membership->save();
+          civicrm_api3('activity', 'create', $activityParam);
+
+          $updateResult['updatedComponents']['CiviMember'] = $membership->status_id;
+          if ($processContributionObject) {
+            $processContribution = TRUE;
+          }
+        }
+      }
+    }
+
+    if ($participant) {
+      $updatedStatusId = array_search('Cancelled', $participantStatuses);
+      CRM_Event_BAO_Participant::updateParticipantStatus($participant->id, $oldStatus, $updatedStatusId, TRUE);
+
+      $updateResult['updatedComponents']['CiviEvent'] = $updatedStatusId;
+      if ($processContributionObject) {
+        $processContribution = TRUE;
+      }
+    }
+
+    if ($pledgePayment) {
+      CRM_Pledge_BAO_PledgePayment::updatePledgePaymentStatus($pledgeID, $pledgePaymentIDs, $contributionStatusId);
+
+      $updateResult['updatedComponents']['CiviPledge'] = $contributionStatusId;
+      if ($processContributionObject) {
+        $processContribution = TRUE;
+      }
+    }
+    return [$updateResult, $processContribution];
+  }
+
+  /**
    * @inheritDoc
    */
   public function addSelectWhereClause() {
@@ -1757,9 +1843,9 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     $participant = &$objects['participant'];
     $pledgePayment = &$objects['pledge_payment'];
     $contribution = &$objects['contribution'];
-
+    $pledgeID = $oldStatus = NULL;
+    $pledgePaymentIDs = [];
     if ($pledgePayment) {
-      $pledgePaymentIDs = array();
       foreach ($pledgePayment as $key => $object) {
         $pledgePaymentIDs[] = $object->id;
       }
@@ -1778,68 +1864,8 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     // we might want to process contribution object.
     $processContribution = FALSE;
     if ($contributionStatusId == array_search('Cancelled', $contributionStatuses)) {
-      if (is_array($memberships)) {
-        foreach ($memberships as $membership) {
-          $update = TRUE;
-          //Update Membership status if there is no other completed contribution associated with the membership.
-          $relatedContributions = CRM_Member_BAO_Membership::getMembershipContributionId($membership->id, TRUE);
-          foreach ($relatedContributions as $contriId) {
-            if ($contriId == $contributionId) {
-              continue;
-            }
-            $statusId = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $contriId, 'contribution_status_id');
-            if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $statusId) === 'Completed') {
-              $update = FALSE;
-            }
-          }
-          if ($membership && $update) {
-            $newStatus = array_search('Cancelled', $membershipStatuses);
-
-            // Create activity
-            $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
-            $activityParam = array(
-              'subject' => "Status changed from {$allStatus[$membership->status_id]} to {$allStatus[$newStatus]}",
-              'source_contact_id' => CRM_Core_Session::singleton()->get('userID'),
-              'target_contact_id' => $membership->contact_id,
-              'source_record_id' => $membership->id,
-              'activity_type_id' => 'Change Membership Status',
-              'status_id' => 'Completed',
-              'priority_id' => 'Normal',
-              'activity_date_time' => 'now',
-            );
-
-            $membership->status_id = $newStatus;
-            $membership->is_override = TRUE;
-            $membership->status_override_end_date = 'null';
-            $membership->save();
-            civicrm_api3('activity', 'create', $activityParam);
-
-            $updateResult['updatedComponents']['CiviMember'] = $membership->status_id;
-            if ($processContributionObject) {
-              $processContribution = TRUE;
-            }
-          }
-        }
-      }
-
-      if ($participant) {
-        $updatedStatusId = array_search('Cancelled', $participantStatuses);
-        CRM_Event_BAO_Participant::updateParticipantStatus($participant->id, $oldStatus, $updatedStatusId, TRUE);
-
-        $updateResult['updatedComponents']['CiviEvent'] = $updatedStatusId;
-        if ($processContributionObject) {
-          $processContribution = TRUE;
-        }
-      }
-
-      if ($pledgePayment) {
-        CRM_Pledge_BAO_PledgePayment::updatePledgePaymentStatus($pledgeID, $pledgePaymentIDs, $contributionStatusId);
-
-        $updateResult['updatedComponents']['CiviPledge'] = $contributionStatusId;
-        if ($processContributionObject) {
-          $processContribution = TRUE;
-        }
-      }
+      // Call interim cancel function - with a goal to cleaning up the signature on it and switching to a tested api Contribution.cancel function.
+      list($updateResult, $processContribution) = self::cancel($processContributionObject, $memberships, $contributionId, $membershipStatuses, $updateResult, $participant, $oldStatus, $pledgePayment, $pledgeID, $pledgePaymentIDs, $contributionStatusId);
     }
     elseif ($contributionStatusId == array_search('Failed', $contributionStatuses)) {
       if (is_array($memberships)) {


### PR DESCRIPTION
Overview
----------------------------------------
Extract contribution cancel function

Before
----------------------------------------
Less readable

After
----------------------------------------
More readable

Technical Details
----------------------------------------
I expect the goal here to be to completely remove cancel handling from transitioncomponents (a function we should eventually remove.)

Basically the next steps would be to look at rationalising the input parameter for the function - e.g we have a contribution id - we can use that to get membership & participant records via the api in the function. This would mean the queries to get them are being done twice but - they are pretty cheap queries & the end goal is to simply call the function directly (bypassing transition components & deprecating calling transition components on a - at which point we would no longer be running them twice

There is a goal of an extension being able to alter the calculated membership status. I can see 3 ways here

1) accept membership_status_id as an option parameter for the final cancel function & calling api. Add a unit test to ensure this can override the outcome & although to check the [api wrappers hook](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/) can alter it 

2) call the existing alterCalculatedMembershipStatus from this cancel function rather than hard-coding the status.

3) assess whether the existing alterCalculatedMembershipStatus function signature makes sense. If not then create a new hook & deprecate the old one (we can deprecate the old hook by throwing a deprecation notice when the variables are changed as a result of it)

Comments
----------------------------------------

