### PR TITLE
Deprecate some deprecated address functions: defaultCurrencySymbol

### DIFF
--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -117,14 +117,14 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
         'weight' => 8,
         'option_values' => [
           'Do_not_show' => ts('Do not show breakdown, only show total -i.e ' .
-            $config->defaultCurrencySymbol . '120.00'),
+            CRM_Core_BAO_Country::defaultCurrencySymbol() . '120.00'),
           'Inclusive' => ts('Show [tax term] inclusive price - i.e. ' .
-            $config->defaultCurrencySymbol .
+            CRM_Core_BAO_Country::defaultCurrencySymbol() .
             '120.00 (includes [tax term] of ' .
-            $config->defaultCurrencySymbol . '20.00)'),
+            CRM_Core_BAO_Country::defaultCurrencySymbol() . '20.00)'),
           'Exclusive' => ts('Show [tax term] exclusive price - i.e. ' .
-            $config->defaultCurrencySymbol . '100.00 + ' .
-            $config->defaultCurrencySymbol . '20.00 [tax term]'),
+            CRM_Core_BAO_Country::defaultCurrencySymbol() . '100.00 + ' .
+            CRM_Core_BAO_Country::defaultCurrencySymbol() . '20.00 [tax term]'),
         ],
       ],
     ];

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -122,6 +122,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       ->addSetting(['setting' => ['monetaryThousandSeparator' => CRM_Core_Config::singleton()->monetaryThousandSeparator]])
       ->addSetting(['setting' => ['monetaryDecimalPoint' => CRM_Core_Config::singleton()->monetaryDecimalPoint]]);
 
+    $this->assign('defaultCurrencySymbol', CRM_Core_BAO_Country::defaultCurrencySymbol());
   }
 
   /**

--- a/CRM/Contribute/BAO/Widget.php
+++ b/CRM/Contribute/BAO/Widget.php
@@ -49,7 +49,7 @@ class CRM_Contribute_BAO_Widget extends CRM_Contribute_DAO_Widget {
     $config = CRM_Core_Config::singleton();
 
     $data = [];
-    $data['currencySymbol'] = $config->defaultCurrencySymbol;
+    $data['currencySymbol'] = CRM_Core_BAO_Country::defaultCurrencySymbol();
 
     if (empty($contributionPageID) ||
       CRM_Utils_Type::validate($contributionPageID, 'Integer') == NULL

--- a/CRM/Core/BAO/Country.php
+++ b/CRM/Core/BAO/Country.php
@@ -160,8 +160,7 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
    * @return string
    */
   public static function getDefaultCurrencySymbol($k = NULL) {
-    $config = CRM_Core_Config::singleton();
-    return $config->defaultCurrencySymbol(Civi::settings()->get('defaultCurrency'));
+    return CRM_Core_BAO_Country::defaultCurrencySymbol(\Civi::settings()->get('defaultCurrency'));
   }
 
 }

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -496,6 +496,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * @return string
    */
   public function defaultCurrencySymbol($defaultCurrency = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_Country::defaultCurrencySymbol');
     return CRM_Core_BAO_Country::defaultCurrencySymbol($defaultCurrency);
   }
 

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -214,6 +214,10 @@ class CRM_Core_Page {
 
     $config = CRM_Core_Config::singleton();
 
+    // @fixme this is probably the wrong place for this.  It is required by jsortable.tpl which is inherited from many page templates.
+    //   So we have to add it here to deprecate $config->defaultCurrencySymbol
+    $this->assign('defaultCurrencySymbol', CRM_Core_BAO_Country::defaultCurrencySymbol());
+
     // Intermittent alert to admins
     CRM_Utils_Check::singleton()->showPeriodicAlerts();
 

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -159,8 +159,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $this->assign('pendingRefund', array_search('Pending refund', $statuses));
     $this->assign('participantStatus', $this->_participantStatus);
 
-    $config = CRM_Core_Config::singleton();
-    $this->assign('currencySymbol', $config->defaultCurrencySymbol);
+    $this->assign('currencySymbol', CRM_Core_BAO_Country::defaultCurrencySymbol());
 
     // line items block
     $lineItem = $event = [];

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -418,7 +418,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   public function buildQuickForm() {
 
     $this->buildQuickEntityForm();
-    $this->assign('currency', CRM_Core_Config::singleton()->defaultCurrencySymbol);
+    $this->assign('currency', CRM_Core_BAO_Country::defaultCurrencySymbol());
     $isUpdateToExistingRecurringMembership = $this->isUpdateToExistingRecurringMembership();
     // build price set form.
     $buildPriceSet = FALSE;

--- a/CRM/Utils/OpenFlashChart.php
+++ b/CRM/Utils/OpenFlashChart.php
@@ -98,8 +98,7 @@ class CRM_Utils_OpenFlashChart {
     $ySteps = $yMax / 5;
 
     $bars = [];
-    $config = CRM_Core_Config::singleton();
-    $symbol = $config->defaultCurrencySymbol;
+    $symbol = CRM_Core_BAO_Country::defaultCurrencySymbol();
     foreach ($values as $barCount => $barVal) {
       $bars[$barCount] = new bar_glass();
 
@@ -214,8 +213,7 @@ class CRM_Utils_OpenFlashChart {
     $graphTitle = !empty($params['legend']) ? $params['legend'] : ts('Pie Chart');
 
     // get the currency.
-    $config = CRM_Core_Config::singleton();
-    $symbol = $config->defaultCurrencySymbol;
+    $symbol = CRM_Core_BAO_Country::defaultCurrencySymbol();
 
     $pie = new pie();
     $pie->radius(100);
@@ -296,8 +294,7 @@ class CRM_Utils_OpenFlashChart {
     }
 
     // get the currency.
-    $config = CRM_Core_Config::singleton();
-    $symbol = $config->defaultCurrencySymbol;
+    $symbol = CRM_Core_BAO_Country::defaultCurrencySymbol();
 
     // set the tooltip.
     $tooltip = CRM_Utils_Array::value('tip', $params, "$symbol #val#");

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -54,7 +54,7 @@
       <td class="label">
         <label>{ts}Total amount entered{/ts}</label>
       </td>
-      <td class="right">{$config->defaultCurrencySymbol} <span class="batch-actual-total"></span></td>
+      <td class="right">{$defaultCurrencySymbol} <span class="batch-actual-total"></span></td>
     </tr>
   </table>
 

--- a/templates/CRM/common/jsortable.tpl
+++ b/templates/CRM/common/jsortable.tpl
@@ -167,7 +167,7 @@
 
   //plugin to sort on currency
   cj.fn.dataTableExt.oSort['currency-asc']  = function(a,b) {
-    var symbol = "{/literal}{$config->defaultCurrencySymbol()}{literal}";
+    var symbol = "{/literal}{$defaultCurrencySymbol}{literal}";
     var x = (a == "-") ? 0 : a.replace( symbol, "" );
     var y = (b == "-") ? 0 : b.replace( symbol, "" );
     x = parseFloat( x );
@@ -176,7 +176,7 @@
   };
 
   cj.fn.dataTableExt.oSort['currency-desc'] = function(a,b) {
-    var symbol = "{/literal}{$config->defaultCurrencySymbol()}{literal}";
+    var symbol = "{/literal}{$defaultCurrencySymbol}{literal}";
     var x = (a == "-") ? 0 : a.replace( symbol, "" );
     var y = (b == "-") ? 0 : b.replace( symbol, "" );
     x = parseFloat( x );


### PR DESCRIPTION
Overview
----------------------------------------
Reviewer's partial of https://github.com/civicrm/civicrm-core/pull/14576

Before
----------------------------------------
Deprecated calls to $config->defaultCurrencySymbol

After
----------------------------------------
Calls to CRM_Core_BAO_Country::defaultCurrencySymbol()

Technical Details
----------------------------------------
This is pretty confusing - $config->defaultCurrencySymbol calls

      'defaultCurrencySymbol' => ['callback', 'CRM_Core_BAO_Country', 'getDefaultCurrencySymbol'],

due to the magic merge - so changing $config->defaultCurrencySymbol to CRM_Core_BAO_Country::defaultCurrencySymbol() does the same thing (and probably I would have rathered keep the scope of one PR to just doing those swaps).

However that function https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:matt?expand=1#diff-cad2bac1dfa829957024f6c1da207254L163 was then calling ```$config->defaultCurrencySymbol(Civi::settings()->get('defaultCurrency')); ``` which in turn calls ```CRM_Core_BAO_Country::defaultCurrencySymbol($defaultCurrency);``` so this cuts the extra function out of that loop & deprecates it

Comments
----------------------------------------
I didn't feel able to review changes to multiple functions in one hit so pulled out one change to review & merge in the first instance from the larger PR
