### PR TITLE
CRM_Extension_System - Only allow `test.*` extensions during headless testing. Hide from regular users. 

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -155,6 +155,12 @@ class CRM_Extension_System {
         }
       }
 
+      if (!defined('CIVICRM_TEST')) {
+        foreach ($containers as $container) {
+          $container->addFilter([__CLASS__, 'isNotTestExtension']);
+        }
+      }
+
       $this->fullContainer = new CRM_Extension_Container_Collection($containers, $this->getCache(), 'full');
     }
     return $this->fullContainer;
@@ -300,6 +306,10 @@ class CRM_Extension_System {
       Civi::$statics[__CLASS__]['compatibility'] = json_decode(file_get_contents(Civi::paths()->getPath('[civicrm.root]/extension-compatibility.json')), TRUE);
     }
     return Civi::$statics[__CLASS__]['compatibility'];
+  }
+
+  public static function isNotTestExtension(CRM_Extension_Info $info) {
+    return (bool) !preg_match('/^test\./', $info->key);
   }
 
   /**


### PR DESCRIPTION
The headless test suite includes integration tests for correct handling of the extension installation/removal process. This involves some dummy extensions. Unfortunately, the dummy extensions are often picked up on other deployments -- where they're a bit distracting/annoying.

Before
------

The `test.*` dummy extensions appear as available in all environments, including headless tests and live sites.

After
-----

The `test.*` dummy extensions are only available in the headless test environment.

Comments
-----------

The extension list is used on every page-load, so one might be concerned: what's the performance impact of adding more filters to this scan process? Fortunately, the output of the scanning is cached post-filtering -- so there should be no discernible penalty.