### PR TITLE
dev/core#1002 fix fatal on searching on related contacts.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4952,7 +4952,7 @@ civicrm_relationship.start_date > {$today}
   public function alphabetQuery() {
     $sqlParts = $this->getSearchSQLParts(NULL, NULL, NULL, FALSE, FALSE, TRUE);
     $query = "SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name
-      {$this->_simpleFromClause}
+      {$sqlParts['from']}
       {$sqlParts['where']}
       {$sqlParts['having']}
       GROUP BY sort_name
@@ -5681,10 +5681,8 @@ civicrm_relationship.start_date > {$today}
     }
     else {
       // create temp table with contact ids
-      $tableName = CRM_Core_DAO::createTempTableName('civicrm_transform', TRUE);
 
-      $sql = "CREATE TEMPORARY TABLE $tableName ( contact_id int primary key) ENGINE=HEAP";
-      CRM_Core_DAO::executeQuery($sql);
+      $tableName = CRM_Utils_SQL_TempTable::build()->createWithColumns('contact_id int primary key')->setMemory(TRUE)->getName();
 
       $sql = "
 REPLACE INTO $tableName ( contact_id )

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -66,13 +66,15 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
       $dataSet['context']
     );
     $queryObject = $selector->getQueryObject();
+    // Make sure there is no fail on alphabet query.
+    $selector->alphabetQuery()->fetchAll();
     $sql = $queryObject->query();
     $this->wrangleDefaultClauses($dataSet['expected_query']);
     foreach ($dataSet['expected_query'] as $index => $queryString) {
       $this->assertEquals($this->strWrangle($queryString), $this->strWrangle($sql[$index]));
     }
     // Ensure that search builder return individual contact as per criteria
-    if (!empty($dataSet['context'] == 'builder')) {
+    if ($dataSet['context'] == 'builder') {
       $contactID = $this->individualCreate(['first_name' => 'James', 'last_name' => 'Bond']);
       if ('Search builder behaviour for Activity' == $dataSet['description']) {
         $this->callAPISuccess('Activity', 'create', [
@@ -284,6 +286,26 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
           'expected_query' => array(
             0 => 'SELECT contact_a.id as contact_id, source_contact.id as source_contact_id',
             2 => 'WHERE ( source_contact.id IS NOT NULL ) AND (contact_a.is_deleted = 0)',
+          ),
+        ),
+      ),
+      array(
+        array(
+          'description' => 'Test display relationships',
+          'class' => 'CRM_Contact_Selector',
+          'settings' => [],
+          'form_values' => ['display_relationship_type' => '1_b_a'],
+          'return_properties' => NULL,
+          'params' => [],
+          'context' => 'advanced',
+          'action' => CRM_Core_Action::NONE,
+          'includeContactIds' => NULL,
+          'searchDescendentGroups' => FALSE,
+          'expected_query' => array(
+            0 => 'SELECT contact_a.id as contact_id, contact_a.contact_type as `contact_type`, contact_a.contact_sub_type as `contact_sub_type`, contact_a.sort_name as `sort_name`, contact_a.display_name as `display_name`, contact_a.do_not_email as `do_not_email`, contact_a.do_not_phone as `do_not_phone`, contact_a.do_not_mail as `do_not_mail`, contact_a.do_not_sms as `do_not_sms`, contact_a.do_not_trade as `do_not_trade`, contact_a.is_opt_out as `is_opt_out`, contact_a.legal_identifier as `legal_identifier`, contact_a.external_identifier as `external_identifier`, contact_a.nick_name as `nick_name`, contact_a.legal_name as `legal_name`, contact_a.image_URL as `image_URL`, contact_a.preferred_communication_method as `preferred_communication_method`, contact_a.preferred_language as `preferred_language`, contact_a.preferred_mail_format as `preferred_mail_format`, contact_a.first_name as `first_name`, contact_a.middle_name as `middle_name`, contact_a.last_name as `last_name`, contact_a.prefix_id as `prefix_id`, contact_a.suffix_id as `suffix_id`, contact_a.formal_title as `formal_title`, contact_a.communication_style_id as `communication_style_id`, contact_a.job_title as `job_title`, contact_a.gender_id as `gender_id`, contact_a.birth_date as `birth_date`, contact_a.is_deceased as `is_deceased`, contact_a.deceased_date as `deceased_date`, contact_a.household_name as `household_name`, IF ( contact_a.contact_type = \'Individual\', NULL, contact_a.organization_name ) as organization_name, contact_a.sic_code as `sic_code`, contact_a.is_deleted as `contact_is_deleted`, IF ( contact_a.contact_type = \'Individual\', contact_a.organization_name, NULL ) as current_employer, civicrm_address.id as address_id, civicrm_address.street_address as `street_address`, civicrm_address.supplemental_address_1 as `supplemental_address_1`, civicrm_address.supplemental_address_2 as `supplemental_address_2`, civicrm_address.supplemental_address_3 as `supplemental_address_3`, civicrm_address.city as `city`, civicrm_address.postal_code_suffix as `postal_code_suffix`, civicrm_address.postal_code as `postal_code`, civicrm_address.geo_code_1 as `geo_code_1`, civicrm_address.geo_code_2 as `geo_code_2`, civicrm_address.state_province_id as state_province_id, civicrm_address.country_id as country_id, civicrm_phone.id as phone_id, civicrm_phone.phone_type_id as phone_type_id, civicrm_phone.phone as `phone`, civicrm_email.id as email_id, civicrm_email.email as `email`, civicrm_email.on_hold as `on_hold`, civicrm_im.id as im_id, civicrm_im.provider_id as provider_id, civicrm_im.name as `im`, civicrm_worldregion.id as worldregion_id, civicrm_worldregion.name as `world_region`',
+            2 => 'WHERE displayRelType.relationship_type_id = 1
+AND   displayRelType.is_active = 1
+AND (contact_a.is_deleted = 0)',
           ),
         ),
       ),
@@ -580,7 +602,7 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
    * @return string
    */
   public function strWrangle($string) {
-    return str_replace('  ', ' ', $string);
+    return trim(str_replace('  ', ' ', $string));
   }
 
   /**

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3913,6 +3913,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     ]);
   }
 
+  /**
+   * Test the related contacts filter.
+   *
+   * @throws \Exception
+   */
   public function testSmartGroupsForRelatedContacts() {
     $rtype1 = $this->callAPISuccess('relationship_type', 'create', array(
       "name_a_b" => uniqid() . " Child of",


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error when searching on related contacts

Before
----------------------------------------
fatal error when chosing to display as related contacts

After
----------------------------------------
Error fixed

Technical Details
----------------------------------------
This is happening because the alphabet query is using the simpleFrom on the class rather than the returned from - @mattwire can you recall the reason for this - I think there was an idea it would bypass the need for disabling FGB mode but as always the query object turns out to me more weird & wonderful that we anticipated...

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1002
