### PR TITLE
(dev/core#944) Report doesn't show value for disabled options in results

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -412,7 +412,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         FALSE,
         FALSE,
         'label',
-        !($context == 'validate' || $context == 'get')
+        !($context == 'validate' || $context == 'get' || $context == 'search')
       );
     }
     elseif ($this->data_type === 'StateProvince') {
@@ -1184,7 +1184,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    * @return string
    * @throws \Exception
    */
-  public static function displayValue($value, $field, $entityId = NULL) {
+  public static function displayValue($value, $field, $entityId = NULL, $context = NULL) {
     $field = is_array($field) ? $field['id'] : $field;
     $fieldId = is_object($field) ? $field->id : (int) str_replace('custom_', '', $field);
 
@@ -1196,7 +1196,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $field = self::getFieldObject($fieldId);
     }
 
-    $fieldInfo = array('options' => $field->getOptions()) + (array) $field;
+    $fieldInfo = array('options' => $field->getOptions($context)) + (array) $field;
 
     return self::formatDisplayValue($value, $fieldInfo, $entityId);
   }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2242,7 +2242,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     foreach ($rows as $rowNum => $row) {
       foreach ($row as $tableCol => $val) {
         if (array_key_exists($tableCol, $customFields)) {
-          $rows[$rowNum][$tableCol] = CRM_Core_BAO_CustomField::displayValue($val, $customFields[$tableCol]);
+          $rows[$rowNum][$tableCol] = CRM_Core_BAO_CustomField::displayValue($val, $customFields[$tableCol], NULL, 'search');
           $entryFound = TRUE;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------

Steps to replicate:

* Create a contribution with custom data *Donor Information* with field *How long have you been a donor?* with seleted option *Less than 1 year*

* Disable *Less than 1 year* option.

*The value is displayed in report result.

 The option should still be present in report results though not on edit/create screens.


Before
----------------------------------------
The value is **not** displayed in report result.

After
----------------------------------------
The value **is** displayed in report result.

Comments
----------------------------------------
The option should still be present in report results though not on edit/create screens.


