### PR TITLE
Remove cached smart group entries when removing from a group

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -239,6 +239,8 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
         CRM_Contact_BAO_SubscriptionHistory::create($historyParams);
         $groupContact->status = $status;
         $groupContact->save();
+        // Remove any rows from the group contact cache so it disappears straight away from smart groups.
+        CRM_Contact_BAO_GroupContactCache::removeContact($contactId, $groupId);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby removing a contact from a smart group does not take effect immediately when viewing the group

Before
----------------------------------------
Contact not dropped from group in search until the cache for the group ages out

After
----------------------------------------
Contact removed immediately

Technical Details
----------------------------------------
In 5.15 we have added fixes for smart groups regarding removed entries. Possibly related to this but also possibly pre-existing
I'm seeing contacts who have been removed from smart groups showing up after removal in search results for the duration of the smart group cache.

Regardless the fix feels safe, sensible and correct so I'm comfortable targetting the rc without further research as to whether it
is a regression. The fix being removal of the cache entry when the group entry is removed.

Comments
----------------------------------------

