### PR TITLE
Decommission recordPartialPayment function

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -942,7 +942,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    *
    * @return int
    */
-  protected static function getToFinancialAccount($contribution, $params) {
+  public static function getToFinancialAccount($contribution, $params) {
     $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     $pendingStatus = [
@@ -4839,7 +4839,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @return CRM_Financial_DAO_FinancialTrxn
    */
   public static function recordPartialPayment($contribution, $params) {
-
+    CRM_Core_Error::deprecatedFunctionWarning('use payment create api');
     $balanceTrxnParams['to_financial_account_id'] = self::getToFinancialAccount($contribution, $params);
     $balanceTrxnParams['from_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($contribution['financial_type_id'], 'Accounts Receivable Account is');
     $balanceTrxnParams['total_amount'] = $params['total_amount'];

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -113,11 +113,11 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
     $contributionTest = new CRM_Contribute_BAO_ContributionTest();
     list($lineItems, $contribution) = $contributionTest->addParticipantWithContribution();
     $contribution = (array) $contribution;
-    $params = array(
+    $params = [
       'contribution_id' => $contribution['id'],
       'total_amount' => 100.00,
-    );
-    $trxn = CRM_Contribute_BAO_Contribution::recordPartialPayment($contribution, $params);
+    ];
+    $this->callAPISuccess('Payment', 'create', $params);
     $paid = CRM_Core_BAO_FinancialTrxn::getTotalPayments($params['contribution_id']);
     $total = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution_id'], 'total_amount');
     $cmp = bccomp($total, $paid, 5);
@@ -125,8 +125,6 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
     if ($cmp == 0 || $cmp == -1) {
       civicrm_api3('Contribution', 'completetransaction', array('id' => $contribution['id']));
     }
-
-    $this->assertEquals('100.00', $trxn->total_amount, 'Amount does not match.');
 
     $totalPaymentAmount = CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribution['id']);
     $this->assertEquals('250.00', $totalPaymentAmount, 'Amount does not match.');


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Payment create passes off to Contribution BAO class to create the payment

After
----------------------------------------
Payment class self-handles

Technical Details
----------------------------------------
While I would normally say extracting is good sometimes if feels like things are being broken down in the
wrong places. In this case I think the function name is misleading and having this in the body of Payment.create
makes the path to cleaning up that function clearer

Comments
----------------------------------------

