### PR TITLE
dev/core#926 & dev/core#1048 Fix group search builder bugs

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2962,6 +2962,8 @@ class CRM_Contact_BAO_Query {
    * Where / qill clause for groups.
    *
    * @param $values
+   *
+   * @throws \CRM_Core_Exception
    */
   public function group($values) {
     list($name, $op, $value, $grouping, $wildcard) = $values;
@@ -3008,8 +3010,10 @@ class CRM_Contact_BAO_Query {
     $isNotOp = ($op == 'NOT IN' || $op == '!=');
 
     $statusJoinClause = $this->getGroupStatusClause($grouping);
+    // If we are searching for 'Removed' contacts then despite it being a smart group we only care about the group_contact table.
+    $isGroupStatusSearch = (!empty($this->getSelectedGroupStatuses($grouping)) && $this->getSelectedGroupStatuses($grouping) !== ["'Added'"]);
     $groupClause = [];
-    if ($hasNonSmartGroups || empty($value)) {
+    if ($hasNonSmartGroups || empty($value) || $isGroupStatusSearch) {
       // include child groups IDs if any
       $childGroupIds = (array) CRM_Contact_BAO_Group::getChildGroupIds($regularGroupIDs);
       foreach ($childGroupIds as $key => $id) {
@@ -3023,7 +3027,13 @@ class CRM_Contact_BAO_Query {
       }
 
       if (empty($regularGroupIDs)) {
-        $regularGroupIDs = [0];
+        if ($isGroupStatusSearch) {
+          $regularGroupIDs = $smartGroupIDs;
+        }
+        // If it is still empty we want a filter that blocks all results.
+        if (empty($regularGroupIDs)) {
+          $regularGroupIDs = [0];
+        }
       }
 
       // if $regularGroupIDs is populated with regular child group IDs
@@ -3059,8 +3069,9 @@ class CRM_Contact_BAO_Query {
     }
 
     //CRM-19589: contact(s) removed from a Smart Group, resides in civicrm_group_contact table
-    $groupContactCacheClause = '';
-    if (count($smartGroupIDs) || empty($value)) {
+    // If we are only searching for Removed or Pending contacts we don't need to resolve the smart group
+    // as that info is in the group_contact table.
+    if ((count($smartGroupIDs) || empty($value)) && !$isGroupStatusSearch) {
       $this->_groupUniqueKey = uniqid();
       $this->_groupKeys[] = $this->_groupUniqueKey;
       $gccTableAlias = "civicrm_group_contact_cache_{$this->_groupUniqueKey}";

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2999,10 +2999,10 @@ class CRM_Contact_BAO_Query {
     $regularGroupIDs = $smartGroupIDs = [];
     foreach ((array) $value as $id) {
       if (CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $id, 'saved_search_id')) {
-        $smartGroupIDs[] = $id;
+        $smartGroupIDs[] = (int) $id;
       }
       else {
-        $regularGroupIDs[] = trim($id);
+        $regularGroupIDs[] = (int) trim($id);
       }
     }
     $hasNonSmartGroups = count($regularGroupIDs);
@@ -3036,29 +3036,22 @@ class CRM_Contact_BAO_Query {
         }
       }
 
-      // if $regularGroupIDs is populated with regular child group IDs
-      //   then change the mysql operator to desired
-      if (count($regularGroupIDs) > 1) {
-        $op = strpos($op, 'IN') ? $op : ($op == '!=') ? 'NOT IN' : 'IN';
-      }
-      $groupIds = '';
-      if (!empty($regularGroupIDs)) {
-        $groupIds = CRM_Utils_Type::validate(
-          implode(',', (array) $regularGroupIDs),
-          'CommaSeparatedIntegers'
-        );
-      }
       $gcTable = "`civicrm_group_contact-" . uniqid() . "`";
       $joinClause = ["contact_a.id = {$gcTable}.contact_id"];
 
-      if (strpos($op, 'IN') !== FALSE) {
-        $clause = "{$gcTable}.group_id $op ( $groupIds ) ";
-      }
-      elseif ($op == '!=') {
+      // @todo consider just casting != to NOT IN & handling both together.
+      if ($op == '!=') {
+        $groupIds = '';
+        if (!empty($regularGroupIDs)) {
+          $groupIds = CRM_Utils_Type::validate(
+            implode(',', (array) $regularGroupIDs),
+            'CommaSeparatedIntegers'
+          );
+        }
         $clause = "{$gcTable}.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact cgc WHERE cgc.group_id = $groupIds )";
       }
       else {
-        $clause = "{$gcTable}.group_id $op $groupIds ";
+        $clause = self::buildClause("{$gcTable}.group_id", $op, ($op === '=' ? $regularGroupIDs[0] : $regularGroupIDs));
       }
       $groupClause[] = "( {$clause} )";
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2973,9 +2973,18 @@ class CRM_Contact_BAO_Query {
       $op = key($value);
       $value = $value[$op];
     }
-
-    // Replace pseudo operators from search builder
-    $op = str_replace('EMPTY', 'NULL', $op);
+    // Translate EMPTY to NULL as EMPTY is cannot be used in it's intended meaning here
+    // so has to be 'squashed into' NULL. (ie. group membership cannot be '').
+    // even one group might equate to multiple when looking at children so IN is simpler.
+    // @todo - also look at != casting but there are rows below to review.
+    $opReplacements = [
+      'EMPTY' => 'NULL',
+      'NOT EMPTY' => 'NOT NULL',
+      '=' => 'IN',
+    ];
+    if (isset($opReplacements[$op])) {
+      $op = $opReplacements[$op];
+    }
 
     if (strpos($op, 'NULL')) {
       $value = NULL;
@@ -3051,7 +3060,7 @@ class CRM_Contact_BAO_Query {
         $clause = "{$gcTable}.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact cgc WHERE cgc.group_id = $groupIds )";
       }
       else {
-        $clause = self::buildClause("{$gcTable}.group_id", $op, ($op === '=' ? $regularGroupIDs[0] : $regularGroupIDs));
+        $clause = self::buildClause("{$gcTable}.group_id", $op, $regularGroupIDs);
       }
       $groupClause[] = "( {$clause} )";
 

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
@@ -91,6 +91,8 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
   /**
    *  Test case for contact search: CRM-6706, CRM-6586 Parent Group search should return contacts from child groups too.
+   *
+   * @throws \Exception
    */
   public function testContactSearchByParentGroup() {
     // create a parent group
@@ -146,7 +148,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     $childContactParams = array(
       'first_name' => 'Child1 Fname',
       'last_name' => 'Child2 Lname',
-      'group' => array($childGroup['id'] => 1),
+      'group' => [$childGroup['id'] => 1],
     );
     $childContact = $this->individualCreate($childContactParams);
 

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -732,11 +732,30 @@ civicrm_relationship.is_active = 1 AND
   }
 
   /**
+   * Test we can narrow a group get by status.
+   *
+   * @throws \Exception
+   */
+  public function testGetByGroupWithStatusSmartGroup() {
+    $groupID = $this->smartGroupCreate();
+    // This means they are actually all hard-added, which is fine for this purpose.
+    $this->groupContactCreate($groupID, 3);
+    $groupContactID = $this->callAPISuccessGetSingle('GroupContact', ['group_id' => $groupID, 'options' => ['limit' => 1]])['id'];
+    $this->callAPISuccess('GroupContact', 'create', ['id' => $groupContactID, 'status' => 'Removed']);
+
+    $queryObj = new CRM_Contact_BAO_Query([['group', '=', $groupID, 0, 0], ['group_contact_status', 'IN', ['Removed' => 1], 0, 0]]);
+    $resultDAO = $queryObj->searchQuery();
+    $this->assertEquals(1, $resultDAO->N);
+  }
+
+  /**
    * Test the group contact clause does not contain an OR.
    *
    * The search should return 3 contacts - 2 households in the smart group of
    * Contact Type = Household and one Individual hard-added to it. The
    * Household that meets both criteria should be returned once.
+   *
+   * @throws \Exception
    */
   public function testGroupClause() {
     $this->householdCreate();

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -36,6 +36,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
       'civicrm_address',
     ];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -49,6 +49,7 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
    *   clause will need changing.
    *
    * @dataProvider querySets
+   * @throws \Exception
    */
   public function testSelectorQuery($dataSet) {
     $params = CRM_Contact_BAO_Query::convertFormValues($dataSet['form_values'], 0, FALSE, NULL, array());
@@ -176,6 +177,20 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
    */
   public function querySets() {
     return array(
+      array(
+        array(
+          'description' => 'Empty group test',
+          'class' => 'CRM_Contact_Selector',
+          'settings' => [],
+          'form_values' => [['contact_type', '=', 'Individual', 1, 0], ['group', 'IS NULL', '', 1, 0]],
+          'params' => [],
+          'return_properties' => NULL,
+          'context' => 'builder',
+          'action' => CRM_Core_Action::NONE,
+          'includeContactIds' => NULL,
+          'searchDescendentGroups' => FALSE,
+        ),
+      ),
       array(
         array(
           'description' => 'Normal default behaviour',

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -37,10 +37,6 @@
  */
 class CRM_Contact_SelectorTest extends CiviUnitTestCase {
 
-  public function tearDown() {
-
-  }
-
   /**
    * Test the query from the selector class is consistent with the dataset expectation.
    *
@@ -189,6 +185,7 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
           'action' => CRM_Core_Action::NONE,
           'includeContactIds' => NULL,
           'searchDescendentGroups' => FALSE,
+          'expected_query' => [],
         ),
       ),
       array(

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1245,13 +1245,15 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @param array $smartGroupParams
    * @param array $groupParams
+   * @param string $contactType
+   *
    * @return int
    */
-  public function smartGroupCreate($smartGroupParams = array(), $groupParams = array()) {
-    $smartGroupParams = array_merge(array(
-      'formValues' => array('contact_type' => array('IN' => array('Household'))),
-    ),
-    $smartGroupParams);
+  public function smartGroupCreate($smartGroupParams = [], $groupParams = [], $contactType = 'Household') {
+    $smartGroupParams = array_merge([
+      'formValues' => ['contact_type' => ['IN' => [$contactType]]],
+    ],
+      $smartGroupParams);
     $savedSearch = CRM_Contact_BAO_SavedSearch::create($smartGroupParams);
 
     $groupParams['saved_search_id'] = $savedSearch->id;


### PR DESCRIPTION
Overview
----------------------------------------
This pulls fixes for 2 group search bugs from other PRs into one
1) search for groups is empty doesn't work via search builder https://github.com/civicrm/civicrm-core/pull/14553
2) searching within a group for removed contacts ignores the removed status https://github.com/civicrm/civicrm-core/pull/14182

I have combined them into one PR as they both work on the same code (and needed some melding) and I think it's important for them to be tested together. They are both regressions of different ages so targetting 5.15

Before
----------------------------------------
Bug 1 - searching on empty smart groups in search builder fails with a fatal error with critieria like this
![Screenshot of failed search critieria](https://i.stack.imgur.com/zGpvW.png)

Bug 2 - removed contacts in search results when status=removed have been selected
![Screenshot 2019-05-02 17 12 39](https://user-images.githubusercontent.com/336308/57060090-3358bf00-6d0c-11e9-81e9-f87f17b2bb0c.png)


After
----------------------------------------

Bug 2
- only removed contacts

Technical Details
----------------------------------------
The underlying issue here (IMHO) is that very complicated group search functionality 'snuck in' through the back door. Some moderately simple (but still tricky) group search functionality was built into advanced search. Since it was done very early on it was not done with the sort of form layer & query layer separation we aim for now. Later groups were exposed in search builder and wound up having all operators exposed. Since some didn't work they were perceived as 'broken' and a succession of people set about trying to fix them to work. Alongside this it was determined that core logic in the way the functionality worked (probably stemming from the very start of group search functionality) was insecure so a series of parallel fixes started tackling that. 

The result has been a very long stream of whack-a-mole in this area :-( The real fix, IMHO, is either to totally re-write it from the ground up with the sort of time budget it should have had in the first place or to remove it from core & let an extension deal with it. However, in practical terms I think we can do neither (people will have pre-existing smart groups based on it). We can do what we have increasingly been doing and insist on unit tests with every fix so we can close the net on the whackamole (I realise some people are frustrated by our requirement that they write unit tests but I also find people remarkably open to us requiring others to meet that standard :-)

The other thing I think we should consider is making a conscious decision to not agree to fixing the remaining underlying issue in core -namely that many of the functions work on regular groups only & in many cases are misleading. Perhaps there is something we can do in the UI to be clearer but I worry we are only one bug-fix away from a whole new round of whackamole and people complaining their server has been brought down by a 'groups empty' search in search builder because it resolves all 2683 smart groups on their site - or similar

Perhaps apiv4 could support something the groaning search builder maybe can't

@monishdeb @jitendrapurohit @jaapjansma @pradpnayak @seamuslee001 @colemanw 

Comments
----------------------------------------
@pradpnayak one of these patches is yours - are you able to review this to check that in my tweaking the 2 together I didn't break anything you fixed (& please also test the other scenario so we can get this merged)

Also, I have a feeling this might not backport well. I'm OK with us trying to port it to 5.14 once merged but let's focus on 5.15 & 5.14 can be an optional extra

https://lab.civicrm.org/dev/core/issues/926
https://lab.civicrm.org/dev/core/issues/1048