### PR TITLE
[REF] Stop passing cacheKey to refillCache

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -359,7 +359,6 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
    *
    * @param int $rgid
    * @param int $gid
-   * @param NULL $cacheKeyString
    * @param array $criteria
    *   Additional criteria to filter by.
    *
@@ -371,18 +370,11 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
    *  The search methodology finds all matches for the searchedContacts so this limits
    *  the number of searched contacts, not the matches found.
    *
-   * @return bool
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function refillCache($rgid, $gid, $cacheKeyString, $criteria, $checkPermissions, $searchLimit = 0) {
-    if (!$cacheKeyString && $rgid) {
-      $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria, $checkPermissions);
-    }
-
-    if (!$cacheKeyString) {
-      return FALSE;
-    }
+  public static function refillCache($rgid, $gid, $criteria, $checkPermissions, $searchLimit = 0) {
+    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria, $checkPermissions);
 
     // 1. Clear cache if any
     $sql = "DELETE FROM civicrm_prevnext_cache WHERE  cachekey LIKE %1";

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1848,11 +1848,10 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $includeConflicts = TRUE, $criteria = [], $checkPermissions = TRUE, $searchLimit = 0) {
     $dupePairs = self::getCachedDuplicateMatches($rule_group_id, $group_id, $batchLimit, $isSelected, $includeConflicts, $criteria, $checkPermissions);
     if (empty($dupePairs) && $reloadCacheIfEmpty) {
-      $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rule_group_id, $group_id, $criteria, $checkPermissions);
       // If we haven't found any dupes, probably cache is empty.
       // Try filling cache and give another try. We don't need to specify include conflicts here are there will not be any
       // until we have done some processing.
-      CRM_Core_BAO_PrevNextCache::refillCache($rule_group_id, $group_id, $cacheKeyString, $criteria, $checkPermissions, $searchLimit);
+      CRM_Core_BAO_PrevNextCache::refillCache($rule_group_id, $group_id, $criteria, $checkPermissions, $searchLimit);
       return self::getCachedDuplicateMatches($rule_group_id, $group_id, $batchLimit, $isSelected, FALSE, $criteria, $checkPermissions);
     }
     return $dupePairs;
@@ -2422,13 +2421,15 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   }
 
   /**
-   * @param $rule_group_id
-   * @param $group_id
-   * @param $batchLimit
-   * @param $isSelected
-   * @param $includeConflicts
-   * @param $criteria
-   * @param $checkPermissions
+   * Get any duplicate merge pairs that have been previously cached.
+   *
+   * @param int $rule_group_id
+   * @param int $group_id
+   * @param int $batchLimit
+   * @param bool $isSelected
+   * @param bool $includeConflicts
+   * @param array $criteria
+   * @param int $checkPermissions
    *
    * @return array
    */


### PR DESCRIPTION
Overview
----------------------------------------
Minor function cleanup

Before
----------------------------------------
Unnecessary param passed in

After
----------------------------------------
Unnecessary param removed.

Technical Details
----------------------------------------
The function is only called from one place & there is no need to pass it in

Comments
----------------------------------------
