### PR TITLE
[REF] do not receive  by reference in CustomField::create

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -151,7 +151,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *
    * @return CRM_Core_DAO_CustomField
    */
-  public static function create(&$params) {
+  public static function create($params) {
     $origParams = array_merge(array(), $params);
 
     $op = empty($params['id']) ? 'create' : 'edit';


### PR DESCRIPTION
Overview
----------------------------------------
Removes an instance of pass-by-reference on CustomField::Create

Before
----------------------------------------
deprecated code pattern in use

After
----------------------------------------
deprecated code pattern removed

Technical Details
----------------------------------------
I audited the places where this is called in core and the  object is not later interrogated for changes

Comments
----------------------------------------

