### PR TITLE
dev/core#1004 Fix regression causing notices on components screen

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -112,14 +112,6 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
    */
   public function commonProcess(&$params) {
 
-    // save components to be enabled
-    if (array_key_exists('enableComponents', $params)) {
-      civicrm_api3('setting', 'create', [
-        'enable_components' => $params['enableComponents'],
-      ]);
-      unset($params['enableComponents']);
-    }
-
     foreach (['verifySSL', 'enableSSL'] as $name) {
       if (isset($params[$name])) {
         Civi::settings()->set($name, $params[$name]);
@@ -127,7 +119,6 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
       }
     }
     try {
-      $settings = $this->getSettingsToSetByMetadata($params);
       $this->saveMetadataDefinedSettings($params);
     }
     catch (CiviCRM_API3_Exception $e) {

--- a/CRM/Admin/Form/Setting/Component.php
+++ b/CRM/Admin/Form/Setting/Component.php
@@ -37,26 +37,15 @@
 class CRM_Admin_Form_Setting_Component extends CRM_Admin_Form_Setting {
   protected $_components;
 
+  protected $_settings = [
+    'enable_components' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+  ];
+
   /**
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - Enable Components'));
-    $components = $this->_getComponentSelectValues();
-    $include = &$this->addElement('advmultiselect', 'enableComponents',
-      ts('Components') . ' ', $components,
-      [
-        'size' => 5,
-        'style' => 'width:150px',
-        'class' => 'advmultiselect',
-      ]
-    );
-
-    $include->setButtonAttributes('add', ['value' => ts('Enable >>')]);
-    $include->setButtonAttributes('remove', ['value' => ts('<< Disable')]);
-
     $this->addFormRule(['CRM_Admin_Form_Setting_Component', 'formRule'], $this);
-
     parent::buildQuickForm();
   }
 
@@ -76,98 +65,20 @@ class CRM_Admin_Form_Setting_Component extends CRM_Admin_Form_Setting {
   public static function formRule($fields, $files, $options) {
     $errors = [];
 
-    if (array_key_exists('enableComponents', $fields) && is_array($fields['enableComponents'])) {
-      if (in_array('CiviPledge', $fields['enableComponents']) &&
-        !in_array('CiviContribute', $fields['enableComponents'])
+    if (array_key_exists('enable_components', $fields) && is_array($fields['enable_components'])) {
+      if (in_array('CiviPledge', $fields['enable_components']) &&
+        !in_array('CiviContribute', $fields['enable_components'])
       ) {
-        $errors['enableComponents'] = ts('You need to enable CiviContribute before enabling CiviPledge.');
+        $errors['enable_components'] = ts('You need to enable CiviContribute before enabling CiviPledge.');
       }
-      if (in_array('CiviCase', $fields['enableComponents']) &&
+      if (in_array('CiviCase', $fields['enable_components']) &&
         !CRM_Core_DAO::checkTriggerViewPermission(TRUE, FALSE)
       ) {
-        $errors['enableComponents'] = ts('CiviCase requires CREATE VIEW and DROP VIEW permissions for the database.');
+        $errors['enable_components'] = ts('CiviCase requires CREATE VIEW and DROP VIEW permissions for the database.');
       }
     }
 
     return $errors;
-  }
-
-  /**
-   * @return array
-   */
-  private function _getComponentSelectValues() {
-    $ret = [];
-    $this->_components = CRM_Core_Component::getComponents();
-    foreach ($this->_components as $name => $object) {
-      $ret[$name] = $object->info['translatedName'];
-    }
-
-    return $ret;
-  }
-
-  public function postProcess() {
-    $params = $this->controller->exportValues($this->_name);
-
-    parent::commonProcess($params);
-
-    // reset navigation when components are enabled / disabled
-    CRM_Core_BAO_Navigation::resetNavigation();
-  }
-
-  /**
-   * Load case sample data.
-   *
-   * @param string $fileName
-   * @param bool $lineMode
-   */
-  public static function loadCaseSampleData($fileName, $lineMode = FALSE) {
-    $dao = new CRM_Core_DAO();
-    $db = $dao->getDatabaseConnection();
-
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    $multiLingual = (bool) $domain->locales;
-    $smarty = CRM_Core_Smarty::singleton();
-    $smarty->assign('multilingual', $multiLingual);
-    $smarty->assign('locales', explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales));
-
-    if (!$lineMode) {
-
-      $string = $smarty->fetch($fileName);
-      // change \r\n to fix windows issues
-      $string = str_replace("\r\n", "\n", $string);
-
-      //get rid of comments starting with # and --
-
-      $string = preg_replace("/^#[^\n]*$/m", "\n", $string);
-      $string = preg_replace("/^(--[^-]).*/m", "\n", $string);
-
-      $queries = preg_split('/;$/m', $string);
-      foreach ($queries as $query) {
-        $query = trim($query);
-        if (!empty($query)) {
-          $res = &$db->query($query);
-          if (PEAR::isError($res)) {
-            die("Cannot execute $query: " . $res->getMessage());
-          }
-        }
-      }
-    }
-    else {
-      $fd = fopen($fileName, "r");
-      while ($string = fgets($fd)) {
-        $string = preg_replace("/^#[^\n]*$/m", "\n", $string);
-        $string = preg_replace("/^(--[^-]).*/m", "\n", $string);
-
-        $string = trim($string);
-        if (!empty($string)) {
-          $res = &$db->query($string);
-          if (PEAR::isError($res)) {
-            die("Cannot execute $string: " . $res->getMessage());
-          }
-        }
-      }
-    }
   }
 
 }

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -319,8 +319,14 @@ trait CRM_Admin_Form_SettingTrait {
   }
 
   /**
-   * @param $params
+   * Save any fields which have been defined via metadata.
    *
+   * (Other fields are hack-handled... sadly.
+   *
+   * @param array $params
+   *   Form input.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   protected function saveMetadataDefinedSettings($params) {
     $settings = $this->getSettingsToSetByMetadata($params);

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -142,6 +142,7 @@ class CRM_Core_Component {
 
   public static function flushEnabledComponents() {
     unset(Civi::$statics[__CLASS__]);
+    CRM_Core_BAO_Navigation::resetNavigation();
   }
 
   /**

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1158,4 +1158,21 @@ class CRM_Core_SelectValues {
     return $options;
   }
 
+  /**
+   * Get components (translated for display.
+   *
+   * @return array
+   *
+   * @throws \Exception
+   */
+  public static function getComponentSelectValues() {
+    $ret = [];
+    $components = CRM_Core_Component::getComponents();
+    foreach ($components as $name => $object) {
+      $ret[$name] = $object->info['translatedName'];
+    }
+
+    return $ret;
+  }
+
 }

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -732,12 +732,11 @@ return [
     'group' => 'core',
     'name' => 'enable_components',
     'type' => 'Array',
-    'quick_form_type' => 'Element',
-    'html_type' => 'advmultiselect',
+    'quick_form_type' => 'Select',
+    'html_type' => 'Select',
     'html_attributes' => [
-      'size' => 5,
-      'style' => 'width:150px',
-      'class' => 'advmultiselect',
+      'multiple' => 1,
+      'class' => 'crm-select2',
     ],
     'default' => NULL,
     'add' => '4.4',
@@ -750,6 +749,9 @@ return [
       'CRM_Case_Info::onToggleComponents',
       'CRM_Core_Component::flushEnabledComponents',
       'call://resources/resetCacheCode',
+    ],
+    'pseudoconstant' => [
+      'callback' => 'CRM_Core_SelectValues::getComponentSelectValues',
     ],
   ],
   'disable_core_css' => [

--- a/templates/CRM/Admin/Form/Setting/Component.tpl
+++ b/templates/CRM/Admin/Form/Setting/Component.tpl
@@ -28,10 +28,7 @@
 </div>
 <div class="crm-block crm-form-block crm-component-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-{$form.enableComponents.html}
-<p class="description">
-    {ts}Enabled components are listed in the right-hand box. Disabled components are listed in the left-hand box. Highlight a component and click the Enable or Disable button to move it from one box to the other. Then click <strong>Save</strong>.{/ts}
-</p>
+{$form.enable_components.html}
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes unreleased regression causing notices on enable components page

Before
----------------------------------------
Notices

After
----------------------------------------
Poof

This DOES change from
advmultiselect to a normal UI - not sure if there is any reason not so, since adv multiselect is
deprecated

<img width="908" alt="Screen Shot 2019-06-01 at 4 54 29 PM" src="https://user-images.githubusercontent.com/336308/58743872-f3613500-848d-11e9-90a6-6efe7963cf72.png">


Technical Details
----------------------------------------
I've cleaned up the metadata & moved relevant functions to the right places. 

----------------------------------------
@colemanw as @jaapjansma pointed out this is an unreleased regression from https://github.com/civicrm/civicrm-core/pull/14264 - I've fixed the form to use the metadata - plse review
