### PR TITLE
Finish removing references to Config.IDS.ini

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -147,10 +147,6 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
 
     // rebuild menu items
     CRM_Core_Menu::store();
-
-    // also delete the IDS file so we can write a new correct one on next load
-    $configFile = $config->uploadDir . 'Config.IDS.ini';
-    @unlink($configFile);
   }
 
 }

--- a/install/index.php
+++ b/install/index.php
@@ -703,16 +703,6 @@ class InstallRequirements {
       $this->requireWriteable($dirName, $testDetails, TRUE);
     }
 
-    //check for Config.IDS.ini, file may exist in re-install
-    $configIDSiniDir = array($cmsPath, 'sites', $siteDir, 'files', 'civicrm', 'upload', 'Config.IDS.ini');
-
-    if (is_array($configIDSiniDir) && !empty($configIDSiniDir)) {
-      $configIDSiniFile = implode(CIVICRM_DIRECTORY_SEPARATOR, $configIDSiniDir);
-      if (file_exists($configIDSiniFile)) {
-        unlink($configIDSiniFile);
-      }
-    }
-
     // Check for rewriting
     if (isset($_SERVER['SERVER_SOFTWARE'])) {
       $webserver = strip_tags(trim($_SERVER['SERVER_SOFTWARE']));


### PR DESCRIPTION
Overview
----------------------------------------

In the past, `CRM_Core_IDS` wrote its configuration to a temp file and then read from the tempfile. This was removed 2 years ago with v4.7.25 (see 76adcecc306b0e6e8fd7598930383fc0b7a73eab, #10709, [CRM-20926](https://issues.civicrm.org/jira/browse/CRM-20926)).  

There are still a few stray references to handle cleanup. IMHO, we don't need these any more.

Before
----------------------------------------
* The `Config.IDS.ini` is not created; and if it exists, it is not used. But it may be deleted.

After
----------------------------------------
* The `Config.IDS.ini` is not created; used; or deleted.
* The code is less noisy.

Comments
----------------------------------------
The worst case here arises if someone upgrades directly from <=4.7.24 to >=5.17.x -- they may have a tiny inert file left over in their upload dir. Of course, the upload dir usually has other tiny inert files, so 🤷‍♂ .