### PR TITLE
[nfc] [test] Skip testGetFromTo on date transition

### DIFF
--- a/tests/phpunit/CRM/Report/FormTest.php
+++ b/tests/phpunit/CRM/Report/FormTest.php
@@ -74,14 +74,18 @@ class CRM_Report_FormTest extends CiviUnitTestCase {
    * Test that getFromTo returns the correct dates.
    *
    * @dataProvider fromToData
-   * @param $expectedFrom
-   * @param $expectedTo
-   * @param $relative
-   * @param $from
-   * @param $to
+   *
+   * @param string $expectedFrom
+   * @param string $expectedTo
+   * @param string $relative
+   * @param string $from
+   * @param string $to
    */
   public function testGetFromTo($expectedFrom, $expectedTo, $relative, $from, $to) {
     $obj = new CRM_Report_Form();
+    if (date('H-i') === '00:00') {
+      $this->markTestIncomplete('The date might have changed since the dataprovider was called. Skip to avoid flakiness');
+    }
     list($calculatedFrom, $calculatedTo) = $obj->getFromTo($relative, $from, $to);
     $this->assertEquals([$expectedFrom, $expectedTo], [$calculatedFrom, $calculatedTo], "fail on data set [ $relative , $from , $to ]. Local php time is " . date('Y-m-d H:i:s') . ' and mysql time is ' . CRM_Core_DAO::singleValueQuery('SELECT NOW()'));
   }


### PR DESCRIPTION
Overview
----------------------------------------
Makes a test that is known to be unreliable when run right on midnight skip if being run at that time.

Before
----------------------------------------
Test intermittently fails

After
----------------------------------------
Test intermittently skipped

Technical Details
----------------------------------------
This avoids fails when the expectations were calculated right at the end of a day but then are compared with the new day's values.

Results in this case look like

CRM_Report_FormTest::testGetFromTo with data set #1 ('20190606000000', '20190606235959', 'this.day', '', '')
fail on data set [ this.day ,  ,  ]. Local php time is 2019-06-07 00:00:13 and mysql time is 2019-06-07 00:00:13
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => '20190606000000'
-    1 => '20190606235959'
+    0 => '20190607000000'
+    1 => '20190607235959'


Comments
----------------------------------------
I don't think there is value in making the test handle this better - skipping feels right
