### PR TITLE
[REF] minor code cleanup - move indexExist calculation to the only place in the code that needs it

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -175,12 +175,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
     $columnName = $params['column_name'];
 
-    $indexExist = FALSE;
-    //as during create if field is_searchable we had created index.
-    if (!empty($params['id'])) {
-      $indexExist = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $params['id'], 'is_searchable');
-    }
-
     switch (CRM_Utils_Array::value('html_type', $params)) {
       case 'Select Date':
         if (empty($params['date_format'])) {
@@ -315,6 +309,11 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $triggerRebuild = CRM_Utils_Array::value('triggerRebuild', $params, TRUE);
     //create/drop the index when we toggle the is_searchable flag
     if ($op == 'edit') {
+      $indexExist = FALSE;
+      //as during create if field is_searchable we had created index.
+      if (!empty($params['id'])) {
+        $indexExist = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $params['id'], 'is_searchable');
+      }
       self::createField($customField, 'modify', $indexExist, $triggerRebuild);
     }
     else {
@@ -327,8 +326,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       // make sure all values are present in the object
       $customField->find(TRUE);
 
-      $indexExist = FALSE;
-      self::createField($customField, 'add', $indexExist, $triggerRebuild);
+      self::createField($customField, 'add', FALSE, $triggerRebuild);
     }
 
     // complete transaction


### PR DESCRIPTION
Overview
----------------------------------------
Improve code readability on CustomField::create function

Before
----------------------------------------
indexExists declared a long way from where it is used

After
----------------------------------------
indexExists declared where it is used (it could also be pushed down into the next function I think in a later round)

Technical Details
----------------------------------------

Comments
----------------------------------------

