### PR TITLE
Removed hardcoded value for registered participant status

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -365,7 +365,11 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     }
     $value_to['contact_id'] = $contact_id;
     $value_to['event_id'] = $this->_event_id;
-    $value_to['status_id'] = 1;
+    $value_to['status_id'] = CRM_Core_PseudoConstant::getKey(
+      'CRM_Event_BAO_Participant',
+      'status_id',
+      'Registered'
+    );
     $value_to['register_date'] = date("Y-m-d");
     //first create the new participant row -don't set registered_by yet or email won't be sent
     $participant = CRM_Event_BAO_Participant::create($value_to);


### PR DESCRIPTION
Overview
----------------------------------------
Removed hardcoded value for registered participant status

Before
----------------------------------------
Hardcoded to 1

After
----------------------------------------
use CRM_Core_PseudoConstant::getKey() function to retrieve ID of Registered participant status.