### PR TITLE
Fix some test leakage

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1798,6 +1798,9 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     $this->setCurrencySeparators(',');
     CRM_Core_PseudoConstant::flush('taxRates');
     System::singleton()->flushProcessors();
+    // @fixme this parameter is leaking - it should not be defined as a class static
+    // but for now we just handle in tear down.
+    CRM_Contribute_BAO_Query::$_contribOrSoftCredit = 'only contribs';
   }
 
   public function restoreDefaultPriceSetConfig() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a cause or false fails in unit tests

Before
----------------------------------------
Doing unit tests which interact with soft credit searching can cause other tests to fail

After
----------------------------------------
Tests stop leaking

Technical Details
----------------------------------------
I encountered this as part of the long saga of https://github.com/civicrm/civicrm-core/pull/14514 - basically there were 3 issues 

1) a static class variable that was leaking between test runs - this is just being handled in test tearDown for now as a larger cleanup is needed to properly address
2) the decision as to whether to create a temp table was an in function static variable - which persisted between runs
3) the table itself persisted between runs

Comments
----------------------------------------
@seamuslee001 FYI with this the soft credit test finally passes!