### PR TITLE
Add Contact.get_merge_conflicts api

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2109,15 +2109,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   protected static function dedupePair(&$resultStats, &$deletedContacts, $mode, $checkPermissions, $mainId, $otherId, $cacheKeyString) {
 
-    // Generate var $migrationInfo. The variable structure is exactly same as
-    // $formValues submitted during a UI merge for a pair of contacts.
-    $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($mainId, $otherId, $checkPermissions);
-    // add additional details that we might need to resolve conflicts
-    $rowsElementsAndInfo['migration_info']['main_details'] = &$rowsElementsAndInfo['main_details'];
-    $rowsElementsAndInfo['migration_info']['other_details'] = &$rowsElementsAndInfo['other_details'];
-    $rowsElementsAndInfo['migration_info']['rows'] = &$rowsElementsAndInfo['rows'];
-    $migrationInfo = $rowsElementsAndInfo['migration_info'];
-    // go ahead with merge if there is no conflict
+    $migrationInfo = [];
     $conflicts = [];
     if (!CRM_Dedupe_Merger::skipMerge($mainId, $otherId, $migrationInfo, $mode, $conflicts)) {
       CRM_Dedupe_Merger::moveAllBelongings($mainId, $otherId, $migrationInfo, $checkPermissions);
@@ -2332,9 +2324,21 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *   -  Does a force merge otherwise (aggressive mode).
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getConflicts(&$migrationInfo, $mainId, $otherId, $mode) {
     $conflicts = [];
+    // Generate var $migrationInfo. The variable structure is exactly same as
+    // $formValues submitted during a UI merge for a pair of contacts.
+    $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($mainId, $otherId, FALSE);
+    // add additional details that we might need to resolve conflicts
+    $migrationInfo = $rowsElementsAndInfo['migration_info'];
+    $migrationInfo['main_details'] = &$rowsElementsAndInfo['main_details'];
+    $migrationInfo['other_details'] = &$rowsElementsAndInfo['other_details'];
+    $migrationInfo['rows'] = &$rowsElementsAndInfo['rows'];
+    // go ahead with merge if there is no conflict
     $originalMigrationInfo = $migrationInfo;
     foreach ($migrationInfo as $key => $val) {
       if ($val === "null") {

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -71,6 +71,7 @@ trait ContactTestTrait {
    *
    * @return int
    *   id of Individual created
+   * @throws \Exception
    */
   public function individualCreate($params = array(), $seq = 0, $random = FALSE) {
     $params = array_merge($this->sampleContact('Individual', $seq, $random), $params);

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1229,7 +1229,8 @@ function _civicrm_api3_contact_merge_spec(&$params) {
   $params['mode'] = [
     'title' => ts('Dedupe mode'),
     'description' => ts("In 'safe' mode conflicts will result in no merge. In 'aggressive' mode the merge will still proceed (hook dependent)"),
-    'api.default' => 'safe',
+    'api.default' => ['safe', 'aggressive'],
+    'options' => ['safe' => ts('Abort on unhandled conflict'), 'aggressive' => ts('Proceed on unhandled conflict. Note hooks may change handling here.')],
   ];
 }
 
@@ -1247,18 +1248,40 @@ function _civicrm_api3_contact_merge_spec(&$params) {
  *
  * @throws \CRM_Core_Exception
  * @throws \CiviCRM_API3_Exception
+ * @throws \API_Exception
  */
 function civicrm_api3_contact_get_merge_conflicts($params) {
   $migrationInfo = [];
-  $result = CRM_Dedupe_Merger::getConflicts(
-    $migrationInfo,
+  $contactFieldsToCompare = [];
+  $entitiesToCompare = [];
+  $return = [];
+  foreach ((array) $params['mode'] as $mode) {
+    $result[$mode] = CRM_Dedupe_Merger::getConflicts(
+      $migrationInfo,
       $params['to_remove_id'], $params['to_keep_id'],
       $params['mode']
-  );
-  $return = [];
-  foreach (array_keys($result) as $index) {
-    $return[str_replace('move_', '', $index)] = [];
+    );
+    $return = [];
+    foreach (array_keys($result[$mode]) as $index) {
+      if (substr($index, 0, 14) === 'move_location_') {
+        $parts = explode('_', $index);
+        $entity = $parts[2];
+        $locationTypeID = $migrationInfo['location_blocks'][$entity][$parts[3]]['locTypeId'];
+        $return[$mode]['conflicts'][$entity][] = ['location_type_id' => $locationTypeID];
+        $entitiesToCompare[$entity][] = $locationTypeID;
+      }
+      elseif (substr($index, 0, 5) === 'move_') {
+        $contactFieldsToCompare[] = str_replace('move_', '', $index);
+        $return[$mode]['conflicts']['contact'][0][str_replace('move_', '', $index)] = [];
+      }
+      else {
+        // Can't think of why this would be the case but perhaps it's ensuring it isn't as we
+        // refactor this.
+        throw new API_Exception(ts('Unknown parameter') . $index);
+      }
+    }
   }
+  // We get the contact & location details once, now we know what we need for both modes (if both being fetched).
   $contacts = civicrm_api3('Contact', 'get', [
     'id' => [
       'IN' => [
@@ -1266,11 +1289,50 @@ function civicrm_api3_contact_get_merge_conflicts($params) {
         $params['to_remove_id'],
       ],
     ],
-    'return' => array_keys($return),
+    'return' => $contactFieldsToCompare,
   ])['values'];
-  foreach (array_keys($return) as $fieldName) {
-    $return[$fieldName][$params['to_keep_id']] = CRM_Utils_Array::value($fieldName, $contacts[$params['to_keep_id']]);
-    $return[$fieldName][$params['to_remove_id']] = CRM_Utils_Array::value($fieldName, $contacts[$params['to_remove_id']]);
+  foreach ($contactFieldsToCompare as $fieldName) {
+    foreach ((array) $params['mode'] as $mode) {
+      if (isset($return[$mode]['conflicts']['contact'][0][$fieldName])) {
+        $return[$mode]['conflicts']['contact'][0][$fieldName][$params['to_keep_id']] = CRM_Utils_Array::value($fieldName, $contacts[$params['to_keep_id']]);
+        $return[$mode]['conflicts']['contact'][0][$fieldName][$params['to_remove_id']] = CRM_Utils_Array::value($fieldName, $contacts[$params['to_remove_id']]);
+      }
+    }
+  }
+  foreach ($entitiesToCompare as $entity => $locations) {
+    $contactLocationDetails = civicrm_api3($entity, 'get', [
+      'contact_id' => ['IN' => [$params['to_keep_id'], $params['to_remove_id']]],
+      'location_type_id' => ['IN' => $locations],
+    ])['values'];
+    $detailsByLocation = [];
+    foreach ($contactLocationDetails as $locationDetail) {
+      if ((int) $locationDetail['contact_id'] === $params['to_keep_id']) {
+        $detailsByLocation[$locationDetail['location_type_id']]['to_keep'] = $locationDetail;
+      }
+      elseif ((int) $locationDetail['contact_id'] === $params['to_remove_id']) {
+        $detailsByLocation[$locationDetail['location_type_id']]['to_remove'] = $locationDetail;
+      }
+      else {
+        // Can't think of why this would be the case but perhaps it's ensuring it isn't as we
+        // refactor this.
+        throw new API_Exception(ts('Unknown parameter') . $index);
+      }
+    }
+    foreach ((array) $params['mode'] as $mode) {
+      foreach ($return[$mode]['conflicts'][$entity] as $index => $entityData) {
+        $locationTypeID = $entityData['location_type_id'];
+        foreach ($detailsByLocation[$locationTypeID]['to_keep'] as $fieldName => $keepContactValue) {
+          $fieldsToIgnore = ['id', 'contact_id', 'is_primary', 'is_billing', 'manual_geo_code', 'contact_id', 'reset_date', 'hold_date'];
+          if (in_array($fieldName, $fieldsToIgnore)) {
+            continue;
+          }
+          $otherContactValue = $detailsByLocation[$locationTypeID]['to_remove'][$fieldName];
+          if (!empty($keepContactValue) && !empty($otherContactValue) && $keepContactValue !== $otherContactValue) {
+            $return[$mode]['conflicts'][$entity][$index][$fieldName] = [$params['to_keep_id'] => $keepContactValue, $params['to_remove_id'] => $otherContactValue];
+          }
+        }
+      }
+    }
   }
   return civicrm_api3_create_success($return, $params);
 }
@@ -1294,7 +1356,7 @@ function _civicrm_api3_contact_get_merge_conflicts_spec(&$params) {
   $params['mode'] = [
     'title' => ts('Dedupe mode'),
     'description' => ts("'safe' or 'aggressive'  - these modes map to the merge actions & may affect resolution done by hooks "),
-    'api.default' => 'safe',
+    'api.default' => ['safe'],
   ];
 }
 

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -62,22 +62,30 @@ trait CRMTraits_Custom_CustomDataTrait {
   }
 
   /**
+   * Create a custom group with a single field.
+   *
+   * @param array $groupParams
+   * @param string $customFieldType
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function createCustomGroupWithFieldOfType($groupParams = [], $customFieldType = 'text') {
+    if ($customFieldType !== 'text') {
+      throw new CRM_Core_Exception('we have not yet extracted other custom field types from createCustomFieldsOfAllTypes, Use consistent syntax when you do');
+    }
+    $groupParams['title'] = empty($groupParams['title']) ? 'Group with field ' . $customFieldType : $groupParams['title'];
+    $this->createCustomGroup($groupParams);
+    $customField = $this->createTextCustomField(['custom_group_id' => $this->ids['CustomGroup'][$groupParams['title']]]);
+    $this->ids['CustomField'][$customFieldType] = $customField['id'];
+  }
+
+  /**
    * @return array
    */
   public function createCustomFieldsOfAllTypes() {
     $customGroupID = $this->ids['CustomGroup']['Custom Group'];
     $ids = [];
-    $params = [
-      'custom_group_id' => $customGroupID,
-      'label' => 'Enter text here',
-      'html_type' => 'Text',
-      'data_type' => 'String',
-      'default_value' => 'xyz',
-      'weight' => 1,
-      'is_required' => 1,
-    ];
-
-    $customField = $this->callAPISuccess('CustomField', 'create', $params);
+    $customField = $this->createTextCustomField(['custom_group_id' => $customGroupID]);
     $ids['text'] = $customField['id'];
 
     $optionValue[] = [
@@ -178,6 +186,28 @@ trait CRMTraits_Custom_CustomDataTrait {
   protected function getCustomFieldName($key) {
     $linkField = 'custom_' . $this->ids['CustomField'][$key];
     return $linkField;
+  }
+
+  /**
+   * Create a custom text fields.
+   *
+   * @param array $params
+   *   Parameter overrides, must include custom_group_id.
+   *
+   * @return array
+   */
+  protected function createTextCustomField($params = []) {
+    $params = array_merge([
+      'label' => 'Enter text here',
+      'html_type' => 'Text',
+      'data_type' => 'String',
+      'default_value' => 'xyz',
+      'weight' => 1,
+      'is_required' => 1,
+      'sequential' => 1,
+    ], $params);
+
+    return $this->callAPISuccess('CustomField', 'create', $params)['values'][0];
   }
 
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1607,7 +1607,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * CRM-20421: This test make sure that inherited memberships are deleted upon merging organization.
    */
   public function testMergeOrganizations() {
-    $organizationID1 = $this->organizationCreate(array(), 0);
+    $organizationID1 = $this->organizationCreate([], 0);
     $organizationID2 = $this->organizationCreate(array(), 1);
     $contact = $this->callAPISuccess('contact', 'create', array_merge($this->_params, array(
       'employer_id' => $organizationID1,
@@ -1648,6 +1648,16 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     ));
 
     $this->assertEquals(0, $contactmembership["count"], "Contact membership must be deleted after merging organization without memberships.");
+  }
+
+  /**
+   * Test the function that determines if 2 contacts have conflicts.
+   */
+  public function testMergeGetConflicts() {
+    $contact1 = $this->individualCreate();
+    $contact2 = $this->individualCreate(['first_name' => 'different']);
+    $conflicts = $this->callAPISuccess('Contact', 'get_merge_conflicts', ['to_keep_id' => $contact1, 'to_remove_id' => $contact2])['values'];
+    $this->assertEquals(['first_name' => [$contact1 => 'Anthony', $contact2 => 'different']], $conflicts);
   }
 
   private function createEmployerOfMembership() {


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up code & exposed Contact.get_merge_conflicts as a merge action

Before
----------------------------------------
Less testing, less readability, no ability to access via api

After
----------------------------------------
API:
```
civicrm_api3('Contact', 'get_merge_conflicts', ['to_keep_id => 1, 'to_remove_id] => 2);
```
Technical Details
----------------------------------------
The goal here is to
1) improve testing
2) cleanup the code & define parameters where they are actually used rather than pass from pillar to post
3) expose to the api so we can be less coupled to the current form

I thought about putting the api on the Dedupe entity but my thinking is that actions relating to
individual pairs go on the contact entity & those relating to the batch find, cache, merge
functionality go on the Dedupe entity.

I'm doing another round of dedupe code cleanup at the moment... In conjunction with efforts to write an
angular form which highlights what functionality a form needs to access & where the code is awful....


Comments
----------------------------------------
@JKingsnorth 
