### PR TITLE
dev/core#1024 Add hook for altering trackable urls

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1388,6 +1388,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     }
     elseif ($type == 'url') {
       if ($this->url_tracking && !empty($this->id)) {
+        CRM_Utils_Hook::alterUrl($token, ['id' => $this->id, 'campaign_id' => $this->campaign_id, 'event_queue_id' => $event_queue_id]);
         // ensure that Google CSS and any .css files are not tracked.
         if (!(strpos($token, 'css?family') || strpos($token, '.css'))) {
           $data = CRM_Mailing_BAO_TrackableURL::getTrackerURL($token, $this->id, $event_queue_id);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2555,4 +2555,20 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook is called before CRM_Mailing_BAO_TrackableURL::getTrackerURL().
+   *
+   * @param string $url
+   * @param array $params
+   *
+   * @return mixed
+   */
+  public static function alterUrl(&$url, $params) {
+    return self::singleton()->invoke(['url', 'params'],
+      $url, $params,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_alterUrl'
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes it's good to have possibility for altering urls from mailing (they will be coded as trackable urls)

Before
----------------------------------------
Url in mailing is untouched.

After
----------------------------------------
Url in mailing could be changed during saving mailing by external extension, for example by https://github.com/WeMoveEU/utmaltor

Technical Details
----------------------------------------
It's possible to add utm params to url. Simple hook with two params: `url` and array of `params`

Comments
----------------------------------------
This solution works fine above two years.
