### PR TITLE
Port regression fixes back to 5.13

### DIFF
--- a/CRM/Core/xml/Menu/Activity.xml
+++ b/CRM/Core/xml/Menu/Activity.xml
@@ -7,7 +7,7 @@
      <page_callback>CRM_Activity_Form_Activity</page_callback>
      <access_arguments>access CiviCRM</access_arguments>
      <page_arguments>attachUpload=1</page_arguments>
-     <path_arguments>action=add,context=standalone</path_arguments>
+     <path_arguments>action=add&amp;context=standalone</path_arguments>
   </item>
   <item>
      <path>civicrm/activity/view</path>

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -389,7 +389,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, ['participant_status_id']);
     }
 
-    if (empty($this->_formValues)) {
+    if (empty($formValues)) {
       $formValues = $this->controller->exportValues($this->_name);
     }
 

--- a/js/crm.drupal8.js
+++ b/js/crm.drupal8.js
@@ -5,7 +5,7 @@ localStorage.setItem('Drupal.toolbar.activeTabID', JSON.stringify('toolbar-item-
 
 (function($) {
   function adjustToggle() {
-    if ($(window).width() < 768) {
+    if ($(window).width() < 768 && $('#toolbar-item-civicrm').length) {
       $('#civicrm-menu-nav .crm-menubar-toggle-btn').css({
         left: '' + $('#toolbar-item-civicrm').offset().left + 'px',
         width: '' + $('#toolbar-item-civicrm').innerWidth() + 'px'


### PR DESCRIPTION
Overview
----------------------------------------
Ports back 3 regressions that are in 5.14

Before
----------------------------------------
various

After
----------------------------------------
various

Technical Details
----------------------------------------
@seamuslee001 @colemanw @mattwire @totten  @agh1 with this we have everything except [the ics handling bug](https://github.com/civicrm/civicrm-core/commit/301ef60208373fdda75098cbea32be5d366b8ae5)
(which is not cherry-pickable & I would potentially skip it)

Also outstanding is [the submit once bug](https://lab.civicrm.org/dev/core/issues/943) which has a few proposed fixes but I think @colemanw needs to look at them.

& [the problem with people not being notified of the security update](https://github.com/civicrm/civicrm-pingback/pull/5/files)




Comments
----------------------------------------
I think the outstanding things can all be out of scope for 5.13.5 but we should aim to address them for 5.14.0 release next week
