### PR TITLE
Error log improvements: Provide severity level and use Civi::log()

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -39,6 +39,8 @@ require_once 'CRM/Core/Exception.php';
 
 require_once 'Log.php';
 
+use Psr\Log\LogLevel;
+
 /**
  * Class CRM_Exception
  */
@@ -232,7 +234,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $errorDetails = CRM_Core_Error::debug('', $error, FALSE);
     $template->assign_by_ref('errorDetails', $errorDetails);
 
-    CRM_Core_Error::debug_var('Fatal Error Details', $error);
+    CRM_Core_Error::debug_var('Fatal Error Details', $error, TRUE, TRUE, '', LogLevel::ERROR);
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
     if ($config->initialized) {
@@ -339,7 +341,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
 
     if (self::$modeException) {
       // CRM-11043
-      CRM_Core_Error::debug_var('Fatal Error Details', $vars);
+      CRM_Core_Error::debug_var('Fatal Error Details', $vars, TRUE, TRUE, '', LogLevel::ERROR);
       CRM_Core_Error::backtrace('backTrace', TRUE);
 
       $details = 'A fatal error was triggered';
@@ -381,7 +383,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       self::backtrace();
     }
 
-    CRM_Core_Error::debug_var('Fatal Error Details', $vars);
+    CRM_Core_Error::debug_var('Fatal Error Details', $vars, TRUE, TRUE, '', LogLevel::ERROR);
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
     // If we are in an ajax callback, format output appropriately
@@ -421,7 +423,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
     catch (Exception $other) {
       // if the exception-handler generates an exception, then that sucks! oh, well. carry on.
-      CRM_Core_Error::debug_var('handleUnhandledException_nestedException', self::formatTextException($other));
+      CRM_Core_Error::debug_var('handleUnhandledException_nestedException', self::formatTextException($other), TRUE, TRUE, '', LogLevel::ERROR);
     }
     $config = CRM_Core_Config::singleton();
     $vars = [
@@ -459,7 +461,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // Case C: Default error handler
 
     // log to file
-    CRM_Core_Error::debug_var('Fatal Error Details', $vars, FALSE);
+    CRM_Core_Error::debug_var('Fatal Error Details', $vars, FALSE, TRUE, '', LogLevel::ERROR);
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
     // print to screen
@@ -544,6 +546,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   Log or return the output?
    * @param string $prefix
    *   Prefix for output logfile.
+   * @param string $level
+   *   The PSR-3 log level.
    *
    * @return string
    *   The generated output
@@ -551,7 +555,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @see CRM_Core_Error::debug()
    * @see CRM_Core_Error::debug_log_message()
    */
-  public static function debug_var($variable_name, $variable, $print = TRUE, $log = TRUE, $prefix = '') {
+  public static function debug_var($variable_name, $variable, $print = TRUE, $log = TRUE, $prefix = '', $level = LogLevel::INFO) {
     // check if variable is set
     if (!isset($variable)) {
       $out = "\$$variable_name is not set";
@@ -574,7 +578,15 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         reset($variable);
       }
     }
-    return self::debug_log_message($out, FALSE, $prefix);
+    Civi::log()->log($level, $out, ['civi.prefix' => $prefix]);
+    return self::debugOutput($out);
+  }
+
+  /**
+   * Generates debug HTML output.
+   */
+  public static function debugOutput($message) {
+    return '<p/><code>' . htmlspecialchars($message) . '</code>';
   }
 
   /**
@@ -600,7 +612,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $file_log = self::createDebugLogger($prefix);
     $file_log->log("$message\n", $priority);
 
-    $str = '<p/><code>' . htmlspecialchars($message) . '</code>';
+    $str = self::debugOutput($message);
     if ($out && CRM_Core_Permission::check('view debug output')) {
       echo $str;
     }
@@ -635,7 +647,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         CRM_Core_Error::backtrace($string, TRUE);
       }
       elseif (CIVICRM_DEBUG_LOG_QUERY) {
-        CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log');
+        CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log', LogLevel::DEBUG);
       }
     }
   }
@@ -647,7 +659,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function debug_query_result($query) {
     $results = CRM_Core_DAO::executeQuery($query)->fetchAll();
-    CRM_Core_Error::debug_var('dao result', ['query' => $query, 'results' => $results]);
+    CRM_Core_Error::debug_var('dao result', ['query' => $query, 'results' => $results], TRUE, TRUE, '', LogLevel::DEBUG);
   }
 
   /**
@@ -731,7 +743,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       CRM_Core_Error::debug($msg, $message);
     }
     else {
-      CRM_Core_Error::debug_var($msg, $message);
+      CRM_Core_Error::debug_var($msg, $message, TRUE, TRUE, '', LogLevel::DEBUG);
     }
   }
 
@@ -948,7 +960,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @throws PEAR_Exception
    */
   public static function exceptionHandler($pearError) {
-    CRM_Core_Error::debug_var('Fatal Error Details', self::getErrorDetails($pearError));
+    CRM_Core_Error::debug_var('Fatal Error Details', self::getErrorDetails($pearError), TRUE, TRUE, '', LogLevel::ERROR);
     CRM_Core_Error::backtrace('backTrace', TRUE);
     throw new PEAR_Exception($pearError->getMessage(), $pearError);
   }
@@ -962,7 +974,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   $obj
    */
   public static function nullHandler($obj) {
-    CRM_Core_Error::debug_log_message("Ignoring exception thrown by nullHandler: {$obj->code}, {$obj->message}");
+    Civi::log()->error("Ignoring exception thrown by nullHandler: {$obj->code}, {$obj->message}");
     CRM_Core_Error::backtrace('backTrace', TRUE);
     return $obj;
   }

--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -59,6 +59,7 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
   public function log($level, $message, array $context = []) {
     // FIXME: This flattens a $context a bit prematurely. When integrating
     // with external/CMS logs, we should pass through $context.
+    $prefix = '';
     if (!empty($context)) {
       if (isset($context['exception'])) {
         $context['exception'] = CRM_Core_Error::formatTextException($context['exception']);
@@ -68,8 +69,11 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
       if (CRM_Utils_System::isDevelopment() && CRM_Utils_Array::value('civi.tag', $context) === 'deprecated') {
         trigger_error($message, E_USER_DEPRECATED);
       }
+      if (isset($context['civi.prefix'])) {
+        $prefix = $context['civi.prefix'];
+      }
     }
-    CRM_Core_Error::debug_log_message($message, FALSE, '', $this->map[$level]);
+    CRM_Core_Error::debug_log_message($message, FALSE, $prefix, $this->map[$level]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
I'm not sure if we want to deprecate `CRM_Core_Error::debug_var()` and stop using it, or make some improvements to it.

If the latter, then we could provide a `$level` argument so that we can assign a severity level to fatal errors and other usages of `CRM_Core_Error::debug_var()`, and in addition, various `CRM_Core_Error` methods could use `Civi::log()` internally rather than `CRM_Core_Error::debug_log_message()`.

Note: I would say that `CRM_Core_Error::debug_log_message()` should also use `Civi::log()`, but this isn't doable as long as `CRM_Core_Error_Log::log()` calls `CRM_Core_Error::debug_log_message()`.. This could be worked on in a future PR if desired.

Before
----------------------------------------
A call like `CRM_Core_Error::debug_var('Fatal Error Details', ...)` logs at the default severity level, and doesn't use `Civi::log()`.

After
----------------------------------------
- `CRM_Core_Error::debug_var()` has an optional `$level` arg;
- Various `CRM_Core_Error` methods use `Civi::log()` internally; and
- `Civi::log()` supports a `civi.prefix` context param to specify the log file prefix.