### PR TITLE
dev/Core#785: Extend addField to support select2 widget

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1507,6 +1507,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
     $isSelect = (in_array($widget, [
       'Select',
+      'Select2',
       'CheckBoxGroup',
       'RadioGroup',
       'Radio',
@@ -1521,7 +1522,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $options = isset($fieldSpec['options']) ? $fieldSpec['options'] : NULL;
       }
       if ($context == 'search') {
-        $widget = 'Select';
+        $widget = $widget == 'Select2' ? $widget : 'Select';
         $props['multiple'] = CRM_Utils_Array::value('multiple', $props, TRUE);
       }
 
@@ -1597,12 +1598,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         return $this->addChainSelect($name, $props);
 
       case 'Select':
+      case 'Select2':
         $props['class'] = CRM_Utils_Array::value('class', $props, 'big') . ' crm-select2';
         if (!array_key_exists('placeholder', $props)) {
           $props['placeholder'] = $required ? ts('- select -') : ($context == 'search' ? ts('- any -') : ts('- none -'));
         }
         // TODO: Add and/or option for fields that store multiple values
-        return $this->add('select', $name, $label, $options, $required, $props);
+        return $this->add(strtolower($widget), $name, $label, $options, $required, $props);
 
       case 'CheckBoxGroup':
         return $this->addCheckBox($name, $label, array_flip($options), $required, $props);


### PR DESCRIPTION
Overview
----------------------------------------
Currently, CiviCRM support select widget via Form::addField() but that doesn't allow us to use the features of select2 like rendering icon against each option. This PR extends addField() to support ```select2``` widget along with ```select```

Before
----------------------------------------
Suppose you want to add an icon only against smart group option(s) it was not possible earlier to simply use
```php
$groupHierarchy = [
1 => [
   .. metdata..
  'name' => 'Smart Group'
   icon => 'fa-bulb-o'
  ],
..
];

$this->addField('group', array[
          'entity' => 'group_contact',
          'label' => ts('in'),
          'placeholder' => ts('- any group -'),
          'options' => $groupHierarchy,
          'type' => 'Select',
        ]);
```
won't work.
<img width="250" alt="Screen Shot 2019-04-04 at 5 54 08 PM" src="https://user-images.githubusercontent.com/3735621/55555351-b6352c80-5702-11e9-83ba-fbb7ced8cd58.png">

After
----------------------------------------
But this will:
```php
$this->addField('group', array[
          'entity' => 'group_contact',
          'label' => ts('in'),
          'placeholder' => ts('- any group -'),
          'options' => $groupHierarchy,
          'type' => 'Select2',
        ]);
```
<img width="219" alt="Screen Shot 2019-04-04 at 5 42 38 PM" src="https://user-images.githubusercontent.com/3735621/55554749-3064b180-5701-11e9-8325-61099940f39e.png">

