### PR TITLE
Fix enotice on formatting credit card details

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -608,7 +608,7 @@ WHERE  contribution_id = {$id}
    * @return void
    */
   public static function formatCreditCardDetails(&$params) {
-    if (in_array('credit_card_type', array_keys($params))) {
+    if (!empty($params['credit_card_type'])) {
       $params['card_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'card_type_id', $params['credit_card_type']);
     }
     if (!empty($params['credit_card_number']) && empty($params['pan_truncation'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix

Before
----------------------------------------
<img width="1040" alt="Screen Shot 2019-07-08 at 11 51 35 AM" src="https://user-images.githubusercontent.com/336308/60775399-c849bf80-a176-11e9-905a-4fa4ed5ab18d.png">


After
----------------------------------------
Gone

Technical Details
----------------------------------------
To be honest I can't' quite see why it gets past the existing ```if (in_array('credit_card_type', array_keys($params))) {``` to cause this enotice but ```if (!empty($params['credit_card_type'])) {``` is also much more consistent with the style in our codebase and we would not want to try to resolve 'set but empty'

Comments
----------------------------------------

