### PR TITLE
Remove handling for legacy PrevNextCache group as it has now been con…

### DIFF
--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -182,7 +182,6 @@ class CRM_Core_BAO_Cache_Psr16 {
   public static function getLegacyGroups() {
     $groups = [
       // Core
-      'CiviCRM Search PrevNextCache',
       'contact fields',
       'navigation',
       'custom data',


### PR DESCRIPTION
…verted

Overview
----------------------------------------
This is just a follow up to #14580 and removes the declaration of the prevNextCache from the psr16 legacy groups declaration

ping @eileenmcnaughton 