### PR TITLE
URL support for some params in event search 

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -419,19 +419,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
   public function addRules() {
   }
 
-  /**
-   * Set the default form values.
-   *
-   *
-   * @return array
-   *   the default array reference
-   */
-  public function setDefaultValues() {
-    $defaults = [];
-    $defaults = $this->_formValues;
-    return $defaults;
-  }
-
   public function fixFormValues() {
     // if this search has been forced
     // then see if there are any get values, and if so over-ride the post values


### PR DESCRIPTION
Overview
----------------------------------------
URL support for some params in event search - 

sort_name
participant_status_id
participant_register_date_low
participant_register_date_high
participant_register_date_relative

Date format is a string of numbers YmdHIS - e.g 20180101

Before
----------------------------------------
No url param support

After
----------------------------------------
URL support for some params 
sort_name
participant_status_id
participant_register_date_low
participant_register_date_high
participant_register_date_relative

Date format is a string of numbers YmdHIS - e.g 20180101
- ie
civicrm/event/search?reset=1&sort_name=p&participant_status_id=1&participant_register_date_low=20180101
gives
<img width="435" alt="Screen Shot 2019-06-07 at 5 25 28 PM" src="https://user-images.githubusercontent.com/336308/59082918-46812f00-8949-11e9-9cf7-a786c3245d8f.png">


Technical Details
----------------------------------------
Part of a generic approach that is not widely used as yet

Comments
----------------------------------------
Utilising this approach requires field standardisation & metadata fixing - which will eventually support a move away from quickform

Docs PR is here https://github.com/civicrm/civicrm-dev-docs/issues/624