### PR TITLE
dev/core#1010 pledge_acknowledge template - capitalization and greeting

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -112,6 +112,15 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'payment_or_refund_notification', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '5.14',
+        'upgrade_descriptor' => ts('Use email greeting and fix capitalization'),
+        'label' => ts('Pledge acknowledgement'),
+        'templates' => [
+          ['name' => 'pledge_acknowledge', 'type' => 'text'],
+          ['name' => 'pledge_acknowledge', 'type' => 'html'],
+        ],
+      ],
     ];
   }
 

--- a/xml/templates/message_templates/pledge_acknowledge_html.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_html.tpl
@@ -21,8 +21,8 @@
 
   <tr>
    <td>
-    <p>{ts 1=$contact.display_name}dear %1{/ts},</p>
-    <p>{ts}thank you for your generous pledge. please print this acknowledgment for your records.{/ts}</p>
+    {assign var="greeting" value="{contact.email_greeting}"}{if $greeting}<p>{$greeting},</p>{/if}
+    <p>{ts}Thank you for your generous pledge. Please print this acknowledgment for your records.{/ts}</p>
    </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/pledge_acknowledge_text.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_text.tpl
@@ -1,4 +1,4 @@
-{ts 1=$contact.display_name}Dear %1{/ts},
+{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}<p>{$greeting},</p>{/if}
 
 {ts}Thank you for your generous pledge. Please print this acknowledgment for your records.{/ts}
 


### PR DESCRIPTION
Overview
----------------------------------------
Pledge Acknowledgements have incorrect capitalization in greetings, and greetings do not use email_greeting.

Before
----------------------------------------
dear DisplayName
thank you....

After
----------------------------------------
Uses Email_Greeting and fixes capitalization

Technical Details
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1010

Comments
----------------------------------------
Not sure what version to use in MessageTemplates.php.