### PR TITLE
Fix deprecation notice on manage events page

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -330,6 +330,8 @@ WHERE  ( civicrm_event.is_template IS NULL OR civicrm_event.is_template = 0 )";
    *
    * @return array
    *   Array of event summary values
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getEventSummary() {
     $eventSummary = $eventIds = [];
@@ -338,7 +340,7 @@ WHERE  ( civicrm_event.is_template IS NULL OR civicrm_event.is_template = 0 )";
     // get permission and include them here
     // does not scale, but rearranging code for now
     // FIXME in a future release
-    $permissions = CRM_Event_BAO_Event::checkPermission();
+    $permissions = self::getAllPermissions();
     $validEventIDs = '';
     if (empty($permissions[CRM_Core_Permission::VIEW])) {
       $eventSummary['total_events'] = 0;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a deprecation notice

Before
----------------------------------------
<img width="936" alt="Screen Shot 2019-05-22 at 10 02 42 AM" src="https://user-images.githubusercontent.com/336308/58135197-ac00ca80-7c7d-11e9-8f0b-fca7002014be.png">


After
----------------------------------------
<img width="907" alt="Screen Shot 2019-05-22 at 10 38 20 AM" src="https://user-images.githubusercontent.com/336308/58135217-be7b0400-7c7d-11e9-8234-af334f8222b4.png">


Technical Details
----------------------------------------
This function is called internally in this code case anyway - see
```
    if (empty($eventId)) {
      CRM_Core_Error::deprecatedFunctionWarning('CRM_Event_BAO_Event::getAllPermissions');
      return self::getAllPermissions();
    }
```

Comments
----------------------------------------
