### PR TITLE
Rewrite subTypeInfo to use caching mechanism

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -149,65 +149,45 @@ WHERE  parent_id IS NULL
    *   ..
    * @param bool $all
    * @param bool $ignoreCache
-   * @param bool $reset
    *
    * @return array
    *   Array of sub type information
    */
-  public static function subTypeInfo($contactType = NULL, $all = FALSE, $ignoreCache = FALSE, $reset = FALSE) {
-    static $_cache = NULL;
-
-    if ($reset === TRUE) {
-      $_cache = NULL;
-    }
-
-    if ($_cache === NULL) {
-      $_cache = [];
-    }
-    if ($contactType && !is_array($contactType)) {
-      $contactType = [$contactType];
-    }
-
+  public static function subTypeInfo($contactType = NULL, $all = FALSE, $ignoreCache = FALSE) {
     $argString = $all ? 'CRM_CT_STI_1_' : 'CRM_CT_STI_0_';
     if (!empty($contactType)) {
+      $contactType = (array) $contactType;
       $argString .= implode('_', $contactType);
     }
+    if (!Civi::cache('contactTypes')->has($argString) || $ignoreCache) {
+      $ctWHERE = '';
+      if (!empty($contactType)) {
+        $ctWHERE = " AND parent.name IN ('" . implode("','", $contactType) . "')";
+      }
 
-    if ((!array_key_exists($argString, $_cache)) || $ignoreCache) {
-      $cache = CRM_Utils_Cache::singleton();
-      $_cache[$argString] = $cache->get($argString);
-      if (!$_cache[$argString] || $ignoreCache) {
-        $_cache[$argString] = [];
-
-        $ctWHERE = '';
-        if (!empty($contactType)) {
-          $ctWHERE = " AND parent.name IN ('" . implode("','", $contactType) . "')";
-        }
-
-        $sql = "
+      $sql = "
 SELECT subtype.*, parent.name as parent, parent.label as parent_label
 FROM   civicrm_contact_type subtype
 INNER JOIN civicrm_contact_type parent ON subtype.parent_id = parent.id
 WHERE  subtype.name IS NOT NULL AND subtype.parent_id IS NOT NULL {$ctWHERE}
 ";
-        if ($all === FALSE) {
-          $sql .= " AND subtype.is_active = 1 AND parent.is_active = 1 ORDER BY parent.id";
-        }
-        $dao = CRM_Core_DAO::executeQuery($sql, [],
-          FALSE, 'CRM_Contact_DAO_ContactType'
-        );
-        while ($dao->fetch()) {
-          $value = [];
-          CRM_Core_DAO::storeValues($dao, $value);
-          $value['parent'] = $dao->parent;
-          $value['parent_label'] = $dao->parent_label;
-          $_cache[$argString][$dao->name] = $value;
-        }
-
-        $cache->set($argString, $_cache[$argString]);
+      if ($all === FALSE) {
+        $sql .= " AND subtype.is_active = 1 AND parent.is_active = 1 ORDER BY parent.id";
       }
+      $dao = CRM_Core_DAO::executeQuery($sql, [],
+        FALSE, 'CRM_Contact_DAO_ContactType'
+      );
+      $values = [];
+      while ($dao->fetch()) {
+        $value = [];
+        CRM_Core_DAO::storeValues($dao, $value);
+        $value['parent'] = $dao->parent;
+        $value['parent_label'] = $dao->parent_label;
+        $values[$dao->name] = $value;
+      }
+      Civi::cache('contactTypes')->set($argString, $values);
     }
-    return $_cache[$argString];
+    return Civi::cache('contactTypes')->get($argString);
   }
 
   /**
@@ -378,6 +358,7 @@ WHERE  type.name IS NOT NULL
     $isSeparator = TRUE,
     $separator = '__'
   ) {
+    // @todo - use Cache class - ie like Civi::cache('contactTypes')
     static $_cache = NULL;
 
     if ($_cache === NULL) {
@@ -467,6 +448,7 @@ AND   ( p.is_active = 1 OR p.id IS NULL )
    *   basicTypes.
    */
   public static function getBasicType($subType) {
+    // @todo - use Cache class - ie like Civi::cache('contactTypes')
     static $_cache = NULL;
     if ($_cache === NULL) {
       $_cache = [];
@@ -617,8 +599,9 @@ DELETE
 FROM civicrm_navigation
 WHERE name = %1";
       $params = [1 => ["New $name", 'String']];
-      $dao = CRM_Core_DAO::executeQuery($sql, $params);
+      CRM_Core_DAO::executeQuery($sql, $params);
       CRM_Core_BAO_Navigation::resetNavigation();
+      Civi::cache('contactTypes')->clear();
     }
     return TRUE;
   }
@@ -680,9 +663,7 @@ WHERE name = %1";
       CRM_Core_BAO_Navigation::add($navigation);
     }
     CRM_Core_BAO_Navigation::resetNavigation();
-
-    // reset the cache after adding
-    self::subTypeInfo(NULL, FALSE, FALSE, TRUE);
+    Civi::cache('contactTypes')->clear();
 
     return $contactType;
   }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1442,6 +1442,7 @@ class CRM_Utils_System {
       Civi::cache('groups')->flush();
       Civi::cache('navigation')->flush();
       Civi::cache('customData')->flush();
+      Civi::cache('contactTypes')->clear();
       CRM_Extension_System::singleton()->getCache()->flush();
       CRM_Cxn_CiviCxnHttp::singleton()->getCache()->flush();
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -159,6 +159,7 @@ class Container {
       'navigation' => 'navigation',
       'customData' => 'custom data',
       'fields' => 'contact fields',
+      'contactTypes' => 'contactTypes',
     ];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
@@ -168,7 +169,7 @@ class Container {
       // For Caches that we don't really care about the ttl for and/or maybe accessed
       // fairly often we use the fastArrayDecorator which improves reads and writes, these
       // caches should also not have concurrency risk.
-      $fastArrayCaches = ['groups', 'navigation', 'customData', 'fields'];
+      $fastArrayCaches = ['groups', 'navigation', 'customData', 'fields', 'contactTypes'];
       if (in_array($cacheSvc, $fastArrayCaches)) {
         $definitionParams['withArray'] = 'fast';
       }

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
@@ -200,8 +200,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test del() with valid data
-   * success expected
+   * Test del() with valid data.
    */
   public function testDel() {
 
@@ -212,11 +211,12 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
     $subtype = CRM_Contact_BAO_ContactType::add($params);
-
-    $del = CRM_Contact_BAO_ContactType::del($subtype->id);
     $result = CRM_Contact_BAO_ContactType::subTypes();
-    $this->assertEquals($del, TRUE);
-    $this->assertEquals(in_array($subtype->name, $result), TRUE);
+    $this->assertEquals(TRUE, in_array($subtype->name, $result, TRUE));
+    $this->callAPISuccess('ContactType', 'delete', ['id' => $subtype->id]);
+
+    $result = CRM_Contact_BAO_ContactType::subTypes();
+    $this->assertEquals(FALSE, in_array($subtype->name, $result, TRUE));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix unnecessary DB lookups on sites with no sub types due to cache miss

Before
----------------------------------------
Cache being missed

After
----------------------------------------
Cache not being missed

Technical Details
----------------------------------------
So @totten @seamuslee001 I spotted this one getting a lot of setex in our redis logs & it also seems a good one for me to clarify the 'right' methodology. The issue here is that the change in this PR seems to work & fixes it but I'm no longer sure the best way to clear the cache - currently if you add a type it calls

```
     // reset the cache after adding
    self::subTypeInfo(NULL, FALSE, FALSE, TRUE);
```

This PR flattens the key so we would need to do multiple cache deletes to achieve the same - what is the right approach?

Comments
----------------------------------------

