### PR TITLE
[test] Call parent tearDown more consistently

### DIFF
--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -68,6 +68,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->locationTypeDelete($this->_locationType->id);
     $this->contactDelete($this->_contactID);
     $this->quickCleanup(array('civicrm_address', 'civicrm_relationship'));
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/CRM11793Test.php
+++ b/tests/phpunit/api/v3/CRM11793Test.php
@@ -27,6 +27,7 @@ class api_v3_CRM11793Test extends CiviUnitTestCase {
   }
 
   public function tearDown() {
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -87,6 +87,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       $this->callAPISuccess('contact', 'delete', array('id' => $id));
     }
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**
@@ -1641,6 +1642,9 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     // put stuff here that should happen before all tests in this unit
   }
 
+  /**
+   * @throws \Exception
+   */
   public static function tearDownAfterClass() {
     $tablesToTruncate = array(
       'civicrm_contact',

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -104,11 +104,14 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
 
   /**
    * Clean up after each test.
+   *
+   * @throws \Exception
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(array('civicrm_uf_match'));
     $this->disableFinancialACLs();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/GrantTest.php
+++ b/tests/phpunit/api/v3/GrantTest.php
@@ -55,13 +55,19 @@ class api_v3_GrantTest extends CiviUnitTestCase {
     );
   }
 
+  /**
+   * Cleanup after test.
+   *
+   * @throws \Exception
+   */
   public function tearDown() {
     foreach ($this->ids as $entity => $entities) {
       foreach ($entities as $id) {
         $this->callAPISuccess($entity, 'delete', array('id' => $id));
       }
     }
-    $this->quickCleanup(array('civicrm_grant'));
+    $this->quickCleanup(['civicrm_grant']);
+    parent::tearDown();
   }
 
   public function testCreateGrant() {

--- a/tests/phpunit/api/v3/GroupNestingTest.php
+++ b/tests/phpunit/api/v3/GroupNestingTest.php
@@ -82,6 +82,7 @@ class api_v3_GroupNestingTest extends CiviUnitTestCase {
         'civicrm_uf_match',
       ]
     );
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -46,12 +46,15 @@ class api_v3_GroupTest extends CiviUnitTestCase {
 
   /**
    * Clean up after test.
+   *
+   * @throws \Exception
    */
   public function tearDown() {
     CRM_Utils_Hook::singleton()->reset();
     $config = CRM_Core_Config::singleton();
     unset($config->userPermissionClass->permissions);
     $this->quickCleanup(['civicrm_group', 'civicrm_group_contact']);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -78,6 +78,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->membershipTypeDelete(array('id' => $this->membershipTypeID));
     $this->cleanUpSetUpIDs();
     $this->quickCleanup(['civicrm_contact', 'civicrm_address', 'civicrm_email', 'civicrm_website', 'civicrm_phone'], TRUE);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -50,8 +50,9 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
 
   public function tearDown() {
     $this->membershipStatusDelete($this->_membershipStatusID);
-    $this->membershipTypeDelete(array('id' => $this->_membershipTypeID));
+    $this->membershipTypeDelete(['id' => $this->_membershipTypeID]);
     $this->contactDelete($this->_contactID);
+    parent::tearDown();
   }
 
   ///////////////// civicrm_membership_status_get methods

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -89,19 +89,10 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function tearDown() {
-    $this->quickCleanup(array(
-      'civicrm_membership',
-      'civicrm_membership_payment',
-      'civicrm_membership_log',
-      'civicrm_uf_match',
-    ),
-      TRUE
-    );
-    $this->membershipStatusDelete($this->_membershipStatusID);
-    $this->membershipTypeDelete(array('id' => $this->_membershipTypeID2));
-    $this->membershipTypeDelete(array('id' => $this->_membershipTypeID));
+    $this->quickCleanUpFinancialEntities();
+    $this->quickCleanup(['civicrm_uf_match'], TRUE);
     $this->contactDelete($this->_contactID);
-
+    parent::tearDown();
   }
 
   /**
@@ -457,6 +448,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   /**
    * Test civicrm_membership_get with relationship.
    * get Memberships.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetWithRelationship() {
     $membershipOrgId = $this->organizationCreate(NULL);

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -55,11 +55,14 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   /**
    * Clean up after each test.
+   *
+   * @throws \Exception
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(['civicrm_uf_match']);
     unset(CRM_Core_Config::singleton()->userPermissionClass->permissions);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/PledgePaymentTest.php
+++ b/tests/phpunit/api/v3/PledgePaymentTest.php
@@ -58,6 +58,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
     );
 
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   public function testGetPledgePayment() {

--- a/tests/phpunit/api/v3/PriceFieldTest.php
+++ b/tests/phpunit/api/v3/PriceFieldTest.php
@@ -79,6 +79,7 @@ class api_v3_PriceFieldTest extends CiviUnitTestCase {
     ));
 
     $this->assertAPISuccess($delete);
+    parent::tearDown();
   }
 
   public function testCreatePriceField() {

--- a/tests/phpunit/api/v3/PriceSetTest.php
+++ b/tests/phpunit/api/v3/PriceSetTest.php
@@ -56,9 +56,6 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
     );
   }
 
-  public function tearDown() {
-  }
-
   /**
    * Test create price set.
    */

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -102,6 +102,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->contactDelete($this->_cId_b2);
     $this->quickCleanup(array('civicrm_relationship'), TRUE);
     $this->relationshipTypeDelete($this->_relTypeID);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -166,8 +166,12 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
     $this->assertAPISuccess($result);
   }
 
+  /**
+   * Cleanup after function.
+   */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   public function setUpContributionPage() {


### PR DESCRIPTION
Overview
----------------------------------------
Fix consistency on test teardown

Before
----------------------------------------
Less consistency on calling parent function

After
----------------------------------------
 More consistency

Technical Details
----------------------------------------
Primarliy consistentcy - also supports checking nullArray is cleared per

https://github.com/civicrm/civicrm-core/pull/14550

Comments
----------------------------------------
