### PR TITLE
Add query object support for receive_date_high & receive_date_low and generically date fields

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2140,6 +2140,12 @@ class CRM_Contact_BAO_Query {
       $field = CRM_Utils_Array::value($locType[0], $this->_fields);
 
       if (!$field) {
+        // Strip any trailing _high & _low that might be appended.
+        $realFieldName = str_replace(['_high', '_low'], '', $name);
+        if (isset($this->_fields[$realFieldName])) {
+          $field = $this->_fields[str_replace(['_high', '_low'], '', $realFieldName)];
+          $this->dateQueryBuilder($values, $field['table_name'], $realFieldName, $realFieldName, $field['title']);
+        }
         return;
       }
     }
@@ -5214,6 +5220,7 @@ civicrm_relationship.start_date > {$today}
     $appendTimeStamp = TRUE,
     $dateFormat = 'YmdHis'
   ) {
+    // @todo - remove dateFormat - pretty sure it's never passed in...
     list($name, $op, $value, $grouping, $wildcard) = $values;
 
     if ($name == "{$fieldName}_low" ||

--- a/tests/phpunit/CRM/Contribute/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/QueryTest.php
@@ -2,12 +2,14 @@
 
 /**
  *  Include dataProvider for tests
+ *
  * @group headless
  */
 class CRM_Contribute_BAO_QueryTest extends CiviUnitTestCase {
 
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**
@@ -19,6 +21,8 @@ class CRM_Contribute_BAO_QueryTest extends CiviUnitTestCase {
    *   Does the order by use a key sort. A key sort uses the mysql 'field' function to
    *   order by a passed in list. It makes sense for option groups & small sets
    *   but may not do for long lists like states - performance testing not done on that yet.
+   *
+   * @throws \CRM_Core_Exception
    *
    * @dataProvider getSortFields
    */
@@ -62,6 +66,22 @@ class CRM_Contribute_BAO_QueryTest extends CiviUnitTestCase {
       ['state_province', FALSE],
       ['country', FALSE],
     ];
+  }
+
+  /**
+   * Test receive_date_high, low & relative work.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testRelativeContributionDates() {
+    $this->contributionCreate(['receive_date' => '2018-01-02', 'contact_id' => $this->individualCreate()]);
+    $this->contributionCreate(['receive_date' => '2017-01-02', 'contact_id' => $this->individualCreate()]);
+    $queryObj = new CRM_Contact_BAO_Query([['receive_date_low', '=', 20170101, 1, 0]]);
+    $this->assertEquals(2, $queryObj->searchQuery(0, 0, NULL, TRUE));
+    $queryObj = new CRM_Contact_BAO_Query([['receive_date_low', '=', 20180101, 1, 0]]);
+    $this->assertEquals(1, $queryObj->searchQuery(0, 0, NULL, TRUE));
+    $queryObj = new CRM_Contact_BAO_Query([['receive_date_high', '=', 20180101, 1, 0]]);
+    $this->assertEquals(1, $queryObj->searchQuery(0, 0, NULL, TRUE));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Further fix on the 5.16 work to switch contribution receive_date over to use datepicker object. We have already merged the main change but it was identified in testing that the low & high date values were not filtering correctly.

Before
----------------------------------------
Choosing from receive date in advanced search not filtering

After
----------------------------------------
Choosing from receive date in advanced search filtering

Technical Details
----------------------------------------
@seamuslee001 I believe in general we should be removing special field handling (when we touch the fields) in favour of generic handling - this accepts the field is 'falling through' to default handling & 'clevers that up' to code with dates

Comments
----------------------------------------
Todo on here - we should add links to related - @seamuslee001 feel free to help on this bit