### PR TITLE
Fix Exception api to save lower id number as contact 1

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -908,6 +908,16 @@ LIMIT {$offset}, {$rowCount}
    * @return \CRM_Core_DAO|mixed|null
    */
   public static function markNonDuplicates($cid, $oid, $oper) {
+    if ($oper == 'dupe-nondupe') {
+      try {
+        civicrm_api3('Exception', 'create', ['contact_id1' => $cid, 'contact_id2' => $oid]);
+        return TRUE;
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        return FALSE;
+      }
+    }
+
     $exception = new CRM_Dedupe_DAO_Exception();
     $exception->contact_id1 = $cid;
     $exception->contact_id2 = $oid;
@@ -918,9 +928,7 @@ LIMIT {$offset}, {$rowCount}
     }
     $exception->find(TRUE);
     $status = NULL;
-    if ($oper == 'dupe-nondupe') {
-      $status = $exception->save();
-    }
+
     if ($oper == 'nondupe-dupe') {
       $status = $exception->delete();
     }

--- a/CRM/Dedupe/BAO/Exception.php
+++ b/CRM/Dedupe/BAO/Exception.php
@@ -46,18 +46,24 @@ class CRM_Dedupe_BAO_Exception extends CRM_Dedupe_DAO_Exception {
   public static function create($params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'Exception', CRM_Utils_Array::value('id', $params), $params);
-
+    $contact1 = CRM_Utils_Array::value('contact_id1', $params);
+    $contact2 = CRM_Utils_Array::value('contact_id2', $params);
     $dao = new CRM_Dedupe_BAO_Exception();
     $dao->copyValues($params);
-    $dao->save();
-    if ($dao->contact_id1 && $dao->contact_id2) {
+    if ($contact1 && $contact2) {
       CRM_Core_DAO::singleValueQuery("
         DELETE FROM civicrm_prevnext_cache 
         WHERE (entity_id1 = %1 AND entity_id2 = %2)
         OR (entity_id1 = %2 AND entity_id2 = %2)",
-        [1 => [$dao->contact_id1, 'Integer'], 2 => [$dao->contact_id2, 'Integer']]
+        [1 => [$contact1, 'Integer'], 2 => [$contact2, 'Integer']]
       );
+      if ($contact2 < $contact1) {
+        // These are expected to be saved lowest first.
+        $dao->contact_id1 = $contact2;
+        $dao->contact_id2 = $contact1;
+      }
     }
+    $dao->save();
 
     CRM_Utils_Hook::post($hook, 'Exception', $dao->id, $dao);
     return $dao;

--- a/tests/phpunit/api/v3/ExceptionTest.php
+++ b/tests/phpunit/api/v3/ExceptionTest.php
@@ -67,4 +67,16 @@ class api_v3_ExceptionTest extends CiviUnitTestCase {
     $this->assertEquals(0, $dupes['count']);
   }
 
+  /**
+   * Per the ajax code there is an expectation the lower id will be contact 1 - ensure api handles this.
+   *
+   * @throws \Exception
+   */
+  public function testExceptionSavesLowerIDFirst() {
+    $contact1 = $this->individualCreate();
+    $contact2 = $this->individualCreate();
+    $this->callAPISuccess('Exception', 'create', ['contact_id1' => $contact2, 'contact_id2' => $contact1]);
+    $this->callAPISuccessGetSingle('Exception', ['contact_id1' => $contact1, 'contact_id2' => $contact2]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Moves functionality for ensuring lowest contact id is saved as contact 1 for dedupe exceptions to the 
BAO/api layer, adds testing

Before
----------------------------------------
Functionality inconsistent between entry points

After
----------------------------------------
Functionality consistent

Technical Details
----------------------------------------
This is already actioned (& tested) via ajax fn markNonDuplicates - this moves the functionality from
the ajax layer to the BAO layer & stdises it under unit tests

Comments
I can rebase out the first commit if that is merged separately first
