### PR TITLE
[REF] Move function onto the processor class

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -42,42 +42,6 @@ class CRM_Export_BAO_Export {
   const EXPORT_ROW_COUNT = 100000;
 
   /**
-   * Get default return property for export based on mode
-   *
-   * @param int $exportMode
-   *   Export mode.
-   *
-   * @return string
-   *   Default Return property
-   */
-  public static function defaultReturnProperty($exportMode) {
-    // hack to add default return property based on export mode
-    $property = NULL;
-    if ($exportMode == CRM_Export_Form_Select::CONTRIBUTE_EXPORT) {
-      $property = 'contribution_id';
-    }
-    elseif ($exportMode == CRM_Export_Form_Select::EVENT_EXPORT) {
-      $property = 'participant_id';
-    }
-    elseif ($exportMode == CRM_Export_Form_Select::MEMBER_EXPORT) {
-      $property = 'membership_id';
-    }
-    elseif ($exportMode == CRM_Export_Form_Select::PLEDGE_EXPORT) {
-      $property = 'pledge_id';
-    }
-    elseif ($exportMode == CRM_Export_Form_Select::CASE_EXPORT) {
-      $property = 'case_id';
-    }
-    elseif ($exportMode == CRM_Export_Form_Select::GRANT_EXPORT) {
-      $property = 'grant_id';
-    }
-    elseif ($exportMode == CRM_Export_Form_Select::ACTIVITY_EXPORT) {
-      $property = 'activity_id';
-    }
-    return $property;
-  }
-
-  /**
    * Get Export component
    *
    * @param int $exportMode
@@ -251,7 +215,7 @@ class CRM_Export_BAO_Export {
           }
         }
       }
-      $defaultExportMode = self::defaultReturnProperty($exportMode);
+      $defaultExportMode = $processor->defaultReturnProperty();
       if ($defaultExportMode) {
         $returnProperties[$defaultExportMode] = 1;
       }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1405,4 +1405,38 @@ class CRM_Export_BAO_ExportProcessor {
     return in_array($contactID, $this->householdsToSkip);
   }
 
+  /**
+   * Get default return property for export based on mode
+   *
+   * @return string
+   *   Default Return property
+   */
+  public function defaultReturnProperty() {
+    // hack to add default return property based on export mode
+    $property = NULL;
+    $exportMode = $this->getExportMode();
+    if ($exportMode == CRM_Export_Form_Select::CONTRIBUTE_EXPORT) {
+      $property = 'contribution_id';
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::EVENT_EXPORT) {
+      $property = 'participant_id';
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::MEMBER_EXPORT) {
+      $property = 'membership_id';
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::PLEDGE_EXPORT) {
+      $property = 'pledge_id';
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::CASE_EXPORT) {
+      $property = 'case_id';
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::GRANT_EXPORT) {
+      $property = 'grant_id';
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::ACTIVITY_EXPORT) {
+      $property = 'activity_id';
+    }
+    return $property;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Code in static function

After
----------------------------------------
Code moved to export object

Technical Details
----------------------------------------
I went to extract the function that determines fields off to be a function on the processor class
but moving this first simplifies it

Comments
----------------------------------------
The function itself is pretty rubbish - I would use early returns - but was less fussed about that
