### PR TITLE
Display description next to 'paperclip' file icon - usually the filename

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1310,7 +1310,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
             // In other contexts show a paperclip icon
             if (CRM_Utils_Rule::integer($value)) {
               $icons = CRM_Core_BAO_File::paperIconAttachment('*', $value);
-              $display = $icons[$value];
+              $display = $icons[$value] . civicrm_api3('File', 'getvalue', ['return' => "description", 'id' => $value]);
             }
             else {
               //CRM-18396, if filename is passed instead


### PR DESCRIPTION
Overview
----------------------------------------
Add description to display of custom file.

Before
----------------------------------------
When a custom file is displayed that cannot be viewed directly (eg. image is rendered as an image) all you see is a paperclip - which is not necessarily very helpful:
![image](https://user-images.githubusercontent.com/2052161/59373662-0d2e3200-8d42-11e9-86b5-608937724d2d.png)

After
----------------------------------------
When a custom file is displayed you see the description next to the paperclip (which is usually the filename):
![image](https://user-images.githubusercontent.com/2052161/59373684-16b79a00-8d42-11e9-8a8c-77c28a198e8f.png)

Technical Details
----------------------------------------
Alter the render function specifically for custom files which do not have a "renderable (image etc)" type.

Comments
----------------------------------------

