### PR TITLE
Fix failing test by changing expected date format

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -420,6 +420,8 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
 
   /**
    *  CRM-21343: Test CRM_Contribute_Form_Search Cancelled filters
+   *
+   * @throws CRM_Core_Exception
    */
   public function testCancelledFilter() {
     $this->quickCleanup($this->_tablesToTruncate);
@@ -462,7 +464,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
         'form_value' => ['contribution_cancel_date' => date('Y-m-d')],
         'expected_count' => 2,
         'expected_contribution' => [$Contribution1['id'], $Contribution3['id']],
-        'expected_qill' => "Cancelled / Refunded Date = " . date('F dS, Y') . " 12:00 AM",
+        'expected_qill' => "Cancelled / Refunded Date = " . date('F jS, Y') . " 12:00 AM",
       ],
       // Case 2: Search for Cancelled Reason
       [
@@ -476,7 +478,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
         'form_value' => ['contribution_cancel_date' => date('Y-m-d'), 'cancel_reason' => 'Insufficient funds'],
         'expected_count' => 1,
         'expected_contribution' => [$Contribution1['id']],
-        'expected_qill' => "Cancellation / Refund Reason Like '%Insufficient funds%'ANDCancelled / Refunded Date = " . date('F dS, Y') . " 12:00 AM",
+        'expected_qill' => "Cancellation / Refund Reason Like '%Insufficient funds%'ANDCancelled / Refunded Date = " . date('F jS, Y') . " 12:00 AM",
       ],
     ];
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1713,11 +1713,11 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @param array $tablesToTruncate
    * @param bool $dropCustomValueTables
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function quickCleanup($tablesToTruncate, $dropCustomValueTables = FALSE) {
     if ($this->tx) {
-      throw new Exception("CiviUnitTestCase: quickCleanup() is not compatible with useTransaction()");
+      throw new \CRM_Core_Exception("CiviUnitTestCase: quickCleanup() is not compatible with useTransaction()");
     }
     if ($dropCustomValueTables) {
       $optionGroupResult = CRM_Core_DAO::executeQuery('SELECT option_group_id FROM civicrm_custom_field');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a test that fails on the first 9 days of the month

Before
----------------------------------------
Failing test on master

After
----------------------------------------
Passing test

Technical Details
----------------------------------------
We have been seeing failures on testCancelledFilter on day one of the month - the reason seems to be
that we are expecting, but not receiving, a date format with a leading zero in the qill. This would
pass for much of the month but fail during the single digit days. This doesn't seem like a regreession to
me - just a test-error surfaced by changes in https://github.com/eileenmcnaughton/civicrm-core/commit/6e7cc0f578e814459b1e1b80c7a922684da46140#diff-984fd916f4708bb4b370841ae0ab69e5R465

Comments
----------------------------------------
@seamuslee001 
