### PR TITLE
dev/core#389 [preliminary cleanup+ test] Standardise metadat for custom field

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -2,9 +2,12 @@
 
 /**
  * Class CRM_Core_BAO_CustomFieldTest
+ *
  * @group headless
  */
 class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
+
+  use CRMTraits_Custom_CustomDataTrait;
 
   protected $customFieldID;
 
@@ -17,14 +20,14 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $customFieldID = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
     );
-    $fields = array(
+    $fields = [
       'id' => $customFieldID,
       'label' => 'editTestFld',
       'is_active' => 1,
       'data_type' => 'String',
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
-    );
+    ];
 
     CRM_Core_BAO_CustomField::create($fields);
     $this->assertDBNotNull('CRM_Core_DAO_CustomField', 1, 'id', 'is_active', 'Database check for edited CustomField.');
@@ -39,14 +42,14 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testCreateCustomFieldColumnName() {
-    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
-    $fields = array(
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $fields = [
       'label' => 'testFld 2',
       'column_name' => 'special_colname',
       'data_type' => 'String',
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
-    );
+    ];
     CRM_Core_BAO_CustomField::create($fields);
     $customFieldID = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
@@ -59,14 +62,14 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testCreateCustomFieldName() {
-    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
-    $fields = array(
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $fields = [
       'label' => 'testFld 2',
       'name' => 'special_fldlname',
       'data_type' => 'String',
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
-    );
+    ];
     CRM_Core_BAO_CustomField::create($fields);
     $customFieldID = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
@@ -79,25 +82,25 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testGetFields() {
-    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
-    $fields = array(
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $fields = [
       'label' => 'testFld1',
       'data_type' => 'String',
       'html_type' => 'Text',
       'is_active' => 1,
       'custom_group_id' => $customGroup['id'],
-    );
+    ];
     CRM_Core_BAO_CustomField::create($fields);
     $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
     );
-    $fields = array(
+    $fields = [
       'label' => 'testFld2',
       'data_type' => 'String',
       'html_type' => 'Text',
       'is_active' => 1,
       'custom_group_id' => $customGroup['id'],
-    );
+    ];
     CRM_Core_BAO_CustomField::create($fields);
     $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
@@ -107,68 +110,68 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testGetDisplayedValues() {
-    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
-    $fieldsToCreate = array(
-      array(
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $fieldsToCreate = [
+      [
         'data_type' => 'Country',
         'html_type' => 'Select Country',
-        'tests' => array(
+        'tests' => [
           'United States' => 1228,
           '' => NULL,
-        ),
-      ),
-      array(
+        ],
+      ],
+      [
         'data_type' => 'StateProvince',
         'html_type' => 'Multi-Select State/Province',
-        'tests' => array(
+        'tests' => [
           '' => 0,
           'Alabama' => 1000,
-          'Alabama, Alaska' => array(1000, 1001),
-        ),
-      ),
-      array(
+          'Alabama, Alaska' => [1000, 1001],
+        ],
+      ],
+      [
         'data_type' => 'String',
         'html_type' => 'Radio',
-        'option_values' => array(
+        'option_values' => [
           'key' => 'KeyLabel',
-        ),
-        'tests' => array(
+        ],
+        'tests' => [
           'KeyLabel' => 'key',
-        ),
-      ),
-      array(
+        ],
+      ],
+      [
         'data_type' => 'String',
         'html_type' => 'CheckBox',
-        'option_values' => array(
+        'option_values' => [
           'key1' => 'Label1',
           'key2' => 'Label2',
           'key3' => 'Label3',
           'key4' => 'Label4',
-        ),
-        'tests' => array(
-          'Label1' => array('key1'),
+        ],
+        'tests' => [
+          'Label1' => ['key1'],
           'Label2' => 'key2',
-          'Label2, Label3' => array('key2', 'key3'),
-          'Label3, Label4' => CRM_Utils_Array::implodePadded(array('key3', 'key4')),
-          'Label1, Label4' => array('key1' => 1, 'key4' => 1),
-        ),
-      ),
-      array(
+          'Label2, Label3' => ['key2', 'key3'],
+          'Label3, Label4' => CRM_Utils_Array::implodePadded(['key3', 'key4']),
+          'Label1, Label4' => ['key1' => 1, 'key4' => 1],
+        ],
+      ],
+      [
         'data_type' => 'Date',
         'html_type' => 'Select Date',
         'date_format' => 'd M yy',
         'time_format' => 1,
-        'tests' => array(
+        'tests' => [
           '1 Jun 1999 1:30PM' => '1999-06-01 13:30',
           '' => '',
-        ),
-      ),
-    );
+        ],
+      ],
+    ];
     foreach ($fieldsToCreate as $num => $field) {
-      $params = $field + array(
-        'label' => 'test field ' . $num,
-        'custom_group_id' => $customGroup['id'],
-      );
+      $params = $field + [
+          'label' => 'test field ' . $num,
+          'custom_group_id' => $customGroup['id'],
+        ];
       unset($params['tests']);
       $createdField = $this->callAPISuccess('customField', 'create', $params);
       foreach ($field['tests'] as $expected => $input) {
@@ -200,13 +203,13 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testDeleteCustomField() {
-    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
-    $fields = array(
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $fields = [
       'custom_group_id' => $customGroup['id'],
       'label' => 'Throwaway Field',
       'dataType' => 'Memo',
       'htmlType' => 'TextArea',
-    );
+    ];
 
     $customField = $this->customFieldCreate($fields);
     $fieldObject = new CRM_Core_BAO_CustomField();
@@ -227,75 +230,75 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   public function testMoveField() {
     $countriesByName = array_flip(CRM_Core_PseudoConstant::country(FALSE, FALSE));
     $this->assertTrue($countriesByName['Andorra'] > 0);
-    $groups = array(
-      'A' => $this->customGroupCreate(array(
+    $groups = [
+      'A' => $this->customGroupCreate([
         'title' => 'Test_Group A',
         'name' => 'test_group_a',
-        'extends' => array('Individual'),
+        'extends' => ['Individual'],
         'style' => 'Inline',
         'is_multiple' => 0,
         'is_active' => 1,
         'version' => 3,
-      )),
-      'B' => $this->customGroupCreate(array(
+      ]),
+      'B' => $this->customGroupCreate([
         'title' => 'Test_Group B',
         'name' => 'test_group_b',
-        'extends' => array('Individual'),
+        'extends' => ['Individual'],
         'style' => 'Inline',
         'is_multiple' => 0,
         'is_active' => 1,
         'version' => 3,
-      )),
-    );
+      ]),
+    ];
     $groupA = $groups['A']['values'][$groups['A']['id']];
     $groupB = $groups['B']['values'][$groups['B']['id']];
-    $countryA = $this->customFieldCreate(array(
+    $countryA = $this->customFieldCreate([
       'custom_group_id' => $groups['A']['id'],
       'label' => 'Country A',
       'dataType' => 'Country',
       'htmlType' => 'Select Country',
       'default_value' => NULL,
-    ));
-    $countryB = $this->customFieldCreate(array(
+    ]);
+    $countryB = $this->customFieldCreate([
       'custom_group_id' => $groups['A']['id'],
       'label' => 'Country B',
       'dataType' => 'Country',
       'htmlType' => 'Select Country',
       'default_value' => NULL,
-    ));
-    $countryC = $this->customFieldCreate(array(
+    ]);
+    $countryC = $this->customFieldCreate([
       'custom_group_id' => $groups['B']['id'],
       'label' => 'Country C',
       'dataType' => 'Country',
       'htmlType' => 'Select Country',
       'default_value' => NULL,
-    ));
+    ]);
 
-    $fields = array(
+    $fields = [
       'countryA' => $countryA['values'][$countryA['id']],
       'countryB' => $countryB['values'][$countryB['id']],
       'countryC' => $countryC['values'][$countryC['id']],
-    );
-    $contacts = array(
-      'alice' => $this->individualCreate(array(
+    ];
+    $contacts = [
+      'alice' => $this->individualCreate([
         'first_name' => 'Alice',
         'last_name' => 'Albertson',
         'custom_' . $fields['countryA']['id'] => $countriesByName['Andorra'],
         'custom_' . $fields['countryB']['id'] => $countriesByName['Barbados'],
-      )),
-      'bob' => $this->individualCreate(array(
+      ]),
+      'bob' => $this->individualCreate([
         'first_name' => 'Bob',
         'last_name' => 'Roberts',
         'custom_' . $fields['countryA']['id'] => $countriesByName['Austria'],
         'custom_' . $fields['countryB']['id'] => $countriesByName['Bermuda'],
         'custom_' . $fields['countryC']['id'] => $countriesByName['Chad'],
-      )),
-      'carol' => $this->individualCreate(array(
+      ]),
+      'carol' => $this->individualCreate([
         'first_name' => 'Carol',
         'last_name' => 'Carolson',
         'custom_' . $fields['countryC']['id'] => $countriesByName['Cambodia'],
-      )),
-    );
+      ]),
+    ];
 
     // Move!
     CRM_Core_BAO_CustomField::moveField($fields['countryB']['id'], $groupB['id']);
@@ -316,10 +319,10 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
             WHERE entity_id = %1
             AND {$fields['countryB']['column_name']} = %3
             AND {$fields['countryC']['column_name']} is null",
-      array(
-        1 => array($contacts['alice'], 'Integer'),
-        3 => array($countriesByName['Barbados'], 'Integer'),
-      )
+      [
+        1 => [$contacts['alice'], 'Integer'],
+        3 => [$countriesByName['Barbados'], 'Integer'],
+      ]
     );
 
     // Bob: Group[B] has merged fields[countryB] and fields[countryC] on the same record
@@ -328,11 +331,11 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
             WHERE entity_id = %1
             AND {$fields['countryB']['column_name']} = %3
             AND {$fields['countryC']['column_name']} = %4",
-      array(
-        1 => array($contacts['bob'], 'Integer'),
-        3 => array($countriesByName['Bermuda'], 'Integer'),
-        4 => array($countriesByName['Chad'], 'Integer'),
-      )
+      [
+        1 => [$contacts['bob'], 'Integer'],
+        3 => [$countriesByName['Bermuda'], 'Integer'],
+        4 => [$countriesByName['Chad'], 'Integer'],
+      ]
     );
 
     // Carol: Group[B] still has fields[countryC] but did not get fields[countryB]
@@ -341,10 +344,10 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
             WHERE entity_id = %1
             AND {$fields['countryB']['column_name']} is null
             AND {$fields['countryC']['column_name']} = %4",
-      array(
-        1 => array($contacts['carol'], 'Integer'),
-        4 => array($countriesByName['Cambodia'], 'Integer'),
-      )
+      [
+        1 => [$contacts['carol'], 'Integer'],
+        4 => [$countriesByName['Cambodia'], 'Integer'],
+      ]
     );
 
     $this->customGroupDelete($groups['A']['id']);
@@ -382,17 +385,108 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   protected function createCustomField($groupTitle = 'new custom group') {
     $customGroup = $this->customGroupCreate([
       'extends' => 'Individual',
-      'title'   => $groupTitle,
+      'title' => $groupTitle,
     ]);
-    $fields = array(
+    $fields = [
       'label' => 'testFld',
       'data_type' => 'String',
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
-    );
+    ];
     $field = CRM_Core_BAO_CustomField::create($fields);
     $this->customFieldID = $field->id;
     return $customGroup;
+  }
+
+  /**
+   * Tet the getFieldsForImport function.
+   */
+  public function testGetFieldsForImport() {
+    $this->entity = 'Contact';
+    $this->createCustomGroupWithFieldsOfAllTypes();
+    $expected = [
+      $this->getCustomFieldName('country') => [
+        'name' => $this->getCustomFieldName('country') ,
+        'type' => 1,
+        'title' => 'Country',
+        'headerPattern' => '//',
+        'import' => 1,
+        'custom_field_id' => $this->getCustomFieldID('country'),
+        'options_per_line' => NULL,
+        'text_length' => NULL,
+        'data_type' => 'Int',
+        'html_type' => 'Select Country',
+        'is_search_range' => '0',
+      ],
+      $this->getCustomFieldName('file')  => [
+        'name' => $this->getCustomFieldName('file'),
+        'type' => 2,
+        'title' => 'Custom Field',
+        'headerPattern' => '//',
+        'import' => 1,
+        'custom_field_id' => $this->getCustomFieldID('file'),
+        'options_per_line' => NULL,
+        'text_length' => NULL,
+        'data_type' => 'File',
+        'html_type' => 'File',
+        'is_search_range' => '0',
+      ],
+      $this->getCustomFieldName('text') => [
+        'name' => $this->getCustomFieldName('text'),
+        'type' => 2,
+        'title' => 'Enter text here',
+        'headerPattern' => '//',
+        'import' => 1,
+        'custom_field_id' => $this->getCustomFieldID('text'),
+        'options_per_line' => NULL,
+        'text_length' => NULL,
+        'data_type' => 'String',
+        'html_type' => 'Text',
+        'is_search_range' => '0',
+      ],
+      $this->getCustomFieldName('select_string') => [
+        'name' =>  $this->getCustomFieldName('select_string'),
+        'type' => 2,
+        'title' => 'Pick Color',
+        'headerPattern' => '//',
+        'import' => 1,
+        'custom_field_id' => $this->getCustomFieldID('select_string'),
+        'options_per_line' => NULL,
+        'text_length' => NULL,
+        'data_type' => 'String',
+        'html_type' => 'Select',
+        'is_search_range' => '0',
+      ],
+      $this->getCustomFieldName('select_date') => [
+        'name' => $this->getCustomFieldName('select_date'),
+        'type' => 4,
+        'title' => 'test_date',
+        'headerPattern' => '//',
+        'import' => 1,
+        'custom_field_id' => $this->getCustomFieldID('select_date'),
+        'options_per_line' => NULL,
+        'text_length' => NULL,
+        'data_type' => 'Date',
+        'html_type' => 'Select Date',
+        'is_search_range' => '0',
+        'date_format' => 'mm/dd/yy',
+        'time_format' => '1',
+      ],
+      $this->getCustomFieldName('link') => [
+        'name' => $this->getCustomFieldName('link'),
+        'type' => 2,
+        'title' => 'test_link',
+        'headerPattern' => '//',
+        'import' => 1,
+        'custom_field_id' => $this->getCustomFieldID('link'),
+        'options_per_line' => NULL,
+        'text_length' => NULL,
+        'data_type' => 'Link',
+        'html_type' => 'Link',
+        'is_search_range' => '0',
+      ],
+    ];
+    $this->assertEquals($expected, CRM_Core_BAO_CustomField::getFieldsForImport());
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -15,19 +15,29 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     parent::setUp();
   }
 
+  /**
+   * Clean up after test.
+   *
+   * @throws \Exception
+   */
+  public function tearDown() {
+    $this->quickCleanup([], TRUE);
+    parent::tearDown();
+  }
+
   public function testCreateCustomField() {
     $customGroup = $this->createCustomField();
     $customFieldID = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
     );
-    $fields = [
+    $fields = array(
       'id' => $customFieldID,
       'label' => 'editTestFld',
       'is_active' => 1,
       'data_type' => 'String',
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
-    ];
+    );
 
     CRM_Core_BAO_CustomField::create($fields);
     $this->assertDBNotNull('CRM_Core_DAO_CustomField', 1, 'id', 'is_active', 'Database check for edited CustomField.');
@@ -42,14 +52,14 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testCreateCustomFieldColumnName() {
-    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
-    $fields = [
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
+    $fields = array(
       'label' => 'testFld 2',
       'column_name' => 'special_colname',
       'data_type' => 'String',
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
-    ];
+    );
     CRM_Core_BAO_CustomField::create($fields);
     $customFieldID = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
@@ -62,14 +72,14 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testCreateCustomFieldName() {
-    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
-    $fields = [
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
+    $fields = array(
       'label' => 'testFld 2',
       'name' => 'special_fldlname',
       'data_type' => 'String',
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
-    ];
+    );
     CRM_Core_BAO_CustomField::create($fields);
     $customFieldID = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
@@ -82,25 +92,25 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testGetFields() {
-    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
-    $fields = [
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
+    $fields = array(
       'label' => 'testFld1',
       'data_type' => 'String',
       'html_type' => 'Text',
       'is_active' => 1,
       'custom_group_id' => $customGroup['id'],
-    ];
+    );
     CRM_Core_BAO_CustomField::create($fields);
     $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
     );
-    $fields = [
+    $fields = array(
       'label' => 'testFld2',
       'data_type' => 'String',
       'html_type' => 'Text',
       'is_active' => 1,
       'custom_group_id' => $customGroup['id'],
-    ];
+    );
     CRM_Core_BAO_CustomField::create($fields);
     $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id', 'custom_group_id',
       'Database check for created CustomField.'
@@ -110,68 +120,68 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testGetDisplayedValues() {
-    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
-    $fieldsToCreate = [
-      [
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
+    $fieldsToCreate = array(
+      array(
         'data_type' => 'Country',
         'html_type' => 'Select Country',
-        'tests' => [
+        'tests' => array(
           'United States' => 1228,
           '' => NULL,
-        ],
-      ],
-      [
+        ),
+      ),
+      array(
         'data_type' => 'StateProvince',
         'html_type' => 'Multi-Select State/Province',
-        'tests' => [
+        'tests' => array(
           '' => 0,
           'Alabama' => 1000,
-          'Alabama, Alaska' => [1000, 1001],
-        ],
-      ],
-      [
+          'Alabama, Alaska' => array(1000, 1001),
+        ),
+      ),
+      array(
         'data_type' => 'String',
         'html_type' => 'Radio',
-        'option_values' => [
+        'option_values' => array(
           'key' => 'KeyLabel',
-        ],
-        'tests' => [
+        ),
+        'tests' => array(
           'KeyLabel' => 'key',
-        ],
-      ],
-      [
+        ),
+      ),
+      array(
         'data_type' => 'String',
         'html_type' => 'CheckBox',
-        'option_values' => [
+        'option_values' => array(
           'key1' => 'Label1',
           'key2' => 'Label2',
           'key3' => 'Label3',
           'key4' => 'Label4',
-        ],
-        'tests' => [
-          'Label1' => ['key1'],
+        ),
+        'tests' => array(
+          'Label1' => array('key1'),
           'Label2' => 'key2',
-          'Label2, Label3' => ['key2', 'key3'],
-          'Label3, Label4' => CRM_Utils_Array::implodePadded(['key3', 'key4']),
-          'Label1, Label4' => ['key1' => 1, 'key4' => 1],
-        ],
-      ],
-      [
+          'Label2, Label3' => array('key2', 'key3'),
+          'Label3, Label4' => CRM_Utils_Array::implodePadded(array('key3', 'key4')),
+          'Label1, Label4' => array('key1' => 1, 'key4' => 1),
+        ),
+      ),
+      array(
         'data_type' => 'Date',
         'html_type' => 'Select Date',
         'date_format' => 'd M yy',
         'time_format' => 1,
-        'tests' => [
+        'tests' => array(
           '1 Jun 1999 1:30PM' => '1999-06-01 13:30',
           '' => '',
-        ],
-      ],
-    ];
+        ),
+      ),
+    );
     foreach ($fieldsToCreate as $num => $field) {
-      $params = $field + [
-          'label' => 'test field ' . $num,
-          'custom_group_id' => $customGroup['id'],
-        ];
+      $params = $field + array(
+        'label' => 'test field ' . $num,
+        'custom_group_id' => $customGroup['id'],
+      );
       unset($params['tests']);
       $createdField = $this->callAPISuccess('customField', 'create', $params);
       foreach ($field['tests'] as $expected => $input) {
@@ -203,13 +213,13 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   public function testDeleteCustomField() {
-    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
-    $fields = [
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
+    $fields = array(
       'custom_group_id' => $customGroup['id'],
       'label' => 'Throwaway Field',
       'dataType' => 'Memo',
       'htmlType' => 'TextArea',
-    ];
+    );
 
     $customField = $this->customFieldCreate($fields);
     $fieldObject = new CRM_Core_BAO_CustomField();
@@ -230,75 +240,75 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   public function testMoveField() {
     $countriesByName = array_flip(CRM_Core_PseudoConstant::country(FALSE, FALSE));
     $this->assertTrue($countriesByName['Andorra'] > 0);
-    $groups = [
-      'A' => $this->customGroupCreate([
+    $groups = array(
+      'A' => $this->customGroupCreate(array(
         'title' => 'Test_Group A',
         'name' => 'test_group_a',
-        'extends' => ['Individual'],
+        'extends' => array('Individual'),
         'style' => 'Inline',
         'is_multiple' => 0,
         'is_active' => 1,
         'version' => 3,
-      ]),
-      'B' => $this->customGroupCreate([
+      )),
+      'B' => $this->customGroupCreate(array(
         'title' => 'Test_Group B',
         'name' => 'test_group_b',
-        'extends' => ['Individual'],
+        'extends' => array('Individual'),
         'style' => 'Inline',
         'is_multiple' => 0,
         'is_active' => 1,
         'version' => 3,
-      ]),
-    ];
+      )),
+    );
     $groupA = $groups['A']['values'][$groups['A']['id']];
     $groupB = $groups['B']['values'][$groups['B']['id']];
-    $countryA = $this->customFieldCreate([
+    $countryA = $this->customFieldCreate(array(
       'custom_group_id' => $groups['A']['id'],
       'label' => 'Country A',
       'dataType' => 'Country',
       'htmlType' => 'Select Country',
       'default_value' => NULL,
-    ]);
-    $countryB = $this->customFieldCreate([
+    ));
+    $countryB = $this->customFieldCreate(array(
       'custom_group_id' => $groups['A']['id'],
       'label' => 'Country B',
       'dataType' => 'Country',
       'htmlType' => 'Select Country',
       'default_value' => NULL,
-    ]);
-    $countryC = $this->customFieldCreate([
+    ));
+    $countryC = $this->customFieldCreate(array(
       'custom_group_id' => $groups['B']['id'],
       'label' => 'Country C',
       'dataType' => 'Country',
       'htmlType' => 'Select Country',
       'default_value' => NULL,
-    ]);
+    ));
 
-    $fields = [
+    $fields = array(
       'countryA' => $countryA['values'][$countryA['id']],
       'countryB' => $countryB['values'][$countryB['id']],
       'countryC' => $countryC['values'][$countryC['id']],
-    ];
-    $contacts = [
-      'alice' => $this->individualCreate([
+    );
+    $contacts = array(
+      'alice' => $this->individualCreate(array(
         'first_name' => 'Alice',
         'last_name' => 'Albertson',
         'custom_' . $fields['countryA']['id'] => $countriesByName['Andorra'],
         'custom_' . $fields['countryB']['id'] => $countriesByName['Barbados'],
-      ]),
-      'bob' => $this->individualCreate([
+      )),
+      'bob' => $this->individualCreate(array(
         'first_name' => 'Bob',
         'last_name' => 'Roberts',
         'custom_' . $fields['countryA']['id'] => $countriesByName['Austria'],
         'custom_' . $fields['countryB']['id'] => $countriesByName['Bermuda'],
         'custom_' . $fields['countryC']['id'] => $countriesByName['Chad'],
-      ]),
-      'carol' => $this->individualCreate([
+      )),
+      'carol' => $this->individualCreate(array(
         'first_name' => 'Carol',
         'last_name' => 'Carolson',
         'custom_' . $fields['countryC']['id'] => $countriesByName['Cambodia'],
-      ]),
-    ];
+      )),
+    );
 
     // Move!
     CRM_Core_BAO_CustomField::moveField($fields['countryB']['id'], $groupB['id']);
@@ -319,10 +329,10 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
             WHERE entity_id = %1
             AND {$fields['countryB']['column_name']} = %3
             AND {$fields['countryC']['column_name']} is null",
-      [
-        1 => [$contacts['alice'], 'Integer'],
-        3 => [$countriesByName['Barbados'], 'Integer'],
-      ]
+      array(
+        1 => array($contacts['alice'], 'Integer'),
+        3 => array($countriesByName['Barbados'], 'Integer'),
+      )
     );
 
     // Bob: Group[B] has merged fields[countryB] and fields[countryC] on the same record
@@ -331,11 +341,11 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
             WHERE entity_id = %1
             AND {$fields['countryB']['column_name']} = %3
             AND {$fields['countryC']['column_name']} = %4",
-      [
-        1 => [$contacts['bob'], 'Integer'],
-        3 => [$countriesByName['Bermuda'], 'Integer'],
-        4 => [$countriesByName['Chad'], 'Integer'],
-      ]
+      array(
+        1 => array($contacts['bob'], 'Integer'),
+        3 => array($countriesByName['Bermuda'], 'Integer'),
+        4 => array($countriesByName['Chad'], 'Integer'),
+      )
     );
 
     // Carol: Group[B] still has fields[countryC] but did not get fields[countryB]
@@ -344,10 +354,10 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
             WHERE entity_id = %1
             AND {$fields['countryB']['column_name']} is null
             AND {$fields['countryC']['column_name']} = %4",
-      [
-        1 => [$contacts['carol'], 'Integer'],
-        4 => [$countriesByName['Cambodia'], 'Integer'],
-      ]
+      array(
+        1 => array($contacts['carol'], 'Integer'),
+        4 => array($countriesByName['Cambodia'], 'Integer'),
+      )
     );
 
     $this->customGroupDelete($groups['A']['id']);
@@ -356,6 +366,8 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
 
   /**
    * Test get custom field id function.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function testGetCustomFieldID() {
     $this->createCustomField();
@@ -399,14 +411,17 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   /**
-   * Tet the getFieldsForImport function.
+   * Test the getFieldsForImport function.
+   *
+   * @throws \Exception
    */
   public function testGetFieldsForImport() {
     $this->entity = 'Contact';
     $this->createCustomGroupWithFieldsOfAllTypes();
+    $customGroupID = $this->ids['CustomGroup']['Custom Group'];
     $expected = [
       $this->getCustomFieldName('country') => [
-        'name' => $this->getCustomFieldName('country') ,
+        'name' => $this->getCustomFieldName('country'),
         'type' => 1,
         'title' => 'Country',
         'headerPattern' => '//',
@@ -417,8 +432,27 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'data_type' => 'Int',
         'html_type' => 'Select Country',
         'is_search_range' => '0',
+        'id' => $this->getCustomFieldID('country'),
+        'label' => 'Country',
+        'groupTitle' => 'Custom Group',
+        'default_value' => NULL,
+        'custom_group_id' => $customGroupID,
+        'extends' => 'Contact',
+        'extends_entity_column_value' => NULL,
+        'extends_entity_column_id' => NULL,
+        'is_view' => '0',
+        'is_multiple' => '0',
+        'option_group_id' => NULL,
+        'date_format' => NULL,
+        'time_format' => NULL,
+        'is_required' => '0',
+        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'column_name' => 'country_' . $this->getCustomFieldID('country'),
+        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.country_' . $this->getCustomFieldID('country'),
+        'extends_table' => 'civicrm_contact',
+        'search_table' => 'contact_a',
       ],
-      $this->getCustomFieldName('file')  => [
+      $this->getCustomFieldName('file') => [
         'name' => $this->getCustomFieldName('file'),
         'type' => 2,
         'title' => 'Custom Field',
@@ -430,6 +464,25 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'data_type' => 'File',
         'html_type' => 'File',
         'is_search_range' => '0',
+        'id' => $this->getCustomFieldID('file'),
+        'label' => 'Custom Field',
+        'groupTitle' => 'Custom Group',
+        'default_value' => NULL,
+        'custom_group_id' => $customGroupID,
+        'extends' => 'Contact',
+        'extends_entity_column_value' => NULL,
+        'extends_entity_column_id' => NULL,
+        'is_view' => '0',
+        'is_multiple' => '0',
+        'option_group_id' => NULL,
+        'date_format' => NULL,
+        'time_format' => NULL,
+        'is_required' => '0',
+        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'column_name' => 'custom_field_' . $this->getCustomFieldID('file'),
+        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.custom_field_' . $this->getCustomFieldID('file'),
+        'extends_table' => 'civicrm_contact',
+        'search_table' => 'contact_a',
       ],
       $this->getCustomFieldName('text') => [
         'name' => $this->getCustomFieldName('text'),
@@ -443,9 +496,28 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'data_type' => 'String',
         'html_type' => 'Text',
         'is_search_range' => '0',
+        'id' => $this->getCustomFieldID('text'),
+        'label' => 'Enter text here',
+        'groupTitle' => 'Custom Group',
+        'default_value' => 'xyz',
+        'custom_group_id' => '1',
+        'extends' => 'Contact',
+        'extends_entity_column_value' => NULL,
+        'extends_entity_column_id' => NULL,
+        'is_view' => '0',
+        'is_multiple' => '0',
+        'option_group_id' => NULL,
+        'date_format' => NULL,
+        'time_format' => NULL,
+        'is_required' => '1',
+        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'column_name' => 'enter_text_here_' . $this->getCustomFieldID('text'),
+        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.enter_text_here_' . $this->getCustomFieldID('text'),
+        'extends_table' => 'civicrm_contact',
+        'search_table' => 'contact_a',
       ],
       $this->getCustomFieldName('select_string') => [
-        'name' =>  $this->getCustomFieldName('select_string'),
+        'name' => $this->getCustomFieldName('select_string'),
         'type' => 2,
         'title' => 'Pick Color',
         'headerPattern' => '//',
@@ -456,6 +528,29 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'data_type' => 'String',
         'html_type' => 'Select',
         'is_search_range' => '0',
+        'id' => $this->getCustomFieldID('select_string'),
+        'label' => 'Pick Color',
+        'groupTitle' => 'Custom Group',
+        'default_value' => NULL,
+        'custom_group_id' => $customGroupID,
+        'extends' => 'Contact',
+        'extends_entity_column_value' => NULL,
+        'extends_entity_column_id' => NULL,
+        'is_view' => '0',
+        'is_multiple' => '0',
+        'option_group_id' => $this->callAPISuccessGetValue('CustomField', ['id' => $this->getCustomFieldID('select_string'), 'return' => 'option_group_id']),
+        'date_format' => NULL,
+        'time_format' => NULL,
+        'is_required' => '1',
+        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'column_name' => 'pick_color_' . $this->getCustomFieldID('select_string'),
+        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.pick_color_' . $this->getCustomFieldID('select_string'),
+        'extends_table' => 'civicrm_contact',
+        'search_table' => 'contact_a',
+        'pseudoconstant' => [
+          'optionGroupName' => $this->callAPISuccessGetValue('CustomField', ['id' => $this->getCustomFieldID('select_string'), 'return' => 'option_group_id.name']),
+          'optionEditPath' => 'civicrm/admin/options/' . $this->callAPISuccessGetValue('CustomField', ['id' => $this->getCustomFieldID('select_string'), 'return' => 'option_group_id.name']),
+        ],
       ],
       $this->getCustomFieldName('select_date') => [
         'name' => $this->getCustomFieldName('select_date'),
@@ -471,6 +566,23 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'is_search_range' => '0',
         'date_format' => 'mm/dd/yy',
         'time_format' => '1',
+        'id' => $this->getCustomFieldID('select_date'),
+        'label' => 'test_date',
+        'groupTitle' => 'Custom Group',
+        'default_value' => '20090711',
+        'custom_group_id' => $customGroupID,
+        'extends' => 'Contact',
+        'extends_entity_column_value' => NULL,
+        'extends_entity_column_id' => NULL,
+        'is_view' => '0',
+        'is_multiple' => '0',
+        'option_group_id' => NULL,
+        'is_required' => '0',
+        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'column_name' => 'test_date_' . $this->getCustomFieldID('select_date'),
+        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.test_date_' . $this->getCustomFieldID('select_date'),
+        'extends_table' => 'civicrm_contact',
+        'search_table' => 'contact_a',
       ],
       $this->getCustomFieldName('link') => [
         'name' => $this->getCustomFieldName('link'),
@@ -484,6 +596,25 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'data_type' => 'Link',
         'html_type' => 'Link',
         'is_search_range' => '0',
+        'id' => $this->getCustomFieldID('link'),
+        'label' => 'test_link',
+        'groupTitle' => 'Custom Group',
+        'default_value' => 'http://civicrm.org',
+        'custom_group_id' => $customGroupID,
+        'extends' => 'Contact',
+        'extends_entity_column_value' => NULL,
+        'extends_entity_column_id' => NULL,
+        'is_view' => '0',
+        'is_multiple' => '0',
+        'option_group_id' => NULL,
+        'date_format' => NULL,
+        'time_format' => NULL,
+        'is_required' => '1',
+        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'column_name' => 'test_link_' . $this->getCustomFieldID('link'),
+        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.test_link_' . $this->getCustomFieldID('link'),
+        'extends_table' => 'civicrm_contact',
+        'search_table' => 'contact_a',
       ],
     ];
     $this->assertEquals($expected, CRM_Core_BAO_CustomField::getFieldsForImport());

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -74,6 +74,12 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       'is_required' => '0',
       'extends_table' => 'civicrm_contact',
       'search_table' => 'contact_a',
+      'headerPattern' => '//',
+      'title' => 'date field',
+      'custom_field_id' => $dateCustomField['id'],
+      'name' => 'custom_' . $dateCustomField['id'],
+      'type' => 4,
+      'where' => 'civicrm_value_testsearchcus_' . $ids['custom_group_id'] . '.date_field_' . $dateCustomField['id'],
     ], $queryObj->getFields()[$dateCustomField['id']]);
 
   }

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -176,7 +176,23 @@ trait CRMTraits_Custom_CustomDataTrait {
    * @return string
    */
   protected function getCustomFieldName($key) {
-    $linkField = 'custom_' . $this->ids['CustomField'][$key];
+    $linkField = 'custom_' . $this->getCustomFieldID($key);
+    return $linkField;
+  }
+
+  /**
+   * Get the custom field name for the relevant key.
+   *
+   * e.g returns 'custom_5' where 5 is the id of the field using the key.
+   *
+   * Generally keys map to data types.
+   *
+   * @param string $key
+   *
+   * @return string
+   */
+  protected function getCustomFieldID($key) {
+    $linkField = $this->ids['CustomField'][$key];
     return $linkField;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Make metadata for custom fields more consistent, add test

Before
----------------------------------------
Less consistent

After
----------------------------------------
More consistent

Technical Details
----------------------------------------
In digging into dev/core#389 I found a major complexity in fixing it was inconsistent metadata available at different
points in the code. This simply adds metadata to the 'inner-most place' & makes the BAO_CustomQuery object use that

I didn't remove the options loop because I wanted to leave that out of scope as I can't see how / if it is used

Comments
----------------------------------------

