### PR TITLE
dev/core#975 Fix url for new activity in breadcrumbs

### DIFF
--- a/CRM/Core/xml/Menu/Activity.xml
+++ b/CRM/Core/xml/Menu/Activity.xml
@@ -7,7 +7,7 @@
      <page_callback>CRM_Activity_Form_Activity</page_callback>
      <access_arguments>access CiviCRM</access_arguments>
      <page_arguments>attachUpload=1</page_arguments>
-     <path_arguments>action=add,context=standalone</path_arguments>
+     <path_arguments>action=add&amp;context=standalone</path_arguments>
   </item>
   <item>
      <path>civicrm/activity/view</path>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug in the URL of the new activity link in breadcrumbs, the issue was that an & was replaced with a ,

Before
----------------------------------------
Faulty URL generated

After
----------------------------------------
Proper URL generated

ping @jusfreeman @eileenmcnaughton 

https://lab.civicrm.org/dev/core/issues/975