### PR TITLE
Permit sort_name as a url parameter on advanced search

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -354,16 +354,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
-   * This virtual function is used to set the default values of various form elements.
-   *
-   * @return array|NULL
-   *   reference to the array of default values
-   */
-  public function setDefaultValues() {
-    return array_merge($this->getEntityDefaults($this->getDefaultEntity()), (array) $this->_formValues);
-  }
-
-  /**
    * Return a descriptive name for the page, used in wizard header
    *
    * @return string

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -190,26 +190,26 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
   /**
    * Set the default form values.
    *
-   *
    * @return array
    *   the default array reference
+   * @throws \Exception
    */
   public function setDefaultValues() {
+    $defaults = parent::setDefaultValues();
     // Set ssID for unit tests.
     if (empty($this->_ssID)) {
       $this->_ssID = $this->get('ssID');
     }
 
-    $defaults = array_merge($this->_formValues, array(
+    $defaults = array_merge($this->_formValues, [
       'privacy_toggle' => 1,
       'operator' => 'AND',
-    ));
+    ], $defaults);
     $this->normalizeDefaultValues($defaults);
 
     if ($this->_context === 'amtg') {
       $defaults['task'] = CRM_Contact_Task::GROUP_ADD;
     }
-
     return $defaults;
   }
 

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -33,9 +33,13 @@
 class CRM_Contact_Form_Search_Criteria {
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Contact_Form_Search_Advanced $form
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function basic(&$form) {
+    $form->addSearchFieldMetadata(['Contact' => self::getSearchFieldMetadata()]);
+    $form->addFormFieldsFromMetadata();
     self::setBasicSearchFields($form);
     $form->addElement('hidden', 'hidden_basic', 1);
 
@@ -99,9 +103,6 @@ class CRM_Contact_Form_Search_Criteria {
         $form->add('hidden', 'tag_types_text', $tagTypesText);
       }
     }
-
-    // add text box for last name, first name, street name, city
-    $form->addElement('text', 'sort_name', ts('Complete OR Partial Name'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
 
     // add text box for last name, first name, street name, city
     $form->add('text', 'email', ts('Complete OR Partial Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
@@ -252,6 +253,20 @@ class CRM_Contact_Form_Search_Criteria {
     $phoneType = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
     $form->add('select', 'phone_location_type_id', ts('Phone Location'), ['' => ts('- any -')] + $locationType, FALSE, ['class' => 'crm-select2']);
     $form->add('select', 'phone_phone_type_id', ts('Phone Type'), ['' => ts('- any -')] + $phoneType, FALSE, ['class' => 'crm-select2']);
+  }
+
+  /**
+   * Get the metadata for fields to be included on the contact search form.
+   */
+  public static function getSearchFieldMetadata() {
+    $fields = [
+      'sort_name' => ['title' => ts('Complete OR Partial Name'), 'template_grouping' => 'basic'],
+    ];
+    $metadata = civicrm_api3('Contact', 'getfields', [])['values'];
+    foreach ($fields as $fieldName => $field) {
+      $fields[$fieldName] = array_merge(CRM_Utils_Array::value($fieldName, $metadata, []), $field);
+    }
+    return $fields;
   }
 
   /**

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -104,9 +104,11 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   /**
    * Metadata for fields on the search form.
    *
+   * Instantiate with empty array for contact to prevent e-notices.
+   *
    * @var array
    */
-  protected $searchFieldMetadata = [];
+  protected $searchFieldMetadata = ['Contact' => []];
 
   /**
    * @return array
@@ -120,6 +122,17 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    */
   public function addSearchFieldMetadata($searchFieldMetadata) {
     $this->searchFieldMetadata = array_merge($this->searchFieldMetadata, $searchFieldMetadata);
+  }
+
+  /**
+   * This virtual function is used to set the default values of various form elements.
+   *
+   * @return array|NULL
+   *   reference to the array of default values
+   * @throws \Exception
+   */
+  public function setDefaultValues() {
+    return array_merge($this->getEntityDefaults($this->getDefaultEntity()), (array) $this->_formValues);
   }
 
   /**
@@ -159,7 +172,11 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
           $this->addDatePickerRange($fieldName, $fieldSpec['title'], ($fieldSpec['type'] === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)));
         }
         else {
-          $this->addField($fieldName, ['entity' => $entity]);
+          $props = ['entity' => $entity];
+          if (isset($fields[$fieldName]['title'])) {
+            $props['label'] = $fields[$fieldName]['title'];
+          }
+          $this->addField($fieldName, $props);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This lays the ground work for our metadata based approach to search forms in the contact form. Specifically it converts one field (sort_name) to be added by metadata and also to be supported via url (sort_name=x)

Before
----------------------------------------
Metadata based approach not extended to contact form

After
----------------------------------------
Approach extended - the one converted field is url-parseable

Technical Details
----------------------------------------
@monishdeb putting this up to show where I think we should be going on this

Comments
----------------------------------------

