### PR TITLE
Fix duplicate households on 'Merge same household' exports

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -334,6 +334,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       $processor->setHouseholdMergeReturnProperties(array_diff_key($returnProperties, array_fill_keys(['location_type', 'im_provider'], 1)));
     }
 
+    // This perhaps only needs calling when $mergeSameHousehold == 1
     self::buildRelatedContactArray($selectAll, $ids, $processor, $componentTable);
 
     // make sure the groups stuff is included only if specifically specified

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3167,6 +3167,15 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   }
 
   /**
+   * Get the boolean options as a provider.
+   *
+   * @return array
+   */
+  public function getBooleanDataProvider() {
+    return [[TRUE], [FALSE]];
+  }
+
+  /**
    * Set the separators for thousands and decimal points.
    *
    * @param string $thousandSeparator


### PR DESCRIPTION
Overview
----------------------------------------
Merge same household was creating duplicate rows for each household, one for the "merged individuals" and one being the explicit household directly exported.

Alternative of https://github.com/civicrm/civicrm-core/pull/14116

Before
----------------------------------------
* Duplicate households on "merge same household" contact export.

After
----------------------------------------
* No duplicate households on "merge same household" contact export.

Technical Details
----------------------------------------
When exporting contacts with "Merge same household" a household record is created by merging the individual record.  However, that household is also exported directly leading to two records for the same household.
If a household has no relationships then we do need to directly export.

Comments
----------------------------------------
@mattwire I managed to replicate this in a test but your fix didn't make it pass - wanna test this?

From Prev PR: 

> Reported on two sites running 5.11 and 5.12.  I don't think this is a regression as "Merge same household" was completely broken until recently.