### PR TITLE
dev/core#1074 fix failure of actions from manage groups screen

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -777,14 +777,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     //for prev/next pagination
     $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
-    if (array_key_exists($this->_searchButtonName, $_POST) ||
-      ($this->_force && !$crmPID)
-    ) {
-      //reset the cache table for new search
-      $cacheKey = "civicrm search {$this->controller->_key}";
-      Civi::service('prevnext')->deleteItem(NULL, $cacheKey);
-    }
-
     //get the button name
     $buttonName = $this->controller->getButtonName();
 
@@ -822,6 +814,13 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       return;
     }
     else {
+      if (array_key_exists($this->_searchButtonName, $_POST) ||
+        ($this->_force && !$crmPID)
+      ) {
+        //reset the cache table for new search
+        $cacheKey = "civicrm search {$this->controller->_key}";
+        Civi::service('prevnext')->deleteItem(NULL, $cacheKey);
+      }
       $output = CRM_Core_Selector_Controller::SESSION;
 
       // create the selector, controller and run - store results in session


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal error removing contact from a group when it is loaded from Manage groups screen

Before
----------------------------------------
Fatal error per https://lab.civicrm.org/dev/core/issues/1074 (steps also in there)

After
----------------------------------------
Can remove contact from the group

Technical Details
----------------------------------------
@seamuslee001 @totten I think this is a fairly old regression now - e.g nearly 1 year - and that, combined with it having perceived risk makes me choose master.

The issue is that the search form clears the prevnext_cache "reset the cache table for new search"  but if the url has force=1 and no paging (as is the case from manage groups screen) then the refresh never happens - which I believe means it should not be flushing the cache in this case. Hence I have moved the clearing further down to be missed in that path

Comments
----------------------------------------

