### PR TITLE
dev/core#1097 - Ensure consistent count on Groups tab

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2730,7 +2730,7 @@ AND       civicrm_openid.is_primary = 1";
 
       case 'group':
 
-        return CRM_Contact_BAO_GroupContact::getContactGroup($contactId, "Added", NULL, TRUE);
+        return CRM_Contact_BAO_GroupContact::getContactGroup($contactId, "Added", NULL, TRUE, FALSE, FALSE, TRUE, NULL, TRUE);
 
       case 'log':
         if (CRM_Core_BAO_Log::useLoggingReport()) {


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a bug in where, if a contact has been explicitly added to any Smart Groups, then the number on their Groups tab changes when the tab is loaded. See [dev/core#1097](https://lab.civicrm.org/dev/core/issues/1097) for details.

Before
----------------------------------------
Before the Groups tab is loaded, the count does not include Smart Groups that the contact has been explicitly added to. After the Groups tab is loaded, the count changes to include Smart Groups that the contact has been explicitly added to.

After
----------------------------------------
The count on the Groups tab always includes Smart Groups that the contact has been explicitly added to.

Technical Details
----------------------------------------
The count is calculated using the **CRM_Contact_BAO_GroupContact::getContactGroup** function, which is called by **CRM_Contact_BAO_Contact::getCountComponent** when the contact page is loaded, and again by **CRM_Contact_Page_View_GroupContact::browse** when the Groups tab is loaded.

The discrepancy arises because the two calls to that function pass different arguments: The first call omits the **$includeSmartGroups** argument, which defaults to **FALSE**, whereas the second call passes **TRUE** to the **$includeSmartGroups** argument.

This PR changes the call to **CRM_Contact_BAO_GroupContact::getContactGroup** in **CRM_Contact_BAO_Contact::getContactGroup** so that it passes **TRUE** to the **$includeSmartGroups** argument. This one-line change ensures that the count on the Groups tab always includes Smart Groups to which the contact has been explicitly added.

Comments
----------------------------------------
The count only includes Smart Groups to which the contact has been _explicitly_ added - not all Smart Groups whose search criteria include the contact. This avoids the [documented](https://issues.civicrm.org/jira/browse/CRM-11068) [problems](https://issues.civicrm.org/jira/browse/CRM-12466) with recalculating all Smart Group memberships, so there is no significant performance hit.