### PR TITLE
dev/core#1066 Fix mailing permissions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -621,7 +621,7 @@ class CRM_Core_Permission {
     }
 
     foreach ($components as $comp) {
-      $perm = $comp->getPermissions(FALSE, $descriptions);
+      $perm = $comp->getPermissions($all, $descriptions);
       if ($perm) {
         $info = $comp->getInfo();
         foreach ($perm as $p => $attr) {

--- a/tests/phpunit/CRM/Core/BAO/NavigationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/NavigationTest.php
@@ -308,6 +308,23 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
 
     CRM_Core_BAO_ConfigSetting::disableComponent('CiviContribute');
     $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviMail');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviMail', 'delete in CiviMail'];
+    $menuItem = [
+      'permission' => 'access CiviMail, delete in CiviMail',
+      'operator' => 'AND',
+    ];
+    $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+    $menuItem['operator'] = 'OR';
+    $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['delete in CiviMail'];
+    $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+    $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviMail', 'delete in CiviMail'];
+    CRM_Core_BAO_ConfigSetting::disableComponent('CiviMail');
+    $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1066
Fixes a bug where switching between "OR" and "AND" operators on the "Civimail" menu item causes it to disappear if mail workflows are disabled. This is because there were some workflow-related permissions that were being hidden from the form, and thus the permission check would fail when checking them all with the AND operator.

Before
----------------------------------------
The default permissions for the "CiviMail" menu item are "access CiviMail,create mailings,approve mailings,schedule mailings,send SMS", yet with workflows disabled the form would look like this:

![image](https://user-images.githubusercontent.com/2874912/59966854-f92bc280-94ef-11e9-81ae-e8fa9a374138.png)

This is because the workflow-related permissions were being omitted by `CRM_Core_Permission::basicPermissions()` even though it was called with `$all = TRUE`.

After
----------------------------------------
This PR fixes `CRM_Core_Permission::basicPermissions()` so the `$all` param actually, you know, fetches all permissions! Now the form looks like this:

![image](https://user-images.githubusercontent.com/2874912/59966889-68091b80-94f0-11e9-8bab-049a59adc503.png)

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1066 was labeled a regression but I'm not sure it's that recent. The code looks a couple years old to me. But I think it's nevertheless a small/safe enough change to merge into the RC. I've grepped and confirmed that the function  `CRM_Core_Permission::basicPermissions()` is only ever called with `$all = TRUE` from this one form, so this patch shouldn't affect anything else.
