### PR TITLE
Migrate custom file attachments to new case on reassignment.

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2184,33 +2184,6 @@ SELECT  id
         }
       }
 
-      //Migrate custom attachments
-      $customFileTables = civicrm_api3('CustomField', 'get', [
-        'sequential' => 1,
-        'return' => ["custom_group_id.table_name"],
-        'custom_group_id.extends' => "Case",
-        'data_type' => "File",
-      ]);
-      $customFileTables = array_column($customFileTables['values'], 'custom_group_id.table_name');
-      $customFileTables = array_unique($customFileTables);
-
-      foreach ($customFileTables as $customFileTable) {
-        $entityFile = new CRM_Core_DAO_EntityFile();
-        $entityFile->entity_id = $otherCaseId;
-        $entityFile->entity_table = $customFileTable;
-        $entityFile->find();
-
-        while ($entityFile->fetch()) {
-          $updatedEntityFile = new CRM_Core_DAO_EntityFile();
-          $updatedEntityFile->id = $entityFile->id;
-          if ($updatedEntityFile->find(TRUE)) {
-            $updatedEntityFile->entity_table = $customFileTable;
-            $updatedEntityFile->entity_id = $mainCaseId;
-            $updatedEntityFile->save();
-          }
-        }
-      }
-
       // migrate all activities and connect to main contact.
       $copiedActivityIds = $activityMappingIds = array();
       sort($otherActivityIds);

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2184,6 +2184,33 @@ SELECT  id
         }
       }
 
+      //Migrate custom attachments
+      $customFileTables = civicrm_api3('CustomField', 'get', [
+        'sequential' => 1,
+        'return' => ["custom_group_id.table_name"],
+        'custom_group_id.extends' => "Case",
+        'data_type' => "File",
+      ]);
+      $customFileTables = array_column($customFileTables['values'], 'custom_group_id.table_name');
+      $customFileTables = array_unique($customFileTables);
+
+      foreach ($customFileTables as $customFileTable) {
+        $entityFile = new CRM_Core_DAO_EntityFile();
+        $entityFile->entity_id = $otherCaseId;
+        $entityFile->entity_table = $customFileTable;
+        $entityFile->find();
+
+        while ($entityFile->fetch()) {
+          $updatedEntityFile = new CRM_Core_DAO_EntityFile();
+          $updatedEntityFile->id = $entityFile->id;
+          if ($updatedEntityFile->find(TRUE)) {
+            $updatedEntityFile->entity_table = $customFileTable;
+            $updatedEntityFile->entity_id = $mainCaseId;
+            $updatedEntityFile->save();
+          }
+        }
+      }
+
       // migrate all activities and connect to main contact.
       $copiedActivityIds = $activityMappingIds = array();
       sort($otherActivityIds);

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -241,11 +241,6 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     $this->assertEquals(1, $cases['rows']['Housing Support']['Ongoing']['count']);
   }
 
-  /* FIXME: requires activities
-   * function testGetRelatedCases() {
-   * }
-   */
-
   /**
    * Test various things after a case is closed.
    *
@@ -319,7 +314,8 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
       'activity_date_time' => $now_date,
       'target_contact_id' => $client_id,
       'source_contact_id' => $loggedInUser,
-      'subject' => 'null', // yeah this is extra weird, but without it you get the wrong subject
+      'subject' => 'null',
+      // yeah this is extra weird, but without it you get the wrong subject
     ];
 
     $form->postProcess($actParams);


### PR DESCRIPTION
Overview
----------------------------------------
Steps to reproduce the bug:
1. Create a Custom Data Group for Cases and a "File" Field within it
2. Create a new Case, including an uploaded file in the created field
3. Verify the uploaded file can be downloaded
4. "Reassign" the Case to another Contact
5. Attempt to download the updated file

That does not work, CiviCRM  Redirects to Contact's Cases Tab with bounce message "Could not retrieve File"

Before
----------------------------------------
Custom file attachments are not migrated to the new case.

After
----------------------------------------
Custom file attachments are migrated to the new case and downloadable.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-967_
