### PR TITLE
dev/drupal#75 Drupal8: fix call to languageNegotiationURL() when called from cv

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -709,7 +709,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     // Drupal might not be bootstrapped if being called by the REST API.
     if (!class_exists('Drupal') || !\Drupal::hasContainer()) {
-      return NULL;
+      return $url;
     }
 
     $language = $this->getCurrentLanguage();


### PR DESCRIPTION
port https://github.com/civicrm/civicrm-core/pull/14772 to 5.16 (which should have been the target)