### PR TITLE
Expose Primary member only/Non primary member only filter in members…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1768,7 +1768,6 @@ class CRM_Report_Form extends CRM_Core_Form {
     switch ($type) {
       case CRM_Report_Form::OP_INT:
       case CRM_Report_Form::OP_FLOAT:
-
         $result = [
           'lte' => ts('Is less than or equal to'),
           'gte' => ts('Is greater than or equal to'),
@@ -1781,6 +1780,12 @@ class CRM_Report_Form extends CRM_Core_Form {
           'nll' => ts('Is empty (Null)'),
           'nnll' => ts('Is not empty (Null)'),
         ];
+
+        if ($fieldName == 'owner_membership_id') {
+          $result['nll'] = ts('Primary members only');
+          $result['nnll'] = ts('Non-primary members only');
+        }
+
         return $result;
 
       case CRM_Report_Form::OP_SELECT:


### PR DESCRIPTION
…hip reports

Overview
----------------------------------------
Expose _Primary member only/Non primary member only_ filter in membership reports which is more intuitive rather than IS NULL/ IS NULL.

Before
----------------------------------------
![mem_before](https://user-images.githubusercontent.com/3455173/59355071-fc7ebb80-8d43-11e9-8e18-ca5883543bbb.png)

After
----------------------------------------
![mem_after](https://user-images.githubusercontent.com/3455173/59355094-02749c80-8d44-11e9-85ba-5586863af1ed.png)

Comments
----------------------------------------
This is a replacement for https://github.com/civicrm/civicrm-core/pull/14242 as discussed in the comments.
