### PR TITLE
Fix checksum failure on editing recurring contributions

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -44,11 +44,12 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
 
   /**
    * Set variables up before form is built.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     parent::preProcess();
     if ($this->_crid) {
-      $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_crid);
       $this->assign('frequency_unit', $this->_subscriptionDetails->frequency_unit);
       $this->assign('frequency_interval', $this->_subscriptionDetails->frequency_interval);
       $this->assign('amount', $this->_subscriptionDetails->amount);
@@ -79,7 +80,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         CRM_Core_Error::fatal(ts('The recurring contribution looks to have been cancelled already.'));
       }
       $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'obj');
-      $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_coid, 'contribution');
 
       $this->assign('frequency_unit', $this->_subscriptionDetails->frequency_unit);
       $this->assign('frequency_interval', $this->_subscriptionDetails->frequency_interval);

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -94,6 +94,13 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   protected $entityFields = [];
 
   /**
+   * Details of the subscription (recurring contribution) to be altered.
+   *
+   * @var array
+   */
+  protected $subscriptionDetails = [];
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -109,6 +116,8 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
 
   /**
    * Set variables up before form is built.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     $this->setAction(CRM_Core_Action::UPDATE);
@@ -116,7 +125,11 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
     $this->_crid = CRM_Utils_Request::retrieve('crid', 'Integer', $this, FALSE);
     $this->contributionRecurID = $this->_crid;
     $this->_coid = CRM_Utils_Request::retrieve('coid', 'Integer', $this, FALSE);
+    $this->setSubscriptionDetails();
     $this->setPaymentProcessor();
+    if ($this->getSubscriptionContactID()) {
+      $this->set('cid', $this->getSubscriptionContactID());
+    }
   }
 
   /**
@@ -133,6 +146,37 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
       }
       $this->_paymentProcessorObj = $this->_paymentProcessor['object'];
     }
+  }
+
+  /**
+   * Set the subscription details on the form.
+   */
+  protected function setSubscriptionDetails() {
+    if ($this->contributionRecurID) {
+      $this->subscriptionDetails = $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_crid);
+    }
+    elseif ($this->_coid) {
+      $this->subscriptionDetails = $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_coid, 'contribution');
+    }
+  }
+
+  /**
+   * Get details for the recurring contribution being altered.
+   *
+   * @return array
+   */
+  public function getSubscriptionDetails() {
+    return $this->subscriptionDetails;
+  }
+
+  /**
+   * Get the contact ID for the subscription.
+   *
+   * @return int|false
+   */
+  protected function getSubscriptionContactID() {
+    $sub = $this->getSubscriptionDetails();
+    return isset($sub->contact_id) ? $sub->contact_id : FALSE;
   }
 
 }

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -45,12 +45,12 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
 
   /**
    * Set variables up before form is built.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     parent::preProcess();
     if ($this->_crid) {
-      $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_crid);
-
       // Are we cancelling a recurring contribution that is linked to an auto-renew membership?
       if ($this->_subscriptionDetails->membership_id) {
         $this->_mid = $this->_subscriptionDetails->membership_id;
@@ -60,7 +60,6 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
     if ($this->_coid) {
       $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'info');
       $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'obj');
-      $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_coid, 'contribution');
     }
 
     if ($this->_mid) {

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -71,15 +71,10 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     parent::preProcess();
     $this->setAction(CRM_Core_Action::UPDATE);
 
-    if ($this->contributionRecurID) {
-      $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->contributionRecurID);
-    }
-
     if ($this->_coid) {
       $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'info');
       // @todo test & replace with $this->_paymentProcessorObj =  Civi\Payment\System::singleton()->getById($this->_paymentProcessor['id']);
       $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'obj');
-      $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_coid, 'contribution');
       $this->contributionRecurID = $this->_subscriptionDetails->recur_id;
     }
     elseif ($this->contributionRecurID) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug (regression) where checksum users are not able to cancel or update recurring contributions

Before
----------------------------------------
Check sum not correctly checked

After
----------------------------------------
Correctly checked

Technical Details
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/14388 - the analysis & logic there is correct, this just does the setting in a more centralised place per @MegaphoneJon's comments.

Comments
----------------------------------------
I handed coid & crid in the url - I left out mid for now as it feels like there is a little more complexity in there & I wanted to keep small & safe & to put against the rc

Also I believe the mid part is only accessed by backoffice users - it seems only generated as
```
    if ($isUpdateToExistingRecurringMembership && CRM_Member_BAO_Membership::isCancelSubscriptionSupported($this->_id)) {
      $this->assign('cancelAutoRenew',
        CRM_Utils_System::url('civicrm/contribute/unsubscribe', "reset=1&mid={$this->_id}")
      );
    }
```