### PR TITLE
 [REF] [export] remove chunk of non-functional code

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -256,19 +256,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     // This perhaps only needs calling when $mergeSameHousehold == 1
     self::buildRelatedContactArray($selectAll, $ids, $processor, $componentTable);
 
-    // make sure the groups stuff is included only if specifically specified
-    // by the fields param (CRM-1969), else we limit the contacts outputted to only
-    // ones that are part of a group
-    if (!empty($returnProperties['groups'])) {
-      $oldClause = "( contact_a.id = civicrm_group_contact.contact_id )";
-      $newClause = " ( $oldClause AND ( civicrm_group_contact.status = 'Added' OR civicrm_group_contact.status IS NULL ) )";
-      // total hack for export, CRM-3618
-      $from = str_replace($oldClause,
-        $newClause,
-        $from
-      );
-    }
-
     $whereClauses = ['trash_clause' => "contact_a.is_deleted != 1"];
     if (!$selectAll && $componentTable) {
       $from .= " INNER JOIN $componentTable ctTable ON ctTable.contact_id = contact_a.id ";


### PR DESCRIPTION
Overview
----------------------------------------
Removes a chunk of code that confuses but nothing more

Before
----------------------------------------
Code present

After
----------------------------------------
Poof

Technical Details
----------------------------------------
I worked through this & groups is only available as a return property from contact export so can only be hit from there.

However, the search string has a very specific format - involving parentheses - that is NOT present in the from
clause as currently calculated

      case 'civicrm_group_contact':
        return " $side JOIN civicrm_group_contact ON contact_a.id = civicrm_group_contact.contact_id ";

I don't know if there is some bug that if this worked it would fix or not but the original bug
it addressed referred to an old query format we don't use https://issues.civicrm.org/jira/browse/CRM-3618 now.

If there is a bug this won't change it & if we identify it we can add tests & fix properly

Comments
----------------------------------------

