### PR TITLE
[REF] Test class cleanup - Extract function to create nuanced custom fields to a trait

### DIFF
--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -1,0 +1,141 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Trait Custom Data trait.
+ *
+ * Trait for setting up custom data in tests.
+ */
+trait CRMTraits_Custom_CustomDataTrait {
+
+  /**
+   * Create a custom group.
+   *
+   * @param array $params
+   *
+   * @return int
+   */
+  public function createCustomGroup($params = []) {
+    $params = array_merge([
+      'title' => 'Custom Group',
+      'extends' => [$this->entity],
+      'weight' => 5,
+      'style' => 'Inline',
+      'max_multiple' => 0,
+    ], $params);
+    $this->ids['CustomGroup'][$params['title']] = $this->callAPISuccess('CustomGroup', 'create', $params)['id'];
+    return $this->ids['CustomGroup'][$params['title']];
+  }
+
+  /**
+   * @return array
+   */
+  public function createCustomFieldsOfAllTypes() {
+    $customGroupID = $this->ids['CustomGroup']['Custom Group'];
+    $ids = [];
+    $params = [
+      'custom_group_id' => $customGroupID,
+      'label' => 'Enter text here',
+      'html_type' => 'Text',
+      'data_type' => 'String',
+      'default_value' => 'xyz',
+      'weight' => 1,
+      'is_required' => 1,
+    ];
+
+    $customField = $this->callAPISuccess('CustomField', 'create', $params);
+    $ids[] = $customField['id'];
+
+    $optionValue[] = [
+      'label' => 'Red',
+      'value' => 'R',
+      'weight' => 1,
+      'is_active' => 1,
+    ];
+    $optionValue[] = [
+      'label' => 'Yellow',
+      'value' => 'Y',
+      'weight' => 2,
+      'is_active' => 1,
+    ];
+    $optionValue[] = [
+      'label' => 'Green',
+      'value' => 'G',
+      'weight' => 3,
+      'is_active' => 1,
+    ];
+
+    $params = [
+      'label' => 'Pick Color',
+      'html_type' => 'Select',
+      'data_type' => 'String',
+      'weight' => 2,
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+      'option_values' => $optionValue,
+      'custom_group_id' => $customGroupID,
+    ];
+
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    $ids[] = $customField['id'];
+
+    $params = [
+      'custom_group_id' => $customGroupID,
+      'name' => 'test_date',
+      'label' => 'test_date',
+      'html_type' => 'Select Date',
+      'data_type' => 'Date',
+      'default_value' => '20090711',
+      'weight' => 3,
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+    ];
+
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+
+    $ids[] = $customField['id'];
+    $params = [
+      'custom_group_id' => $customGroupID,
+      'name' => 'test_link',
+      'label' => 'test_link',
+      'html_type' => 'Link',
+      'data_type' => 'Link',
+      'default_value' => 'http://civicrm.org',
+      'weight' => 4,
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+    ];
+
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    $ids[] = $customField['id'];
+    return $ids;
+  }
+
+}

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -30,6 +30,9 @@
  * @group headless
  */
 class api_v3_RelationshipTest extends CiviUnitTestCase {
+
+  use CRMTraits_Custom_CustomDataTrait;
+
   protected $_apiversion = 3;
   protected $_cId_a;
   /**
@@ -45,12 +48,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    */
   protected $_cId_b2;
   protected $_relTypeID;
-  protected $_ids = array();
-  protected $_customGroupId = NULL;
+  protected $_ids = [];
   protected $_customFieldId = NULL;
   protected $_params;
 
-  protected $_entity;
+  protected $entity;
 
   /**
    * Set up function.
@@ -65,7 +67,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     ));
     $this->_cId_b = $this->organizationCreate();
     $this->_cId_b2 = $this->organizationCreate(array('organization_name' => ' Org 2'));
-    $this->_entity = 'relationship';
+    $this->entity = 'Relationship';
     //Create a relationship type.
     $relTypeParams = array(
       'name_a_b' => 'Relation 1 for delete',
@@ -397,7 +399,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    */
   public function testRelationshipCreateEditWithCustomData() {
     $this->createCustomGroup();
-    $this->_ids = $this->createCustomField();
+    $this->_ids = $this->createCustomFieldsOfAllTypes();
     //few custom Values for comparing
     $custom_params = array(
       "custom_{$this->_ids[0]}" => 'Hello! this is custom data for relationship',
@@ -453,120 +455,15 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
 
-    $result = $this->callAPISuccess($this->_entity, 'create', $params);
+    $result = $this->callAPISuccess($this->entity, 'create', $params);
     $this->assertEquals($result['id'], $result['values'][$result['id']]['id']);
 
     $getParams = array('id' => $result['id']);
-    $check = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $check = $this->callAPIAndDocument($this->entity, 'get', $getParams, __FUNCTION__, __FILE__);
     $this->assertEquals("custom string", $check['values'][$check['id']]['custom_' . $ids['custom_field_id']], ' in line ' . __LINE__);
 
     $this->customFieldDelete($ids['custom_field_id']);
     $this->customGroupDelete($ids['custom_group_id']);
-  }
-
-  /**
-   * @return mixed
-   */
-  public function createCustomGroup() {
-    $params = array(
-      'title' => 'Custom Group',
-      'extends' => array('Relationship'),
-      'weight' => 5,
-      'style' => 'Inline',
-      'is_active' => 1,
-      'max_multiple' => 0,
-    );
-    $customGroup = $this->callAPISuccess('custom_group', 'create', $params);
-    $this->_customGroupId = $customGroup['id'];
-    return $customGroup['id'];
-  }
-
-  /**
-   * @return array
-   */
-  public function createCustomField() {
-    $ids = array();
-    $params = array(
-      'custom_group_id' => $this->_customGroupId,
-      'label' => 'Enter text about relationship',
-      'html_type' => 'Text',
-      'data_type' => 'String',
-      'default_value' => 'xyz',
-      'weight' => 1,
-      'is_required' => 1,
-      'is_searchable' => 0,
-      'is_active' => 1,
-    );
-
-    $customField = $this->callAPISuccess('CustomField', 'create', $params);
-    $ids[] = $customField['id'];
-
-    $optionValue[] = array(
-      'label' => 'Red',
-      'value' => 'R',
-      'weight' => 1,
-      'is_active' => 1,
-    );
-    $optionValue[] = array(
-      'label' => 'Yellow',
-      'value' => 'Y',
-      'weight' => 2,
-      'is_active' => 1,
-    );
-    $optionValue[] = array(
-      'label' => 'Green',
-      'value' => 'G',
-      'weight' => 3,
-      'is_active' => 1,
-    );
-
-    $params = array(
-      'label' => 'Pick Color',
-      'html_type' => 'Select',
-      'data_type' => 'String',
-      'weight' => 2,
-      'is_required' => 1,
-      'is_searchable' => 0,
-      'is_active' => 1,
-      'option_values' => $optionValue,
-      'custom_group_id' => $this->_customGroupId,
-    );
-
-    $customField = $this->callAPISuccess('custom_field', 'create', $params);
-    $ids[] = $customField['id'];
-
-    $params = array(
-      'custom_group_id' => $this->_customGroupId,
-      'name' => 'test_date',
-      'label' => 'test_date',
-      'html_type' => 'Select Date',
-      'data_type' => 'Date',
-      'default_value' => '20090711',
-      'weight' => 3,
-      'is_required' => 1,
-      'is_searchable' => 0,
-      'is_active' => 1,
-    );
-
-    $customField = $this->callAPISuccess('custom_field', 'create', $params);
-
-    $ids[] = $customField['id'];
-    $params = array(
-      'custom_group_id' => $this->_customGroupId,
-      'name' => 'test_link',
-      'label' => 'test_link',
-      'html_type' => 'Link',
-      'data_type' => 'Link',
-      'default_value' => 'http://civicrm.org',
-      'weight' => 4,
-      'is_required' => 1,
-      'is_searchable' => 0,
-      'is_active' => 1,
-    );
-
-    $customField = $this->callAPISuccess('custom_field', 'create', $params);
-    $ids[] = $customField['id'];
-    return $ids;
   }
 
   /**
@@ -675,7 +572,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    */
   public function testRelationshipCreateDuplicateWithCustomFields() {
     $this->createCustomGroup();
-    $this->_ids = $this->createCustomField();
+    $this->_ids = $this->createCustomFieldsOfAllTypes();
 
     $custom_params_1 = array(
       "custom_{$this->_ids[0]}" => 'Hello! this is custom data for relationship',
@@ -719,7 +616,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    */
   public function testRelationshipCreateDuplicateWithCustomFields2() {
     $this->createCustomGroup();
-    $this->_ids = $this->createCustomField();
+    $this->_ids = $this->createCustomFieldsOfAllTypes();
 
     $custom_params_2 = array(
       "custom_{$this->_ids[0]}" => 'Hello! this is other custom data',
@@ -755,7 +652,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    */
   public function testRelationshipCreateDuplicateWithCustomFields3() {
     $this->createCustomGroup();
-    $this->_ids = $this->createCustomField();
+    $this->_ids = $this->createCustomFieldsOfAllTypes();
 
     $custom_params_1 = array(
       "custom_{$this->_ids[0]}" => 'Hello! this is other custom data',
@@ -1097,18 +994,18 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * an incorrect one
    */
   public function testGetRelationshipByTypeReciprocal() {
-    $created = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $created = $this->callAPISuccess($this->entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id' => $this->_cId_a,
       'relationship_type_id' => $this->_relTypeID,
     ));
     $this->assertEquals(1, $result['count']);
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id' => $this->_cId_a,
       'relationship_type_id' => $this->_relTypeID + 1,
     ));
     $this->assertEquals(0, $result['count']);
-    $this->callAPISuccess($this->_entity, 'delete', array('id' => $created['id']));
+    $this->callAPISuccess($this->entity, 'delete', array('id' => $created['id']));
   }
 
   /**
@@ -1119,17 +1016,17 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * an incorrect one
    */
   public function testGetRelationshipByTypeDAO() {
-    $this->_ids['relationship'] = $this->callAPISuccess($this->_entity, 'create', array('format.only_id' => TRUE) +
+    $this->_ids['relationship'] = $this->callAPISuccess($this->entity, 'create', array('format.only_id' => TRUE) +
       $this->_params);
-    $this->callAPISuccess($this->_entity, 'getcount', array(
+    $this->callAPISuccess($this->entity, 'getcount', array(
       'contact_id_a' => $this->_cId_a,
     ), 1);
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id_a' => $this->_cId_a,
       'relationship_type_id' => $this->_relTypeID,
     ));
     $this->assertEquals(1, $result['count']);
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id_a' => $this->_cId_a,
       'relationship_type_id' => $this->_relTypeID + 1,
     ));
@@ -1144,7 +1041,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * an incorrect one
    */
   public function testGetRelationshipByTypeArrayDAO() {
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $this->callAPISuccess($this->entity, 'create', $this->_params);
     $org3 = $this->organizationCreate();
     // lets just assume built in ones aren't being messed with!
     $relType2 = 5;
@@ -1152,7 +1049,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $relType3 = 6;
 
     // Relationship 2.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType2,
         'contact_id_b' => $this->_cId_b2,
@@ -1160,14 +1057,14 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     );
 
     // Relationship 3.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType3,
         'contact_id_b' => $org3,
       ))
     );
 
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id_a' => $this->_cId_a,
       'relationship_type_id' => array('IN' => array($this->_relTypeID, $relType3)),
     ));
@@ -1186,14 +1083,14 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * an incorrect one
    */
   public function testGetRelationshipByTypeArrayReciprocal() {
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $this->callAPISuccess($this->entity, 'create', $this->_params);
     $org3 = $this->organizationCreate();
     // lets just assume built in ones aren't being messed with!
     $relType2 = 5;
     $relType3 = 6;
 
     // Relationship 2.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType2,
         'contact_id_b' => $this->_cId_b2,
@@ -1201,14 +1098,14 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     );
 
     // Relationship 3.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType3,
         'contact_id_b' => $org3,
       ))
     );
 
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id' => $this->_cId_a,
       'relationship_type_id' => array('IN' => array($this->_relTypeID, $relType3)),
     ));
@@ -1229,7 +1126,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * an incorrect one
    */
   public function testGetRelationshipByMembershipTypeDAO() {
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $this->callAPISuccess($this->entity, 'create', $this->_params);
     $org3 = $this->organizationCreate();
 
     // lets just assume built in ones aren't being messed with!
@@ -1243,7 +1140,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     ));
 
     // Relationship 2.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType2,
         'contact_id_b' => $this->_cId_b2,
@@ -1251,7 +1148,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     );
 
     // Relationship 3.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType3,
         'contact_id_b' => $org3,
@@ -1259,7 +1156,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     );
 
     // Relationship 4 with reversal.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType1,
         'contact_id_a' => $this->_cId_a,
@@ -1267,7 +1164,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       ))
     );
 
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id_a' => $this->_cId_a,
       'membership_type_id' => $memberType,
     ));
@@ -1286,7 +1183,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * an incorrect one
    */
   public function testGetRelationshipByMembershipTypeReciprocal() {
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $this->callAPISuccess($this->entity, 'create', $this->_params);
     $org3 = $this->organizationCreate();
 
     // Let's just assume built in ones aren't being messed with!
@@ -1299,7 +1196,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     ));
 
     // Relationship 2.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType2,
         'contact_id_b' => $this->_cId_b2,
@@ -1307,7 +1204,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     );
 
     // Relationship 4.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType3,
         'contact_id_b' => $org3,
@@ -1315,7 +1212,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     );
 
     // Relationship 4 with reversal.
-    $this->callAPISuccess($this->_entity, 'create',
+    $this->callAPISuccess($this->entity, 'create',
       array_merge($this->_params, array(
         'relationship_type_id' => $relType1,
         'contact_id_a' => $this->_cId_a,
@@ -1323,7 +1220,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       ))
     );
 
-    $result = $this->callAPISuccess($this->_entity, 'get', array(
+    $result = $this->callAPISuccess($this->entity, 'get', array(
       'contact_id' => $this->_cId_a,
       'membership_type_id' => $memberType,
     ));
@@ -1339,9 +1236,9 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * Check for e-notices on enable & disable as reported in CRM-14350
    */
   public function testSetActive() {
-    $relationship = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $this->callAPISuccess($this->_entity, 'create', array('id' => $relationship['id'], 'is_active' => 0));
-    $this->callAPISuccess($this->_entity, 'create', array('id' => $relationship['id'], 'is_active' => 1));
+    $relationship = $this->callAPISuccess($this->entity, 'create', $this->_params);
+    $this->callAPISuccess($this->entity, 'create', array('id' => $relationship['id'], 'is_active' => 0));
+    $this->callAPISuccess($this->entity, 'create', array('id' => $relationship['id'], 'is_active' => 1));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Move test setup function to a trait for re-usability 

Before
----------------------------------------
Function in RelationshipTest class

After
----------------------------------------
Function in CRMTraits_Custom_CustomDataTrait

Technical Details
----------------------------------------
I want to write a test involving set up of multiple custom fields - this seems like the most
useful function for that, so moving to a trait for re-use


Comments
----------------------------------------
