### PR TITLE
Fix url support for receive_date_high & receive_date_low

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -149,8 +149,10 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
    * Set defaults.
    *
    * @return array
+   * @throws \Exception
    */
   public function setDefaultValues() {
+    $this->_defaults = parent::setDefaultValues();
     if (empty($this->_defaults['contribution_status'])) {
       $this->_defaults['contribution_status'][1] = 1;
     }

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -251,19 +251,19 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    */
   protected function getEntityDefaults($entity) {
     $defaults = [];
-    foreach ($this->getSearchFieldMetadata()[$entity] as $fieldSpec) {
+    foreach ($this->getSearchFieldMetadata()[$entity] as $fieldName => $fieldSpec) {
       if (empty($_POST[$fieldSpec['name']])) {
-        $value = CRM_Utils_Request::retrieveValue($fieldSpec['name'], $this->getValidationTypeForField($entity, $fieldSpec['name']), FALSE, NULL, 'GET');
-        if ($value !== FALSE) {
-          $defaults[$fieldSpec['name']] = $value;
+        $value = CRM_Utils_Request::retrieveValue($fieldName, $this->getValidationTypeForField($entity, $fieldName), FALSE, NULL, 'GET');
+        if ($value !== NULL) {
+          $defaults[$fieldName] = $value;
         }
         if ($fieldSpec['type'] === CRM_Utils_Type::T_DATE || ($fieldSpec['type'] === CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)) {
-          $low = CRM_Utils_Request::retrieveValue($fieldSpec['name'] . '_low', 'Timestamp', FALSE, NULL, 'GET');
-          $high = CRM_Utils_Request::retrieveValue($fieldSpec['name'] . '_high', 'Timestamp', FALSE, NULL, 'GET');
+          $low = CRM_Utils_Request::retrieveValue($fieldName . '_low', 'Timestamp', FALSE, NULL, 'GET');
+          $high = CRM_Utils_Request::retrieveValue($fieldName . '_high', 'Timestamp', FALSE, NULL, 'GET');
           if ($low !== FALSE || $high !== FALSE) {
-            $defaults[$fieldSpec['name'] . '_relative'] = 0;
-            $defaults[$fieldSpec['name'] . '_low'] = $low ? date('Y-m-d H:i:s', strtotime($low)) : NULL;
-            $defaults[$fieldSpec['name'] . '_high'] = $high ? date('Y-m-d H:i:s', strtotime($high)) : NULL;
+            $defaults[$fieldName . '_relative'] = 0;
+            $defaults[$fieldName . '_low'] = $low ? date('Y-m-d H:i:s', strtotime($low)) : NULL;
+            $defaults[$fieldName . '_high'] = $high ? date('Y-m-d H:i:s', strtotime($high)) : NULL;
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Url support for some fields on contribution search - this is part of a general standardisation. 

receive_date_high=20180101
receive_date_low=20180909120000
contribution_cancel_date_high
contribution_cancel_date_low
invoice_number=9

Documentation issue https://github.com/civicrm/civicrm-dev-docs/issues/624

Before
----------------------------------------
No support

After
----------------------------------------
Standardised Fields prefill - see invoice_number & receive date (cancel_date is off screen)
<img width="966" alt="Screen Shot 2019-06-21 at 10 23 12 AM" src="https://user-images.githubusercontent.com/336308/59929365-ad551c80-940e-11e9-98a2-b54f6f2fc95e.png">


Technical Details
----------------------------------------
Ensuring we get these is a standardised way also avoids some ad-hoc insecure adds we have had in the past. 

Note that in doing this I fixed the new & somewhat experimental default function to use field uniquenames rather than field names (as this is how they are added to the form & it was required for cancel_date.

Support for receive_date_relative=this.day etc would be trivial but not yet tackled

Also I see that we historically support 'start' and 'end' I think something like this makes sense here (as a follow up)
```
+++ b/CRM/Contribute/Form/Search.php
@@ -152,6 +152,16 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
    * @throws \Exception
    */
   public function setDefaultValues() {
+    $lowReceiveDate = CRM_Utils_Request::retrieve('start', 'Timestamp');
+    if (!empty($lowReceiveDate)) {
+      $this->_formValues['receive_date_low'] = date('Y-m-d H:i:s', strtotime($lowReceiveDate));
+      CRM_Core_Error::deprecatedFunctionWarning('pass receive_date_low not start');
+    }
+    $highReceiveDate = CRM_Utils_Request::retrieve('end', 'Timestamp');
+    if (!empty($highReceiveDate)) {
+      $this->_formValues['receive_date_high'] = date('Y-m-d H:i:s', strtotime($highReceiveDate));
+      CRM_Core_Error::deprecatedFunctionWarning('pass receive_date_high not end');
+    }
     $this->_defaults = parent::setDefaultValues();
     if (empty($this->_defaults['contribution_status'])) {
       $this->_defaults['contribution_status'][1] = 1;
@@ -425,25 +435,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       }
     }
 
-    $lowDate = CRM_Utils_Request::retrieve('start', 'Timestamp');
-    if ($lowDate) {
-      $lowDate = CRM_Utils_Type::escape($lowDate, 'Timestamp');
-      $date = CRM_Utils_Date::setDateDefaults($lowDate);
-      $this->_formValues['contribution_date_low'] = $this->_defaults['contribution_date_low'] = $date[0];
-    }
-
-    $highDate = CRM_Utils_Request::retrieve('end', 'Timestamp');
-    if ($highDate) {
-      $highDate = CRM_Utils_Type::escape($highDate, 'Timestamp');
-      $date = CRM_Utils_Date::setDateDefaults($highDate);
-      $this->_formValues['contribution_date_high'] = $this->_defaults['contribution_date_high'] = $date[0];
-    }
-
-    if ($highDate || $lowDate) {
-      //set the Choose Date Range value
-      $this->_formValues['contribution_date_relative'] = 0;
-    }
-
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive',
       $this
     );
```

Comments
----------------------------------------

@seamuslee001 @monishdeb @yashodha 