### PR TITLE
Stop overriding is_active default when saving new relationship

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -473,7 +473,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    */
   public static function getdefaults() {
     return array(
-      'is_active' => 0,
+      'is_active' => 1,
       'is_permission_a_b' => self::NONE,
       'is_permission_b_a' => self::NONE,
       'description' => '',


### PR DESCRIPTION
Overview
----------------------------------------
Makes the is_active default more consistent when creating a new relationship.
For some obscure reason the relationsip BAO was forcing the is_active field to default to 0 even though the schema sets a more sensible default of 1.

Before
----------------------------------------
Creating a new relationship is not active by default.

After
----------------------------------------
Creating a new relationship will be active by default.
