### PR TITLE
[REF] Move sort_name definition to searchFieldMetadata

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -275,7 +275,13 @@ class CRM_Contact_Form_Search_Criteria {
    * @param CRM_Core_Form $form
    */
   protected static function setBasicSearchFields($form) {
-    $form->assign('basicSearchFields', self::getBasicSearchFields());
+    $searchFields = [];
+    foreach (self::getSearchFieldMetadata() as $fieldName => $field) {
+      if ($field['template_grouping'] === 'basic') {
+        $searchFields[$fieldName] = $field;
+      }
+    }
+    $form->assign('basicSearchFields', array_merge(self::getBasicSearchFields(), $searchFields));
   }
 
   /**
@@ -285,7 +291,6 @@ class CRM_Contact_Form_Search_Criteria {
   public static function getBasicSearchFields() {
     $userFramework = CRM_Core_Config::singleton()->userFramework;
     return [
-      'sort_name' => ['name' => 'sort_name'],
       'email' => ['name' => 'email'],
       'contact_type' => ['name' => 'contact_type'],
       'group' => [


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup - move from one form of metadata definition to our new function

Before
----------------------------------------
sort_name metadata declared in 2 places

After
----------------------------------------
one place serves 2 purposes

Technical Details
----------------------------------------
@monishdeb so this is my thinking of how we can start to consolidate the 2 metadata structures

Comments

