### PR TITLE
e-notice fix & unit test

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -913,6 +913,13 @@ COLS;
 
     // logging is enabled, so now lets create the trigger info tables
     foreach ($tableNames as $table) {
+      if (!isset($this->logTableSpec[$table])) {
+        // Per testIgnoreCustomTableByHook this would be unset if a hook had
+        // intervened to prevent logging / triggers on this table.
+        // This could go to the extent of blocking the updates to 'modified_date'
+        // which makes sense, in particular, for calculated fields.
+        continue;
+      }
       $columns = $this->columnsOf($table, $force);
 
       // only do the change if any data has changed


### PR DESCRIPTION
Overview
----------------------------------------
This addresses a fairly obscure enotice. The notice occurs when a table has been excluded from
triggers by a hook (as makes sense if the table includes only calculated fields) and then a new
custom field is added to the table (or presumably edited or removed). In this case we should
not go through the whole trigger handling loop.

Before
----------------------------------------
Enotice (under obscure circumstances)

After
----------------------------------------
No enotice

Technical Details
----------------------------------------
Note I see it as a feature rather than a bug that this would also apply to triggers that
update the contact.modified_date as it's not helpful to update this when updating a
calculation - if someone decides to intervene by hook we should trust them

Comments
----------------------------------------
@pfigel @jmcclelland you might care about this one
