### PR TITLE
Activity search - convert priority_id to a metadata field and add location as a searchable field

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -463,7 +463,7 @@ class CRM_Activity_BAO_Query {
    * rather than a static function.
    */
   public static function getSearchFieldMetadata() {
-    $fields = ['activity_type_id', 'activity_date_time'];
+    $fields = ['activity_type_id', 'activity_date_time', 'priority_id', 'activity_location'];
     $metadata = civicrm_api3('Activity', 'getfields', [])['values'];
     return array_intersect_key($metadata, array_flip($fields));
   }
@@ -514,17 +514,6 @@ class CRM_Activity_BAO_Query {
 
     $form->addRadio('activity_option', '', CRM_Core_SelectValues::activityTextOptions());
     $form->setDefaults(['activity_option' => 'both']);
-
-    $priority = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id');
-    $form->addSelect('priority_id',
-      [
-        'entity' => 'activity',
-        'label' => ts('Priority'),
-        'multiple' => 'multiple',
-        'option_url' => NULL,
-        'placeholder' => ts('- any -'),
-      ]
-    );
 
     $form->addYesNo('activity_test', ts('Activity is a Test?'));
     $activity_tags = CRM_Core_BAO_Tag::getColorTags('civicrm_activity');
@@ -680,7 +669,9 @@ class CRM_Activity_BAO_Query {
    * Where/qill clause for notes
    *
    * @param array $values
-   * @param object $query
+   * @param CRM_Contact_BAO_Query $query
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function whereClauseSingleActivityText(&$values, &$query) {
     list($name, $op, $value, $grouping, $wildcard) = $values;

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -110,6 +110,11 @@
     &nbsp; {$form.activity_test.html}
   </td>
 </tr>
+<tr>
+<td>{$form.activity_location.label}<br />
+  {$form.activity_location.html}</td>
+<td></td>
+</tr>
 {if $buildSurveyResult }
   <tr>
     <td id="activityResult">


### PR DESCRIPTION
Overview
----------------------------------------
Adds location as a search field on activity search and converts priority_id to be a metadata field (which makes it url reachable

Before
----------------------------------------

After
----------------------------------------
<img width="524" alt="Screen Shot 2019-07-02 at 5 24 25 PM" src="https://user-images.githubusercontent.com/336308/60485160-129eec80-9cf0-11e9-929c-2d52dd14f114.png">


Technical Details
----------------------------------------
The location field on activity in a generally exposed field so it makes sense it should be in the search. Priority_id conversion is part of ongoing standardisation which includes adding url parameter support for the field.

However, in digging into this I started to feel like priority_id is a little bit of a can of worms in that I think maybe we should add a unique_name for it as it gets renamed straight away on submit @seamuslee001 what do you think - I think only receive date has been a real mare. I wondered about pulling it back out of this PR but it only changes next steps


Comments
----------------------------------------
