### PR TITLE
Removing unused spec function

### DIFF
--- a/api/v3/PledgePayment.php
+++ b/api/v3/PledgePayment.php
@@ -118,17 +118,3 @@ function civicrm_api3_pledge_payment_get($params) {
 
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
-
-/**
- * Gets field for civicrm_pledge_payment functions.
- *
- * @param array $params
- *   Modifiable list of fields allowed for the PledgePayment.get action.
- */
-function civicrm_api3_pledge_payment_get_spec(&$params) {
-  $params['option.create_new'] = [
-    'title' => "Create New",
-    'description' => "Create new field rather than update an unpaid payment",
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-  ];
-}


### PR DESCRIPTION
Overview
----------------------------------------
This spec function was incorrectly named (spec functions should start with an underscore) and therefore not actually doing anything. No one was complaining before, so we probably don't need it. This PR is my vote to remove it.

Before
----------------------------------------
Spec function not actually used.

After
----------------------------------------
Spec function gone.

Comments
----------------------------------------
IMO documenting an option by calling it a field is not a great practice which made me less inclined to keep the function around.
