### PR TITLE
Minimum supported PHP version is 7.0

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -49,6 +49,9 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
 
   /**
    * Minimum php version required to run (equal to or lower than the minimum install version)
+   *
+   * Even though 5.6 is no longer supported, this value is left here for a while
+   * so as not to block stragglers from upgrading.
    */
   const MINIMUM_PHP_VERSION = '5.6';
 

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -53,7 +53,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '5.6';
+  const MIN_INSTALL_PHP_VER = '7.0';
 
   /**
    * Compute any messages which should be displayed before upgrade.


### PR DESCRIPTION
Overview
----------------------------------------
This actually changes the minimum PHP version to 7.0 from 5.6.

Before
----------------------------------------
You can install CiviCRM on a server with 5.6 or higher.  A site on PHP 5.6 will have a `warning` status message saying, "This meets the minimum requirements for CiviCRM to function but is not recommended."

After
----------------------------------------
You can only install CiviCRM on a server with PHP 7.0 or higher.  A site on PHP 5.6 will have an `error` status message saying, "To ensure the continued operation of CiviCRM, upgrade your server now."  However, it will still be possible to upgrade CiviCRM on PHP 5.6.

Technical Details
----------------------------------------
This only changes `CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER`, and *does not* change `CRM_Upgrade_Form::MINIMUM_PHP_VERSION`.  The former triggers status messages and the pre-install check, while the latter is the gatekeeper for upgrades.

Comments
----------------------------------------
I was asked to flag this in the release notes, but I noticed there actually wasn't any code change dropping PHP 5.6.