### PR TITLE
dev/report#17 fix postal_code_suffix col

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5718,7 +5718,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       ],
       $options['prefix'] . 'postal_code_suffix' => [
         'title' => $options['prefix_label'] . ts('Postal Code Suffix'),
-        'name' => 'postal_code',
+        'name' => 'postal_code_suffix',
         'type' => 1,
         'is_fields' => TRUE,
         'is_filters' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
When the postal code suffix column is displayed, it returns the postal code value instead of the suffix.

Before
----------------------------------------
Postal code suffix column displays postal code value.

After
----------------------------------------
Postal code suffix column displays correct value.
