### PR TITLE
Invalidate smart group cache for group following deletion of group_c…

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -180,7 +180,6 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     if (!is_array($contactIds)) {
       return [0, 0, 0];
     }
-
     if ($status == 'Removed' || $status == 'Deleted') {
       $op = 'delete';
     }
@@ -200,8 +199,11 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
 
     foreach ($contactIds as $contactId) {
       if ($status == 'Deleted') {
-        $query = "DELETE FROM civicrm_group_contact WHERE contact_id=$contactId AND group_id=$groupId";
-        $dao = CRM_Core_DAO::executeQuery($query);
+        $query = "DELETE FROM civicrm_group_contact WHERE contact_id = %1 AND group_id = %2";
+        $dao = CRM_Core_DAO::executeQuery($query, [
+          1 => [$contactId, 'Positive'],
+          2 => [$groupId, 'Positive'],
+        ]);
         $historyParams = [
           'group_id' => $groupId,
           'contact_id' => $contactId,
@@ -211,6 +213,10 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
           'tracking' => $tracking,
         ];
         CRM_Contact_BAO_SubscriptionHistory::create($historyParams);
+        // Removing a row from civicrm_group_contact for a smart group may mean a contact
+        // Is now back in a group based on criteria so we will invalidate the cache if it is there
+        // So that accurate group cache is created next time it is needed.
+        CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupId);
       }
       else {
         $groupContact = new CRM_Contact_DAO_GroupContact();

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -760,4 +760,16 @@ ORDER BY   gc.contact_id, g.children
     return date('YmdHis', strtotime("+ " . self::smartGroupCacheTimeout() . " Minutes"));
   }
 
+  /**
+   * Invalidates the smart group cache for a particular group
+   * @param int $groupID - Group to invalidate
+   */
+  public static function invalidateGroupContactCache($groupID) {
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_group
+      SET cache_date = NULL, refresh_date = NULL
+      WHERE id = %1", [
+        1 => [$groupID, 'Positive'],
+      ]);
+  }
+
 }


### PR DESCRIPTION
…ontact row

Overview
----------------------------------------
This is a follow on from @eileenmcnaughton 's work to ensure that when contacts are removed from a smart group they are removed from the cache instantly, This follows a similar principle however in this case what we are doing is removing a row such as saying a contact that would otherwise be in a smart group is removed. If that row is deleted from the civicrm_group_contact table we should ensure the cache gets updated

Before
----------------------------------------
Contact maybe back in smart group but not until cache is refreshed. 

After
----------------------------------------
Cache updated immediately

ping @mattwire 