### PR TITLE
dev/drupal#19 Drupal8: fix bootstrap when used by the REST API

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -659,7 +659,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    */
   public function getCurrentLanguage() {
     // Drupal might not be bootstrapped if being called by the REST API.
-    if (!class_exists('Drupal')) {
+    if (!class_exists('Drupal') || !\Drupal::hasContainer()) {
       return NULL;
     }
 
@@ -706,7 +706,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     }
 
     // Drupal might not be bootstrapped if being called by the REST API.
-    if (!class_exists('Drupal')) {
+    if (!class_exists('Drupal') || !\Drupal::hasContainer()) {
       return NULL;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

Minor follow-up to #12152 regarding Drupal8 multi-lingual and the REST API.

Before
----------------------------------------

Error 500 when calling the REST API endpoint.

After
----------------------------------------

fixed

Technical Details
----------------------------------------

This had been discussed in #12152 but got lost in the rebase.

cc @monishdeb 