### PR TITLE
[NFC] Fix issue with Job Manager Test giving out a warning

### DIFF
--- a/tests/phpunit/CRM/Core/JobManagerTest.php
+++ b/tests/phpunit/CRM/Core/JobManagerTest.php
@@ -37,7 +37,9 @@ class CRM_Core_JobManagerTest extends CiviUnitTestCase {
 
   public function testHookCron() {
     $mockFunction = $this->mockMethod;
-    $hook = $this->$mockFunction('stdClass', array('civicrm_cron'));
+    $hook = $this->getMockBuilder(stdClass::class)
+      ->setMethods(['civicrm_cron'])
+      ->getMock();
     $hook->expects($this->once())
       ->method('civicrm_cron')
       ->with($this->isInstanceOf('CRM_Core_JobManager'));


### PR DESCRIPTION
Overview
----------------------------------------
Currently test gives a warning `Trying to configure method "civicrm_cron" which cannot be configured because it does not exist, has not been specified, is final, or is static` this fixes it

Before
----------------------------------------
Test produces warning

After
----------------------------------------
No errors or warnings

ping @eileenmcnaughton @colemanw @mattwire @totten 