### PR TITLE
Switch recordAdditionalPayment fully over to api

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3902,40 +3902,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   }
 
   /**
-   * Function to record additional payment for partial and refund contributions.
-   *
-   * @param int $contributionId
-   *   is the invoice contribution id (got created after processing participant payment).
-   * @param array $trxnsData
-   *   to take user provided input of transaction details.
-   * @param string $paymentType
-   *   'owed' for purpose of recording partial payments, 'refund' for purpose of recording refund payments.
-   * @param int $participantId
-   * @param bool $updateStatus
-   *
-   * @return int
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
-   */
-  public static function recordAdditionalPayment($contributionId, $trxnsData, $paymentType = 'owed', $participantId = NULL, $updateStatus = TRUE) {
-
-    if ($paymentType == 'owed') {
-      $financialTrxn = CRM_Financial_BAO_Payment::recordPayment($contributionId, $trxnsData, $participantId);
-      if (!empty($financialTrxn)) {
-        self::recordPaymentActivity($contributionId, $participantId, $financialTrxn->total_amount, $financialTrxn->currency, $financialTrxn->trxn_date);
-        return $financialTrxn->id;
-      }
-    }
-    elseif ($paymentType == 'refund') {
-      $trxnsData['total_amount'] = -$trxnsData['total_amount'];
-      $trxnsData['participant_id'] = $participantId;
-      $trxnsData['contribution_id'] = $contributionId;
-      return civicrm_api3('Payment', 'create', $trxnsData)['id'];
-    }
-  }
-
-  /**
    * @param int $targetCid
    * @param $activityType
    * @param string $title

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -73,6 +73,11 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
   public $_action = NULL;
 
+  /**
+   * Pre process form.
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function preProcess() {
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
@@ -118,11 +123,11 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->_paymentType = 'owed';
     }
     else {
-      CRM_Core_Error::fatal(ts('No payment information found for this record'));
+      throw new CRM_Core_Exception(ts('No payment information found for this record'));
     }
 
     if (!empty($this->_mode) && $this->_paymentType == 'refund') {
-      CRM_Core_Error::fatal(ts('Credit card payment is not for Refund payments use'));
+      throw new CRM_Core_Exception(ts('Credit card payment is not for Refund payments use'));
     }
 
     list($this->_contributorDisplayName, $this->_contributorEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
@@ -139,6 +144,8 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
    * Is this function being called from a datatable selector.
    *
    * If so we don't want to show the buttons.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function isBeingCalledFromSelectorContext() {
     return CRM_Utils_Request::retrieve('selector', 'Positive');
@@ -356,19 +363,16 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->processCreditCard();
     }
 
-    $defaults = [];
-    $contribution = civicrm_api3('Contribution', 'getsingle', [
-      'return' => ["contribution_status_id"],
-      'id' => $this->_contributionId,
-    ]);
-    $contributionStatusId = CRM_Utils_Array::value('contribution_status_id', $contribution);
-    $paymentID = CRM_Contribute_BAO_Contribution::recordAdditionalPayment($this->_contributionId, $this->_params, $this->_paymentType, $participantId);
-    // Fetch the contribution & do proportional line item assignment
-    $params = ['id' => $this->_contributionId];
-    $contribution = CRM_Contribute_BAO_Contribution::retrieve($params, $defaults, $params);
-    // @todo - this line needs to be moved to the Payment.create api - it's not form layer appropriate.
-    // testing required.
-    CRM_Contribute_BAO_Contribution::addPayments([$contribution], $contributionStatusId);
+    $trxnsData = $this->_params;
+    if ($this->_paymentType == 'refund') {
+      $trxnsData['total_amount'] = -$trxnsData['total_amount'];
+    }
+    $trxnsData['participant_id'] = $participantId;
+    $trxnsData['contribution_id'] = $this->_contributionId;
+    // From the
+    $trxnsData['is_send_contribution_notification'] = FALSE;
+    $paymentID = civicrm_api3('Payment', 'create', $trxnsData)['id'];
+
     if ($this->_contributionId && CRM_Core_Permission::access('CiviMember')) {
       $membershipPaymentCount = civicrm_api3('MembershipPayment', 'getCount', ['contribution_id' => $this->_contributionId]);
       if ($membershipPaymentCount) {

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -162,6 +162,7 @@ class CRM_Financial_BAO_Payment {
         civicrm_api3('Contribution', 'completetransaction', [
           'id' => $contribution['id'],
           'is_post_payment_create' => TRUE,
+          'is_email_receipt' => $params['is_send_contribution_notification'],
         ]);
         // Get the trxn
         $trxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');
@@ -359,8 +360,6 @@ class CRM_Financial_BAO_Payment {
    * @param $trxnData
    * @param $updateStatus
    *   - deprecate this param
-   *
-   * @todo  - make this protected once recordAdditionalPayment no longer calls it.
    *
    * @return CRM_Financial_DAO_FinancialTrxn
    */

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -178,6 +178,12 @@ function _civicrm_api3_payment_create_spec(&$params) {
       'title' => ts('Cancel Date'),
       'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
     ],
+    'is_send_contribution_notification' => [
+      'title' => ts('Send out notifications based on contribution status change?'),
+      'description' => ts('Most commonly this equates to emails relating to the contribution, event, etcwhen a payment completes a contribution'),
+      'type' => CRM_Utils_Type::T_BOOLEAN,
+      'api.default' => TRUE,
+    ],
   ];
 }
 


### PR DESCRIPTION
Let's see what fails first

Overview
----------------------------------------
Code consolidation on payment handling

Before
----------------------------------------
Disparate code paths

After
----------------------------------------
Consolidated code paths

Technical Details
----------------------------------------
The payment code was originally tightly coupled with the additional payment form. Later a payment.create api was split off but the form was never changed to use it & they grew up separately. Fortunately both have pretty good testing by now

Comments
----------------------------------------

