### PR TITLE
dev/core#1008 add ended status to new contribution recur status group

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.15.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.15.alpha1.mysql.tpl
@@ -21,5 +21,9 @@ VALUES(
 ),
 (
 @option_group_id_ps, {localize field='label'}'Failing'{/localize}, @maxValue + 2, 'Failing', @maxWeight + 2, 1 , 1 , 0
+),
+(
+@option_group_id_ps, {localize field='label'}'Ended'{/localize}, @maxValue + 3, 'Ended', @maxWeight + 3, 1 , 1 , 0
 )
 ON DUPLICATE KEY UPDATE id=id;
+

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1056,6 +1056,7 @@ VALUES
   (@option_group_id_crs, '{ts escape="sql"}Overdue{/ts}'    , 6, 'Overdue'    , NULL, 0, NULL, 6, NULL, 0, 1, 1, NULL, NULL, NULL),
   (@option_group_id_crs, '{ts escape="sql"}Processing{/ts}' , 7, 'Processing' , NULL, 0, NULL, 7, NULL, 0, 1, 1, NULL, NULL, NULL),
   (@option_group_id_crs, '{ts escape="sql"}Failing{/ts}'    , 8, 'Failing'    , NULL, 0, NULL, 8, NULL, 0, 1, 1, NULL, NULL, NULL),
+  (@option_group_id_crs, '{ts escape="sql"}Ended{/ts}'      , 9, 'Ended'      , NULL, 0, NULL, 8, NULL, 0, 1, 1, NULL, NULL, NULL),
 
 -- CiviCase - Activity Assignee Default
 --  (`option_group_id`,             `label`,                                                `value`, `name`,                    `grouping`, `filter`, `is_default`, `weight`, `description`, `is_optgroup`, `is_reserved`, `is_active`, `component_id`, `visibility_id`, `icon`)


### PR DESCRIPTION
Overview
----------------------------------------
 Per https://lab.civicrm.org/dev/core/issues/1008 I think there is a case for another using facing status for the
    nunaces on ways that recurrings end - somewhere between 'they actively cancelled it' and 'they completed it'
    lies - it ended & neither of the others are quite the right fit


Before
----------------------------------------
Ended status does not exist

After
----------------------------------------
Ended status exists 

Technical Details
----------------------------------------
 Builds on the work in https://github.com/civicrm/civicrm-core/pull/14395 & the earlier PR that separated out recurring contribution statuses from contribution statuses

Comments
----------------------------------------

