### PR TITLE
Support api3 & 4 language syntax & improve test

### DIFF
--- a/Civi/API/Subscriber/I18nSubscriber.php
+++ b/Civi/API/Subscriber/I18nSubscriber.php
@@ -46,6 +46,8 @@ class I18nSubscriber implements EventSubscriberInterface {
   }
 
   /**
+   * Support multi-lingual requests
+   *
    * @param \Civi\API\Event\Event $event
    *   API preparation event.
    *
@@ -54,8 +56,14 @@ class I18nSubscriber implements EventSubscriberInterface {
   public function onApiPrepare(\Civi\API\Event\Event $event) {
     $apiRequest = $event->getApiRequest();
 
-    // support multi-lingual requests
-    if ($language = \CRM_Utils_Array::value('option.language', $apiRequest['params'])) {
+    $params = $apiRequest['params'];
+    if ($apiRequest['version'] < 4) {
+      $language = !empty($params['options']['language']) ? $params['options']['language'] : \CRM_Utils_Array::value('option.language', $params);
+    }
+    else {
+      $language = \CRM_Utils_Array::value('language', $params);
+    }
+    if ($language) {
       $this->setLocale($language);
     }
   }

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -306,8 +306,12 @@ trait Api3TestTrait {
     $indexBy = in_array($v3Action, ['get', 'create', 'replace']) && !$sequential ? 'id' : NULL;
     $onlyId = !empty($v3Params['format.only_id']);
     $onlySuccess = !empty($v3Params['format.is_success']);
-    if (!empty($v3Params['filters']['is_current']) || !empty($params['isCurrent'])) {
+    if (!empty($v3Params['filters']['is_current']) || !empty($v3Params['isCurrent'])) {
       $v4Params['current'] = TRUE;
+    }
+    $language = !empty($v3Params['options']['language']) ? $v3Params['options']['language'] : \CRM_Utils_Array::value('option.language', $v3Params);
+    if ($language) {
+      $v4Params['language'] = $language;
     }
     $toRemove = ['option.', 'return', 'api.', 'format.'];
     $chains = [];

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -50,8 +50,12 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
-  public function testOptionLanguage() {
+  /**
+   * @dataProvider versionThreeAndFour
+   */
+  public function testOptionLanguage($version) {
     $this->enableMultilingual();
+    $this->_apiversion = $version;
 
     CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
 
@@ -83,7 +87,7 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
     $french = $this->callAPISuccess('OptionValue', 'getsingle', array(
       'option_group_id' => $group['id'],
       'name' => 'IM',
-      'option.language' => 'fr_CA',
+      'options' => ['language' => 'fr_CA'],
     ));
 
     $default = $this->callAPISuccess('OptionValue', 'getsingle', array(


### PR DESCRIPTION
Overview
----------------------------------------
This is a reviewer's cut of #14215.
Fixes support for api3 "language" option and extends test coverage to the new syntax as well as api v4.

Before
----------------------------------------
Calling an API with `  'options' => ['language' => "fr_FR"], ` won't return labels in specific language, only with `  'option.language' => "fr_FR",`

After
----------------------------------------
Both old and new API options format will return the labels in specific language.
Test coverage for the new format and also for api4.
