### PR TITLE
Activity formRule status check cleanup

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -865,13 +865,17 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $errors['activity_type_id'] = ts('Activity Type is a required field');
     }
 
-    if (CRM_Utils_Array::value('activity_type_id', $fields) == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email')
-      && CRM_Utils_Array::value('status_id', $fields) == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled')) {
-      $errors['status_id'] = ts('You cannot record scheduled email activity.');
-    }
-    elseif (CRM_Utils_Array::value('activity_type_id', $fields) == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'SMS')
-      && CRM_Utils_Array::value('status_id', $fields) == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled')) {
-      $errors['status_id'] = ts('You cannot record scheduled SMS activity.');
+    $activity_type_id = CRM_Utils_Array::value('activity_type_id', $fields);
+    $activity_status_id = CRM_Utils_Array::value('status_id', $fields);
+    $scheduled_status_id = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled');
+
+    if ($activity_type_id && $activity_status_id == $scheduled_status_id) {
+      if ($activity_type_id == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email')) {
+        $errors['status_id'] = ts('You cannot record scheduled email activity.');
+      }
+      elseif ($activity_type_id == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'SMS')) {
+        $errors['status_id'] = ts('You cannot record scheduled SMS activity');
+      }
     }
 
     if (!empty($fields['followup_activity_type_id']) && empty($fields['followup_date'])) {


### PR DESCRIPTION
Under some circumstances, the activity_type_id from fields and from the getKey
call can both return NULL, causing the formRule to raise an error that one cannot
record a scheduled SMS activity.

Overview
----------------------------------------

To be honest, I cannot reproduce this on dmaster. I encounter this bug when:

- create a new Scheduled 'meeting' activity
- edit the activity, change the status to Complete.

![Capture d’écran de 2019-06-24 10-36-01](https://user-images.githubusercontent.com/254741/60027680-e50cd000-966b-11e9-89e7-5bddf6a0348a.png)


This is happening on databases that started using CiviCRM with version 1.6beta, so they may have a quirk or two, but I could not figure it out. The Option Value for the 'SMS' activity type is correctly set and is enabled. I tried disabling civimail on dmaster, but on my sites where this is happening, most components are enabled.

That said, the original validation code is difficult to read and not defensive enough. I would label this commit NFC, but it does fix a bug for me.