### PR TITLE
Handle relative start & end dates passed to datepicker widget

### DIFF
--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -49,6 +49,12 @@
         $dateField = $('<input type="' + type + '">').insertAfter($dataField);
         CRM.utils.copyAttributes($dataField, $dateField, ['placeholder', 'style', 'class', 'disabled', 'aria-label']);
         $dateField.addClass('crm-form-' + type);
+        if (!settings.minDate && !_.isUndefined(settings.start_date_years)) {
+          settings.minDate = '' + (new Date().getFullYear() - settings.start_date_years) + '-01-01';
+        }
+        if (!settings.maxDate && !_.isUndefined(settings.end_date_years)) {
+          settings.maxDate = '' + (new Date().getFullYear() + settings.end_date_years) + '-12-31';
+        }
         if (hasDatepicker) {
           settings.minDate = settings.minDate ? CRM.utils.makeDate(settings.minDate) : null;
           settings.maxDate = settings.maxDate ? CRM.utils.makeDate(settings.maxDate) : null;


### PR DESCRIPTION
Overview
----------------------------------------
Adds some client-side logic to the datepicker widget that was previously done server-side. Paves the way for afform.

Before
----------------------------------------
Relative max/min dates not accepted and had to be preprocessed server-side.

After
----------------------------------------
Relative max/min dates work.

Notes
----
This basically copies the php logic from [CRM_Core_BAO_CustomField](https://github.com/civicrm/civicrm-core/blob/5.14/CRM/Core/BAO/CustomField.php#L946-L948) into javascript.