### PR TITLE
dev/core#994 remove Thousands Separator can not have more than 1 character rule

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -137,10 +137,6 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
       $errors['monetaryThousandSeparator'] = ts('Thousands Separator can not be empty. You can use a space character instead.');
     }
 
-    if (strlen($fields['monetaryThousandSeparator']) > 1) {
-      $errors['monetaryThousandSeparator'] = ts('Thousands Separator can not have more than 1 character.');
-    }
-
     if (strlen($fields['monetaryDecimalPoint']) > 1) {
       $errors['monetaryDecimalPoint'] = ts('Decimal Delimiter can not have more than 1 character.');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes form rule preventing location separators having more than one character.

Before
----------------------------------------
Can't save a non-breaking space as a thousand separator

After
----------------------------------------
Can save a non-breaking space (or other string longer than one char)

Technical Details
----------------------------------------
Per issue it seems unnecessarily opinionated to block longer strings & we not know of at least one case where it is inappropriate

Comments
----------------------------------------

