### PR TITLE
[NFC] fix comment blocks capitalising null

### DIFF
--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -43,12 +43,14 @@ class CRM_Case_XMLRepository {
   protected $xml = [];
 
   /**
-   * @var array|NULL
+   * @var array|null
    */
   protected $hookCache = NULL;
 
   /**
-   * @var array|NULL symbolic names of case-types
+   * Symbolic names of case-types.
+   *
+   * @var array|null
    */
   protected $allCaseTypes = NULL;
 

--- a/CRM/Core/CodeGen/Main.php
+++ b/CRM/Core/CodeGen/Main.php
@@ -37,13 +37,18 @@ class CRM_Core_CodeGen_Main {
   public $database;
 
   /**
-   * @var string|NULL path in which to store a marker that indicates the last execution of
-   * GenCode. If a matching marker already exists, GenCode doesn't run.
+   * Path in which to store a marker that indicates the last execution of GenCode.
+   *
+   * If a matching marker already exists, GenCode doesn't run.
+   *
+   * @var string|null
    */
   public $digestPath;
 
   /**
-   * @var string|NULL a digest of the inputs to the code-generator (eg the properties and source files)
+   * Digest of the inputs to the code-generator (eg the properties and source files).
+   *
+   * @var string|null
    */
   public $sourceDigest;
 

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -31,8 +31,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2019
- * $Id$
- *
  */
 abstract class CRM_Core_Component_Info {
 
@@ -79,14 +77,16 @@ abstract class CRM_Core_Component_Info {
   const COMPONENT_MENU_XML = 'Menu';
 
   /**
-   * Stores component information.
-   * @var array component settings as key/value pairs
+   * Component settings as key/value pairs.
+   *
+   * @var array
    */
   public $info;
 
   /**
-   * Stores component keyword.
-   * @var string name of component keyword
+   * Component keyword.
+   *
+   * @var string
    */
   protected $keyword;
 

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -325,7 +325,7 @@ class CRM_Report_Form extends CRM_Core_Form {
 
   /**
    * Variables to hold the acl inner join and where clause
-   * @var string|NULL
+   * @var string|null
    */
   protected $_aclFrom = NULL;
   protected $_aclWhere = NULL;
@@ -358,7 +358,7 @@ class CRM_Report_Form extends CRM_Core_Form {
    *
    * (it's unclear if this could be merged with outputMode at this stage)
    *
-   * @var string|NULL
+   * @var string|null
    */
   protected $_format;
 
@@ -380,21 +380,24 @@ class CRM_Report_Form extends CRM_Core_Form {
   public $_havingClauses = [];
 
   /**
-   * DashBoardRowCount Dashboard row count
-   * @var Integer
+   * DashBoardRowCount Dashboard row count.
+   *
+   * @var int
    */
   public $_dashBoardRowCount;
 
   /**
    * Is this being called without a form controller (ie. the report is being render outside the normal form
-   * - e.g the api is retrieving the rows
+   * - e.g the api is retrieving the rows.
+   *
    * @var bool
    */
   public $noController = FALSE;
 
   /**
-   * Variable to hold the currency alias
-   * @var string|NULL
+   * Variable to hold the currency alias.
+   *
+   * @var string|null
    */
   protected $_currencyColumn = NULL;
 

--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -149,14 +149,14 @@ abstract class Mapping implements MappingInterface {
 
   /**
    * Date filter -- the field name.
-   * @var string|NULL
+   * @var string|null
    *   Ex: 'event_start_date'
    */
   private $entity_date_start;
 
   /**
    * Date filter -- the field name.
-   * @var string|NULL
+   * @var string|null
    *   Ex: 'event_end_date'.
    */
   private $entity_date_end;

--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -62,7 +62,7 @@ class AngularLoader {
   protected $modules;
 
   /**
-   * @var array|NULL
+   * @var array|null
    */
   protected $crmApp = NULL;
 

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -14,7 +14,9 @@ class Manager {
   protected $res = NULL;
 
   /**
-   * @var array|NULL
+   * Modules.
+   *
+   * @var array|null
    *   Each item has some combination of these keys:
    *   - ext: string
    *     The Civi extension which defines the Angular module.

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -70,7 +70,7 @@ class SettingsBag {
    * The result of combining default values, mandatory
    * values, and user values.
    *
-   * @var array|NULL
+   * @var array|null
    *   Array(string $settingName => mixed $value).
    */
   protected $combined;

--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -80,7 +80,7 @@ class SettingsManager {
   protected $bagsByContact = [];
 
   /**
-   * @var array|NULL
+   * @var array|null
    *   Array(string $entity => array(string $settingName => mixed $value)).
    *   Ex: $mandatory['domain']['uploadDir'].
    *   NULL means "autoload from $civicrm_setting".

--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -38,7 +38,7 @@ class SqlTriggers {
   /**
    * The name of the output file.
    *
-   * @var string|NULL
+   * @var string|null
    */
   private $file = NULL;
 

--- a/Civi/Test/CiviEnvBuilder.php
+++ b/Civi/Test/CiviEnvBuilder.php
@@ -22,7 +22,7 @@ class CiviEnvBuilder {
   private $steps = [];
 
   /**
-   * @var string|NULL
+   * @var string|null
    *   A digest of the values in $steps.
    */
   private $targetSignature = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup to comply with tighter coder standard

Before
----------------------------------------
@var string|NULL

After
----------------------------------------
@var string|null

Technical Details
----------------------------------------
From running the drupal code sniffer with type checking enabled it turns out the capitalisation of NULL
does not extend to docblocks.

See https://github.com/civicrm/coder/pull/7

Comments
----------------------------------------

