### PR TITLE
[REF] final cleanup - call bulkCreate from migrate_utils

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -154,7 +154,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
   public static function create($params) {
     $customField = self::createCustomFieldRecord($params);
     $op = empty($params['id']) ? 'add' : 'modify';
-    self::createField($customField, $op, CRM_Utils_Array::value('triggerRebuild', $params, TRUE));
+    self::createField($customField, $op);
 
     CRM_Utils_Hook::post(($op === 'add' ? 'create' : 'edit'), 'CustomField', $customField->id, $customField);
 
@@ -1692,9 +1692,8 @@ SELECT $columnName
    *
    * @param CRM_Core_DAO_CustomField $field
    * @param string $operation
-   * @param bool $triggerRebuild
    */
-  public static function createField($field, $operation, $triggerRebuild = TRUE) {
+  public static function createField($field, $operation) {
     $sql = str_repeat(' ', 8);
     $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $field->custom_group_id, 'table_name');
     $sql .= "ALTER TABLE " . $tableName;
@@ -1714,10 +1713,7 @@ SELECT $columnName
       }
     }
 
-    if ($triggerRebuild) {
-      Civi::service('sql_triggers')->rebuild($tableName, TRUE);
-    }
-
+    Civi::service('sql_triggers')->rebuild($tableName, TRUE);
   }
 
   /**

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -288,6 +288,8 @@ ALTER TABLE {$tableName}
   }
 
   /**
+   * @deprecated
+   *
    * @param array $params
    * @param bool $indexExist
    * @param bool $triggerRebuild

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -363,37 +363,7 @@ AND        v.name = %1
       }
     }
     foreach ($fields_indexed_by_group_id as $group_id => $fields) {
-      $total = count($fields);
-      $count = 0;
-      foreach ($fields as $customFieldXML) {
-        $count++;
-        $customField = new CRM_Core_DAO_CustomField();
-        $customField->custom_group_id = $group_id;
-        $skipStore = FALSE;
-        if (!$this->copyData($customField, $customFieldXML, FALSE, 'label')) {
-          $skipStore = TRUE;
-        }
-
-        if (empty($customField->option_group_id) &&
-          isset($customFieldXML->option_group_name)
-        ) {
-          $customField->option_group_id = $idMap['option_group'][(string ) $customFieldXML->option_group_name];
-        }
-        if ($skipStore) {
-          continue;
-        }
-        $customField->save();
-
-        // Only rebuild the table's trigger on the last field added to avoid un-necessary
-        // and slow rebuilds when adding many fields at the same time.
-        // @todo - call bulkSave instead.
-        $triggerRebuild = FALSE;
-        if ($count == $total) {
-          $triggerRebuild = TRUE;
-        }
-        $indexExist = FALSE;
-        CRM_Core_BAO_CustomField::createField($customField, 'add', $indexExist, $triggerRebuild);
-      }
+      CRM_Core_BAO_CustomField::bulkSave(json_decode(json_encode($fields), TRUE), ['custom_group_id' => $group_id]);
     }
   }
 

--- a/tests/phpunit/CRM/Utils/Migrate/ImportExportTest.php
+++ b/tests/phpunit/CRM/Utils/Migrate/ImportExportTest.php
@@ -137,7 +137,7 @@ class CRM_Utils_Migrate_ImportExportTest extends CiviUnitTestCase {
       // CustomGroup params
       array(
         'extends' => 'Activity',
-        'extends_entity_column_value' => array(array_search('Meeting', CRM_Core_PseudoConstant::activityType())),
+        'extends_entity_column_value' => [1],
         'title' => 'example',
       ),
       // CustomField params


### PR DESCRIPTION
Overview
----------------------------------------
This is a final cleanup to call rather than replicate bulkCreate from migrate utils

Before
----------------------------------------
Lots of single use code

After
----------------------------------------
DRY

Technical Details
----------------------------------------
Good testing on this function - rest of commits will be rebased out of this before it is up for final review - but I had to tweak the test to run in isolation

Comments
----------------------------------------