### PR TITLE
dev/core#1035 Add in new setting http_timeout to set how long in seco…

### DIFF
--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -62,16 +62,20 @@ abstract class CRM_Utils_Check_Component {
    * Check if file exists on given URL.
    *
    * @param string $url
-   * @param float $timeout
+   * @param float|bool $timeoutOverride
    *
    * @return bool
    */
-  public function fileExists($url, $timeout = 0.50) {
+  public function fileExists($url, $timeoutOverride = FALSE) {
+    // Timeout past in maybe 0 in which case we should still permit it (0 is infinite).
+    if (!$timeoutOverride && $timeoutOverride !== 0) {
+      $timeoutOverride = (float) Civi::settings()->get('http_timeout');
+    }
     $fileExists = FALSE;
     try {
       $guzzleClient = new GuzzleHttp\Client();
       $guzzleResponse = $guzzleClient->request('GET', $url, array(
-        'timeout' => $timeout,
+        'timeout' => $timeoutOverride,
       ));
       $fileExists = ($guzzleResponse->getStatusCode() == 200);
     }

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1062,4 +1062,23 @@ return [
     'description' => ts('Acceptable Mime Types that can be used as part of file urls'),
     'help_text' => NULL,
   ],
+  'http_timeout' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'http_timeout',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'html_type' => 'text',
+    'html_attributes' => [
+      'size' => 2,
+      'maxlength' => 3,
+    ],
+    'default' => 5,
+    'add' => '5.15',
+    'title' => ts('HTTP request timeout'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('How long should HTTP requests through Guzzle application run for in seconds'),
+    'help_text' => ts('Set the number of seconds http requests should run for before terminating'),
+  ],
 ];


### PR DESCRIPTION
…nds should HTTP requests last for to fix dev/core#1035

Overview
----------------------------------------
CiviCRM performs system status checks when the CiviCRM menu route is executed. This can be on every page load. Some of the system status checks execute an internal HTTP request back to the CiviCRM site.
Some users (2 on Stack Exchange URL?) have reported that they are seeing incorrect CiviCRM status check alert failure messages in the CiviCRM UI. This is due to the default timeout being too low and not long enough for their CiviCRM site to complete the individual status check via HTTP.
This PR increases the default from 0.5 seconds to 5 seconds, with the view that this should be sufficient time for most CiviCRM sites to complete the check successfully and not trigger the alert message to the user.
It should be noted that prior to the 0.5 second timeout being introduced, there was no timeout at all and CiviCRM would wait indefinitely until the status check was completed.

From CiviCRM 5.15 onwards there is a hidden setting (http_timeout) for the HTTP request timeout in seconds. The default for this is 5 seconds. Adjusting the timeout will affect both the page load times (lower time, pages will load faster), too low a timeout and CiviCRM status checks may not complete in time resulting in users seeing an incorrect status alert check failed warning message.

Before
----------------------------------------
No setting and time out was half a second

After
----------------------------------------
Setting with default timeout of 5s 

This adds a setting to allow administrators to set how long HTTP requests should last for, especially for status checks, I have put this against the RC as it is a recent issue / regression on status checks

ping @eileenmcnaughton @totten 