### PR TITLE
[code-quality] [jcalendar] remove jcalendar usage from participant_register_date on event search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1553,22 +1553,20 @@ class CRM_Contact_BAO_Query {
     }
 
     self::filterCountryFromValuesIfStateExists($formValues);
-
+    // We shouldn't have to whitelist fields to not hack but here we are, for now.
+    $nonLegacyDateFields = ['participant_register_date_relative'];
     // Handle relative dates first
     foreach (array_keys($formValues) as $id) {
-      if (preg_match('/_date_relative$/', $id) ||
+      if (
+        !in_array($id, $nonLegacyDateFields) && (
+        preg_match('/_date_relative$/', $id) ||
         $id == 'event_relative' ||
         $id == 'case_from_relative' ||
-        $id == 'case_to_relative' ||
-        $id == 'participant_relative'
+        $id == 'case_to_relative')
       ) {
         if ($id == 'event_relative') {
           $fromRange = 'event_start_date_low';
           $toRange = 'event_end_date_high';
-        }
-        elseif ($id == 'participant_relative') {
-          $fromRange = 'participant_register_date_low';
-          $toRange = 'participant_register_date_high';
         }
         elseif ($id == 'case_from_relative') {
           $fromRange = 'case_from_start_date_low';
@@ -1647,11 +1645,12 @@ class CRM_Contact_BAO_Query {
       ) {
         self::convertCustomRelativeFields($formValues, $params, $values, $id);
       }
-      elseif (preg_match('/_date_relative$/', $id) ||
-        $id == 'event_relative' ||
-        $id == 'case_from_relative' ||
-        $id == 'case_to_relative' ||
-        $id == 'participant_relative'
+      elseif (
+        !in_array($id, $nonLegacyDateFields) && (
+          preg_match('/_date_relative$/', $id) ||
+          $id == 'event_relative' ||
+          $id == 'case_from_relative' ||
+          $id == 'case_to_relative')
       ) {
         // Already handled in previous loop
         continue;

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -95,8 +95,6 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
     $specialDateFields = [
       'event_start_date_low' => 'event_date_low',
       'event_end_date_high' => 'event_date_high',
-      'participant_register_date_low' => 'participant_date_low',
-      'participant_register_date_high' => 'participant_date_high',
       'case_from_start_date_low' => 'case_from_date_low',
       'case_from_start_date_high' => 'case_from_date_high',
       'case_to_end_date_low' => 'case_to_date_low',

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -186,7 +186,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
     foreach ($form->getSearchFieldMetadata() as $entity => $spec) {
       foreach ($spec as $fieldName => $fieldSpec) {
         if ($fieldSpec['type'] === CRM_Utils_Type::T_DATE || $fieldSpec['type'] === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)) {
-          if (isset($fields[$fieldName . '_high']) && isset($fields[$fieldName . '_low']) && empty($fields[$fieldName . '_relative'])) {
+          if (!empty($fields[$fieldName . '_high']) && !empty($fields[$fieldName . '_low']) && empty($fields[$fieldName . '_relative'])) {
             if (strtotime($fields[$fieldName . '_low']) > strtotime($fields[$fieldName . '_high'])) {
               $errors[$fieldName . '_low'] = ts('%1: Please check that your date range is in correct chronological order.', [1 => $fieldSpec['title']]);
             }

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -125,7 +125,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   /**
    * Common buildForm tasks required by all searches.
    */
-  public function buildQuickform() {
+  public function buildQuickForm() {
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'js/crm.searchForm.js', 1, 'html-header')
       ->addStyleFile('civicrm', 'css/searchForm.css', 1, 'html-header');

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -575,9 +575,29 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
   }
 
   /**
-   * @param CRM_Core_Form $form
+   * Get the metadata for fields to be included on the grant search form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getSearchFieldMetadata() {
+    $fields = [
+      'participant_status_id',
+    ];
+    $metadata = civicrm_api3('Participant', 'getfields', [])['values'];
+    return array_intersect_key($metadata, array_flip($fields));
+  }
+
+  /**
+   * Build the event search form.
+   *
+   * @param \CRM_Event_Form_Search $form
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function buildSearchForm(&$form) {
+    $form->addSearchFieldMetadata(['Participant' => self::getSearchFieldMetadata()]);
+    $form->addFormFieldsFromMetadata();
     $dataURLEventFee = CRM_Utils_System::url('civicrm/ajax/eventFee',
       "reset=1",
       FALSE, NULL, FALSE
@@ -615,16 +635,6 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
     $form->addFormRule(['CRM_Event_BAO_Query', 'formRule'], $form);
 
     $form->addElement('checkbox', "event_include_repeating_events", NULL, ts('Include participants from all events in the %1 series', [1 => '<em>%1</em>']));
-
-    $form->addSelect('participant_status_id',
-      [
-        'entity' => 'participant',
-        'label' => ts('Participant Status'),
-        'multiple' => 'multiple',
-        'option_url' => NULL,
-        'placeholder' => ts('- any -'),
-      ]
-    );
 
     $form->addSelect('participant_role_id',
       [

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -582,6 +582,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
   public static function getSearchFieldMetadata() {
     $fields = [
       'participant_status_id',
+      'participant_register_date',
     ];
     $metadata = civicrm_api3('Participant', 'getfields', [])['values'];
     return array_intersect_key($metadata, array_flip($fields));
@@ -628,10 +629,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
 
     CRM_Core_Form_Date::buildDateRange($form, 'event', 1, '_start_date_low', '_end_date_high', ts('From'), FALSE);
 
-    CRM_Core_Form_Date::buildDateRange($form, 'participant', 1, '_register_date_low', '_register_date_high', ts('From'), FALSE);
-
     $form->addElement('hidden', 'event_date_range_error');
-    $form->addElement('hidden', 'participant_date_range_error');
     $form->addFormRule(['CRM_Event_BAO_Query', 'formRule'], $form);
 
     $form->addElement('checkbox', "event_include_repeating_events", NULL, ts('Include participants from all events in the %1 series', [1 => '<em>%1</em>']));
@@ -686,7 +684,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
   public static function formRule($fields, $files, $form) {
     $errors = [];
 
-    if ((empty($fields['event_start_date_low']) || empty($fields['event_end_date_high'])) && (empty($fields['participant_register_date_low']) || empty($fields['participant_register_date_high']))) {
+    if ((empty($fields['event_start_date_low']) || empty($fields['event_end_date_high']))) {
       return TRUE;
     }
     $lowDate = strtotime($fields['event_start_date_low']);
@@ -696,12 +694,6 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
       $errors['event_date_range_error'] = ts('Please check that your Event Date Range is in correct chronological order.');
     }
 
-    $lowDate1 = strtotime($fields['participant_register_date_low']);
-    $highDate1 = strtotime($fields['participant_register_date_high']);
-
-    if ($lowDate1 > $highDate1) {
-      $errors['participant_date_range_error'] = ts('Please check that your Registration Date Range is in correct chronological order.');
-    }
     return empty($errors) ? TRUE : $errors;
   }
 

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -77,8 +77,9 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    */
   protected $searchFieldMetadata = [];
 
-
   /**
+   * Get the default entity for the form.
+   *
    * @return string
    */
   public function getDefaultEntity() {

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -32,10 +32,6 @@
  */
 
 /**
- * Files required
- */
-
-/**
  * This file is for civievent search
  */
 class CRM_Event_Form_Search extends CRM_Core_Form_Search {
@@ -73,6 +69,21 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    * @var int
    */
   protected $_ssID;
+
+  /**
+   * Metadata of all fields to include on the form.
+   *
+   * @var array
+   */
+  protected $searchFieldMetadata = [];
+
+
+  /**
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'Participant';
+  }
 
   /**
    * Processing needed for buildForm and later.
@@ -138,8 +149,9 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
   /**
    * Build the form object.
    *
-   *
    * @return void
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     parent::buildQuickForm();

--- a/CRM/Upgrade/Incremental/php/FiveFifteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveFifteen.php
@@ -76,6 +76,11 @@ class CRM_Upgrade_Incremental_php_FiveFifteen extends CRM_Upgrade_Incremental_Ba
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Fix errant deferred revenue settings', 'updateContributeSettings');
     $this->addTask('Fix cache key column name in prev next cache', 'fixCacheKeyColumnNamePrevNext');
+    $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
+      'datepickerConversion' => [
+        'participant_register_date',
+      ],
+    ]);
   }
 
   public static function fixCacheKeyColumnNamePrevNext() {

--- a/templates/CRM/Event/Form/Search/Common.tpl
+++ b/templates/CRM/Event/Form/Search/Common.tpl
@@ -36,7 +36,7 @@
   {include file="CRM/Core/DateRange.tpl" fieldName="event" from='_start_date_low' to='_end_date_high' label="<label>Event Dates</label>"}
 </tr>
 <tr>
-  {include file="CRM/Core/DateRange.tpl" fieldName="participant" from='_register_date_low' to='_register_date_high' label="<label>Registration Date</label>"}
+  {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="participant_register_date" colspan="2"}
 </tr>
 <tr>
   <td class="crm-event-form-block-participant_status"><label>{$form.participant_status_id.label}</label>


### PR DESCRIPTION
Overview
----------------------------------------
This removes one more place where legacy jcalendar is used.

Before
----------------------------------------
Deprecated pattern used

After
----------------------------------------
preferred pattern used

Technical Details
----------------------------------------
 There is actually still one left on the form (event date)
which I left out for now as it involves thinking about the fact event is a different entity & might warrant different representation in the arrays

Comments
----------------------------------------
@seamuslee001 @mattwire @colemanw maybe one last push will rid us of that pesky jcalendar....
