### PR TITLE
dev/core#985 Fix trailing slash for urls on Windows

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -681,7 +681,7 @@ abstract class CRM_Utils_System_Base {
     }
 
     return [
-      'url' => CRM_Utils_File::addTrailingSlash($userFrameworkResourceURL),
+      'url' => CRM_Utils_File::addTrailingSlash($userFrameworkResourceURL, '/'),
       'path' => CRM_Utils_File::addTrailingSlash($civicrm_root),
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where addTrailingSlash would generate a `\` instead of a '/' on Windows for URLs which is in correct

Before
----------------------------------------
Wrong trailing slash added to urls

After
----------------------------------------
correct trailing slash added

ping @demeritcowboy @eileenmcnaughton 
