### PR TITLE
Add a unit test to lock in fix to dev/core#1000

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1623,4 +1623,13 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->contactDelete($contactId);
   }
 
+  public function testContactEmailDetailsWithNoProimaryEmail() {
+    $params = $this->contactParams();
+    unset($params['email']);
+    $contact = CRM_Contact_BAO_Contact::create($params);
+    $contactId = $contact->id;
+    $result = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactId);
+    $this->assertEquals([$contact->display_name, NULL, NULL, NULL], $result);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a unit test for #14374 

Before
----------------------------------------
Test fails because display_name isn't returned if the email is not found

After
----------------------------------------
display_name always returned even if email is not found

ping @eileenmcnaughton @mattwire 