### PR TITLE
dev/report#16 Unreleased regression - fee levels incorrectly show sol…

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -347,7 +347,7 @@ SELECT  id, html_type
         $form->_pId, 'contribution_id', 'participant_id'
       )
       ) {
-        $form->_online = TRUE;
+        $form->_online = !$form->isBackOffice;
       }
     }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -258,7 +258,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $this->_id = NULL;
     }
     else {
-      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
+      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     }
 
     if ($this->_id) {
@@ -594,9 +594,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @throws \CiviCRM_API3_Exception
    */
   public function buildQuickForm() {
-    if ($this->_id) {
-      $this->add('hidden', 'id', $this->_id);
-    }
 
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     $partiallyPaidStatusId = array_search('Partially paid', $participantStatuses);

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -395,6 +395,9 @@
           {if $urlPathVar}
           dataUrl += '&' + '{$urlPathVar}';
           {/if}
+          {if $isBackOffice}
+            dataUrl += '&' + 'is_backoffice=1';
+          {/if}
 
           {literal}
           var eventId = $('[name=event_id], #event_id', $form).val();


### PR DESCRIPTION
Overview
----------------------------------------
Fees are incorrectly showing as sold out, blocking change fee selection.

Before
----------------------------------------
Event selections cannot be changed as they appear sold out

After
----------------------------------------
Editability restored.

Technical Details
----------------------------------------
Fairly long tirade is over here https://lab.civicrm.org/dev/report/issues/16

Comments
----------------------------------------
