### PR TITLE
Reset language at end of localized api call

### DIFF
--- a/Civi/API/Subscriber/APIv3SchemaAdapter.php
+++ b/Civi/API/Subscriber/APIv3SchemaAdapter.php
@@ -82,6 +82,9 @@ class APIv3SchemaAdapter implements EventSubscriberInterface {
    */
   public function onApiPrepare_validate(\Civi\API\Event\Event $event) {
     $apiRequest = $event->getApiRequest();
+    if ($apiRequest['version'] > 3) {
+      return;
+    }
     // Not sure why this is omitted for generic actions. It would make sense
     // to omit 'getfields', but that's only one generic action.
 

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -90,10 +90,10 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
       'options' => ['language' => 'fr_CA'],
     ));
 
+    // Ensure that after language is changed in previous call it will go back to the default.
     $default = $this->callAPISuccess('OptionValue', 'getsingle', array(
       'option_group_id' => $group['id'],
       'name' => 'IM',
-      'option.language' => 'en_US',
     ));
 
     $this->assertEquals($french['label'], 'Messagerie instantanée');


### PR DESCRIPTION
Overview
----------------------------------------
Restore the original language after changing it for an api call.

Before
----------------------------------------
Calling the api with `options['language']` would leave the system in that state through the end of the request. Not usually a problem because php requests are often short-lived (e.g. calling the ajax api creates a request for just that one call and then it ends). But for longer-running processes it could bleed through. And it's wrong. So here's a fix :)

After
----------------------------------------
Original language restored after every multilingual api call.
