### PR TITLE
Force link in confirmation email to be front-end

### DIFF
--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -231,7 +231,7 @@ SELECT     civicrm_email.id as email_id
 
     $url = CRM_Utils_System::url('civicrm/mailing/confirm',
       "reset=1&cid={$this->contact_id}&sid={$this->id}&h={$this->hash}",
-      TRUE
+      TRUE, NULL, TRUE, TRUE
     );
 
     $html = $component->body_html;


### PR DESCRIPTION
Overview
----------------------------------------
The `MailingEventSubscribe` API should always force the URL in the confirmation email to be a front-end URL. Fixes [Issue 1005 on Lab](https://lab.civicrm.org/dev/core/issues/1005).

Before
----------------------------------------
The `MailingEventSubscribe` API does not always force the URL in the confirmation email to be a front-end URL.

This can be reproduced by using the CiviCRM API Explorer in WordPress but also applies when a form is submitted via the standard WordPress AJAX route of `admin_url('admin-ajax.php')`.

After
----------------------------------------
The `MailingEventSubscribe` API always forces the URL in the confirmation email to be a front-end URL.