### PR TITLE
dev/core#1039 Make the contact details in the contact summary screen …

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -887,6 +887,12 @@ input.crm-form-entityref {
   font-weight: bold;
 }
 
+/* dev/core#1039 Make contact details in popup on merge screen non bold */
+#crm-container tr.columnheader td [class*="crm-summary-col-"] {
+  font-size: 13px;
+  font-weight: normal;
+}
+
 #crm-container tr.columnheader-dark th span.extra {
   font-size: .95em;
   font-weight: normal;


### PR DESCRIPTION
…popup on merge screens non bold a-la contact summary screen

Overview
----------------------------------------
Title says it all

Before
----------------------------------------
![civi_css_change_before](https://user-images.githubusercontent.com/6799125/59410556-78d4d580-8dfc-11e9-9240-adb884bba4a1.png)

After
----------------------------------------
![civi_css_change_after](https://user-images.githubusercontent.com/6799125/59410592-9013c300-8dfc-11e9-9a3f-372e084f31a6.png)

Technical Details
----------------------------------------
This change is needed as the popup in this case is in a header region of a table rather than in general table body

ping @colemanw @eileenmcnaughton @monishdeb @andrew-cormick-dockery @johntwyman