### PR TITLE
Wysiwyg support for i18n event fields

### DIFF
--- a/xml/schema/Event/Event.xml
+++ b/xml/schema/Event/Event.xml
@@ -52,7 +52,7 @@
     <uniqueName>event_description</uniqueName>
     <title>Event Description</title>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>8</rows>
       <cols>60</cols>
     </html>
@@ -349,7 +349,7 @@
     <name>intro_text</name>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>
@@ -363,7 +363,7 @@
     <title>Footer Message</title>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>
@@ -388,7 +388,7 @@
     <name>confirm_text</name>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>
@@ -402,7 +402,7 @@
     <type>text</type>
     <title>Footer Text</title>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>
@@ -508,7 +508,7 @@
     <name>thankyou_text</name>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>
@@ -522,7 +522,7 @@
     <type>text</type>
     <title>Footer Text</title>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>
@@ -549,7 +549,7 @@
     <comment>The text displayed to the user in the main form</comment>
     <add>2.0</add>
     <html>
-      <type>Text</type>
+      <type>RichTextEditor</type>
     </html>
   </field>
   <field>


### PR DESCRIPTION
Overview
----------------------------------------
Following https://github.com/civicrm/civicrm-core/pull/5734, adds support for wysiwyg editor in i18n popup for event fields

Before
----------------------------------------
![Screenshot_2019-05-30 Configure Event](https://user-images.githubusercontent.com/372004/58655618-7cd70280-82e8-11e9-959e-ed13b5c34e97.png)


After
----------------------------------------
![Screenshot_2019-05-30 Configure Event - with WYSIWYG](https://user-images.githubusercontent.com/372004/58655630-83657a00-82e8-11e9-9415-0dd44f2cdb09.png)


Technical Details
----------------------------------------
The xml will be used to generate CRM_Core_I18n_SchemaStructure::widgets that is used by the i18n popup.

Comments
----------------------------------------
See also https://github.com/civicrm/civicrm-core/pull/5734
