### PR TITLE
Try enabling api4 extension in test suite

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -321,6 +321,12 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     // disable any left-over test extensions
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_extension WHERE full_name LIKE "test.%"');
 
+    $extensions = \CRM_Extension_System::singleton()->getManager();
+    $api4Status = $extensions->getStatus('org.civicrm.api4');
+    if ($api4Status != $extensions::STATUS_INSTALLED && $api4Status != $extensions::STATUS_UNKNOWN) {
+      $extensions->enable(['org.civicrm.api4']);
+    }
+
     // reset all the caches
     CRM_Utils_System::flushCache();
 


### PR DESCRIPTION
Make the api4 extension available when running unit tests.
Depends on civicrm/civicrm-buildkit#451