### PR TITLE
Make apiRequst nextId accessible for api4 constructor

### DIFF
--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -115,4 +115,8 @@ class Request {
     return strtolower(\CRM_Utils_String::munge($action));
   }
 
+  public static function getNextId() {
+    return self::$nextId++;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Each api request is supposed to get a unique id; this allows api4 requests to partake.

Before
----------------------------------------
Private variable, api4 constructor couldn't access.

After
----------------------------------------
Getter function so api4 requests can be assigned an id.

Technical Details
----------------------------------------
Extracted from #14153 - if this piece passes I think we should merge it & I'll rebase the other.