### PR TITLE
Remove use of deprecated path in function `CRM_Event_BAO_Event::checkPermission()`

### DIFF
--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -86,7 +86,9 @@ class CRM_Event_Form_ManageEvent_TabHeader {
     $tabs['location'] = ['title' => ts('Event Location')] + $default;
     $tabs['fee'] = ['title' => ts('Fees')] + $default;
     $tabs['registration'] = ['title' => ts('Online Registration')] + $default;
-    if (CRM_Core_Permission::check('administer CiviCRM') || CRM_Event_BAO_Event::checkPermission(NULL, CRM_Core_Permission::EDIT)) {
+    // @fixme I don't understand the event permissions check here - can we just get rid of it?
+    $permissions = CRM_Event_BAO_Event::getAllPermissions();
+    if (CRM_Core_Permission::check('administer CiviCRM') || !empty($permissions[CRM_Core_Permission::EDIT])) {
       $tabs['reminder'] = ['title' => ts('Schedule Reminders'), 'class' => 'livePage'] + $default;
     }
     $tabs['conference'] = ['title' => ts('Conference Slots')] + $default;

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -178,7 +178,9 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
           'field' => 'is_online_registration',
         ];
 
-      if (CRM_Core_Permission::check('administer CiviCRM') || CRM_Event_BAO_Event::checkPermission(NULL, CRM_Core_Permission::EDIT)) {
+      // @fixme I don't understand the event permissions check here - can we just get rid of it?
+      $permissions = CRM_Event_BAO_Event::getAllPermissions();
+      if (CRM_Core_Permission::check('administer CiviCRM') || !empty($permissions[CRM_Core_Permission::EDIT])) {
         self::$_tabLinks[$cacheKey]['reminder']
           = [
             'title' => ts('Schedule Reminders'),


### PR DESCRIPTION
Overview
----------------------------------------
Switch from deprecated to non deprecated function.

Before
----------------------------------------
Throws PHP notice and calls `getAllPermissions()`

After
----------------------------------------
Calls `getAllPermissions()` directly.

Technical Details
----------------------------------------
Per previous work, checkPermissions() should only be called for a specific event ID.

Comments
----------------------------------------
This permission check seems to hide the "scheduled reminders" tab if you are not an administrator or if you don't have edit permissions on any events.  That doesn't really make sense to me - as I don't really see why it should be treated differently to other manageevent tabs?  @lcdservices @alifrumin Any thoughts?