### PR TITLE
dev/core#953 Add test for updating email via import & ensuring it is primary

### DIFF
--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -344,8 +344,18 @@ class CRM_Core_BAO_Block {
       }
 
       $blockFields = array_merge($value, $contactFields);
-      $baoString = 'CRM_Core_BAO_' . $name;
-      $blocks[] = $baoString::add($blockFields);
+      if ($name === 'Email') {
+        // @todo ideally all would call the api which is our main tested function,
+        // and towards that call the create rather than add which is preferred by the
+        // api. In order to be careful with change only email is swapped over here because it
+        // is specifically tested in testImportParserWithUpdateWithContactID
+        // and the primary handling is otherwise bypassed on importing an email update.
+        $blocks[] = CRM_Core_BAO_Email::create($blockFields);
+      }
+      else {
+        $baoString = 'CRM_Core_BAO_' . $name;
+        $blocks[] = $baoString::add($blockFields);
+      }
     }
 
     return $blocks;


### PR DESCRIPTION
Overview
----------------------------------------
Add test attempting to replicate dev/core#953

Before
----------------------------------------
No test

After
----------------------------------------
test

Technical Details
----------------------------------------
@stesi561 I didn't manage to replicate the bug in a test. 

But if you look at CRM_Contact_Import_Parser_ContactTest::testImportPrimaryAddress it has location type mappings so maybe that needs to be added to the test to get it to replicate the bug - what location type are you mapping to?

Comments
----------------------------------------
