### PR TITLE
dev/core#1108 Use api call to retrieve mailing_id

### DIFF
--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -125,6 +125,8 @@ WHERE  email = %2
    *
    * @return array|null
    *   $groups    Array of all groups from which the contact was removed, or null if the queue event could not be found.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function &unsub_from_mailing($job_id, $queue_id, $hash, $return = FALSE) {
     // First make sure there's a matching queue event.
@@ -152,12 +154,7 @@ WHERE  email = %2
     $abObject = new CRM_Mailing_DAO_MailingAB();
     $ab = $abObject->getTableName();
 
-    //We Need the mailing Id for the hook...
-    $do->query("SELECT $job.mailing_id as mailing_id
-                     FROM   $job
-                     WHERE $job.id = " . CRM_Utils_Type::escape($job_id, 'Integer'));
-    $do->fetch();
-    $mailing_id = $do->mailing_id;
+    $mailing_id = civicrm_api3('MailingJob', 'getvalue', ['id' => $job_id, 'return' => 'mailing_id']);
     $mailing_type = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $mailing_id, 'mailing_type', 'id');
     $entity = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_MailingGroup', $mailing_id, 'entity_table', 'mailing_id');
 


### PR DESCRIPTION
Overview
----------------------------------------
This replaces several lines of code with one & avoids ad hoc handling on translation

Before
----------------------------------------
Ad hoc function

After
----------------------------------------
API call

Technical Details
----------------------------------------
Multilingual field handling is already built into the api & this is a really simple function call so let's make it look simple


Comments
----------------------------------------
There is test cover in testUnsubscribeGroupList
