### PR TITLE
Switch to calling Payment.create api when processing a refund from AdditionalPayment form

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -362,10 +362,12 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       'id' => $this->_contributionId,
     ]);
     $contributionStatusId = CRM_Utils_Array::value('contribution_status_id', $contribution);
-    $result = CRM_Contribute_BAO_Contribution::recordAdditionalPayment($this->_contributionId, $this->_params, $this->_paymentType, $participantId);
+    $paymentID = CRM_Contribute_BAO_Contribution::recordAdditionalPayment($this->_contributionId, $this->_params, $this->_paymentType, $participantId);
     // Fetch the contribution & do proportional line item assignment
     $params = ['id' => $this->_contributionId];
     $contribution = CRM_Contribute_BAO_Contribution::retrieve($params, $defaults, $params);
+    // @todo - this line needs to be moved to the Payment.create api - it's not form layer appropriate.
+    // testing required.
     CRM_Contribute_BAO_Contribution::addPayments([$contribution], $contributionStatusId);
     if ($this->_contributionId && CRM_Core_Permission::access('CiviMember')) {
       $membershipPaymentCount = civicrm_api3('MembershipPayment', 'getCount', ['contribution_id' => $this->_contributionId]);
@@ -382,8 +384,8 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     $statusMsg = ts('The payment record has been processed.');
     // send email
-    if (!empty($result) && !empty($this->_params['is_email_receipt'])) {
-      $sendResult = civicrm_api3('Payment', 'sendconfirmation', ['id' => $result->id])['values'][$result->id];
+    if (!empty($paymentID) && !empty($this->_params['is_email_receipt'])) {
+      $sendResult = civicrm_api3('Payment', 'sendconfirmation', ['id' => $paymentID])['values'][$paymentID];
       if ($sendResult['is_sent']) {
         $statusMsg .= ' ' . ts('A receipt has been emailed to the contributor.');
       }

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -102,6 +102,7 @@ class CRM_Financial_BAO_Payment {
     }
     elseif ($params['total_amount'] < 0) {
       $trxn = self::recordRefundPayment($params['contribution_id'], $params, FALSE);
+      CRM_Contribute_BAO_Contribution::recordPaymentActivity($params['contribution_id'], CRM_Utils_Array::value('participant_id', $params), $params['total_amount'], $trxn->currency, $trxn->trxn_date);
     }
 
     if ($isPaymentCompletesContribution) {
@@ -319,7 +320,7 @@ class CRM_Financial_BAO_Payment {
    *
    * @return CRM_Financial_DAO_FinancialTrxn
    */
-  public static function recordRefundPayment($contributionId, $trxnData, $updateStatus) {
+  protected static function recordRefundPayment($contributionId, $trxnData, $updateStatus) {
     list($contributionDAO, $params) = self::getContributionAndParamsInFormatForRecordFinancialTransaction($contributionId);
 
     $params['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $trxnData, CRM_Utils_Array::value('payment_instrument_id', $params));


### PR DESCRIPTION
Overview
----------------------------------------
Code consolidation around processing negative payments.

Before
----------------------------------------
Logic is on form layer for processing refunds through additional payment form

After
----------------------------------------
Logic moved to BAO layer

Technical Details
----------------------------------------
This is in conjunction with a series of changes consolidating & adding testing for creating payments with the goal
being that the logic is all in the Payment.create api/BAO & none of the logic remains in the CRM_Contribute_Form_AdditionalPayment form

This change completes switching the refund action over. There is logic in there to update the Participant status to
Registered when a refund is processed - seemingly regardless of what it's original status is or the appropriate status
afterwards.

I tested through the UI and if you create a participant record & then change the line items, thus reducing the cost
and changing the contribution status to 'Pending Refund' the participant status remains 'Completed' so I think
this was not working / not required already & I simply dropped it

Comments
----------------------------------------
@monishdeb @pradpnayak getting there....
