### PR TITLE
WIP Upgrade Snappy and load it using composer instead of from civicrm_packages

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -28,6 +28,7 @@
 
 use Dompdf\Dompdf;
 use Dompdf\Options;
+use Knp\Snappy\Pdf;
 
 /**
  *
@@ -221,9 +222,8 @@ class CRM_Utils_PDF_Utils {
    * @param string $fileName
    */
   public static function _html2pdf_wkhtmltopdf($paper_size, $orientation, $margins, $html, $output, $fileName) {
-    require_once 'packages/snappy/src/autoload.php';
     $config = CRM_Core_Config::singleton();
-    $snappy = new Knp\Snappy\Pdf($config->wkhtmltopdfPath);
+    $snappy = new Pdf($config->wkhtmltopdfPath);
     $snappy->setOption("page-width", $paper_size[2] . "pt");
     $snappy->setOption("page-height", $paper_size[3] . "pt");
     $snappy->setOption("orientation", $orientation);

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.1",
     "ezyang/htmlpurifier": "4.10",
-    "katzien/php-mime-type": "2.1.0"
+    "katzien/php-mime-type": "2.1.0",
+    "knplabs/knp-snappy": "v1.0.4"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,8 @@
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.1",
     "ezyang/htmlpurifier": "4.10",
-    "katzien/php-mime-type": "2.1.0",
-    "knplabs/knp-snappy": "v1.0.4"
+    "knplabs/knp-snappy": "v1.0.4",
+    "katzien/php-mime-type": "2.1.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a06373b9174ae3aa2bfb820e2e5a35e",
+    "content-hash": "9519d73c5b898e7b9824c3cf7417c494",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -497,6 +497,72 @@
                 "php"
             ],
             "time": "2017-03-23T02:05:33+00:00"
+        },
+        {
+            "name": "knplabs/knp-snappy",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/snappy.git",
+                "reference": "144c4ecd1ccaeda936bf832b93079efc490e6850"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/snappy/zipball/144c4ecd1ccaeda936bf832b93079efc490e6850",
+                "reference": "144c4ecd1ccaeda936bf832b93079efc490e6850",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "psr/log": "^1.0",
+                "symfony/process": "~2.3 || ~3.0 || ~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.36"
+            },
+            "suggest": {
+                "h4cc/wkhtmltoimage-amd64": "Provides wkhtmltoimage-amd64 binary for Linux-compatible machines, use version `~0.12` as dependency",
+                "h4cc/wkhtmltoimage-i386": "Provides wkhtmltoimage-i386 binary for Linux-compatible machines, use version `~0.12` as dependency",
+                "h4cc/wkhtmltopdf-amd64": "Provides wkhtmltopdf-amd64 binary for Linux-compatible machines, use version `~0.12` as dependency",
+                "h4cc/wkhtmltopdf-i386": "Provides wkhtmltopdf-i386 binary for Linux-compatible machines, use version `~0.12` as dependency",
+                "wemersonjanuario/wkhtmltopdf-windows": "Provides wkhtmltopdf executable for Windows, use version `~0.12` as dependency"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Knp\\Snappy\\": "src/Knp/Snappy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://github.com/KnpLabs/snappy/contributors"
+                }
+            ],
+            "description": "PHP5 library allowing thumbnail, snapshot or PDF generation from a url or a html page. Wrapper for wkhtmltopdf/wkhtmltoimage.",
+            "homepage": "http://github.com/KnpLabs/snappy",
+            "keywords": [
+                "knp",
+                "knplabs",
+                "pdf",
+                "snapshot",
+                "thumbnail",
+                "wkhtmltopdf"
+            ],
+            "time": "2018-01-22T19:40:51+00:00"
         },
         {
             "name": "marcj/topsort",


### PR DESCRIPTION
Overview
----------------------------------------
The Snappy in [civicrm-packages](https://github.com/civicrm/civicrm-packages) has not been updated in 4 years. This change upgrades snappy to [v1.0.4](https://github.com/KnpLabs/snappy/releases/tag/v1.0.4) the last version of Snappy that is compatible which has a minimum php version of 7.0. 

Before
----------------------------------------
Snappy out of date and loaded from civicrm-packages

After
----------------------------------------
Snappy v1.0.4 and loaded with composer

Comments
----------------------------------------
If this gets merged snappy could be removed from civicrm_packages
