### PR TITLE
dev/core#945 - fix  use of $this error in static method

### DIFF
--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -416,7 +416,7 @@ class CRM_Contact_Import_ImportJob {
     $result = CRM_Core_DAO::executeQuery($query, array($database));
     $incompleteImportTables = array();
     while ($importTable = $result->fetch()) {
-      if (!$this->isComplete($importTable)) {
+      if (!self::isComplete($importTable)) {
         $incompleteImportTables[] = $importTable;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
"$this can not be used in static methods". is the error thrown in public static function `getIncompleteImportTables() in CRM/Contact/Import/ImportJob.php`

this is an attempt to fix it


