### PR TITLE
Move log and compilation dirs from "Runtime" to "Paths"

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -106,8 +106,6 @@ class CRM_Core_Config_MagicMerge {
       'userFrameworkURLVar' => ['runtime'],
       'userHookClass' => ['runtime'],
       'cleanURL' => ['runtime'],
-      'configAndLogDir' => ['runtime'],
-      'templateCompileDir' => ['runtime'],
       'templateDir' => ['runtime'],
 
       // "boot-svc" properties are critical services needed during init.
@@ -189,6 +187,12 @@ class CRM_Core_Config_MagicMerge {
       'wkhtmltopdfPath' => ['setting'],
       'wpBasePage' => ['setting'],
       'wpLoadPhp' => ['setting'],
+
+      // "path" properties are managed via Civi::paths and $civicrm_paths
+      // Option: `mkdir` - auto-create dir
+      // Option: `restrict` - auto-restrict remote access
+      'configAndLogDir' => ['path', 'civicrm.log', ['mkdir', 'restrict']],
+      'templateCompileDir' => ['path', 'civicrm.compile', ['mkdir', 'restrict']],
 
       // "setting-path" properties are settings with special filtering
       // to return normalized file paths.

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -241,10 +241,14 @@ class CRM_Core_Config_MagicMerge {
       case 'setting':
         return $this->getSettings()->get($name);
 
+      // The interpretation of 'path' and 'setting-path' is similar, except
+      // that the latter originates in a stored setting.
+      case 'path':
       case 'setting-path':
         // Array(0 => $type, 1 => $setting, 2 => $actions).
-        $value = $this->getSettings()->get($name);
-        $value = Civi::paths()->getPath($value);
+        $value = ($type === 'path')
+          ? Civi::paths()->getVariable($name, 'path')
+          : Civi::paths()->getPath($this->getSettings()->get($name));
         if ($value) {
           $value = CRM_Utils_File::addTrailingSlash($value);
           if (isset($this->map[$k][2]) && in_array('mkdir', $this->map[$k][2])) {
@@ -322,6 +326,7 @@ class CRM_Core_Config_MagicMerge {
       case 'setting':
       case 'setting-path':
       case 'setting-url':
+      case 'path':
       case 'user-system':
       case 'runtime':
       case 'callback':

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -106,7 +106,7 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
       CRM_Utils_File::restrictAccess($this->templateCompileDir);
     }
 
-    $civicrm_private = $GLOBALS['civicrm_paths']['civicrm.private'];
+    $civicrm_private = $GLOBALS['civicrm_paths']['civicrm.private']['path'];
     if (!empty($civicrm_private)) {
       $this->configAndLogDir = rtrim($civicrm_private, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
     }

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -101,13 +101,17 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
 
     if (defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
       $this->configAndLogDir = CRM_Utils_File::baseFilePath() . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
-      CRM_Utils_File::createDir($this->configAndLogDir);
-      CRM_Utils_File::restrictAccess($this->configAndLogDir);
-
       $this->templateCompileDir = defined('CIVICRM_TEMPLATE_COMPILEDIR') ? CRM_Utils_File::addTrailingSlash(CIVICRM_TEMPLATE_COMPILEDIR) : NULL;
       CRM_Utils_File::createDir($this->templateCompileDir);
       CRM_Utils_File::restrictAccess($this->templateCompileDir);
     }
+
+    $civicrm_private = Civi::paths()->getPath('[civicrm.private]');
+    if (!empty($civicrm_private)) {
+      $this->configAndLogDir = rtrim($civicrm_private, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
+    }
+    CRM_Utils_File::createDir($this->configAndLogDir);
+    CRM_Utils_File::restrictAccess($this->configAndLogDir);
 
     if (!defined('CIVICRM_UF')) {
       $this->fatal('You need to define CIVICRM_UF in civicrm.settings.php');

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -74,13 +74,6 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
   public $cleanURL;
 
   /**
-   * @var string
-   */
-  public $configAndLogDir;
-
-  public $templateCompileDir;
-
-  /**
    * The root directory of our template tree.
    * @var string
    */
@@ -98,20 +91,6 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
     if (!defined('CIVICRM_TEMPLATE_COMPILEDIR') && $loadFromDB) {
       $this->fatal('You need to define CIVICRM_TEMPLATE_COMPILEDIR in civicrm.settings.php');
     }
-
-    if (defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
-      $this->configAndLogDir = CRM_Utils_File::baseFilePath() . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
-      $this->templateCompileDir = defined('CIVICRM_TEMPLATE_COMPILEDIR') ? CRM_Utils_File::addTrailingSlash(CIVICRM_TEMPLATE_COMPILEDIR) : NULL;
-      CRM_Utils_File::createDir($this->templateCompileDir);
-      CRM_Utils_File::restrictAccess($this->templateCompileDir);
-    }
-
-    $civicrm_private = $GLOBALS['civicrm_paths']['civicrm.private']['path'];
-    if (!empty($civicrm_private)) {
-      $this->configAndLogDir = rtrim($civicrm_private, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
-    }
-    CRM_Utils_File::createDir($this->configAndLogDir);
-    CRM_Utils_File::restrictAccess($this->configAndLogDir);
 
     if (!defined('CIVICRM_UF')) {
       $this->fatal('You need to define CIVICRM_UF in civicrm.settings.php');

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -88,10 +88,6 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
     }
     $this->dsn = defined('CIVICRM_DSN') ? CIVICRM_DSN : NULL;
 
-    if (!defined('CIVICRM_TEMPLATE_COMPILEDIR') && $loadFromDB) {
-      $this->fatal('You need to define CIVICRM_TEMPLATE_COMPILEDIR in civicrm.settings.php');
-    }
-
     if (!defined('CIVICRM_UF')) {
       $this->fatal('You need to define CIVICRM_UF in civicrm.settings.php');
     }

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -106,7 +106,7 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
       CRM_Utils_File::restrictAccess($this->templateCompileDir);
     }
 
-    $civicrm_private = Civi::paths()->getPath('[civicrm.private]');
+    $civicrm_private = $GLOBALS['civicrm_paths']['civicrm.private'];
     if (!empty($civicrm_private)) {
       $this->configAndLogDir = rtrim($civicrm_private, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'ConfigAndLog' . DIRECTORY_SEPARATOR;
     }

--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -118,7 +118,7 @@ class CRM_Core_IDS {
    */
   public static function createBaseConfig() {
     $config = \CRM_Core_Config::singleton();
-    $tmpDir = empty($config->uploadDir) ? CIVICRM_TEMPLATE_COMPILEDIR : $config->uploadDir;
+    $tmpDir = empty($config->uploadDir) ? Civi::paths()->getVariable('civicrm.compile', 'path') : $config->uploadDir;
     global $civicrm_root;
 
     return [

--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -77,7 +77,7 @@ class CRM_Extension_ClassLoader {
    */
   public function register() {
     // In pre-installation environments, don't bother with caching.
-    if (!defined('CIVICRM_TEMPLATE_COMPILEDIR') || !defined('CIVICRM_DSN') || defined('CIVICRM_TEST') || \CRM_Utils_System::isInUpgradeMode()) {
+    if (!defined('CIVICRM_DSN') || defined('CIVICRM_TEST') || \CRM_Utils_System::isInUpgradeMode()) {
       return $this->buildClassLoader()->register();
     }
 
@@ -146,7 +146,7 @@ class CRM_Extension_ClassLoader {
    */
   protected function getCacheFile() {
     $envId = \CRM_Core_Config_Runtime::getId();
-    $file = CIVICRM_TEMPLATE_COMPILEDIR . "/CachedExtLoader.{$envId}.php";
+    $file = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
     return $file;
   }
 

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -496,10 +496,10 @@ class Container {
     $bootServices = [];
     \Civi::$statics[__CLASS__]['boot'] = &$bootServices;
 
+    $bootServices['paths'] = new \Civi\Core\Paths();
+
     $bootServices['runtime'] = $runtime = new \CRM_Core_Config_Runtime();
     $runtime->initialize($loadFromDB);
-
-    $bootServices['paths'] = new \Civi\Core\Paths();
 
     $class = $runtime->userFrameworkClass;
     $bootServices['userSystem'] = $userSystem = new $class();

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -496,10 +496,10 @@ class Container {
     $bootServices = [];
     \Civi::$statics[__CLASS__]['boot'] = &$bootServices;
 
-    $bootServices['paths'] = new \Civi\Core\Paths();
-
     $bootServices['runtime'] = $runtime = new \CRM_Core_Config_Runtime();
     $runtime->initialize($loadFromDB);
+
+    $bootServices['paths'] = new \Civi\Core\Paths();
 
     $class = $runtime->userFrameworkClass;
     $bootServices['userSystem'] = $userSystem = new $class();

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -46,7 +46,6 @@ class Container {
    *   - CIVICRM_CONTAINER_CACHE -- 'always' [default], 'never', 'auto'
    *   - CIVICRM_DSN
    *   - CIVICRM_DOMAIN_ID
-   *   - CIVICRM_TEMPLATE_COMPILEDIR
    *
    * @return \Symfony\Component\DependencyInjection\ContainerInterface
    */
@@ -58,14 +57,14 @@ class Container {
     $cacheMode = defined('CIVICRM_CONTAINER_CACHE') ? CIVICRM_CONTAINER_CACHE : 'auto';
 
     // In pre-installation environments, don't bother with caching.
-    if (!defined('CIVICRM_TEMPLATE_COMPILEDIR') || !defined('CIVICRM_DSN') || $cacheMode === 'never' || \CRM_Utils_System::isInUpgradeMode()) {
+    if (!defined('CIVICRM_DSN') || $cacheMode === 'never' || \CRM_Utils_System::isInUpgradeMode()) {
       $containerBuilder = $this->createContainer();
       $containerBuilder->compile();
       return $containerBuilder;
     }
 
     $envId = \CRM_Core_Config_Runtime::getId();
-    $file = CIVICRM_TEMPLATE_COMPILEDIR . "/CachedCiviContainer.{$envId}.php";
+    $file = \Civi::paths()->getPath("[civicrm.compile]/CachedCiviContainer.{$envId}.php");
     $containerConfigCache = new ConfigCache($file, $cacheMode === 'auto');
     if (!$containerConfigCache->isFresh()) {
       $containerBuilder = $this->createContainer();

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -56,6 +56,9 @@ class Paths {
       ->register('civicrm.files', function () {
         return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
       })
+      ->register('civicrm.private', function () {
+        return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
+      })
       ->register('wp.frontend.base', function () {
         return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
       })

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -57,7 +57,26 @@ class Paths {
         return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
       })
       ->register('civicrm.private', function () {
-        return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
+        return [
+          // For backward compatibility with existing deployments, this
+          // effectively returns `dirname(CIVICRM_TEMPLATE_COMPILEDIR)`.
+          // That's confusing. Future installers should probably set `civicrm.private`
+          // explicitly instead of setting `CIVICRM_TEMPLATE_COMPILEDIR`.
+          'path' => \CRM_Utils_File::baseFilePath(),
+        ];
+      })
+      ->register('civicrm.log', function () {
+        return [
+          'path' => \Civi::paths()->getPath('[civicrm.private]/ConfigAndLog'),
+        ];
+      })
+      ->register('civicrm.compile', function () {
+        return [
+          // These two formulations are equivalent in typical deployments; however,
+          // for existing systems which previously customized CIVICRM_TEMPLATE_COMPILEDIR,
+          // using the constant should be more backward-compatibility.
+          'path' => defined('CIVICRM_TEMPLATE_COMPILEDIR') ? CIVICRM_TEMPLATE_COMPILEDIR : \Civi::paths()->getPath('[civicrm.private]/templates_c'),
+        ];
       })
       ->register('wp.frontend.base', function () {
         return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];


### PR DESCRIPTION
Overview
----------------------

This is an update to the path-handling convention for  data folders that allows more intuitive management of the file-paths. It aims to:

* Provide clearer separation between public and private data folders.
* Provide backward-compatiblity with the vast majority of installations.
* Provide better tunability for data folders -- so that sysadmins and installers can manage paths precisely in `civicrm.settings.php` (*without as much concern for the wonky/legacy/default computations*).

This PR continues previous work (circa 4.7.x) which added `$civicrm_paths` to `civicrm.settings.php`. It extends the work to address the "private" folders, creating a hierarchy of configurable paths.

|Variable|Example Value|Default Value|
|--|--|--|
|`civicrm.private`|`sites/default/files/civicrm`| |
|`civicrm.log`|`sites/default/files/civicrm/ConfigAndLog`|`[civicrm.private]/ConfigAndLog`|
|`civicrm.compile`|`sites/default/files/civicrm/templates_c`|`[civicrm.private]/templates_c`|


General Effect: Before
----------------------

In `civicrm.settings.php`, one sets `CIVICRM_TEMPLATE_COMPILEDIR` to be some value ending with `templates_c`, e.g.
 
```php
define('CIVICRM_TEMPLATE_COMPILEDIR',  '/var/www/example.com/htdocs/sites/default/files/civicrm/templates_c');
```

Changing this field has surprising side-effects on other paths (which do not involve template-compilation) -- such as the public data-folders (`[civicrm.files]`) and the log folder (`ConfigAndLog`). Some effects can be mitigated by overriding `$civicrm_paths['civicrm.files']`, but not all.

General Effect: After
----------------------

In `civicrm.settings.php`, one may set `CIVICRM_TEMPLATE_COMPILEDIR` as before. For good or ill, this will have the same surprising side-effects as before.

Alternatively, one may remove `CIVICRM_TEMPLATE_COMPILEDIR`. Instead, set all paths using `$civicrm_paths`. We present a few examples -- the consequences should be more intuitive.

__Example 1__: This is a minimalist example in which all public and private data go to the same folder, `sites/default/files/civicrm`.

```php
$civicrm_paths['civicrm.files']['path'] = '/srv/example.com/htdocs/sites/default/files/civicrm';
$civicrm_paths['civicrm.private']['path'] = '/srv/example.com/htdocs/sites/default/files/civicrm';
```

The constant `CIVICRM_TEMPLATE_COMPILEDIR` is never consulted. Updating `civicrm.files` changes only public data-folders. Updating `civicrm.private` changes only private data-folders (e.g. `templates_c` and `ConfigAndLogDir`). 

__Example 2__: The public and private data are stored in separate places, akin to Drupal's public and private folders.

```php
$civicrm_paths['civicrm.files']['path'] = '/srv/example.com/htdocs/sites/default/files/civicrm');
$civicrm_paths['civicrm.private']['path'] = '/srv/example.com/private/civicrm');
```

__Example 3__: This is a maximalist example in which we reject most of the default paths and instead try to follow Linux FHS.

```php
$civicrm_paths['civicrm.files']['path'] = '/var/www/sites/default/files/civicrm');
$civicrm_paths['civicrm.private']['path'] = '/var/lib/civicrm');
$civicrm_paths['civicrm.log']['path'] = '/var/log/civicrm');
$civicrm_paths['civicrm.compile']['path'] = '/var/run/civicrm-compile');
$civicrm_paths['civicrm.root']['path'] = '/usr/share/php/civicrm-core');
$civicrm_paths['civicrm.root']['url'] = 'https://example.com/civicrm-core'); // with httpd path alias
$civicrm_paths['cms.root']['path'] = '/usr/share/php/drupal-core');
$civicrm_paths['cms.root']['url'] = 'https://example.com/'); // with httpd path alias
```

Mechanics: Before
----------------------

* The `templateCompileDir` is calculated procedurally by `CRM_Core_Config_Runtime`  using `CIVICRM_TEMPLATE_COMPILEDIR`.
* The `configAndLogDir` is calculated procedurally by `CRM_Core_Config_Runtime` using `CRM_Utils_File::baseFilePath() . '/configAndLog'` (*which in turn is derived from `CIVICRM_TEMPLATE_COMPILEDIR`*).
* There are several references to `CIVICRM_TEMPLATE_COMPILEDIR` in the codebase.

Mechanics: After
----------------------

* The `templateCompileDir` is calculated on-demand by `Civi::paths()`; it will be the first available item from this list:
    1. `$civicrm_paths['civicrm.compile']['path']`
    2. `CIVICRM_TEMPLATE_COMPILEDIR`
    3. `$civicrm_paths['civicrm.private']['path'] . '/templates_c'`
    4. ~~`CRM_Utils_File::baseFilePath() . '/templates_c'`~~ (*This is a hypothetical scenario which roughly equates to rule "ii" above. It would be more elegant than rule "ii"; however, in some wonky configurations, rule "ii" provides better backward-compatibility. The presence of rule "ii" makes this code-path irrelevant.*)
* The `configAndLogDir` is calculated on-demand by `Civi::paths()`; it will be the first available item from this list:
    1. `$civicrm_paths['civicrm.log']['path']`
    2. `$civicrm_paths['civicrm.private']['path'] . '/ConfigAndLog'`
    3. `CRM_Utils_File::baseFilePath() . '/ConfigAndLog'` (*which in turn is derived from `CIVICRM_TEMPLATE_COMPILEDIR`*)
* There are are only two references to `CIVICRM_TEMPLATE_COMPILEDIR`.

Comments
----------------------

This PR only changes the mechanism for determining paths - updates to configuration is left as a separate issue. In the phone meeting circa July 10, we decided to continue using `CIVICRM_TEMPLATE_COMPILEDIR` in the old installer (ie `install/`, `civicrm.settings.php.template`) and start using the new conventions in newer installers (ie `civicrm-setup`).

Original issue: https://lab.civicrm.org/dev/cloud-native/issues/3