### PR TITLE
dev/core#1030 fix mis-saving of hidden smart group when sending mail from search builder

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -695,7 +695,8 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     //create/update saved search record.
     $savedSearch = new CRM_Contact_BAO_SavedSearch();
     $savedSearch->id = $ssId;
-    $savedSearch->form_values = serialize(CRM_Contact_BAO_Query::convertFormValues($params['form_values']));
+    $formValues = $params['search_context'] === 'builder' ? $params['form_values'] : CRM_Contact_BAO_Query::convertFormValues($params['form_values']);
+    $savedSearch->form_values = serialize($formValues);
     $savedSearch->mapping_id = $mappingId;
     $savedSearch->search_custom_id = CRM_Utils_Array::value('search_custom_id', $params);
     $savedSearch->save();

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -777,14 +777,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     //for prev/next pagination
     $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
-    if (array_key_exists($this->_searchButtonName, $_POST) ||
-      ($this->_force && !$crmPID)
-    ) {
-      //reset the cache table for new search
-      $cacheKey = "civicrm search {$this->controller->_key}";
-      Civi::service('prevnext')->deleteItem(NULL, $cacheKey);
-    }
-
     //get the button name
     $buttonName = $this->controller->getButtonName();
 
@@ -822,6 +814,13 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       return;
     }
     else {
+      if (array_key_exists($this->_searchButtonName, $_POST) ||
+        ($this->_force && !$crmPID)
+      ) {
+        //reset the cache table for new search
+        $cacheKey = "civicrm search {$this->controller->_key}";
+        Civi::service('prevnext')->deleteItem(NULL, $cacheKey);
+      }
       $output = CRM_Core_Selector_Controller::SESSION;
 
       // create the selector, controller and run - store results in session

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -546,7 +546,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
         // Advanced search sets queryParams, for builder you need formValues.
         // This is kinda fragile but ....  see CRM_Mailing_Form_Task_AdhocMailingTest for test effort.
         // Moral never touch anything ever again and the house of cards will stand tall, unless there is a breeze
-        'form_values' => $this->get('isSearchBuilder') ?  $this->get('formValues') : $this->get('queryParams'),
+        'form_values' => $this->get('isSearchBuilder') ? $this->get('formValues') : $this->get('queryParams'),
         'saved_search_id' => $ssId,
         'search_custom_id' => $this->get('customSearchID'),
         'search_context' => $this->get('context'),

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -543,7 +543,10 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
         'group_type' => ['2' => 1],
         // queryParams have been preprocessed esp WRT any entity reference fields - see +
         // https://github.com/civicrm/civicrm-core/pull/13250
-        'form_values' => $this->get('queryParams'),
+        // Advanced search sets queryParams, for builder you need formValues.
+        // This is kinda fragile but ....  see CRM_Mailing_Form_Task_AdhocMailingTest for test effort.
+        // Moral never touch anything ever again and the house of cards will stand tall, unless there is a breeze
+        'form_values' => $this->get('isSearchBuilder') ?  $this->get('formValues') : $this->get('queryParams'),
         'saved_search_id' => $ssId,
         'search_custom_id' => $this->get('customSearchID'),
         'search_context' => $this->get('context'),

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -46,6 +46,14 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
   }
 
   /**
+   * @param string $name
+   * @param string $value
+   */
+  public function setHttpHeader($name, $value) {
+    Civi::$statics[__CLASS__]['header'][] = ("$name: $value");
+  }
+
+  /**
    * @inheritDoc
    */
   public function authenticate($name, $password, $loadCMSBootstrap = FALSE, $realPath = NULL) {

--- a/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
@@ -28,15 +28,18 @@
  * Test class for CRM_Contact_Form_Task_EmailCommon.
  * @group headless
  */
-class CRM_Mailing_Form_Task_AdHocMailingTest extends CiviUnitTestCase {
+class CRM_Mailing_Form_Task_AdhocMailingTest extends CiviUnitTestCase {
 
+  /**
+   * @throws \Exception
+   */
   protected function setUp() {
     parent::setUp();
     $this->_contactIds = [
       $this->individualCreate(['first_name' => 'Antonia', 'last_name' => 'D`souza']),
       $this->individualCreate(['first_name' => 'Anthony', 'last_name' => 'Collins']),
     ];
-    $this->_optionValue = $this->callApiSuccess('optionValue', 'create', [
+    $this->_optionValue = $this->callAPISuccess('optionValue', 'create', [
       'label' => '"Seamus Lee" <seamus@example.com>',
       'option_group_id' => 'from_email_address',
     ]);
@@ -64,6 +67,9 @@ class CRM_Mailing_Form_Task_AdHocMailingTest extends CiviUnitTestCase {
     ];
     $form = $this->getFormObject('CRM_Mailing_Form_Task_AdhocMailing', $formValues, 'Builder');
     $form->setAction(CRM_Core_Action::PROFILE);
+    $form->set('formValues', $formValues);
+    $form->set('isSearchBuilder', 1);
+    $form->set('context', 'builder');
     try {
       $form->preProcess();
     }
@@ -71,7 +77,7 @@ class CRM_Mailing_Form_Task_AdHocMailingTest extends CiviUnitTestCase {
       // Nothing to see here.
     }
     $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
-    $this->assertEquals(['bla'], $savedSearch);
+    $this->assertEquals($formValues, $savedSearch['form_values']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where sending a civimail from search builder was sending out to the wrong list

Before
----------------------------------------
Criteria disregarded when sending civimail from search builder

After
----------------------------------------
Criteria work

Technical Details
----------------------------------------
This has been a bit of an ongoing whackamole string :-( @MegaphoneJon while this has some test I don;'t think it meets the robustness you had hoped for. On the other hand the fix feels very safe to me - ie. the thing it's currently doing for searchbuilder doesn't work so keep doing the same thing for advanced search but do something that does work for search builder. The code also makes the 'builder' vs 'something else' a bit clearer. We should get this out.

Comments
----------------------------------------
I'm over search builder! Time to start figuring out how to build searches off apiv4. I feel like the first chunk is to be able to save searches from apiv4 - which will take us back into this mar-ish code, but hopefully in search or a robust way forwards this time
