### PR TITLE
Set title properly on Move/Copy/File on Case popup

### DIFF
--- a/CRM/Case/Form/ActivityToCase.php
+++ b/CRM/Case/Form/ActivityToCase.php
@@ -48,6 +48,17 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
     $this->_currentCaseId = CRM_Utils_Request::retrieve('caseId', 'Positive');
     $this->assign('currentCaseId', $this->_currentCaseId);
     $this->assign('buildCaseActivityForm', TRUE);
+
+    switch (CRM_Utils_Request::retrieve('fileOnCaseAction', 'String')) {
+      case 'move':
+        CRM_Utils_System::setTitle(ts('Move to Case'));
+        break;
+
+      case 'copy':
+        CRM_Utils_System::setTitle(ts('Copy to Case'));
+        break;
+
+    }
   }
 
   /**

--- a/templates/CRM/Case/Form/ActivityToCase.tpl
+++ b/templates/CRM/Case/Form/ActivityToCase.tpl
@@ -60,7 +60,7 @@
     }
 
     var dataUrl = {/literal}"{crmURL p='civicrm/case/addToCase' q='reset=1' h=0}"{literal};
-    dataUrl += '&activityId=' + activityID + '&caseId=' + currentCaseId + '&cid=' + {/literal}"{$contactID}"{literal};
+    dataUrl += '&activityId=' + activityID + '&caseId=' + currentCaseId + '&cid=' + {/literal}"{$contactID}"{literal} + '&fileOnCaseAction=' + action;
 
     function save() {
       if (!$("#file_on_case_unclosed_case_id").val()) {


### PR DESCRIPTION
Overview
----------------------------------------
When clicking "Move to Case"/"Copy to Case" from the Manage cases activity list the title is initially set correctly but then always reverts to "File on Case".

Before
----------------------------------------
Incorrect title on popup.

After
----------------------------------------
Correct title on popup.

Technical Details
----------------------------------------
Initially set by javascript but then loaded via quickform defaults.

Comments
----------------------------------------
@lcdservices @alifrumin A "simple" cases UI one if you have time?
