### PR TITLE
GenCode, Cache::cleanKey() - Fix deploop during clean initialization

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -851,7 +851,7 @@ SELECT g.*
       $aclKeys = array_keys($acls);
       $aclKeys = implode(',', $aclKeys);
 
-      $cacheKey = CRM_Core_BAO_Cache::cleanKey("$tableName-$aclKeys");
+      $cacheKey = CRM_Utils_Cache::cleanKey("$tableName-$aclKeys");
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
       if (!$ids) {

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -387,7 +387,7 @@ WHERE  type.name IS NOT NULL
     $argString = $all ? 'CRM_CT_GSE_1' : 'CRM_CT_GSE_0';
     $argString .= $isSeparator ? '_1' : '_0';
     $argString .= $separator;
-    $argString = CRM_Core_BAO_Cache::cleanKey($argString);
+    $argString = CRM_Utils_Cache::cleanKey($argString);
     if (!array_key_exists($argString, $_cache)) {
       $cache = CRM_Utils_Cache::singleton();
       $_cache[$argString] = $cache->get($argString);

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -475,24 +475,11 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @return string
    *   Ex: '_abcd1234abcd1234' or 'ab_xx/cd_xxef'.
    *   A similar key, but suitable for use with PSR-16-compliant cache providers.
+   * @deprecated
+   * @see CRM_Utils_Cache::cleanKey()
    */
   public static function cleanKey($key) {
-    if (!is_string($key) && !is_int($key)) {
-      throw new \RuntimeException("Malformed cache key");
-    }
-
-    $maxLen = 64;
-    $escape = '-';
-
-    if (strlen($key) >= $maxLen) {
-      return $escape . md5($key);
-    }
-
-    $r = preg_replace_callback(';[^A-Za-z0-9_\.];', function($m) use ($escape) {
-      return $escape . dechex(ord($m[0]));
-    }, $key);
-
-    return strlen($r) >= $maxLen ? $escape . md5($key) : $r;
+    return CRM_Utils_Cache::cleanKey($key);
   }
 
 }

--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -95,7 +95,7 @@ class CRM_Core_BAO_Cache_Psr16 {
           'path' => $path,
         ]);
     }
-    return self::getGroup($group)->get(CRM_Core_BAO_Cache::cleanKey($path));
+    return self::getGroup($group)->get(CRM_Utils_Cache::cleanKey($path));
   }
 
   /**
@@ -138,7 +138,7 @@ class CRM_Core_BAO_Cache_Psr16 {
         ]);
     }
     self::getGroup($group)
-      ->set(CRM_Core_BAO_Cache::cleanKey($path), $data, self::TTL);
+      ->set(CRM_Utils_Cache::cleanKey($path), $data, self::TTL);
   }
 
   /**
@@ -153,7 +153,7 @@ class CRM_Core_BAO_Cache_Psr16 {
     // FIXME: Generate a general deprecation notice.
 
     if ($path) {
-      self::getGroup($group)->delete(CRM_Core_BAO_Cache::cleanKey($path));
+      self::getGroup($group)->delete(CRM_Utils_Cache::cleanKey($path));
     }
     else {
       self::getGroup($group)->clear();

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -447,7 +447,7 @@ WHERE      c.group_name = %1
 AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
 ";
     $params = [
-      1 => [CRM_Core_BAO_Cache::cleanKey('CiviCRM Search PrevNextCache'), 'String'],
+      1 => [CRM_Utils_Cache::cleanKey('CiviCRM Search PrevNextCache'), 'String'],
       2 => [$cacheTimeIntervalDays, 'Integer'],
     ];
     CRM_Core_DAO::executeQuery($sql, $params);

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -530,7 +530,7 @@ class CRM_Core_PseudoConstant {
     $key = 'id',
     $force = NULL
   ) {
-    $cacheKey = CRM_Core_BAO_Cache::cleanKey("CRM_PC_{$name}_{$all}_{$key}_{$retrieve}_{$filter}_{$condition}_{$orderby}");
+    $cacheKey = CRM_Utils_Cache::cleanKey("CRM_PC_{$name}_{$all}_{$key}_{$retrieve}_{$filter}_{$condition}_{$orderby}");
     $cache = CRM_Utils_Cache::singleton();
     $var = $cache->get($cacheKey);
     if ($var !== NULL && empty($force)) {

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -215,7 +215,7 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
     CRM_Utils_Cache::assertValidKey($key);
     // If we are triggering a deletion of a prevNextCache key in the civicrm_cache tabl
     // Alssure that the relevant prev_next_cache values are also removed.
-    if ($this->group == CRM_Core_BAO_Cache::cleanKey('CiviCRM Search PrevNextCache')) {
+    if ($this->group == CRM_Utils_Cache::cleanKey('CiviCRM Search PrevNextCache')) {
       Civi::service('prevnext')->deleteItem(NULL, $key);
     }
     CRM_Core_DAO::executeQuery("DELETE FROM {$this->table} WHERE {$this->where($key)}");
@@ -225,7 +225,7 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
   }
 
   public function flush() {
-    if ($this->group == CRM_Core_BAO_Cache::cleanKey('CiviCRM Search PrevNextCache') &&
+    if ($this->group == CRM_Utils_Cache::cleanKey('CiviCRM Search PrevNextCache') &&
       Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
       // Use the standard PrevNextCache cleanup function here not just delete from civicrm_cache
       CRM_Core_BAO_PrevNextCache::cleanupCache();

--- a/tests/phpunit/CRM/Core/BAO/CacheTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CacheTest.php
@@ -109,7 +109,7 @@ class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
    * @dataProvider getCleanKeyExamples
    */
   public function testCleanKeys($inputKey, $expectKey) {
-    $actualKey = CRM_Core_BAO_Cache::cleanKey($inputKey);
+    $actualKey = CRM_Utils_Cache::cleanKey($inputKey);
     $this->assertEquals($expectKey, $actualKey);
   }
 


### PR DESCRIPTION
Overview
--------

Suppose you have a clean codebase with no DAO files, and you try to run `xml/GenCode.php`.
This currently crashes.

The problem is not symptomatic day-to-day because we commit DAOs, so it's
very rare to run a full/clean initialization.  However, it does get in the
way of stress-testing the correctness of GenCode.

These are the steps I've used to try `GenCode` with a (relatively) clean slate:

```
rm CRM/*/DAO/*.php -f
git checkout -- CRM/Contact/DAO/Factory.php CRM/Core/DAO/AllCoreTables.php CRM/Core/DAO/Factory.php CRM/Core/DAO/permissions.php
./bin/setup.sh -g
```

Before
------

Running `setup.sh` above crashes:

```
[bknix-min:~/bknix/build/dmaster/sites/all/modules/civicrm] ./bin/setup.sh -g
+ '[' -n '' ']'
+ '[' -n 1 -a -d /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/./bin/../xml ']'
+ pushd /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/./bin/../xml
~/bknix/build/dmaster/sites/all/modules/civicrm/xml ~/bknix/build/dmaster/sites/all/modules/civicrm
+ '[' -z 3307 ']'
+ PHP_MYSQL_HOSTPORT=127.0.0.1:3307
+ php -d mysql.default_host=127.0.0.1:3307 -d mysql.default_user=dmasterciv_mqc44 -d mysql.default_password=NOTREALLYTHIS GenCode.php schema/Schema.xml '' Drupal

civicrm_domain.version := 5.17.alpha1

Parsing schema description schema/Schema.xml
Extracting database information
Extracting table information
PHP Fatal error:  Class 'CRM_Core_DAO_Cache' not found in /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Core/BAO/Cache.php on line 41
PHP Stack trace:
PHP   1. {main}() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/xml/GenCode.php:0
PHP   2. CRM_Core_CodeGen_Main->main() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/xml/GenCode.php:55
PHP   3. CRM_Core_CodeGen_Main->getTasks() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:109
PHP   4. CRM_Core_CodeGen_Schema->__construct() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:127
PHP   5. CRM_Core_CodeGen_Schema->findLocales() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Core/CodeGen/Schema.php:15
PHP   6. CRM_Core_Config::singleton() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Core/CodeGen/Schema.php:113
PHP   7. Civi\Core\Container::boot() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Core/Config.php:113
PHP   8. CRM_Utils_Cache::create() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/Civi/Core/Container.php:503
PHP   9. spl_autoload_call() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Utils/Cache.php:186
PHP  10. CRM_Core_ClassLoader->loadClass() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Utils/Cache.php:186
PHP  11. require_once() /Users/totten/bknix/build/dmaster/sites/all/modules/civicrm/CRM/Core/ClassLoader.php:221
```

Since 76e697a9d750d568d0d12c10dd8173f656e8bb1e, `CRM_Utils_Cache::create()` calls `CRM_Core_BAO_Cache::cleanKey()`. However, the class `CRM_Core_BAO_Cache` cannot be loaded because its parent (`CRM_Core_DAO_Cache`) does not yet exist.

After
-----

* The utility function `CRM_Core_BAO_Cache::cleanKey()` is migrated to `CRM_Utils_Cache::cleanKey()`.
* Thus, `CRM_Utils_Cache::create()` no longer loads `CRM_Core_BAO_Cache` or `CRM_Core_DAO_Cache`. Thus, it works.