### PR TITLE
 Filter out from create and APIv3 get results protected fields as defined in the schema

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -129,8 +129,6 @@ function civicrm_api3_contact_create($params) {
     _civicrm_api3_object_to_array_unique_fields($contact, $values[$contact->id]);
   }
 
-  $values = _civicrm_api3_contact_formatResult($params, $values);
-
   return civicrm_api3_create_success($values, $params, 'Contact', 'create');
 }
 
@@ -179,10 +177,7 @@ function _civicrm_api3_contact_create_spec(&$params) {
  *   API Result Array
  */
 function civicrm_api3_contact_get($params) {
-  $options = [];
-  _civicrm_api3_contact_get_supportanomalies($params, $options);
-  $contacts = _civicrm_api3_get_using_query_object('Contact', $params, $options);
-  $contacts = _civicrm_api3_contact_formatResult($params, $contacts);
+  $contacts = CRM_Contact_BAO_Contact::apiGet($params);
   return civicrm_api3_create_success($contacts, $params, 'Contact');
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Title says it all this is the doing part of #14274 

Before
----------------------------------------
only api_key filtered at the API level not at BAO level

After
----------------------------------------
api_key and any other future contact fields that are deemed protected are then filtered at the BAO create level and same for get API 

ping @eileenmcnaughton @colemanw @totten 