### PR TITLE
Temporarily remove activity submit once pending PR 14519

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -813,7 +813,6 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
           'type' => 'upload',
           'name' => ts('Save'),
           'isDefault' => TRUE,
-          'submitOnce' => TRUE,
         ],
         [
           'type' => 'cancel',


### PR DESCRIPTION
Overview
----------------------------------------
A few months ago, the "submit once" functionality was added to the "New Activity" screen. This protects users in some web-browsers from making a mistake (i.e. clicking the save/submit button multiple times => producing multiple activities). Unfortunately, the change also created multiple problems for other users/configurations.

This PR reverts that change and restores the old behavior of the "New Activity" screen (circa ~5.11). This should be temporary -- the plan is to bring it back in some form, e.g. PR #14519. 

Before
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1045

https://lab.civicrm.org/dev/core/issues/943

https://lab.civicrm.org/dev/core/issues/914

After
----------------------------------------
None of the above issues.

Comments
----------------------------------------
I've left in all the other references for now, e.g. CRM/XXX/Task.php and CRM_Core_Form::addDefaultButtons().

ping @mattwire @eileenmcnaughton @colemanw 
