### PR TITLE
Fixed event type id fetch

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -126,10 +126,10 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
       }
 
       if (!empty($query->_returnProperties['event_type_id'])) {
-        $query->_select['event_type_id'] = "event_type.id as event_type_id";
+        $query->_select['event_type_id'] = "civicrm_event.event_type_id as event_type_id";
         $query->_element['event_type_id'] = 1;
-        $query->_tables['event_type'] = 1;
-        $query->_whereTables['event_type'] = 1;
+        $query->_tables['civicrm_event'] = 1;
+        $query->_whereTables['civicrm_event'] = 1;
       }
 
       //add status_id

--- a/tests/phpunit/CRM/Event/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Event/BAO/QueryTest.php
@@ -39,4 +39,50 @@ class CRM_Event_BAO_QueryTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result->N);
   }
 
+  /**
+   * Unit test to check if participant search retrieves correct event type id.
+   *
+   */
+  public function testEventType() {
+    $event = $this->eventCreate();
+    $contactId = $this->individualCreate([
+      'api.participant.create' => [
+        'event_id' => $event['id'],
+      ],
+    ]);
+    $params = [
+      [
+        0 => 'event_id',
+        1 => '=',
+        2 => $event['id'],
+        3 => 1,
+        4 => 0,
+      ],
+    ];
+
+    $returnProperties = [
+      'event_type_id' => 1,
+      'contact_id' => 1,
+      'event_id' => 1,
+    ];
+
+    $query = new CRM_Contact_BAO_Query(
+      $params, $returnProperties, NULL,
+      FALSE, FALSE, CRM_Contact_BAO_Query::MODE_EVENT
+    );
+    $sql = $query->query(FALSE);
+    $result = CRM_Core_DAO::executeQuery(implode(' ', $sql));
+
+    $this->assertEquals(1, $result->N);
+    $result->fetch();
+
+    $this->assertEquals($contactId, $result->contact_id);
+    $this->assertEquals($event['id'], $result->event_id);
+    $eventTypeId = $this->callAPISuccessGetValue('Event', [
+      'id' => $event['id'],
+      'return' => 'event_type_id',
+    ]);
+    $this->assertEquals($eventTypeId, $result->event_type_id);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
When using query search the event type id is returned as option_value.id instead option_value.value.

Before
----------------------------------------
When using query search the event type id is returned as option_value.id instead option_value.value.


After
----------------------------------------
When using query search the event type id is returned as option_value.value 

Technical Details
----------------------------------------
Changed the select clause to get event type id from civicrm_event.event_type_id and also avoided join to option value when fetching only event type id.