### PR TITLE
dev/core#1059 Fix contribution search to work with url parameters in force mode

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -419,19 +419,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
   public function addRules() {
   }
 
-  /**
-   * Set the default form values.
-   *
-   *
-   * @return array
-   *   the default array reference
-   */
-  public function setDefaultValues() {
-    $defaults = [];
-    $defaults = $this->_formValues;
-    return $defaults;
-  }
-
   public function fixFormValues() {
     // if this search has been forced
     // then see if there are any get values, and if so over-ride the post values


### PR DESCRIPTION
Overview
----------------------------------------
This is an additional PR in the work on converting receive_date to a datepicker - it fixes an issue where url parameters were not being respected in force mode

Before
----------------------------------------
From manage contribution page choose contributions this month - date criteria not applied

After
----------------------------------------
Date criteria applied

Technical Details
----------------------------------------
@seamuslee001 this is the missing piece on your PR - not I will rebase out the patch from https://github.com/civicrm/civicrm-core/pull/14477 once this is merged

Comments
----------------------------------------

I couldn't find other references to 'contribution_date' - I think there is a test for relative dates that references it still which should probably be fixed...