### PR TITLE
[code-cleanup] remove orderBy param from getDuplicatePairs, it is not used

### DIFF
--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -182,7 +182,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
         CRM_Dedupe_Merger::resetMergeStats($cacheKeyString);
       }
 
-      $this->_mainContacts = CRM_Dedupe_Merger::getDuplicatePairs($rgid, $gid, !$isConflictMode, 0, $this->isSelected(), '', $isConflictMode, $criteria, TRUE, $limit);
+      $this->_mainContacts = CRM_Dedupe_Merger::getDuplicatePairs($rgid, $gid, !$isConflictMode, 0, $this->isSelected(), $isConflictMode, $criteria, TRUE, $limit);
 
       if (empty($this->_mainContacts)) {
         if ($isConflictMode) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused parameter $orderBy from getDuplicatePairs

Before
----------------------------------------
Function called twice - blank param passed in both places

After
----------------------------------------
Function called twice, param no longer needed

Technical Details
----------------------------------------
Only 2 calls to this function - both fixed

Comments
----------------------------------------
@JKingsnorth wanna check?
