### PR TITLE
dev/joomla#11 Fix php warning when viewing profiles

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -228,8 +228,9 @@ WHERE  id IN ( $idString )
     $inputLF = CRM_Utils_Array::value(2, $input);
 
     $check = self::generateChecksum($contactID, $inputTS, $inputLF);
-
-    if (!hash_equals($check, $inputCheck)) {
+    // Joomla_11 - If $inputcheck is null without explicitly casting to a string
+    // you get an error.
+    if (!hash_equals($check, (string) $inputCheck)) {
       return FALSE;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes php warning message

Before
----------------------------------------
_The current status.
When viewing a contact at the Joomla front end you can get this warning:
Warning: hash_equals(): Expected user_string to be a string, null given in .../administrator/components/com_civicrm/civicrm/CRM/Contact/BAO/Contact/Utils.php on line 232

After
----------------------------------------
_What has been changed. 

Casting the user_string explicitly to a string variable removes the error.

Technical Details
----------------------------------------

Change line 232 as follows:
 if (!hash_equals($check, **(string)** $inputCheck)) {


Comments
----------------------------------------
https://lab.civicrm.org/dev/joomla/issues/11
