### PR TITLE
i18n - Improve multilingual popup for text and wysiwyg fields

### DIFF
--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -78,7 +78,10 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
 
     if ($widget['type'] == 'RichTextEditor') {
       $widget['type'] = 'wysiwyg';
-      $attributes['class'] .= ' collapsed';
+      $attributes['class'] = 'collapsed';
+    }
+    elseif ($widget['type'] == 'Text') {
+      $attributes['class'] = 'huge';
     }
 
     $languages = CRM_Core_I18n::languages(TRUE);

--- a/js/crm.multilingual.js
+++ b/js/crm.multilingual.js
@@ -7,18 +7,21 @@ CRM.$(function($) {
   $('body').on('click', 'a.crm-multilingual-edit-button', function(e) {
     var $el = $(this),
       $form = $el.closest('form'),
-      $field = $('#' + $el.data('field'), $form);
+      $field = $('#' + $el.data('field'), $form),
+      wysiwyg = $field.hasClass('crm-form-wysiwyg');
 
     CRM.loadForm($el.attr('href'), {
       dialog: {width: '50%', height: '50%'}
     })
       // Sync the primary language field with what the user has entered on the main form
       .on('crmFormLoad', function() {
-        $('.default-lang', this).val($field.val());
+        CRM.wysiwyg.setVal($('.default-lang', this), CRM.wysiwyg.getVal($field));
+        $('.default-lang', this).triggerHandler('change');
       })
       .on('crmFormSubmit', function() {
         // Sync the primary language field with what the user has entered in the popup
-        $field.val($('.default-lang', this).val());
+        CRM.wysiwyg.setVal($field, CRM.wysiwyg.getVal($('.default-lang', this)));
+        $field.triggerHandler('change');
         $el.trigger('crmPopupFormSuccess');
       });
     e.preventDefault();

--- a/js/wysiwyg/crm.wysiwyg.js
+++ b/js/wysiwyg/crm.wysiwyg.js
@@ -54,6 +54,9 @@
           CRM.wysiwyg.destroy(item);
           $(item).hide().next('.replace-plain').show().html($(item).val());
         })
+        .on('change', function() {
+          $(this).next('.replace-plain').html($(this).val());
+        })
         .after('<div class="replace-plain" tabindex="0"></div>');
       $(item).next('.replace-plain')
         .attr('title', ts('Click to edit'))


### PR DESCRIPTION
Overview
----------------------------------------
- Fixes copying of values between multilingual popup and main form for wysiwyg fields.
- Makes text fields larger in multilingual poupp.

Before
----------------------------------------
- Updated values between main form and popup would not be reflected for wysiwyg fields.
- Text fields too small.

After
----------------------------------------
- Updated values between main form and popup work for wysiwyg fields.
- Text fields larger.

To reproduce the bug
----------------------------------------
1. Go to a "Configure event: Info and Settings" screen.
2. Type something in the "Event Title" field, and (without saving first) click the multilingual button.
3. Notice that whatever you typed has been inserted in the default language box, but the textfield is too small.
4. Change the default language text and click save.
5. Notice that whatever you typed in the popup has been inserted into the form field.
6. Now try it with the "Complete Description" wysiwyg field.
7. Notice that whatever you typed into that field prior to opening the popup is *not* copied to the popup, and whatever you type in the popup is *not* copied back to the wysiwyg on the form. This PR fixes those issues.
