### PR TITLE
(dev/core#1044) Extension/MIME-type matching should be case insensitive

### DIFF
--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -80,7 +80,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
       }
       $extension = CRM_Utils_File::getExtensionFromPath($path);
       $candidateExtensions = CRM_Utils_File::getAcceptableExtensionsForMimeType($passedInMimeType);
-      if (!in_array($extension, $candidateExtensions)) {
+      if (!in_array(strtolower($extension), array_map('strtolower', $candidateExtensions))) {
         throw new CRM_Core_Exception("Supplied mime-type does not match file extension");
       }
       // Now that we have validated mime-type supplied as much as possible lets now set the MimeType variable/


### PR DESCRIPTION
Overview
--------

For CIVI-SA-2019-15, the delivery of file attachments was tightened to ensure that the file-extension and mime-type were in agreement.  However, the check yields a false-negative in the common case where the filename has been capitalized.  It should treat `foo.jpg`, `foo.JPG`, and `FOO.JPG` as equally valid.

This is a backport of #14544.

Before
------

* When viewing a contact profile image ending with `.JPG`, there is an error
  message, `Supplied mime-type does not match file extension`.

After
-----

* When viewing a contact profile image ending with `.JPG`, the image is
  delivered.

Comments
--------

See also:

* https://github.com/civicrm/civicrm-core/pull/14544
* https://civicrm.org/advisory/civi-sa-2019-15-xss-via-forged-mime-type
* https://lab.civicrm.org/dev/core/issues/1044
