### PR TITLE
Fixing the display of checkboxes in event confirm / thank you (dev/core#1058)

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1638,6 +1638,16 @@ WHERE  id = $cfID
                   }
                   $skip = TRUE;
                 }
+                // for checkboxes, change array of [key => bool] to array of [idx => key]
+                elseif ($dao->html_type == 'CheckBox') {
+                  $v = [];
+                  foreach ($params[$name] as $key => $val) {
+                    if ($val) {
+                      $v[] = $key;
+                    }
+                  }
+                  $customVal = $v;
+                }
                 else {
                   $customVal = $params[$name];
                 }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1640,13 +1640,7 @@ WHERE  id = $cfID
                 }
                 // for checkboxes, change array of [key => bool] to array of [idx => key]
                 elseif ($dao->html_type == 'CheckBox') {
-                  $v = [];
-                  foreach ($params[$name] as $key => $val) {
-                    if ($val) {
-                      $v[] = $key;
-                    }
-                  }
-                  $customVal = $v;
+                  $customVal = array_keys(array_filter($params[$name]));
                 }
                 else {
                   $customVal = $params[$name];


### PR DESCRIPTION
Overview
----------------------------------------

Checkboxes are not displayed properly in event Confirmation and Thank You pages.

It's only a display problem on the screen :  the receipt is correct and the values are correctly saved in the database.

See dev/core#1058

Before
----------------------------------------
Form: 

![Screenshot_2019-06-19 - Event with custom checkboxes](https://user-images.githubusercontent.com/372004/59854280-9c3dda00-9340-11e9-8dc5-7525582c11a3.png)

Confirmation page :

![Screenshot_2019-06-19 Event with custom checkboxes - confirm](https://user-images.githubusercontent.com/372004/59855615-4d457400-9343-11e9-91ad-d05cca9b7c3d.png)

After
----------------------------------------
The display is as expected : `Choice 2, Choice 3`

Technical Details
----------------------------------------
I have ensured that the change applies only to Confirm / Thank you page.

- CRM_Event_BAO_Event::displayProfile is only called from CRM_Event_Form_Registration_Confirm::assignProfiles
- CRM_Event_Form_Registration_Confirm::assignProfiles is only called from CRM_Event_Form_Registration_Confirm::buildQuickForm and CRM_Event_Form_Registration_ThankYou::preProcess

Comments
----------------------------------------
Quickly comparing Contribution form with Event form, they doesn't seems to use the same method to display the profile information. Eventually, we might want to have a uniform way of doing it...
