### PR TITLE
Fix core#1026 where an email address synced from a CMS contact is created with no location field.

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -431,25 +431,23 @@ AND    domain_id    = %4
       $contactDetails = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactId);
 
       if (trim($contactDetails[1])) {
+        //update if record is found but different
         $emailID = $contactDetails[3];
-        //update if record is found
-        $query = "UPDATE  civicrm_email
-                     SET email = %1
-                     WHERE id =  %2";
-        $p = [
-          1 => [$emailAddress, 'String'],
-          2 => [$emailID, 'Integer'],
-        ];
-        $dao = CRM_Core_DAO::executeQuery($query, $p);
+        if (trim($contactDetails[1]) != $emailAddress) {
+          civicrm_api3('Email', 'create', [
+            'id' => $emailID,
+            'email' => $emailAddress,
+          ]);
+        }
       }
       else {
         //else insert a new email record
-        $email = new CRM_Core_DAO_Email();
-        $email->contact_id = $contactId;
-        $email->is_primary = 1;
-        $email->email = $emailAddress;
-        $email->save();
-        $emailID = $email->id;
+        $result = civicrm_api3('Email', 'create', [
+          'contact_id' => $contactId,
+          'email' => $emailAddress,
+          'is_primary' => 1,
+        ]);
+        $emailID = $result->id;
       }
 
       CRM_Core_BAO_Log::register($contactId,

--- a/api/v3/Email.php
+++ b/api/v3/Email.php
@@ -57,6 +57,10 @@ function _civicrm_api3_email_create_spec(&$params) {
   $params['is_primary']['api.default'] = 0;
   $params['email']['api.required'] = 1;
   $params['contact_id']['api.required'] = 1;
+  $defaultLocation = CRM_Core_BAO_LocationType::getDefault();
+  if ($defaultLocation) {
+    $params['location_type_id']['api.default'] = $defaultLocation->id;
+  }
 }
 
 /**

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -82,9 +82,11 @@ class api_v3_EmailTest extends CiviUnitTestCase {
    * If no location is specified when creating a new email, it should default to
    * the LocationType default
    *
-   * Only API v3
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateEmailDefaultLocation() {
+  public function testCreateEmailDefaultLocation($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['location_type_id']);
     $result = $this->callAPIAndDocument('email', 'create', $params, __FUNCTION__, __FILE__);

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -79,6 +79,20 @@ class api_v3_EmailTest extends CiviUnitTestCase {
   }
 
   /**
+   * If no location is specified when creating a new email, it should default to
+   * the LocationType default
+   *
+   * Only API v3
+   */
+  public function testCreateEmailDefaultLocation() {
+    $params = $this->_params;
+    unset($params['location_type_id']);
+    $result = $this->callAPIAndDocument('email', 'create', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
+    $delresult = $this->callAPISuccess('email', 'delete', array('id' => $result['id']));
+  }
+
+  /**
    * If a new email is set to is_primary the prev should no longer be.
    *
    * If is_primary is not set then it should become is_primary is no others exist


### PR DESCRIPTION
Overview
----------------------------------------
Fix core#1026 where an email address synced from a CMS contact is created with no location field.

Before
----------------------------------------
An email address synced from a CMS contact has no location field

After
----------------------------------------
An email address synced from a CMS contact has a location field which is the current default LocationType

Technical Details
----------------------------------------
Adds a default for `location_type_id` in the API Email.create

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1026
