### PR TITLE
Adding a Primary member filter in the Membership Detail report.

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -122,6 +122,11 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
             'title' => ts('Membership Owner ID'),
             'operatorType' => CRM_Report_Form::OP_INT,
           ],
+          'primary_member' => array(
+            'title' => ts('Primary Member?'),
+            'type' => CRM_Utils_Type::T_BOOLEAN,
+            'pseudofield' => TRUE,
+          ),
           'tid' => [
             'name' => 'membership_type_id',
             'title' => ts('Membership Types'),
@@ -252,6 +257,17 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
 
     $this->_currencyColumn = 'civicrm_contribution_currency';
     parent::__construct();
+  }
+
+  public function where() {
+    parent::where();
+    $dbAlias = $this->_columns['civicrm_membership']['alias'];
+    if ($this->_params['primary_member_value'] == 1) {
+      $this->_where .= ' AND ( ' . $dbAlias . '.owner_membership_id IS NULL )';
+    }
+    if ($this->_params['primary_member_value'] != '' && $this->_params['primary_member_value'] == 0) {
+      $this->_where .= ' AND ( ' . $dbAlias . '.owner_membership_id IS NOT NULL )';
+    }
   }
 
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
Adding a Primary member filter in the Membership Detail report.

Before
----------------------------------------
Users could not filter out Primary member or non-Primary member.

After
----------------------------------------
Additional filter for filtering out Primary member or non-Primary member added.
The filter is displayed under 'Membership Owner ID' filter.


Agileware Ref: CIVICRM-1187