### PR TITLE
dev/core#389 [preliminary cleanup] Standardise metadata for custom field use

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -94,6 +94,13 @@ class CRM_Core_BAO_CustomQuery {
   public $_fields;
 
   /**
+   * @return array
+   */
+  public function getFields() {
+    return $this->_fields;
+  }
+
+  /**
    * Searching for contacts?
    *
    * @var bool

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -159,8 +159,8 @@ class CRM_Core_BAO_CustomQuery {
     $this->_qill = [];
     $this->_options = [];
 
-    $this->_fields = [];
     $this->_contactSearch = $contactSearch;
+    $this->_fields = CRM_Core_BAO_CustomField::getFields('ANY', FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE);
 
     if (empty($this->_ids)) {
       return;
@@ -184,28 +184,6 @@ SELECT f.id, f.label, f.data_type,
 
     $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
-      // get the group dao to figure which class this custom field extends
-      $extends = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $dao->custom_group_id, 'extends');
-      $extendsTable = '';
-      if (array_key_exists($extends, self::$extendsMap)) {
-        $extendsTable = self::$extendsMap[$extends];
-      }
-      elseif (in_array($extends, CRM_Contact_BAO_ContactType::subTypes())) {
-        // if $extends is a subtype, refer contact table
-        $extendsTable = self::$extendsMap['Contact'];
-      }
-      $this->_fields[$dao->id] = [
-        'id' => $dao->id,
-        'label' => $dao->label,
-        'extends' => $extendsTable,
-        'data_type' => $dao->data_type,
-        'html_type' => $dao->html_type,
-        'is_search_range' => $dao->is_search_range,
-        'column_name' => $dao->column_name,
-        'table_name' => $dao->table_name,
-        'option_group_id' => $dao->option_group_id,
-      ];
-
       // Deprecated (and poorly named) cache of field attributes
       $this->_options[$dao->id] = [
         'attributes' => [
@@ -242,27 +220,15 @@ SELECT f.id, f.label, f.data_type,
       $this->_element["{$name}_id"] = 1;
       $this->_select[$fieldName] = "{$field['table_name']}.{$field['column_name']} as $fieldName";
       $this->_element[$fieldName] = 1;
-      $joinTable = NULL;
+      $joinTable = $field['search_table'];
       // CRM-14265
-      if ($field['extends'] == 'civicrm_group') {
-        return;
-      }
-      elseif ($field['extends'] == 'civicrm_contact') {
-        $joinTable = 'contact_a';
-      }
-      elseif ($field['extends'] == 'civicrm_contribution') {
-        $joinTable = $field['extends'];
-      }
-      elseif (in_array($field['extends'], self::$extendsMap)) {
-        $joinTable = $field['extends'];
-      }
-      else {
+      if ($joinTable == 'civicrm_group' || empty($joinTable)) {
         return;
       }
 
       $this->_tables[$name] = "\nLEFT JOIN $name ON $name.entity_id = $joinTable.id";
 
-      if ($this->_ids[$id]) {
+      if (!empty($this->_ids[$id])) {
         $this->_whereTables[$name] = $this->_tables[$name];
       }
 
@@ -276,7 +242,7 @@ SELECT f.id, f.label, f.data_type,
           $joinClause = "\nLEFT JOIN $joinTable `$locationType-address` ON (`$locationType-address`.contact_id = contact_a.id AND `$locationType-address`.location_type_id = $locationTypeId)";
         }
         $this->_tables[$name] = "\nLEFT JOIN $name ON $name.entity_id = `$joinTableAlias`.id";
-        if ($this->_ids[$id]) {
+        if (!empty($this->_ids[$id])) {
           $this->_whereTables[$name] = $this->_tables[$name];
         }
         if ($joinTable != 'contact_a') {

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -50,6 +50,18 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       $queryObj->_where[0][0]
     );
     $this->assertEquals($queryObj->_qill[0][0], "date field BETWEEN 'January 1st, " . date('Y') . " 12:00 AM AND December 31st, " . date('Y') . " 11:59 PM'");
+    $this->assertEquals([
+      'id' => $dateCustomField['id'],
+      'label' => 'date field',
+      'extends' => 'civicrm_contact',
+      'data_type' => 'Date',
+      'html_type' => 'Select Date',
+      'is_search_range' => '0',
+      'column_name' => 'date_field_' . $dateCustomField['id'],
+      'table_name' => 'civicrm_value_testsearchcus_' . $ids['custom_group_id'],
+      'option_group_id' => NULL,
+    ], $queryObj->getFields()[$dateCustomField['id']]);
+
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -53,13 +53,27 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     $this->assertEquals([
       'id' => $dateCustomField['id'],
       'label' => 'date field',
-      'extends' => 'civicrm_contact',
+      'extends' => 'Contact',
       'data_type' => 'Date',
       'html_type' => 'Select Date',
       'is_search_range' => '0',
       'column_name' => 'date_field_' . $dateCustomField['id'],
       'table_name' => 'civicrm_value_testsearchcus_' . $ids['custom_group_id'],
       'option_group_id' => NULL,
+      'groupTitle' => 'testSearchCustomDataDateRelative',
+      'default_value' => NULL,
+      'text_length' => NULL,
+      'options_per_line' => NULL,
+      'custom_group_id' => '1',
+      'extends_entity_column_value' => NULL,
+      'extends_entity_column_id' => NULL,
+      'is_view' => '0',
+      'is_multiple' => '0',
+      'date_format' => 'mm/dd/yy',
+      'time_format' => NULL,
+      'is_required' => '0',
+      'extends_table' => 'civicrm_contact',
+      'search_table' => 'contact_a',
     ], $queryObj->getFields()[$dateCustomField['id']]);
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup - make available metadata more consistent for custom fields, reduce duplication

Before
----------------------------------------
Metadata less consistent

After
----------------------------------------
Metadata more consistent

Technical Details
----------------------------------------
In digging into dev/core#389 I found a major complexity in fixing it was inconsistent metadata available at different points in the code. This simply adds metadata to the 'inner-most place' & makes the BAO_CustomQuery object use that

I didn't remove the options loop because I wanted to leave that out of scope as I can't see how / if it is used

Comments
----------------------------------------
Note if you look at the before test you can see nothing was 'taken away' - stuff was added & 'extends' was put back to it's original value, giving extends_table as a new value for that meaning
