### PR TITLE
[TEST] Fix intermittent test fail on NULL array getting contaminated 

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1960,7 +1960,7 @@ ORDER BY civicrm_email.is_primary DESC";
    */
   public static function createProfileContact(
     &$params,
-    &$fields,
+    &$fields = [],
     $contactID = NULL,
     $addToGroupID = NULL,
     $ufGroupId = NULL,

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1679,8 +1679,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       if (!isset($submitted['suffix_id']) && !empty($migrationInfo['main_details']['suffix_id'])) {
         $submitted['suffix_id'] = $migrationInfo['main_details']['suffix_id'];
       }
-
-      CRM_Contact_BAO_Contact::createProfileContact($submitted, CRM_Core_DAO::$_nullArray, $mainId);
+      $null = [];
+      CRM_Contact_BAO_Contact::createProfileContact($submitted, $null, $mainId);
     }
     $transaction->commit();
     CRM_Utils_Hook::post('merge', 'Contact', $mainId);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a hard-to-diagnose test bug where certain combinations of tests don't pass due to variable contamination. This could cause bugs on live but we don't have any known cases

Before
----------------------------------------
CRM_Core_DAO::$_nullArray passed to profileCreate but in the test it is actually not null & causes a fail

After
----------------------------------------
empty var passed

Technical Details
----------------------------------------
This took a lot of bisecting to find :-(

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
