### PR TITLE
Generate D8/Backdrop CMS permission URLs

### DIFF
--- a/CRM/Admin/Page/Access.php
+++ b/CRM/Admin/Page/Access.php
@@ -45,6 +45,14 @@ class CRM_Admin_Page_Access extends CRM_Core_Page {
     $config = CRM_Core_Config::singleton();
 
     switch ($config->userFramework) {
+      case 'Drupal8':
+        $this->assign('ufAccessURL', \Drupal\Core\Url::fromUri('internal:/admin/people/permissions')->toString());
+        break;
+
+      case 'Backdrop':
+        $this->assign('ufAccessURL', url('admin/config/people/permissions'));
+        break;
+
       case 'Drupal':
         $this->assign('ufAccessURL', url('admin/people/permissions'));
         break;


### PR DESCRIPTION
Overview
----------------------------------------
When on the "ACL" main page, there's a link to the CMS permission page.  It doesn't currently support Backdrop/D8.

Before
----------------------------------------
Generated link just reloads the same page.

After
----------------------------------------
Brings you to the CMS permission page.

Comments
----------------------------------------
I'm not sure why we're using the Drupal-specific URL functions.  Can't we just pass the string and just have it be a relative URL?