### PR TITLE
Add default receive_date for contributions at BAO level

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -301,6 +301,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         FALSE, FALSE, FALSE, 'AND is_default = 1')
       ),
       'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      'receive_date' => date('Y-m-d H:i:s'),
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes test bug by setting a default contribution receive_date in the Contribution.create BAO

Before
----------------------------------------
test fails in isolation. Can create contributions with no receive date by api

After
----------------------------------------
test passes. All contributions have a receive date.

Technical Details
----------------------------------------
This PR assumes
1) receive_date is required
2) if nothing is provided by the time it hits the BAO::create then 'now' is an appropriate default

We know 1 to be true because contributions with no receive_date cannot be edited - I can't find the gitlab right now (maybe @seamuslee001 can but there was a related regression fixed by setting this on the membership renewal form  here https://github.com/civicrm/civicrm-core/pull/14316  - which is fine to do on forms but if it's 'never ok' we should 'never do it'

I found that CRM_Contribute_Page_AjaxTest actually fails if run in isolation - obviously 'something' is
helping it out when run together but in isolation the receive_date is missing on the contribution
which causes an error when it goes to save financial item. (There was a similar test issue recently
that turned out to impact form users - this solves the issue deeper down. The default is only applied
if id is not present

Comments
----------------------------------------
There is 'something' happening in test cleanup at the moment. 2 recent PRs have triggered seemingly unrelated tests to fail. In this case it's the opposite - a failure was hidden

@JoeMurray @monishdeb @pradpnayak @mattwire 