### PR TITLE
Follow up to receive_date convert to datepicker - update test

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -184,23 +184,21 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
       'operator' => 'AND',
       'event_relative' => 'this.month',
       'participant_relative' => 'today',
-      'contribution_date_relative' => 'this.week',
       'participant_test' => 0,
       'title' => 'testsmart',
       'radio_ts' => 'ts_all',
     );
-    $queryParams = array();
+    $queryParams = [];
     CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
     CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
     $savedSearch->form_values = serialize($queryParams);
     $savedSearch->save();
 
     $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
-    $expectedResult = array(
+    $expectedResult = [
       'event' => 'this.month',
       'participant' => 'today',
-      'contribution' => 'this.week',
-    );
+    ];
     $this->checkArrayEquals($result['relative_dates'], $expectedResult);
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1899,7 +1899,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   public function checkArrayEquals(&$actual, &$expected) {
     self::unsetId($actual);
     self::unsetId($expected);
-    $this->assertEquals($actual, $expected);
+    $this->assertEquals($expected, $actual);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a test that is no longer testing the right format

Before
----------------------------------------
Testing for old format - https://test.civicrm.org/job/CiviCRM-Core-PR/27239/testReport/junit/(root)/CRM_Contact_BAO_SavedSearchTest/testRelativeDateValues/ shows this failing

After
----------------------------------------
contribution_date should no longer be handled in this way - altering the test

Technical Details
----------------------------------------


Comments
----------------------------------------
@seamuslee001 