### PR TITLE
[REF] Remove call to getMappingFields in favour of api call.

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -77,6 +77,8 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
    * Build the form object.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function buildQuickForm() {
     // To save the current mappings.
@@ -90,14 +92,8 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
       $savedMapping = $this->get('savedMapping');
       // Mapping is to be loaded from database.
 
-      list($mappingName, $mappingContactType, $mappingLocation, $mappingPhoneType, $mappingRelation) = CRM_Core_BAO_Mapping::getMappingFields($savedMapping);
-
-      // Get loaded Mapping Fields.
-      $mappingName = CRM_Utils_Array::value('1', $mappingName);
-      $mappingContactType = CRM_Utils_Array::value('1', $mappingContactType);
-      $mappingLocation = CRM_Utils_Array::value('1', $mappingLocation);
-      $mappingPhoneType = CRM_Utils_Array::value('1', $mappingPhoneType);
-      $mappingRelation = CRM_Utils_Array::value('1', $mappingRelation);
+      // Get an array of the name values for mapping fields associated with this mapping_id.
+      $mappingName = CRM_Core_BAO_Mapping::getMappingFieldValues($savedMapping, 'name');
 
       $this->assign('loadedMapping', $savedMapping);
       $this->set('loadedMapping', $savedMapping);

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -242,6 +242,22 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
   }
 
   /**
+   * Get un-indexed array of the field values for the given mapping id.
+   *
+   * For example if passing a mapping ID & name the returned array would look like
+   *   ['First field name', 'second field name']
+   *
+   * @param int $mappingID
+   * @param string $fieldName
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getMappingFieldValues($mappingID, $fieldName) {
+    return array_merge(CRM_Utils_Array::collect($fieldName, civicrm_api3('MappingField', 'get', ['mapping_id' => $mappingID, 'return' => $fieldName])['values']));
+  }
+
+  /**
    * Check Duplicate Mapping Name.
    *
    * @param string $nameField


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup

Before
----------------------------------------
<img width="807" alt="Screen Shot 2019-07-09 at 11 03 24 AM" src="https://user-images.githubusercontent.com/336308/60848347-5f2b8000-a23a-11e9-8853-08c69b99306d.png">


After
----------------------------------------
No change

Technical Details
----------------------------------------
The getMappingFields function is confusing - it turns out we just need an array of names

Comments
----------------------------------------
@colemanw after you asked about contact_type I dug to see what these lines actually do....
