### PR TITLE
Specifiy allowed_classes on unserialize

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -194,7 +194,7 @@ WHERE  cachekey     = %3 AND
     while ($pncFind->fetch()) {
       $data = $pncFind->data;
       if (!empty($data)) {
-        $data = unserialize($data);
+        $data = unserialize($data, ['allowed_classes' => FALSE]);
         $data['conflicts'] = implode(",", array_values($conflicts));
 
         $pncUp = new CRM_Core_DAO_PrevNextCache();

--- a/api/v3/Dedupe.php
+++ b/api/v3/Dedupe.php
@@ -51,7 +51,7 @@ function civicrm_api3_dedupe_get($params) {
   }
   foreach ($result as $index => $values) {
     if (isset($values['data']) && !empty($values['data'])) {
-      $result[$index]['data'] = unserialize($values['data']);
+      $result[$index]['data'] = unserialize($values['data'], ['allowed_classes' => FALSE]);
     }
   }
   return civicrm_api3_create_success($result, $params, 'PrevNextCache');


### PR DESCRIPTION
Overview
----------------------------------------
Code standards improvement

Before
----------------------------------------
Php storm reports error in it's inspection

After
----------------------------------------
Php storm is cheery

Technical Details
----------------------------------------
This is in response to phpstorm grumpily pointing to
https://github.com/kalessil/phpinspectionsea/blob/master/docs/security.md#exploiting-unserialize
in it's inspections. I think in this case it is very much cosmetic. However,
I wonder is we should have a function
CRM_Utils_String::unserialize() that does this by default & becomes the place we
add other handling if we identify any. (It might also make it easier to migrate to
json at some point

Comments
----------------------------------------

