### PR TITLE
Add csv reader package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.1",
-    "katzien/php-mime-type": "2.1.0"
+    "katzien/php-mime-type": "2.1.0",
+    "league/csv": "^9.2"
   },
   "require-dev": {
     "cache/integration-tests": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a337d7adf0d57f28a1aff44917fe1b92",
+    "content-hash": "027475804731d7ef0bd3e0feb2139d3c",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -450,6 +450,73 @@
                 "php"
             ],
             "time": "2017-03-23T02:05:33+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "9.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "b574a7d8b28f1528e011d8652fb7d2e83410d4c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/b574a7d8b28f1528e011d8652fb7d2e83410d4c9",
+                "reference": "b574a7d8b28f1528e011d8652fb7d2e83410d4c9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.0.10"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "friendsofphp/php-cs-fixer": "^2.12",
+                "phpstan/phpstan": "^0.9.2",
+                "phpstan/phpstan-phpunit": "^0.9.4",
+                "phpstan/phpstan-strict-rules": "^0.9.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Csv data manipulation made easy in PHP",
+            "homepage": "http://csv.thephpleague.com",
+            "keywords": [
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "write"
+            ],
+            "time": "2019-06-07T06:24:33+00:00"
         },
         {
             "name": "marcj/topsort",


### PR DESCRIPTION
Overview
----------------------------------------
Adds the CSV processing utility, [league/csv ^9.2](https://csv.thephpleague.com/9.0/).

This is generally a good library for CSVs. It will help with other PRs in which we will introduce more test-coverage for CSV outputs.

It will also help us cleanup some of our csv code down the way.

Before
----------------------------------------
Modern csv reader/writer = pipedream

After
----------------------------------------
Modern csv reader/writer = ships

Technical Details
----------------------------------------
This is workable now that Civi targets php7.0+.

Comments
----------------------------------------
@totten as discussed - can you add merge on pass?

