### PR TITLE
Update UFGroup to lookup image by directory

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1189,7 +1189,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
                 // Core image; .htaccess blocks direct URL access, so find it by directory instead.
                 $imagename = substr($details->$name, $iscoreimage + strlen($coreimagepattern));
                 list($width, $height) = getimagesize(CRM_Utils_String::unstupifyUrl($config->customFileUploadDir . $imagename));
-              } else {
+              }
+              else {
                 // Could be a webform uploaded image so try by URL.
                 list($width, $height) = getimagesize(CRM_Utils_String::unstupifyUrl($details->$name));
               }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1183,7 +1183,16 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
               }
             }
             elseif ($name == 'image_URL') {
-              list($width, $height) = getimagesize(CRM_Utils_String::unstupifyUrl($details->$name));
+              $coreimagepattern = 'imagefile?photo=';
+              $iscoreimage = strpos($details->$name, $coreimagepattern);
+              if ($iscoreimage) {
+                // Core image; .htaccess blocks direct URL access, so find it by directory instead.
+                $imagename = substr($details->$name, $iscoreimage + strlen($coreimagepattern));
+                list($width, $height) = getimagesize(CRM_Utils_String::unstupifyUrl($config->customFileUploadDir . $imagename));
+              } else {
+                // Could be a webform uploaded image so try by URL.
+                list($width, $height) = getimagesize(CRM_Utils_String::unstupifyUrl($details->$name));
+              }
               list($thumbWidth, $thumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($width, $height);
 
               $image_URL = '<img src="' . $details->$name . '" height= ' . $thumbHeight . ' width= ' . $thumbWidth . '  />';


### PR DESCRIPTION
Overview
----------------------------------------
When adding a contact image field to a profile that shows up in the Backdrop/Drupal user page, CiviCRM attempts to get the image size via URL. The `.htaccess` file in the `custom` directory blocks all access via URL.

Before
----------------------------------------
Due to the `.htaccess` file, this fails and I was seeing the following warning:

> Warning: getimagesize(https://example.org/civicrm/contact/imagefile?photo=filename.jpg): failed to open stream: HTTP request failed! HTTP/1.1 401 Unauthorized in CRM_Core_BAO_UFGroup::getValues() (line 1195 of /path/modules/civicrm/CRM/Core/BAO/UFGroup.php). 

After
----------------------------------------
See what you think of the following change that at least seems to fix that warning by changing it from a URL to a directory path when using `getimagesize`.

