### PR TITLE
Bugfix - getting id from hash

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -3065,7 +3065,9 @@ ORDER BY civicrm_mailing.name";
       'return' => 'visibility',
     ])) === 'Public Pages') {
 
-      if ($hash = CRM_Mailing_BAO_Mailing::getMailingHash($id)) {
+      // if hash setting is on then we change the public url into a hash
+      $hash = CRM_Mailing_BAO_Mailing::getMailingHash($id);
+      if(!empty($hash)){
         $id = $hash;
       }
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -3067,7 +3067,7 @@ ORDER BY civicrm_mailing.name";
 
       // if hash setting is on then we change the public url into a hash
       $hash = CRM_Mailing_BAO_Mailing::getMailingHash($id);
-      if(!empty($hash)){
+      if (!empty($hash)) {
         $id = $hash;
       }
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -3064,6 +3064,11 @@ ORDER BY civicrm_mailing.name";
       'id' => $id,
       'return' => 'visibility',
     ])) === 'Public Pages') {
+
+      if ($hash = CRM_Mailing_BAO_Mailing::getMailingHash($id)) {
+        $id = $hash;
+      }
+
       return CRM_Utils_System::url('civicrm/mailing/view', ['id' => $id], $absolute, NULL, TRUE, TRUE);
     }
   }

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -113,7 +113,14 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       $this->_mailing = new CRM_Mailing_BAO_Mailing();
 
       if (!is_numeric($this->_mailingID)) {
+
+        //lets get the id from the hash
+        $result_id = civicrm_api3('Mailing', 'get', [
+          'return' => ["id"],
+          'hash' => $this->_mailingID,
+        ]);
         $this->_mailing->hash = $this->_mailingID;
+        $this->_mailingID     = $result_id['id'];
       }
       elseif (is_numeric($this->_mailingID)) {
         $this->_mailing->id = $this->_mailingID;

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -116,7 +116,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
 
         //lets get the id from the hash
         $result_id = civicrm_api3('Mailing', 'get', [
-          'return' => ["id"],
+          'return' => ['id'],
           'hash' => $this->_mailingID,
         ]);
         $this->_mailing->hash = $this->_mailingID;


### PR DESCRIPTION
Overview
----------------------------------------
CiviMail has a setting for 'Hashed Mailing URL's'
However, if this setting is enabled it is impossible to view the mailing.
Clicking 'View complete mailing' results in a server error:

Before
----------------------------------------
Issue was reported here:  https://lab.civicrm.org/dev/core/issues/1037

![image](https://user-images.githubusercontent.com/17023531/59427550-ce948800-8dd2-11e9-8d8c-48998ea48018.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/17023531/59427896-ad806700-8dd3-11e9-90ce-cb86e38ad6f2.png)

You can now view your email

Technical Details
----------------------------------------


Comments
----------------------------------------
Issue was reported here:  https://lab.civicrm.org/dev/core/issues/1037

