### PR TITLE
dev/core#553: Creating new event takes value from default value not from saved template for custom fields

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1599,11 +1599,14 @@ FROM   civicrm_domain
    * @param string $blockCopyOfDependencies
    *   Fields that you want to block from.
    *   getting copied
+   * @param bool $blockCopyofCustomValues
+   *   Case when you don't want to copy the custom values set in a
+   *   template as it will override/ignore the submitted custom values
    *
    * @return CRM_Core_DAO|bool
    *   the newly created copy of the object. False if none created.
    */
-  public static function copyGeneric($daoName, $criteria, $newData = NULL, $fieldsFix = NULL, $blockCopyOfDependencies = NULL) {
+  public static function copyGeneric($daoName, $criteria, $newData = NULL, $fieldsFix = NULL, $blockCopyOfDependencies = NULL, $blockCopyofCustomValues = FALSE) {
     $object = new $daoName();
     $newObject = FALSE;
     if (!$newData) {
@@ -1671,7 +1674,9 @@ FROM   civicrm_domain
         }
       }
       $newObject->save();
-      $newObject->copyCustomFields($object->id, $newObject->id);
+      if (!$blockCopyofCustomValues) {
+        $newObject->copyCustomFields($object->id, $newObject->id);
+      }
       CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getBriefName($daoName), $newObject->id, $newObject);
     }
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -946,11 +946,15 @@ WHERE civicrm_event.is_active = 1
       $fieldsFix['prefix']['is_show_location'] = 0;
     }
 
+    $blockCopyOfCustomValue = (!empty($params['custom']));
+
     $copyEvent = CRM_Core_DAO::copyGeneric('CRM_Event_DAO_Event',
       ['id' => $id],
       // since the location is sharable, lets use the same loc_block_id.
       ['loc_block_id' => CRM_Utils_Array::value('loc_block_id', $eventValues)] + $params,
-      $fieldsFix
+      $fieldsFix,
+      NULL,
+      $blockCopyOfCustomValue
     );
     CRM_Price_BAO_PriceSet::copyPriceSet('civicrm_event', $id, $copyEvent->id);
     CRM_Core_DAO::copyGeneric('CRM_Core_DAO_UFJoin',
@@ -990,6 +994,10 @@ WHERE civicrm_event.is_active = 1
     );
 
     $copyEvent->save();
+
+    if ($blockCopyOfCustomValue) {
+      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_event', $copyEvent->id);
+    }
 
     CRM_Utils_System::flushCache();
     CRM_Utils_Hook::copy('Event', $copyEvent);


### PR DESCRIPTION
Overview
----------------------------------------
When creating a new event using a template the new event screen is taking the default values directly from the custom fields, and not from what's saved in the event template.

Steps to replicate:
1. Create a custom field for Events
2. Set default value say 'abc' for that custom field
3. Create/Edit an event template and save with custom field value say 'def'
4. Now create a new event using that event template

Issue - Custom field is set to default value 'abc' instead of 'def'

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/56207119-97705780-606b-11e9-8f79-05a9413af6bd.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/56207131-a0612900-606b-11e9-8ef7-c45556d22ed4.gif)


