### PR TITLE
dev/core#389 Fix custom data relative date searching

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -607,7 +607,7 @@ class CRM_Contact_BAO_Query {
       if (empty($value[0])) {
         continue;
       }
-      $cfID = CRM_Core_BAO_CustomField::getKeyID($value[0]);
+      $cfID = CRM_Core_BAO_CustomField::getKeyID(str_replace('_relative', '', $value[0]));
       if ($cfID) {
         if (!array_key_exists($cfID, $this->_cfIDs)) {
           $this->_cfIDs[$cfID] = [];
@@ -1638,8 +1638,7 @@ class CRM_Contact_BAO_Query {
       }
       elseif (substr($id, 0, 7) == 'custom_'
         &&  (
-          substr($id, -9, 9) == '_relative'
-          || substr($id, -5, 5) == '_from'
+          substr($id, -5, 5) == '_from'
           || substr($id, -3, 3) == '_to'
         )
       ) {
@@ -6932,7 +6931,9 @@ AND   displayRelType.is_active = 1
     $tableName = $fieldSpec['table_name'];
     $filters = CRM_Core_OptionGroup::values('relative_date_filters');
     $grouping = CRM_Utils_Array::value(3, $values);
-    $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;
+    // If the table value is already set for a custom field it will be more nuanced than just '1'.
+    $this->_tables[$tableName] = $this->_tables[$tableName] ?? 1;
+    $this->_whereTables[$tableName] = $this->_whereTables[$tableName] ?? 1;
 
     $dates = CRM_Utils_Date::getFromTo($value, NULL, NULL);
     if (empty($dates[0])) {

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -434,10 +434,12 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
    * @param array $formValues
    */
   public static function saveRelativeDates(&$queryParams, $formValues) {
+    // This is required only until all fields are converted to datepicker fields as the new format is truer to the
+    // form format and simply saves (e.g) custom_3_relative => "this.year"
     $relativeDates = ['relative_dates' => []];
     $specialDateFields = ['event_relative', 'case_from_relative', 'case_to_relative', 'participant_relative'];
     foreach ($formValues as $id => $value) {
-      if ((preg_match('/(_date|custom_[0-9]+)_relative$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
+      if ((preg_match('/_date$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
         $entityName = strstr($id, '_date', TRUE);
         if (empty($entityName)) {
           $entityName = strstr($id, '_relative', TRUE);

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -205,9 +205,11 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
   /**
    * Test relative dates
    *
-   * The function saveRelativeDates should detect whether a field is using
-   * a relative date range and include in the fromValues a relative_date
-   * index so it is properly detects when executed.
+   * This is a slightly odd test because it was originally created to test that we DO create a
+   * special 'relative_dates' key but the new favoured format is not to do that and to
+   * save (eg) custom_1_relative = this.day.
+   *
+   * It still presumably provides useful 'this does not fatal or give enotice' coverage.
    */
   public function testCustomFieldRelativeDates() {
     // Create a custom field.
@@ -246,8 +248,7 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
     // Since custom_13 doesn't have the word 'date' in it, the key is
     // set to 0, rather than the field name.
-    $err = 'Relative date in custom field smart group creation failed.';
-    $this->assertArrayHasKey('relative_dates', $queryParams, $err);
+    $this->assertArrayNotHasKey('relative_dates', $queryParams, 'Relative date in custom field smart group creation failed.');
     $dropCustomValueTables = TRUE;
     $this->quickCleanup(array('civicrm_saved_search'), $dropCustomValueTables);
   }

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -42,14 +42,15 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     // Assigning the relevant form value to be within a custom key is normally done in
     // build field params. It would be better if it were all done in convertFormValues
     // but for now we just imitate it.
-    $params[$dateCustomField['id']] = CRM_Contact_BAO_Query::convertFormValues($formValues);
-    $queryObj = new CRM_Core_BAO_CustomQuery($params);
-    $queryObj->Query();
+
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues);
+    $queryObj = new CRM_Contact_BAO_Query($params);
     $this->assertEquals(
-      'civicrm_value_testsearchcus_1.date_field_2 BETWEEN "' . date('Y') . '0101000000" AND "' . date('Y') . '1231235959"',
+      "civicrm_value_testsearchcus_1.date_field_2 BETWEEN '" . date('Y') . "0101000000' AND '" . date('Y') . "1231235959'",
       $queryObj->_where[0][0]
     );
-    $this->assertEquals($queryObj->_qill[0][0], "date field BETWEEN 'January 1st, " . date('Y') . " 12:00 AM AND December 31st, " . date('Y') . " 11:59 PM'");
+    $this->assertEquals("date field is This calendar year (between January 1st, " . date('Y') . " 12:00 AM and December 31st, " . date('Y') . " 11:59 PM)", $queryObj->_qill[0][0]);
+    $queryObj = new CRM_Core_BAO_CustomQuery($params);
     $this->assertEquals([
       'id' => $dateCustomField['id'],
       'label' => 'date field',


### PR DESCRIPTION
Overview
----------------------------------------
This addresses a fairly old regression where smart groups based on relative dates for custom fields stopped being relative & started using the date as of the query being saved.

Note this will not fix previously saved groups


Before
----------------------------------------
Create a smart group based on a custom field using relative dates (to do this on a default data set you need to alter marriage date custom field to support range searching and also ensure some contacts have this data. Today is a good date range to choose!
<img width="1039" alt="Screen Shot 2019-06-24 at 1 31 41 PM" src="https://user-images.githubusercontent.com/336308/59985231-6c663d80-9684-11e9-9d0f-cc4e09738631.png">

Check the smart group can be reloaded.

Check that when the date changes the search contents do too...

After
----------------------------------------
The smart group can still be created but it no longer stores any fixed dates in the saved_search.form_value field. The 'relative_dates' field is also no longer used for any fields that use datepicker

a:8:{i:0;a:5:{i:0;s:8:"entryURL";i:1;s:1:"=";i:2;s:105:"http://dmaster.local/civicrm/admin/custom/group/field/update?action=update&amp;reset=1&amp;gid=1&amp;id=3";i:3;i:0;i:4;i:0;}i:1;a:5:{i:0;s:21:"group_search_selected";i:1;s:1:"=";i:2;s:5:"group";i:3;i:0;i:4;i:0;}i:2;a:5:{i:0;s:16:"privacy_operator";i:1;s:1:"=";i:2;s:2:"OR";i:3;i:0;i:4;i:0;}i:3;a:5:{i:0;s:14:"privacy_toggle";i:1;s:1:"=";i:2;s:1:"1";i:3;i:0;i:4;i:0;}i:4;a:5:{i:0;s:18:"custom_11_operator";i:1;s:1:"=";i:2;s:2:"or";i:3;i:0;i:4;i:0;}i:5;a:5:{i:0;s:17:"custom_3_relative";i:1;s:1:"=";i:2;s:9:"this.year";i:3;i:0;i:4;i:0;}i:6;a:5:{i:0;s:8:"operator";i:1;s:1:"=";i:2;s:3:"AND";i:3;i:0;i:4;i:0;}i:7;a:5:{i:0;s:14:"component_mode";i:1;s:1:"=";i:2;s:1:"1";i:3;i:0;i:4;i:0;}}

Technical Details
----------------------------------------
This does not fix any existing groups (& I am leaving that out of scope for safety & because it is an old regression & people may have 'taken steps' but any new ones saved will work, hence no upgrade script

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/389