### PR TITLE
dev/core#1023 - E_NOTICE when creating bulk SMS

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -594,7 +594,7 @@ function civicrm_api3_mailing_preview($params) {
   return civicrm_api3_create_success([
     'id' => $mailingID,
     'contact_id' => $contactID,
-    'subject' => $mime->headers()['Subject'],
+    'subject' => CRM_Utils_Array::value('Subject', $mime->headers(), ''),
     'body_html' => $mime->getHTMLBody(),
     'body_text' => $mime->getTXTBody(),
   ]);

--- a/tests/phpunit/CRM/SMS/PreviewTest.php
+++ b/tests/phpunit/CRM/SMS/PreviewTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ *  Test SMS Preview
+ *
+ * @group headless
+ */
+class CRM_SMS_PreviewTest extends CiviUnitTestCase {
+
+  /**
+   * Set Up Function
+   */
+  public function setUp() {
+    parent::setUp();
+    $option = $this->callAPISuccess('option_value', 'create', ['option_group_id' => 'sms_provider_name', 'name' => 'test_provider_name', 'label' => 'Test Provider Label', 'value' => 1]);
+    $this->option_value = $option['id'];
+  }
+
+  /**
+   * Clean up after each test.
+   */
+  public function tearDown() {
+    parent::tearDown();
+    $this->callAPISuccess('option_value', 'delete', ['id' => $this->option_value]);
+  }
+
+  /**
+   * Test SMS preview.
+   */
+  public function testSMSPreview() {
+    $result = $this->callAPISuccess('SmsProvider', 'create', [
+      'title' => 'test SMS provider',
+      'username' => 'test',
+      'password' => 'password',
+      // 'name' is the option_value 'value' (not id, not name) we created in setUp()
+      'name' => 1,
+      'is_active' => 1,
+      'is_default' => 1,
+      'api_type' => 1,
+    ]);
+    $provider_id = $result['id'];
+    $result = $this->callAPISuccess('Mailing', 'create', [
+      'name' => "Test1",
+      'from_name' => "+12223334444",
+      'from_email' => "test@test.com",
+      'replyto_email' => "test@test.com",
+      'body_text' => "Testing body",
+      'sms_provider_id' => $provider_id,
+      'header_id' => NULL,
+      'footer_id' => NULL,
+      'unsubscribe_id' => NULL,
+    ]);
+    $mailing_id = $result['id'];
+    $result = $this->callAPISuccess('Mailing', 'preview', [
+      'id' => $mailing_id,
+    ]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
1. Under Mailings choose New SMS.
2. Start creating the SMS. Click Next.
3. Fill out some text. Click Next.
4. Now when you click any of the three buttons to either go back, submit, or continue later, you get the notice:

`Notice: Undefined index: Subject in civicrm_api3_mailing_preview() (line 597 of blah/blah/api/v3/Mailing.php).`

Everything still works, it's just because SMS doesn't have a subject.

Before
----------------------------------------
E_NOTICE, and the proposed test fails.

After
----------------------------------------
No E_NOTICE, and the test passes.

https://lab.civicrm.org/dev/core/issues/1023