### PR TITLE
Ensure that completed status is selected by default on search contrib…

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -163,8 +163,12 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       CRM_Core_Error::deprecatedFunctionWarning('pass receive_date_high not end');
     }
     $this->_defaults = parent::setDefaultValues();
-    if (empty($this->_defaults['contribution_status'])) {
-      $this->_defaults['contribution_status'][1] = 1;
+    if (empty($this->_defaults['contribution_status_id'])) {
+      $this->_defaults['contribution_status_id'][1] = CRM_Core_PseudoConstant::getKey(
+        'CRM_Contribute_BAO_Contribution',
+        'contribution_status_id',
+        'Completed'
+      );
     }
     return $this->_defaults;
   }


### PR DESCRIPTION
…ution form

Overview
----------------------------------------
This fixes a small bug where when loading the contribution form the status field doesn't have a default of completed status.

Before
----------------------------------------
![contribution_search_change_pre](https://user-images.githubusercontent.com/6799125/59972292-cbb64600-95cf-11e9-8bde-657c9aea83c4.jpg)

After
----------------------------------------
![contribution_search_change_post](https://user-images.githubusercontent.com/6799125/59972294-d375ea80-95cf-11e9-8805-918eb0676d67.jpg)

ping @eileenmcnaughton @monishdeb @mattwire 