### PR TITLE
dev/core#628 - Make Quicksearch options sortable

### DIFF
--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -61,19 +61,13 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
 
     parent::buildQuickForm();
 
-    // @todo remove the following adds in favour of setting via the settings array (above).
-
-    // Autocomplete for Contact Search (quick search etc.)
+    // Option 1 can't be unchecked. @see self::enableOptionOne
     $element = $this->getElement('contact_autocomplete_options');
-    $element->_elements[0]->_flagFrozen = TRUE;
+    $element->_elements[0]->setAttribute('disabled', 'disabled');
 
-    // Autocomplete for Contact Reference (custom fields)
+    // Option 1 can't be unchecked. @see self::enableOptionOne
     $element = $this->getElement('contact_reference_options');
-    $element->_elements[0]->_flagFrozen = TRUE;
-
-    // Freeze first element of quicksearch options
-    $element = $this->getElement('quicksearch_options');
-    $element->_elements[0]->_flagFrozen = TRUE;
+    $element->_elements[0]->setAttribute('disabled', 'disabled');
   }
 
   /**
@@ -100,6 +94,22 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
    */
   public static function getContactReferenceOptions() {
     return [1 => ts('Contact Name')] + CRM_Core_OptionGroup::values('contact_reference_options', FALSE, FALSE, TRUE);
+  }
+
+  /**
+   * Presave callback for contact_reference_options and contact_autocomplete_options.
+   *
+   * Ensures "1" is always contained in the array.
+   *
+   * @param $value
+   * @return bool
+   */
+  public static function enableOptionOne(&$value) {
+    $values = (array) CRM_Utils_Array::explodePadded($value);
+    if (!in_array(1, $values)) {
+      $value = CRM_Utils_Array::implodePadded(array_merge([1], $values));
+    }
+    return TRUE;
   }
 
 }

--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -95,7 +95,7 @@ class CRM_Admin_Page_AJAX {
   }
 
   public static function getSearchOptions() {
-    $searchOptions = array_merge(['sort_name'], Civi::settings()->get('quicksearch_options'));
+    $searchOptions = Civi::settings()->get('quicksearch_options');
     $labels = CRM_Core_SelectValues::quicksearchOptions();
     $result = [];
     foreach ($searchOptions as $key) {

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3266,6 +3266,27 @@ span.crm-select-item-color {
   background-color: #fffdb2
 }
 
+.crm-container ul.crm-sortable-list li label {
+  padding-left: 40px;
+  cursor: move;
+}
+.crm-container ul.crm-sortable-list li label:after {
+  display: block;
+  font-family: "FontAwesome";
+  content: "\f047";
+  position: absolute;
+  left: 4px;
+  top: 2px;
+  font-size: 10px;
+  color: grey;
+}
+.crm-container ul.crm-sortable-list li:hover label:after {
+  color: inherit;
+}
+.crm-container ul.crm-checkbox-list.crm-sortable-list li input {
+  left: 23px;
+}
+
 /* classes related to batch entry operation */
 .crm-container span.batch-edit,
 .crm-container span.batch-valid,

--- a/js/Common.js
+++ b/js/Common.js
@@ -879,6 +879,7 @@ if (!CRM.vars) CRM.vars = {};
           }
         })
         .find('input.select-row:checked').parents('tr').addClass('crm-row-selected');
+      $('.crm-sortable-list', e.target).sortable();
       $('table.crm-sortable', e.target).DataTable();
       $('table.crm-ajax-table', e.target).each(function() {
         var

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -365,7 +365,12 @@
           $('#crm-qsearch-input').focus().autocomplete("search");
         }, 1);
       });
-      $('.crm-quickSearchField input[value="' + CRM.cache.get('quickSearchField', 'sort_name') + '"]').prop('checked', true);
+      var savedDefault = CRM.cache.get('quickSearchField');
+      if (savedDefault) {
+        $('.crm-quickSearchField input[value="' + savedDefault + '"]').prop('checked', true);
+      } else {
+        $('.crm-quickSearchField:first input').prop('checked', true);
+      }
       setQuickSearchValue();
       $('#civicrm-menu').on('activate.smapi', function(e, item) {
         return !$('ul.crm-quickSearch-results').is(':visible:not(.ui-state-disabled)');

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -300,6 +300,7 @@ return [
     'description' => ts("Selected fields will be displayed in back-office autocomplete dropdown search results (Quick Search, etc.). Contact Name is always included."),
     'help_text' => NULL,
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+    'validate_callback' => 'CRM_Admin_Form_Setting_Search::enableOptionOne',
   ],
   'contact_reference_options' => [
     'group_name' => 'CiviCRM Preferences',
@@ -318,6 +319,7 @@ return [
     'description' => ts("Selected fields will be displayed in autocomplete dropdown search results for 'Contact Reference' custom fields. Contact Name is always included. NOTE: You must assign 'access contact reference fields' permission to the anonymous role if you want to use custom contact reference fields in profiles on public pages. For most situations, you should use the 'Limit List to Group' setting when configuring a contact reference field which will be used in public forms to prevent exposing your entire contact list."),
     'help_text' => NULL,
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+    'validate_callback' => 'CRM_Admin_Form_Setting_Search::enableOptionOne',
   ],
   'contact_smart_group_display' => [
     'group_name' => 'CiviCRM Preferences',

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -235,6 +235,7 @@ return [
     'type' => 'string',
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
     'html_type' => 'checkboxes',
+    'sortable' => TRUE,
     'pseudoconstant' => [
       'callback' => 'CRM_Core_SelectValues::quicksearchOptions',
     ],


### PR DESCRIPTION
Overview
----------------------------------------
This is a reviewers cut of #13565, implementing the feature of allowing quicksearch options to be rearranged, but doing so in a way that is reusable for potentially other settings without any special handling.

See https://lab.civicrm.org/dev/core/issues/628

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/58994015-2cb2e100-87bd-11e9-8d0f-d2fac58b322a.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/58993992-1e64c500-87bd-11e9-8fd9-cf6717099478.png)
