### PR TITLE
Fix A.net to resolve time when using default

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -230,6 +230,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
    * @param array $ids
    *
    * @return bool
+   * @throws \CRM_Core_Exception
    */
   public function getInput(&$input, &$ids) {
     $input['amount'] = $this->retrieve('x_amount', 'String');
@@ -241,7 +242,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
     $input['subscription_paynum'] = $this->retrieve('x_subscription_paynum', 'Integer', FALSE, 0);
     $input['trxn_id'] = $this->retrieve('x_trans_id', 'String', FALSE);
     $input['trxn_id'] = $this->retrieve('x_trans_id', 'String', FALSE);
-    $input['receive_date'] = $this->retrieve('receive_date', 'String', FALSE, 'now');
+    $input['receive_date'] = $this->retrieve('receive_date', 'String', FALSE, date('YmdHis', strtotime('now')));
 
     if ($input['trxn_id']) {
       $input['is_test'] = 0;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes failure to resolve date in authorize.net - this is likely a test-only bug.

Before
----------------------------------------
In the unit test when it is run in isolation there is no receive_date in $_REQUEST so it uses the default of 'now' however this is not correctly handled

After
----------------------------------------
Default is formatted to a date string

Technical Details
----------------------------------------
This has been passing in our test suite -but in fact it seems that it only passes because some other test is contaminating the $_REQUES

Comments
----------------------------------------
This is presumably passed through to the contribution api & hence it is not so grumpy but when
passed to the activity create fn it is failing when the test is run in isolation (& maybe other scenarios?)
due to 'now' not being parsed correctly.

Presumably it is not left blank in production scenarios as this would have triggered bug reports since it is a clear bug
