### PR TITLE
[REF] Centralize logic for resolving settings pseudoconstants

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -66,8 +66,7 @@ trait CRM_Admin_Form_SettingTrait {
    */
   protected function getSettingsMetaData() {
     if (empty($this->settingsMetadata)) {
-      $allSettingMetaData = civicrm_api3('setting', 'getfields', []);
-      $this->settingsMetadata = array_intersect_key($allSettingMetaData['values'], $this->_settings);
+      $this->settingsMetadata = \Civi\Core\SettingsMetadata::getMetadata(['name' => array_keys($this->_settings)], NULL, TRUE);
       // This array_merge re-orders to the key order of $this->_settings.
       $this->settingsMetadata = array_merge($this->_settings, $this->settingsMetadata);
     }
@@ -174,10 +173,7 @@ trait CRM_Admin_Form_SettingTrait {
       $quickFormType = $this->getQuickFormType($props);
       if (isset($quickFormType)) {
         $options = CRM_Utils_Array::value('options', $props);
-        if (isset($props['pseudoconstant'])) {
-          $options = civicrm_api3('Setting', 'getoptions', [
-            'field' => $setting,
-          ])['values'];
+        if ($options) {
           if ($props['html_type'] === 'Select' && isset($props['is_required']) && $props['is_required'] === FALSE && !isset($options[''])) {
             // If the spec specifies the field is not required add a null option.
             // Why not if empty($props['is_required']) - basically this has been added to the spec & might not be set to TRUE

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -148,33 +148,14 @@ function _civicrm_api3_setting_getdefaults_spec(&$params) {
  * @throws \API_Exception
  */
 function civicrm_api3_setting_getoptions($params) {
-  $specs = CRM_Core_BAO_Setting::getSettingSpecification();
+  $domainId = CRM_Utils_Array::value('domain_id', $params);
+  $specs = \Civi\Core\SettingsMetadata::getMetadata(['name' => $params['field']], $domainId, TRUE);
 
-  if (empty($specs[$params['field']]) || empty($specs[$params['field']]['pseudoconstant'])) {
+  if (empty($specs[$params['field']]) || !is_array(CRM_Utils_Array::value('options', $specs[$params['field']]))) {
     throw new API_Exception("The field '" . $params['field'] . "' has no associated option list.");
   }
 
-  $pseudoconstant = $specs[$params['field']]['pseudoconstant'];
-
-  // It would be nice if we could leverage CRM_Core_PseudoConstant::get() somehow,
-  // but it's tightly coupled to DAO/field. However, if you really need to support
-  // more pseudoconstant types, then probably best to refactor it. For now, KISS.
-  if (!empty($pseudoconstant['callback'])) {
-    $values = Civi\Core\Resolver::singleton()->call($pseudoconstant['callback'], []);
-    return civicrm_api3_create_success($values, $params, 'Setting', 'getoptions');
-  }
-  elseif (!empty($pseudoconstant['optionGroupName'])) {
-    $keyColumn = 'value';
-    if (!empty($pseudoconstant['keyColumn'])) {
-      $keyColumn = $pseudoconstant['keyColumn'];
-    }
-    return civicrm_api3_create_success(
-      CRM_Core_OptionGroup::values($pseudoconstant['optionGroupName'], FALSE, FALSE, TRUE, NULL, 'label', TRUE, FALSE, $keyColumn),
-      $params, 'Setting', 'getoptions'
-    );
-  }
-
-  throw new API_Exception("The field '" . $params['field'] . "' uses an unsupported option list.");
+  return civicrm_api3_create_success($specs[$params['field']]['options'], $params, 'Setting', 'getoptions');
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Moves the pseudoconstant lookup for settings out of api3 and into the SettingsMetadata class.

Before
----------------------------------------
Code in an api3 silo.

After
----------------------------------------
Same code, better spot.

Notes
-------------
Also switches the settings form trait to use SettingsMetadata class instead of api3, and improves the filters on`getSettingsMetaData`.