### PR TITLE
dev/core#1088 Fix fatal error when copying profile with civirules enabled

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1672,7 +1672,7 @@ FROM   civicrm_domain
       }
       $newObject->save();
       $newObject->copyCustomFields($object->id, $newObject->id);
-      CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getBriefName($daoName), $newObject->id, $newObject);
+      CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getBriefName(str_replace('_BAO_', '_DAO_', $daoName)), $newObject->id, $newObject);
     }
 
     return $newObject;


### PR DESCRIPTION
Overview
----------------------------------------
In Oct last year we started calling the post create hook when copying entities. In some cases the object name was not passed correctly and where that co-incided with CiviRules the NULL objectName resulted in a fatal rather than being silently ignored. This fixes by passing the object name when bao name rather than bao name is known

Before
----------------------------------------
Fatal error when copying a profile with CiviRules enabled 

After
----------------------------------------
No error

Technical Details
----------------------------------------
More of a 'never worked' than a regression but targetting the rc still makes sense I think since it could be experienced as a regression



Comments
----------------------------------------
@jaapjansma FYI - I'm not sure if you want to do some different error handling on objectName not being passed - it won't happen from copyGeneric again since that would be an odd thing to do but presumably this means the civirules experience has been quietly broken in an obscure way for 8 months (obviously no-one noticed .....)

https://lab.civicrm.org/dev/core/issues/1088