### PR TITLE
Add in uniqueness to cache keys to mitigate clashes on multisite inst…

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1318,6 +1318,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     $cacheKeyString .= $showAll ? '_1' : '_0';
     $cacheKeyString .= $isProfile ? '_1' : '_0';
     $cacheKeyString .= $checkPermission ? '_1' : '_0';
+    $cacheKeyString .= '_' . CRM_Core_Config::domainID() . '_';
 
     $fields = CRM_Utils_Array::value($cacheKeyString, self::$_importableFields);
 

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -503,6 +503,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $cacheKey .= $onlyParent ? '_1_' : '_0_';
     $cacheKey .= $onlySubType ? '_1_' : '_0_';
     $cacheKey .= $checkPermission ? '_1_' : '_0_';
+    $cacheKey .= '_' . CRM_Core_Config::domainID() . '_';
 
     $cgTable = CRM_Core_DAO_CustomGroup::getTableName();
 

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -159,7 +159,7 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
    *   returns associated array
    */
   public static function getNavigationList() {
-    $cacheKeyString = "navigationList";
+    $cacheKeyString = "navigationList_" . CRM_Core_Config::domainID();
     $whereClause = '';
 
     $config = CRM_Core_Config::singleton();


### PR DESCRIPTION
…alls

Overview
----------------------------------------
in our system we have been seeing some issues where the unique key already exists in the cache database when it goes to try and insert. This aims to try and fix it by adding some uniquness in this case the domain_id to the cache key

Before
----------------------------------------
CacheKeys could be the same across different domains

After
----------------------------------------
Cache Keys unique to the specific domain

ping @totten @eileenmcnaughton thoughts?