### PR TITLE
[NFC] test cleanup. Uses CRM_Core_Exceptions, properly outputs unfiltered results

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -169,10 +169,13 @@ trait Api3TestTrait {
    * This function exists to wrap api getValue function & check the result
    * so we can ensure they succeed & throw exceptions without litterering the test with checks
    * There is a type check in this
+   *
    * @param string $entity
    * @param array $params
-   * @param null $count
-   * @throws \Exception
+   * @param int $count
+   *
+   * @throws \CRM_Core_Exception
+   *
    * @return array|int
    */
   public function callAPISuccessGetCount($entity, $params, $count = NULL) {
@@ -182,7 +185,7 @@ trait Api3TestTrait {
     ];
     $result = $this->civicrm_api($entity, 'getcount', $params);
     if (!is_int($result) || !empty($result['is_error']) || isset($result['values'])) {
-      throw new \Exception('Invalid getcount result : ' . print_r($result, TRUE) . " type :" . gettype($result));
+      throw new \CRM_Core_Exception('Invalid getcount result : ' . print_r($result, TRUE) . " type :" . gettype($result));
     }
     if (is_int($count)) {
       $this->assertEquals($count, $result, "incorrect count returned from $entity getcount");
@@ -205,7 +208,8 @@ trait Api3TestTrait {
    *   - array
    *   - object
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
+   *
    * @return array|int
    */
   public function callAPISuccessGetSingle($entity, $params, $checkAgainst = NULL) {
@@ -214,8 +218,8 @@ trait Api3TestTrait {
     ];
     $result = $this->civicrm_api($entity, 'getsingle', $params);
     if (!is_array($result) || !empty($result['is_error']) || isset($result['values'])) {
-      $unfilteredResult = $this->civicrm_api($entity, 'get', $params);
-      throw new \Exception(
+      $unfilteredResult = $this->civicrm_api($entity, 'get', ['version' => $this->_apiversion]);
+      throw new \CRM_Core_Exception(
         'Invalid getsingle result' . print_r($result, TRUE)
         . "\n entity: $entity . \n params \n " . print_r($params, TRUE)
         . "\n entities retrieved with blank params \n" . print_r($unfilteredResult, TRUE)

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -71,7 +71,8 @@ trait ContactTestTrait {
    *
    * @return int
    *   id of Individual created
-   * @throws \Exception
+   *
+   * @throws \CRM_Core_Exception
    */
   public function individualCreate($params = array(), $seq = 0, $random = FALSE) {
     $params = array_merge($this->sampleContact('Individual', $seq, $random), $params);
@@ -151,7 +152,7 @@ trait ContactTestTrait {
    * @param array $params
    *   For civicrm_contact_add api function call.
    *
-   * @throws \Exception
+   * @throws CRM_Core_Exception
    *
    * @return int
    *   id of Household created
@@ -159,7 +160,7 @@ trait ContactTestTrait {
   private function _contactCreate($params) {
     $result = $this->callAPISuccess('contact', 'create', $params);
     if (!empty($result['is_error']) || empty($result['id'])) {
-      throw new \Exception('Could not create test contact, with message: ' . \CRM_Utils_Array::value('error_message', $result) . "\nBacktrace:" . \CRM_Utils_Array::value('trace', $result));
+      throw new \CRM_Core_Exception('Could not create test contact, with message: ' . \CRM_Utils_Array::value('error_message', $result) . "\nBacktrace:" . \CRM_Utils_Array::value('trace', $result));
     }
     return $result['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup in tests class

Before
----------------------------------------
More variants of Exception in play, printing unfiltered results on fail doesn't work

After
----------------------------------------
Above fixed

Technical Details
----------------------------------------
The comment blocks should show all exceptions thrown by a function so trying to stdise a little.

Comments
----------------------------------------

