### PR TITLE
[REF] Simplify ACL page template

### DIFF
--- a/templates/CRM/Admin/Page/Access.tpl
+++ b/templates/CRM/Admin/Page/Access.tpl
@@ -28,28 +28,14 @@
     <p>{ts 1=$docLink}ACLs (Access Control Lists) allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of Data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}
     {if $config->userSystem->is_drupal EQ '1'}{ts}Note that a CiviCRM ACL Role is not related to the Drupal Role.{/ts}{/if}</p>
     <p>{ts}<strong>EXAMPLE:</strong> 'Team Leaders' (<em>ACL Role</em>) can 'Edit' (<em>Operation</em>) all contacts in the 'Active Volunteers Group' (<em>Data</em>).{/ts}</p>
-    {if $config->userSystem->is_drupal EQ '1'}
-        <p>{ts 1=$ufAccessURL}Use <a href='%1'>Drupal Access Control</a> to manage basic access to CiviCRM components and menu items. Use CiviCRM ACLs to control access to specific CiviCRM contact groups. You can also configure ACLs to grant or deny access to specific Events Profiles, and/or Custom Data Fields.{/ts}</p>
-    {elseif $config->userFramework EQ 'Joomla'}
-        <p>{ts 1=$ufAccessURL 2=$jAccessParams}Use <a href='%1' %2>Joomla Access Control</a> to manage basic access to CiviCRM components and menu items. Use CiviCRM ACLs to control access to specific CiviCRM contact groups. You can also configure ACLs to grant or deny access to specific Events, Profiles, and/or Custom Data Fields.{/ts}</p>
-   {elseif $config->userFramework EQ 'WordPress'}
-        <p>{ts 1=$ufAccessURL}Use <a href='%1'>WordPress Access Control</a> to manage basic access to CiviCRM components and menu items. Use CiviCRM ACLs to control access to specific CiviCRM contact groups. You can also configure ACLs to grant or deny access to specific Events, Profiles, and/or Custom Data Fields.{/ts}</p>
-   {/if}
+    <p>{ts 1=$ufAccessURL 2=$jAccessParams 3=$config->userFramework}Use <a href='%1' %2>%3 Access Control</a> to manage basic access to CiviCRM components and menu items. Use CiviCRM ACLs to control access to specific CiviCRM contact groups. You can also configure ACLs to grant or deny access to specific Events, Profiles, and/or Custom Data Fields.{/ts}</p>
    <p>{ts 1=$config->userFramework}Note that %1 Access Control permissions take precedence over CiviCRM ACLs. If you wish to use CiviCRM ACLs, first disable the related permission in %1 Access control for a user role, and then gradually add ACLs to replace that permission for certain groups of contacts.{/ts}
 </div>
 
     <table class="report">
         <tr>
-    {if $config->userSystem->is_drupal EQ '1'}
-            <td class="nowrap"><a href="{$ufAccessURL}" id="adminAccess">&raquo; {ts}Drupal Access Control{/ts}</a></td>
+            <td class="nowrap"><a href="{$ufAccessURL}" {$jAccessParams} id="adminAccess">&raquo; {ts 1=$config->userFramework}%1 Access Control{/ts}</a></td>
             <td>{ts}Grant access to CiviCRM components and other CiviCRM permissions.{/ts}</td>
-    {elseif $config->userFramework EQ 'Joomla'}
-            <td class="nowrap"><a href="{$ufAccessURL}" {$jAccessParams} id="adminAccess">&raquo; {ts}Joomla Access Control{/ts}</a></td>
-            <td>{ts}Grant access to CiviCRM components and other CiviCRM permissions.{/ts}</td>
-    {elseif $config->userFramework EQ 'WordPress'}
-            <td class="nowrap"><a href="{$ufAccessURL}" id="adminAccess">&raquo; {ts}WordPress Access Control{/ts}</a></td>
-            <td>{ts}Grant access to CiviCRM components and other CiviCRM permissions.{/ts}</td>
-    {/if}
         </tr>
         <tr><td colspan="2" class="separator"><strong>{ts}Use following steps if you need to control View and/or Edit permissions for specific contact groups, specific profiles or specific custom data fields.{/ts}</strong></td></tr>
     <tr>


### PR DESCRIPTION
Overview
----------------------------------------
I noticed that the ACL page template says "Drupal Access Control" on Backdrop.  When I went to look at it, I realized that there was no need for the complex conditionals at all.

Before
----------------------------------------
ACL page works except with a bad label on Backdrop.

After
----------------------------------------
ACL page still works, Backdrop label is accurate, file has 25% fewer lines and no conditionals.