### PR TITLE
dev/core#980 [phpunit test] update phpunit extends class to support later versions

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -52,7 +52,7 @@ define('API_LATEST_VERSION', 3);
  *  Common functions for unit tests
  * @package CiviCRM
  */
-class CiviUnitTestCase extends PHPUnit_Framework_TestCase {
+class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
   use \Civi\Test\Api3DocTrait;
   use \Civi\Test\GenericAssertionsTrait;


### PR DESCRIPTION
Overview
----------------------------------------
Updates phpunit version support in the test suite

Before
----------------------------------------
Supported versions of phpunit (7 & 8) do not work with CiviCRM test suite.

After
----------------------------------------
Supported versions of phpunit (7 & 8) do work with CiviCRM test suite. Versions prior to 4.8 do not

Technical Details
----------------------------------------
Per https://engineering.facile.it/blog/eng/phpunit-upgrade-namespace/ this works with phpunit 4.8 +

Phpunit support for php versions is here https://phpunit.de/supported-versions.html

Basically we need phpunit 7 to support php 7.3 - which we should be adding to our
test suite now. It's hard to make a case that we still need to support phpunit 4.8 - let
alone versions before that - 5.7 still covers php 5.6 which we need for some of our current branches.

Unit testing on master would ideally switch up to a supported version of phpunit - 7 or 8

Comments
----------------------------------------
@totten @seamuslee001 
