### PR TITLE
Set title using standard form method and use for success message on contributionpage

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -120,13 +120,13 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     CRM_Contribute_Form_ContributionPage_TabHeader::build($this);
 
     if ($this->_action == CRM_Core_Action::UPDATE) {
-      CRM_Utils_System::setTitle(ts('Configure Page - %1', [1 => $title]));
+      $this->setTitle(ts('Configure Page - %1', [1 => $title]));
     }
     elseif ($this->_action == CRM_Core_Action::VIEW) {
-      CRM_Utils_System::setTitle(ts('Preview Page - %1', [1 => $title]));
+      $this->setTitle(ts('Preview Page - %1', [1 => $title]));
     }
     elseif ($this->_action == CRM_Core_Action::DELETE) {
-      CRM_Utils_System::setTitle(ts('Delete Page - %1', [1 => $title]));
+      $this->setTitle(ts('Delete Page - %1', [1 => $title]));
     }
 
     //cache values.
@@ -420,7 +420,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
 
       CRM_Core_Session::setStatus(ts("'%1' information has been saved.",
         [1 => CRM_Utils_Array::value('title', CRM_Utils_Array::value($subPage, $this->get('tabHeader')), $className)]
-      ), ts('Saved'), 'success');
+      ), $this->getTitle(), 'success');
 
       $this->postProcessHook();
 


### PR DESCRIPTION
Overview
----------------------------------------
Switch to using standard form method for assigning title so we have access to the title during postprocess.

Before
----------------------------------------
Title not set on form object during postprocess.

After
----------------------------------------
Title set on form object during postprocess and used in the "Saved" message

Technical Details
----------------------------------------
Switch from CRM_Utils_System::setTitle() to $this->setTitle(). Assign the title to the form in CRM_Core_Form::setTitle() method as we've done with other extractions.

Comments
----------------------------------------
