### PR TITLE
contributor-keys file - jira/lab.c.o username fix

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -314,7 +314,7 @@
 
 - github      : demeritcowboy
   name        : Dave D
-  jira        : demeritcowboy
+  jira        : Dave D
 
 - github      : dereklewis123
   name        : Derek Lewis


### PR DESCRIPTION
Before
----------------------------------------
Able to get away with blaming others for my stuff since has wrong jira name.

After
----------------------------------------
I'll find some new ways to blame others.