### PR TITLE
(dev/core#1000) Fixes contact's displayname not appearing in membership edit, if no registered email is found

### DIFF
--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -45,21 +45,34 @@ class CRM_Contact_BAO_Contact_Location {
    *   Array of display_name, email, location type and location id if found, or (null,null,null, null)
    */
   public static function getEmailDetails($id, $isPrimary = TRUE, $locationTypeID = NULL) {
-    $params = [
-      'location_type_id' => $locationTypeID,
+    $params = array(
       'contact_id' => $id,
-      'return' => ['contact_id.display_name', 'email', 'location_type_id', 'id'],
-    ];
+      'return' => array('display_name', 'email.email'),
+      'api.Email.get' => array(
+        'location_type_id' => $locationTypeID,
+        'sequential' => 0,
+        'return' => array('email', 'location_type_id', 'id'),
+      ),
+    );
     if ($isPrimary) {
-      $params['is_primary'] = 1;
+      $params['api.Email.get']['is_primary'] = 1;
     }
-    $emails = civicrm_api3('Email', 'get', $params);
 
-    if ($emails['count'] > 0) {
-      $email = reset($emails['values']);
-      return [$email['contact_id.display_name'], $email['email'], $email['location_type_id'], $email['id']];
+    $contacts = civicrm_api3('Contact', 'get', $params);
+    if ($contacts['count'] > 0) {
+      $contact = reset($contacts['values']);
+      if ($contact['api.Email.get']['count'] > 0) {
+        $email = reset($contact['api.Email.get']['values']);
+      }
     }
-    return [NULL, NULL, NULL, NULL];
+    $returnParams = array(
+      (isset($contact['display_name'])) ? $contact['display_name'] : NULL,
+      (isset($email['email'])) ? $email['email'] : NULL,
+      (isset($email['location_type_id'])) ? $email['location_type_id'] : NULL,
+      (isset($email['id'])) ? $email['id'] : NULL,
+    );
+
+    return $returnParams;
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1623,4 +1623,18 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->contactDelete($contactId);
   }
 
+  /**
+   * Test that contact details are still displayed if no email is present.
+   *
+   * @throws \Exception
+   */
+  public function testContactEmailDetailsWithNoPrimaryEmail() {
+    $params = $this->contactParams();
+    unset($params['email']);
+    $contact = CRM_Contact_BAO_Contact::create($params);
+    $contactId = $contact->id;
+    $result = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactId);
+    $this->assertEquals([$contact->display_name, NULL, NULL, NULL], $result);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
When someone edits a contact's membership and that contact has no registered email, membership displays no contact name in membership edit mode.

Before
----------------------------------------
No `display_name` is coming back from the call to `CRM_Contact_BAO_Contact_Location::getEmailDetails`

After
----------------------------------------
`display_name` returns properly (along with an email, if available)

Technical Details
----------------------------------------
Rework on API call `Email.get` (becomes `Contact.get` along with API Chain to `Email.get`)

Comments
----------------------------------------
Related issue [here](https://lab.civicrm.org/dev/core/issues/1000)

Pulls https://github.com/civicrm/civicrm-core/pull/14429 & https://github.com/civicrm/civicrm-core/pull/14374 into one PR against the rc