### PR TITLE
Fix inconsistent handling when searching contribution text fields

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -159,6 +159,9 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function buildQuickForm() {
     if ($this->isFormInViewOrEditMode()) {
@@ -261,7 +264,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if (!empty($_POST) && !$this->_force) {
       $this->_formValues = $this->controller->exportValues($this->_name);
     }
-
+    $this->convertTextStringsToUseLikeOperator();
     $this->fixFormValues();
 
     // We don't show test records in summaries or dashboards
@@ -284,7 +287,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
         'financial_type_id',
         'contribution_soft_credit_type_id',
         'contribution_status_id',
-        'contribution_source',
         'contribution_trxn_id',
         'contribution_page_id',
         'contribution_product_id',

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -255,6 +255,23 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   }
 
   /**
+   * Convert any submitted text fields to use 'like' rather than '=' as the operator.
+   *
+   * This excludes any with options.
+   *
+   * Note this will only pick up fields declared via metadata.
+   */
+  protected function convertTextStringsToUseLikeOperator() {
+    foreach ($this->getSearchFieldMetadata()[$this->getDefaultEntity()] as $fieldName => $field) {
+      if (!empty($this->_formValues[$fieldName]) && empty($field['options']) && empty($field['pseudoconstant'])) {
+        if (in_array($field['type'], [CRM_Utils_Type::T_STRING, CRM_Utils_Type::T_TEXT])) {
+          $this->_formValues[$fieldName] = ['LIKE' => CRM_Contact_BAO_Query::getWildCardedValue(TRUE, 'LIKE', $this->_formValues[$fieldName])];
+        }
+      }
+    }
+  }
+
+  /**
    * Add checkboxes for each row plus a master checkbox.
    *
    * @param array $rows


### PR DESCRIPTION
Overview
----------------------------------------
I found that if you search on contribution source it adds wildcards & uses 'like' but with cancel_reason not so much, so you need the exact string

Before
----------------------------------------
<img width="456" alt="Screen Shot 2019-05-27 at 11 58 58 AM" src="https://user-images.githubusercontent.com/336308/58388738-d6d09180-8076-11e9-8541-c3fb36bd213a.png">


After
----------------------------------------
<img width="664" alt="Screen Shot 2019-05-27 at 11 58 06 AM" src="https://user-images.githubusercontent.com/336308/58388733-bb658680-8076-11e9-9f78-147ff51a022a.png">


Technical Details
----------------------------------------
I found that for contribution_source there was field-specific hacky handling, so I converted both fields
to be metadata based and added handling for string fields on the form layer

Comments
----------------------------------------
Per the images the qill formatting is inconsistent. This is not made worse by this PR & I would prefer to leave out of scope as I don't think it makes sense to do it without cleaning up the getWhereClause fn
