### PR TITLE
Remove superfluous pass-by-ref in api3

### DIFF
--- a/api/v3/Address.php
+++ b/api/v3/Address.php
@@ -42,7 +42,7 @@
  * @return array
  *   API result array
  */
-function civicrm_api3_address_create(&$params) {
+function civicrm_api3_address_create($params) {
   _civicrm_api3_check_edit_permissions('CRM_Core_BAO_Address', $params);
   /**
    * If street_parsing, street_address has to be parsed into
@@ -163,6 +163,6 @@ function civicrm_api3_address_delete($params) {
  * @return array
  *   API result array
  */
-function civicrm_api3_address_get(&$params) {
+function civicrm_api3_address_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'Address');
 }

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -41,7 +41,7 @@
  * @return array
  *   Api result array
  */
-function civicrm_api3_contribution_create(&$params) {
+function civicrm_api3_contribution_create($params) {
   $values = [];
   _civicrm_api3_custom_format_params($params, $values, 'Contribution');
   $params = array_merge($params, $values);
@@ -534,7 +534,7 @@ function _civicrm_api3_contribution_sendconfirmation_spec(&$params) {
  * @throws \CRM_Core_Exception
  * @throws \Exception
  */
-function civicrm_api3_contribution_completetransaction(&$params) {
+function civicrm_api3_contribution_completetransaction($params) {
   $input = $ids = [];
   if (isset($params['payment_processor_id'])) {
     $input['payment_processor_id'] = $params['payment_processor_id'];
@@ -629,7 +629,7 @@ function _civicrm_api3_contribution_completetransaction_spec(&$params) {
  *   Api result array.
  * @throws API_Exception
  */
-function civicrm_api3_contribution_repeattransaction(&$params) {
+function civicrm_api3_contribution_repeattransaction($params) {
   $input = $ids = [];
   civicrm_api3_verify_one_mandatory($params, NULL, ['contribution_recur_id', 'original_contribution_id']);
   if (empty($params['original_contribution_id'])) {

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -84,7 +84,7 @@ function _civicrm_api3_order_get_spec(&$params) {
  * @return array
  *   Api result array
  */
-function civicrm_api3_order_create(&$params) {
+function civicrm_api3_order_create($params) {
 
   $entity = NULL;
   $entityIds = [];

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -84,7 +84,7 @@ function civicrm_api3_payment_get($params) {
  * @return array
  *   Api result array
  */
-function civicrm_api3_payment_delete(&$params) {
+function civicrm_api3_payment_delete($params) {
   return civicrm_api3('FinancialTrxn', 'delete', $params);
 }
 
@@ -98,7 +98,7 @@ function civicrm_api3_payment_delete(&$params) {
  * @return array
  *   Api result array
  */
-function civicrm_api3_payment_cancel(&$params) {
+function civicrm_api3_payment_cancel($params) {
   $eftParams = [
     'entity_table' => 'civicrm_contribution',
     'financial_trxn_id' => $params['id'],
@@ -130,7 +130,7 @@ function civicrm_api3_payment_cancel(&$params) {
  * @return array
  *   Api result array
  */
-function civicrm_api3_payment_create(&$params) {
+function civicrm_api3_payment_create($params) {
   // Check if it is an update
   if (CRM_Utils_Array::value('id', $params)) {
     $amount = $params['total_amount'];

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -109,7 +109,7 @@ function _civicrm_api3_setting_getfields_spec(&$params) {
  * @throws \CiviCRM_API3_Exception
  * @throws \Exception
  */
-function civicrm_api3_setting_getdefaults(&$params) {
+function civicrm_api3_setting_getdefaults($params) {
   $settings = civicrm_api3('Setting', 'getfields', $params);
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $defaults = [];
@@ -166,7 +166,7 @@ function civicrm_api3_setting_getoptions($params) {
  * @return array
  * @throws \Exception
  */
-function civicrm_api3_setting_revert(&$params) {
+function civicrm_api3_setting_revert($params) {
   $defaults = civicrm_api('Setting', 'getdefaults', $params);
   $fields = civicrm_api('Setting', 'getfields', $params);
   $fields = $fields['values'];
@@ -216,7 +216,7 @@ function _civicrm_api3_setting_revert_spec(&$params) {
  * @throws \CiviCRM_API3_Exception
  * @throws \Exception
  */
-function civicrm_api3_setting_fill(&$params) {
+function civicrm_api3_setting_fill($params) {
   $defaults = civicrm_api3('Setting', 'getdefaults', $params);
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $result = [];

--- a/api/v3/SurveyRespondant.php
+++ b/api/v3/SurveyRespondant.php
@@ -54,7 +54,7 @@ function _civicrm_api3_survey_respondant_deprecation() {
  *
  * @return array
  */
-function civicrm_api3_survey_respondant_get(&$params) {
+function civicrm_api3_survey_respondant_get($params) {
 
   civicrm_api3_verify_one_mandatory($params, NULL, ['survey_id', 'id']);
 


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup 

Before
----------------------------------------
Parameters passed by reference unnecessarily

After
----------------------------------------
Parameters not passed by reference

Technical Details
----------------------------------------
Deprecated pattern - passing parameters as a reference when the receiving function does not alter them. This was once thought to be more performance & php4 friendly....