### PR TITLE
Fix version for pledge message update, also remove 'please print'

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -113,7 +113,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
         ],
       ],
       [
-        'version' => '5.14',
+        'version' => '5.15.alpha1',
         'upgrade_descriptor' => ts('Use email greeting and fix capitalization'),
         'label' => ts('Pledge acknowledgement'),
         'templates' => [

--- a/xml/templates/message_templates/pledge_acknowledge_html.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_html.tpl
@@ -22,7 +22,7 @@
   <tr>
    <td>
     {assign var="greeting" value="{contact.email_greeting}"}{if $greeting}<p>{$greeting},</p>{/if}
-    <p>{ts}Thank you for your generous pledge. Please print this acknowledgment for your records.{/ts}</p>
+    <p>{ts}Thank you for your generous pledge.{/ts}</p>
    </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/pledge_acknowledge_text.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_text.tpl
@@ -1,6 +1,6 @@
 {assign var="greeting" value="{contact.email_greeting}"}{if $greeting}<p>{$greeting},</p>{/if}
 
-{ts}Thank you for your generous pledge. Please print this acknowledgment for your records.{/ts}
+{ts}Thank you for your generous pledge.{/ts}
 
 ===========================================================
 {ts}Pledge Information{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Follow up reviewer's commit on https://github.com/civicrm/civicrm-core/pull/14465

Before
----------------------------------------
Fixes the upgrade script to target the right version

After
----------------------------------------
Fixed, also removes the 'please print' line (@jusfreeman FYI - another one)

Technical Details
----------------------------------------
@philmb these are the things I was saying on the other PR - note if this doesn't get merged pretty soon the version will need to be changed again

Comments
----------------------------------------
@yashodha in doing this I also note an old version of the pledge_acknowledge_text & html in 4.5 upgrade files - do you think we can remove these now? Anyone upgrading to the latest version will eventually get this version & the don't need the intermediary do they?
