### PR TITLE
dev/joomla#13 - followup - Some class names have wrong upper/lower case spelling

### DIFF
--- a/CRM/Admin/Page/CKEditorConfig.php
+++ b/CRM/Admin/Page/CKEditorConfig.php
@@ -163,7 +163,7 @@ class CRM_Admin_Page_CKEditorConfig extends CRM_Core_Page {
     foreach (glob($pluginDir . '/*', GLOB_ONLYDIR) as $dir) {
       $dir = rtrim(str_replace('\\', '/', $dir), '/');
       $name = substr($dir, strrpos($dir, '/') + 1);
-      $dir = CRM_Utils_file::addTrailingSlash($dir, '/');
+      $dir = CRM_Utils_File::addTrailingSlash($dir, '/');
       if (is_file($dir . 'plugin.js')) {
         $plugins[$name] = [
           'id' => $name,

--- a/CRM/Grant/Page/Tab.php
+++ b/CRM/Grant/Page/Tab.php
@@ -177,7 +177,7 @@ class CRM_Grant_Page_Tab extends CRM_Contact_Page_View {
         break;
 
       case 'edit':
-        $url = CRM_utils_System::url('civicrm/contact/view/grant', 'reset=1&id=' . $this->_id . '&cid=' . $this->_contactId . '&action=view&context=grant&selectedChild=grant');
+        $url = CRM_Utils_System::url('civicrm/contact/view/grant', 'reset=1&id=' . $this->_id . '&cid=' . $this->_contactId . '&action=view&context=grant&selectedChild=grant');
         break;
 
       case 'grant':

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -603,7 +603,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
       }
       \Civi::$statics[__CLASS__]['columnsOf'][$table] = [];
       while ($dao->fetch()) {
-        \Civi::$statics[__CLASS__]['columnsOf'][$table][] = CRM_Utils_type::escape($dao->Field, 'MysqlColumnNameOrAlias');
+        \Civi::$statics[__CLASS__]['columnsOf'][$table][] = CRM_Utils_Type::escape($dao->Field, 'MysqlColumnNameOrAlias');
       }
     }
     return \Civi::$statics[__CLASS__]['columnsOf'][$table];

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -427,7 +427,7 @@ WHERE li.contribution_id = %1";
    */
   public static function processPriceSet($entityId, $lineItem, $contributionDetails = NULL, $entityTable = 'civicrm_contribution', $update = FALSE) {
     if (!$entityId || !is_array($lineItem)
-      || CRM_Utils_system::isNull($lineItem)
+      || CRM_Utils_System::isNull($lineItem)
     ) {
       return;
     }

--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -171,7 +171,7 @@ class CRM_Utils_Cache {
    *     Support varies by driver:
    *       - For most memory backed caches, this option is meaningful.
    *       - For SqlGroup, this option is ignored. SqlGroup has equivalent behavior built-in.
-   *       - For Arraycache, this option is ignored. It's redundant.
+   *       - For ArrayCache, this option is ignored. It's redundant.
    *      If this is a short-lived process in which TTL's don't matter, you might
    *      use 'fast' mode. It sacrifices some PSR-16 compliance and cache-coherency
    *      protections to improve performance.

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -32,9 +32,9 @@
  */
 
 /**
- * Class CRM_Utils_Cache_Arraycache
+ * Class CRM_Utils_Cache_ArrayCache
  */
-class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
+class CRM_Utils_Cache_ArrayCache implements CRM_Utils_Cache_Interface {
 
   use CRM_Utils_Cache_NaiveMultipleTrait;
   // TODO Native implementation
@@ -56,7 +56,7 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
    * @param array $config
    *   An array of configuration params.
    *
-   * @return \CRM_Utils_Cache_Arraycache
+   * @return \CRM_Utils_Cache_ArrayCache
    */
   public function __construct($config) {
     $this->_cache = [];

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1432,7 +1432,7 @@ class CRM_Utils_System {
     // zealous about destroying *all* memory-backed caches during a flush().
     // These flushes simulate that legacy behavior. However, they should probably
     // be removed at some point.
-    $localDrivers = ['CRM_Utils_Cache_Arraycache', 'CRM_Utils_Cache_NoCache'];
+    $localDrivers = ['CRM_Utils_Cache_ArrayCache', 'CRM_Utils_Cache_NoCache'];
     if (Civi\Core\Container::isContainerBooted()
       && !in_array(get_class(CRM_Utils_Cache::singleton()), $localDrivers)) {
       Civi::cache('long')->flush();

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -160,7 +160,7 @@ class CRM_Utils_VersionCheck {
         'co' => $config->defaultContactCountry,
         'ufv' => $config->userSystem->getVersion(),
         'PHP' => phpversion(),
-        'MySQL' => CRM_CORE_DAO::singleValueQuery('SELECT VERSION()'),
+        'MySQL' => CRM_Core_DAO::singleValueQuery('SELECT VERSION()'),
         'communityMessagesUrl' => Civi::settings()->get('communityMessagesUrl'),
       ];
       $this->getDomainStats();

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -50,7 +50,7 @@ class Manager {
    */
   public function __construct($res, \CRM_Utils_Cache_Interface $cache = NULL) {
     $this->res = $res;
-    $this->cache = $cache ? $cache : new \CRM_Utils_Cache_Arraycache([]);
+    $this->cache = $cache ? $cache : new \CRM_Utils_Cache_ArrayCache([]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Based on discovery by @agh1 in https://lab.civicrm.org/dev/joomla/issues/13 that ~~Pseudoconstant~~ PseudoConstant was mistyped in some places causing problems, this follows up to find other misspelled classnames.

This is WIP. There's still others I can see just want to put this up.

Before
----------------------------------------
Possible hard to diagnose problems.

After
----------------------------------------
TBD.

Technical Details
----------------------------------------
PHP is case-insensitive for classnames. Autoloaders and other code sometimes not. Fun ensues.

Comments
----------------------------------------
Suggest all classes be named using non-ascii characters since then case-insensitive mismatch is impossible. I'm kidding. (Not kidding). (Maybe kidding).
