### PR TITLE
dev/core#980 [dbunit] remove dependency on discontinued dbunit

### DIFF
--- a/tests/fixtures/contacts.yaml
+++ b/tests/fixtures/contacts.yaml
@@ -3,14 +3,13 @@ civicrm_contact:
     id: 3
     contact_type: Individual
     contact_sub_type:
-    do_not_email:
-    do_not_phone:
-    do_not_mail:
-    do_not_sms:
-    do_not_trade:
+    do_not_email: 0
+    do_not_phone: 0
+    do_not_mail: 0
+    do_not_sms: 0
+    do_not_trade: 0
     is_opt_out: 0
     legal_identifier:
-    external_identifier:
     sort_name: Site Administrator
     display_name: Site Administrator
     nick_name:
@@ -24,38 +23,18 @@ civicrm_contact:
     first_name: Site
     middle_name:
     last_name: Administrator
-    prefix_id:
-    suffix_id:
-    email_greeting_id:
-    email_greeting_custom:
-    postal_greeting_id:
-    postal_greeting_custom:
-    addressee_id:
-    addressee_custom:
-    job_title:
-    gender_id:
-    birth_date:
-    is_deceased:
-    deceased_date:
-    household_name:
-    primary_contact_id:
-    organization_name:
-    sic_code:
-    user_unique_id:
-    employer_id:
 
   -
     id: 17
     contact_type: Individual
     contact_sub_type:
-    do_not_email:
-    do_not_phone:
-    do_not_mail:
-    do_not_sms:
-    do_not_trade:
+    do_not_email: 0
+    do_not_phone: 0
+    do_not_mail: 0
+    do_not_sms: 0
+    do_not_trade: 0
     is_opt_out: 0
     legal_identifier:
-    external_identifier:
     sort_name:
     display_name: Test Contact
     nick_name:
@@ -69,22 +48,3 @@ civicrm_contact:
     first_name: Test
     middle_name:
     last_name: Contact
-    prefix_id:
-    suffix_id:
-    email_greeting_id:
-    email_greeting_custom:
-    postal_greeting_id:
-    postal_greeting_custom:
-    addressee_id:
-    addressee_custom:
-    job_title:
-    gender_id:
-    birth_date:
-    is_deceased: 0
-    deceased_date:
-    household_name:
-    primary_contact_id:
-    organization_name:
-    sic_code:
-    user_unique_id:
-    employer_id:

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -27,6 +27,7 @@
  */
 
 use Civi\Payment\System;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  *  Include class definitions
@@ -371,17 +372,33 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   public function loadAllFixtures() {
     $fixturesDir = __DIR__ . '/../../fixtures';
 
-    $this->getConnection()->getConnection()->query("SET FOREIGN_KEY_CHECKS = 0;");
+    CRM_Core_DAO::executeQuery("SET FOREIGN_KEY_CHECKS = 0;");
 
     $yamlFiles = glob($fixturesDir . '/*.yaml');
     foreach ($yamlFiles as $yamlFixture) {
-      $op = new PHPUnit_Extensions_Database_Operation_Insert();
-      $dataset = new PHPUnit_Extensions_Database_DataSet_YamlDataSet($yamlFixture);
-      $this->_tablesToTruncate = array_merge($this->_tablesToTruncate, $dataset->getTableNames());
-      $op->execute($this->_dbconn, $dataset);
+      $yaml = Yaml::parse(file_get_contents($yamlFixture));
+      foreach ($yaml as $tableName => $vars) {
+        if ($tableName === 'civicrm_contact') {
+          CRM_Core_DAO::executeQuery('DELETE c FROM civicrm_contact c LEFT JOIN civicrm_domain d ON d.contact_id = c.id WHERE d.id IS NULL');
+        }
+        else {
+          CRM_Core_DAO::executeQuery("TRUNCATE $tableName");
+        }
+        foreach ($vars as $entity) {
+          $keys = $values = [];
+          foreach ($entity as $key => $value) {
+            $keys[] = $key;
+            $values[] = is_numeric($value) ? $value : "'{$value}'";
+          }
+          CRM_Core_DAO::executeQuery("
+            INSERT INTO $tableName (" . implode(',', $keys) . ') VALUES(' . implode(',', $values) . ')'
+          );
+        }
+
+      }
     }
 
-    $this->getConnection()->getConnection()->query("SET FOREIGN_KEY_CHECKS = 1;");
+    CRM_Core_DAO::executeQuery("SET FOREIGN_KEY_CHECKS = 1;");
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove obsolete phphunit/dbunit package from our test suite

https://github.com/sebastianbergmann/dbunit/issues/217

Removing our dependency on this removes a hurdle in supporting more recent phpunit versions since we need to migrate over our own classes to extend the namespaced classes, but currently they extend a dbunit class so getting rid of that is a first useful step.

Before
----------------------------------------
phpunit/dbunit used in tests 

After
----------------------------------------
phpunit/dbunit not used in tests 

Technical Details
----------------------------------------
I came into this as the path to updating our phpunit version expectations requires us to start changing how we call phpunit & the path for this is much less clear ... and then it stops

The phpunit/dbunit package has been discontinued. I've removed the reference to it from the top level
extends and one call to it & the test I tried locally passes so it's not needed for ALL tests.

Let's see where it IS needed & what our options are - have at it jenkins

Comments
----------------------------------------
