### PR TITLE
Translation in billingblock.tpl - dropping 'Information'

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -539,7 +539,7 @@ abstract class CRM_Core_Payment {
    * @return string
    */
   public function getPaymentTypeLabel() {
-    return $this->_paymentProcessor['payment_type'] == 1 ? 'Credit Card' : 'Direct Debit';
+    return $this->_paymentProcessor['payment_type'] == 1 ? ts('Credit Card') : ts('Direct Debit');
   }
 
   /**

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -204,7 +204,7 @@ class CRM_Core_Payment_Form {
    * @return string
    */
   public static function getPaymentTypeLabel($paymentProcessor) {
-    return ts('%1 Information', [$paymentProcessor->getPaymentTypeLabel()]);
+    return $paymentProcessor->getPaymentTypeLabel();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Problem with the translation of the fieldset legend for payment block.

This PR is a replacement for https://github.com/civicrm/civicrm-core/pull/14253

It's quite difficult to translate properly because the payment processor type is dynamic and could be overridden by extensions. Removing the 'Information' part and let the payment processor be responsible for giving the (translated) label.


Before
----------------------------------------
In contribution or event payment forms, when an amount and a payment processor is selected, displays the untranslated title : "Credit Card Information" or "Debit Card Information" or "Unicorn Information"

After
----------------------------------------
Displays translated : "Credit Card" or "Debit Card" or "Unicorn"


Comments
----------------------------------------
This PR is a replacement for https://github.com/civicrm/civicrm-core/pull/14253

