### PR TITLE
Fix public URL link with hashed URLs in mailing browse screen

### DIFF
--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -444,17 +444,21 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           $validLinks[CRM_Core_Action::BROWSE] = [
             'name' => ts('Public View'),
             'url' => 'civicrm/mailing/view',
-            'qs' => 'id=%%mid%%&reset=1',
+            'qs' => 'id=%%hashOrMid%%&reset=1',
             'title' => ts('Public View'),
             'fe' => TRUE,
           ];
           $actionMask |= CRM_Core_Action::BROWSE;
         }
 
+        $hash = CRM_Mailing_BAO_Mailing::getMailingHash($row['id']);
         $rows[$key]['action'] = CRM_Core_Action::formLink(
           $validLinks,
           $actionMask,
-          ['mid' => $row['id']],
+          [
+            'mid' => $row['id'],
+            'hashOrMid' => $hash ? $hash : $row['id'],
+          ],
           "more",
           FALSE,
           $opString,


### PR DESCRIPTION
Overview
----------------------------------------
Follow up from https://github.com/civicrm/civicrm-core/pull/14508

If 'hashed mailing URLs' setting is enabled then the 'Public view' links in the mailing browser page do not work correctly. They do not use the 'hash' when required.

Now they do: (sorry for the dodgy screenshot)

![image](https://user-images.githubusercontent.com/5212601/60607816-f5ccec80-9db5-11e9-914d-a9d7ded5b9c4.png)


Technical Details
----------------------------------------
Added a replacement pattern to the 'actions' selector, so that the mailing ID or the hash is used when appropriate.
