### PR TITLE
fixes issue #981: sort participants did not remember search criteria

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -389,7 +389,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, ['participant_status_id']);
     }
 
-    if (empty($this->_formValues)) {
+    if (empty($formValues)) {
       $formValues = $this->controller->exportValues($this->_name);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Sorting participants ignored search values.

Before
----------------------------------------
When you search for participants of a specific event and then sort the result (e.g. alphabetically), you get all participants of all events.

After
----------------------------------------
The search criteria are respected after sorting.

Technical Details
----------------------------------------
See discussion https://lab.civicrm.org/dev/core/issues/981

Comments
----------------------------------------
