### PR TITLE
Php 7.2 notices fix on import

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -56,11 +56,11 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
    * Class constructor.
    *
    * @param $mapperKeys
-   * @param null $mapperSoftCredit
+   * @param array $mapperSoftCredit
    * @param null $mapperPhoneType
-   * @param null $mapperSoftCreditType
+   * @param array $mapperSoftCreditType
    */
-  public function __construct(&$mapperKeys, $mapperSoftCredit = NULL, $mapperPhoneType = NULL, $mapperSoftCreditType = NULL) {
+  public function __construct(&$mapperKeys, $mapperSoftCredit = [], $mapperPhoneType = NULL, $mapperSoftCreditType = []) {
     parent::__construct();
     $this->_mapperKeys = &$mapperKeys;
     $this->_mapperSoftCredit = &$mapperSoftCredit;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes enotices displayed (config dependent) on import. Enotices are harmless but are messages to developers to update code to be standard compliant

Before
----------------------------------------
<img width="1035" alt="Screen Shot 2019-06-14 at 8 01 03 AM" src="https://user-images.githubusercontent.com/336308/59508213-31d9f500-8e7b-11e9-97ac-7ed37757858f.png">


After
----------------------------------------
errors gone

Technical Details
----------------------------------------
Fixes a known issue where php 7.2 is 'noisy' if you try to count NULL - solution is to use an empty array


Comments
----------------------------------------

