### PR TITLE
Fixed fatal error for Event Participants custom search if price set field option is disabled after a registrant has already selected it.

### DIFF
--- a/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -116,19 +116,24 @@ WHERE  p.contact_id = c.id
     CRM_Core_DAO::executeQuery($sql);
 
     $sql = "
-SELECT c.id as contact_id,
-       p.id as participant_id,
-       l.price_field_value_id as price_field_value_id,
-       l.qty
-FROM   civicrm_contact c,
-       civicrm_participant  p,
-       civicrm_line_item    l
-WHERE  c.id = p.contact_id
-AND    p.event_id = {$this->_eventID}
-AND    p.id = l.entity_id
-AND    l.entity_table ='civicrm_participant'
-ORDER BY c.id, l.price_field_value_id;
-";
+      SELECT c.id as contact_id,
+        p.id as participant_id,
+        l.price_field_value_id AS price_field_value_id,
+        l.qty
+      FROM civicrm_contact c,
+        INNER JOIN civicrm_participant p
+          ON p.contact_id = c.id AND c.is_deleted = 0
+        INNER JOIN civicrm_line_item l
+          ON p.id = l.entity_id AND l.entity_table ='civicrm_participant'
+        INNER JOIN civicrm_price_field_value cpfv
+          ON cpfv.id = l.price_field_value_id AND cpfv.is_active = 1
+        INNER JOIN civicrm_price_field cpf
+          ON cpf.id = l.price_field_id AND cpf.is_active = 1
+        INNER JOIN civicrm_price_set cps
+          ON cps.id = cpf.price_set_id AND cps.is_active = 1
+      WHERE  p.event_id = {$this->_eventID}
+      ORDER BY c.id, l.price_field_value_id;
+    ";
 
     $dao = CRM_Core_DAO::executeQuery($sql);
 


### PR DESCRIPTION
Overview
----------------------------------------
From https://civicrm.stackexchange.com/questions/30602/unable-to-use-price-set-details-for-event-participants-custom-search-if-price-se

Before
----------------------------------------
Fatal error

After
----------------------------------------
No Fatal error
