### PR TITLE
[ref] Remove reference symbol from 2 variables

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1736,7 +1736,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    * @return array
    *   Contact details
    */
-  public static function getHierContactDetails($contactId, &$fields) {
+  public static function getHierContactDetails($contactId, $fields) {
     $params = array(array('contact_id', '=', $contactId, 0, 0));
     $options = array();
 
@@ -2073,7 +2073,7 @@ ORDER BY civicrm_email.is_primary DESC";
    */
   public static function formatProfileContactParams(
     &$params,
-    &$fields,
+    $fields,
     $contactID = NULL,
     $ufGroupId = NULL,
     $ctype = NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Minor readability fix

Before
----------------------------------------
Variables passed by reference

After
----------------------------------------
Variables not passed by reference

Technical Details
----------------------------------------
I checked & these are not altered in the function - so passing by reference only adds confusion

Comments
----------------------------------------

