### PR TITLE
dev/core#961 - Contribution page including 2 email fields does not re…

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -280,7 +280,8 @@ class CRM_Dedupe_Finder {
       $matches = [];
       if (preg_match('/(.*)-(Primary-[\d+])$|(.*)-(\d+|Primary)$/', $key, $matches)) {
         $return = array_values(array_filter($matches));
-        $flat[$return[1]] = $value;
+        // make sure the first occurrence is kept, not the last
+        $flat[$return[1]] = empty($flat[$return[1]]) ? $value : $flat[$return[1]];
         unset($flat[$key]);
       }
     }

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -40,7 +40,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function testUnsupervisedDupes() {
-    // make dupe checks based on based on following contact sets:
+    // make dupe checks based on following contact sets:
     // FIRST - LAST - EMAIL
     // ---------------------------------
     // robin  - hood - robin@example.com
@@ -56,6 +56,28 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
 
     $foundDupes = CRM_Dedupe_Finder::dupesInGroup($ruleGroup['id'], $this->groupID);
     $this->assertEquals(count($foundDupes), 3, 'Check Individual-Fuzzy dupe rule for dupesInGroup().');
+  }
+
+  /**
+   * Test duplicate contact retrieval with 2 email fields.
+   */
+  public function testUnsupervisedWithTwoEmailFields() {
+    $this->setupForGroupDedupe();
+    $emails = [
+      ['hood@example.com', ''],
+      ['', 'hood@example.com'],
+    ];
+    for ($i = 0; $i < 2; $i++) {
+      $fields = [
+        'first_name' => 'robin',
+        'last_name' => 'hood',
+        'email-1' => $emails[$i][0],
+        'email-2' => $emails[$i][1],
+      ];
+      $dedupeParams = CRM_Dedupe_Finder::formatParams($fields, 'Individual');
+      $dedupeResults = CRM_Dedupe_Finder::dupesByParams($dedupeParams, 'Individual');
+      $this->assertEquals(count($dedupeResults), 1);
+    }
   }
 
   /**


### PR DESCRIPTION
…spect dedupe rule.

Overview
----------------------------------------
Unsupervised rule fails if we have 2 email fields to match on with latter set as empty.

Before
----------------------------------------
 To replicate -

- Add a profile with first name, last name, billing email and work email.
- Create a contact with first name = "Test", Last name = "Dedupe" and email = "test@example.com"
- Add the profile to a contribution page.
- Submit the contribution page anonymously and enter First name = Test, Last name = "Dedupe" and billing email = "test@example.com". Keep work email as empty.

![image](https://user-images.githubusercontent.com/5929648/57774067-28a02000-7737-11e9-90ef-0e86747b1232.png)

- Complete the payment. 
- The payment should be recorded against the existing contact based on dedupe matching.
- As we do not have any value filled for second email field, dedupe fails and a new contact is created with same details.

After
----------------------------------------
Payment gets created on the existing contact. Dedupe match works correctly.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/961