### PR TITLE
Convert Navigation cache group to current cache defition system

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -187,7 +187,9 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     CRM_Core_BAO_Cache::deleteGroup('contact fields');
 
     //CRM-8559, cache navigation do not respect locale if it is changed, so reseting cache.
-    CRM_Core_BAO_Cache::deleteGroup('navigation');
+    Civi::cache('navigation')->flush();
+    // reset ACL and System caches
+    CRM_Core_BAO_Cache::resetCaches();
 
     // we do this only to initialize monetary decimal point and thousand separator
     $config = CRM_Core_Config::singleton();

--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -183,7 +183,6 @@ class CRM_Core_BAO_Cache_Psr16 {
     $groups = [
       // Core
       'contact fields',
-      'navigation',
       'custom data',
 
       // Universe

--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -156,7 +156,7 @@ class CRM_Core_BAO_ConfigSetting {
 
         //CRM-8559, cache navigation do not respect locale if it is changed, so reseting cache.
         // Ed: This doesn't sound good.
-        // CRM_Core_BAO_Cache::deleteGroup('navigation');
+        // Civi::cache('navigation')->flush();
       }
       else {
         $requestLocale = NULL;

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -165,7 +165,7 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
     $config = CRM_Core_Config::singleton();
 
     // check if we can retrieve from database cache
-    $navigations = CRM_Core_BAO_Cache::getItem('navigation', $cacheKeyString);
+    $navigations = Civi::cache('navigation')->get($cacheKeyString);
 
     if (!$navigations) {
       $domainID = CRM_Core_Config::domainID();
@@ -186,7 +186,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       $navigations = [];
       self::_getNavigationLabel($pidGroups[''], $navigations);
 
-      CRM_Core_BAO_Cache::setItem($navigations, 'navigation', $cacheKeyString);
+      Civi::cache('navigation')->set($cacheKeyString, $navigations);
     }
     return $navigations;
   }
@@ -567,7 +567,9 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       $ser = serialize($newKey);
       $query = "UPDATE civicrm_setting SET value = '$ser' WHERE name='navigation' AND contact_id IS NOT NULL";
       CRM_Core_DAO::executeQuery($query);
-      CRM_Core_BAO_Cache::deleteGroup('navigation');
+      Civi::cache('navigation')->flush();
+      // reset ACL and System caches
+      CRM_Core_BAO_Cache::resetCaches();
     }
     else {
       // before inserting check if contact id exists in db

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1440,6 +1440,7 @@ class CRM_Utils_System {
       Civi::cache('js_strings')->flush();
       Civi::cache('community_messages')->flush();
       Civi::cache('groups')->flush();
+      Civi::cache('navigation')->flush();
       CRM_Extension_System::singleton()->getCache()->flush();
       CRM_Cxn_CiviCxnHttp::singleton()->getCache()->flush();
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -157,6 +157,7 @@ class Container {
       'session' => 'CiviCRM Session',
       'long' => 'long',
       'groups' => 'contact groups',
+      'navigation' => 'navigation',
     ];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -167,7 +167,7 @@ class Container {
       // For Caches that we don't really care about the ttl for and/or maybe accessed
       // fairly often we use the fastArrayDecorator which improves reads and writes, these
       // caches should also not have concurrency risk.
-      $fastArrayCaches = ['groups'];
+      $fastArrayCaches = ['groups', 'navigation'];
       if (in_array($cacheSvc, $fastArrayCaches)) {
         $definitionParams['withArray'] = 'fast';
       }


### PR DESCRIPTION
Overview
----------------------------------------
This is a subset of #14487 which only coverts the navigation cache group to standard cache definition

Before
----------------------------------------
Navigation cache group used deprecated cache methods

After
----------------------------------------
Navigation cache group uses current caching definition

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
When doing an r-run a reviewer should test that the following can occur:

When you navigate to menu/rebuild?reset=1 the cache is appropriately cleared and re-populated
When you save the Localisation settings form check that the cache gets appropriately rebuilt. Also confirm that when you add an item to the navigation menu etc it stays there appropriately. 
