### PR TITLE
Expose Primary member only/Non primary member only filter in membersh…

### DIFF
--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -612,6 +612,18 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
     return $statistics;
   }
 
+  public function getOperationPair($type = "string", $fieldName = NULL) {
+    $result = parent::getOperationPair($type, $fieldName);
+
+    //re-name IS NULL/IS NOT NULL for clarity
+    if ($fieldName == 'owner_membership_id') {
+      $result['nll'] = ts('Primary members only');
+      $result['nnll'] = ts('Non-primary members only');
+    }
+
+    return $result;
+  }
+
   public function postProcess() {
     // get the acl clauses built before we assemble the query
     $this->buildACLClause($this->_aliases['civicrm_contact']);


### PR DESCRIPTION
…ip reports.

Overview
----------------------------------------
Expose _Primary member only/Non primary member only_ filter in membership reports which is more intuitive rather than IS NULL/ IS NULL.

Before
----------------------------------------
![mem_before](https://user-images.githubusercontent.com/3455173/59355071-fc7ebb80-8d43-11e9-8e18-ca5883543bbb.png)

After
----------------------------------------
![mem_after](https://user-images.githubusercontent.com/3455173/59355094-02749c80-8d44-11e9-85ba-5586863af1ed.png)

Comments
----------------------------------------
Found one more occurence of the said filter.