### PR TITLE
Fix deletion of contact sub_type in api4

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -140,11 +140,6 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
         $params['contact_sub_type'] = CRM_Utils_Array::implodePadded($params['contact_sub_type']);
       }
     }
-    else {
-      // Reset the value.
-      // CRM-101XX.
-      $params['contact_sub_type'] = 'null';
-    }
 
     if (isset($params['preferred_communication_method']) && is_array($params['preferred_communication_method'])) {
       CRM_Utils_Array::formatArrayKeys($params['preferred_communication_method']);

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -128,7 +128,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       if (empty($params['contact_sub_type'])) {
         $params['contact_sub_type'] = 'null';
       }
-      else {
+      elseif ($params['contact_sub_type'] !== 'null') {
         if (!CRM_Contact_BAO_ContactType::isExtendsContactType($params['contact_sub_type'],
           $params['contact_type'], TRUE
         )

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
@@ -270,7 +270,7 @@ DELETE FROM civicrm_contact_type
     }
 
     $updateParams = [
-      'contact_sub_type' => NULL,
+      'contact_sub_type' => 'null',
       'contact_type' => 'Individual',
       'contact_id' => $contact->id,
     ];

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -226,9 +226,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * Verify that sub-types are created successfully and not deleted by subsequent updates.
    *
-   * v3 only - uses nonstandard syntax
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testIndividualSubType() {
+  public function testIndividualSubType($version) {
+    $this->_apiversion = $version;
     $params = array(
       'first_name' => 'test abc',
       'contact_type' => 'Individual',

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -245,11 +245,18 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'middle_name' => 'foo',
     );
     $this->callAPISuccess('contact', 'create', $params);
-    unset($params['middle_name']);
 
-    $contact = $this->callAPISuccess('contact', 'get', $params);
+    $contact = $this->callAPISuccess('contact', 'get', ['id' => $cid]);
 
     $this->assertEquals(array('Student', 'Staff'), $contact['values'][$cid]['contact_sub_type']);
+
+    $this->callAPISuccess('Contact', 'create', [
+      'id' => $cid,
+      'contact_sub_type' => [],
+    ]);
+
+    $contact = $this->callAPISuccess('contact', 'get', ['id' => $cid]);
+    $this->assertTrue(empty($contact['values'][$cid]['contact_sub_type']));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://github.com/civicrm/org.civicrm.api4/issues/160 and cleans up the contact BAO to not arbitrarily delete a contact's sub-type.

Before
----------------------------------------
BAO deletes a contact's sub-type for no apparent reason. I think this was a workaround from back when the field was a single select or checkboxes on the form and an empty value would come back as null. That's no longer the case and the form seems to work fine without this hack, so I removed it.

After
----------------------------------------
A contact can be saved without the subtype being deleted.

Comments
----------------------------------------
Api4 test coverage added.
