### PR TITLE
dev/drupal#21 Drupal8: fix url() *path* handling

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -303,7 +303,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     // dev/drupal#21 Drupal8 does not like this path, so it would output '/*path*'
     // instead of the expected '/en/*path*' when using multilingual.
     if ($path == '*path*') {
-      $path = 'civicrm/*path*';
+      $path = 'civicrm/12345789';
     }
 
     $config = CRM_Core_Config::singleton();
@@ -325,13 +325,13 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     // Special case: CiviCRM passes us "*path*?*query*" as a skeleton, but asterisks
     // are invalid and Drupal will attempt to escape them. We unescape them here:
-    if ($path == 'civicrm/*path*') {
+    if ($path == 'civicrm/12345789') {
       // First remove trailing equals sign that has been added since the key '?*query*' has no value.
       $url = rtrim($url, '=');
       $url = urldecode($url);
 
       // Remove the civicrm prefix that we added earlier in this function
-      $url = str_replace('civicrm/*path*', '*path*', $url);
+      $url = str_replace('civicrm/123456789', '*path*', $url);
     }
 
     return $url;

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -300,6 +300,12 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   ) {
     $query = html_entity_decode($query);
 
+    // dev/drupal#21 Drupal8 does not like this path, so it would output '/*path*'
+    // instead of the expected '/en/*path*' when using multilingual.
+    if ($path == '*path*') {
+      $path = 'civicrm/*path*';
+    }
+
     $config = CRM_Core_Config::singleton();
     $base = $absolute ? $config->userFrameworkBaseURL : 'internal:/';
 
@@ -319,10 +325,13 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     // Special case: CiviCRM passes us "*path*?*query*" as a skeleton, but asterisks
     // are invalid and Drupal will attempt to escape them. We unescape them here:
-    if ($path == '*path*') {
+    if ($path == 'civicrm/*path*') {
       // First remove trailing equals sign that has been added since the key '?*query*' has no value.
       $url = rtrim($url, '=');
       $url = urldecode($url);
+
+      // Remove the civicrm prefix that we added earlier in this function
+      $url = str_replace('civicrm/*path*', '*path*', $url);
     }
 
     return $url;


### PR DESCRIPTION
Overview
----------------------------------------

This fixes issues with the new KAM menu when used on multilingual CiviCRM sites running Drupal8.

`CRM.url()` would generate URLs that omit the language prefix, so the menu would always be displayed in the default site language.

Before
----------------------------------------

No language prefix URL:

```
CRM.url('civicrm');
/civicrm
```

After
----------------------------------------

Language prefix is included:

```
CRM.url('civicrm');
/en/civicrm
```

Technical Details
----------------------------------------

d8 does not like `*path*`, so it would generate an empty url.

Comments
----------------------------------------

More details in https://lab.civicrm.org/dev/drupal/issues/21#note_17893