### PR TITLE
dev/core#964 Add start date and end date values on page contribution widget ajax response

### DIFF
--- a/CRM/Contribute/BAO/Widget.php
+++ b/CRM/Contribute/BAO/Widget.php
@@ -127,6 +127,7 @@ class CRM_Contribute_BAO_Widget extends CRM_Contribute_DAO_Widget {
         $now = time();
         if ($dao->start_date) {
           $startDate = CRM_Utils_Date::unixTime($dao->start_date);
+          $data['start_date'] = $dao->start_date;
           if ($startDate && $startDate >= $now) {
             $data['is_active'] = FALSE;
             $data['campaign_start'] = ts('Campaign starts on %1', [
@@ -137,6 +138,7 @@ class CRM_Contribute_BAO_Widget extends CRM_Contribute_DAO_Widget {
 
         if ($dao->end_date) {
           $endDate = CRM_Utils_Date::unixTime($dao->end_date);
+          $data['end_date'] = $dao->end_date;
           if ($endDate &&
             $endDate < $now
           ) {


### PR DESCRIPTION
Overview
----------------------------------------
Contribution page widgets calls civicrm/extern/widget.php to extract info of the campaign related to the widget. In some cases it maybe interesting to have the time to start or to finish the campaign to customize the widget with options such as "Starts in X days", "Ends in X days" or anything else.

in the line of https://issues.civicrm.org/jira/browse/CRM-21454

Before
----------------------------------------

After
----------------------------------------
Json response includes "start_date":YYYY-MM-DD hh:mm:ss,"time_to_end":YYYY-MM-DD hh:mm:ss if start date and end date are defined respectively.

Comments
----------------------------------------
An example of how to take advantage of these new fields:

```
var start_date = new Date(jsonvar.start_date.replace(/ /g,"T"));
var end_date = new Date(jsonvar.end_date.replace(/ /g,"T"));
var now = Date.now();

if ( start_date > now ) {
  var time_left = start_date - now;
  if ( time_left > 86400000 ) {
    document.getElementById('crm_cpid_'+cpid+'_status-item').innerHTML =
    "Starts in " + Math.ceil(time_left/86400000) + " days";
  }
  else {
    document.getElementById('crm_cpid_'+cpid+'_status-item').innerHTML =
    "Starts in " + Math.ceil(time_left3600000) + " hours";
  }
}
else if (end_date < now) {
  document.getElementById('crm_cpid_'+cpid+'_status-item').style.display = "none";
}
else {
  var time_left = end_date - now;
  if ( time_left > 86400000 ) {
    document.getElementById('crm_cpid_'+cpid+'_status-item').innerHTML =
    "Ends in " +Math.ceil(time_left/86400000) + " days";
  }
  else {
    document.getElementById('crm_cpid_'+cpid+'_status-item').innerHTML =
    "Ends in " +Math.ceil(time_left/3600000) + " hours";
  }
}

```

"start_date" and "end_date" values also allows customize predefined "campaign_start" messages ('Campaign starts on %1', 'Campaign ended on %1', etc.)