### PR TITLE
dev/core#1038 partial - fix checksum url for cancelling recurring with mid in the url

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -83,10 +83,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
       $this->_mode = 'auto_renew';
       // CRM-18468: crid is more accurate than mid for getting
       // subscriptionDetails, so don't get them again.
-      if (!$this->_crid) {
-        $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_mid, 'membership', 'obj');
-        $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_mid, 'membership');
-      }
 
       $membershipTypes = CRM_Member_PseudoConstant::membershipType();
       $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_mid, 'membership_type_id');
@@ -136,7 +132,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
       'cancel_reason' => ['name' => 'cancel_reason'],
     ];
     $this->entityFields['send_cancel_request'] = [
-      'title' => ts('Send cancellation request to %1 ?', [1 => $this->_paymentProcessorObj->_processorName]),
+      'title' => ts('Send cancellation request?'),
       'name' => 'send_cancel_request',
       'not-auto-addable' => TRUE,
     ];

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -162,6 +162,10 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
       }
       $this->_paymentProcessorObj = $this->_paymentProcessor['object'];
     }
+    elseif ($this->_mid) {
+      $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_mid, 'membership', 'obj');
+      $this->_paymentProcessor = $this->_paymentProcessorObj->getPaymentProcessor();
+    }
   }
 
   /**
@@ -174,6 +178,11 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
     elseif ($this->_coid) {
       $this->subscriptionDetails = $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_coid, 'contribution');
     }
+    elseif ($this->_mid) {
+      $this->subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_mid, 'membership');
+    }
+    // This is being set temporarily - we should eventually just use the getter fn.
+    $this->_subscriptionDetails = $this->subscriptionDetails;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression bug where checksum does not permit access to cancel a recurring with mid in the url.

For example in a url like this the checksum would not be respected.

http://dmaster.local/civicrm/contribute/unsubscribe?reset=1&mid=35&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

Before
----------------------------------------
Attempts to cancel recurring memberships at the url sent out when creating a recurring membership are just bounced to the front page when relying on a checksum

<img width="991" alt="Screen Shot 2019-06-17 at 7 37 52 PM" src="https://user-images.githubusercontent.com/336308/59643631-6bd71f80-9137-11e9-89f6-6d9741ef05b4.png">


After
----------------------------------------
Screen loads
<img width="756" alt="Screen Shot 2019-06-17 at 7 37 11 PM" src="https://user-images.githubusercontent.com/336308/59643608-5661f580-9137-11e9-8baf-2855ed1979c4.png">


Technical Details
----------------------------------------
These are the urls that are affected (& which I have tested to make sure they load without a permission error)

** Update Billing**
Note my membership id is 35, my recurring is 10 and my contribution id is 235
My checksum is 2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

http://dmaster.local/civicrm/contribute/updatebilling?reset=1&mid=35&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

http://dmaster.local/civicrm/contribute/updatebilling?reset=1&crid=10&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168


http://dmaster.local/civicrm/contribute/updatebilling?reset=1&coid=235&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

**Unsubscribe**
http://dmaster.local/civicrm/contribute/unsubscribe?reset=1&mid=35&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

http://dmaster.local/civicrm/contribute/unsubscribe?reset=1&crid=10&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

http://dmaster.local/civicrm/contribute/unsubscribe?reset=1&coid=235&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

**Update Recur**
These ones had issues -

1. mid seems unsupported & this seems non-new reading the code
http://dmaster.local/civicrm/contribute/unsubscribe?
2. There is a bounce message coming from ajax - I'll look at this separately as it's tangental & probably not a regression from the same change. I believe it relates to custom data loading
3. coid gives a required data missing

http://dmaster.local/civicrm/contribute/updaterecur?reset=1&crid=10&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

http://dmaster.local/civicrm/contribute/updaterecur?reset=1&mid=35&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168

http://dmaster.local/civicrm/contribute/updaterecur?reset=1&coid=235&cs=2eefe06c8d2f07bd644233c525dde0d6_1560813106_168


Comments
----------------------------------------
@MegaphoneJon 

Note that I think there are 3 follow on issues - per above. Of these I suspect the ajax one is a recent regression from another change. I think the the others may be long-standing