### PR TITLE
Add a helper function to ensure we always set the correct tab for manage events

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -101,6 +101,21 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
   }
 
   /**
+   * Set the active tab
+   *
+   * @param string $default
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function setSelectedChild($default = NULL) {
+    $selectedChild = CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $this, FALSE, $default);
+    if (!empty($selectedChild)) {
+      $this->set('selectedChild', $selectedChild);
+      $this->assign('selectedChild', $selectedChild);
+    }
+  }
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -46,7 +46,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
    */
   public function preProcess() {
     parent::preProcess();
-    $this->assign('selectedChild', 'settings');
+    $this->setSelectedChild('settings');
 
     $entityID = $this->_id ?: $this->_templateId;
     if ($entityID) {

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -62,7 +62,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
    */
   public function preProcess() {
     parent::preProcess();
-    $this->assign('selectedChild', 'fee');
+    $this->setSelectedChild('fee');
   }
 
   /**

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -73,7 +73,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
    */
   public function preProcess() {
     parent::preProcess();
-    $this->assign('selectedChild', 'location');
+    $this->setSelectedChild('location');
 
     $this->_values = $this->get('values');
     if ($this->_id && empty($this->_values)) {

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -55,7 +55,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $this->_profileBottomNumAdd = CRM_Utils_Array::value('addProfileNumAdd', $_GET, 0);
 
     parent::preProcess();
-    $this->assign('selectedChild', 'registration');
+    $this->setSelectedChild('registration');
 
     $this->assign('addProfileBottom', $this->_addProfileBottom);
     $this->assign('profileBottomNum', $this->_profileBottomNum);

--- a/CRM/Event/Form/ManageEvent/Repeat.php
+++ b/CRM/Event/Form/ManageEvent/Repeat.php
@@ -26,7 +26,7 @@ class CRM_Event_Form_ManageEvent_Repeat extends CRM_Event_Form_ManageEvent {
 
   public function preProcess() {
     parent::preProcess();
-    $this->assign('selectedChild', 'repeat');
+    $this->setSelectedChild('repeat');
     $this->assign('currentEventId', $this->_id);
 
     $checkParentExistsForThisId = CRM_Core_BAO_RecurringEntity::getParentFor($this->_id, 'civicrm_event');

--- a/CRM/Event/Form/ManageEvent/ScheduleReminders.php
+++ b/CRM/Event/Form/ManageEvent/ScheduleReminders.php
@@ -47,7 +47,7 @@ class CRM_Event_Form_ManageEvent_ScheduleReminders extends CRM_Event_Form_Manage
    */
   public function preProcess() {
     parent::preProcess();
-    $this->assign('selectedChild', 'reminder');
+    $this->setSelectedChild('reminder');
     $setTab = CRM_Utils_Request::retrieve('setTab', 'Int', $this, FALSE, 0);
 
     $mapping = CRM_Utils_Array::first(CRM_Core_BAO_ActionSchedule::getMappings([

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -45,8 +45,6 @@ class CRM_Event_Form_ManageEvent_TabHeader {
    * @throws \CRM_Core_Exception
    */
   public static function build(&$form) {
-    $form->assign('selectedChild', CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $form));
-
     $tabs = $form->get('tabHeader');
     if (!$tabs || empty($_GET['reset'])) {
       $tabs = self::process($form);

--- a/CRM/Friend/Form/Event.php
+++ b/CRM/Friend/Form/Event.php
@@ -48,7 +48,7 @@ class CRM_Friend_Form_Event extends CRM_Event_Form_ManageEvent {
 
   public function preProcess() {
     parent::preProcess();
-    $this->assign('selectedChild', 'friend');
+    $this->setSelectedChild('friend');
   }
 
   /**

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -48,7 +48,7 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
 
   public function preProcess() {
     parent::preProcess();
-    $this->assign('selectedChild', 'pcp');
+    $this->setSelectedChild('pcp');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When using the "selectedChild" URL parameter to select a specific events tab it does not always work

Before
----------------------------------------
"selectedChild" URL parameter unreliable for manage events.

After
----------------------------------------
"selectedChild" parameter reliable for manage events.

Technical Details
----------------------------------------
The "Manage Event" form can be accessed via various different URL paths depending on the entrypoint.  When accessed via a specific URL endpoint the selectedChild parameter was being overwritten with the specific tab ID.  But we should first be checking if the selectedChild parameter has been passed in, and using that instead.  So we create a new function `setSelectedChild()` which handles this function for all tabs and allows a default to be passed in.

Comments
----------------------------------------
The problem is most obvious when extensions are adding tabs to the manage events form - for example when using https://lab.civicrm.org/extensions/civicrm-advanced-events.
