### PR TITLE
 [test] convert export test to handle exception rather than early return

### DIFF
--- a/CRM/Core/Exception/PrematureExitException.php
+++ b/CRM/Core/Exception/PrematureExitException.php
@@ -41,4 +41,19 @@
  */
 class CRM_Core_Exception_PrematureExitException extends RuntimeException {
 
+  /**
+   * Construct the exception. Note: The message is NOT binary safe.
+   *
+   * @link https://php.net/manual/en/exception.construct.php
+   *
+   * @param string $message [optional] The Exception message to throw.
+   * @param array $errorData
+   * @param int $error_code
+   * @param throwable $previous [optional] The previous throwable used for the exception chaining.
+   */
+  public function __construct($message = "", $errorData = [], $error_code = 0, throwable $previous = NULL) {
+    parent::__construct($message, $error_code, $previous);
+    $this->errorData = $errorData + ['error_code' => $error_code];
+  }
+
 }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -144,6 +144,31 @@ class CRM_Export_BAO_ExportProcessor {
   protected $outputSpecification = [];
 
   /**
+   * Name of a temporary table created to hold the results.
+   *
+   * Current decision making on when to create a temp table is kinda bad so this might change
+   * a bit as it is reviewed but basically we need a temp table or similar to calculate merging
+   * addresses. Merging households is handled in php. We create a temp table even when we don't need them.
+   *
+   * @var string
+   */
+  protected $temporaryTable;
+
+  /**
+   * @return string
+   */
+  public function getTemporaryTable(): string {
+    return $this->temporaryTable;
+  }
+
+  /**
+   * @param string $temporaryTable
+   */
+  public function setTemporaryTable(string $temporaryTable) {
+    $this->temporaryTable = $temporaryTable;
+  }
+
+  /**
    * CRM_Export_BAO_ExportProcessor constructor.
    *
    * @param int $exportMode

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1396,12 +1396,12 @@ class CRM_Utils_System {
    * @param int $status
    *   (optional) Code with which to exit.
    *
-   * @throws \CRM_Core_PrematureExit_Exception
+   * @param array $testParameters
    */
-  public static function civiExit($status = 0) {
+  public static function civiExit($status = 0, $testParameters = []) {
 
     if (CIVICRM_UF === 'UnitTests') {
-      throw new CRM_Core_Exception_PrematureExitException('civiExit called');
+      throw new CRM_Core_Exception_PrematureExitException('civiExit called', $testParameters);
     }
     if ($status > 0) {
       http_response_code(500);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -27,6 +27,7 @@
  */
 
 use Civi\Payment\System;
+use League\Csv\Reader;
 
 /**
  *  Include class definitions
@@ -3283,6 +3284,38 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     // Create an SMS provider "CiviTestSMSProvider". Civi handles "CiviTestSMSProvider" as a special case and allows it to be instantiated
     //  in CRM/Sms/Provider.php even though it is not an extension.
     return civicrm_api3('option_value', 'create', $params);
+  }
+
+  /**
+   * Start capturing browser output.
+   *
+   * The starts the process of browser output being captured, setting any variables needed for e-notice prevention.
+   */
+  protected function startCapturingOutput() {
+    ob_start();
+    $_SERVER['HTTP_USER_AGENT'] = 'unittest';
+  }
+
+  /**
+   * Stop capturing browser output and return as a csv.
+   *
+   * @param bool $isFirstRowHeaders
+   *
+   * @return \League\Csv\Reader
+   *
+   * @throws \League\Csv\Exception
+   */
+  protected function captureOutputToCSV($isFirstRowHeaders = TRUE) {
+    $output = ob_get_flush();
+    $stream = fopen('php://memory', 'r+');
+    fwrite($stream, $output);
+    rewind($stream);
+    $csv = Reader::createFromString($output);
+    if ($isFirstRowHeaders) {
+      $csv->setHeaderOffset(0);
+    }
+    ob_clean();
+    return $csv;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is primarily an improvement in our testing of export output.

However, it does has the effect that altering the table name in the export hook is deprecated. Part of the longer term plan here is to write temp tables only when required (currently we write row by row to the temp table & then read it row by row and write to a csv file. The only scenario where we could not skip the temp table step is when we are merging same address.

Before
----------------------------------------
No precedent for testing csv output directly

After
----------------------------------------
Precedent set

Technical Details
----------------------------------------
This is our first in-test usage of the premature exit exception (thrown in civiExit for the benefit of tests). It is a bit of a prototype but holds the answer to a lot of problems we've had testing some flows

Comments
----------------------------------------
Written over another formatting commit - will rebase once that is merged
