### PR TITLE
[REF] Copy assignProportional Line items back into Payment.create function

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -118,7 +118,17 @@ class CRM_Financial_BAO_Payment {
         }
       }
       elseif (!empty($trxn)) {
-        CRM_Contribute_BAO_Contribution::assignProportionalLineItems($params, $trxn->id, $contribution['total_amount']);
+        $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($params['contribution_id']);
+        if (!empty($lineItems)) {
+          // get financial item
+          list($ftIds, $taxItems) = CRM_Contribute_BAO_Contribution::getLastFinancialItemIds($params['contribution_id']);
+          $entityParams = [
+            'contribution_total_amount' => $contribution['total_amount'],
+            'trxn_total_amount' => $params['total_amount'],
+            'trxn_id' => $trxn->id,
+          ];
+          CRM_Contribute_BAO_Contribution::createProportionalFinancialEntries($entityParams, $lineItems, $ftIds, $taxItems);
+        }
       }
     }
     elseif ($params['total_amount'] < 0) {


### PR DESCRIPTION
Overview
----------------------------------------
No functional change, moving code for readability

Before
----------------------------------------
Payment.create calls assignProportionalLineItems

After
----------------------------------------
Code from assignProportionalLineItems copied into payment create, no longer shared.

Technical Details
----------------------------------------
This is a case where (unintuitively) I feel reducing code sharing and extraction makes sense. The reason being I think the 'needs' of adding a payment are not obviously the same as the needs of 'changing a payment instrument' and the code feels confusion and like the extractions make less sense now than they did. In the interests of improving it bringing it back together seems the right path to me here. We can then edit for the purposes of payment create code very specifically (and all functions that add payments need to call that)

Comments
----------------------------------------
@monishdeb another in this chain all towards a final fix on @kcristiano line item allocation PR - note there is another one in the queue that also needs resolution before we fix the 'actual bug' - ie https://github.com/civicrm/civicrm-core/pull/14589
