### PR TITLE
(dev/core#1000) Fixes contact's displayname not appearing in membership edit, if no r…

### DIFF
--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -69,7 +69,7 @@ class CRM_Contact_BAO_Contact_Location {
       (isset($contact['display_name'])) ? $contact['display_name'] : NULL,
       (isset($email['email'])) ? $email['email'] : NULL,
       (isset($email['location_type_id'])) ? $email['location_type_id'] : NULL,
-      (isset($email['id'])) ? $email['id'] : NULL
+      (isset($email['id'])) ? $email['id'] : NULL,
     );
 
     return $returnParams;


### PR DESCRIPTION
…egistered email is found

Overview
----------------------------------------
When someone edits a contact's membership and that contact has no registered email, membership displays no contact name in membership edit mode.

Before
----------------------------------------
No `display_name` is coming back from the call to `CRM_Contact_BAO_Contact_Location::getEmailDetails`

After
----------------------------------------
`display_name` returns properly (along with an email, if available)

Technical Details
----------------------------------------
Rework on API call `Email.get` (becomes `Contact.get` along with API Chain to `Email.get`)

Comments
----------------------------------------
Related issue [here](https://lab.civicrm.org/dev/core/issues/1000)

