### PR TITLE
Update PSR16 handling for multisite extension legacy caching group

### DIFF
--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -180,7 +180,7 @@ class CRM_Core_BAO_Cache_Psr16 {
    * @return array
    */
   public static function getLegacyGroups() {
-    return [
+    $groups = [
       // Core
       'CiviCRM Search PrevNextCache',
       'contact fields',
@@ -202,9 +202,17 @@ class CRM_Core_BAO_Cache_Psr16 {
       // nz.co.fuzion.entitysetting
       'CiviCRM setting Spec',
 
-      // org.civicrm.multisite
-      'descendant groups for an org',
     ];
+    // Handle Legacy Multisite caching group.
+    $extensions = CRM_Extension_System::singleton()->getManager();
+    $multisiteExtensionStatus = $extensions->getStatus('org.civicrm.multisite');
+    if ($multisiteExtensionStatus == $extensions::STATUS_INSTALLED) {
+      $extension_version = civicrm_api3('Extension', 'get', ['key' => 'org.civicrm.multisite'])['values'][0]['version'];
+      if (version_compare($extension_version, '2.7', '<')) {
+        $groups[] = 'descendant groups for an org';
+      }
+    }
+    return $groups;
   }
 
 }

--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -209,6 +209,10 @@ class CRM_Core_BAO_Cache_Psr16 {
     if ($multisiteExtensionStatus == $extensions::STATUS_INSTALLED) {
       $extension_version = civicrm_api3('Extension', 'get', ['key' => 'org.civicrm.multisite'])['values'][0]['version'];
       if (version_compare($extension_version, '2.7', '<')) {
+        Civi::log()->warning(
+          'CRM_Core_BAO_Cache_PSR is deprecated for multisite extension, you should upgrade to the latest version to avoid this warning, this code will be removed at the end of 2019',
+          ['civi.tag' => 'deprecated']
+        );
         $groups[] = 'descendant groups for an org';
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This updates the PSR16 handling for the Multisite Extension's legacy cache group handling, such that there is now a new version of the multisite extension out there with a converted caching so we only need this if we are on the version of extension that still uses the legacy format

Before
----------------------------------------
Legacy Group created all the time

After
----------------------------------------
Legacy group only used if version is before 2.6

ping @monishdeb @totten @eileenmcnaughton 