### PR TITLE
[TEST] add assert to ensure nullArray & nullObject are not contaminated

### DIFF
--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -331,11 +331,11 @@ class CiviMailUtils extends PHPUnit\Framework\TestCase {
    * @param int $limit
    *  How many recent messages to remove, defaults to 0 (all).
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function clearMessages($limit = 0) {
     if ($this->_webtest) {
-      throw new Exception("Not implemented: clearMessages for WebTest");
+      throw new \CRM_Core_Exception("Not implemented: clearMessages for WebTest");
     }
     else {
       $sql = 'DELETE FROM civicrm_mailing_spool ORDER BY id DESC';

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -482,6 +482,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
     $this->cleanTempDirs();
     $this->unsetExtensionSystem();
+    $this->assertEquals([], CRM_Core_DAO::$_nullArray);
+    $this->assertEquals(NULL, CRM_Core_DAO::$_nullObject);
   }
 
   /**

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -153,6 +153,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   /**
    * Test email receipt for partial payment.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testPaymentEmailReceiptFullyPaid() {
     $mut = new CiviMailUtils($this);


### PR DESCRIPTION
Overview
----------------------------------------
Test fix to ensure the nullArray & nullObject are not being contaminated during test runs

Before
----------------------------------------
Less testing

After
----------------------------------------
More testing

Technical Details
----------------------------------------
After deep & excruciating pain I found an intermittent test fail was caused by contamination of these 'helpful helpers' - search & destroy similar cases

Comments
----------------------------------------

