### PR TITLE
dev/financial#54 Fix mishandling of deferred revenue settings

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -166,7 +166,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
 
     if (!$contributionID
       && CRM_Utils_Array::value('membership_id', $params)
-      && self::checkContributeSettings('deferred_revenue_enabled')
+      && Civi::settings()->get('deferred_revenue_enabled')
     ) {
       $memberStartDate = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $params['membership_id'], 'start_date');
       if ($memberStartDate) {
@@ -5562,7 +5562,7 @@ LIMIT 1;";
    * @return null
    */
   public static function recordAlwaysAccountsReceivable(&$trxnParams, $contributionParams) {
-    if (!self::checkContributeSettings('always_post_to_accounts_receivable')) {
+    if (!Civi::settings()->get('always_post_to_accounts_receivable')) {
       return NULL;
     }
     $statusId = $contributionParams['contribution']->contribution_status_id;

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -692,7 +692,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     // CRM-16189, add Revenue Recognition Date
-    if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
+    if (Civi::settings()->get('deferred_revenue_enabled')) {
       $revenueDate = $this->add('date', 'revenue_recognition_date', ts('Revenue Recognition Date'), CRM_Core_SelectValues::date(NULL, 'M Y', NULL, 5));
       if ($this->_id && !CRM_Contribute_BAO_Contribution::allowUpdateRevenueRecognitionDate($this->_id)) {
         $revenueDate->freeze();

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -374,7 +374,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
     $this->addElement('submit', $this->getButtonName('submit'), ts('Add Discount Set to Fee Table'),
       ['class' => 'crm-form-submit cancel']
     );
-    if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
+    if (Civi::settings()->get('deferred_revenue_enabled')) {
       $deferredFinancialType = CRM_Financial_BAO_FinancialAccount::getDeferredFinancialType();
       $this->assign('deferredFinancialType', array_keys($deferredFinancialType));
     }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1002,7 +1002,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $contributionParams = ['skipCleanMoney' => TRUE];
       $lineItem = [];
       $additionalParticipantDetails = [];
-      if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
+      if (Civi::settings()->get('deferred_revenue_enabled')) {
         $eventStartDate = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_eventId, 'start_date');
         if (strtotime($eventStartDate) > strtotime(date('Ymt'))) {
           $contributionParams['revenue_recognition_date'] = date('Ymd', strtotime($eventStartDate));

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1052,7 +1052,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       );
     }
 
-    if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
+    if (Civi::settings()->get('deferred_revenue_enabled')) {
       $eventStartDate = CRM_Utils_Array::value(
         'start_date',
         CRM_Utils_Array::value(

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -379,7 +379,7 @@ LIMIT 1";
    *
    */
   public static function checkFinancialTypeHasDeferred($params, $contributionID = NULL, $priceSetFields = NULL) {
-    if (!CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
+    if (!Civi::settings()->get('deferred_revenue_enabled')) {
       return FALSE;
     }
     $recognitionDate = CRM_Utils_Array::value('revenue_recognition_date', $params);

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -312,7 +312,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
 
     $this->assign('membershipTypeId', $this->_id);
 
-    if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
+    if (Civi::settings()->get('deferred_revenue_enabled')) {
       $deferredFinancialType = CRM_Financial_BAO_FinancialAccount::getDeferredFinancialType();
       $this->assign('deferredFinancialType', array_keys($deferredFinancialType));
     }

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -197,6 +197,29 @@ class CRM_Upgrade_Incremental_Base {
   }
 
   /**
+   * Re-save any valid values from contribute settings into the normal setting
+   * format.
+   *
+   * We render the array of contribution_invoice_settings and any that have
+   * metadata defined we add to the correct key. This is safe to run even if no
+   * settings are to be converted, per the test in
+   * testConvertUpgradeContributeSettings.
+   *
+   * @param $ctx
+   *
+   * @return bool
+   */
+  public static function updateContributeSettings($ctx) {
+    $settings = Civi::settings()->get('contribution_invoice_settings');
+    $metadata = \Civi\Core\SettingsMetadata::getMetadata();
+    $conversions = array_intersect_key((array) $settings, $metadata);
+    foreach ($conversions as $key => $conversion) {
+      Civi::settings()->set($key, $conversion);
+    }
+    return TRUE;
+  }
+
+  /**
    * Do any relevant smart group updates.
    *
    * @param CRM_Queue_TaskContext $ctx

--- a/CRM/Upgrade/Incremental/php/FiveFifteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveFifteen.php
@@ -67,21 +67,14 @@ class CRM_Upgrade_Incremental_php_FiveFifteen extends CRM_Upgrade_Incremental_Ba
    * (change the x in the function name):
    */
 
-  //  /**
-  //   * Upgrade function.
-  //   *
-  //   * @param string $rev
-  //   */
-  //  public function upgrade_5_0_x($rev) {
-  //    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
-  //    $this->addTask('Do the foo change', 'taskFoo', ...);
-  //    // Additional tasks here...
-  //    // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
-  //    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
-  //  }
-
-  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
-  //   return TRUE;
-  // }
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_15_alpha1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Fix errant deferred revenue settings', 'updateContributeSettings');
+  }
 
 }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1003,7 +1003,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
    * Test checkContributeSettings.
    */
   public function testCheckContributeSettings() {
-    $settings = CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled');
+    $settings = Civi::settings()->get('deferred_revenue_enabled');
     $this->assertNull($settings);
     $params = array(
       'contribution_invoice_settings' => array(
@@ -1011,7 +1011,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       ),
     );
     $this->callAPISuccess('Setting', 'create', $params);
-    $settings = CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled');
+    $settings = Civi::settings()->get('deferred_revenue_enabled');
     $this->assertEquals($settings, 1, 'Check for settings has failed');
   }
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1000,22 +1000,6 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
   }
 
   /**
-   * Test checkContributeSettings.
-   */
-  public function testCheckContributeSettings() {
-    $settings = Civi::settings()->get('deferred_revenue_enabled');
-    $this->assertNull($settings);
-    $params = array(
-      'contribution_invoice_settings' => array(
-        'deferred_revenue_enabled' => '1',
-      ),
-    );
-    $this->callAPISuccess('Setting', 'create', $params);
-    $settings = Civi::settings()->get('deferred_revenue_enabled');
-    $this->assertEquals($settings, 1, 'Check for settings has failed');
-  }
-
-  /**
    * Test allowUpdateRevenueRecognitionDate.
    */
   public function testAllowUpdateRevenueRecognitionDate() {

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -275,8 +275,8 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
    * Test for validating financial type has deferred revenue account relationship.
    */
   public function testcheckFinancialTypeHasDeferred() {
-    Civi::settings()->set('contribution_invoice_settings', array('deferred_revenue_enabled' => '1'));
-    $params = array();
+    Civi::settings()->set('deferred_revenue_enabled', 1);
+    $params = [];
     $valid = CRM_Financial_BAO_FinancialAccount::checkFinancialTypeHasDeferred($params);
     $this->assertFalse($valid, "This should have been false");
     $cid = $this->individualCreate();

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -151,6 +151,8 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
 
   /**
    * Test renaming multiple fields.
+   *
+   * @throws Exception
    */
   public function testRenameFields() {
     $this->callAPISuccess('SavedSearch', 'create', [
@@ -167,6 +169,17 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
     $this->assertEquals('activity_date_time_low', $savedSearch['form_values'][0][0]);
     $this->assertEquals('activity_date_time_relative', $savedSearch['form_values'][1][0]);
+  }
+
+  /**
+   * Test that a mis-saved variable in 'contribute settings' can be converted to a
+   * 'proper' setting.
+   */
+  public function testConvertUpgradeContributeSettings() {
+    Civi::settings()->set('contribution_invoice_settings', ['foo' => 'bar', 'deferred_revenue_enabled' => 1]);
+    $this->assertEquals(0, Civi::settings()->get('deferred_revenue_enabled'));
+    CRM_Upgrade_Incremental_Base::updateContributeSettings(NULL, 5.1);
+    $this->assertEquals(1, Civi::settings()->get('deferred_revenue_enabled'));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
When invoicing was added to core the invoicing settings were added as an array rather than individual settings. This is against our standard but it was a long time ago & our review processes were poor then. However, it has had ongoing repercussions. This addresses one of them and also adds a process for converting them. We need this because switching to correctly referencing the deferred revenue settings might otherwise miss some where people have added the settings to follow the wrong format

Before
----------------------------------------
Saving the 2 settings
Always post to Accounts Receivable?
Enable Deferred Revenue?
Through the contribution settings form does not result in them being respected

After
----------------------------------------
The settings are respected

Technical Details
----------------------------------------
We should follow this up by changing the remaining settings in this array to being meta-data defined & then call the convert function

Comments
----------------------------------------
@mattwire @monishdeb @JoeMurray 

https://lab.civicrm.org/dev/financial/issues/54#