### PR TITLE
Convert Contact Groups cache group to standard cache definition

### DIFF
--- a/CRM/Contact/BAO/GroupNestingCache.php
+++ b/CRM/Contact/BAO/GroupNestingCache.php
@@ -100,7 +100,7 @@ WHERE  id = $id
     }
 
     // this tree stuff is quite useful, so lets store it in the cache
-    CRM_Core_BAO_Cache::setItem($tree, 'contact groups', 'nestable tree hierarchy');
+    Civi::cache('groups')->set('nestable tree hierarchy', $tree);
   }
 
   /**
@@ -153,11 +153,11 @@ WHERE  id = $id
    * @return array
    */
   public static function getPotentialCandidates($id, &$groups) {
-    $tree = CRM_Core_BAO_Cache::getItem('contact groups', 'nestable tree hierarchy');
+    $tree = Civi::cache('groups')->get('nestable tree hierarchy');
 
     if ($tree === NULL) {
       self::update();
-      $tree = CRM_Core_BAO_Cache::getItem('contact groups', 'nestable tree hierarchy');
+      $tree = Civi::cache('groups')->get('nestable tree hierarchy');
     }
 
     $potential = $groups;
@@ -219,11 +219,11 @@ WHERE  id = $id
    * @return string
    */
   public static function json() {
-    $tree = CRM_Core_BAO_Cache::getItem('contact groups', 'nestable tree hierarchy');
+    $tree = Civi::cache('groups')->get('nestable tree hierarchy');
 
     if ($tree === NULL) {
       self::update();
-      $tree = CRM_Core_BAO_Cache::getItem('contact groups', 'nestable tree hierarchy');
+      $tree = Civi::cache('groups')->get('nestable tree hierarchy');
     }
 
     // get all the groups

--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -185,7 +185,6 @@ class CRM_Core_BAO_Cache_Psr16 {
       'CiviCRM Search PrevNextCache',
       'contact fields',
       'navigation',
-      'contact groups',
       'custom data',
 
       // Universe

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -156,6 +156,7 @@ class Container {
       'checks' => 'checks',
       'session' => 'CiviCRM Session',
       'long' => 'long',
+      'groups' => 'contact groups',
     ];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $container->setDefinition("cache.{$cacheSvc}", new Definition(


### PR DESCRIPTION
Overview
----------------------------------------
This converts the contact groups cache group to a standard cache definition a split off from #14487

Before
----------------------------------------
contact groups cache uses deprecated code paths

After
----------------------------------------
contact groups uses standard caching definition

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
When r-running this a review should create a new group and make it a child of another group and then confirm that the parent - child group relationship shows correctly on the manage group page and also in the groups box in the Advanced Search
