### PR TITLE
dev/core#1022 - Manage Case deleted activities search filter no longer working

### DIFF
--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -99,7 +99,7 @@
               d.activity_type_id = $("select#activity_type_filter_id_" + caseId).val(),
               d.activity_date_low = $("#activity_date_low_" + caseId).val(),
               d.activity_date_high = $("#activity_date_high_" + caseId).val(),
-              d.activity_deleted = ($("#activity_deleted_1").prop('checked')) ? 1 : 0; 
+              d.activity_deleted = ($("#activity_deleted_" + caseId).prop('checked')) ? 1 : 0;
             }
           }
         });


### PR DESCRIPTION
Overview
----------------------------------------
On manage case expand the search filters section just above the activities. There's a checkbox there to show deleted activities. It's no longer working.

Before
----------------------------------------
Clicking the checkbox just reloads all the non-deleted activities.

After
----------------------------------------
Clicking the checkbox works like it used to, showing just the deleted activities.

