### PR TITLE
Towards Convert receive_date to use datepicker in search 

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -709,15 +709,14 @@ LEFT JOIN civicrm_contribution_soft ON civicrm_contribution_soft.contribution_id
       'contribution_receipt_date_is_not_null',
       'contribution_pcp_made_through_id',
       'contribution_pcp_display_in_roll',
-      'contribution_date_relative',
       'contribution_amount_low',
       'contribution_amount_high',
       'contribution_in_honor_of',
       'contact_tags',
       'group',
-      'contribution_date_relative',
-      'contribution_date_high',
-      'contribution_date_low',
+      'receive_date_relative',
+      'receive_date_high',
+      'receive_date_low',
       'contribution_check_number',
       'contribution_status_id',
       'financial_trxn_card_type_id',
@@ -740,11 +739,11 @@ LEFT JOIN civicrm_contribution_soft ON civicrm_contribution_soft.contribution_id
         if ($field == 'group') {
           $from .= " LEFT JOIN civicrm_group_contact `civicrm_group_contact-{$params[$field]}` ON contact_a.id = `civicrm_group_contact-{$params[$field]}`.contact_id ";
         }
-        if ($field == 'contribution_date_relative') {
+        if ($field == 'receive_date_relative') {
           $relativeDate = explode('.', $params[$field]);
           $date = CRM_Utils_Date::relativeToAbsolute($relativeDate[0], $relativeDate[1]);
-          $values['contribution_date_low'] = $date['from'];
-          $values['contribution_date_high'] = $date['to'];
+          $values['receive_date_low'] = $date['from'];
+          $values['receive_date_high'] = $date['to'];
         }
       }
     }

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1554,7 +1554,7 @@ class CRM_Contact_BAO_Query {
 
     self::filterCountryFromValuesIfStateExists($formValues);
     // We shouldn't have to whitelist fields to not hack but here we are, for now.
-    $nonLegacyDateFields = ['participant_register_date_relative'];
+    $nonLegacyDateFields = ['participant_register_date_relative', 'receive_date_relative'];
     // Handle relative dates first
     foreach (array_keys($formValues) as $id) {
       if (


### PR DESCRIPTION
Overview
----------------------------------------
Partial fix of batch search with regards to the conversion of receive_date to date picker on search screens as included in 5.16 

Before
----------------------------------------
Search screen just whirs when you try to search on a relative receive date

After
----------------------------------------
Relative receive date works

Technical Details
----------------------------------------
@seamuslee001 Can we merge this as a partial - I want to look a bit more carefully into the 2 outstanding issues ie
1) date default not handled - I think we can do this via metadata almost all the pieces are in place - will dig
2) it seems from date & to date are not working on either screen with this - I'm gonna fix this but I want to try to ensure the fix is the right model.

Comments
----------------------------------------

