### PR TITLE
(dev/core#705) Disabling Alphabetical Pager is not respected for events

### DIFF
--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -314,7 +314,10 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
     $this->_searchResult = CRM_Utils_Request::retrieve('searchResult', 'Boolean', $this);
 
     $whereClause = $this->whereClause($params, FALSE, $this->_force);
-    $this->pagerAToZ($whereClause, $params);
+
+    if (CRM_Core_Config::singleton()->includeAlphabeticalPager) {
+      $this->pagerAToZ($whereClause, $params);
+    }
 
     $params = [];
     $whereClause = $this->whereClause($params, TRUE, $this->_force);


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate :

Go to _Admin > Search Preferences_ and turn off _Include Alphabetical Pager_

A to Z Pager is off for _Find Contacts_, _Find Contributions_, etc
However it is still shown on _Manage Events_.

https://lab.civicrm.org/dev/core/issues/705

Before
----------------------------------------
Alphabetical Pager is visible on Manage Events

After
----------------------------------------
Alphabetical Pager is not visible on Manage Events

Comments
----------------------------------------
This is keeping it consistent with other selectors where Alphabetical Pager is already suppressed. This is  in continuation of https://github.com/civicrm/civicrm-core/pull/13592