### PR TITLE
Fix dev/core#1052 Activities causing a fatal error if target_contact is not accessable to logged in user

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -751,8 +751,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       GROUP BY activity_id', [
         1 => [
           CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets'),
-          'Integer'
-        ]
+          'Integer',
+        ],
       ])->fetchAll();
     }
     foreach ($targetCount as $activityTarget) {
@@ -2566,23 +2566,26 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
           $firstTargetName = reset($values['target_contact_name']);
           $firstTargetContactID = key($values['target_contact_name']);
 
-          $targetLink = CRM_Utils_System::href($firstTargetName, 'civicrm/contact/view', "reset=1&cid={$firstTargetContactID}");
-          if ($showContactOverlay) {
-            $targetTypeImage = CRM_Contact_BAO_Contact_Utils::getImage(
-              CRM_Contact_BAO_Contact::getContactType($firstTargetContactID),
-              FALSE,
-              $firstTargetContactID);
-            $activity['target_contact_name'] .= "<div>$targetTypeImage  $targetLink";
-          }
-          else {
-            $activity['target_contact_name'] .= $targetLink;
-          }
+          // The first target may not be accessable to the logged in user dev/core#1052
+          if ($firstTargetName) {
+            $targetLink = CRM_Utils_System::href($firstTargetName, 'civicrm/contact/view', "reset=1&cid={$firstTargetContactID}");
+            if ($showContactOverlay) {
+              $targetTypeImage = CRM_Contact_BAO_Contact_Utils::getImage(
+                CRM_Contact_BAO_Contact::getContactType($firstTargetContactID),
+                FALSE,
+                $firstTargetContactID);
+              $activity['target_contact_name'] .= "<div>$targetTypeImage  $targetLink";
+            }
+            else {
+              $activity['target_contact_name'] .= $targetLink;
+            }
 
-          if ($extraCount = $values['target_contact_count'] - 1) {
-            $activity['target_contact_name'] .= ";<br />" . "(" . ts('%1 more', [1 => $extraCount]) . ")";
-          }
-          if ($showContactOverlay) {
-            $activity['target_contact_name'] .= "</div> ";
+            if ($extraCount = $values['target_contact_count'] - 1) {
+              $activity['target_contact_name'] .= ";<br />" . "(" . ts('%1 more', [1 => $extraCount]) . ")";
+            }
+            if ($showContactOverlay) {
+              $activity['target_contact_name'] .= "</div> ";
+            }
           }
         }
         elseif (!$values['target_contact_name']) {

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -6,6 +6,8 @@
  */
 class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
+  private $allowedContactsACL = [];
+
   public function setUp() {
     parent::setUp();
     $this->prepareForACLs();
@@ -151,6 +153,45 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
     $this->contactDelete($contactId);
     $this->contactDelete($targetContactId);
+  }
+
+  /**
+   * Test Assigning a target contact but then the logged in user cannot see the contact
+   */
+  public function testTargetContactNotavaliable() {
+    $contactId = $this->individualCreate();
+    $params = array(
+      'first_name' => 'liz',
+      'last_name' => 'hurleey',
+    );
+    $targetContactId = $this->individualCreate($params);
+
+    $params = array(
+      'source_contact_id' => $contactId,
+      'subject' => 'Scheduling Meeting',
+      'activity_type_id' => 2,
+      'target_contact_id' => array($targetContactId),
+      'activity_date_time' => date('Ymd'),
+    );
+
+    CRM_Activity_BAO_Activity::create($params);
+
+    // set custom hook
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'hook_civicrm_aclWhereClause'));
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM');
+
+    $this->allowedContactsACL = array($contactId);
+
+    // get logged in user
+    $user_id = $this->createLoggedInUser();
+    $activityGetParams = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
+    $activityGetParams += ['contact_id' => $contactId];
+    $activities = CRM_Activity_BAO_Activity::getContactActivitySelector($activityGetParams);
+    $this->assertEquals(1, $activites[1]['target_contact_count']);
+    $this->assertEquals([], $activites[1]['target_contact_name']);
+    $config = CRM_Core_Config::singleton();
+    $config->userPermissionClass->permissions = array();
   }
 
   /**
@@ -1287,6 +1328,16 @@ $text
     $this->loadXMLDataSet(dirname(__FILE__) . '/activities_for_dashboard_count.xml');
     // Make changes to improve variation in php since the xml method is brittle & relies on option values being unchanged.
     $this->callAPISuccess('Activity', 'create', ['id' => 12, 'activity_type_id' => 'Bulk Email']);
+  }
+
+  /**
+   * ACL HOOK implementation for various tests
+   */
+  public function hook_civicrm_aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where) {
+    if (!empty($this->allowedContactsACL)) {
+      $contact_id_list = implode(',', $this->allowedContactsACL);
+      $where = " contact_a.id IN ($contact_id_list)";
+    }
   }
 
 }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -188,8 +188,12 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $activityGetParams = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
     $activityGetParams += ['contact_id' => $contactId];
     $activities = CRM_Activity_BAO_Activity::getContactActivitySelector($activityGetParams);
-    $this->assertEquals(1, $activites[1]['target_contact_count']);
-    $this->assertEquals([], $activites[1]['target_contact_name']);
+    // Aseert that we have sensible data to display in the contact tab
+    $this->assertEquals('Anderson, Anthony', $activities['data'][0]['source_contact_name']);
+    // Note that becasue there is a target contact but it is not accessable the output is an empty string not n/a
+    $this->assertEquals('', $activities['data'][0]['target_contact_name']);
+    // verify that doing the underlying query shows we get a target contact_id
+    $this->assertEquals(1, CRM_Activity_BAO_Activity::getActivities(['contact_id' => $contactId])[1]['target_contact_count']);
     $config = CRM_Core_Config::singleton();
     $config->userPermissionClass->permissions = array();
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#1052 Fix issue where target_contact may not be accessable to logged in user which currently generates a fatal error when accessing contact activites

Before
----------------------------------------
Fatal error generated

After
----------------------------------------
No fatal error