### PR TITLE
Remove htmlpurifier from composer and move it back to within IDS to f…

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -190,7 +190,7 @@ class CRM_Core_ClassLoader {
     // we do this to prevent a autoloader errors with joomla / 3rd party packages
     // Use absolute path, since we don't know the content of include_path yet.
     // CRM-11304
-    $file = dirname(__FILE__) . '/../../vendor/ezyang/htmlpurifier/library/HTMLPurifier/Bootstrap.php';
+    $file = dirname(__FILE__) . '/../../packages/IDS/vendors/htmlpurifer/HTMLPurifier/Bootstrap.php';
     if (file_exists($file)) {
       return $file;
     }

--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -126,7 +126,7 @@ class CRM_Core_IDS {
         'filter_type' => 'xml',
         'filter_path' => "{$civicrm_root}/packages/IDS/default_filter.xml",
         'tmp_path' => $tmpDir,
-        'HTML_Purifier_Path' => $civicrm_root . '/vendor/ezyang/htmlpurifier/library/HTMLPurifier.auto.php',
+        'HTML_Purifier_Path' => $civicrm_root . 'packages/IDS/vendors/htmlpurifer/HTMLPurifier.auto.php',
         'HTML_Purifier_Cache' => $tmpDir,
         'scan_keys' => '',
         'exceptions' => ['__utmz', '__utmc'],

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,6 @@
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.1",
-    "ezyang/htmlpurifier": "4.10",
     "katzien/php-mime-type": "2.1.0"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a06373b9174ae3aa2bfb820e2e5a35e",
+    "content-hash": "a786aecfcc51b68f1ebafb0f43f99d08",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -225,53 +225,6 @@
             "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
             "homepage": "http://code.google.com/p/phpquery/",
             "time": "2013-03-21T12:39:33+00:00"
-        },
-        {
-            "name": "ezyang/htmlpurifier",
-            "version": "v4.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "d85d39da4576a6934b72480be6978fb10c860021"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/d85d39da4576a6934b72480be6978fb10c860021",
-                "reference": "d85d39da4576a6934b72480be6978fb10c860021",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "simpletest/simpletest": "^1.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "HTMLPurifier": "library/"
-                },
-                "files": [
-                    "library/HTMLPurifier.composer.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL"
-            ],
-            "authors": [
-                {
-                    "name": "Edward Z. Yang",
-                    "email": "admin@htmlpurifier.org",
-                    "homepage": "http://ezyang.com"
-                }
-            ],
-            "description": "Standards compliant HTML filter written in PHP",
-            "homepage": "http://htmlpurifier.org/",
-            "keywords": [
-                "html"
-            ],
-            "time": "2018-02-23T01:58:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
…ix breakage on drupal with the htmlpurifier module

Overview
----------------------------------------
This removes the htmlpurifier from composer as classes were being autoloaded by it and the Drupal Libraries module when the htmlpurifier module was being used. This depends on https://github.com/civicrm/civicrm-packages/pull/249

Before
----------------------------------------
WSOD on drupal installs on CiviCRM bootstrapped pages with the htmlpurifier module installed

After
----------------------------------------
no WSOD

ping @eileenmcnaughton @mfb @totten @jusfreeman 