### PR TITLE
dev/core#369 Prevent hard fail of API Job when SMS provider has been deleted

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -546,6 +546,12 @@ FROM civicrm_action_schedule cas
       return ["sms_phone_missing" => "Couldn't find recipient's phone number."];
     }
 
+    // dev/core#369 If an SMS provider is deleted then the relevant row in the action_schedule_table is set to NULL
+    // So we need to exclude them.
+    if (CRM_Utils_System::isNull($schedule->sms_provider_id)) {
+      return ["sms_provider_missing" => "SMS Provider is NULL in database cannot send reminder"];
+    }
+
     $messageSubject = $tokenRow->render('subject');
     $sms_body_text = $tokenRow->render('sms_body_text');
 

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -31,39 +31,6 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
-   * Setup or clean up SMS tests
-   * @param bool $teardown
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function setupForSmsTests($teardown = FALSE) {
-    require_once 'CiviTest/CiviTestSMSProvider.php';
-
-    // Option value params for CiviTestSMSProvider
-    $groupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'sms_provider_name', 'id', 'name');
-    $params = array(
-      'option_group_id' => $groupID,
-      'label' => 'unittestSMS',
-      'value' => 'unit.test.sms',
-      'name'  => 'CiviTestSMSProvider',
-      'is_default' => 1,
-      'is_active'  => 1,
-      'version'    => 3,
-    );
-
-    if ($teardown) {
-      // Test completed, delete provider
-      $providerOptionValueResult = civicrm_api3('option_value', 'get', $params);
-      civicrm_api3('option_value', 'delete', array('id' => $providerOptionValueResult['id']));
-      return;
-    }
-
-    // Create an SMS provider "CiviTestSMSProvider". Civi handles "CiviTestSMSProvider" as a special case and allows it to be instantiated
-    //  in CRM/Sms/Provider.php even though it is not an extension.
-    civicrm_api3('option_value', 'create', $params);
-  }
-
-  /**
    * Test case for create() method.
    */
   public function testCreate() {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3150,4 +3150,37 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     $dbLocale = '_en_US';
   }
 
+  /**
+   * Setup or clean up SMS tests
+   * @param bool $teardown
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function setupForSmsTests($teardown = FALSE) {
+    require_once 'CiviTest/CiviTestSMSProvider.php';
+
+    // Option value params for CiviTestSMSProvider
+    $groupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'sms_provider_name', 'id', 'name');
+    $params = array(
+      'option_group_id' => $groupID,
+      'label' => 'unittestSMS',
+      'value' => 'unit.test.sms',
+      'name'  => 'CiviTestSMSProvider',
+      'is_default' => 1,
+      'is_active'  => 1,
+      'version'    => 3,
+    );
+
+    if ($teardown) {
+      // Test completed, delete provider
+      $providerOptionValueResult = civicrm_api3('option_value', 'get', $params);
+      civicrm_api3('option_value', 'delete', array('id' => $providerOptionValueResult['id']));
+      return;
+    }
+
+    // Create an SMS provider "CiviTestSMSProvider". Civi handles "CiviTestSMSProvider" as a special case and allows it to be instantiated
+    //  in CRM/Sms/Provider.php even though it is not an extension.
+    return civicrm_api3('option_value', 'create', $params);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Currently if an SMS provider is deleted from the database the relevant row is set to NULL in the action_schedule table and then when the reminder is processed it can cause a hard fail because it gets caught in a ::fatal, This resolves it by doing an early exist and aiding in logging correct details in the reminder log

Before
----------------------------------------
Hard Fail and no tests on sending SMS reminders

After
----------------------------------------
No hard fail and tests on sending reminder smses

ping @eileenmcnaughton @mattwire 