### PR TITLE
NFC  - Changed release notes info about Jira to GitLab

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,11 +1,11 @@
 # Release Notes
 
-These release notes are manually compiled from pull requests and Jira issues
-starting with CiviCRM 4.7.14.
+These release notes are manually compiled from pull requests and CiviCRM GitLab issues
+starting after March 31 2018.
 
 Other resources for identifying changes are:
 
-* The Jira project management system at https://issues.civicrm.org
+* The CiviCRM GitLab project management system at https://lab.civicrm.org/groups/dev/-/issues
 * The following GitHub projects:
     * https://github.com/civicrm/civicrm-core
     * https://github.com/civicrm/civicrm-packages
@@ -13,6 +13,10 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-drupal
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
+    
+These release notes were manually compiled from pull requests and Jira issues
+starting with CiviCRM 4.7.14. Jira issue creation at https://issues.civicrm.org was 
+disabled on March 31 2018.
 
 ## CiviCRM 5.13.4
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,7 +15,6 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
     
-These release notes were manually compiled from pull requests and Jira issues
 starting with CiviCRM 4.7.14. Jira issue creation at https://issues.civicrm.org was 
 disabled on March 31 2018.
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -6,6 +6,7 @@ starting with CiviCRM 4.7.14.
 Other resources for identifying changes are:
 
 * The CiviCRM GitLab project management system at https://lab.civicrm.org/groups/dev/-/issues
+* The Jira project management system at https://issues.civicrm.org
 * The following GitHub projects:
     * https://github.com/civicrm/civicrm-core
     * https://github.com/civicrm/civicrm-packages

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,7 +15,6 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
     
-disabled on March 31 2018.
 
 ## CiviCRM 5.13.4
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-These release notes are manually compiled from pull requests, Jira and GitLab issues
+These release notes are manually compiled from pull requests, GitLab and Jira issues
 starting with CiviCRM 4.7.14.
 
 Other resources for identifying changes are:

--- a/release-notes.md
+++ b/release-notes.md
@@ -14,7 +14,6 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-drupal
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
-    
 
 ## CiviCRM 5.13.4
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,7 +15,6 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
     
-starting with CiviCRM 4.7.14. Jira issue creation at https://issues.civicrm.org was 
 disabled on March 31 2018.
 
 ## CiviCRM 5.13.4

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 These release notes are manually compiled from pull requests, Jira and GitLab issues
-starting after March 31 2018.
+starting with CiviCRM 4.7.14.
 
 Other resources for identifying changes are:
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-These release notes are manually compiled from pull requests and CiviCRM GitLab issues
+These release notes are manually compiled from pull requests, Jira and GitLab issues
 starting after March 31 2018.
 
 Other resources for identifying changes are:


### PR DESCRIPTION
I'd love some feedback on exactly which release the issues dropped Jira/started using GitLab, as I don't know that information.

Overview
----------------------------------------
_I removed the references to Jira from the release notes file, as Jira has been deprecated. I substituted with references to GitLab, but don't have the exactly release number that the switch occurred. If someone has those numbers/info, please feel free to edit this PR and add those release numbers._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_