### PR TITLE
[REF] Fix pointless use of CRM_Utils_Array::value in Campaign BAO

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -49,18 +49,18 @@ class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign {
       return NULL;
     }
 
-    if (!(CRM_Utils_Array::value('id', $params))) {
+    if (empty($params['id'])) {
 
-      if (!(CRM_Utils_Array::value('created_id', $params))) {
+      if (empty($params['created_id'])) {
         $session = CRM_Core_Session::singleton();
         $params['created_id'] = $session->get('userID');
       }
 
-      if (!(CRM_Utils_Array::value('created_date', $params))) {
+      if (empty($params['created_date'])) {
         $params['created_date'] = date('YmdHis');
       }
 
-      if (!(CRM_Utils_Array::value('name', $params))) {
+      if (empty($params['name'])) {
         $params['name'] = CRM_Utils_String::titleToVar($params['title'], 64);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Just a small code cleanup

Before
----------------------------------------
`!(CRM_Utils_Array::value('bar', $foo))`

After
----------------------------------------
`empty($foo['bar'])`

