### PR TITLE
Update testGetActivityAccessCiviCRMEnough test for clarity

### DIFF
--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -571,15 +571,19 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   }
 
   /**
-   * View all activities is required unless id is passed in, in which case ACLs are used.
+   * Check the error message is not a permission error.
    */
-  public function testGetActivityAccessCiviCRMNotEnough() {
+  public function testGetActivityAccessCiviCRMEnough() {
     $activity = $this->activityCreate();
     $this->setPermissions(['access CiviCRM']);
     $this->callAPIFailure('Activity', 'getsingle', [
       'check_permissions' => 1,
       'id' => $activity['id'],
-    ]);
+    ], 'Expected one Activity but found 0');
+    $this->callAPISuccessGetCount('Activity', [
+      'check_permissions' => 1,
+      'id' => $activity['id'],
+    ], 0);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Updates a test for clarity

Before
----------------------------------------
test is misleading

After
----------------------------------------
Updates an old test to make it clear what is happening

Technical Details
----------------------------------------
'access CiviCRM' should be enough to call Activity.getsingle. However, the test should still fail as non are fetched, this clarifies & also adds a getcount

Comments
----------------------------------------
@pradpnayak I did this in conjunction with a chat question I understand you are digging into
