### PR TITLE
[REF] dev/core#998 make processDupes testable & add test

### DIFF
--- a/tests/phpunit/CRM/Contact/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Contact/Page/AjaxTest.php
@@ -46,6 +46,22 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
     $this->assertEquals(array('data' => array(), 'recordsTotal' => 0, 'recordsFiltered' => 0), $result);
   }
 
+  /**
+   * Tests the 'guts' of the processDupes function.
+   *
+   * @throws \Exception
+   */
+  public function testProcessDupes() {
+    $contact1 = $this->individualCreate();
+    $contact2 = $this->individualCreate();
+    $contact3 = $this->individualCreate();
+    CRM_Contact_Page_AJAX::markNonDuplicates($contact1, $contact2, 'dupe-nondupe');
+    CRM_Contact_Page_AJAX::markNonDuplicates($contact3, $contact1, 'dupe-nondupe');
+    $this->callAPISuccessGetSingle('Exception', ['contact_id1' => $contact1, 'contact_id2' => $contact2]);
+    // Note that in saving the order is changed to have the lowest ID first.
+    $this->callAPISuccessGetSingle('Exception', ['contact_id1' => $contact1, 'contact_id2' => $contact3]);
+  }
+
   public function testGetDedupesPostCode() {
     $_REQUEST['gid'] = 1;
     $_REQUEST['rgid'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Preliminary code cleanup & test add

Before
----------------------------------------
Code untestable & untested

After
----------------------------------------
Code tested

Technical Details
----------------------------------------
I am pretty sure that there is an issue here with flipped contacts mis-comparing but this change
is just preliminary - improving testing & preparing to consolidate code so we always go via the api
and the same logic always applies


Comments
----------------------------------------

