### PR TITLE
Remove deprecated :hover jQuery selector

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -78,7 +78,7 @@
             })
             .on('show.smapi', function(e, menu) {
               // Focus menu when opened with an accesskey
-              $(menu).siblings('a[accesskey]:not(:hover)').focus();
+              $(menu).siblings('a[accesskey]').focus();
             })
             .smartmenus(CRM.menubar.settings);
           initialized = true;


### PR DESCRIPTION
Overview
----------------------------------------
Backport from 5.14 https://github.com/civicrm/civicrm-core/pull/14219

Before
----------------------------------------
error in console on browser debuggers

After
----------------------------------------
Error gone

Technical Details
----------------------------------------
This is pretty harmless but as it's new code it's a regression of sorts & reduces debugging noise

Comments
----------------------------------------

