### PR TITLE
 Reduce cache bypasses - do not bypass custom metadata cache in setGroupTree

### DIFF
--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -188,15 +188,18 @@ class CRM_Custom_Form_CustomData {
   }
 
   /**
-   * @param $form
-   * @param $subType
-   * @param $gid
-   * @param $onlySubType
-   * @param $getCachedTree
+   * Add the group data as a formatted array to the form.
+   *
+   * @param CRM_Core_Form $form
+   * @param string $subType
+   * @param integer $gid
+   * @param bool $onlySubType
+   * @param bool $getCachedTree
    *
    * @return array
+   * @throws \CRM_Core_Exception
    */
-  public static function setGroupTree(&$form, $subType, $gid, $onlySubType = NULL, $getCachedTree = FALSE) {
+  public static function setGroupTree(&$form, $subType, $gid, $onlySubType = NULL, $getCachedTree = TRUE) {
     $singleRecord = NULL;
     if (!empty($form->_groupCount) && !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
       $singleRecord = $form->_groupCount;


### PR DESCRIPTION
Overview
----------------------------------------
When editing a form with custom data on it the cached metadata is ignored &I  rebuilt. This changes it to use it

Before
----------------------------------------
More DB queries

After
----------------------------------------
Less DB queries

Technical Details
----------------------------------------
We have been running this patch in production for some months. When you load up a contribution edit page
(for example) the custom data metadata is loaded without hitting the cache. This means that
unnecessary queries are done. The only reason to bypass the cache would be that it is stale
or parameter dependent. However, the staleness is/ should be dealt with when editing custom
fields & if it is not then there will be other impacts. The entity id is NOT passed into the part of
the code that goes into the cached value

In order to demonstrate the params that go into the cache are in the cachekey I also did an extraction

Comments
----------------------------------------

