### PR TITLE
Fix notice on editing contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -398,8 +398,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
             'id' => $contributionID,
             'return' => ['total_amount', 'net_amount', 'fee_amount'],
           ]);
-          $totalAmount = isset($params['total_amount']) ? $params['total_amount'] : CRM_Utils_Array::value('total_amount', $contribution);
-          $feeAmount = isset($params['fee_amount']) ? $params['fee_amount'] : CRM_Utils_Array::value('fee_amount', $contribution);
+          $totalAmount = (isset($params['total_amount']) ? (float) $params['total_amount'] : (float) CRM_Utils_Array::value('total_amount', $contribution));
+          $feeAmount = (isset($params['fee_amount']) ? (float) $params['fee_amount'] : (float) CRM_Utils_Array::value('fee_amount', $contribution));
           $params['net_amount'] = $totalAmount - $feeAmount;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a notice I was hitting when testing financial acls in conjunction with https://github.com/civicrm/civicrm-core/pull/14244

Before
----------------------------------------
<img width="741" alt="Screen Shot 2019-06-24 at 2 37 53 PM" src="https://user-images.githubusercontent.com/336308/59987329-7db44780-968e-11e9-9443-3a97ad54c2f7.png">


After
----------------------------------------
No notice

Technical Details
----------------------------------------
I'm just casting these to a float - fee_amount was '' so I assume that was the issue

Comments
----------------------------------------

