### PR TITLE
Fix setup.sh crash when using the -a flag

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -60,6 +60,7 @@ while getopts "aDgsdef" opt; do
       DO_GENCODE=1
       DO_SCHEMA=1
       DO_DATA=1
+      DEFAULT_DATA=civicrm_generated.mysql
       DO_FLUSH=1
       FOUND_ACTION=1
       ;;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an error where the command `setup.sh -a` dies with an error because it doesn't know what database to load.

Before
----------------------------------------
`setup.sh -a` dies with an error because it doesn't know what database to load.

After
----------------------------------------
`setup.sh -a` uses the example database, same as calling `setup.sh` with no arguments.
