### PR TITLE
dev/core#1077 Fixes making report listing actions links hookable

### DIFF
--- a/CRM/Report/Page/InstanceList.php
+++ b/CRM/Report/Page/InstanceList.php
@@ -282,7 +282,12 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
         'confirm_message' => ts('Are you sure you want delete this report? This action cannot be undone.'),
       ];
     }
-
+    //Call link hook.
+    CRM_Utils_Hook::links('view.report.links',
+      NULL,
+      CRM_Core_DAO::$_nullObject,
+      $actions
+    );
     return $actions;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Making report action link on report listing page hookable.
Before
----------------------------------------
Not able to change action links with civicrm links hook.

After
----------------------------------------
Able to change action links with civicrm links hook.

Comments
----------------------------------------
More details: https://lab.civicrm.org/dev/core/issues/1077