### PR TITLE
[test] test for whether api_key is returned on get

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -572,6 +572,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @param int $version
    *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testCreateApiKey($version) {
     $this->_apiversion = $version;
@@ -606,6 +607,10 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'api_key' => 'defg4321',
     ]);
     $this->assertRegExp(';Permission denied to modify api key;', $result['error_message']);
+
+    // Specifically check get action.
+    $check = $this->callAPISuccessGetSingle('Contact', ['id' => $contactId, 'return' => ['api_key', 'display_name']]);
+    $this->assertTrue(!isset($check['api_key']));
 
     // Return everything -- because permissions are not being checked
     $config->userPermissionClass->permissions = [];


### PR DESCRIPTION
Overview
----------------------------------------
I did this in conjunction with review on https://github.com/civicrm/civicrm-core/pull/14660
it appears that api_key is being returned LESS than the code appears to imply is the case -the
BAO_Query is never fetching it I think... We should perhaps just lock in existing with a test
so we notice change - this is not that test

Before
----------------------------------------
get not tested

After
----------------------------------------
get tested

Technical Details
----------------------------------------
@colemanw I tried this in conjunction with your PR - the behaviour for get is unchanged but also seems different to what you seemed to expect & also what the code expected...

Comments
----------------------------------------

