### PR TITLE
Fix fatal error when using the "Renew - Credit Card" form to renew a membership (only for certain membership setups)

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3408,6 +3408,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   public static function recordFinancialAccounts(&$params, $financialTrxnValues = NULL) {
     $skipRecords = $update = $return = $isRelatedId = FALSE;
 
+    $params['contribution']->receive_date = ($params['contribution']->receive_date) ? $params['contribution']->receive_date : date('YmdHis');
     $additionalParticipantId = [];
     $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     $contributionStatus = empty($params['contribution_status_id']) ? NULL : $contributionStatuses[$params['contribution_status_id']];


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a fatal error when renewing a membership on the backend thru the "Renew - Credit Card" form 

Before
----------------------------------------
Fatal error 
![erroronRenewCreditCard](https://user-images.githubusercontent.com/11323624/58738326-52ae3f00-83d3-11e9-83a1-63dacad3b753.png)

After
----------------------------------------
Form works as expected

Technical Details
----------------------------------------
In some instances the receive date was not being set on the contribution which would lead to a fatal error when submitting the form. This ensures the receive date is set.

