### PR TITLE
Add angular-xeditable to angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,8 @@
     "angular-sanitize": "~1.5.0",
     "smartmenus": "~1.1",
     "phantomjs-polyfill": "^0.0.2",
-    "es6-promise": "^4.2.4"
+    "es6-promise": "^4.2.4",
+    "angular-xeditable": "^0.9.0"
   },
   "resolutions": {
     "angular": "~1.5.11",


### PR DESCRIPTION
Overview
----------------------------------------
Add angular xeditable component to our bower_components

Before
----------------------------------------
Not present

After
----------------------------------------
Present

Technical Details
----------------------------------------
From my digging xeditable seems like the main option for angular edit in place
https://vitalets.github.io/angular-xeditable/#overview

I think it makes sense to ship with core & sooner rather than later so we don't get
in muddles with different versions in extensions

My sample afform using this is here

https://github.com/totten/afform/issues/15


Comments
----------------------------------------

