### PR TITLE
Remove failing assertion

### DIFF
--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -346,7 +346,6 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
   public function testRevertRestrictedTables() {
 
     CRM_Core_DAO::executeQuery("SET @uniqueID = 'temp name'");
-    $this->assertEquals(TRUE, $this->callAPISuccessGetValue('Setting', ['name' => 'logging_all_tables_uniquid']));
     $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
 
     $contactId = $this->individualCreate(array('address' => array(array('street_address' => '27 Cool way', 'location_type_id' => 1))));


### PR DESCRIPTION
Overview
----------------------------------------
Remove failing test assertion - that never worked

Before
----------------------------------------
Test failing as false negative

After
----------------------------------------
Test fail is gone

Technical Details
----------------------------------------
This was a 'never worked' as the original call was doing no check. I changed it to do a check but
got confused & didn't realise the check was actually failing when I merged. This check was never successful
we should remove it

Comments
----------------------------------------

