### PR TITLE
Improve handling of 'Manage Event' title

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -171,33 +171,21 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
 
     $this->assign('isTemplate', $this->_isTemplate);
 
+    // Set "Manage Event" Title
+    $title = NULL;
     if ($this->_id) {
       if ($this->_isTemplate) {
-        $title = CRM_Utils_Array::value('template_title', $eventInfo);
-        CRM_Utils_System::setTitle(ts('Edit Event Template') . " - $title");
+        $title = ts('Edit Event Template') . ' - ' . CRM_Utils_Array::value('template_title', $eventInfo);
       }
       else {
-        $configureText = ts('Configure Event');
-        $title = CRM_Utils_Array::value('title', $eventInfo);
-        //If it is a repeating event change title
-        if ($this->_isRepeatingEvent) {
-          $configureText = 'Configure Repeating Event';
-        }
-        CRM_Utils_System::setTitle($configureText . " - $title");
+        $configureText = $this->_isRepeatingEvent ? ts('Configure Repeating Event') : ts('Configure Event');
+        $title = $configureText . ' - ' . CRM_Utils_Array::value('title', $eventInfo);
       }
-      $this->assign('title', $title);
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {
-      if ($this->_isTemplate) {
-        $title = ts('New Event Template');
-        CRM_Utils_System::setTitle($title);
-      }
-      else {
-        $title = ts('New Event');
-        CRM_Utils_System::setTitle($title);
-      }
-      $this->assign('title', $title);
+      $title = $this->_isTemplate ? ts('New Event Template') : ts('New Event');
     }
+    $this->setTitle($title);
 
     if (CRM_Core_Permission::check('view event participants') &&
       CRM_Core_Permission::check('view all contacts')
@@ -393,7 +381,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
 
       CRM_Core_Session::setStatus(ts("'%1' information has been saved.",
         [1 => CRM_Utils_Array::value('title', CRM_Utils_Array::value($subPage, $this->get('tabHeader')), $className)]
-      ), ts('Saved'), 'success');
+      ), $this->getTitle(), 'success');
 
       $config = CRM_Core_Config::singleton();
       if (in_array('CiviCampaign', $config->enableComponents)) {


### PR DESCRIPTION
Overview
----------------------------------------
Switch to using standard form method for assigning title so we have access to the title during postprocess.

Before
----------------------------------------
Title not set on form object during postprocess.

After
----------------------------------------
Title set on form object during postprocess and used in the "Saved" message:
![image](https://user-images.githubusercontent.com/2052161/59975182-00fd6c80-95ad-11e9-99c6-f4a4f52ad8cb.png)


Technical Details
----------------------------------------
Switch from CRM_Utils_System::setTitle() to $this->setTitle().  Assign the title to the form in `CRM_Core_Form::setTitle()` method as we've done with other extractions.

Comments
----------------------------------------
@alifrumin @lcdservices Either of you in a position to test from a UI POV?
