### PR TITLE
dev/core#980 [test-dbunit] Test cleanup to remove references to discontinued package dbunit

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -367,14 +367,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
 
     $this->getConnection()->getConnection()->query("SET FOREIGN_KEY_CHECKS = 0;");
 
-    $xmlFiles = glob($fixturesDir . '/*.xml');
-    foreach ($xmlFiles as $xmlFixture) {
-      $op = new PHPUnit_Extensions_Database_Operation_Insert();
-      $dataset = $this->createXMLDataSet($xmlFixture);
-      $this->_tablesToTruncate = array_merge($this->_tablesToTruncate, $dataset->getTableNames());
-      $op->execute($this->_dbconn, $dataset);
-    }
-
     $yamlFiles = glob($fixturesDir . '/*.yaml');
     foreach ($yamlFiles as $yamlFixture) {
       $op = new PHPUnit_Extensions_Database_Operation_Insert();

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2612,19 +2612,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
-   * Set up helper to create a contact.
-   */
-  public function createContactFromXML() {
-    // Insert a row in civicrm_contact creating contact 17.
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    $op->execute($this->_dbconn,
-      $this->createXMLDataSet(
-        dirname(__FILE__) . '/dataset/contact_17.xml'
-      )
-    );
-  }
-
-  /**
    * Test contact proximity api.
    */
   public function testContactProximity() {

--- a/tests/phpunit/api/v3/MailingContactTest.php
+++ b/tests/phpunit/api/v3/MailingContactTest.php
@@ -134,24 +134,12 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
    * Test that the API returns a mailing properly when there is only one.
    */
   public function testMailingContactDelivered() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    //Create the User
-    $op->execute($this->_dbconn,
-      $this->createXMLDataSet(
-        dirname(__FILE__) . '/dataset/mailing_contact.xml'
-      )
-    );
-    // Create the Mailing and connections to the user.
-    $op->execute($this->_dbconn,
-      $this->createXMLDataSet(
-        dirname(__FILE__) . '/dataset/mailing_delivered.xml'
-      )
-    );
+    $contactID = $this->individualCreate(['first_name' => 'Test']);
 
-    $params = array(
-      'contact_id' => 23,
+    $params = [
+      'contact_id' => $contactID,
       'type' => 'Delivered',
-    );
+    ];
 
     $result = $this->callAPISuccess('MailingContact', 'get', $params);
     $count = $this->callAPISuccess('MailingContact', 'getcount', $params);

--- a/tests/phpunit/api/v3/MailingContactTest.php
+++ b/tests/phpunit/api/v3/MailingContactTest.php
@@ -40,21 +40,20 @@
  * @group headless
  */
 class api_v3_MailingContactTest extends CiviUnitTestCase {
-  protected $_apiversion = 3;
   protected $_entity = 'mailing';
 
   public function setUp() {
     parent::setUp();
-    $params = array(
+    $params = [
       'first_name' => 'abc1',
       'contact_type' => 'Individual',
       'last_name' => 'xyz1',
-    );
+    ];
     $this->_contact = $this->callAPISuccess("contact", "create", $params);
   }
 
   public function tearDown() {
-    $this->callAPISuccess("contact", "delete", array('id' => $this->_contact['id']));
+    $this->callAPISuccess("contact", "delete", ['id' => $this->_contact['id']]);
     parent::tearDown();
   }
 
@@ -88,10 +87,7 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
    * belongs in the SyntaxConformance class
    */
   public function testMailingNoContactID() {
-    $params = array(
-      'something' => 'This is not a real field',
-    );
-    $this->callAPIFailure('MailingContact', 'get', $params);
+    $this->callAPIFailure('MailingContact', 'get', ['something' => 'This is not a real field']);
   }
 
   /**
@@ -103,8 +99,7 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
    * belongs in the SyntaxConformance class
    */
   public function testMailingContactInvalidContactID() {
-    $params = array('contact_id' => 'This is not a number');
-    $this->callAPIFailure('MailingContact', 'get', $params);
+    $this->callAPIFailure('MailingContact', 'get', ['contact_id' => 'This is not a number']);
   }
 
   /**
@@ -134,7 +129,8 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
    * Test that the API returns a mailing properly when there is only one.
    */
   public function testMailingContactDelivered() {
-    $contactID = $this->individualCreate(['first_name' => 'Test']);
+    list($contactID, $mailingID, $eventQueueID) = $this->setupEventQueue();
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_mailing_event_delivered (event_queue_id) VALUES(%1)", [1 => [$eventQueueID, 'Integer']]);
 
     $params = [
       'contact_id' => $contactID,
@@ -148,40 +144,54 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
     $this->assertFalse(empty($result['values']));
     $this->assertEquals($result['values'][1]['mailing_id'], 1);
     $this->assertEquals($result['values'][1]['subject'], "Some Subject");
-    $this->assertEquals($result['values'][1]['creator_id'], 3);
-    $this->assertEquals($result['values'][1]['creator_name'], "xyz1, abc1");
+    $this->assertEquals(CRM_Core_Session::getLoggedInContactID(), $result['values'][1]['creator_id']);
   }
 
   /**
-   * Test that the API returns only the "Bounced" mailings when instructed to do so.
+   * Test that the API returns only the "Bounced" mailings when instructed to
+   * do so.
+   *
+   * @throws \Exception
    */
   public function testMailingContactBounced() {
-    $op = new PHPUnit_Extensions_Database_Operation_Insert();
-    // Create the User.
-    $op->execute($this->_dbconn,
-      $this->createXMLDataSet(
-        dirname(__FILE__) . '/dataset/mailing_contact.xml'
-      )
-    );
-    // Create the Mailing and connections to the user.
-    $op->execute($this->_dbconn,
-      $this->createXMLDataSet(
-        dirname(__FILE__) . '/dataset/mailing_bounced.xml'
-      )
-    );
+    list($contactID, $mailingID, $eventQueueID) = $this->setupEventQueue();
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_mailing_event_bounce (event_queue_id, bounce_type_id) VALUES(%1, 6)", [1 => [$eventQueueID, 'Integer']]);
 
-    $params = array(
-      'contact_id' => 23,
+    $params = [
+      'contact_id' => $contactID,
       'type' => 'Bounced',
-    );
+    ];
 
-    $result = $this->callAPISuccess('MailingContact', 'get', $params);
-    $this->assertEquals($result['count'], 1);
-    $this->assertFalse(empty($result['values']));
-    $this->assertEquals($result['values'][2]['mailing_id'], 2);
-    $this->assertEquals($result['values'][2]['subject'], "Some Subject");
-    $this->assertEquals($result['values'][2]['creator_id'], 3);
-    $this->assertEquals($result['values'][2]['creator_name'], "xyz1, abc1");
+    $result = $this->callAPISuccess('MailingContact', 'get', $params)['values'];
+    $this->assertEquals(1, count($result));
+    $this->assertEquals($mailingID, $result[$mailingID]['mailing_id']);
+    $this->assertEquals('Some Subject', $result[$mailingID]['subject']);
+    $this->assertEquals(CRM_Core_Session::getLoggedInContactID(), $result[$mailingID]['creator_id'], 3);
+  }
+
+  /**
+   * @return array
+   * @throws \Exception
+   */
+  public function setupEventQueue() {
+    $contactID = $this->individualCreate(['first_name' => 'Test']);
+    $emailID = $this->callAPISuccessGetValue('Email', [
+      'return' => 'id',
+      'contact_id' => $contactID,
+    ]);
+    $this->createLoggedInUser();
+    $mailingID = $this->callAPISuccess('Mailing', 'create', [
+      'name' => 'Test Mailing',
+      'subject' => 'Some Subject',
+    ])['id'];
+    $mailingJobID = $this->callAPISuccess('MailingJob', 'create', ['mailing_id' => $mailingID])['id'];
+    $eventQueueID = $this->callAPISuccess('MailingEventQueue', 'create', [
+      'contact_id' => $contactID,
+      'mailing_id' => $mailingID,
+      'email_id' => $emailID,
+      'job_id' => $mailingJobID,
+    ])['id'];
+    return [$contactID, $mailingID, $eventQueueID];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/14268 dbunit is discontinued. This helps remove a dependency on it

Before
----------------------------------------
Tests use dbunit functions for data set up

After
----------------------------------------
Tests use civi functions

Technical Details
----------------------------------------


Comments
----------------------------------------

