### PR TITLE
dev/financial#50 - Fix contributions and participants getting overwritten

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -466,6 +466,10 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    * Build the form object.
    */
   public function buildQuickForm() {
+    if ($this->_id) {
+      $this->add('hidden', 'id', $this->_id);
+    }
+
     if ($this->_action & CRM_Core_Action::DELETE) {
       $this->addButtons([
         [
@@ -824,7 +828,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     // if contribution is related to membership or participant freeze Financial Type, Amount
     if ($this->_id) {
-      $this->add('hidden', 'id', $this->_id);
       $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
       $isCancelledStatus = ($this->_values['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled'));
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -824,6 +824,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     // if contribution is related to membership or participant freeze Financial Type, Amount
     if ($this->_id) {
+      $this->add('hidden', 'id', $this->_id);
       $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
       $isCancelledStatus = ($this->_values['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled'));
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -250,7 +250,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('action', $this->_action);
 
     // Get the contribution id if update
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
     if (!empty($this->_id)) {
       $this->assignPaymentInfoBlock();
       $this->assign('contribID', $this->_id);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -258,7 +258,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $this->_id = NULL;
     }
     else {
-      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
     }
 
     if ($this->_id) {

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -689,6 +689,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     if ($this->_id) {
       $this->assign('entityID', $this->_id);
+      $this->add('hidden', 'id', $this->_id);
     }
 
     $this->addSelect('role_id', ['multiple' => TRUE, 'class' => 'huge'], TRUE);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -594,6 +594,10 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @throws \CiviCRM_API3_Exception
    */
   public function buildQuickForm() {
+    if ($this->_id) {
+      $this->add('hidden', 'id', $this->_id);
+    }
+
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     $partiallyPaidStatusId = array_search('Partially paid', $participantStatuses);
     $this->assign('partiallyPaidStatusId', $partiallyPaidStatusId);
@@ -689,7 +693,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     if ($this->_id) {
       $this->assign('entityID', $this->_id);
-      $this->add('hidden', 'id', $this->_id);
     }
 
     $this->addSelect('role_id', ['multiple' => TRUE, 'class' => 'huge'], TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where contributions or participants may be overwritten when users open an existing contribution or participant after opening the creation form (but before actually submitting it).

Before
----------------------------------------
An existing contribution or participant is overwritten if it's been opened after the creation form was loaded.

After
----------------------------------------
A new contribution or participant is recorded.

Technical Details
----------------------------------------
The form passes a reference to itself when calling `CRM_Utils_Request::retrieve`, which eventually leads to the ID being loaded from `$_SESSION` (via `CRM_Core_Controller::get()`).

Some forms bypass this behaviour by not loading the ID for `CRM_Core_Action::ADD` (or only for `CRM_Core_Action::UPDATE`), but I could not find any issues with this approach (i.e. not passing `$this`).


https://lab.civicrm.org/dev/financial/issues/50