### PR TITLE
Fix upgrade on participant_register date

### DIFF
--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -54,7 +54,10 @@ class CRM_Upgrade_Incremental_SmartGroups {
       $fieldPossibilities[] = $field . '_high';
       $fieldPossibilities[] = $field . '_low';
     }
-    $relativeDateMappings = ['activity_date_time' => 'activity'];
+    $relativeDateMappings = [
+      'activity_date_time' => 'activity',
+      'participant_register_date' => 'participant',
+    ];
 
     foreach ($fields as $field) {
       foreach ($this->getSearchesWithField($field) as $savedSearch) {
@@ -74,7 +77,10 @@ class CRM_Upgrade_Incremental_SmartGroups {
             // Any actual criteria will have this key set but skip any weird lines
             continue;
           }
-          if (in_array($formValue[0], $fieldPossibilities)) {
+          if ($formValue[0] === $relativeFieldName && empty($formValue[2])) {
+            unset($formValues[$index]);;
+          }
+          elseif (in_array($formValue[0], $fieldPossibilities)) {
             if ($isRelative) {
               unset($formValues[$index]);
             }


### PR DESCRIPTION
Overview
----------------------------------------
On testing I found the conversion routing on participant register date wasn't working properly when
upgrading to 5.15 - this fixes

Before
----------------------------------------
Jcalendar groups are stored with hard-date formatted fields in participant_register_date_low & high and then a relative format in the relative dates array

After
----------------------------------------
For relative dates relative_dates array & the high & low fields should be empty.  participant_register_date_relative should be handled

Technical Details
----------------------------------------
@seamuslee001 can you take a look at this - it could be a potentially regression about to hit 5.15 if not resolved before it's cut but my brain has stopped processing it. I have lot of groups & they have names which meant something once but now I can't figure out whether old new smartgroup should be the same as 'a bit newer group' or more like 'old group but not as old as old group'

Comments
----------------------------------------
@mattwire I think you merged the upgrade but I guess neither of us tested well