### PR TITLE
Fix refund payment not recording from additional payment form

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3891,6 +3891,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'In Progress' => ['Cancelled', 'Completed', 'Failed'],
       'Refunded' => ['Cancelled', 'Completed'],
       'Partially paid' => ['Completed'],
+      'Pending refund' => ['Completed', 'Refunded'],
     ];
 
     if (!in_array($contributionStatuses[$fields['contribution_status_id']],
@@ -4013,6 +4014,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     elseif ($paymentType == 'refund') {
       $trxnsData['total_amount'] = -$trxnsData['total_amount'];
       $trxnsData['participant_id'] = $participantId;
+      $trxnsData['contribution_id'] = $contributionId;
       return civicrm_api3('Payment', 'create', $trxnsData)['id'];
     }
   }

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -294,7 +294,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     if ($self->_paymentType == 'refund' && $fields['total_amount'] != abs($self->_refund)) {
       $errors['total_amount'] = ts('Refund amount must equal refund due amount.');
     }
-    $netAmt = $fields['total_amount'] - CRM_Utils_Array::value('fee_amount', $fields, 0);
+    $netAmt = (float) $fields['total_amount'] - (float) CRM_Utils_Array::value('fee_amount', $fields, 0);
     if (!empty($fields['net_amount']) && $netAmt != $fields['net_amount']) {
       $errors['net_amount'] = ts('Net amount should be equal to the difference between payment amount and fee amount.');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix unreleased regression recording a refund payment using backoffice form

Before
----------------------------------------
Refund payment failing

After
----------------------------------------
Payment succeeding

Technical Details
----------------------------------------
@monishdeb @kcristiano part of this is just a dumb error that snuck in but there is also a notice fix I hit in the same process and also the assumption that if you pay $415 for an event and then change the fee to $400 and refund $15 it is OK for the contribution status to now be 'Completed'

Comments
----------------------------------------