### PR TITLE
Partially revert "Update example dates from 2009 to current year"

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -730,23 +730,22 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function getDatePluginInputFormats() {
-    $yy = date('Y');
     return [
-      "mm/dd/yy" => ts("mm/dd/yyyy (12/31/$yy)"),
-      "dd/mm/yy" => ts("dd/mm/yyyy (31/12/$yy)"),
-      "yy-mm-dd" => ts("yyyy-mm-dd ($yy-12-31)"),
-      "dd-mm-yy" => ts("dd-mm-yyyy (31-12-$yy)"),
-      "dd.mm.yy" => ts("dd.mm.yyyy (31.12.$yy)"),
-      "M d, yy" => ts("M d, yyyy (Dec 31, $yy)"),
-      "d M yy" => ts("d M yyyy (31 Dec $yy)"),
-      "MM d, yy" => ts("MM d, yyyy (December 31, $yy)"),
-      "d MM yy" => ts("d MM yyyy (31 December $yy)"),
-      "DD, d MM yy" => ts("DD, d MM yyyy (Thursday, 31 December $yy)"),
-      "mm/dd" => ts("mm/dd (12/31)"),
-      "dd-mm" => ts("dd-mm (31-12)"),
-      "yy-mm" => ts("yyyy-mm ($yy-12)"),
-      "M yy" => ts("M yyyy (Dec $yy)"),
-      "yy" => ts("yyyy ($yy)"),
+      "mm/dd/yy" => ts('mm/dd/yyyy (12/31/2009)'),
+      "dd/mm/yy" => ts('dd/mm/yyyy (31/12/2009)'),
+      "yy-mm-dd" => ts('yyyy-mm-dd (2009-12-31)'),
+      "dd-mm-yy" => ts('dd-mm-yyyy (31-12-2009)'),
+      'dd.mm.yy' => ts('dd.mm.yyyy (31.12.2009)'),
+      "M d, yy" => ts('M d, yyyy (Dec 31, 2009)'),
+      'd M yy' => ts('d M yyyy (31 Dec 2009)'),
+      "MM d, yy" => ts('MM d, yyyy (December 31, 2009)'),
+      'd MM yy' => ts('d MM yyyy (31 December 2009)'),
+      "DD, d MM yy" => ts('DD, d MM yyyy (Thursday, 31 December 2009)'),
+      "mm/dd" => ts('mm/dd (12/31)'),
+      "dd-mm" => ts('dd-mm (31-12)'),
+      "yy-mm" => ts('yyyy-mm (2009-12)'),
+      'M yy' => ts('M yyyy (Dec 2009)'),
+      "yy" => ts('yyyy (2009)'),
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Reverts #14635 due to translation issues.

Comments
----------------------------------------
Strings within `ts()` cannot contain variables.
Also, those strings would have been tricky to translate, so changing the year just so they can be "up to date looking" seems like a frivolous waste of translators' time.