### PR TITLE
support api multi-lingual request in new options format

### DIFF
--- a/Civi/API/Subscriber/I18nSubscriber.php
+++ b/Civi/API/Subscriber/I18nSubscriber.php
@@ -54,8 +54,15 @@ class I18nSubscriber implements EventSubscriberInterface {
   public function onApiPrepare(\Civi\API\Event\Event $event) {
     $apiRequest = $event->getApiRequest();
 
-    // support multi-lingual requests
-    if ($language = \CRM_Utils_Array::value('option.language', $apiRequest['params'])) {
+    // support multi-lingual requests in old & new formats.
+    if (is_array(\CRM_Utils_Array::value('options', $apiRequest['params']))) {
+      $language = \CRM_Utils_Array::value('language', $apiRequest['params']['options']);
+    }
+    else {
+      $language = \CRM_Utils_Array::value('option.language', $apiRequest['params']);
+    }
+
+    if ($language) {
       $this->setLocale($language);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
For multilingual CiviCRM sites, support api multi-lingual requests in new `options` array format.

Before
----------------------------------------
Calling an API with `  'options' => ['language' => "fr_FR"], ` won't return labels in specific language, only with `  'option.language' => "fr_FR",`

After
----------------------------------------
Both old and new API options format will return the labels in specific language

Comments
----------------------------------------
The goal of this PR is to *normalize* the options format for API calls

related issues:
- https://issues.civicrm.org/jira/browse/CRM-19037
- https://issues.civicrm.org/jira/browse/CRM-11755
