### PR TITLE
Civi/Test/TAP - Replace Symfony YAML dependency

### DIFF
--- a/Civi/Test/TAP.php
+++ b/Civi/Test/TAP.php
@@ -97,10 +97,21 @@ class TAP extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListen
         );
       }
     }
-    $yaml = new \Symfony\Component\Yaml\Dumper();
-    $this
-      ->write(sprintf("  ---\n%s  ...\n", $yaml
-        ->dump($diagnostic, 2, 2)));
+
+    if (function_exists('yaml_emit')) {
+      $content = \yaml_emit($diagnostic, YAML_UTF8_ENCODING);
+      $content = '  ' . strtr($content, ["\n" => "\n  "]);
+    }
+    else {
+      // Any valid JSON document is a valid YAML document.
+      $content = json_encode($diagnostic, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+      // For closest match, drop outermost {}'s. Realign indentation.
+      $content = substr($content, 0, strrpos($content, "}")) . '  }';
+      $content = '  ' . ltrim($content);
+      $content = sprintf("  ---\n%s\n  ...\n", $content);
+    }
+
+    $this->write($content);
   }
 
   /**

--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -87,12 +87,20 @@ $cmd =
 passthru($cmd);
 
 function findPhp() {
-  if (defined('PHP_BINARY')) {
-    return PHP_BINARY; // php 5.4+
-  } elseif (defined('PHP_BINDIR') && file_exists(PHP_BINDIR . '/php')) {
-    return PHP_BINDIR . '/php'; // php 5.3
-  } else {
-    die("Failed to determine active PHP version.");
+  // The autodetect behavior here is a potential point of contention. These two cases are hard to reconcile:
+  // 1. `php` is actually a wrapper script which delegates to another PHP binary and
+  //    passes options (such as INI's and PECL extensions). Subprocesses should use the wrapper script.
+  //    Examples: bitnami, bknix
+  // 2. There are multiple PHP binaries (eg `php55`, `php70`). Subprocesses should use
+  //    the final executable (regardless of its name).
+  //    Example: using MAMP and adding 'ln -s /Application/MAMP/.../php7.1.2/bin/php ~/bin/php71`
+  // Since the test infra uses a wrapper script like (1), we use autodetect logic that works there.
+  // If you're in situation (2), then set an env-var or just skip on using `tools/scripts/phpunit`.
+  if (getenv('PHP')) {
+    return getenv('PHP');
+  }
+  else {
+    return 'php';
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow-up to #14527 to further remove the dependency on Symfony YAML. It resolves an issue where some unit-tests would crash (e.g. when outputting another failure).

Before
----------------------------------------
* If the TAP printer needs to output YAML data (such as error messages), then it crashes.

After
----------------------------------------
* If you have the YAML PECL extension, then that will be used. To get the best output, you can install it.
* If you don't have YAML PECL, then it'll output JSON. It's not typical of TAP, but YAML is a superset of JSON (i.e. JSON is valid YAML). It's not clear that everyone reading the document will handle the full range of YAML, but... we don't actually have any listeners that care to parse the TAP output...
