### PR TITLE
Fix running of CRM_Utils_MoneyTest on PHPUnit6+

### DIFF
--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -82,7 +82,7 @@ class CRM_Utils_MoneyTest extends CiviUnitTestCase {
    * Test that passing an invalid currency throws an error
    */
   public function testInvalidCurrency() {
-    $this->setExpectedException(CRM_Core_Exception::class, 'Invalid currency "NOT_A_CURRENCY"');
+    $this->expectException(\CRM_Core_Exception::class, 'Invalid currency "NOT_A_CURRENCY"');
     CRM_Utils_Money::format(4.00, 'NOT_A_CURRENCY');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a test failure that occurs on PHPUnit6+ https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=max,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/CRM_Utils_MoneyTest/testInvalidCurrency/

Before
----------------------------------------
Test fails on PHPUnit6

After
----------------------------------------
Test passes

Technical Details
----------------------------------------
It appears that according to https://twitter.com/asgrim/status/696320062823755776 the setExpectedException Method has been removed in favour of expectExecption 

