### PR TITLE
core#1006 - don't overwrite existing data on profile submission with …

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2330,7 +2330,7 @@ ORDER BY civicrm_email.is_primary DESC";
 
           // if auth source is not checksum / login && $value is blank, do not proceed - CRM-10128
           if (($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 &&
-            ($value == '' || !isset($value))
+            ($value == '' || !isset($value) || empty($value))
           ) {
             continue;
           }


### PR DESCRIPTION
…a blank Select2

Overview
----------------------------------------
See [CRM-10128](https://issues.civicrm.org/jira/browse/CRM-10128).  @deepak-srivastava mostly fixed this with #1701, but we need to handle the case where a custom field submits an array (i.e. Select2 fields).

To replicate:
* Create a custom field that can submit multiple values.
* Add that custom field to a profile.
* Create a contact and fill in the new custom field.
* As an *anonymous* user, submit the profile, but a) leave the new custom field blank, b) ensure that you match your new contact through the Unsupervised Dedupe rule.

Before
----------------------------------------
The existing data is overwritten with NULL.

After
----------------------------------------
The existing data is preserved, identical to how other fields are treated via #1701.

Comments
----------------------------------------
This is a very small fix, and easy to test.  I'm going to tag it as such :)