### PR TITLE
Improve performance on getSoftContribution details - only run one query instead of one per contribution

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -299,39 +299,53 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    *   Array of soft contribution ids, amounts, and associated contact ids
    */
   public static function getSoftContribution($contributionID, $all = FALSE) {
-    $pcpFields = array(
+    $softContributionFields = self::getSoftCreditContributionFields([$contributionID], $all);
+    return isset($softContributionFields[$contributionID]) ? $softContributionFields[$contributionID] : [];
+  }
+
+  /**
+   * Retrieve soft contributions for an array of contribution records.
+   *
+   * @param array $contributionIDs
+   * @param bool $all
+   *   Include PCP data.
+   *
+   * @return array
+   *   Array of soft contribution ids, amounts, and associated contact ids
+   */
+  public static function getSoftCreditContributionFields($contributionIDs, $all = FALSE) {
+    $pcpFields = [
       'pcp_id',
       'pcp_title',
       'pcp_display_in_roll',
       'pcp_roll_nickname',
       'pcp_personal_note',
-    );
+    ];
 
-    $query = '
-    SELECT ccs.id, pcp_id, cpcp.title as pcp_title, pcp_display_in_roll, pcp_roll_nickname, pcp_personal_note, ccs.currency as currency, amount, ccs.contact_id as contact_id, c.display_name, ccs.soft_credit_type_id
+    $query = "
+    SELECT ccs.id, pcp_id, ccs.contribution_id as contribution_id, cpcp.title as pcp_title, pcp_display_in_roll, pcp_roll_nickname, pcp_personal_note, ccs.currency as currency, amount, ccs.contact_id as contact_id, c.display_name, ccs.soft_credit_type_id
     FROM civicrm_contribution_soft ccs INNER JOIN civicrm_contact c on c.id = ccs.contact_id
     LEFT JOIN civicrm_pcp cpcp ON ccs.pcp_id = cpcp.id
-    WHERE contribution_id = %1;
-    ';
+    WHERE contribution_id IN (%1)
+    ";
+    $queryParams = [1 => [implode(',', $contributionIDs), 'CommaSeparatedIntegers']];
+    $dao = CRM_Core_DAO::executeQuery($query, $queryParams);
 
-    $params = array(1 => array($contributionID, 'Integer'));
-
-    $dao = CRM_Core_DAO::executeQuery($query, $params);
-
-    $softContribution = array();
-    $count = 1;
+    $softContribution = $indexes = [];
     while ($dao->fetch()) {
       if ($dao->pcp_id) {
         if ($all) {
           foreach ($pcpFields as $val) {
-            $softContribution[$val] = $dao->$val;
+            $softContribution[$dao->contribution_id][$val] = $dao->$val;
           }
-          $softContribution['pcp_soft_credit_to_name'] = $dao->display_name;
-          $softContribution['pcp_soft_credit_to_id'] = $dao->contact_id;
+          $softContribution[$dao->contribution_id]['pcp_soft_credit_to_name'] = $dao->display_name;
+          $softContribution[$dao->contribution_id]['pcp_soft_credit_to_id'] = $dao->contact_id;
         }
       }
       else {
-        $softContribution['soft_credit'][$count] = array(
+        // Use a 1-based array because that's what this function returned before refactoring in https://github.com/civicrm/civicrm-core/pull/14747
+        $indexes[$dao->contribution_id] = isset($indexes[$dao->contribution_id]) ? $indexes[$dao->contribution_id] + 1 : 1;
+        $softContribution[$dao->contribution_id]['soft_credit'][$indexes[$dao->contribution_id]] = [
           'contact_id' => $dao->contact_id,
           'soft_credit_id' => $dao->id,
           'currency' => $dao->currency,
@@ -339,8 +353,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
           'contact_name' => $dao->display_name,
           'soft_credit_type' => $dao->soft_credit_type_id,
           'soft_credit_type_label' => CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', $dao->soft_credit_type_id),
-        );
-        $count++;
+        ];
       }
     }
 

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -265,15 +265,16 @@ function civicrm_api3_contribution_get($params) {
   $additionalOptions = _civicrm_api3_contribution_get_support_nonunique_returns($params);
   $returnProperties = CRM_Contribute_BAO_Query::defaultReturnProperties($mode);
 
+  // Get the contributions based on parameters passed in
   $contributions = _civicrm_api3_get_using_query_object('Contribution', $params, $additionalOptions, NULL, $mode, $returnProperties);
-
-  foreach ($contributions as $id => $contribution) {
-    $softContribution = CRM_Contribute_BAO_ContributionSoft::getSoftContribution($id, TRUE);
-    $contributions[$id] = array_merge($contribution, $softContribution);
-    // format soft credit for backward compatibility
-    _civicrm_api3_format_soft_credit($contributions[$id]);
-    _civicrm_api3_contribution_add_supported_fields($contributions[$id]);
-
+  if (!empty($contributions)) {
+    $softContributions = CRM_Contribute_BAO_ContributionSoft::getSoftCreditContributionFields(array_keys($contributions), TRUE);
+    foreach ($contributions as $id => $contribution) {
+      $contributions[$id] = isset($softContributions[$id]) ? array_merge($contribution, $softContributions[$id]) : $contribution;
+      // format soft credit for backward compatibility
+      _civicrm_api3_format_soft_credit($contributions[$id]);
+      _civicrm_api3_contribution_add_supported_fields($contributions[$id]);
+    }
   }
   return civicrm_api3_create_success($contributions, $params, 'Contribution', 'get');
 }


### PR DESCRIPTION
Overview
----------------------------------------
When calling the `CRM_Contribute_BAO_ContributionSoft::getSoftContribution()` function for multiple contributions it gets pretty inefficient as a separate query is run every time.  When retrieving bulk contributions we can improve performance significantly by just running the query once for all contribution IDs.

Before
----------------------------------------
Execution time (first run, second run):
0.053346, 0.043242

After
----------------------------------------
Execution time (first run, second run):
0.0052369999999999, 0.00575

About 10 times faster on my test system!

Technical Details
----------------------------------------
Create a new function that runs the query for multiple contributions instead of calling a function that runs the query separately for each contribution.

Comments
----------------------------------------
Currently I've only switched over api3 Contribution.get but there are multiple other places where this could be switched over and might improve performance.  @eileenmcnaughton @pfigel This was something I noticed when doing some other work and I couldn't resist trying to fix... But I don't actually need it.. so if either of you have an interest in picking this up that would be great :-)
