### PR TITLE
expose smarty's compile_check to be overridden in civicrm.settings.php

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -144,6 +144,8 @@ class CRM_Core_Smarty extends Smarty {
       $this->plugins_dir = [$smartyDir . 'plugins', $pluginsDir];
     }
 
+    $this->compile_check = $this->isCheckSmartyIsCompiled();
+
     // add the session and the config here
     $session = CRM_Core_Session::singleton();
 
@@ -338,6 +340,16 @@ class CRM_Core_Smarty extends Smarty {
     }
 
     return 'en_US';
+  }
+
+  /**
+   * Get the compile_check value.
+   *
+   * @return bool
+   */
+  private function isCheckSmartyIsCompiled() {
+    // check for define in civicrm.settings.php as FALSE, otherwise returns TRUE
+    return CRM_Utils_Constant::value('CIVICRM_TEMPLATE_COMPILE_CHECK', TRUE);
   }
 
 }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -184,6 +184,21 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
 }
 
 /**
+ * SMARTY Compile Check:
+ *
+ * This tells Smarty whether to check for recompiling or not. Recompiling
+ * does not need to happen unless a template or config file is changed.
+ * Typically you enable this during development, and disable for production.
+ *
+ * Related issue:
+ * https://lab.civicrm.org/dev/core/issues/1073
+ *
+ */
+//if (!defined('CIVICRM_TEMPLATE_COMPILE_CHECK')) {
+//  define( 'CIVICRM_TEMPLATE_COMPILE_CHECK', FALSE);
+//}
+
+/**
  * Site URLs:
  *
  * This section defines absolute and relative URLs to access the host CMS (Backdrop, Drupal, or Joomla) resources.


### PR DESCRIPTION
Overview
----------------------------------------
Expose Smarty variable `compile_force` to be able to override its value from `civicrm.settings.php`.  
In some *prod* environments this value in **FALSE** has a positive impact on page rendering performance

Before
----------------------------------------
Smarty var `compile_force` is set to **TRUE** by default, and cannot be modified per-site without changing core file

After
----------------------------------------
Smarty var `compile_force` is set to **TRUE** by default, and a new define `CIVICRM_TEMPLATE_COMPILE_CHECK` is exposed on `civicrm.settings.php` to be able to change its value on-demand

Technical Details
----------------------------------------
First step to be able to change this Smarty variable, depending on further testings, the default value of it may change in the future

Comments
----------------------------------------
related issue: https://lab.civicrm.org/dev/core/issues/1073
related obsolete PR: https://github.com/civicrm/civicrm-packages/pull/257
