### PR TITLE
WIP Refactor cancel/failed functions in baseIPN so we don't duplicate code and business logic is separated out

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1016,6 +1016,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    * @return array
    */
   protected static function cancel($processContributionObject, $memberships, $contributionId, $membershipStatuses, $updateResult, $participant, $oldStatus, $pledgePayment, $pledgeID, $pledgePaymentIDs, $contributionStatusId) {
+    // @fixme https://lab.civicrm.org/dev/core/issues/927 Cancelling membership etc is not desirable for all use-cases and we should be able to disable it
     $processContribution = FALSE;
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     if (is_array($memberships)) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -284,6 +284,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $recur->cancel_date = date('YmdHis');
       $recur->save();
 
+      // @fixme https://lab.civicrm.org/dev/core/issues/927 Cancelling membership etc is not desirable for all use-cases and we should be able to disable it
       $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurId);
       if ($dao && $dao->recur_id) {
         $details = CRM_Utils_Array::value('details', $activityParams);

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -388,7 +388,7 @@ class CRM_Core_Payment_BaseIPN {
    */
   public function unhandled(&$objects, &$transaction) {
     $transaction->rollback();
-    CRM_Core_Error::debug_log_message("returning since contribution status: is not handled");
+    Civi::log()->debug("Returning since contribution status is not handled");
     echo "Failure: contribution status is not handled<p>";
     return FALSE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
In https://lab.civicrm.org/dev/core/issues/927 we identify some undesirable "business logic" related to cancelling of memberships if a contribution is cancelled.  This is a refactor of the BaseIPN class to remove duplicate code and separate out the functions which cancel memberships / participants when a contribution is marked cancelled / failed.  This does not "fix" 927 but gets us one step closer to having the code responsible in one place!

Next steps could be to share the `cancelMembership()`/`cancelParticipant()` functions with `CRM_Contribute_BAO_Contribution::cancel()`

Before
----------------------------------------
BaseIPN has almost identical code duplicated for `cancelled()` and `failed()` actions.

After
----------------------------------------
BaseIPN has shared code for `cancelled()` and `failed()` actions.  Participant and Membership related actions are moved into their own functions.

Technical Details
----------------------------------------
There should be no change to behaviour here.

Comments
----------------------------------------
@sluc23 Could anyone from your team review this?  @eileenmcnaughton More contribution actions refactoring here... :-)
