### PR TITLE
Alter PSR16 code to take into account of new entitysetting release wi…

### DIFF
--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -199,9 +199,6 @@ class CRM_Core_BAO_Cache_Psr16 {
       // civihr/uk.co.compucorp.civicrm.hrcore
       'HRCore_Info',
 
-      // nz.co.fuzion.entitysetting
-      'CiviCRM setting Spec',
-
     ];
     // Handle Legacy Multisite caching group.
     $extensions = CRM_Extension_System::singleton()->getManager();
@@ -214,6 +211,17 @@ class CRM_Core_BAO_Cache_Psr16 {
           ['civi.tag' => 'deprecated']
         );
         $groups[] = 'descendant groups for an org';
+      }
+    }
+    $entitySettingExtensionStatus = $extensions->getStatus('nz.co.fuzion.entitysetting');
+    if ($multisiteExtensionStatus == $extensions::STATUS_INSTALLED) {
+      $extension_version = civicrm_api3('Extension', 'get', ['key' => 'nz.co.fuzion.entitysetting'])['values'][0]['version'];
+      if (version_compare($extension_version, '1.3', '<')) {
+        Civi::log()->warning(
+          'CRM_Core_BAO_Cache_PSR is deprecated for entity setting extension, you should upgrade to the latest version to avoid this warning, this code will be removed at the end of 2019',
+          ['civi.tag' => 'deprecated']
+        );
+        $groups[] = 'CiviCRM setting Spec';
       }
     }
     return $groups;


### PR DESCRIPTION
…th upgraded caching

Overview
----------------------------------------
This updates the PSR16 caching code to be like what we have done with multisite now that there is a new entity setting extension release with a conversion to new cache code

ping @totten @eileenmcnaughton 
