### PR TITLE
Add buttons to 'Cleanup caches and update paths' in standard way

### DIFF
--- a/CRM/Admin/Form/Setting/UpdateConfigBackend.php
+++ b/CRM/Admin/Form/Setting/UpdateConfigBackend.php
@@ -42,22 +42,25 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Settings - Cleanup Caches and Update Paths'));
 
-    $this->addElement(
-      'submit', $this->getButtonName('next', 'cleanup'), 'Cleanup Caches',
-      ['class' => 'crm-form-submit', 'id' => 'cleanup-cache']
-    );
+    $this->addButtons([
+      [
+        'type' => 'next',
+        'name' => ts('Cleanup Caches'),
+        'subName' => 'cleanup',
+        'icon' => 'fa-undo',
 
-    $this->addElement(
-      'submit', $this->getButtonName('next', 'resetpaths'), 'Reset Paths',
-      ['class' => 'crm-form-submit', 'id' => 'resetpaths']
-    );
-
-    //parent::buildQuickForm();
+      ],
+      [
+        'type' => 'next',
+        'name' => ts('Reset Paths'),
+        'subName' => 'resetpaths',
+        'icon' => 'fa-terminal',
+      ],
+    ]);
   }
 
   public function postProcess() {
-    if (!empty($_POST['_qf_UpdateConfigBackend_next_cleanup'])) {
-
+    if (isset($_REQUEST['_qf_UpdateConfigBackend_next_cleanup'])) {
       $config = CRM_Core_Config::singleton();
 
       // cleanup templates_c directory
@@ -74,14 +77,13 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
 
       CRM_Core_Session::setStatus(ts('Cache has been cleared and menu has been rebuilt successfully.'), ts("Success"), "success");
     }
-
-    if (!empty($_POST['_qf_UpdateConfigBackend_next_resetpaths'])) {
+    elseif (isset($_REQUEST['_qf_UpdateConfigBackend_next_resetpaths'])) {
       $msg = CRM_Core_BAO_ConfigSetting::doSiteMove();
 
       CRM_Core_Session::setStatus($msg, ts("Success"), "success");
     }
 
-    return CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/setting/updateConfigBackend', 'reset=1'));
+    CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/setting/updateConfigBackend', 'reset=1'));
   }
 
 }

--- a/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
+++ b/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
@@ -24,26 +24,15 @@
  +--------------------------------------------------------------------+
 *}
 <div class="help">
-    <p>
+  <p>
     {ts}When migrating a site to a new server, the paths and URLs of your CiviCRM installation may change. {/ts}
-    </p>
-    <p>
+  </p>
+  <p>
     {capture assign="pathsURL"}{crmURL p="civicrm/admin/setting/path" q="reset=1"}{/capture}
     {capture assign="urlsURL"}{crmURL p="civicrm/admin/setting/url" q="reset=1"}{/capture}
     {ts 1=$pathsURL 2=$urlsURL}The old paths and URLs may be retained in some database records. Use this form to clear caches or to reset paths to their defaults. If you need further customizations, then update the <a href="%1">Directories</a> and <a href="%2">Resource URLs</a>.{/ts}
-    </p>
+  </p>
 </div>
 <div class="crm-block crm-form-block crm-config-backend-form-block">
-        <div class="crm-submit-buttons">
-          <span class="crm-button crm-i-button">
-            <i class="crm-i fa-undo"></i>
-            {$form._qf_UpdateConfigBackend_next_cleanup.html}
-          </span>
-          <span class="crm-button crm-i-button">
-            <i class="crm-i fa-terminal"></i>
-            {$form._qf_UpdateConfigBackend_next_resetpaths.html}
-          </span>
-        </div>
-        <div>{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-<div class="spacer"></div>
+  <div>{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Change to standard method to add buttons to this form

Before
----------------------------------------
Added using hardcoded method on form.  Not using standard formButtons template.

After
----------------------------------------
Added using standard formButtons method.
![image](https://user-images.githubusercontent.com/2052161/59441821-10ccc200-8df1-11e9-9387-c614891ca90f.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
This allows themes such as haystack (shown) to theme buttons consistently.
