### PR TITLE
dev/core#1327 Implement new view status checks permission (reduce noize)

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -348,7 +348,7 @@ class CRM_Core_Invoke {
    * @param CRM_Core_Smarty $template
    */
   public static function statusCheck($template) {
-    if (CRM_Core_Config::isUpgradeMode() || !CRM_Core_Permission::check('administer CiviCRM')) {
+    if (CRM_Core_Config::isUpgradeMode() || !CRM_Core_Permission::check('view status checks')) {
       return;
     }
     // always use cached results - they will be refreshed by the session timer

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -348,7 +348,17 @@ class CRM_Core_Invoke {
    * @param CRM_Core_Smarty $template
    */
   public static function statusCheck($template) {
-    if (CRM_Core_Config::isUpgradeMode() || !CRM_Core_Permission::check('view status checks')) {
+    $permissions = [];
+    // Transitional arrangement until end of 2019, we have added a new permission
+    // view status checks and if CIVICRM_DISABLE_TRANSITION_STATUS_CHECKS is not defined
+    // or defined as false fall back to standard administer CiviCRM permission
+    if (!CRM_Utils_Constant::value('CIVICRM_DISABLE_TRANSITION_STATUS_CHECKS')) {
+      $permissions[] = ['view status checks', 'administer CiviCRM'];
+    }
+    else {
+      $permissions[0] = 'view status checks';
+    }
+    if (CRM_Core_Config::isUpgradeMode() || !CRM_Core_Permission::check($permissions)) {
       return;
     }
     // always use cached results - they will be refreshed by the session timer

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -914,6 +914,10 @@ class CRM_Core_Permission {
         $prefix . ts('send SMS'),
         ts('Send an SMS'),
       ],
+      'view status checks' => [
+        $prefix . ts('View CiviCRM Status Checks'),
+        ts('View CiviCRM Status Checks'),
+      ],
     ];
 
     return $permissions;

--- a/CRM/Upgrade/Incremental/php/FiveSixteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixteen.php
@@ -41,7 +41,10 @@ class CRM_Upgrade_Incremental_php_FiveSixteen extends CRM_Upgrade_Incremental_Ba
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     if ($rev == '5.16.alpha1') {
-      $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the CiviCRM Status Checks notices.', array(1 => ts('View CiviCRM Status Checks'))) . '</p>';
+      $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. For the moment this new permission or %2 permission will be enough to see the status checks. This will change at the end of 2019 when the permissions %1 will be required to access the status checks. We recommend at least one user has that permission granted to them. If System Administrators want to switch to just using the new permission check to control access to the status checks. They can add a define in civicrm.settings.php setting CIVICRM_DISABLE_TRANSITION_STATUS_CHECKS to be TRUE to disable the transitional arrangement .', [
+        1 => 'View CiviCRM Status Checks',
+        2 => 'Administer CiviCRM',
+      ]) . '</p>';
     }
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveSixteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixteen.php
@@ -40,10 +40,9 @@ class CRM_Upgrade_Incremental_php_FiveSixteen extends CRM_Upgrade_Incremental_Ba
    * @param null $currentVer
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
-    // Example: Generate a pre-upgrade message.
-    // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
-    // }
+    if ($rev == '5.16.alpha1') {
+      $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the CiviCRM Status Checks notices.', array(1 => ts('View CiviCRM Status Checks'))) . '</p>';
+    }
   }
 
   /**

--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -80,7 +80,16 @@ class CRM_Utils_Check {
    * Display daily system status alerts (admin only).
    */
   public function showPeriodicAlerts() {
-    if (CRM_Core_Permission::check('view status checks')) {
+    // Transitional arrangement until end of 2019, we have added a new permission
+    // view status checks and if CIVICRM_DISABLE_TRANSITION_STATUS_CHECKS is not defined
+    // or defined as false fall back to standard administer CiviCRM permission
+    if (!CRM_Utils_Constant::value('CIVICRM_DISABLE_TRANSITION_STATUS_CHECKS')) {
+      $permissions[] = ['view status checks', 'administer CiviCRM'];
+    }
+    else {
+      $permissions[0] = 'view status checks';
+    }
+    if (CRM_Core_Permission::check($permissions)) {
       $session = CRM_Core_Session::singleton();
       if ($session->timer('check_' . __CLASS__, self::CHECK_TIMER)) {
 

--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -80,7 +80,7 @@ class CRM_Utils_Check {
    * Display daily system status alerts (admin only).
    */
   public function showPeriodicAlerts() {
-    if (CRM_Core_Permission::check('administer CiviCRM')) {
+    if (CRM_Core_Permission::check('view status checks')) {
       $session = CRM_Core_Session::singleton();
       if ($session->timer('check_' . __CLASS__, self::CHECK_TIMER)) {
 

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -477,6 +477,15 @@ define('CIVICRM_DEADLOCK_RETRIES', 3);
  */
 // define('CIVICRM_BAO_CACHE_ADAPTER', 'CRM_Core_BAO_Cache_Psr16');
 
+/**
+ * Specify if CiviCRM should not translate administer CiviCRM Permission
+ * to include view status checks permission.
+ *
+ * This is a transitional arrangement and if left undefined administer civicrm
+ * will be treated like view status checks permission
+ */
+// define('CIVICRM_DISABLE_TRANSITION_STATUS_CHECKS', TRUE);
+
 if (CIVICRM_UF === 'UnitTests') {
   if (!defined('CIVICRM_CONTAINER_CACHE')) define('CIVICRM_CONTAINER_CACHE', 'auto');
   if (!defined('CIVICRM_MYSQL_STRICT')) define('CIVICRM_MYSQL_STRICT', true);


### PR DESCRIPTION
Add in upgrade notice

Overview
----------------------------------------
This implements the new View Status Checks permission to allow for some more granularity of who gets to see the status checks

Before
----------------------------------------
Anyone with CiviCRM administration gets the status checks

After
----------------------------------------
Only roles with the view status checks permission get the status checks

ping @mattwire @eileenmcnaughton @jusfreeman 