### PR TITLE
Block classes in unserialize field for IDE cheer

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -172,6 +172,7 @@ WHERE  cachekey     = %3 AND
    * @param array $conflicts
    *
    * @return bool
+   * @throws CRM_Core_Exception
    */
   public static function markConflict($id1, $id2, $cacheKey, $conflicts) {
     if (empty($cacheKey) || empty($conflicts)) {
@@ -194,7 +195,7 @@ WHERE  cachekey     = %3 AND
     while ($pncFind->fetch()) {
       $data = $pncFind->data;
       if (!empty($data)) {
-        $data = unserialize($data);
+        $data = CRM_Core_DAO::unSerializeField($data, CRM_Core_DAO::SERIALIZE_PHP);
         $data['conflicts'] = implode(",", array_values($conflicts));
 
         $pncUp = new CRM_Core_DAO_PrevNextCache();

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2877,8 +2877,9 @@ SELECT contact_id
    *
    * @param string|null $value
    * @param $serializationType
+   *
    * @return array|null
-   * @throws \Exception
+   * @throws CRM_Core_Exception
    */
   public static function unSerializeField($value, $serializationType) {
     if ($value === NULL) {
@@ -2898,13 +2899,13 @@ SELECT contact_id
         return strlen($value) ? json_decode($value, TRUE) : [];
 
       case self::SERIALIZE_PHP:
-        return strlen($value) ? unserialize($value) : [];
+        return strlen($value) ? unserialize($value, ['allowed_classes' => FALSE]) : [];
 
       case self::SERIALIZE_COMMA:
         return explode(',', trim(str_replace(', ', '', $value)));
 
       default:
-        throw new Exception('Unknown serialization method for field.');
+        throw new CRM_Core_Exception('Unknown serialization method for field.');
     }
   }
 

--- a/api/v3/Dedupe.php
+++ b/api/v3/Dedupe.php
@@ -51,7 +51,7 @@ function civicrm_api3_dedupe_get($params) {
   }
   foreach ($result as $index => $values) {
     if (isset($values['data']) && !empty($values['data'])) {
-      $result[$index]['data'] = unserialize($values['data']);
+      $result[$index]['data'] = CRM_Core_DAO::unSerializeField($values['data'], CRM_Core_DAO::SERIALIZE_PHP);
     }
   }
   return civicrm_api3_create_success($result, $params, 'PrevNextCache');


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/14680

Before
----------------------------------------
Unserialize permits class unserialization - which is not recommended practice

After
----------------------------------------
Serialization excludes classes

Technical Details
----------------------------------------
@colemanw after looking further only settings & apiv4 currently use this - I feel like we could make this change

Comments
----------------------------------------

