### PR TITLE
Fix bug where contribution status is mishandled if label is changed

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1198,7 +1198,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         return [FALSE, $isARefund];
       }
     }
-    // @todo - figure out when, if ever this is reached.
     return [TRUE, $isARefund];
   }
 
@@ -3757,7 +3756,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $trxnID = NULL;
     $inputParams = $params;
     $isARefund = FALSE;
-    $currentContributionStatus = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution']->contribution_status_id);
+    $currentContributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution']->contribution_status_id);
     $previousContributionStatus = CRM_Contribute_PseudoConstant::contributionStatus($params['prevContribution']->contribution_status_id, 'name');
 
     if (($previousContributionStatus == 'Pending'

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -679,6 +679,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'contribution_id' => $contribution['id'],
       'total_amount' => 40,
     );
+    // Rename the 'completed' status label first to check that we are not using the labels!
+    $this->callAPISuccess('OptionValue', 'get', ['name' => 'Completed', 'option_group_id' => 'contribution_status', 'api.OptionValue.create' => ['label' => 'Unicorn']]);
     $payment = $this->callAPISuccess('Payment', 'create', $params);
     $expectedResult = array(
       $payment['id'] => array(
@@ -706,11 +708,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->assertEquals($eft['values'][$eft['id']]['amount'], 40);
     // Check contribution for completed status
     $contribution = $this->callAPISuccess('contribution', 'get', array('id' => $contribution['id']));
-    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status'], 'Completed');
+    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status'], 'Unicorn');
     $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 100.00);
     $this->callAPISuccess('Contribution', 'Delete', array(
       'id' => $contribution['id'],
     ));
+    $this->callAPISuccess('OptionValue', 'get', ['name' => 'Completed', 'option_group_id' => 'contribution_status', 'api.OptionValue.create' => ['label' => 'Completed']]);
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where the handling of contribution code relies on label rather than name. This could cause obscure bugs

Before
----------------------------------------
Comparison is label based

After
----------------------------------------
Comparison is name based, tested

Technical Details
----------------------------------------
I also stuck in a couple of deprecation warnings to see what happens... This might come out again

Comments
----------------------------------------
@mattwire yeah that label thing you spotted was probably pretty bad