### PR TITLE
Unit test for FGB error in #14331

### DIFF
--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -93,10 +93,17 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
         ]);
         $rows = $selector->getRows(CRM_Core_Action::VIEW, 0, 50, '');
         $this->assertEquals(1, count($rows));
+
+        CRM_Core_DAO::reenableFullGroupByMode();
+        $rows = $selector->getRows(CRM_Core_Action::VIEW, 0, 50, '');
+
         $sortChar = $selector->alphabetQuery()->fetchAll();
         // sort name is stored in '<last_name>, <first_name>' format, as per which the first character would be B of Bond
         $this->assertEquals('B', $sortChar[0]['sort_name']);
         $this->assertEquals($contactID, key($rows));
+
+        CRM_Core_DAO::reenableFullGroupByMode();
+        $selector->getQueryObject()->getCachedContacts([$contactID], FALSE);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Adds unit test to demonstrate that without https://github.com/civicrm/civicrm-core/pull/14331 we get an error

Before
----------------------------------------
No test cover

After
----------------------------------------
Test cover

Technical Details
----------------------------------------
@seamuslee001 despite the temptation I couldn't justify fixing #14331 without a test as I wouldn't have accepted a FGB fix from someone else without one & really if it was just a case of fixing without a test I would have done it 2 months ago https://lab.civicrm.org/dev/core/issues/754 since it would have been a 5 minute job

Comments
----------------------------------------
