### PR TITLE
Convert the contact fields cache group to standard cache backend

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -688,7 +688,7 @@ SELECT $acl.*
    */
   public static function setIsActive($id, $is_active) {
     // note this also resets any ACL cache
-    CRM_Core_BAO_Cache::deleteGroup('contact fields');
+    Civi::cache('fields')->flush();
 
     return CRM_Core_DAO::setFieldValue('CRM_ACL_DAO_ACL', $id, 'is_active', $is_active);
   }

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -688,10 +688,8 @@ SELECT $acl.*
    */
   public static function setIsActive($id, $is_active) {
     Civi::cache('fields')->flush();
-    // also reset ACL Cache
-    CRM_ACL_BAO_Cache::resetCache();
-    // also reset memory cache if any
-    CRM_Utils_System::flushCache();
+    // reset ACL and system caches.
+    CRM_Core_BAO_Cache::resetCaches();
 
     return CRM_Core_DAO::setFieldValue('CRM_ACL_DAO_ACL', $id, 'is_active', $is_active);
   }

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -687,8 +687,11 @@ SELECT $acl.*
    *   true if we found and updated the object, else false
    */
   public static function setIsActive($id, $is_active) {
-    // note this also resets any ACL cache
     Civi::cache('fields')->flush();
+    // also reset ACL Cache
+    CRM_ACL_BAO_Cache::resetCache();
+    // also reset memory cache if any
+    CRM_Utils_System::flushCache();
 
     return CRM_Core_DAO::setFieldValue('CRM_ACL_DAO_ACL', $id, 'is_active', $is_active);
   }

--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -254,7 +254,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
    */
   public function postProcess() {
     // note this also resets any ACL cache
-    CRM_Core_BAO_Cache::deleteGroup('contact fields');
+    Civi::cache('fields')->flush();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_ACL_BAO_ACL::del($this->_id);

--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -255,6 +255,8 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
   public function postProcess() {
     // note this also resets any ACL cache
     Civi::cache('fields')->flush();
+    // reset ACL and system caches.
+    CRM_Core_BAO_Cache::resetCaches();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_ACL_BAO_ACL::del($this->_id);

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -184,7 +184,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
 
     //cache contact fields retaining localized titles
     //though we changed localization, so reseting cache.
-    CRM_Core_BAO_Cache::deleteGroup('contact fields');
+    Civi::cache('fields')->flush();
 
     //CRM-8559, cache navigation do not respect locale if it is changed, so reseting cache.
     Civi::cache('navigation')->flush();

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1351,12 +1351,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     $cacheKeyString .= $checkPermission ? '_1' : '_0';
     $cacheKeyString .= '_' . CRM_Core_Config::domainID() . '_';
 
-    $fields = CRM_Utils_Array::value($cacheKeyString, self::$_importableFields);
-
-    if (!$fields) {
-      // check if we can retrieve from database cache
-      $fields = CRM_Core_BAO_Cache::getItem('contact fields', $cacheKeyString);
-    }
+    $fields = CRM_Utils_Array::value($cacheKeyString, self::$_importableFields) ?: Civi::cache('fields')->get($cacheKeyString);
 
     if (!$fields) {
       $fields = CRM_Contact_DAO_Contact::import();
@@ -1494,7 +1489,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       //Sorting fields in alphabetical order(CRM-1507)
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
 
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
+      Civi::cache('fields')->set($cacheKeyString, $fields);
     }
 
     self::$_importableFields[$cacheKeyString] = $fields;
@@ -1552,7 +1547,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       }
 
       // check if we can retrieve from database cache
-      $fields = CRM_Core_BAO_Cache::getItem('contact fields', $cacheKeyString);
+      $fields = Civi::cache('fields')->get($cacheKeyString);
 
       if (!$fields) {
         $fields = CRM_Contact_DAO_Contact::export();
@@ -1742,7 +1737,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
           }
         }
 
-        CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
+        Civi::cache('fields')->set($cacheKeyString, $fields);
       }
       self::$_exportableFields[$cacheKeyString] = $fields;
     }

--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -181,9 +181,6 @@ class CRM_Core_BAO_Cache_Psr16 {
    */
   public static function getLegacyGroups() {
     $groups = [
-      // Core
-      'contact fields',
-
       // Universe
 
       // be.chiro.civi.atomfeeds

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -401,7 +401,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       }
 
       // check if we can retrieve from database cache
-      $fields = CRM_Core_BAO_Cache::getItem('contact fields', "custom importableFields $cacheKey");
+      $fields = Civi::Cache('fields')->get("custom importableFields $cacheKey");
 
       if ($fields === NULL) {
         $cfTable = self::getTableName();
@@ -547,10 +547,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
         }
 
-        CRM_Core_BAO_Cache::setItem($fields,
-          'contact fields',
-          "custom importableFields $cacheKey"
-        );
+        Civi::cache('fields')->set("custom importableFields $cacheKey", $fields);
       }
       self::$_importFields[$cacheKey] = $fields;
     }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -259,7 +259,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
    */
   public static function setIsActive($id, $is_active) {
     // reset the cache
-    CRM_Core_BAO_Cache::deleteGroup('contact fields');
+    Civi::cache('fields')->flush();
 
     if (!$is_active) {
       CRM_Core_BAO_UFField::setUFFieldStatus($id, $is_active);

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -260,6 +260,8 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
   public static function setIsActive($id, $is_active) {
     // reset the cache
     Civi::cache('fields')->flush();
+    // reset ACL and system caches.
+    CRM_Core_BAO_Cache::resetCaches();
 
     if (!$is_active) {
       CRM_Core_BAO_UFField::setUFFieldStatus($id, $is_active);

--- a/CRM/Custom/Form/ChangeFieldType.php
+++ b/CRM/Custom/Form/ChangeFieldType.php
@@ -188,6 +188,8 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
 
     // Reset cache for custom fields
     Civi::cache('fields')->flush();
+    // reset ACL and system caches.
+    CRM_Core_BAO_Cache::resetCaches();
 
     CRM_Core_Session::setStatus(ts('Input type of custom field \'%1\' has been successfully changed to \'%2\'.',
       [1 => $this->_values['label'], 2 => $dstHtmlType]

--- a/CRM/Custom/Form/ChangeFieldType.php
+++ b/CRM/Custom/Form/ChangeFieldType.php
@@ -187,7 +187,7 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
     $customField->save();
 
     // Reset cache for custom fields
-    CRM_Core_BAO_Cache::deleteGroup('contact fields');
+    Civi::cache('fields')->flush();
 
     CRM_Core_Session::setStatus(ts('Input type of custom field \'%1\' has been successfully changed to \'%2\'.',
       [1 => $this->_values['label'], 2 => $dstHtmlType]

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -1019,7 +1019,7 @@ SELECT id
     $this->_id = $customField->id;
 
     // reset the cache
-    CRM_Core_BAO_Cache::deleteGroup('contact fields');
+    Civi::cache('fields')->flush();
 
     $msg = '<p>' . ts("Custom field '%1' has been saved.", [1 => $customField->label]) . '</p>';
 

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -458,6 +458,8 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
 
     // reset the cache
     Civi::cache('fields')->flush();
+    // reset ACL and system caches.
+    CRM_Core_BAO_Cache::resetCaches();
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       CRM_Core_Session::setStatus(ts('Your custom field set \'%1 \' has been saved.', [1 => $group->title]), ts('Saved'), 'success');

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -457,7 +457,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     $group = CRM_Core_BAO_CustomGroup::create($params);
 
     // reset the cache
-    CRM_Core_BAO_Cache::deleteGroup('contact fields');
+    Civi::cache('fields')->flush();
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       CRM_Core_Session::setStatus(ts('Your custom field set \'%1 \' has been saved.', [1 => $group->title]), ts('Saved'), 'success');

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1449,7 +1449,7 @@ class CRM_Utils_System {
     // also reset the various static memory caches
 
     // reset the memory or array cache
-    CRM_Core_BAO_Cache::deleteGroup('contact fields', NULL, FALSE);
+    Civi::cache('fields')->flush();
 
     // reset ACL cache
     CRM_ACL_BAO_Cache::resetCache();

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -169,7 +169,7 @@ class Container {
       // For Caches that we don't really care about the ttl for and/or maybe accessed
       // fairly often we use the fastArrayDecorator which improves reads and writes, these
       // caches should also not have concurrency risk.
-      $fastArrayCaches = ['groups', 'navigation', 'customData'];
+      $fastArrayCaches = ['groups', 'navigation', 'customData', 'fields'];
       if (in_array($cacheSvc, $fastArrayCaches)) {
         $definitionParams['withArray'] = 'fast';
       }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -159,6 +159,7 @@ class Container {
       'groups' => 'contact groups',
       'navigation' => 'navigation',
       'customData' => 'custom data',
+      'fields' => 'contact fields',
     ];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [


### PR DESCRIPTION
Overview
----------------------------------------
This is a partial of #14487 which converts the contact fields cache group to a standard cache backend

Before
----------------------------------------
contact fields cache group uses deprecated functions

After
----------------------------------------
contact fields cache group uses standard cache definition and functions

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
When r-running this a reviewer should check the following:

* Ensure that when adding a new custom group / custom field set that the current contact fields caches are removed,
* Ensure that setting a custom field to be active or inactive flushes the cache
* Ensure that creating an ACL set flushes the cache as well
* Ensure that running cv api system.flush flushes the cache as appropriate
* Check that changing a custom field changes the appropriate cache
* Ensure that fields are sensible when going to do a contact import and export