### PR TITLE
Fix fatal error when full group by mysql mode enabled & selecting contacts

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4960,6 +4960,7 @@ civicrm_relationship.start_date > {$today}
    * @return CRM_Core_DAO
    */
   public function getCachedContacts($cids, $includeContactIds) {
+    CRM_Core_DAO::disableFullGroupByMode();
     CRM_Utils_Type::validateAll($cids, 'Positive');
     $this->_includeContactIds = $includeContactIds;
     $onlyDeleted = in_array(['deleted_contacts', '=', '1', '0', '0'], $this->_params);
@@ -4971,7 +4972,9 @@ civicrm_relationship.start_date > {$today}
     $limit = '';
     $query = "$select $from $where $groupBy $order $limit";
 
-    return CRM_Core_DAO::executeQuery($query);
+    $result = CRM_Core_DAO::executeQuery($query);
+    CRM_Core_DAO::reenableFullGroupByMode();
+    return $result;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal error under some circumstances. 

To replicate - on a server with full group by mysql mode enabled do a contact search. Select a contact & click next

Before
----------------------------------------
<img width="1371" alt="Screen Shot 2019-05-25 at 8 34 40 PM" src="https://user-images.githubusercontent.com/336308/58366882-97962980-7f2c-11e9-94da-38a906499ae5.png">


After
----------------------------------------
No fatal

Technical Details
----------------------------------------
Disable full group by when selecting contacts. Per the screen shot the query is pretty non-std & it makes sense fgb mode rejects it - this is our std solution

Comments
----------------------------------------

