### PR TITLE
[REF] Cleanup fixSchemaDifferencesFor()

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -73,7 +73,7 @@ class CRM_Core_BAO_SchemaHandler {
     if ($config->logging) {
       // logging support
       $logging = new CRM_Logging_Schema();
-      $logging->fixSchemaDifferencesFor($params['name'], NULL, FALSE);
+      $logging->fixSchemaDifferencesFor($params['name']);
     }
 
     // always do a trigger rebuild for this table
@@ -312,7 +312,7 @@ ALTER TABLE {$tableName}
       // Are there any modifies we DON'T was to call this function for (& shouldn't it be clever enough to cope?)
       if ($params['operation'] == 'add' || $params['operation'] == 'modify') {
         $logging = new CRM_Logging_Schema();
-        $logging->fixSchemaDifferencesFor($params['table_name'], [trim(strtoupper($params['operation'])) => [$params['name']]], FALSE);
+        $logging->fixSchemaDifferencesFor($params['table_name'], [trim(strtoupper($params['operation'])) => [$params['name']]]);
       }
     }
 

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -430,12 +430,10 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    *   name of the relevant table.
    * @param array $cols
    *   Mixed array of columns to add or null (to check for the missing columns).
-   * @param bool $rebuildTrigger
-   *   should we rebuild the triggers.
    *
    * @return bool
    */
-  public function fixSchemaDifferencesFor($table, $cols = [], $rebuildTrigger = FALSE) {
+  public function fixSchemaDifferencesFor($table, $cols = []) {
     if (empty($table)) {
       return FALSE;
     }
@@ -469,10 +467,6 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
       }
     }
 
-    if ($rebuildTrigger) {
-      // invoke the meta trigger creation call
-      CRM_Core_DAO::triggerRebuild($table);
-    }
     return TRUE;
   }
 
@@ -523,7 +517,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
     }
 
     foreach ($diffs as $table => $cols) {
-      $this->fixSchemaDifferencesFor($table, $cols, FALSE);
+      $this->fixSchemaDifferencesFor($table, $cols);
     }
     if ($rebuildTrigger) {
       // invoke the meta trigger creation call

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -443,7 +443,7 @@ function civicrm_api3_system_createmissinglogtables() {
   $missingLogTables = $schema->getMissingLogTables();
   if (!empty($missingLogTables)) {
     foreach ($missingLogTables as $tableName) {
-      $schema->fixSchemaDifferencesFor($tableName, NULL, FALSE);
+      $schema->fixSchemaDifferencesFor($tableName);
     }
   }
   return civicrm_api3_create_success(1);

--- a/tests/phpunit/CRM/Logging/LoggingTest.php
+++ b/tests/phpunit/CRM/Logging/LoggingTest.php
@@ -43,8 +43,9 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
     CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` ADD COLUMN `logging_test` INT DEFAULT '0'", array(), FALSE, NULL, FALSE, FALSE);
     CRM_Core_I18n_Schema::rebuildMultilingualSchema(array('en_US'));
     \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
-    $logging->fixSchemaDifferencesFor('civicrm_option_value', array(), TRUE);
-    $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", array(), TRUE, NULL, FALSE, FALSE);
+    $logging->fixSchemaDifferencesFor('civicrm_option_value');
+    Civi::service('sql_triggers')->rebuild('civicrm_option_value');
+    $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", [], TRUE, NULL, FALSE, FALSE);
     $query->fetch();
     $create = explode("\n", $query->Create_Table);
     // MySQL may return "DEFAULT 0" or "DEFAULT '0'" depending on version
@@ -52,15 +53,16 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
       in_array("  `logging_test` int(11) DEFAULT '0'", $create)
       || in_array("  `logging_test` int(11) DEFAULT 0", $create)
     );
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` DROP COLUMN `logging_test`", array(), FALSE, NULL, FALSE, FALSE);
-    $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", array(), TRUE, NULL, FALSE, FALSE);
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` DROP COLUMN `logging_test`", [], FALSE, NULL, FALSE, FALSE);
+    $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", [], TRUE, NULL, FALSE, FALSE);
     $query->fetch();
     $domain = new CRM_Core_DAO_Domain();
     $domain->find(TRUE);
     $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
-    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
     CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales);
-    $logging->fixSchemaDifferencesFor('civicrm_option_value', array(), TRUE);
+    $logging->fixSchemaDifferencesFor('civicrm_option_value');
+    Civi::service('sql_triggers')->rebuild('civicrm_option_value');
     $this->assertTrue(
       in_array("  `logging_test` int(11) DEFAULT '0'", $create)
       || in_array("  `logging_test` int(11) DEFAULT 0", $create));


### PR DESCRIPTION
Overview
----------------------------------------
Clean up signature for fixSchemaDifferencesFor() function

Before
----------------------------------------
Function has parameter for triggerRebuild which calls a deprecated function but is never passed except by unit tests

After
----------------------------------------
Parameter removed. In addition $cols not passed when it is empty as that is the default

Technical Details
----------------------------------------
This is always called with FALSE as the last param except from the unit test - the test can do it's own work on it
Also passing NULL for param 2 is the same as not passing anything

Comments
----------------------------------------
