### PR TITLE
Address BAO - Handle standard 'custom' param as well as individual fields

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -162,15 +162,20 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
     $address->save();
 
     if ($address->id) {
-      $customFields = CRM_Core_BAO_CustomField::getFields('Address', FALSE, TRUE, NULL, NULL, FALSE, FALSE, $checkPermissions);
+      if (isset($params['custom'])) {
+        $addressCustom = $params['custom'];
+      }
+      else {
+        $customFields = CRM_Core_BAO_CustomField::getFields('Address', FALSE, TRUE, NULL, NULL, FALSE, FALSE, $checkPermissions);
 
-      if (!empty($customFields)) {
-        $addressCustom = CRM_Core_BAO_CustomField::postProcess($params,
-          $address->id,
-          'Address',
-          FALSE,
-          $checkPermissions
-        );
+        if (!empty($customFields)) {
+          $addressCustom = CRM_Core_BAO_CustomField::postProcess($params,
+            $address->id,
+            'Address',
+            FALSE,
+            $checkPermissions
+          );
+        }
       }
       if (!empty($addressCustom)) {
         CRM_Core_BAO_CustomValueTable::store($addressCustom, 'civicrm_address', $address->id);


### PR DESCRIPTION
Overview
----------------------------------------
The Address BAO was an oddball in that it took raw unformatted custom field input and processed it.
Other BAOs expect the custom field input to alreay be processed.
This allows it to handle either format.

Before
----------------------------------------
Api4 test fails.

After
----------------------------------------
Api4 test passes

