### PR TITLE
dev/core#578 follow up fix on activity summary report

### DIFF
--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -491,7 +491,9 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
     // store the result in temporary table
     $insertQuery = "INSERT INTO {$this->_tempDurationSumTableName} (civicrm_activity_duration_total)
     {$sql}";
+    CRM_Core_DAO::disableFullGroupByMode();
     CRM_Core_DAO::executeQuery($insertQuery);
+    CRM_Core_DAO::reenableFullGroupByMode();
 
     $sql = "SELECT {$this->_tempTableName}.*,  {$this->_tempDurationSumTableName}.civicrm_activity_duration_total
     FROM {$this->_tempTableName} INNER JOIN {$this->_tempDurationSumTableName}


### PR DESCRIPTION
Overview
----------------------------------------
Completes https://github.com/civicrm/civicrm-core/pull/13540 by getting us past the full group by error

Before
----------------------------------------
Steps to replicate:

From the standard pre-defined Contact Reports, go to Activity Summary.
Leave Columns as default, with Contact Name not checked.
Leave Grouping as default (Activity Type + Activity Status).
In Sorting, select Contact Name.
Click "Refresh results".

results in error when full group by enabled

After
----------------------------------------
No error

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/13540  @davejenx tidied up the report to support unit tests and fixed another bug. This completes that by fixing the remaining FGB bug. Note that test coverage does not exactly address this but we have a standard that when fixing a bug in an area of code with poor test coverage it's OK to take us towards having test cover (which Dave did) rather than to cover the specific code break down. This reflects the fact that multiple technical hurdles often need to be over come to bring a report / code path under testing

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/578