### PR TITLE
[test] Add PrematureExitException to support unit testing where the code would otherwise exit

### DIFF
--- a/CRM/Core/Exception/PrematureExitException.php
+++ b/CRM/Core/Exception/PrematureExitException.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Exception thrown during tests where live code would exit.
+ *
+ * This is when the code would exit in live mode.
+ *
+ * @param string $message
+ *   The human friendly error message.
+ * @param string $error_code
+ *   A computer friendly error code. By convention, no space (but underscore allowed).
+ *   ex: mandatory_missing, duplicate, invalid_format
+ * @param array $data
+ *   Extra params to return. eg an extra array of ids. It is not mandatory, but can help the computer using the api.
+ * Keep in mind the api consumer isn't to be trusted. eg. the database password is NOT a good extra data.
+ */
+class CRM_Core_Exception_PrematureExitException extends RuntimeException {
+
+}

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1395,9 +1395,14 @@ class CRM_Utils_System {
    *
    * @param int $status
    *   (optional) Code with which to exit.
+   *
+   * @throws \CRM_Core_PrematureExit_Exception
    */
   public static function civiExit($status = 0) {
 
+    if (CIVICRM_UF === 'UnitTests') {
+      throw new CRM_Core_Exception_PrematureExitException('civiExit called');
+    }
     if ($status > 0) {
       http_response_code(500);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Adds new exception too support unit tests

Before
----------------------------------------
Hard to deal with situation when CiviExit called within Civi when writing a test

After
----------------------------------------
Test can catch the PrematureExitException

Technical Details
----------------------------------------
New exception created & this exception is thrown in civi exit in UnitTest context

Comments
----------------------------------------
Original discussion & sample usage in #14511

Against rc as a regression fix is expected to use this in the test part