### PR TITLE
core#1030 - fix creating hidden smart groups from Search Builder

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -699,8 +699,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     if ($params['search_context'] == 'builder') {
       $savedSearch->form_values = serialize(($params['form_values']));
     }
-    else
-    {
+    else {
       $savedSearch->form_values = serialize(CRM_Contact_BAO_Query::convertFormValues($params['form_values']));
     }
     CRM_Core_Error::debug_var('test-testin333', CRM_Contact_BAO_Query::convertFormValues($params['form_values']));

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -695,7 +695,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     //create/update saved search record.
     $savedSearch = new CRM_Contact_BAO_SavedSearch();
     $savedSearch->id = $ssId;
-    $savedSearch->form_values = serialize(CRM_Contact_BAO_Query::convertFormValues($params['form_values']));
+    $savedSearch->form_values = serialize(($params['form_values']));
     $savedSearch->mapping_id = $mappingId;
     $savedSearch->search_custom_id = CRM_Utils_Array::value('search_custom_id', $params);
     $savedSearch->save();

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -695,7 +695,15 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     //create/update saved search record.
     $savedSearch = new CRM_Contact_BAO_SavedSearch();
     $savedSearch->id = $ssId;
-    $savedSearch->form_values = serialize(($params['form_values']));
+    // Search Builder's form values have already been converted.
+    if ($params['search_context'] == 'builder') {
+      $savedSearch->form_values = serialize(($params['form_values']));
+    }
+    else
+    {
+      $savedSearch->form_values = serialize(CRM_Contact_BAO_Query::convertFormValues($params['form_values']));
+    }
+    CRM_Core_Error::debug_var('test-testin333', CRM_Contact_BAO_Query::convertFormValues($params['form_values']));
     $savedSearch->mapping_id = $mappingId;
     $savedSearch->search_custom_id = CRM_Utils_Array::value('search_custom_id', $params);
     $savedSearch->save();

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -543,7 +543,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
         'group_type' => ['2' => 1],
         // queryParams have been preprocessed esp WRT any entity reference fields - see +
         // https://github.com/civicrm/civicrm-core/pull/13250
-        'form_values' => $this->get('queryParams'),
+        'form_values' => $searchParams,
         'saved_search_id' => $ssId,
         'search_custom_id' => $this->get('customSearchID'),
         'search_context' => $this->get('context'),


### PR DESCRIPTION
Overview
----------------------------------------
When you select "Email - send/schedule via CiviMail" from Search Builder's actions, the hidden smart group that's created has the wrong contacts in it.

Before
----------------------------------------
Too many contacts.

After
----------------------------------------
The right number.

Technical Details
----------------------------------------
We're passing the wrong set of params down to the function that creates the hidden smart group.

Comments
----------------------------------------
`CRM_Contact_BAO_Group::createHiddenSmartGroup()` isn't called from anywhere else in the codebase, so this should be a safe change.

While it's not obvious from the PR, this not only creates the wrong group entity but doesn't create the `FieldMapping` entities that it needs for a search builder smart group.