### PR TITLE
WIP Refactor submitOnce handling so it works and support button elements too

### DIFF
--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -204,6 +204,7 @@ class CRM_Case_Form_Activity_OpenCase {
         'type' => 'upload',
         'name' => ts('Save and New'),
         'subName' => 'new',
+        'submitOnce' => TRUE,
       ],
       [
         'type' => 'cancel',

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -478,6 +478,10 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    */
   public function getButtonName() {
     $data = &$this->container();
+    if (!empty($_REQUEST['_qf_button_override'])) {
+      // @see js/Common.js::submitOnce() and CRM_Core_Form::addButtons() and HTML_QuickForm_Controller::getActionName().
+      return $_REQUEST['_qf_button_override'];
+    }
     return CRM_Utils_Array::value('_qf_button_name', $data);
   }
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -640,9 +640,15 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public function addButtons($params) {
     $prevnext = $spacing = [];
+    $addedButtonOverride = FALSE;
     foreach ($params as $button) {
       if (!empty($button['submitOnce'])) {
         $button['js']['onclick'] = "return submitOnce(this,'{$this->_name}','" . ts('Processing') . "');";
+        if (! $addedButtonOverride) {
+          $addedButtonOverride = TRUE;
+          // @see js/Common.js::submitOnce() and CRM_Core_Controller::getButtonName() and HTML_QuickForm_Controller::getActionName().
+          $this->addElement('hidden', '_qf_button_override', '', ['id' => '_qf_button_override']);
+        }
       }
 
       $attrs = ['class' => 'crm-form-submit'] + (array) CRM_Utils_Array::value('js', $button);
@@ -1270,7 +1276,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         'isDefault' => TRUE,
       ];
       if ($submitOnce) {
-        $nextButton['js'] = ['onclick' => "return submitOnce(this,'{$this->_name}','" . ts('Processing') . "');"];
+        $nextButton['submitOnce'] = TRUE;
       }
       $buttons[] = $nextButton;
     }

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -723,6 +723,7 @@ class CRM_Core_Resources {
       "js/crm.datepicker.js",
       "js/crm.ajax.js",
       "js/wysiwyg/crm.wysiwyg.js",
+      "js/crm.buttons.js",
     ];
 
     // Dynamic localization script

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -290,11 +290,13 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
           'type' => 'upload',
           'name' => ts('Save'),
           'isDefault' => TRUE,
+          'submitOnce' => TRUE,
         ],
         [
           'type' => 'upload',
           'name' => ts('Save and New'),
           'subName' => 'new',
+          'submitOnce' => TRUE,
         ],
         [
           'type' => 'cancel',

--- a/js/Common.js
+++ b/js/Common.js
@@ -145,40 +145,6 @@ function showHideByValue(trigger_field_id, trigger_value, target_element_id, tar
 }
 
 /**
- * Function to change button text and disable one it is clicked
- * @deprecated
- * @param obj object - the button clicked
- * @param formID string - the id of the form being submitted
- * @param string procText - button text after user clicks it
- * @return bool
- */
-var submitcount = 0;
-/* Changes button label on submit, and disables button after submit for newer browsers.
- Puts up alert for older browsers. */
-function submitOnce(obj, formId, procText) {
-  // if named button clicked, change text
-  if (obj.value != null) {
-    cj('input[name=' + obj.name + ']').val(procText + " ...");
-  }
-  cj(obj).closest('form').attr('data-warn-changes', 'false');
-  if (document.getElementById) { // disable submit button for newer browsers
-    cj('input[name=' + obj.name + ']').attr("disabled", true);
-    document.getElementById(formId).submit();
-    return true;
-  }
-  else { // for older browsers
-    if (submitcount == 0) {
-      submitcount++;
-      return true;
-    }
-    else {
-      alert("Your request is currently being processed ... Please wait.");
-      return false;
-    }
-  }
-}
-
-/**
  * Function to show / hide the row in optionFields
  * @deprecated
  * @param index string, element whose innerHTML is to hide else will show the hidden row.

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -456,13 +456,13 @@
         var buttonContainers = '.crm-submit-buttons, .action-link',
           buttons = [],
           added = [];
-        $(buttonContainers, $el).find('input.crm-form-submit, a.button').each(function() {
+        $(buttonContainers, $el).find('input.crm-form-submit, a.button, button').each(function() {
           var $el = $(this),
             label = $el.is('input') ? $el.attr('value') : $el.text(),
             identifier = $el.attr('name') || $el.attr('href');
           if (!identifier || identifier === '#' || $.inArray(identifier, added) < 0) {
             var $icon = $el.find('.icon, .crm-i'),
-              button = {'data-identifier': identifier, text: label, click: function() {
+              button = {class: 'crm-button button', 'data-identifier': identifier, text: label, click: function() {
                 $el[0].click();
               }};
             if ($icon.length) {

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -464,7 +464,17 @@
           if (!identifier || identifier === '#' || $.inArray(identifier, added) < 0) {
             var $icon = $el.find('.icon, .crm-i'),
               button = {class: 'crm-button button', 'data-identifier': identifier, 'data-form-name': formName, text: label, click: function() {
-                $el[0].click();
+                console.log('submitting via ajaxform click');
+                CRM.$('form[name="' + formName + '"]#_qf_button_override').val(identifier);
+                CRM.$('form[name="' + formName + '"]').submit();
+              }, keydown: function(event) {
+                  console.log(event.which);
+                  if (event.which === 13) {
+                    event.preventDefault();
+                    console.log('submitting via ajaxform enter key');
+                    CRM.$('form[name="' + formName + '"]#_qf_button_override').val(identifier);
+                    CRM.$('form[name="' + formName + '"]').submit();
+                  }
               }};
             if ($icon.length) {
               button.icons = {primary: $icon.attr('class')};

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -452,6 +452,7 @@
         });
       }
       if ($el.data('uiDialog')) {
+        var formName = $el.children('form').first().attr('name');
         // Show form buttons as part of the dialog
         var buttonContainers = '.crm-submit-buttons, .action-link',
           buttons = [],
@@ -462,7 +463,7 @@
             identifier = $el.attr('name') || $el.attr('href');
           if (!identifier || identifier === '#' || $.inArray(identifier, added) < 0) {
             var $icon = $el.find('.icon, .crm-i'),
-              button = {class: 'crm-button button', 'data-identifier': identifier, text: label, click: function() {
+              button = {class: 'crm-button button', 'data-identifier': identifier, 'data-form-name': formName, text: label, click: function() {
                 $el[0].click();
               }};
             if ($icon.length) {

--- a/js/crm.buttons.js
+++ b/js/crm.buttons.js
@@ -1,0 +1,19 @@
+/**
+ * Function to change button text and disable one it is clicked
+ * @deprecated
+ * @param obj object - the button clicked
+ * @param formID string - the id of the form being submitted
+ * @param string procText - button text after user clicks it
+ * @return bool
+ */
+/* Changes button label on submit, and disables button after submit for newer browsers.
+ Puts up alert for older browsers. */
+function submitOnce(obj, formId, procText) {
+  CRM.$(obj).closest('form').attr('data-warn-changes', 'false');
+  CRM.$('.crm-button input').attr('disabled', true);
+  CRM.$('button.crm-button').attr('disabled', true);
+  // Needed because calling .submit() below will always send the default button in the POST data. @see also CRM_Core_Controller::getButtonName().
+  CRM.$('#_qf_button_override').val(obj.name);
+  document.getElementById(formId).submit();
+  return true;
+}

--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -88,4 +88,25 @@
 {/if}
 {/crmRegion}
 
+  {if $form.formName}
+  {literal}
+    <script type="text/javascript">
+      var alreadySubmitting = false;
+      console.log('alreadySubmitting loaded...');
+      CRM.$('#{/literal}{$form.formName}{literal}').on('submit', function(ev){
+        if (alreadySubmitting) {
+          ev.preventDefault();
+          return;
+        }
+        alreadySubmitting = true;
+        CRM.$('button.crm-button, .crm-button input').prop('disabled', true);
+      });
+      CRM.$('button .crm-button ui-button, .crm-button input ui-button').on('click', function(){
+        CRM.$('#_qf_button_override').val(CRM.$(this).attr('data-identifier'));
+        CRM.$(CRM.$(this).attr('data-form-name')).submit();
+      });
+    </script>
+  {/literal}
+  {/if}
+
 </div> {* end crm-container div *}

--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -91,19 +91,46 @@
   {if $form.formName}
   {literal}
     <script type="text/javascript">
+      CRM.$(document).on('keydown', function(event) {
+        console.log('document keydown triggered: ' + event.which);
+        if (event.which === 13) {
+          event.preventDefault();
+          // On firefox, enter submits the form. So detect if the button is "linked" to a form and prevent the default action if so.
+          if (CRM.$(event.target).attr('data-form-name') !== undefined) {
+            var formName = CRM.$(event.target).attr('data-form-name');
+            console.log('formName: ' + formName);
+          }
+        }
+      });
       var alreadySubmitting = false;
       console.log('alreadySubmitting loaded...');
-      CRM.$('#{/literal}{$form.formName}{literal}').on('submit', function(ev){
+      CRM.$('form').on('submit', function(ev){
+        console.log('form submitted...');
         if (alreadySubmitting) {
           ev.preventDefault();
           return;
         }
         alreadySubmitting = true;
         CRM.$('button.crm-button, .crm-button input').prop('disabled', true);
+      }).on('keydown', function(event) {
+        console.log('form keydown triggered');
       });
       CRM.$('button .crm-button ui-button, .crm-button input ui-button').on('click', function(){
         CRM.$('#_qf_button_override').val(CRM.$(this).attr('data-identifier'));
+        console.log('submitting via standard');
+        var formName = CRM.$(this).attr('data-form-name');
         CRM.$(CRM.$(this).attr('data-form-name')).submit();
+      }).on('keydown', function(event) {
+        console.log(event.which);
+        if (event.which === 13) {
+          event.preventDefault();
+          var formName = CRM.$(this).attr('data-form-name');
+          console.log('submitting via standard enter key');
+          CRM.$('form[name="' + formName + '"]#_qf_button_override').val(identifier);
+          CRM.$('form[name="' + formName + '"]').submit();
+        }
+      }).on('submit', function(event) {
+        console.log('submit triggered');
       });
     </script>
   {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/914

Before
----------------------------------------
Submitting forms "once" unreliable.  Many forms can be submitted multiple times.  Not possible to have more than one submit button that works properly.

After
----------------------------------------
* Submitting forms always disables all crm buttons so you can't do something else once you've submitted the form.
* Button elements supported as well as input elements for buttons.
* Forms which implement multiple submit buttons (eg. Save, Save and New) now work properly - thanks @demeritcowboy 


Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/914

Comments
----------------------------------------
@eileenmcnaughton @totten @demeritcowboy 
