### PR TITLE
Multilingual test fix and cleanup

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -230,11 +230,11 @@ class CRM_Core_I18n {
     }
 
     if ($enabled === NULL) {
-      $config = CRM_Core_Config::singleton();
+      $languageLimit = Civi::settings()->get('languageLimit');
       $enabled = [];
-      if (isset($config->languageLimit) and $config->languageLimit) {
+      if ($languageLimit) {
         foreach ($all as $code => $name) {
-          if (in_array($code, array_keys($config->languageLimit))) {
+          if (array_key_exists($code, $languageLimit)) {
             $enabled[$code] = $name;
           }
         }

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -59,12 +59,12 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
 
     CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
 
-    $this->callAPISuccess('Setting', 'create', array(
-      'languageLimit' => array(
-        'en_US',
-        'fr_CA',
-      ),
-    ));
+    $this->callAPISuccess('Setting', 'create', [
+      'languageLimit' => [
+        'en_US' => 1,
+        'fr_CA' => 1,
+      ],
+    ]);
 
     // Take a semi-random OptionGroup and test manually changing its label
     // in one language, while making sure it stays the same in English.


### PR DESCRIPTION
Overview
----------------------------------------
Simplifies the multilingual api wrapper code and fixes a hidden test failure.

Before
----------------------------------------
Test was passing, but for the wrong reason.

After
----------------------------------------
Test passes because it's actually correct.
