### PR TITLE
Consolidate handling of conflicts between the batch job and get_conflicts api

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -192,11 +192,16 @@ WHERE  cachekey     = %3 AND
     ];
     $pncFind = CRM_Core_DAO::executeQuery($sql, $params);
 
+    $conflictTexts = [];
+    foreach ($conflicts as $conflict) {
+      $conflictTexts[] = "{$conflict['title']}: '{$conflict[$id1]}' vs. '{$conflict[$id2]}'";
+    }
+    $conflictString = implode(', ', $conflictTexts);
     while ($pncFind->fetch()) {
       $data = $pncFind->data;
       if (!empty($data)) {
         $data = CRM_Core_DAO::unSerializeField($data, CRM_Core_DAO::SERIALIZE_PHP);
-        $data['conflicts'] = implode(",", array_values($conflicts));
+        $data['conflicts'] = $conflictString;
 
         $pncUp = new CRM_Core_DAO_PrevNextCache();
         $pncUp->id = $pncFind->id;

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -170,11 +170,12 @@ WHERE  cachekey     = %3 AND
    * @param int $id2
    * @param string $cacheKey
    * @param array $conflicts
+   * @param string $mode
    *
    * @return bool
    * @throws CRM_Core_Exception
    */
-  public static function markConflict($id1, $id2, $cacheKey, $conflicts) {
+  public static function markConflict($id1, $id2, $cacheKey, $conflicts, $mode) {
     if (empty($cacheKey) || empty($conflicts)) {
       return FALSE;
     }
@@ -193,15 +194,31 @@ WHERE  cachekey     = %3 AND
     $pncFind = CRM_Core_DAO::executeQuery($sql, $params);
 
     $conflictTexts = [];
-    foreach ($conflicts as $conflict) {
-      $conflictTexts[] = "{$conflict['title']}: '{$conflict[$id1]}' vs. '{$conflict[$id2]}'";
+
+    foreach ($conflicts as $entity => $entityConflicts) {
+      if ($entity === 'contact') {
+        foreach ($entityConflicts as $conflict) {
+          $conflictTexts[] = "{$conflict['title']}: '{$conflict[$id1]}' vs. '{$conflict[$id2]}'";
+        }
+      }
+      else {
+        foreach ($entityConflicts as $locationConflict) {
+          if (!is_array($locationConflict)) {
+            continue;
+          }
+          $displayField = CRM_Dedupe_Merger::getLocationBlockInfo()[$entity]['displayField'];
+          $conflictTexts[] = "{$locationConflict['title']}: '{$locationConflict[$displayField][$id1]}' vs. '{$locationConflict[$displayField][$id2]}'";
+        }
+      }
     }
     $conflictString = implode(', ', $conflictTexts);
+
     while ($pncFind->fetch()) {
       $data = $pncFind->data;
       if (!empty($data)) {
         $data = CRM_Core_DAO::unSerializeField($data, CRM_Core_DAO::SERIALIZE_PHP);
         $data['conflicts'] = $conflictString;
+        $data[$mode]['conflicts'] = $conflicts;
 
         $pncUp = new CRM_Core_DAO_PrevNextCache();
         $pncUp->id = $pncFind->id;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2129,7 +2129,13 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     // store any conflicts
     if (!empty($conflicts)) {
       foreach ($conflicts as $key => $dnc) {
-        $conflicts[$key] = "{$migrationInfo['rows'][$key]['title']}: '{$migrationInfo['rows'][$key]['main']}' vs. '{$migrationInfo['rows'][$key]['other']}'";
+        unset($conflicts[$key]);
+        $conflicts[substr($key, 5)] = [
+          'title' => $migrationInfo['rows'][$key]['title'],
+          $mainId => $migrationInfo['rows'][$key]['main'],
+          $otherId => $migrationInfo['rows'][$key]['other'],
+          'key' => $key,
+        ];
       }
       CRM_Core_BAO_PrevNextCache::markConflict($mainId, $otherId, $cacheKeyString, $conflicts);
     }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -919,22 +919,16 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *  An empty array to be filed with conflict information.
    *
    * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
   public static function skipMerge($mainId, $otherId, &$migrationInfo, $mode = 'safe', &$conflicts = []) {
 
     $conflicts = self::getConflicts($migrationInfo, $mainId, $otherId, $mode);
 
     if (!empty($conflicts)) {
-      foreach ($conflicts as $key => $val) {
-        if ($val === NULL and $mode == 'safe') {
-          // un-resolved conflicts still present. Lets skip this merge after saving the conflict / reason.
-          return TRUE;
-        }
-        else {
-          // copy over the resolved values
-          $migrationInfo[$key] = $val;
-        }
-      }
       // if there are conflicts and mode is aggressive, allow hooks to decide if to skip merges
       return (bool) $migrationInfo['skip_merge'];
     }
@@ -950,15 +944,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @return bool
    */
   public static function locationIsSame($mainAddress, $comparisonAddress) {
-    $keysToIgnore = [
-      'id',
-      'is_primary',
-      'is_billing',
-      'manual_geo_code',
-      'contact_id',
-      'reset_date',
-      'hold_date',
-    ];
+    $keysToIgnore = self::ignoredFields();
     foreach ($comparisonAddress as $field => $value) {
       if (in_array($field, $keysToIgnore)) {
         continue;
@@ -2106,6 +2092,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
   protected static function dedupePair(&$resultStats, &$deletedContacts, $mode, $checkPermissions, $mainId, $otherId, $cacheKeyString) {
 
@@ -2128,16 +2115,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
     // store any conflicts
     if (!empty($conflicts)) {
-      foreach ($conflicts as $key => $dnc) {
-        unset($conflicts[$key]);
-        $conflicts[substr($key, 5)] = [
-          'title' => $migrationInfo['rows'][$key]['title'],
-          $mainId => $migrationInfo['rows'][$key]['main'],
-          $otherId => $migrationInfo['rows'][$key]['other'],
-          'key' => $key,
-        ];
-      }
-      CRM_Core_BAO_PrevNextCache::markConflict($mainId, $otherId, $cacheKeyString, $conflicts);
+      CRM_Core_BAO_PrevNextCache::markConflict($mainId, $otherId, $cacheKeyString, $conflicts, $mode);
     }
     else {
       CRM_Core_BAO_PrevNextCache::deletePair($mainId, $otherId, $cacheKeyString);
@@ -2426,8 +2404,69 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $conflicts = $migrationData['fields_in_conflict'];
     // allow hook to override / manipulate migrationInfo as well
     $migrationInfo = $migrationData['migration_info'];
-    $migrationInfo['skip_merge'] = CRM_Utils_Array::value('skip_merge', $migrationData);
-    return $conflicts;
+    foreach ($conflicts as $key => $val) {
+      if ($val !== NULL || $mode !== 'safe') {
+        // copy over the resolved values
+        $migrationInfo[$key] = $val;
+        unset($conflicts[$key]);
+      }
+    }
+    $migrationInfo['skip_merge'] = $migrationData['skip_merge'] ?? !empty($conflicts);
+    return self::formatConflictArray($conflicts, $migrationInfo['rows'], $migrationInfo['main_details']['location_blocks'], $migrationInfo['other_details']['location_blocks'], $mainId, $otherId);
+  }
+
+  /**
+   * @param array $conflicts
+   * @param array $migrationInfo
+   * @param $toKeepContactLocationBlocks
+   * @param $toRemoveContactLocationBlocks
+   * @param $toKeepID
+   * @param $toRemoveID
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  protected static function formatConflictArray($conflicts, $migrationInfo, $toKeepContactLocationBlocks, $toRemoveContactLocationBlocks, $toKeepID, $toRemoveID) {
+    $return = [];
+    foreach (array_keys($conflicts) as $index) {
+      if (substr($index, 0, 14) === 'move_location_') {
+        $parts = explode('_', $index);
+        $entity = $parts[2];
+        $blockIndex = $parts[3];
+        $locationTypeID = $toKeepContactLocationBlocks[$entity][$blockIndex]['location_type_id'];
+        $entityConflicts = [
+          'location_type_id' => $locationTypeID,
+          'title' => $migrationInfo[$index]['title'],
+        ];
+        foreach ($toKeepContactLocationBlocks[$entity][$blockIndex] as $fieldName => $fieldValue) {
+          if (in_array($fieldName, self::ignoredFields())) {
+            continue;
+          }
+          $toRemoveValue = CRM_Utils_Array::value($fieldName, $toRemoveContactLocationBlocks[$entity][$blockIndex]);
+          if ($fieldValue !== $toRemoveValue) {
+            $entityConflicts[$fieldName] = [
+              $toKeepID => $fieldValue,
+              $toRemoveID => $toRemoveValue,
+            ];
+          }
+        }
+        $return[$entity][] = $entityConflicts;
+      }
+      elseif (substr($index, 0, 5) === 'move_') {
+        $contactFieldsToCompare[] = str_replace('move_', '', $index);
+        $return['contact'][str_replace('move_', '', $index)] = [
+          'title' => $migrationInfo[$index]['title'],
+          $toKeepID => $migrationInfo[$index]['main'],
+          $toRemoveID => $migrationInfo[$index]['other'],
+        ];
+      }
+      else {
+        // Can't think of why this would be the case but perhaps it's ensuring it isn't as we
+        // refactor this.
+        throw new CRM_Core_Exception(ts('Unknown parameter') . $index);
+      }
+    }
+    return $return;
   }
 
   /**
@@ -2452,6 +2491,22 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       [], '',
       $includeConflicts
     );
+  }
+
+  /**
+   * @return array
+   */
+  protected static function ignoredFields(): array {
+    $keysToIgnore = [
+      'id',
+      'is_primary',
+      'is_billing',
+      'manual_geo_code',
+      'contact_id',
+      'reset_date',
+      'hold_date',
+    ];
+    return $keysToIgnore;
   }
 
 }

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -249,6 +249,7 @@ trait Api3TestTrait {
    *   - object
    *
    * @return array|int
+   * @throws \CRM_Core_Exception
    */
   public function callAPISuccessGetValue($entity, $params, $type = NULL) {
     $params += [
@@ -257,10 +258,10 @@ trait Api3TestTrait {
     ];
     $result = $this->civicrm_api($entity, 'getvalue', $params);
     if (is_array($result) && (!empty($result['is_error']) || isset($result['values']))) {
-      throw new \Exception('Invalid getvalue result' . print_r($result, TRUE));
+      throw new \CRM_Core_Exception('Invalid getvalue result' . print_r($result, TRUE));
     }
     if ($type) {
-      if ($type == 'integer') {
+      if ($type === 'integer') {
         // api seems to return integers as strings
         $this->assertTrue(is_numeric($result), "expected a numeric value but got " . print_r($result, 1));
       }

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -889,10 +889,8 @@ class api_v3_JobTest extends CiviUnitTestCase {
     // Each row specifies: contact 1 on_hold, contact 2 on_hold, merge? (0 or 1),
     $sets = [
       [0, 0, 1, NULL],
-      [0, 1, 0, "Email 2 (Work): 'batman@gotham.met' vs. 'batman@gotham.met
-(On Hold)'"],
-      [1, 0, 0, "Email 2 (Work): 'batman@gotham.met
-(On Hold)' vs. 'batman@gotham.met'"],
+      [0, 1, 0, "Email 2 (Work): 'batman@gotham.met' vs. 'batman@gotham.met\n(On Hold)'"],
+      [1, 0, 0, "Email 2 (Work): 'batman@gotham.met\n(On Hold)' vs. 'batman@gotham.met'"],
       [1, 1, 1, NULL],
     ];
     return $sets;

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -843,12 +843,15 @@ class api_v3_JobTest extends CiviUnitTestCase {
    *
    * @dataProvider getOnHoldSets
    *
-   * @param
+   * @param bool $onHold1
+   * @param bool $onHold2
+   * @param bool $merge
+   * @param string $conflictText
    *
    * @throws \CRM_Core_Exception
    */
-  public function testBatchMergeEmailOnHold($onHold1, $onHold2, $merge) {
-    $contactID1 = $this->individualCreate([
+  public function testBatchMergeEmailOnHold($onHold1, $onHold2, $merge, $conflictText) {
+    $this->individualCreate([
       'api.email.create' => [
         'email' => 'batman@gotham.met',
         'location_type_id' => 'Work',
@@ -856,7 +859,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
         'on_hold' => $onHold1,
       ],
     ]);
-    $contactID2 = $this->individualCreate([
+    $this->individualCreate([
       'api.email.create' => [
         'email' => 'batman@gotham.met',
         'location_type_id' => 'Work',
@@ -865,7 +868,18 @@ class api_v3_JobTest extends CiviUnitTestCase {
       ],
     ]);
     $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
-    $this->assertEquals($merge, count($result['values']['merged']));
+    $this->assertCount($merge, $result['values']['merged']);
+    if ($conflictText) {
+      $defaultRuleGroupID = $this->callAPISuccessGetValue('RuleGroup', [
+        'contact_type' => 'Individual',
+        'used' => 'Unsupervised',
+        'return' => 'id',
+        'options' => ['limit' => 1],
+      ]);
+
+      $duplicates = $this->callAPISuccess('Dedupe', 'getduplicates', ['rule_group_id' => $defaultRuleGroupID]);
+      $this->assertEquals($conflictText, $duplicates['values'][0]['conflicts']);
+    }
   }
 
   /**
@@ -874,10 +888,12 @@ class api_v3_JobTest extends CiviUnitTestCase {
   public function getOnHoldSets() {
     // Each row specifies: contact 1 on_hold, contact 2 on_hold, merge? (0 or 1),
     $sets = [
-      [0, 0, 1],
-      [0, 1, 0],
-      [1, 0, 0],
-      [1, 1, 1],
+      [0, 0, 1, NULL],
+      [0, 1, 0, "Email 2 (Work): 'batman@gotham.met' vs. 'batman@gotham.met
+(On Hold)'"],
+      [1, 0, 0, "Email 2 (Work): 'batman@gotham.met
+(On Hold)' vs. 'batman@gotham.met'"],
+      [1, 1, 1, NULL],
     ];
     return $sets;
   }

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -1050,9 +1050,11 @@ class api_v3_JobTest extends CiviUnitTestCase {
    *
    * Note that we set 0 on 2 fields with one on each contact to ensure that
    * both merged & mergee fields are respected.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testBatchMergeCustomDataZeroValueField() {
-    $customGroup = $this->CustomGroupCreate();
+    $customGroup = $this->customGroupCreate();
     $customField = $this->customFieldCreate(['custom_group_id' => $customGroup['id'], 'default_value' => NULL]);
 
     $mouseParams = ['first_name' => 'Mickey', 'last_name' => 'Mouse', 'email' => 'tha_mouse@mouse.com'];


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow up to adding Contact.get_merge_conflicts

 api action which consolidates conflict handling and formatting

Before
----------------------------------------
Script-friendly format of conflicts returned from Contact.get_merge_conflicts api but not from retrieving results of Job.process_batch_merge, which only returned a text string

After
----------------------------------------
The same conflicts format that is returned by calling contact.get_merge_conflicts is saved to the database for calls to Job.process_batch_merge. The underlying code is moved out of the api layer & into the BAO where it would be equally available to apiv4

Technical Details
----------------------------------------
This ensures that conflicts are stored during batch_merge to the prev_next cache with the same format as when the api
calls get_conflicts. The code doing this wrangling is moved from the api to the BAO layer.

We add a test to ensure the output is the same & use the previously added test to check the string is the same too.

Test cover here is very good (got quite a lot of fails off enotices in the process)

Comments
----------------------------------------
@pfigel this is really part & parcel of https://github.com/civicrm/civicrm-core/pull/14394 & I'd like to get it into the same release (5.16) as the tidy up / consolidation that goes with #14394 - I can also then document it properly https://github.com/civicrm/civicrm-dev-docs/issues/632 & demonstrate usage in https://github.com/eileenmcnaughton/org.wikimedia.dedupetools
