### PR TITLE
Don't apply api3 pre/post processing to api4 actions

### DIFF
--- a/Civi/API/Subscriber/TransactionSubscriber.php
+++ b/Civi/API/Subscriber/TransactionSubscriber.php
@@ -79,6 +79,9 @@ class TransactionSubscriber implements EventSubscriberInterface {
    * @return bool
    */
   public function isTransactional($apiProvider, $apiRequest) {
+    if ($apiRequest['version'] == 4) {
+      return FALSE;
+    }
     if ($this->isForceRollback($apiProvider, $apiRequest)) {
       return TRUE;
     }
@@ -98,6 +101,9 @@ class TransactionSubscriber implements EventSubscriberInterface {
    * @return bool
    */
   public function isForceRollback($apiProvider, $apiRequest) {
+    if ($apiRequest['version'] == 4) {
+      return FALSE;
+    }
     // FIXME: When APIv3 uses better parsing, only one check will be needed.
     if (isset($apiRequest['params']['options']['force_rollback'])) {
       return \CRM_Utils_String::strtobool($apiRequest['params']['options']['force_rollback']);

--- a/Civi/API/Subscriber/WrapperAdapter.php
+++ b/Civi/API/Subscriber/WrapperAdapter.php
@@ -97,8 +97,8 @@ class WrapperAdapter implements EventSubscriberInterface {
    * @return array<\API_Wrapper>
    */
   public function getWrappers($apiRequest) {
-    if (!isset($apiRequest['wrappers'])) {
-      $apiRequest['wrappers'] = $this->defaults;
+    if (!isset($apiRequest['wrappers']) || is_null($apiRequest['wrappers'])) {
+      $apiRequest['wrappers'] = $apiRequest['version'] < 4 ? $this->defaults : [];
       \CRM_Utils_Hook::apiWrappers($apiRequest['wrappers'], $apiRequest);
     }
     return $apiRequest['wrappers'];


### PR DESCRIPTION
Overview
----------------------------------------
Removes some api3 specific handling of api4 actions.

Before
----------------------------------------
Some unexpected bugs in api4 being caused by extra api3 processing.

After
----------------------------------------
Api4 is faster and less buggy.
