### PR TITLE
dev/core#1081 fix for error on contribution detail when using custom data order by without select

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5929,7 +5929,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
     if ($this->groupConcatTested && (!empty($this->_groupByArray) || $this->isForceGroupBy)) {
       if ((empty($field['statistics']) || in_array('GROUP_CONCAT', $field['statistics']))) {
         $label = CRM_Utils_Array::value('title', $field);
-        $alias = "{$tableName}_{$fieldName}";
+        $alias = $field['tplField'] ?? "{$tableName}_{$fieldName}";
         $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $label;
         $this->_selectAliases[] = $alias;
         if (empty($this->_groupByArray[$tableName . '_' . $fieldName])) {

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -740,7 +740,9 @@ ROUND(AVG({$this->_aliases['civicrm_contribution_soft']}.amount), 2) as civicrm_
    * @param array $rows
    */
   public function buildRows($sql, &$rows) {
+    CRM_Core_DAO::disableFullGroupByMode();
     $dao = CRM_Core_DAO::executeQuery($sql);
+    CRM_Core_DAO::reenableFullGroupByMode();
     $this->addToDeveloperTab($sql);
     if (!is_array($rows)) {
       $rows = array();

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -223,6 +223,7 @@ trait CRMTraits_Custom_CustomDataTrait {
       'weight' => 1,
       'is_required' => 1,
       'sequential' => 1,
+      'is_searchable' => 1,
     ], $params);
 
     return $this->callAPISuccess('CustomField', 'create', $params)['values'][0];

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -36,6 +36,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
   use CRMTraits_ACL_PermissionTrait;
   use CRMTraits_PCP_PCPTestTrait;
+  use CRMTraits_Custom_CustomDataTrait;
 
   protected $contactIDs = [];
 
@@ -46,7 +47,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
-    $this->quickCleanup(array('civicrm_group', 'civicrm_saved_search', 'civicrm_group_contact', 'civicrm_group_contact_cache', 'civicrm_group'));
+    $this->quickCleanup(['civicrm_group', 'civicrm_saved_search', 'civicrm_group_contact', 'civicrm_group_contact_cache', 'civicrm_group'], TRUE);
     parent::tearDown();
   }
 
@@ -911,6 +912,26 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     foreach ($rows['values'] as $row) {
       $this->assertEquals(array_pop($count), count($row['rows']), "Report failed to get row count");
     }
+  }
+
+  /**
+   * Test the custom data order by works when not in select.
+   *
+   * @dataProvider getMembershipAndContributionReportTemplatesForGroupTests
+   *
+   * @param string $template
+   *   Report template unique identifier.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testReportsCustomDataOrderBy($template) {
+    $this->entity = 'Contact';
+    $this->createCustomGroupWithFieldOfType();
+    $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => $template,
+      'contribution_or_soft_value' => 'contributions_only',
+      'order_bys' => [['column' => 'custom_' . $this->ids['CustomField']['text'], 'order' => 'ASC']],
+    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal error on contribution detail report when sorting by a custom field that is not selected

Before
----------------------------------------
Fatal error

After
----------------------------------------
Report succeeds & is tested

Technical Details
----------------------------------------
I swept up 4 reports in the test (using an existing dataProvider function) - the contribution summary report failed in Full Group By mode so I added a disable->re-enable to address that

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1081
