### PR TITLE
Civi\Angular\ChangeSet - Relax debug-mode consistency check

### DIFF
--- a/Civi/Angular/ChangeSet.php
+++ b/Civi/Angular/ChangeSet.php
@@ -55,9 +55,6 @@ class ChangeSet implements ChangeSetInterface {
           if (preg_match($filter['regex'], $path)) {
             if ($doc === NULL) {
               $doc = \phpQuery::newDocument($html, 'text/html');
-              if (\CRM_Core_Config::singleton()->debug && !$coder->checkConsistentHtml($html)) {
-                throw new \CRM_Core_Exception("Cannot process $path: inconsistent markup. Use check-angular.php to investigate.");
-              }
             }
             call_user_func($filter['callback'], $doc, $path);
           }


### PR DESCRIPTION
Overview
--------

The Angular subsystem *sometimes* includes a consistency-check. The consistency check ensures that an HTML document is read/written in consistent format (i.e. `encode(decode($html)) === $html`). However, the check is not often run, and it sometimes produces errors on consistency issues which we don't care about.

The approach here is to relax the checks in `civicrm-core` and reproduce them in separate developer-oriented tooling.

Before
------

* If an Angular HTML partial is *not* altered (`hook_civicrm_alterAngular`), then the partial is *not* checked for consistency.
* If a site is in production/non-debug mode, then the partial is *not* checked for consistency.
* If a site is in debug mode, then the partial *is* checked for consistency.
* tldr: The consistency-check is executed very rarely.

After
-----

* The partial is not checked for consistency.
* A task is recorded on the [Afform roadmap](https://github.com/totten/afform/blob/master/docs/roadmap.md) to include better consistency checks in the `afform_auditor` extension.
