### PR TITLE
Fix test / possible live error on submitting credit card renewals

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -528,6 +528,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       $this->_params['description'] = ts("Contribution submitted by a staff person using member's credit card for renewal");
       $this->_params['amount'] = $this->_params['total_amount'];
       $this->_params['payment_instrument_id'] = $this->_paymentProcessor['payment_instrument_id'];
+      $this->_params['receive_date'] = $now;
 
       // at this point we've created a contact and stored its address etc
       // all the payment processors expect the name and address to be in the passed params


### PR DESCRIPTION
Overview
----------------------------------------
Fix intermittent error on credit card renewal by credit card

Before
----------------------------------------
Intermittent ? fail

After
----------------------------------------
No fail

Technical Details
----------------------------------------
In the course of fixing https://github.com/civicrm/civicrm-core/pull/14315 I found that I was getting test failures due to the contribution having no receive_date - this is carried over as trxn_date to the financialTrxn date and fatals.

I was able to replicate in the UI renewing with a dummy processor - but I suspect there must be some factor that makes this intermittent despite it seeming reliable for me. I have a feeling I've seen it as an intermittent error on jenkins

We 'know' that the receive_date is 'now' if we are paying by card so this should be safe

Comments
----------------------------------------

