### PR TITLE
 Move api_key read/write permission checks from api to BAO

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -437,7 +437,34 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       self::processGreetings($contact);
     }
 
+    if (!empty($params['check_permissions'])) {
+      $contacts = [&$contact];
+      self::unsetProtectedFields($contacts);
+    }
+
     return $contact;
+  }
+
+  /**
+   * Format the output of the create contact function
+   * @param CRM_Contact_DAO_Contact[]|array[] $contacts
+   */
+  public static function unsetProtectedFields(&$contacts) {
+    if (!CRM_Core_Permission::check([['edit api keys', 'administer CiviCRM']])) {
+      $currentUser = CRM_Core_Session::getLoggedInContactID();
+      $editOwn = $currentUser && CRM_Core_Permission::check('edit own api keys');
+      foreach ($contacts as &$contact) {
+        $cid = is_object($contact) ? $contact->id : CRM_Utils_Array::value('id', $contact);
+        if (!($editOwn && $cid == $currentUser)) {
+          if (is_object($contact)) {
+            unset($contact->api_key);
+          }
+          else {
+            unset($contact['api_key']);
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -67,18 +67,6 @@ function civicrm_api3_contact_create($params) {
     return $values;
   }
 
-  if (array_key_exists('api_key', $params) && !empty($params['check_permissions'])) {
-    if (CRM_Core_Permission::check('edit api keys') || CRM_Core_Permission::check('administer CiviCRM')) {
-      // OK
-    }
-    elseif ($contactID && CRM_Core_Permission::check('edit own api keys') && CRM_Core_Session::singleton()->get('userID') == $contactID) {
-      // OK
-    }
-    else {
-      throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify api key');
-    }
-  }
-
   if (!$contactID) {
     // If we get here, we're ready to create a new contact
     if (($email = CRM_Utils_Array::value('email', $params)) && !is_array($params['email'])) {

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -129,8 +129,6 @@ function civicrm_api3_contact_create($params) {
     _civicrm_api3_object_to_array_unique_fields($contact, $values[$contact->id]);
   }
 
-  $values = _civicrm_api3_contact_formatResult($params, $values);
-
   return civicrm_api3_create_success($values, $params, 'Contact', 'create');
 }
 
@@ -182,37 +180,10 @@ function civicrm_api3_contact_get($params) {
   $options = [];
   _civicrm_api3_contact_get_supportanomalies($params, $options);
   $contacts = _civicrm_api3_get_using_query_object('Contact', $params, $options);
-  $contacts = _civicrm_api3_contact_formatResult($params, $contacts);
-  return civicrm_api3_create_success($contacts, $params, 'Contact');
-}
-
-/**
- * Filter the result.
- *
- * @param array $result
- *
- * @return array
- * @throws \CRM_Core_Exception
- */
-function _civicrm_api3_contact_formatResult($params, $result) {
-  $apiKeyPerms = ['edit api keys', 'administer CiviCRM'];
-  $allowApiKey = empty($params['check_permissions']) || CRM_Core_Permission::check([$apiKeyPerms]);
-  if (!$allowApiKey) {
-    if (is_array($result)) {
-      // Single-value $result
-      if (isset($result['api_key'])) {
-        unset($result['api_key']);
-      }
-
-      // Multi-value $result
-      foreach ($result as $key => $row) {
-        if (is_array($row)) {
-          unset($result[$key]['api_key']);
-        }
-      }
-    }
+  if (!empty($params['check_permissions'])) {
+    CRM_Contact_BAO_Contact::unsetProtectedFields($contacts);
   }
-  return $result;
+  return civicrm_api3_create_success($contacts, $params, 'Contact');
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Move logic for checking api_key field permissions from api layer to BAO layer so it can be reused by api4 and other things.
This is a replacement PR for #14275.

Before
----------------------------------------
Field permission checks in api layer.

After
----------------------------------------
Field permission checks in BAO layer.

Comments
----------------------------------------
This is both more and less ambitious than Seamus Lee's #14275 - more in that it consolidates additional permission checks, and less in that it doesn't try to use field metadata. The unresolved problems with using field metadata are:

- The PR #14274 adds the word "protected" but that's not enough information to know which permissions to check.
- The api_key field is more nuanced than a single permission check, as we also need to match the cid of the contact to that of the logged-in user to check "edit own api keys".
- We're only talking about one field anyway, so a metadata-based approach might be overkill.

We could address those issues in a future PR, but to move this along I've sidestepped them for now.
