### PR TITLE
[REF+ test] start process of cleaning up payment activity handling

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -897,18 +897,18 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       $inputParams['id'] = $participantId;
       $values = [];
       $ids = [];
-      $component = 'event';
       $entityObj = CRM_Event_BAO_Participant::getValues($inputParams, $values, $ids);
       $entityObj = $entityObj[$participantId];
+      $title = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Event', $entityObj->event_id, 'title');
     }
     else {
       $entityObj = new CRM_Contribute_BAO_Contribution();
       $entityObj->id = $contributionId;
       $entityObj->find(TRUE);
-      $component = 'contribution';
+      $title = ts('Contribution');
     }
 
-    self::addActivityForPayment($entityObj, $financialTrxn, $activityType, $component, $contributionId);
+    self::addActivityForPayment($entityObj->contact_id, $financialTrxn, $activityType, $title, $contributionId);
   }
 
   /**
@@ -3916,25 +3916,18 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   }
 
   /**
-   * @param $entityObj
+   * @param int $targetCid
    * @param $trxnObj
    * @param $activityType
-   * @param $component
+   * @param string $title
    * @param int $contributionId
    *
    * @throws CRM_Core_Exception
    */
-  public static function addActivityForPayment($entityObj, $trxnObj, $activityType, $component, $contributionId) {
-    if ($component == 'event') {
-      $title = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Event', $entityObj->event_id, 'title');
-    }
-    else {
-      $title = ts('Contribution');
-    }
+  public static function addActivityForPayment($targetCid, $trxnObj, $activityType, $title, $contributionId) {
     $paymentAmount = CRM_Utils_Money::format($trxnObj->total_amount, $trxnObj->currency);
     $subject = "{$paymentAmount} - Offline {$activityType} for {$title}";
     $date = CRM_Utils_Date::isoToMysql($trxnObj->trxn_date);
-    $targetCid = $entityObj->contact_id;
     // source record id would be the contribution id
     $srcRecId = $contributionId;
 

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -179,6 +179,15 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // pay additional amount
     $this->submitPayment(20);
     $this->checkResults(array(30, 50, 20), 3);
+    $activities = $this->callAPISuccess('Activity', 'get', [
+      'source_record_id' => $this->_contributionId,
+      'activity_type_id' => 'Payment',
+      'options' => ['sort' => 'id'],
+      'sequential' => 1,
+    ])['values'];
+    $this->assertEquals(2, count($activities));
+    $this->assertEquals('$ 50.00 - Offline Payment for Contribution', $activities[0]['subject']);
+    $this->assertEquals('$ 20.00 - Offline Payment for Contribution', $activities[1]['subject']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor readability cleanup + test extension

Before
----------------------------------------
Less readable, less test cover

After
----------------------------------------
More readable, more test cover

Technical Details
----------------------------------------
At the moment activities are created when using the additional payment form but not the UI.
This needs cleaning up & this takes the first step by adding testing & slightly
simplifying where decisions are made about variables (assign title directly rather than component
just to assign title deeper down

Comments
----------------------------------------
