### PR TITLE
WIP Fix redirection on manage event tabs

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -313,7 +313,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     if ($this->_single) {
       $buttons = [
         [
-          'type' => 'upload',
+          'type' => 'next',
           'name' => ts('Save'),
           'isDefault' => TRUE,
         ],
@@ -395,19 +395,18 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
         }
       }
       $this->postProcessHook();
-      if ($this->controller->getButtonName('submit') == "_qf_{$className}_upload_done") {
-        if ($this->_isTemplate) {
-          CRM_Core_Session::singleton()
-            ->pushUserContext(CRM_Utils_System::url('civicrm/admin/eventTemplate', 'reset=1'));
-        }
-        else {
-          CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/event/manage', 'reset=1'));
-        }
-      }
-      else {
+      if ($this->controller->getButtonName('submit') == "_qf_{$className}_next") {
         CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url("civicrm/event/manage/{$subPage}",
           "action=update&reset=1&id={$this->_id}"
         ));
+      }
+      else {
+        if ($this->_isTemplate) {
+          CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/eventTemplate', 'reset=1'));
+        }
+        else {
+          CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/manage', 'reset=1'));
+        }
       }
     }
   }

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -146,8 +146,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
       if (!CRM_Utils_System::isNull($eventTemplates)) {
         $this->add('select', 'template_id', ts('From Template'), ['' => ts('- select -')] + $eventTemplates, FALSE, ['class' => 'crm-select2 huge']);
       }
-      // Make sure this form redirects properly
-      $this->preventAjaxSubmit();
     }
 
     // add event title, make required if this is not a template

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -78,11 +78,10 @@ class CRM_Event_Form_ManageEvent_TabHeader {
       'valid' => TRUE,
       'active' => TRUE,
       'current' => FALSE,
-      'class' => 'ajaxForm',
     ];
 
     $tabs = [];
-    $tabs['settings'] = ['title' => ts('Info and Settings'), 'class' => 'ajaxForm livePage'] + $default;
+    $tabs['settings'] = ['title' => ts('Info and Settings')] + $default;
     $tabs['location'] = ['title' => ts('Event Location')] + $default;
     $tabs['fee'] = ['title' => ts('Fees')] + $default;
     $tabs['registration'] = ['title' => ts('Online Registration')] + $default;
@@ -155,11 +154,8 @@ WHERE      e.id = %1
       }
     }
 
-    // see if any other modules want to add any tabs
-    // note: status of 'valid' flag of any injected tab, needs to be taken care in the hook implementation.
-    CRM_Utils_Hook::tabset('civicrm/event/manage', $tabs,
-      ['event_id' => $eventID]);
-
+    // Call tabset hook to add/remove custom tabs
+    CRM_Utils_Hook::tabset('civicrm/event/manage', $tabs, ['event_id' => $eventID]);
     $fullName = $form->getVar('_name');
     $className = CRM_Utils_String::getClassName($fullName);
     $new = '';


### PR DESCRIPTION
Overview
----------------------------------------
I have been having various issues with "Save and Done", "Cancel" buttons either not redirecting, or redirecting to the wrong place.  I've traced this to the classes being added during tabset creation and the buttons now seem to redirect correctly in all circumstances I could test.

Before
----------------------------------------
"Save and Done", "Cancel" buttons unreliable on some tabs, or when loaded directly rather than redirected from another page etc.

After
----------------------------------------
"Save and Done", "Cancel" buttons reliable in all cases (as far as I can tell).

Technical Details
----------------------------------------
ajaxForm and livePage classes affect what the "tab" does, but they should not be added except in specific circumstances (eg. you have a list of entities).  I've removed them and cleaned up the redirect logic to be more specific (and aligned with the way contributionpage does it).

Comments
----------------------------------------
