### PR TITLE
(dev/cloud-native#3) CRM_Utils_File - Deprecate baseFilePath() et al

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -666,12 +666,12 @@ HTACCESS;
 
   /**
    * @param $directory
-   * @param string|NULL $basePath
+   * @param string $basePath
    *   The base path when evaluating relative paths. Should include trailing slash.
    *
    * @return string
    */
-  public static function absoluteDirectory($directory, $basePath = NULL) {
+  public static function absoluteDirectory($directory, $basePath) {
     // check if directory is already absolute, if so return immediately
     // Note: Windows PHP accepts any mix of "/" or "\", so "C:\htdocs" or "C:/htdocs" would be a valid absolute path
     if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && preg_match(';^[a-zA-Z]:[/\\\\];', $directory)) {
@@ -683,8 +683,12 @@ HTACCESS;
       return $directory;
     }
 
-    // make everything absolute from the baseFilePath
-    $basePath = ($basePath === NULL) ? self::baseFilePath() : $basePath;
+    if ($basePath === NULL) {
+      // Previous versions interpreted `NULL` to mean "default to `self::baseFilePath()`".
+      // However, no code in the known `universe` relies on this interpretation, and
+      // the `baseFilePath()` function is problematic/deprecated.
+      throw new \RuntimeException("absoluteDirectory() requires specifying a basePath");
+    }
 
     // ensure that $basePath has a trailing slash
     $basePath = self::addTrailingSlash($basePath);

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -577,8 +577,19 @@ HTACCESS;
   }
 
   /**
-   * Create the base file path from which all our internal directories are
-   * offset. This is derived from the template compile directory set
+   * (Deprecated) Create the file-path from which all other internal paths are
+   * computed. This implementation determines it as `dirname(CIVICRM_TEMPLATE_COMPILEDIR)`.
+   *
+   * This approach is problematic - e.g. it prevents one from authentically
+   * splitting the CIVICRM_TEMPLATE_COMPILEDIR away from other dirs. The implementation
+   * is preserved for backwards compatibility (and should only be called by
+   * CMS-adapters and by Civi\Core\Paths).
+   *
+   * Do not use it for new path construction logic. Instead, use Civi::paths().
+   *
+   * @deprecated
+   * @see \Civi::paths()
+   * @see \Civi\Core\Paths
    */
   public static function baseFilePath() {
     static $_path = NULL;

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -640,6 +640,10 @@ HTACCESS;
    * @param $directory
    *
    * @return string
+   * @deprecated
+   *   Computation of a relative path requires some base.
+   *   This implementation is problematic because it relies on an
+   *   implicit base which was constructed problematically.
    */
   public static function relativeDirectory($directory) {
     // Do nothing on windows


### PR DESCRIPTION
Overview
----------------------------------------
This deprecates a function which was enabling/complicit in problematic file-construction logic.

Before
----------------------------------------
* In `CRM_Utils_File`, the functions `baseFilePath()`, `relativeDirectory($directory)`, and `absoluteDirectory($directory, $basePath = NULL)` exist. They are not deprecated.

After
----------------------------------------
* In `CRM_Utils_File`, the functions `baseFilePath()` and `relativeDirectory($directory)` exist. They are deprecated,  but they behave the same as before.
* In `CRM_Utils_File`, the function `absoluteDirectory($directory, $basePath)` now requires the second parameter. This parameter is actually provided by all callers in the known `universe`.

Technical Details
----------------------------------------

The function `baseFilePath()` represents a hack: the configuration in `civicrm.settings.php` did not provide a genuine way to figure out the path to the civicrm data folder (e.g. `/var/www/sites/default/files/civicrm`), but it did provide `CIVICRM_TEMPLATE_COMPILEDIR` (e.g. `/var/www/sites/default/files/civicrm/templates_c`).  In absence of a proper reference to the data-folder, various bits of code used `baseFilePath()` to guess it.

This hack means that paths are brittle: if one changes `CIVICRM_TEMPLATE_COMPILEDIR`, it could have confusing repercussions on other folders which have nothing to do with template compilation.

Since Civi 4.7, there has been a way to identify `/var/www/sites/default/files/civicrm` specifically (and even customize/override it) using `Civi::paths()`.

However, this only deprecates `baseFilePath()`. The function is useful in providing backward-compatibility with existing deployments/`civicrm.settings.php`-content.

https://lab.civicrm.org/dev/cloud-native/issues/3