### PR TITLE
Remove broken delete from customGroupCreate

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1357,12 +1357,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
 
     $params = array_merge($defaults, $params);
 
-    //have a crack @ deleting it first in the hope this will prevent derailing our tests
-    $this->callAPISuccess('custom_group', 'get', array(
-      'title' => $params['title'],
-      array('api.custom_group.delete' => 1),
-    ));
-
     return $this->callAPISuccess('custom_group', 'create', $params);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes a broken api call from unit tests. This only affects tests.

Before
----------------------------------------
Have a crack at using the api with the wrong syntax.

After
----------------------------------------
Don't bother.

Technical Details
----------------------------------------
If you look closely at the api call, it was broken. Probably a copy-paste error, as other places in the test suite the params consist only of `array('api.foo.bar' => 1)` but here they accidentally wrapped that array in another array, which would cause it to be ignored.
Rather than fix it, I concluded that it isn't needed because tests pass without it.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
