### PR TITLE
dev/core#968 Fix javascript error on public pages

### DIFF
--- a/js/crm.drupal8.js
+++ b/js/crm.drupal8.js
@@ -5,7 +5,7 @@ localStorage.setItem('Drupal.toolbar.activeTabID', JSON.stringify('toolbar-item-
 
 (function($) {
   function adjustToggle() {
-    if ($(window).width() < 768) {
+    if ($(window).width() < 768 && $('#toolbar-item-civicrm').length) {
       $('#civicrm-menu-nav .crm-menubar-toggle-btn').css({
         left: '' + $('#toolbar-item-civicrm').offset().left + 'px',
         width: '' + $('#toolbar-item-civicrm').innerWidth() + 'px'


### PR DESCRIPTION
Overview
----------------------------------------
Checks for the existence of the toolbar item before referencing it.

Before
----------------------------------------
Js error on public pages. See https://lab.civicrm.org/dev/core/issues/968

After
----------------------------------------
No error.

