### PR TITLE
dev/core#1049: Use FrontEndPaymentFormTrait to assign line items…

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -34,6 +34,7 @@
  * This class generates form components for processing Event.
  */
 class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
+  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * The values for the contribution db object.
@@ -297,25 +298,16 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
     if ($this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config')) {
       $lineItemForTemplate = [];
-      $getTaxDetails = FALSE;
       if (!empty($this->_lineItem) && is_array($this->_lineItem)) {
         foreach ($this->_lineItem as $key => $value) {
           if (!empty($value)) {
             $lineItemForTemplate[$key] = $value;
           }
-          if ($invoicing) {
-            foreach ($value as $v) {
-              if (isset($v['tax_rate'])) {
-                $getTaxDetails = TRUE;
-              }
-            }
-          }
         }
       }
       if (!empty($lineItemForTemplate)) {
-        $this->assign('lineItem', $lineItemForTemplate);
+        $this->assignLineItemsToTemplate($lineItemForTemplate);
       }
-      $this->assign('getTaxDetails', $getTaxDetails);
     }
 
     //display additional participants profile.

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -39,6 +39,7 @@
  *
  */
 class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
+  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * Set variables up before form is built.
@@ -97,7 +98,6 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     $this->assignToTemplate();
 
     $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();
-    $getTaxDetails = FALSE;
     $taxAmount = 0;
 
     $lineItemForTemplate = [];
@@ -109,7 +109,6 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
             foreach ($value as $v) {
               if (isset($v['tax_amount']) || isset($v['tax_rate'])) {
                 $taxAmount += $v['tax_amount'];
-                $getTaxDetails = TRUE;
               }
             }
           }
@@ -121,13 +120,11 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
       !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config') &&
       !empty($lineItemForTemplate)
     ) {
-      $this->assign('lineItem', $lineItemForTemplate);
+      $this->assignLineItemsToTemplate($lineItemForTemplate);
     }
 
     if ($invoicing) {
-      $this->assign('getTaxDetails', $getTaxDetails);
       $this->assign('totalTaxAmount', $taxAmount);
-      $this->assign('taxTerm', CRM_Invoicing_Utils::getTaxTerm());
     }
     $this->assign('totalAmount', $this->_totalAmount);
 


### PR DESCRIPTION
… on Event Registration Confirm and ThankYou "forms"

Overview
----------------------------------------
Code cleanup around tax assignments, following pattern on #13899 but for Event Confirmation and ThankYou pages
Agileware ref CIVICRM-1244

Before
----------------------------------------
Event Confirmation and ThankYou Forms are implementing their own line item assignments, causing inconsistency in line item display.  This is most immediately obvious in the tax rate column when tax & invoicing is enabled

After
----------------------------------------
These Forms use the previously implemented trait to assign line items in a consistent manner.
