### PR TITLE
ActivityForm - Redirect to contact page or activity view in standalone mode

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -992,6 +992,17 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $activity = $this->processActivity($params);
     }
 
+    // Redirect to contact page or activity view in standalone mode
+    if ($this->_context == 'standalone') {
+      if (count($params['target_contact_id']) == 1) {
+        $url = CRM_Utils_System::url('civicrm/contact/view', ['cid' => CRM_Utils_Array::first($params['target_contact_id']), 'selectedChild' => 'activity']);
+      }
+      else {
+        $url = CRM_Utils_System::url('civicrm/activity', ['action' => 'view', 'reset' => 1, 'id' => $this->_activityId]);
+      }
+      CRM_Core_Session::singleton()->pushUserContext($url);
+    }
+
     $activityIds = empty($this->_activityIds) ? [$this->_activityId] : $this->_activityIds;
     foreach ($activityIds as $activityId) {
       // set params for repeat configuration in create mode


### PR DESCRIPTION
Overview
----------------------------------------
When using the "standalone" New Activity form, it always redirects to the dashboard after saving. This changes it to redirect to the contact page (if 1 contact) or the activity view screen (if multiple).

Before
----------------------------------------
New Activity redirects to dashboard after save (in standalone mode).

After
----------------------------------------
New activity redirects to view the activity, or if it involves a single contact, to their activity tab.
