### PR TITLE
[REF] Remove extraneous variable

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -138,19 +138,18 @@ WHERE  cacheKey     = %3 AND
   }
 
   /**
-   * Delete from the previous next cache table for a pair of ids.
+   * Delete pair from the previous next cache table to remove it from further merge consideration.
+   *
+   * The pair may have been flipped, so make sure we delete using both orders
    *
    * @param int $id1
    * @param int $id2
    * @param string $cacheKey
-   * @param bool $isViceVersa
-   * @param string $entityTable
    */
-  public static function deletePair($id1, $id2, $cacheKey = NULL, $isViceVersa = FALSE, $entityTable = 'civicrm_contact') {
-    $sql = "DELETE FROM civicrm_prevnext_cache WHERE  entity_table = %1";
-    $params = [1 => [$entityTable, 'String']];
+  public static function deletePair($id1, $id2, $cacheKey = NULL) {
+    $sql = "DELETE FROM civicrm_prevnext_cache WHERE  entity_table = 'civicrm_contact'";
 
-    $pair = !$isViceVersa ? "entity_id1 = %2 AND entity_id2 = %3" : "(entity_id1 = %2 AND entity_id2 = %3) OR (entity_id1 = %3 AND entity_id2 = %2)";
+    $pair = "(entity_id1 = %2 AND entity_id2 = %3) OR (entity_id1 = %3 AND entity_id2 = %2)";
     $sql .= " AND ( {$pair} )";
     $params[2] = [$id1, 'Integer'];
     $params[3] = [$id2, 'Integer'];

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2155,9 +2155,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       CRM_Core_BAO_PrevNextCache::markConflict($mainId, $otherId, $cacheKeyString, $conflicts);
     }
     else {
-      // delete entry from PrevNextCache table so we don't consider the pair next time
-      // pair may have been flipped, so make sure we delete using both orders
-      CRM_Core_BAO_PrevNextCache::deletePair($mainId, $otherId, $cacheKeyString, TRUE);
+      CRM_Core_BAO_PrevNextCache::deletePair($mainId, $otherId, $cacheKeyString);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup

Before
----------------------------------------
Code less readable

After
----------------------------------------
Code more readable

Technical Details
----------------------------------------
Delete Pair is only called from one place in the code & it does not pass the $entityTable
variable - so remove it & reduce complexity.

In addition the viceVersa variable is always true so we can remove this too.


Comments
----------------------------------------

