### PR TITLE
Convert Custom Data cache group to be using standard cache backend

### DIFF
--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -183,7 +183,6 @@ class CRM_Core_BAO_Cache_Psr16 {
     $groups = [
       // Core
       'contact fields',
-      'custom data',
 
       // Universe
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1818,7 +1818,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
 
     // fetch submitted custom field values later use to set as a default values
     if ($qfKey) {
-      $submittedValues = CRM_Core_BAO_Cache::getItem('custom data', $qfKey);
+      $submittedValues = Civi::cache('customData')->get($qfKey);
     }
 
     foreach ($groupTree as $key => $value) {
@@ -1877,7 +1877,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
       if (count($formValues)) {
         $qf = $form->get('qfKey');
         $form->assign('qfKey', $qf);
-        CRM_Core_BAO_Cache::setItem($formValues, 'custom data', $qf);
+        Civi::cache('customData')->set($qf, $formValues);
       }
 
       // hack for field type File

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1441,6 +1441,7 @@ class CRM_Utils_System {
       Civi::cache('community_messages')->flush();
       Civi::cache('groups')->flush();
       Civi::cache('navigation')->flush();
+      Civi::cache('customData')->flush();
       CRM_Extension_System::singleton()->getCache()->flush();
       CRM_Cxn_CiviCxnHttp::singleton()->getCache()->flush();
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -158,6 +158,7 @@ class Container {
       'long' => 'long',
       'groups' => 'contact groups',
       'navigation' => 'navigation',
+      'customData' => 'custom data',
     ];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -168,7 +168,7 @@ class Container {
       // For Caches that we don't really care about the ttl for and/or maybe accessed
       // fairly often we use the fastArrayDecorator which improves reads and writes, these
       // caches should also not have concurrency risk.
-      $fastArrayCaches = ['groups', 'navigation'];
+      $fastArrayCaches = ['groups', 'navigation', 'customData'];
       if (in_array($cacheSvc, $fastArrayCaches)) {
         $definitionParams['withArray'] = 'fast';
       }


### PR DESCRIPTION
Overview
----------------------------------------
This is a partial of #14487 which converts the custom data cache group to standard cache definition

Before
----------------------------------------
Uses deprecated caching functions

After
----------------------------------------
Uses standard caching functions and cache definition 

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
When r-running this the reviewer should preform an advanced search and filter on a custom field, and confirm that when the advanced search pane re-loads that the custom field value that was set is retained
