### PR TITLE
Add CRM_Utils_System::sendResponse(). Fix AssetBuilder's status-code on WP.

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -53,7 +53,7 @@
  * @method static array synchronizeUsers() Create CRM contacts for all existing CMS users.
  * @method static appendCoreResources(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_coreResourceList.
  * @method static alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_getAssetUrl.
- * @method static sendResponse(array $responseData) function to set HTTP status response and return specific response to client initially for assetBuilder content.
+ * @method static sendResponse(\Psr\Http\Message\ResponseInterface $response) function to handle RepsoseInterface for delivering HTTP Responses.
  */
 class CRM_Utils_System {
 
@@ -1864,18 +1864,11 @@ class CRM_Utils_System {
 
   /**
    * Return an HTTP Response with appropriate content and status code set.
-   * @param array $responseData
+   * @param \Psr\Http\Message\ResponseInterface $response
    */
-  public static function sendResponse($responseData) {
+  public static function sendResponse(\Psr\Http\Message\ResponseInterface $response) {
     $config = CRM_Core_Config::singleton();
-    if (!empty($responseData['statusCode'])) {
-      $config->userSystem->setStatusCode($responseData['statusCode']);
-    }
-    if (!empty($responseData['mimeType'])) {
-      self::setHttpHeader('Content-Type', $responseData['mimeType']);
-    }
-    echo $responseData['content'];
-    self::civiExit();
+    $config->userSystem->sendResponse($response);
   }
 
 }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -53,6 +53,7 @@
  * @method static array synchronizeUsers() Create CRM contacts for all existing CMS users.
  * @method static appendCoreResources(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_coreResourceList.
  * @method static alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_getAssetUrl.
+ * @method static sendResponse(array $responseData) function to set HTTP status response and return specific response to client initially for assetBuilder content.
  */
 class CRM_Utils_System {
 
@@ -1859,6 +1860,22 @@ class CRM_Utils_System {
     }
 
     return NULL;
+  }
+
+  /**
+   * Return an HTTP Response with appropriate content and status code set.
+   * @param array $responseData
+   */
+  public static function sendResponse($responseData) {
+    $config = CRM_Core_Config::singleton();
+    if (!empty($responseData['statusCode'])) {
+      $config->userSystem->setStatusCode($responseData['statusCode']);
+    }
+    if (!empty($responseData['mimeType'])) {
+      self::setHttpHeader('Content-Type', $responseData['mimeType']);
+    }
+    echo $responseData['content'];
+    self::civiExit();
   }
 
 }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1867,8 +1867,7 @@ class CRM_Utils_System {
    * @param \Psr\Http\Message\ResponseInterface $response
    */
   public static function sendResponse(\Psr\Http\Message\ResponseInterface $response) {
-    $config = CRM_Core_Config::singleton();
-    $config->userSystem->sendResponse($response);
+    $config = CRM_Core_Config::singleton()->userSystem->sendResponse($response);
   }
 
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -946,17 +946,23 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
-   * Set the HTTP Status Code for a request
-   * @param string $statusCode
+   * Send an HTTP Response base on PSR HTTP RespnseInterface response.
+   *
+   * @param \Psr\Http\Message\ResponseInterface $response
    */
-  public function setStatusCode($statusCode) {
+  public function sendResponse(\Psr\Http\Message\ResponseInterface $response) {
     if (function_exists('http_response_code')) {
       // PHP 5.4+
-      http_response_code($statusCode);
+      http_response_code($response->getStatusCode());
     }
     else {
-      header('X-PHP-Response-Code: ' . $statusCode, TRUE, $statusCode);
+      // @todo should we remove this given we are no longer supporting < PHP 5.6 however keeping
+      // in for the moment for compatability with the original AssetBuilder code.
+      header('X-PHP-Response-Code: ' . $response->getStatusCode(), TRUE, $reponse->getStatusCode());
     }
+    CRM_Utils_System::setHttpHeader('Content-Type', $response->getHeaderLine('Content-Type'));
+    echo $response->getBody();
+    CRM_Utils_System::civiExit();
   }
 
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -951,10 +951,7 @@ abstract class CRM_Utils_System_Base {
    * @param \Psr\Http\Message\ResponseInterface $response
    */
   public function sendResponse(\Psr\Http\Message\ResponseInterface $response) {
-    if (function_exists('http_response_code')) {
-      // PHP 5.4+
-      http_response_code($response->getStatusCode());
-    }
+    http_response_code($response->getStatusCode());
     foreach ($response->getHeaders() as $name => $values) {
       CRM_Utils_System::setHttpHeader($name, implode(', ', (array) $values));
     }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -945,4 +945,18 @@ abstract class CRM_Utils_System_Base {
     return [];
   }
 
+  /**
+   * Set the HTTP Status Code for a request
+   * @param string $statusCode
+   */
+  public function setStatusCode($statusCode) {
+    if (function_exists('http_response_code')) {
+      // PHP 5.4+
+      http_response_code($statusCode);
+    }
+    else {
+      header('X-PHP-Response-Code: ' . $statusCode, TRUE, $statusCode);
+    }
+  }
+
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -955,12 +955,9 @@ abstract class CRM_Utils_System_Base {
       // PHP 5.4+
       http_response_code($response->getStatusCode());
     }
-    else {
-      // @todo should we remove this given we are no longer supporting < PHP 5.6 however keeping
-      // in for the moment for compatability with the original AssetBuilder code.
-      header('X-PHP-Response-Code: ' . $response->getStatusCode(), TRUE, $reponse->getStatusCode());
+    foreach ($response->getHeaders() as $name => $values) {
+      CRM_Utils_System::setHttpHeader($name, implode(', ', (array) $values));
     }
-    CRM_Utils_System::setHttpHeader('Content-Type', $response->getHeaderLine('Content-Type'));
     echo $response->getBody();
     CRM_Utils_System::civiExit();
   }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -863,4 +863,19 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     ];
   }
 
+  /**
+   * Set the HTTP Status Code for a request
+   * @param string $statusCode
+   */
+  public function setStatusCode($statusCode) {
+    status_header($statusCode);
+    if (function_exists('http_response_code')) {
+      // PHP 5.4+
+      http_response_code($statusCode);
+    }
+    else {
+      header('X-PHP-Response-Code: ' . $statusCode, TRUE, $statusCode);
+    }
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -871,16 +871,9 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   public function sendResponse(\Psr\Http\Message\ResponseInterface $response) {
     // use WordPress function status_header to ensure 404 response is sent
     status_header($response->getStatusCode());
-    if (function_exists('http_response_code')) {
-      // PHP 5.4+
-      http_response_code($response->getStatusCode());
+    foreach ($response->getHeaders() as $name => $values) {
+      CRM_Utils_System::setHttpHeader($name, implode(', ', (array) $values));
     }
-    else {
-      // @todo should we remove this given we are no longer supporting < PHP 5.6 however keeping
-      // in for the moment for compatability with the original AssetBuilder code.
-      header('X-PHP-Response-Code: ' . $response->getStatusCode(), TRUE, $response->getStatusCode());
-    }
-    CRM_Utils_System::setHttpHeader('Content-Type', $response->getHeaderLine('Content-Type'));
     echo $response->getBody();
     CRM_Utils_System::civiExit();
   }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -864,18 +864,25 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
-   * Set the HTTP Status Code for a request
-   * @param string $statusCode
+   * Send an HTTP Response base on PSR HTTP RespnseInterface response.
+   *
+   * @param \Psr\Http\Message\ResponseInterface $response
    */
-  public function setStatusCode($statusCode) {
-    status_header($statusCode);
+  public function sendResponse(\Psr\Http\Message\ResponseInterface $response) {
+    // use WordPress function status_header to ensure 404 response is sent
+    status_header($response->getStatusCode());
     if (function_exists('http_response_code')) {
       // PHP 5.4+
-      http_response_code($statusCode);
+      http_response_code($response->getStatusCode());
     }
     else {
-      header('X-PHP-Response-Code: ' . $statusCode, TRUE, $statusCode);
+      // @todo should we remove this given we are no longer supporting < PHP 5.6 however keeping
+      // in for the moment for compatability with the original AssetBuilder code.
+      header('X-PHP-Response-Code: ' . $response->getStatusCode(), TRUE, $response->getStatusCode());
     }
+    CRM_Utils_System::setHttpHeader('Content-Type', $response->getHeaderLine('Content-Type'));
+    echo $response->getBody();
+    CRM_Utils_System::civiExit();
   }
 
 }

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -342,7 +342,7 @@ class AssetBuilder {
   public static function pageRun() {
     // Beg your pardon, sir. Please may I have an HTTP response class instead?
     $asset = self::pageRender($_GET);
-    \CRM_Utils_System::sendResponse($asset);
+    \CRM_Utils_System::sendResponse(new \GuzzleHttp\Psr7\Response($asset['statusCode'], ['Content-Type' => $asset['mimeType']], $asset['content']));
   }
 
   /**

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -342,17 +342,7 @@ class AssetBuilder {
   public static function pageRun() {
     // Beg your pardon, sir. Please may I have an HTTP response class instead?
     $asset = self::pageRender($_GET);
-    if (function_exists('http_response_code')) {
-      // PHP 5.4+
-      http_response_code($asset['statusCode']);
-    }
-    else {
-      header('X-PHP-Response-Code: ' . $asset['statusCode'], TRUE, $asset['statusCode']);
-    }
-
-    header('Content-Type: ' . $asset['mimeType']);
-    echo $asset['content'];
-    \CRM_Utils_System::civiExit();
+    \CRM_Utils_System::sendResponse($asset);
   }
 
   /**


### PR DESCRIPTION
…r_system based method to set HTTP Status code

Overview
----------------------------------------
This aims to ensure that there is a consistent response returned between Drupal/Backdrop/WordPress in regards to Asset Builder URLs, at the moment when a URL is not found Drupal/Backdrop return a 404 status which Guzzle can pick up but WordPress returns 200 because of internal WordPress 404 handling, this fixes it so that WordPress will also return status of 404 if we want it to

Before
----------------------------------------
Different Responses sent and E2E Unit Tests fail on WordPress

After
----------------------------------------
Consistent passing on all 3 CMSes

ping @totten @eileenmcnaughton @kcristiano 
