### PR TITLE
Allow public access to CiviContribute unsubscribe for cancelling recurring contributions

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -354,6 +354,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     }
     $this->selfService = FALSE;
     if (!CRM_Core_Permission::check('edit contributions')) {
+      $this->set('cid', $this->_subscriptionDetails->contact_id);
       if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
         CRM_Core_Error::statusBounce(ts('You do not have permission to cancel this recurring contribution.'));
       }

--- a/CRM/Contribute/xml/Menu/Contribute.xml
+++ b/CRM/Contribute/xml/Menu/Contribute.xml
@@ -229,6 +229,8 @@
     <title>Cancel Subscription</title>
     <page_callback>CRM_Contribute_Form_CancelSubscription</page_callback>
     <access_arguments>make online contributions</access_arguments>
+    <is_ssl>true</is_ssl>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/contribute/onbehalf</path>


### PR DESCRIPTION
and set contact_id from contribution data for checksum check

Overview
----------------------------------------
Our contribution form sends a receipt containing the unsubscribe link for recurring contributions, but not everyone who receives this will have a site CMS account. So I needed the CRM_Contribute_Form_CancelSubscription to allow public access.

I then found that the checksum validation wasn't working, because getContactID() didn't have a means to access the contact ID that it's verifying the checksum for. So I added a line to set `cid` based on the subscription details that we get, looking up the contribution from the `coid` in the URL.

Since it involves the checksum code, this has security implications. Does it seem complete, as a fix? You all are much more aware of how the whole system comes together.