### PR TITLE
dev/core#538 fix advanced search on activity subject, detail to use wildcards like activity search does

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -465,7 +465,13 @@ class CRM_Activity_BAO_Query {
   public static function getSearchFieldMetadata() {
     $fields = ['activity_type_id', 'activity_date_time', 'priority_id', 'activity_location'];
     $metadata = civicrm_api3('Activity', 'getfields', [])['values'];
-    return array_intersect_key($metadata, array_flip($fields));
+    $metadata = array_intersect_key($metadata, array_flip($fields));
+    $metadata['activity_text'] = [
+      'title' => ts('Activity Text'),
+      'type' => CRM_Utils_Type::T_STRING,
+      'is_pseudofield' => TRUE,
+    ];
+    return $metadata;
   }
 
   /**

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -196,14 +196,12 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     }
 
     $this->_done = TRUE;
-
+    $this->setFormValues();
     if (!empty($_POST)) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
       $specialParams = [
         'activity_type_id',
         'status_id',
         'priority_id',
-        'activity_text',
       ];
       $changeNames = [
         'status_id' => 'activity_status_id',

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3452,7 +3452,7 @@ WHERE  $smartGroupClause
       return;
     }
 
-    $input = $value = trim($value);
+    $input = $value = is_array($value) ? trim($value['LIKE']) : trim($value);
 
     if (!strlen($value)) {
       return;

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -228,10 +228,10 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
   public function postProcess() {
     $this->set('isAdvanced', '1');
 
+    $this->setFormValues();
     // get user submitted values
     // get it from controller only if form has been submitted, else preProcess has set this
     if (!empty($_POST)) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
       $this->normalizeFormValues();
       // FIXME: couldn't figure out a good place to do this,
       // FIXME: so leaving this as a dependency for now
@@ -349,8 +349,6 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       'activity_type_id',
       'status_id',
       'priority_id',
-      'activity_subject',
-      'activity_details',
       'contribution_page_id',
       'contribution_product_id',
       'payment_instrument_id',

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -288,10 +288,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
 
     $this->_done = TRUE;
 
-    if (!empty($_POST) && !$this->_force) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
-    $this->convertTextStringsToUseLikeOperator();
+    $this->setFormValues();
     $this->fixFormValues();
 
     // We don't show test records in summaries or dashboards


### PR DESCRIPTION
Overview
----------------------------------------
Makes searching on (some) fields consistent between advanced search & component searches - tested are invoice_number, activity details & subject, activity location. (Not these are all fields that are defined as search metadata 

Before
----------------------------------------
Searching for activity subject or details in activity search does a 'like %%' search but from advanced search it does = '' search

e.g create an activity with location 'here' - search for it with the string 'here' - it's findable - search with just 'her' & it isn't.

After
----------------------------------------
Searching on activity details (or other mentioned fields) from advanced search does a like '%blah%' search (or LIKE 'blah%' if wildcards disabled for performance . - which all large sites should)

Technical Details
----------------------------------------
This builds off https://github.com/civicrm/civicrm-core/pull/14701 which I will rebase out of it once merged

Comments
----------------------------------------
Original issues seem to be duplicates
https://lab.civicrm.org/dev/core/issues/509
https://lab.civicrm.org/dev/core/issues/538
