### PR TITLE
dev/core#965 Fix destination in payment edit

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -181,7 +181,12 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
 
     $this->submit($params);
 
-    CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url(CRM_Utils_System::currentPath()));
+    $contactId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionID, 'contact_id');
+    $url = CRM_Utils_System::url(
+      "civicrm/contact/view/contribution",
+      "reset=1&action=update&id={$this->_contributionID}&cid={$contactId}&context=contribution"
+    );
+    CRM_Core_Session::singleton()->pushUserContext($url);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is a reviewer's cut of #14362
When ajax popup forms are disabled, the form on "civicrm/payment/edit" shows a fatal error: "Expected one FinancialTrxn but found 25".

Before
----------------------------------------
"Expected one FinancialTrxn but found 25".

After
----------------------------------------
Redirects to contact edit form.

Comments
----------------------------------------
issue gitlab: https://lab.civicrm.org/dev/core/issues/965
