### PR TITLE
dev/core/966 skip urlencode for email in elavon xml

### DIFF
--- a/CRM/Core/Payment/Elavon.php
+++ b/CRM/Core/Payment/Elavon.php
@@ -343,7 +343,13 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
 
     $xml = '<txn>';
     foreach ($requestFields as $key => $value) {
-      $xml .= '<' . $key . '>' . self::tidyStringforXML($value, $xmlFieldLength[$key]) . '</' . $key . '>';
+      //dev/core/966 Don't send email through the urlencode.
+      if ($key == 'ssl_email') {
+        $xml .= '<' . $key . '>' . substr($value, 0, $xmlFieldLength[$key]) . '</' . $key . '>';
+      }
+      else {
+        $xml .= '<' . $key . '>' . self::tidyStringforXML($value, $xmlFieldLength[$key]) . '</' . $key . '>';
+      }
     }
     $xml .= '</txn>';
     return $xml;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/966

Report of failure to process any payment with Elavon processor.

Before
----------------------------------------
Every transaction sends email value in XML as urlencoded value. Elavon responds with `4005 E-mail Address Invalid The E-mail Address supplied in the authorization request appears to be invalid.` for every authorization request and transactions cannot be processed.

After
----------------------------------------
Transactions are processed as expected.

Technical Details
----------------------------------------
Email address is validated by default in the forms, so it seems like it should be ok to skip the XML string tidy function for email only as long as we still enforce the length.

Comments
----------------------------------------
Nothing has changed on our end in ages. Presumably they just stopped accepting this type of value? I'm not very familiar with this payment processor.
