### PR TITLE
[WIP] submitOnce alternate to PR 14251

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -642,7 +642,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $prevnext = $spacing = [];
     foreach ($params as $button) {
       if (!empty($button['submitOnce'])) {
-        $button['js']['onclick'] = "return submitOnce(this,'{$this->_name}','" . ts('Processing') . "');";
+        CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/crm.submitOnce.js');
       }
 
       $attrs = ['class' => 'crm-form-submit'] + (array) CRM_Utils_Array::value('js', $button);
@@ -1270,7 +1270,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         'isDefault' => TRUE,
       ];
       if ($submitOnce) {
-        $nextButton['js'] = ['onclick' => "return submitOnce(this,'{$this->_name}','" . ts('Processing') . "');"];
+        $nextButton['submitOnce'] = TRUE;
       }
       $buttons[] = $nextButton;
     }

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -485,6 +485,10 @@
       });
       // For convenience, focus the first field
       $('input[type=text], textarea, select', this).filter(':visible').first().not('.dateplugin').focus();
+      $('.action-link button, .action-link .button, div.ui-dialog-buttonset button, div.ui-dialog-buttonset .button').click(function() {
+        console.log('boo2');
+        $('div.ui-dialog-buttonset').css('visibility', 'hidden');
+      });
     });
     return widget;
   };

--- a/js/crm.submitOnce.js
+++ b/js/crm.submitOnce.js
@@ -1,0 +1,10 @@
+(function($, CRM, undefined) {
+  $('div.crm-submit-buttons input').click(function() {
+    $('div.crm-submit-buttons').css('visibility', 'hidden');
+  });
+
+  $('.action-link button, .action-link .button, div.ui-dialog-buttonset button, div.ui-dialog-buttonset .button').click(function() {
+    console.log('boo');
+    $('div.ui-dialog-buttonset').css('visibility', 'hidden');
+  });
+}(jQuery, CRM));


### PR DESCRIPTION
Overview
----------------------------------------
This is another approach to submitOnce, but it almost seems too simple I'm wondering what I'm missing...

Before
----------------------------------------
At the moment submitOnce only works with primary buttons and causes duplicates when using e.g. the ajax popup version of the new activity form (e.g. as in https://lab.civicrm.org/dev/core/issues/943).

After
----------------------------------------
submitOnce works with multiple buttons, in both the standalone and ajax form, and no duplicates.

Comments
----------------------------------------
This does not attempt to deal with hitting the enter key multiple times in an ajax popup on firefox (which seems like a separate problem that would have existed even before submitOnce). It would be nice to solve too of course.

@mattwire
