### PR TITLE
dev/drupal#75 Drupal8: fix call to languageNegotiationURL() when called from cv

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -709,7 +709,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     // Drupal might not be bootstrapped if being called by the REST API.
     if (!class_exists('Drupal') || !\Drupal::hasContainer()) {
-      return NULL;
+      return $url;
     }
 
     $language = $this->getCurrentLanguage();


### PR DESCRIPTION


Overview
----------------------------------------

Silly/obvious coding error was causing `cv` to fail.

https://lab.civicrm.org/dev/drupal/issues/75

