### PR TITLE
Expose Primary member only/Non primary member only filter in membersh…

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -284,6 +284,18 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
     }
   }
 
+  public function getOperationPair($type = "string", $fieldName = NULL) {
+    $result = parent::getOperationPair($type, $fieldName);
+
+    //re-name IS NULL/IS NOT NULL for clarity
+    if ($fieldName == 'owner_membership_id') {
+      $result['nll'] = ts('Primary members only');
+      $result['nnll'] = ts('Non-primary members only');
+    }
+
+    return $result;
+  }
+
   /**
    * Alter display of rows.
    *

--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -436,6 +436,18 @@ GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
     parent::postProcess();
   }
 
+  public function getOperationPair($type = "string", $fieldName = NULL) {
+    $result = parent::getOperationPair($type, $fieldName);
+
+    //re-name IS NULL/IS NOT NULL for clarity
+    if ($fieldName == 'owner_membership_id') {
+      $result['nll'] = ts('Primary members only');
+      $result['nnll'] = ts('Non-primary members only');
+    }
+
+    return $result;
+  }
+
   /**
    * @param $rows
    */


### PR DESCRIPTION
…ip reports.

Overview
----------------------------------------
Expose _Primary member only/Non primary member only_ filter in membership reports which is more intuitive rather than IS NULL/ IS NULL.

Before
----------------------------------------
![mem_before](https://user-images.githubusercontent.com/3455173/59355071-fc7ebb80-8d43-11e9-8e18-ca5883543bbb.png)

After
----------------------------------------
![mem_after](https://user-images.githubusercontent.com/3455173/59355094-02749c80-8d44-11e9-85ba-5586863af1ed.png)

Comments
----------------------------------------
This is a replacement for https://github.com/civicrm/civicrm-core/pull/14242 as discussed in the comments.
