### PR TITLE
Convert prevNextCache to standard Cache Defintiion format

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -296,7 +296,7 @@ FROM {$sql['from']}
 
       if (Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
         // SQL-backed prevnext cache uses an extra record for pruning the cache.
-        CRM_Core_BAO_Cache::setItem($cacheKey, 'CiviCRM Search PrevNextCache', $cacheKey);
+        Civi::cache('prevNextCache')->set($cacheKey, $cacheKey);
       }
     }
   }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1063,7 +1063,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     if (Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
       // SQL-backed prevnext cache uses an extra record for pruning the cache.
-      CRM_Core_BAO_Cache::setItem($cacheKey, 'CiviCRM Search PrevNextCache', $cacheKey);
+      Civi::cache('prevNextCache')->set($cacheKey, $cacheKey);
     }
   }
 

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -424,7 +424,7 @@ WHERE      c.group_name = %1
 AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
 ";
     $params = [
-      1 => ['CiviCRM Search PrevNextCache', 'String'],
+      1 => [CRM_Core_BAO_Cache::cleanKey('CiviCRM Search PrevNextCache'), 'String'],
       2 => [$cacheTimeIntervalDays, 'Integer'],
     ];
     CRM_Core_DAO::executeQuery($sql, $params);

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -213,6 +213,11 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
    */
   public function delete($key) {
     CRM_Utils_Cache::assertValidKey($key);
+    // If we are triggering a deletion of a prevNextCache key in the civicrm_cache tabl
+    // Alssure that the relevant prev_next_cache values are also removed.
+    if ($this->group == CRM_Core_BAO_Cache::cleanKey('CiviCRM Search PrevNextCache')) {
+      Civi::service('prevnext')->deleteItem(NULL, $key);
+    }
     CRM_Core_DAO::executeQuery("DELETE FROM {$this->table} WHERE {$this->where($key)}");
     unset($this->valueCache[$key]);
     unset($this->expiresCache[$key]);
@@ -220,7 +225,14 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
   }
 
   public function flush() {
-    CRM_Core_DAO::executeQuery("DELETE FROM {$this->table} WHERE {$this->where()}");
+    if ($this->group == CRM_Core_BAO_Cache::cleanKey('CiviCRM Search PrevNextCache') &&
+      Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
+      // Use the standard PrevNextCache cleanup function here not just delete from civicrm_cache
+      CRM_Core_BAO_PrevNextCache::cleanupCache();
+    }
+    else {
+      CRM_Core_DAO::executeQuery("DELETE FROM {$this->table} WHERE {$this->where()}");
+    }
     $this->valueCache = [];
     $this->expiresCache = [];
     return TRUE;

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -169,6 +169,18 @@ class Container {
       ))->setFactory('CRM_Utils_Cache::create');
     }
 
+    // PrevNextCache cannot use memory or array cache at the moment because the
+    // Code in CRM_Core_BAO_PrevNextCache assumes that this cache is sql backed.
+    $container->setDefinition("cache.prevNextCache", new Definition(
+      'CRM_Utils_Cache_Interface',
+      [
+        [
+          'name' => 'CiviCRM Search PrevNextCache',
+          'type' => ['SqlGroup'],
+        ],
+      ]
+    ))->setFactory('CRM_Utils_Cache::create');
+
     $container->setDefinition('sql_triggers', new Definition(
       'Civi\Core\SqlTriggers',
       []


### PR DESCRIPTION
Overview
----------------------------------------
This is a subset of #14487 and aims to only convert the PrevNextCache to standardised Cache definition function

Before
----------------------------------------
Used deprecated cache methods

After
----------------------------------------
Used standard Cache definition methods

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
To Test this, someone performing an r-run should do the following

1. Ensure that under misc the prevNext service is SQL backed or auto.
2. Perform a search in advanced search. 
3. Confirm that the cache key has been stored in the civicrm_cache table sensibly
4. Open a new table and copy the Advanced search URL with cache key in it and load in new tab confirm that the advanced search pane is the same
5. Do the same but this time with CiviCampaign Search
6. Run an update to the civicrm_cache table altering the created_date column for the keys to be > 2 days previous from now
7. create and run a Cli script calling CRM_Core_BAO_PrevNextCache::cleanupCache() a la

```php
<?php
civicrm_initialize();
CRM_Core_BAO_PrevNextCache::cleanupCache();
```
and then verify that the cache keys you had altered in 6 are now removed from the database and the relevant rows for the same cache keys are gone from civicrm_prevnext_cache also
