### PR TITLE
$this->_selectedTables is not populated incase of boleen filters

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4300,7 +4300,8 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         }
         if (array_key_exists('filters', $table)) {
           foreach ($table['filters'] as $filterName => $filter) {
-            if (!empty($this->_params["{$filterName}_value"])
+            if ((isset($this->_params["{$filterName}_value"])
+                && !CRM_Utils_System::isNull($this->_params["{$filterName}_value"]))
               || !empty($this->_params["{$filterName}_relative"])
               || CRM_Utils_Array::value("{$filterName}_op", $this->_params) ==
               'nll'


### PR DESCRIPTION
Overview
----------------------------------------
When you filter on report for boolean fields with option No then $this->_selectedTables is not populated.

Before
----------------------------------------
When you filter on report for boolean fields with option No then $this->_selectedTables is not populated.

After
----------------------------------------
When you filter on report for boolean fields with option No then $this->_selectedTables is populated.

Technical Details
----------------------------------------
Boolean filters use 1 or 0 values and !empty on 0 will return false. Hence used CRM_Utils_System::isNull() to check if its null or empty
