### PR TITLE
dev/core#1025 fix unreleased regression on contact.get with custom fields

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -213,7 +213,8 @@ SELECT f.id, f.label, f.data_type,
       return;
     }
 
-    foreach ($this->_fields as $id => $field) {
+    foreach (array_keys($this->_ids) as $id) {
+      $field = $this->_fields[$id];
       $name = $field['table_name'];
       $fieldName = 'custom_' . $field['id'];
       $this->_select["{$name}_id"] = "{$name}.id as {$name}_id";
@@ -227,10 +228,7 @@ SELECT f.id, f.label, f.data_type,
       }
 
       $this->_tables[$name] = "\nLEFT JOIN $name ON $name.entity_id = $joinTable.id";
-
-      if (!empty($this->_ids[$id])) {
-        $this->_whereTables[$name] = $this->_tables[$name];
-      }
+      $this->_whereTables[$name] = $this->_tables[$name];
 
       if ($joinTable) {
         $joinClause = 1;

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -67,16 +67,18 @@ trait CRMTraits_Custom_CustomDataTrait {
    * @param array $groupParams
    * @param string $customFieldType
    *
+   * @param string $identifier
+   *
    * @throws \CRM_Core_Exception
    */
-  public function createCustomGroupWithFieldOfType($groupParams = [], $customFieldType = 'text') {
+  public function createCustomGroupWithFieldOfType($groupParams = [], $customFieldType = 'text', $identifier = '') {
     if ($customFieldType !== 'text') {
       throw new CRM_Core_Exception('we have not yet extracted other custom field types from createCustomFieldsOfAllTypes, Use consistent syntax when you do');
     }
-    $groupParams['title'] = empty($groupParams['title']) ? 'Group with field ' . $customFieldType : $groupParams['title'];
+    $groupParams['title'] = empty($groupParams['title']) ? $identifier . 'Group with field ' . $customFieldType : $groupParams['title'];
     $this->createCustomGroup($groupParams);
     $customField = $this->createTextCustomField(['custom_group_id' => $this->ids['CustomGroup'][$groupParams['title']]]);
-    $this->ids['CustomField'][$customFieldType] = $customField['id'];
+    $this->ids['CustomField'][$identifier . $customFieldType] = $customField['id'];
   }
 
   /**

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1165,6 +1165,20 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Tests that using 'return' with a custom field not of type contact does not inappropriately filter.
+   *
+   * https://lab.civicrm.org/dev/core/issues/1025
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetWithCustomOfActivityType() {
+    $this->createCustomGroupWithFieldOfType(['extends' => 'Activity']);
+    $this->createCustomGroupWithFieldOfType(['extends' => 'Contact'], 'text', 'contact_');
+    $contactID = $this->individualCreate();
+    $this->callAPISuccessGetSingle('Contact', ['id' => $contactID, 'return' => ['external_identifier', $this->getCustomFieldName('contact_text')]]);
+  }
+
+  /**
    * Check with complete array + custom field.
    *
    * Note that the test is written on purpose without any


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an unreleased regression where contact.get does not retrieve results if a custom field is requested and an activity custom field exists

Before
----------------------------------------
api call Contact.get with ['return' => 'custom_2'] was not returning results if activity custom fields exist

After
----------------------------------------
Normality resumed

Technical Details
----------------------------------------
This bug came about because a recent fix made metadata more consistent https://github.com/civicrm/civicrm-core/commit/1f61a7b1165bdf1bf45439b475b98268a44bbf57#diff-f7844105b59390da9d2993f5c8e93fd0R163 but it turns out this class was filtering the
metadata by the ids passed in https://github.com/civicrm/civicrm-core/blob/697aad03976383019e2762596d13cd1067aa9d20/CRM/Core/BAO/CustomQuery.php#L183  - and then iterating through the metadata. Now it iterates the ids instead, which has the same effect as the original but is clearer


Comments
----------------------------------------
@pfigel 