### PR TITLE
Add missing 'submit credit card event registration' link to standalone event registration form

### DIFF
--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -184,6 +184,16 @@
     {assign var=registerMode value="LIVE"}
   {/if}
   <div class="crm-block crm-form-block crm-participant-form-block">
+    {if $newCredit AND $action EQ 1 AND $participantMode EQ null}
+      <div class="action-link css_right crm-link-credit-card-mode">
+        {if $contactId}
+          {capture assign=ccModeLink}{crmURL p='civicrm/contact/view/participant' q="reset=1&action=add&cid=`$contactId`&context=`$context`&mode=live"}{/capture}
+        {else}
+          {capture assign=ccModeLink}{crmURL p='civicrm/contact/view/participant' q="reset=1&action=add&context=standalone&mode=live"}{/capture}
+        {/if}
+        <a class="open-inline-noreturn action-item crm-hover-button" href="{$ccModeLink}">&raquo; {ts}submit credit card event registration{/ts}</a>
+      </div>
+    {/if}
     <div class="view-content">
       {if $participantMode}
         <div class="help">


### PR DESCRIPTION
Overview
----------------------------------------
Add missing 'submit credit card event registration' link to standalone event registration form - see https://github.com/civicrm/civicrm-core/pull/14049

Before
----------------------------------------
Missing "submit credit card event registration" link.

After
----------------------------------------
Per other forms (contribution / membership):
![image](https://user-images.githubusercontent.com/2052161/58752534-4e078a80-84a8-11e9-881e-be57149ca22c.png)


Technical Details
----------------------------------------
Just adds a link to the template.  The functionality already works and this makes it consistent pending further refactor.

Comments
----------------------------------------
@agh1 @Stoob Please could you review?
