### PR TITLE
Fix use of cached schema information in SchemaHandler

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -77,7 +77,7 @@ class CRM_Core_BAO_SchemaHandler {
     }
 
     // always do a trigger rebuild for this table
-    CRM_Core_DAO::triggerRebuild($params['name']);
+    Civi::service('sql_triggers')->rebuild($params['name'], TRUE);
 
     return TRUE;
   }
@@ -347,7 +347,7 @@ ALTER TABLE {$tableName}
     }
 
     if ($triggerRebuild) {
-      CRM_Core_DAO::triggerRebuild($params['table_name']);
+      Civi::service('sql_triggers')->rebuild($params['table_name'], TRUE);
     }
 
     return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where `CRM_Core_BAO_SchemaHandler` uses outdated schema/column information from cache when rebuilding triggers.

Before
----------------------------------------
In certain scenarios, for example when multiple custom fields are deleted during a single script execution, use of outdated schema information could cause generated SQL to reference deleted columns, throwing an error.

After
----------------------------------------
`CRM_Core_BAO_SchemaHandler` does not used cached schema information, preventing errors due to deleted columns.

Technical Details
----------------------------------------
I added a test for the `DROP COLUMN` scenario in `alterFieldSQL`. `createTable` is mostly covered by `CRM_Core_BAO_CustomGroupTest`.

Comments
----------------------------------------
Swapped deprecated `CRM_Core_DAO::triggerRebuild` for `Civi::service('sql_triggers')->rebuild` while I was at it.

Chat references: https://chat.civicrm.org/civicrm/pl/s1nnhfhppbgufe3ub3owdw7awy, https://chat.civicrm.org/civicrm/pl/nec31k8nh3yfmna55px155yyqr