### PR TITLE
Fix AssetBuilderTest by altering error_reporting level to match Dru…

### DIFF
--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -162,9 +162,13 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
   public function testInvalid() {
     \Civi::service('asset_builder')->setCacheEnabled(FALSE);
     $url = \Civi::service('asset_builder')->getUrl('invalid.json');
+    // WordPress has different error reporting to Drupal so manually set to Drupal
+    $previousErrorReporting = error_reporting(1);
     $this->assertEmpty(file_get_contents($url));
-    $this->assertNotEmpty(preg_grep(';HTTP/1.1 404;', $http_response_header),
+    $this->assertNotEmpty(preg_grep(';HTTP/\d+.\d+ 404;', $http_response_header),
       'Expect to find HTTP 404. Found: ' . json_encode(preg_grep(';^HTTP;', $http_response_header)));
+    // Now Reset Error Reporting.
+    error_reporting($previousErrorReporting);
   }
 
 }


### PR DESCRIPTION
…pal and changing regex to not care about HTTP version

Overview
----------------------------------------
This is an alternate fix for https://github.com/civicrm/civicrm-core/pull/14201

Before
----------------------------------------
Test Fails on WordPress Passes on Drupal

After
----------------------------------------
Test Passes on both CMSes

ping @totten 

I note that with the assetBuilder here we aren't using a core function to actually give us the content which might be ok