### PR TITLE
EntityPageTrait: Set logged in contact ID as default if one is not specified - this allows permission checks etc. to work properly.

### DIFF
--- a/CRM/Core/Page/EntityPageTrait.php
+++ b/CRM/Core/Page/EntityPageTrait.php
@@ -145,7 +145,8 @@ trait CRM_Core_Page_EntityPageTrait {
     $this->assign('action', $this->getAction());
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->setContactId(CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE));
+    $this->setContactId(CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, CRM_Core_Session::getLoggedInContactID()));
+
     $this->assign('contactId', $this->getContactId());
 
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, $this->getDefaultContext());


### PR DESCRIPTION
Overview
----------------------------------------
Currently the entitypagetrait is only in use by `CRM_Contact_Page_View_Relationship`.  However the plan is to extend it to other pages too.  This PR updates it to get the logged in contact ID if none is passed in - so it can be used on non-contact forms (eg. event lists).

Before
----------------------------------------
Requires a contact ID to be passed in via `$_GET`

After
----------------------------------------
Uses a contact ID passed in via `$_GET`, if not set gets the logged in contact ID.

Technical Details
----------------------------------------


Comments
----------------------------------------

