### PR TITLE
Create payment activity when creating a payment via the api, test

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -102,7 +102,6 @@ class CRM_Financial_BAO_Payment {
     }
     elseif ($params['total_amount'] < 0) {
       $trxn = self::recordRefundPayment($params['contribution_id'], $params, FALSE);
-      CRM_Contribute_BAO_Contribution::recordPaymentActivity($params['contribution_id'], CRM_Utils_Array::value('participant_id', $params), $params['total_amount'], $trxn->currency, $trxn->trxn_date);
     }
 
     if ($isPaymentCompletesContribution) {
@@ -133,7 +132,7 @@ class CRM_Financial_BAO_Payment {
         ]
       );
     }
-
+    CRM_Contribute_BAO_Contribution::recordPaymentActivity($params['contribution_id'], CRM_Utils_Array::value('participant_id', $params), $params['total_amount'], $trxn->currency, $trxn->trxn_date);
     return $trxn;
   }
 

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -633,7 +633,9 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test create payment api for paylater contribution with partial payment.
+   * Test create payment api for pay later contribution with partial payment.
+   *
+   * @throws \Exception
    */
   public function testCreatePaymentPayLaterPartialPayment() {
     $this->createLoggedInUser();
@@ -717,7 +719,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'id' => $contribution['id'],
     ]);
     $this->callAPISuccess('OptionValue', 'get', ['name' => 'Completed', 'option_group_id' => 'contribution_status', 'api.OptionValue.create' => ['label' => 'Completed']]);
-
+    $this->callAPISuccessGetCount('Activity', ['target_contact_id' => $this->_individualId, 'activity_type_id' => 'Payment'], 2);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Makes api behaviour match the form layer - ie. creating an activity when a payment is made should be path-independent

Before
----------------------------------------
No activity created when paying via api

After
----------------------------------------
Activity created & it's tested

Technical Details
----------------------------------------
This is a pre-requisite for switching AdditionalPayment form to the api

https://github.com/civicrm/civicrm-core/pull/14408/files

Comments
----------------------------------------

