### PR TITLE
Update example dates from 2009 to current year

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -730,38 +730,24 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function getDatePluginInputFormats() {
-    $dateInputFormats = [
-      "mm/dd/yy" => ts('mm/dd/yyyy (12/31/2009)'),
-      "dd/mm/yy" => ts('dd/mm/yyyy (31/12/2009)'),
-      "yy-mm-dd" => ts('yyyy-mm-dd (2009-12-31)'),
-      "dd-mm-yy" => ts('dd-mm-yyyy (31-12-2009)'),
-      'dd.mm.yy' => ts('dd.mm.yyyy (31.12.2009)'),
-      "M d, yy" => ts('M d, yyyy (Dec 31, 2009)'),
-      'd M yy' => ts('d M yyyy (31 Dec 2009)'),
-      "MM d, yy" => ts('MM d, yyyy (December 31, 2009)'),
-      'd MM yy' => ts('d MM yyyy (31 December 2009)'),
-      "DD, d MM yy" => ts('DD, d MM yyyy (Thursday, 31 December 2009)'),
-      "mm/dd" => ts('mm/dd (12/31)'),
-      "dd-mm" => ts('dd-mm (31-12)'),
-      "yy-mm" => ts('yyyy-mm (2009-12)'),
-      'M yy' => ts('M yyyy (Dec 2009)'),
-      "yy" => ts('yyyy (2009)'),
+    $yy = date('Y');
+    return [
+      "mm/dd/yy" => ts("mm/dd/yyyy (12/31/$yy)"),
+      "dd/mm/yy" => ts("dd/mm/yyyy (31/12/$yy)"),
+      "yy-mm-dd" => ts("yyyy-mm-dd ($yy-12-31)"),
+      "dd-mm-yy" => ts("dd-mm-yyyy (31-12-$yy)"),
+      "dd.mm.yy" => ts("dd.mm.yyyy (31.12.$yy)"),
+      "M d, yy" => ts("M d, yyyy (Dec 31, $yy)"),
+      "d M yy" => ts("d M yyyy (31 Dec $yy)"),
+      "MM d, yy" => ts("MM d, yyyy (December 31, $yy)"),
+      "d MM yy" => ts("d MM yyyy (31 December $yy)"),
+      "DD, d MM yy" => ts("DD, d MM yyyy (Thursday, 31 December $yy)"),
+      "mm/dd" => ts("mm/dd (12/31)"),
+      "dd-mm" => ts("dd-mm (31-12)"),
+      "yy-mm" => ts("yyyy-mm ($yy-12)"),
+      "M yy" => ts("M yyyy (Dec $yy)"),
+      "yy" => ts("yyyy ($yy)"),
     ];
-
-    /*
-    Year greater than 2000 get wrong result for following format
-    echo date( 'Y-m-d', strtotime( '7 Nov, 2001') );
-    echo date( 'Y-m-d', strtotime( '7 November, 2001') );
-    Return current year
-    expected :: 2001-11-07
-    output   :: 2009-11-07
-    However
-    echo date( 'Y-m-d', strtotime( 'Nov 7, 2001') );
-    echo date( 'Y-m-d', strtotime( 'November 7, 2001') );
-    gives proper result
-     */
-
-    return $dateInputFormats;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When creating a custom field the example dates are all 10 years old. This ensures they will always reflect the current year.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/60104311-329e4100-972f-11e9-924d-acc3f01b0e61.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/60104253-13071880-972f-11e9-9c6e-c4095078e3a1.png)

Comments
----------------------------------------
It's been 10 years. We're all a little older and wiser and able to use variables...
