### PR TITLE
Scheduled jobs: replace outdated wiki link

### DIFF
--- a/templates/CRM/Admin/Page/Job.tpl
+++ b/templates/CRM/Admin/Page/Job.tpl
@@ -25,7 +25,7 @@
 *}
 {capture assign=runAllURL}{crmURL p='civicrm/admin/runjobs' q="reset=1"}{/capture}
 <div class="help">
-    {ts 1=$runAllURL}You can configure scheduled jobs (cron tasks) for your CiviCRM installation. For most sites, your system administrator should set up one or more 'cron' tasks to run the enabled jobs. However, you can also <a href="%1">run all scheduled jobs manually</a>, or run specific jobs from this screen (click 'more' and then 'Execute Now').{/ts} {docURL page="Managing Scheduled Jobs" resource="wiki" text="(Job parameters and command line syntax documentation...)"}
+    {ts 1=$runAllURL}You can configure scheduled jobs (cron tasks) for your CiviCRM installation. For most sites, your system administrator should set up one or more 'cron' tasks to run the enabled jobs. However, you can also <a href="%1">run all scheduled jobs manually</a>, or run specific jobs from this screen (click 'more' and then 'Execute Now').{/ts} {docURL page="sysadmin/setup/jobs" text="(Job parameters and command line syntax documentation...)"}
 </div>
 
 {if $action eq 1 or $action eq 2 or $action eq 8}


### PR DESCRIPTION
Overview
----------------------------------------
In the help text at the top of the Scheduled Jobs page, the URL goes to the front page of the old Confluence wiki.  This updates it to use the Sysadmin Guide.

![image](https://user-images.githubusercontent.com/1682375/60194744-ebd04a00-9807-11e9-8041-de3417be5b02.png)

Before
----------------------------------------
Old link to Managing Scheduled Jobs page, which redirects to the front page of the wiki.

After
----------------------------------------
Link to https://docs.civicrm.org/sysadmin/en/stable/setup/jobs

Technical Details
----------------------------------------
It looks like there is a lot of work to do here in terms of updating docs links and standardizing usage in the Smarty and CRM_Utils_System helper functions.  This just fixes the one link, but it should be a step forward.