### PR TITLE
CiviDist fails on BSD flavor of 'cp' with '-r -p' switch to '-R -p'

### DIFF
--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -37,7 +37,7 @@ cp "$SRC/joomla/admin/admin.civicrm.php" "$DM_TMPDIR/com_civicrm/admin/civicrm.p
 cd $DM_TMPDIR;
 
 # generate alt version of package
-cp -r -p civicrm com_civicrm/admin/civicrm
+cp -R -p civicrm com_civicrm/admin/civicrm
 ${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
 ${DM_ZIP:-zip} -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
 rm -rf com_civicrm/admin/civicrm


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-buildkit/issues/452

When building Joomla tarballs on OSX the build will fail on the alternate Joomla install zip generation.

Specifically this occurs at https://github.com/civicrm/civicrm-core/blob/master/distmaker/dists/joomla_php5.sh#L40

cp -r -p civicrm com_civicrm/admin/civicrm fails on the symlinked file vendor/pear/log/README.rst

Changing the command to cp -R -p civicrm com_civicrm/admin/civicrm allows both cividist and distmaker to complete successfully.

Before
----------------------------------------
cividist fails for joomla-alt om MacOSX

After
----------------------------------------
cividist will complete on all platforms. 

Technical Details
----------------------------------------
Switch to GNU style option of '-R' that is supported on both GNU and BSD

Comments
----------------------------------------
 There will need to be diligent testing on all platforms, MACOSX, linux, bknx after merge 
