### PR TITLE
[REF] Activity Summary report - move temp table generation etc from postProcess to buildQuery, remove postProcess, don't skip in unit tests

### DIFF
--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -355,7 +355,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $reportsToSkip = array(
       'event/income' => 'I do no understand why but error is Call to undefined method CRM_Report_Form_Event_Income::from() in CRM/Report/Form.php on line 2120',
       'contribute/history' => 'Declaration of CRM_Report_Form_Contribute_History::buildRows() should be compatible with CRM_Report_Form::buildRows($sql, &$rows)',
-      'activitySummary' => 'We use temp tables for the main query generation and name are dynamic. These names are not available in stats() when called directly.',
     );
 
     $reports = civicrm_api3('report_template', 'get', array('return' => 'value', 'options' => array('limit' => 500)));
@@ -934,9 +933,9 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test activity summary report - requiring all current fields to be output.
+   * Test activity details report - requiring all current fields to be output.
    */
-  public function testActivitySummary() {
+  public function testActivityDetails() {
     $this->createContactsWithActivities();
     $fields = [
       'contact_source' => '1',


### PR DESCRIPTION
Overview
----------------------------------------
Refactor Activity Summary report to a more standard structure so that it no longer needs to be skipped in unit tests.

Before
----------------------------------------
Activity Summary report has to be skipped in unit tests.
ReportTemplateTest.php gives:

```
OK, but incomplete, skipped, or risky tests!
Tests: 213, Assertions: 1245, Incomplete: 11.
```

After
----------------------------------------
Activity Summary report is not skipped in unit tests and tests pass.
ReportTemplateTest.php gives:

```
OK, but incomplete, skipped, or risky tests!
Tests: 214, Assertions: 1252, Incomplete: 8.
```

Technical Details
----------------------------------------
Refactor CRM/Report/Form/ActivitySummary.php, removing postProcess(), moving temp table creation etc into buildQuery(). In tests/phpunit/api/v3/ReportTemplateTest.php, remove activitySummary from reportsToSkip, as tests pass after this refactoring; also rename testActivitySummary() to testActivityDetails(), as it actually tests report_id = Activity which is the activity details report.

This PR builds on @eileenmcnaughton's refactoring in #14364.
It is work towards improving unit tests for activity summary, which is needed for #13540 to be merged.