### PR TITLE
Mailing tokens return empty string

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -120,11 +120,6 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $e->string = \CRM_Utils_Token::replaceDomainTokens($e->string, $domain, $isHtml, $e->message['tokens'], $useSmarty);
 
     if (!empty($e->context['contact'])) {
-      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], TRUE, $useSmarty);
-
-      // FIXME: This may depend on $contact being merged with hook values.
-      $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
-
       \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, $useSmarty);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Tokens return an empty string when using the mosaico email editor as discuss at this [issue](https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/issues/266).

### Step to reproduce
1. enable extensions flexmailer, mosaico and gdpr
1. create or edit a mail with mosaico editor
1. put a token, e.g. {contact.email_greeting}, in the text
1. preview the mail

### Environment
PHP: 7.1.30
WordPress: 5.2.2
CiviCRM: 5.14.1

Before
----------------------------------------
Tokens return empty string after parsing. For example, when working with the GDPR extension, most of the 'contact' tokens broken.

After
----------------------------------------
Tokens will return the expected value or remain no change for unknown tokens.

Technical Details
----------------------------------------
When an extension adds a token to the reserved categories, like 'contact', it may break the process for those default tokens. This PR fixes it by preventing the replacement. Another way to fix it is to merge the context before the process. Therefore it will always find a replacement.
```php
// FIXME: This may depend on $contact being merged with hook values.
$e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
```

Comments
----------------------------------------
This bug is caused by extensions, but we think it is worth to fix in the core.

Agileware ref: CIVICRM-1251
