### PR TITLE
dev/core#950 Remove deprecated :hover jQuery selector

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -78,7 +78,7 @@
             })
             .on('show.smapi', function(e, menu) {
               // Focus menu when opened with an accesskey
-              $(menu).siblings('a[accesskey]:not(:hover)').focus();
+              $(menu).siblings('a[accesskey]').focus();
             })
             .smartmenus(CRM.menubar.settings);
           initialized = true;


### PR DESCRIPTION
Overview
----------------------------------------
Removes a jQuery selector that wasn't working anyway and was logging errors in the console.

Before
----------------------------------------
Errors in console.

After
----------------------------------------
No errors, at least not from this :)

See https://lab.civicrm.org/dev/core/issues/950