### PR TITLE
WIP Allow contribution pages to accept a fixed amount via parameter

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -281,17 +281,17 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $config = CRM_Core_Config::singleton();
+    $this->_params = $this->controller->exportValues('Main');
     parent::preProcess();
 
     // lineItem isn't set until Register postProcess
     $this->_lineItem = $this->get('lineItem');
     $this->_ccid = $this->get('ccid');
 
-    $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
     $this->_params['amount'] = $this->get('amount');
-    if (isset($this->_params['amount'])) {
+
+    if (!$this->getFixedAmountSubmitted($this->_params) && isset($this->_params['amount'])) {
       $this->setFormAmountFields($this->_params['priceSetId']);
     }
 
@@ -303,7 +303,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->_params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($this->_params);
     }
 
-    $this->_params['currencyID'] = $config->defaultCurrency;
+    $this->_params['currencyID'] = CRM_Core_Config::singleton()->defaultCurrency;
 
     if (!empty($this->_membershipBlock)) {
       $this->_params['selectMembership'] = $this->get('selectMembership');
@@ -538,8 +538,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->set('productID', $productID);
       $this->set('option', $option);
     }
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviMember', $config->enableComponents) && empty($this->_ccid)) {
+    if (in_array('CiviMember', CRM_Core_Config::singleton()->enableComponents) && empty($this->_ccid)) {
       if (isset($params['selectMembership']) &&
         $params['selectMembership'] != 'no_thanks'
       ) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -35,6 +35,7 @@
  * This class generates form components for processing a contribution.
  */
 class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
+  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * The id of the contribution page that we are processing.
@@ -238,8 +239,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // this was used prior to the cleverer this_>getContactID - unsure now
     $this->_userID = CRM_Core_Session::singleton()->getLoggedInContactID();
-
     $this->_contactID = $this->_membershipContactID = $this->getContactID();
+
     $this->_mid = NULL;
     if ($this->_contactID) {
       $this->_mid = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
@@ -446,13 +447,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // check if one of the (amount , membership)  blocks is active or not.
     $this->_membershipBlock = $this->get('membershipBlock');
-
-    if (!$this->_values['amount_block_is_active'] &&
-      !$this->_membershipBlock['is_active'] &&
-      !$this->_priceSetId
-    ) {
-      CRM_Core_Error::fatal(ts('The requested online contribution page is missing a required Contribution Amount section or Membership section or Price Set. Please check with the site administrator for assistance.'));
-    }
 
     if ($this->_values['amount_block_is_active']) {
       $this->set('amount_block_is_active', $this->_values['amount_block_is_active']);

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -373,7 +373,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       }
     }
     else {
-      if ($fields['amount_block_is_active'] && empty($fields['payment_processor'])) {
+      if (!empty($fields['amount_block_is_active']) && empty($fields['payment_processor'])) {
         $errors['payment_processor'] = ts('You have listed fixed contribution options or selected a price set, but no payment option has been selected. Please select at least one payment processor and/or enable the pay later option.');
       }
     }

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -79,4 +79,24 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     $this->assign('lineItem', $tplLineItems);
   }
 
+  /**
+   * Once the form has been submitted return the
+   * @param array $params Form params
+   *
+   * @return bool|float
+   */
+  protected function getFixedAmountSubmitted($params) {
+    return empty($params['fixed_amount']) ? FALSE : (float) $params['fixed_amount'];
+  }
+
+  /**
+   * Get the configured fixed amount value for a contribution page, or NULL if not configured
+   *
+   * @return NULL|float
+   * @throws \CRM_Core_Exception
+   */
+  protected function getFixedAmount() {
+    return CRM_Utils_Request::retrieve('fixed_amount', 'Float');
+  }
+
 }

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -107,9 +107,15 @@
         <td><span>{$form.total_amount.html|crmMoney}&nbsp;&nbsp;{if $taxAmount}{ts 1=$taxTerm 2=$taxAmount|crmMoney}(includes %1 of %2){/ts}{/if}</span></td>
       </div>
     {/if}
-  {else}
+  {elseif $priceSetID}
     <div id="priceset-div">
     {include file="CRM/Price/Form/PriceSet.tpl" extends="Contribution"}
+    </div>
+  {else}
+    <div id="fixedamount-div" class="crm-public-form-item crm-section {$form.fixed_amount.name}-section">
+      <div class="label">{$form.fixed_amount.label}</div>
+      <div class="content">{$form.fixed_amount.html|crmMoney}&nbsp;&nbsp;{if $taxAmount}{ts 1=$taxTerm 2=$taxAmount|crmMoney}(includes %1 of %2){/ts}{/if}</div>
+      <div class="clear"></div>
     </div>
   {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
This allows a contribution page to be used with an amount specified via the URL rather than via priceset etc.  Useful for customised workflows, transfers from external fundraising sites etc. where you want a contribution to be made using a CiviCRM contribution page.

Before
----------------------------------------
Not possible to specify a fixed amount for a contribution page.

After
----------------------------------------
Can specify via URL parameter fixed_amount (eg. http://localhost:8000/civicrm/contribute/transact?reset=1&id=4&fixed_amount=12.52)
![Peek 2019-06-12 19-38](https://user-images.githubusercontent.com/2052161/59377356-f4c21580-8d49-11e9-88b3-5331ea2f4e3b.gif)


Technical Details
----------------------------------------
Reworks various parts of the contribution page to allow a fixed amount to be specified and processed.

Comments
----------------------------------------
@michaelmcandrew Could this be of interest to you?
