### PR TITLE
Fix AssetBuilderTest when running on WordPress. Use Guzzle.

### DIFF
--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -162,13 +162,9 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
   public function testInvalid() {
     \Civi::service('asset_builder')->setCacheEnabled(FALSE);
     $url = \Civi::service('asset_builder')->getUrl('invalid.json');
-    // WordPress has different error reporting to Drupal so manually set to Drupal
-    $previousErrorReporting = error_reporting(1);
     $this->assertEmpty(file_get_contents($url));
-    $this->assertNotEmpty(preg_grep(';HTTP/\d+.\d+ 404;', $http_response_header),
+    $this->assertNotEmpty(preg_grep(';HTTP/1.1 404;', $http_response_header),
       'Expect to find HTTP 404. Found: ' . json_encode(preg_grep(';^HTTP;', $http_response_header)));
-    // Now Reset Error Reporting.
-    error_reporting($previousErrorReporting);
   }
 
 }

--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -165,10 +165,12 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
     try {
       $guzzleClient = new \GuzzleHttp\Client();
       $guzzleResponse = $guzzleClient->request('GET', $url, array('timeout' => 1));
+      $this->fail('Expecting ClientException... but it was not thrown!');
     }
     catch (\GuzzleHttp\Exception\ClientException $e) {
       $this->assertNotEmpty(preg_match(';404;', $e->getMessage()),
         'Expect to find HTTP 404. Found: ' . json_encode(preg_match(';^HTTP;', $e->getMessage())));
+      $this->assertEquals('Unrecognized asset name: invalid.json', $e->getResponse()->getBody());
     }
   }
 

--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -162,9 +162,14 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
   public function testInvalid() {
     \Civi::service('asset_builder')->setCacheEnabled(FALSE);
     $url = \Civi::service('asset_builder')->getUrl('invalid.json');
-    $this->assertEmpty(file_get_contents($url));
-    $this->assertNotEmpty(preg_grep(';HTTP/1.1 404;', $http_response_header),
-      'Expect to find HTTP 404. Found: ' . json_encode(preg_grep(';^HTTP;', $http_response_header)));
+    try {
+      $guzzleClient = new \GuzzleHttp\Client();
+      $guzzleResponse = $guzzleClient->request('GET', $url, array('timeout' => 1));
+    }
+    catch (\GuzzleHttp\Exception\ClientException $e) {
+      $this->assertNotEmpty(preg_match(';404;', $e->getMessage()),
+        'Expect to find HTTP 404. Found: ' . json_encode(preg_match(';^HTTP;', $e->getMessage())));
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the AssetBuilder E2E test testInvalid when running on wordpress

Before
----------------------------------------
Test fails on wordpress

After
----------------------------------------
Test passes

ping @totten @eileenmcnaughton 