### PR TITLE
dev/core#1012 Fix selection of quicksearch options

### DIFF
--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -233,7 +233,7 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   }
 
   /* Pseudo-element to ensure vertical alignment */
-  #civicrm-menu > li > a:after {
+  #civicrm-menu > li:not(#crm-qsearch) > a:after {
     content: '';
     display: inline-block;
     height: 100%;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where the Name/Email radio cannot be selected in the menubar quicksearch.

Before
----------------------------------------
![Screenshot](https://lab.civicrm.org/dev/core/uploads/d7c3b865712add17c1a47eb776043281/quickseach-select-bug-chrome.gif)

After
----------------------------------------
Fixed
