### PR TITLE
When creating relationship types don't munge names

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -208,8 +208,8 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
 
       if (empty($params['id'])) {
         // Set name on created but don't update on update as the machine name is not exposed.
-        $params['name_b_a'] = CRM_Utils_String::munge($params['label_b_a']);
-        $params['name_a_b'] = CRM_Utils_String::munge($params['label_a_b']);
+        $params['name_b_a'] = $params['label_b_a'];
+        $params['name_a_b'] = $params['label_a_b'];
       }
 
       $result = civicrm_api3('RelationshipType', 'create', $params);


### PR DESCRIPTION
Overview
----------------------------------------
as @agh1 points out [here](https://github.com/civicrm/civicrm-core/pull/13916#discussion_r281787339) this change https://github.com/civicrm/civicrm-core/pull/12097 made on May 8, 2018 made it so relationship types names get munged. This change reverts back to not munging relationship type names.

Before
----------------------------------------
Creating a Relationship type for example:

![create](https://user-images.githubusercontent.com/11323624/57390487-78587780-718a-11e9-9227-a00636188111.png)

Results in the Relationship type names being munged  see `name_a_b` and `name_b_a` below:

```
{
    "id": "17",
    "name_a_b": "banana_peeler_is",
    "label_a_b": "banana peeler is",
    "name_b_a": "banana_peeler_for",
    "label_b_a": "banana peeler for",
    "is_active": "1",
    "is_error": 0
}
```

After
----------------------------------------
When creating a Relationship type names are not munged see `name_a_b` and `name_b_a` in the example below:

```
{
    "id": "17",
    "name_a_b": "banana peeler is",
    "label_a_b": "banana peeler is",
    "name_b_a": "banana peeler for",
    "label_b_a": "banana peeler for",
    "is_active": "1",
    "is_error": 0
}
```

