### PR TITLE
dev/core#942 fix failure to render names for some activities.

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -646,6 +646,7 @@ function _civicrm_api3_activity_fill_activity_contact_names(&$activities, $param
       'contact_id.display_name',
       'contact_id',
     ],
+    'options' => ['limit' => 0],
     'check_permissions' => !empty($params['check_permissions']),
   ];
   if (count($activityContactTypes) < 3) {


### PR DESCRIPTION
Overview
----------------------------------------
Set limit for activity_contact retrieval to 0, allowing to retrieve more than 25 activity contacts when rendering the first 25 activities on the activity contact tab

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/336308/57439801-e42a0580-729a-11e9-80a1-45df93d0c5eb.jpg)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/336308/57439960-39fead80-729b-11e9-9701-acd79ff73497.jpg)


Technical Details
----------------------------------------
Without setting limit explicitly to 0 we wind up rendering the names for only the first 25 activity contacts

Comments
----------------------------------------
There is a bit of a question as to whether this would be slower for an activity with a very large number of contacts attached - eg. 30,000. However those would have been much slower in each of the previous methods used (the one with the slow query & the one with a query per contact to get their name). If we DID switch to 25 separate queries with a limit on each (instead of one plus php rendering) we would want to be sure it is actually faster.
