### PR TITLE
install/index.php - Fix misleading install text

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -623,7 +623,7 @@ class InstallRequirements {
 
     $this->requirePHPVersion(array(
       ts("PHP Configuration"),
-      ts("PHP5 installed"),
+      ts("PHP7 installed"),
     ));
 
     // Check that we can identify the root folder successfully

--- a/release-notes/5.14.0.md
+++ b/release-notes/5.14.0.md
@@ -26,7 +26,7 @@ Released June 5, 2019
 ### Core CiviCRM
 
 - **Minimum supported PHP version is 7.0
-  ([14437](https://github.com/civicrm/civicrm-core/pull/14437))**
+  ([14437](https://github.com/civicrm/civicrm-core/pull/14437), [14459](https://github.com/civicrm/civicrm-core/pull/14459))**
 
   CiviCRM now requires PHP 7.0 or higher.  While sites running PHP 5.6 will be
   able to upgrade to CiviCRM 5.14.0, they will see an error message saying it is


### PR DESCRIPTION
Overview
----------------------------------------
During GUI install, there's a health-check based on the PHP version.  Now
that PHP 7 is required, this message *always* talks about PHP 7.x. But
it's presented under a bucket labeled "PHP5".

This is a follow-up to #14437.