### PR TITLE
dev-core#1079: Improper character encoding breaks xml processor

### DIFF
--- a/templates/CRM/Case/XMLProcessor/Report.tpl
+++ b/templates/CRM/Case/XMLProcessor/Report.tpl
@@ -25,7 +25,7 @@
 *}
 <?xml version="1.0" encoding="UTF-8"?>
 <Case>
-  <Client>{$case.clientName}</Client>
+  <Client>{$case.clientName|escape}</Client>
   <CaseType>{$case.caseType}</CaseType>
   <CaseSubject>{$case.subject|escape}</CaseSubject>
   <CaseStatus>{$case.status}</CaseStatus>
@@ -70,4 +70,3 @@
 {/foreach}
   </ActivitySet>
 </Case>
-


### PR DESCRIPTION
Overview
----------------------------------------
When printing a case, if the contact name has an ampersand (&) it breaks loadXML due to improper encoding, resulting in the activity listing not displaying.
Steps to replicate:

1. Create a Case where client name should have & character
2. Go to 'Manage Case'
3. Click 'Print Report'


Before
----------------------------------------
There are no activities on the preview screen.

After
----------------------------------------
Activities are listed on the preview screen


Comments
----------------------------------------
ping @colemanw @lcdservices 