### PR TITLE
dev/core996 Ensure that the oldest created_date is retained no matter…

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1618,6 +1618,22 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       CRM_Core_BAO_CustomValueTable::setValues($viewOnlyCustomFields);
     }
 
+    // dev/core#996 Ensure that the earliest created date is stored against the kept contact id
+    $mainCreatedDate = civicrm_api3('Contact', 'getsingle', [
+      'id' => $mainId,
+      'return' => ['created_date'],
+    ])['created_date'];
+    $otherCreatedDate = civicrm_api3('Contact', 'getsingle', [
+      'id' => $otherId,
+      'return' => ['created_date'],
+    ])['created_date'];
+    if ($otherCreatedDate < $mainCreatedDate) {
+      CRM_Core_DAO::executeQuery("UPDATE civicrm_contact SET created_date = %1 WHERE id = %2", [
+        1 => [$otherCreatedDate, 'String'],
+        2 => [$mainId, 'Positive'],
+      ]);
+    }
+
     if (!$checkPermissions || (CRM_Core_Permission::check('merge duplicate contacts') &&
         CRM_Core_Permission::check('delete contacts'))
     ) {


### PR DESCRIPTION
… the ids of the contacts being merged

Overview
----------------------------------------
When contacts are flipped around during merge it is possible that the oldest created_date gets lost in the merge process this fixes it

Before
----------------------------------------
oldest created date may get lost

After
----------------------------------------
oldest created date is always retained

ping @eileenmcnaughton @mattwire @lcdservices @JKingsnorth @andrew-cormick-dockery @johntwyman