### PR TITLE
dev/core#1017: Always bootstrap CRM_Utils_System for extern/ipn.php

### DIFF
--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -81,9 +81,8 @@ try {
       CRM_Utils_System::loadBootStrap();
       break;
 
-    case 'Drupal':
-    case 'Backdrop':
-      // Gitlab issue: #973
+    default:
+      // Gitlab issues: #973, #1017
       CRM_Utils_System::loadBootStrap([], FALSE);
       break;
 


### PR DESCRIPTION
Overview
----------------------------------------
Changes the legacy Paypal IPN endpoint to always bootstrap the user system.  This was already being done for Joomla, Drupal, and Backdrop, but needs to happen for WordPress as well.

Before
----------------------------------------
Posting to `extern/ipn.php` fails on WordPress with Uncaught Error: Call to undefined function get_option()

After
----------------------------------------
`extern.ipn.php` works on WordPress as well as Joomla, Drupal, and Backdrop