### PR TITLE
dev/joomla#13 - followup 5 - Some class names have wrong upper/lower case spelling

### DIFF
--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -162,7 +162,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
    * Add local and global form rules.
    */
   public function addRules() {
-    $this->addFormRule(['CRM_Contact_Form_task_AddToGroup', 'formRule']);
+    $this->addFormRule(['CRM_Contact_Form_Task_AddToGroup', 'formRule']);
   }
 
   /**

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4736,7 +4736,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // Use input value if supplied.
     if (!empty($input['receipt_from_email'])) {
       return [
-        CRM_Utils_array::value('receipt_from_name', $input, ''),
+        CRM_Utils_Array::value('receipt_from_name', $input, ''),
         $input['receipt_from_email'],
       ];
     }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1236,7 +1236,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    *
    * @param string $elementName
    * @param array $optionIds
-   * @param CRM_Core_form $form
+   * @param CRM_Core_Form $form
    */
   public static function resetSubmittedValue($elementName, $optionIds = array(), &$form) {
     if (empty($elementName) ||


### PR DESCRIPTION
Part 5 of 5
See https://github.com/civicrm/civicrm-core/pull/14702