### PR TITLE
Fix Batch searching on receive date following conversion and handle r…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2017,6 +2017,13 @@ class CRM_Contact_BAO_Query {
         // handled by the proximity_distance clause
         return;
 
+      case 'receive_date_relative':
+      case 'receive_date_high':
+      case 'receive_date_low':
+        // Handled by Contribution not properly name spaced for reasons.
+        CRM_Contribute_BAO_Query::whereClauseSingle($values, $this);
+        return;
+
       default:
         $this->restWhere($values);
         return;

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -193,6 +193,24 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         );
         return;
 
+      case 'contribution_receive_date_relative':
+      case 'contribution_receive_date_low':
+      case 'contribution_receive_date_high':
+        // process to / from date
+        $query->dateQueryBuilder($values,
+          'civicrm_contribution', 'contribution_receive_date', 'receive_date', ts('Contribution Date')
+        );
+        return;
+
+      case 'receive_date_relative':
+      case 'receive_date_low':
+      case 'receive_date_high':
+        // process to / from date
+        $query->dateQueryBuilder($values,
+          'civicrm_contribution', 'receive_date', 'receive_date', ts('Contribution Date')
+        );
+        return;
+
       case 'contribution_amount':
       case 'contribution_amount_low':
       case 'contribution_amount_high':

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -427,14 +427,14 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if ($lowDate) {
       $lowDate = CRM_Utils_Type::escape($lowDate, 'Timestamp');
       $date = CRM_Utils_Date::setDateDefaults($lowDate);
-      $this->_formValues['contribution_date_low'] = $this->_defaults['contribution_date_low'] = $date[0];
+      $this->_formValues['receive_date_low'] = $this->_defaults['receive_date_low'] = $date[0];
     }
 
     $highDate = CRM_Utils_Request::retrieve('end', 'Timestamp');
     if ($highDate) {
       $highDate = CRM_Utils_Type::escape($highDate, 'Timestamp');
       $date = CRM_Utils_Date::setDateDefaults($highDate);
-      $this->_formValues['contribution_date_high'] = $this->_defaults['contribution_date_high'] = $date[0];
+      $this->_formValues['receive_date_high'] = $this->_defaults['receive_date_high'] = $date[0];
     }
 
     if ($highDate || $lowDate) {


### PR DESCRIPTION
…eceive_date param for the moment as not properly namespaced

Overview
----------------------------------------
_This ensures that following the changes to the contribution search form the accounting back searching process works

Before
----------------------------------------
Fails silently

After
----------------------------------------
Works

Technical Details
----------------------------------------
I have had to add in some handling in CRM/Contact/BAO/Query.php to handle receive_date as it is not properly namespaced which is a todo

ping @eileenmcnaughton @monishdeb 
