### PR TITLE
Update Owner Membership ID label in reports to be Primary Membership …

### DIFF
--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -315,7 +315,7 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
           'membership_start_date' => ['operatorType' => CRM_Report_Form::OP_DATE],
           'membership_end_date' => ['operatorType' => CRM_Report_Form::OP_DATE],
           'owner_membership_id' => [
-            'title' => ts('Membership Owner ID'),
+            'title' => ts('Primary Membership'),
             'operatorType' => CRM_Report_Form::OP_INT,
           ],
           'tid' => [
@@ -613,14 +613,21 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
   }
 
   public function getOperationPair($type = "string", $fieldName = NULL) {
-    $result = parent::getOperationPair($type, $fieldName);
-
     //re-name IS NULL/IS NOT NULL for clarity
     if ($fieldName == 'owner_membership_id') {
+      $result = [];
       $result['nll'] = ts('Primary members only');
       $result['nnll'] = ts('Non-primary members only');
+      $options = parent::getOperationPair($type, $fieldName);
+      foreach ($options as $key => $label) {
+        if (!array_key_exists($key, $result)) {
+          $result[$key] = $label;
+        }
+      }
     }
-
+    else {
+      $result = parent::getOperationPair($type, $fieldName);
+    }
     return $result;
   }
 

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -119,7 +119,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
           'membership_start_date' => ['operatorType' => CRM_Report_Form::OP_DATE],
           'membership_end_date' => ['operatorType' => CRM_Report_Form::OP_DATE],
           'owner_membership_id' => [
-            'title' => ts('Membership Owner ID'),
+            'title' => ts('Primary Membership'),
             'operatorType' => CRM_Report_Form::OP_INT,
           ],
           'tid' => [
@@ -285,14 +285,21 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
   }
 
   public function getOperationPair($type = "string", $fieldName = NULL) {
-    $result = parent::getOperationPair($type, $fieldName);
-
     //re-name IS NULL/IS NOT NULL for clarity
     if ($fieldName == 'owner_membership_id') {
+      $result = [];
       $result['nll'] = ts('Primary members only');
       $result['nnll'] = ts('Non-primary members only');
+      $options = parent::getOperationPair($type, $fieldName);
+      foreach ($options as $key => $label) {
+        if (!array_key_exists($key, $result)) {
+          $result[$key] = $label;
+        }
+      }
     }
-
+    else {
+      $result = parent::getOperationPair($type, $fieldName);
+    }
     return $result;
   }
 

--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -91,7 +91,7 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
             'operatorType' => CRM_Report_Form::OP_DATE,
           ],
           'owner_membership_id' => [
-            'title' => ts('Membership Owner ID'),
+            'title' => ts('Primary Membership'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_INT,
           ],
@@ -437,14 +437,21 @@ GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
   }
 
   public function getOperationPair($type = "string", $fieldName = NULL) {
-    $result = parent::getOperationPair($type, $fieldName);
-
     //re-name IS NULL/IS NOT NULL for clarity
     if ($fieldName == 'owner_membership_id') {
+      $result = [];
       $result['nll'] = ts('Primary members only');
       $result['nnll'] = ts('Non-primary members only');
+      $options = parent::getOperationPair($type, $fieldName);
+      foreach ($options as $key => $label) {
+        if (!array_key_exists($key, $result)) {
+          $result[$key] = $label;
+        }
+      }
     }
-
+    else {
+      $result = parent::getOperationPair($type, $fieldName);
+    }
     return $result;
   }
 


### PR DESCRIPTION
…to be more consistant with rest of system

Overview
----------------------------------------
This changes the label in membership reports from Owner Membership ID to be Primary Membership as per discussion on #14530 

Before
----------------------------------------
Unusual label Owner Membership ID used

After
----------------------------------------
More standardised label Primary Membership used

ping @jusfreeman @MegaphoneJon @agh1 @eileenmcnaughton @yashodha i tend to agree with Andrew that Primary Membership will suffice especially given the other places where we use the term Primary rather than Owner Membership or similar