### PR TITLE
mail#46 - show label, not value, on contribution custom field tokens

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5905,18 +5905,36 @@ LIMIT 1;";
     }
     $contributionDetails = [];
     foreach ($contributionIds as $id) {
-      $result = civicrm_api3('Contribution', 'get', ['id' => $id]);
-      // lab.c.o mail#46 - show labels, not values, for custom fields with option values.
-      foreach ($result['values'][$id] as $fieldName => $fieldValue) {
-        if (strpos($fieldName, 'custom_') === 0 && array_search($fieldName, $messageToken['contribution']) !== FALSE) {
-          $result['values'][$id][$fieldName] = CRM_Core_BAO_CustomField::displayValue($result['values'][$id][$fieldName], $fieldName);
-        }
-      }
+      $result = self::getContributionTokenValues($id, $messageToken);
       $contributionDetails[$result['values'][$result['id']]['contact_id']]['subject'] = CRM_Utils_Token::replaceContributionTokens($subject, $result, FALSE, $subjectToken, FALSE, $escapeSmarty);
       $contributionDetails[$result['values'][$result['id']]['contact_id']]['text'] = CRM_Utils_Token::replaceContributionTokens($text, $result, FALSE, $messageToken, FALSE, $escapeSmarty);
       $contributionDetails[$result['values'][$result['id']]['contact_id']]['html'] = CRM_Utils_Token::replaceContributionTokens($html, $result, FALSE, $messageToken, FALSE, $escapeSmarty);
     }
     return $contributionDetails;
+  }
+
+  /**
+   * Get the contribution fields for $id and display labels where
+   * appropriate (if the token is present).
+   *
+   * @param int $id
+   * @param array $messageToken
+   * @return array
+   */
+  public static function getContributionTokenValues($id, $messageToken) {
+    if (empty($id)) {
+      return [];
+    }
+    $result = civicrm_api3('Contribution', 'get', ['id' => $id]);
+    // lab.c.o mail#46 - show labels, not values, for custom fields with option values.
+    if (!empty($messageToken)) {
+      foreach ($result['values'][$id] as $fieldName => $fieldValue) {
+        if (strpos($fieldName, 'custom_') === 0 && array_search($fieldName, $messageToken['contribution']) !== FALSE) {
+          $result['values'][$id][$fieldName] = CRM_Core_BAO_CustomField::displayValue($result['values'][$id][$fieldName], $fieldName);
+        }
+      }
+    }
+    return $result;
   }
 
   /**

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5906,6 +5906,12 @@ LIMIT 1;";
     $contributionDetails = [];
     foreach ($contributionIds as $id) {
       $result = civicrm_api3('Contribution', 'get', ['id' => $id]);
+      // lab.c.o mail#46 - show labels, not values, for custom fields with option values.
+      foreach ($result['values'][$id] as $fieldName => $fieldValue) {
+        if (strpos($fieldName, 'custom_') === 0 && array_search($fieldName, $messageToken['contribution']) !== FALSE) {
+          $result['values'][$id][$fieldName] = CRM_Core_BAO_CustomField::displayValue($result['values'][$id][$fieldName], $fieldName);
+        }
+      }
       $contributionDetails[$result['values'][$result['id']]['contact_id']]['subject'] = CRM_Utils_Token::replaceContributionTokens($subject, $result, FALSE, $subjectToken, FALSE, $escapeSmarty);
       $contributionDetails[$result['values'][$result['id']]['contact_id']]['text'] = CRM_Utils_Token::replaceContributionTokens($text, $result, FALSE, $messageToken, FALSE, $escapeSmarty);
       $contributionDetails[$result['values'][$result['id']]['contact_id']]['html'] = CRM_Utils_Token::replaceContributionTokens($html, $result, FALSE, $messageToken, FALSE, $escapeSmarty);

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -257,16 +257,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
   public static function buildContributionArray($groupBy, $contributionIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator, $isIncludeSoftCredits) {
     $contributions = $contacts = [];
     foreach ($contributionIDs as $item => $contributionId) {
-      // Basic return attributes available to the template.
-      $returnValues = ['contact_id', 'total_amount', 'financial_type', 'receive_date', 'contribution_campaign_title'];
-      if (!empty($messageToken['contribution'])) {
-        $returnValues = array_merge($messageToken['contribution'], $returnValues);
-      }
-      // retrieve contribution tokens listed in $returnProperties using Contribution.Get API
-      $contribution = civicrm_api3('Contribution', 'getsingle', [
-        'id' => $contributionId,
-        'return' => $returnValues,
-      ]);
+      $contribution = CRM_Contribute_BAO_Contribution::getContributionTokenValues($contributionId, $messageToken)['values'][$contributionId];
       $contribution['campaign'] = CRM_Utils_Array::value('contribution_campaign_title', $contribution);
       $contributions[$contributionId] = $contribution;
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1501,7 +1501,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $html = "<p>Contribution Source: {contribution.contribution_source}</p></br>
       <p>Contribution Invoice ID: {contribution.invoice_id}</p></br>
       <p>Contribution Receive Date: {contribution.receive_date}</p></br>
-      <p>Contribution Custom Field 1: {contribution.custom_1}</p></br>";
+      <p>Contribution Custom Field: {contribution.custom_{$customField['id']}}</p></br>";
 
     $subjectToken = CRM_Utils_Token::getTokens($subject);
     $messageToken = CRM_Utils_Token::getTokens($text);
@@ -1521,7 +1521,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $this->assertEquals("<p>Contribution Source: ABC</p></br>
       <p>Contribution Invoice ID: 12345</p></br>
       <p>Contribution Receive Date: May 11th, 2015</p></br>
-      <p>Contribution Custom Field 1: Label2</p></br>", $contributionDetails[$contactId2]['html'], "The html does not match");
+      <p>Contribution Custom Field: Label2</p></br>", $contributionDetails[$contactId2]['html'], "The html does not match");
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1466,7 +1466,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
    *   This function tests whether the contribution tokens are replaced with values from contribution.
    */
   public function testReplaceContributionTokens() {
-    $customGroup = $this->customGroupCreate(['extends' => 'Contribution']);
+    $customGroup = $this->customGroupCreate(['extends' => 'Contribution', 'title' => 'contribution stuff']);
     $customField = $this->customFieldOptionValueCreate($customGroup, 'myCustomField');
     $contactId1 = $this->individualCreate();
     $params = array(

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1466,6 +1466,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
    *   This function tests whether the contribution tokens are replaced with values from contribution.
    */
   public function testReplaceContributionTokens() {
+    $customGroup = $this->customGroupCreate(['extends' => 'Contribution']);
+    $customField = $this->customFieldOptionValueCreate($customGroup, 'myCustomField');
     $contactId1 = $this->individualCreate();
     $params = array(
       'contact_id' => $contactId1,
@@ -1476,6 +1478,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'invoice_id' => 67890,
       'source' => 'SSF',
       'contribution_status_id' => 2,
+      "custom_{$customField['id']}" => 'value1',
     );
     $contribution1 = $this->contributionCreate($params);
     $contactId2 = $this->individualCreate();
@@ -1488,6 +1491,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'invoice_id' => 12345,
       'source' => 'ABC',
       'contribution_status_id' => 1,
+      "custom_{$customField['id']}" => 'value2',
     );
     $contribution2 = $this->contributionCreate($params);
     $ids = array($contribution1, $contribution2);
@@ -1496,7 +1500,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $text = "Contribution Amount: {contribution.total_amount}";
     $html = "<p>Contribution Source: {contribution.contribution_source}</p></br>
       <p>Contribution Invoice ID: {contribution.invoice_id}</p></br>
-      <p>Contribution Receive Date: {contribution.receive_date}</p></br>";
+      <p>Contribution Receive Date: {contribution.receive_date}</p></br>
+      <p>Contribution Custom Field 1: {contribution.custom_1}</p></br>";
 
     $subjectToken = CRM_Utils_Token::getTokens($subject);
     $messageToken = CRM_Utils_Token::getTokens($text);
@@ -1515,7 +1520,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $this->assertEquals("Contribution Amount: $ 100.00", $contributionDetails[$contactId1]['text'], "The text does not match");
     $this->assertEquals("<p>Contribution Source: ABC</p></br>
       <p>Contribution Invoice ID: 12345</p></br>
-      <p>Contribution Receive Date: May 11th, 2015</p></br>", $contributionDetails[$contactId2]['html'], "The html does not match");
+      <p>Contribution Receive Date: May 11th, 2015</p></br>
+      <p>Contribution Custom Field 1: Label2</p></br>", $contributionDetails[$contactId2]['html'], "The html does not match");
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1683,7 +1683,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'option_value' => array('value1', 'value2'),
       'option_name' => array($name . '_1', $name . '_2'),
       'option_weight' => array(1, 2),
-      'option_status' => 1,
+      'option_status' => array(1, 1),
     );
 
     $params = array_merge($fieldParams, $optionGroup, $optionValue, $extraParams);


### PR DESCRIPTION
Overview
----------------------------------------
When using contribution tokens that have option values ("multiple choice"), the token renders the value instead of the label.

Before
----------------------------------------
The token renders the value, e.g., "1", "2".

After
----------------------------------------
The token should render the label of the selected option, e.g. "Less than 1 year", "1-3 years".

Technical Details
----------------------------------------
Steps to replicate this are available on the [lab.c.o ticket](https://lab.civicrm.org/dev/mail/issues/46).

Comments
----------------------------------------
This also fixes a bug in `CiviUnitTestCase::customFieldOptionValueCreate()` where option values are created as inactive.  I looked at the other places this method is called and it shouldn't have any effect.