### PR TITLE
financial#55: support IPN logging on processors that send JSON data as POST

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -261,7 +261,14 @@ abstract class CRM_Core_Payment {
     }
 
     $log = new CRM_Utils_SystemLogger();
-    $log->alert($message, $_REQUEST);
+    // $_REQUEST doesn't handle JSON, to support providers that POST JSON we need the raw POST data.
+    $rawRequestData = file_get_contents("php://input");
+    if (CRM_Utils_JSON::isValidJSON($rawRequestData)) {
+      $log->alert($message, json_decode($rawRequestData, TRUE));
+    }
+    else {
+      $log->alert($message, $_REQUEST);
+    }
   }
 
   /**

--- a/CRM/Utils/JSON.php
+++ b/CRM/Utils/JSON.php
@@ -47,6 +47,16 @@ class CRM_Utils_JSON {
   }
 
   /**
+   * Test whether the input string is valid JSON.
+   * @param string $str
+   * @return boolean
+   */
+  public static function isValidJSON($str) {
+    json_decode($str);
+    return json_last_error() == JSON_ERROR_NONE;
+  }
+
+  /**
    * Do not use this function. See CRM-16353.
    * @deprecated
    *


### PR DESCRIPTION
Overview
----------------------------------------
Payment processors whose IPNs send JSON data, notably Stripe, aren't logged properly to `civicrm_system_log`.

Before
----------------------------------------
Stripe doesn't log to `civicrm_system_log`.

After
----------------------------------------
Stripe logs to `civicrm_system_log`.

Technical Details
----------------------------------------
Currently, `CRM_Core_Payment::logPaymentNotification()`, the method which logs to `civicrm_system_log` uses `$_REQUEST` to grab the POST data.  However, `$_REQUEST` doesn't handle raw POST data, it assumes it's form-encoded.  This patch handles JSON-encrypted POST requests, notably Stripe, so they can be stored in `civicrm_system_log`.

Comments
----------------------------------------
The default (lazy) config of Stripe is to send ALL events to the Civi IPN endpoint.  This will generate about 10 log records per contribution!  After some discussion, we agreed it was best to log what's sent instead of trying to filter for what "should" be sent.
