### PR TITLE
dev/drupal#21 Remove asterisks from placeholder url

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -317,14 +317,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
       \Drupal::logger('civicrm')->error($e->getMessage());
     }
 
-    // Special case: CiviCRM passes us "*path*?*query*" as a skeleton, but asterisks
-    // are invalid and Drupal will attempt to escape them. We unescape them here:
-    if ($path == '*path*') {
-      // First remove trailing equals sign that has been added since the key '?*query*' has no value.
-      $url = rtrim($url, '=');
-      $url = urldecode($url);
-    }
-
     return $url;
   }
 

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -270,11 +270,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       // pre-existing logic
       if (isset($path)) {
         $queryParts[] = 'page=CiviCRM';
-        // Encode all but the *path* placeholder
-        if ($path !== '*path*') {
-          $path = rawurlencode($path);
-        }
-        $queryParts[] = "q={$path}";
+        $queryParts[] = 'q=' . rawurlencode($path);
       }
       if ($wpPageParam) {
         $queryParts[] = $wpPageParam;

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -23,13 +23,13 @@
     }
     query = query || '';
     var frag = path.split('?');
-    var url = tplURL[mode].replace("*path*", frag[0]);
+    var url = tplURL[mode].replace("civicrm-placeholder-url-path", frag[0]);
 
     if (!query) {
-      url = url.replace(/[?&]\*query\*/, '');
+      url = url.replace(/[?&]civicrm-placeholder-url-query=1/, '');
     }
     else {
-      url = url.replace("*query*", typeof query === 'string' ? query : $.param(query));
+      url = url.replace("civicrm-placeholder-url-query=1", typeof query === 'string' ? query : $.param(query));
     }
     if (frag[1]) {
       url += (url.indexOf('?') < 0 ? '?' : '&') + frag[1];

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -42,7 +42,7 @@
   CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});
 
   // Initialize CRM.url and CRM.formatMoney
-  CRM.url({ldelim}back: '{crmURL p="*path*" q="*query*" h=0 fb=1}', front: '{crmURL p="*path*" q="*query*" h=0 fe=1}'{rdelim});
+  CRM.url({ldelim}back: '{crmURL p="civicrm-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fb=1}', front: '{crmURL p="civicrm-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fe=1}'{rdelim});
   CRM.formatMoney('init', false, {$moneyFormat});
 
   // Localize select2

--- a/tests/karma/unit/crmMailingSpec.js
+++ b/tests/karma/unit/crmMailingSpec.js
@@ -17,7 +17,7 @@ describe('crmMailing', function() {
         $provide.value('crmNavigator', navigator);
       });
       inject(['crmLegacy', function(crmLegacy) {
-        crmLegacy.url({back: '/*path*?*query*', front: '/*path*?*query*'});
+        crmLegacy.url({back: '/civicrm-placeholder-url-path?civicrm-placeholder-url-query=1', front: '/civicrm-placeholder-url-path?civicrm-placeholder-url-query=1'});
       }]);
       inject(['$controller', function($controller) {
         ctrl = $controller('ListMailingsCtrl', {});


### PR DESCRIPTION
Overview
----------------------------------------
CRM.url is a clientside helper for turning relative paths into url strings. It relies on a dummy url to serve as a placeholder. That dummy url was `*path*?*query*`, however asterisks are invalid url characters and sometimes get escaped by the CMS. This changes to a different, plain text placeholder.

Before
----------------------------------------
Placeholder is `*path*?*query*`.

After
----------------------------------------
Placeholder is `civicrm-placeholder-url-path?civicrm-placeholder-url-query=1`.

Notes
------------------
Removed special handing in D8 & WP code that dealt with the escaping.