### PR TITLE
dev/report/15 Add fix and tests for contact subtype report filter

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2129,12 +2129,30 @@ class CRM_Report_Form extends CRM_Core_Form {
    * @return string
    */
   public function whereSubtypeClause($field, $value, $op) {
+    // Get the correct SQL operator.
+    switch ($op) {
+      case 'notin':
+        $op = 'nhas';
+        $clauseSeparator = 'AND';
+        break;
+
+      case 'in':
+        $op = 'has';
+        $clauseSeparator = 'OR';
+        break;
+    }
+    $sqlOp = $this->getSQLOperator($op);
     $clause = '( ';
     $subtypeFilters = count($value);
-    for ($i = 0; $i < $subtypeFilters; $i++) {
-      $clause .= "{$field['dbAlias']} LIKE '%$value[$i]%'";
-      if ($i !== ($subtypeFilters - 1)) {
-        $clause .= " OR ";
+    if ($sqlOp == 'IS NULL' || $sqlOp == 'IS NOT NULL') {
+      $clause .= "{$field['dbAlias']} $sqlOp";
+    }
+    else {
+      for ($i = 0; $i < $subtypeFilters; $i++) {
+        $clause .= "{$field['dbAlias']} $sqlOp '%$value[$i]%'";
+        if ($i !== ($subtypeFilters - 1)) {
+          $clause .= " $clauseSeparator ";
+        }
       }
     }
     $clause .= ' )';

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1124,6 +1124,44 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test contact subtype filter on summary report.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testContactSubtypeNotNull() {
+    $this->individualCreate(['contact_sub_type' => ['Student', 'Parent']]);
+    $this->individualCreate();
+
+    $rows = $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => 'contact/summary',
+      'contact_sub_type_op' => 'nnll',
+      'contact_sub_type_value' => [],
+      'contact_type_op' => 'eq',
+      'contact_type_value' => 'Individual',
+    ]);
+    $this->assertEquals(1, $rows['count']);
+  }
+
+  /**
+   * Test contact subtype filter on summary report.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testContactSubtypeNull() {
+    $this->individualCreate(['contact_sub_type' => ['Student', 'Parent']]);
+    $this->individualCreate();
+
+    $rows = $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => 'contact/summary',
+      'contact_sub_type_op' => 'nll',
+      'contact_sub_type_value' => [],
+      'contact_type_op' => 'eq',
+      'contact_type_value' => 'Individual',
+    ]);
+    $this->assertEquals(1, $rows['count']);
+  }
+
+  /**
    * Test PCP report to ensure total donors and total committed is accurate.
    */
   public function testPcpReportTotals() {


### PR DESCRIPTION
Overview
----------------------------------------
Adding a PR for the fix by @MegaphoneJon along with some tests for the filter options that are now available.

Before
----------------------------------------
On the contact summary report (or other reports), using the 'IS NULL' or 'IS NOT NULL' filters for "Contact Subtype" would result in a DB error.

After
----------------------------------------
Filters are working as expected and tests have been added to keep it that way.

Technical Details
----------------------------------------
This is a WIP because i've written the tests how I believe they're supposed to go (I've also tried the /api/v3/ReportTemplateTest.php style tests) ... I cannot seem to get them to pass. I've tried adding the null and not null filters a bunch of ways but the rows returned are always 2 (all) instead of the expected 1.

The functionality from Jon's commit, however, is working exactly as it should if I actually go run the report through the GUI and use the filters... so this is just a problem with the tests i've written.
