### PR TITLE
Remove wasteful double-caching of settings metadata

### DIFF
--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -33,8 +33,6 @@ namespace Civi\Core;
  */
 class SettingsMetadata {
 
-  const ALL = 'all';
-
   /**
    * WARNING: This interface may change.
    *
@@ -72,25 +70,14 @@ class SettingsMetadata {
 
     $cache = \Civi::cache('settings');
     $cacheString = 'settingsMetadata_' . $domainID . '_';
-    // the caching into 'All' seems to be a duplicate of caching to
-    // settingsMetadata__ - I think the reason was to cache all settings as defined & then those altered by a hook
     $settingsMetadata = $cache->get($cacheString);
-    $cached = is_array($settingsMetadata);
 
-    if (!$cached) {
-      $settingsMetadata = $cache->get(self::ALL);
-      if (empty($settingsMetadata)) {
-        global $civicrm_root;
-        $metaDataFolders = [$civicrm_root . '/settings'];
-        \CRM_Utils_Hook::alterSettingsFolders($metaDataFolders);
-        $settingsMetadata = self::loadSettingsMetaDataFolders($metaDataFolders);
-        $cache->set(self::ALL, $settingsMetadata);
-      }
-    }
-
-    \CRM_Utils_Hook::alterSettingsMetaData($settingsMetadata, $domainID, NULL);
-
-    if (!$cached) {
+    if (!is_array($settingsMetadata)) {
+      global $civicrm_root;
+      $metaDataFolders = [$civicrm_root . '/settings'];
+      \CRM_Utils_Hook::alterSettingsFolders($metaDataFolders);
+      $settingsMetadata = self::loadSettingsMetaDataFolders($metaDataFolders);
+      \CRM_Utils_Hook::alterSettingsMetaData($settingsMetadata, $domainID, NULL);
       $cache->set($cacheString, $settingsMetadata);
     }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1942,12 +1942,12 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    * @return void
    */
   public function setMockSettingsMetaData($extras) {
-    Civi::service('settings_manager')->flush();
-
     CRM_Utils_Hook::singleton()
       ->setHook('civicrm_alterSettingsMetaData', function (&$metadata, $domainId, $profile) use ($extras) {
         $metadata = array_merge($metadata, $extras);
       });
+
+    Civi::service('settings_manager')->flush();
 
     $fields = $this->callAPISuccess('setting', 'getfields', array());
     foreach ($extras as $key => $spec) {

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -110,7 +110,6 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   public function testGetFieldsCaching() {
     $settingsMetadata = array();
     Civi::cache('settings')->set('settingsMetadata_' . \CRM_Core_Config::domainID() . '_', $settingsMetadata);
-    Civi::cache('settings')->set(\Civi\Core\SettingsMetadata::ALL, $settingsMetadata);
     $result = $this->callAPISuccess('setting', 'getfields', array());
     $this->assertArrayNotHasKey('customCSSURL', $result['values']);
     $this->quickCleanup(array('civicrm_cache'));


### PR DESCRIPTION
Overview
----------------------------------------
Improves efficiency by removing redundant caching and repeated calls to the same hook.

Before
----------------------------------------
Settings metadata was being cached once per domain and one extra time for good measure.
`hook_civicrm_alterSettingsMetaData()` was invoked even when fetching cached data, even though the hook-altered data was stored in the cache.

After
----------------------------------------
Settings metadata cached once per domain.
`hook_civicrm_alterSettingsMetaData()` is invoked only once per domain; as its results were being cached anyway I don't see the need to invoke it repeatedly.

Technical details
---------------------------------------
Instead of firing `hook_civicrm_alterSettingsMetaData()` once and then caching the results, the hook was fired once, cached, and then fired *again* every time metadata was loaded (potentially hundreds of times per request). In addition to being inefficient this could cause weird bugs since the data already altered by hook was then being passed into the hook to be altered again; depending on how the hook implementation was written this could give unexpected results.