### PR TITLE
dev/core#965 Fix destination in payment edit

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -131,6 +131,15 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
         'name' => ts('Cancel'),
       ],
     ]);
+
+    $contact = civicrm_api3('Contribution', 'getsingle', ['return' => ["contact_id"], 'id' => "{$this->_contributionID}"]);
+
+    $url = CRM_Utils_System::url(
+      "civicrm/contact/view/contribution",
+      "reset=1&action=update&id={$this->_contributionID}&cid={$contact['contact_id']}&context=contribution"
+    );
+
+    $this->controller->setDestination($url);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When editing to pay in contribution "civicrm/payment/edit" and later save and try to leave the following error appears: "Expected one FinancialTrxn but found 25". I have seen that it does not happen when Popup Forms are enabled. 

Before
----------------------------------------
* Button update return same form/view.
* Button cancel return to contribution view.

After
----------------------------------------
* Button update return to contribution view.
* Button cancel return to contribution view.

Technical Details
----------------------------------------
we modified the class PaymentEdit and update destination in controller with correct values for return to contribution.

Comments
----------------------------------------
issue gitlab: https://lab.civicrm.org/dev/core/issues/965