### PR TITLE
Extract code converting a date object to local timezone object to own…

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -398,9 +398,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
        * The `payment_date` that Paypal sends back is in their timezone. Example return: 08:23:05 Jan 11, 2019 PST
        * Subsequently, we need to account for that, otherwise the recieve time will be incorrect for the local system
        */
-      $systemTimeZone = new DateTimeZone(CRM_Core_Config::singleton()->userSystem->getTimeZoneString());
-      $receiveDateTime->setTimezone($systemTimeZone);
-      $input['receive_date'] = $receiveDateTime->format('YmdHis');
+      $input['receive_date'] = CRM_Utils_Date::convertDateToLocalTime($receiveDateTime);
     }
   }
 

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -2204,4 +2204,17 @@ class CRM_Utils_Date {
     }
   }
 
+  /**
+   * Print out a date object in specified format in local timezone
+   *
+   * @param DateTimeObject $dateObject
+   * @param string $format
+   * @return string
+   */
+  public static function convertDateToLocalTime($dateObject, $format = 'YmdHis') {
+    $systemTimeZone = new DateTimeZone(CRM_Core_Config::singleton()->userSystem->getTimeZoneString());
+    $dateObject->setTimezone($systemTimeZone);
+    return $dateObject->format($format);
+  }
+
 }


### PR DESCRIPTION
… function

Overview
----------------------------------------
This is a simple extract of the code used to convert a date string into local time zone

Before
----------------------------------------
Code only found in PayPal IPN code

After
----------------------------------------
Code re-usable

ping @mattwire @eileenmcnaughton @totten 