### PR TITLE
 Fix erroneous variable passed to callAPISuccessGetValue

### DIFF
--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -346,7 +346,7 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
   public function testRevertRestrictedTables() {
 
     CRM_Core_DAO::executeQuery("SET @uniqueID = 'temp name'");
-    $this->callAPISuccessGetValue('Setting', array('name' => 'logging_all_tables_uniquid'), TRUE);
+    $this->assertEquals(TRUE, $this->callAPISuccessGetValue('Setting', ['name' => 'logging_all_tables_uniquid']));
     $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
 
     $contactId = $this->individualCreate(array('address' => array(array('street_address' => '27 Cool way', 'location_type_id' => 1))));


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a mis-call to getValue that results in test fails when we clean up the exception calls

Before
----------------------------------------
Wrong parameter passed

After
----------------------------------------
Wrong parameter not passed


Technical Details
----------------------------------------

Comments
----------------------------------------

