### PR TITLE
[NFC] [REF] [TEST] [EXPORT] Update various export tests to test csv output with new functions

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -660,6 +660,9 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
 
   /**
    * Attempt to do a fairly full export of location data.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
    */
   public function testExportIMData() {
     // Use default providers.
@@ -737,119 +740,20 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
         }
       }
     }
-    list($tableName, $sqlColumns) = $this->doExport($fields, $this->contactIDs[0]);
+    $this->doExportTest(['fields' => $fields, 'ids' => [$this->contactIDs[0]]]);
 
-    $dao = CRM_Core_DAO::executeQuery('SELECT * FROM ' . $tableName);
-    while ($dao->fetch()) {
-      $id = $dao->contact_id;
-      $this->assertEquals('AIM', $dao->billing_im_provider);
-      $this->assertEquals('BillingJabber' . $id, $dao->billing_im_screen_name_jabber);
-      $this->assertEquals('BillingSkype' . $id, $dao->billing_im_screen_name_skype);
+    foreach ($this->csv->getRecords() as $row) {
+      $id = $row['contact_id'];
+      $this->assertEquals('AIM', $row['Billing-IM Provider']);
+      $this->assertEquals('AIM', $row['Whare Kai-IM Provider']);
+      $this->assertEquals('BillingJabber' . $id, $row['Billing-IM Screen Name-Jabber']);
+      $this->assertEquals('Whare KaiJabber' . $id, $row['Whare Kai-IM Screen Name-Jabber']);
+      $this->assertEquals('BillingSkype' . $id, $row['Billing-IM Screen Name-Skype']);
       foreach ($relationships as $relatedContactID => $relationship) {
-        $relationshipString = $field = $relationship['relationship_type_id'] . '_a_b';
-        $field = $relationshipString . '_billing_im_screen_name_yahoo';
-        $this->assertEquals('BillingYahoo' . $relatedContactID, $dao->$field);
-        // @todo efforts to output 'im_provider' for related contacts seem to be giving a blank field.
+        $this->assertEquals('BillingYahoo' . $relatedContactID, $row[$relationship['label'] . '-Billing-IM Screen Name-Yahoo']);
+        $this->assertEquals('Whare KaiJabber' . $relatedContactID, $row[$relationship['label'] . '-Whare Kai-IM Screen Name-Jabber']);
       }
     }
-
-    $this->assertEquals([
-      'billing_im_provider' => 'billing_im_provider text',
-      'billing_im_screen_name' => 'billing_im_screen_name varchar(64)',
-      'billing_im_screen_name_jabber' => 'billing_im_screen_name_jabber varchar(64)',
-      'billing_im_screen_name_skype' => 'billing_im_screen_name_skype varchar(64)',
-      'billing_im_screen_name_yahoo' => 'billing_im_screen_name_yahoo varchar(64)',
-      'home_im_provider' => 'home_im_provider text',
-      'home_im_screen_name' => 'home_im_screen_name varchar(64)',
-      'home_im_screen_name_jabber' => 'home_im_screen_name_jabber varchar(64)',
-      'home_im_screen_name_skype' => 'home_im_screen_name_skype varchar(64)',
-      'home_im_screen_name_yahoo' => 'home_im_screen_name_yahoo varchar(64)',
-      'main_im_provider' => 'main_im_provider text',
-      'main_im_screen_name' => 'main_im_screen_name varchar(64)',
-      'main_im_screen_name_jabber' => 'main_im_screen_name_jabber varchar(64)',
-      'main_im_screen_name_skype' => 'main_im_screen_name_skype varchar(64)',
-      'main_im_screen_name_yahoo' => 'main_im_screen_name_yahoo varchar(64)',
-      'other_im_provider' => 'other_im_provider text',
-      'other_im_screen_name' => 'other_im_screen_name varchar(64)',
-      'other_im_screen_name_jabber' => 'other_im_screen_name_jabber varchar(64)',
-      'other_im_screen_name_skype' => 'other_im_screen_name_skype varchar(64)',
-      'other_im_screen_name_yahoo' => 'other_im_screen_name_yahoo varchar(64)',
-      'im_provider' => 'im_provider text',
-      'im_screen_name' => 'im_screen_name varchar(64)',
-      'contact_id' => 'contact_id varchar(255)',
-      '2_a_b_im_provider' => '2_a_b_im_provider text',
-      '2_a_b_billing_im_screen_name' => '2_a_b_billing_im_screen_name varchar(64)',
-      '2_a_b_billing_im_screen_name_jabber' => '2_a_b_billing_im_screen_name_jabber varchar(64)',
-      '2_a_b_billing_im_screen_name_skype' => '2_a_b_billing_im_screen_name_skype varchar(64)',
-      '2_a_b_billing_im_screen_name_yahoo' => '2_a_b_billing_im_screen_name_yahoo varchar(64)',
-      '2_a_b_home_im_screen_name' => '2_a_b_home_im_screen_name varchar(64)',
-      '2_a_b_home_im_screen_name_jabber' => '2_a_b_home_im_screen_name_jabber varchar(64)',
-      '2_a_b_home_im_screen_name_skype' => '2_a_b_home_im_screen_name_skype varchar(64)',
-      '2_a_b_home_im_screen_name_yahoo' => '2_a_b_home_im_screen_name_yahoo varchar(64)',
-      '2_a_b_main_im_screen_name' => '2_a_b_main_im_screen_name varchar(64)',
-      '2_a_b_main_im_screen_name_jabber' => '2_a_b_main_im_screen_name_jabber varchar(64)',
-      '2_a_b_main_im_screen_name_skype' => '2_a_b_main_im_screen_name_skype varchar(64)',
-      '2_a_b_main_im_screen_name_yahoo' => '2_a_b_main_im_screen_name_yahoo varchar(64)',
-      '2_a_b_other_im_screen_name' => '2_a_b_other_im_screen_name varchar(64)',
-      '2_a_b_other_im_screen_name_jabber' => '2_a_b_other_im_screen_name_jabber varchar(64)',
-      '2_a_b_other_im_screen_name_skype' => '2_a_b_other_im_screen_name_skype varchar(64)',
-      '2_a_b_other_im_screen_name_yahoo' => '2_a_b_other_im_screen_name_yahoo varchar(64)',
-      '2_a_b_im_screen_name' => '2_a_b_im_screen_name varchar(64)',
-      '8_a_b_im_provider' => '8_a_b_im_provider text',
-      '8_a_b_billing_im_screen_name' => '8_a_b_billing_im_screen_name varchar(64)',
-      '8_a_b_billing_im_screen_name_jabber' => '8_a_b_billing_im_screen_name_jabber varchar(64)',
-      '8_a_b_billing_im_screen_name_skype' => '8_a_b_billing_im_screen_name_skype varchar(64)',
-      '8_a_b_billing_im_screen_name_yahoo' => '8_a_b_billing_im_screen_name_yahoo varchar(64)',
-      '8_a_b_home_im_screen_name' => '8_a_b_home_im_screen_name varchar(64)',
-      '8_a_b_home_im_screen_name_jabber' => '8_a_b_home_im_screen_name_jabber varchar(64)',
-      '8_a_b_home_im_screen_name_skype' => '8_a_b_home_im_screen_name_skype varchar(64)',
-      '8_a_b_home_im_screen_name_yahoo' => '8_a_b_home_im_screen_name_yahoo varchar(64)',
-      '8_a_b_main_im_screen_name' => '8_a_b_main_im_screen_name varchar(64)',
-      '8_a_b_main_im_screen_name_jabber' => '8_a_b_main_im_screen_name_jabber varchar(64)',
-      '8_a_b_main_im_screen_name_skype' => '8_a_b_main_im_screen_name_skype varchar(64)',
-      '8_a_b_main_im_screen_name_yahoo' => '8_a_b_main_im_screen_name_yahoo varchar(64)',
-      '8_a_b_other_im_screen_name' => '8_a_b_other_im_screen_name varchar(64)',
-      '8_a_b_other_im_screen_name_jabber' => '8_a_b_other_im_screen_name_jabber varchar(64)',
-      '8_a_b_other_im_screen_name_skype' => '8_a_b_other_im_screen_name_skype varchar(64)',
-      '8_a_b_other_im_screen_name_yahoo' => '8_a_b_other_im_screen_name_yahoo varchar(64)',
-      '8_a_b_im_screen_name' => '8_a_b_im_screen_name varchar(64)',
-      '5_a_b_im_provider' => '5_a_b_im_provider text',
-      '5_a_b_billing_im_screen_name' => '5_a_b_billing_im_screen_name varchar(64)',
-      '5_a_b_billing_im_screen_name_jabber' => '5_a_b_billing_im_screen_name_jabber varchar(64)',
-      '5_a_b_billing_im_screen_name_skype' => '5_a_b_billing_im_screen_name_skype varchar(64)',
-      '5_a_b_billing_im_screen_name_yahoo' => '5_a_b_billing_im_screen_name_yahoo varchar(64)',
-      '5_a_b_home_im_screen_name' => '5_a_b_home_im_screen_name varchar(64)',
-      '5_a_b_home_im_screen_name_jabber' => '5_a_b_home_im_screen_name_jabber varchar(64)',
-      '5_a_b_home_im_screen_name_skype' => '5_a_b_home_im_screen_name_skype varchar(64)',
-      '5_a_b_home_im_screen_name_yahoo' => '5_a_b_home_im_screen_name_yahoo varchar(64)',
-      '5_a_b_main_im_screen_name' => '5_a_b_main_im_screen_name varchar(64)',
-      '5_a_b_main_im_screen_name_jabber' => '5_a_b_main_im_screen_name_jabber varchar(64)',
-      '5_a_b_main_im_screen_name_skype' => '5_a_b_main_im_screen_name_skype varchar(64)',
-      '5_a_b_main_im_screen_name_yahoo' => '5_a_b_main_im_screen_name_yahoo varchar(64)',
-      '5_a_b_other_im_screen_name' => '5_a_b_other_im_screen_name varchar(64)',
-      '5_a_b_other_im_screen_name_jabber' => '5_a_b_other_im_screen_name_jabber varchar(64)',
-      '5_a_b_other_im_screen_name_skype' => '5_a_b_other_im_screen_name_skype varchar(64)',
-      '5_a_b_other_im_screen_name_yahoo' => '5_a_b_other_im_screen_name_yahoo varchar(64)',
-      '5_a_b_im_screen_name' => '5_a_b_im_screen_name varchar(64)',
-      'whare_kai_im_provider' => 'whare_kai_im_provider text',
-      'whare_kai_im_screen_name' => 'whare_kai_im_screen_name varchar(64)',
-      'whare_kai_im_screen_name_jabber' => 'whare_kai_im_screen_name_jabber varchar(64)',
-      'whare_kai_im_screen_name_skype' => 'whare_kai_im_screen_name_skype varchar(64)',
-      'whare_kai_im_screen_name_yahoo' => 'whare_kai_im_screen_name_yahoo varchar(64)',
-      '2_a_b_whare_kai_im_screen_name' => '2_a_b_whare_kai_im_screen_name varchar(64)',
-      '2_a_b_whare_kai_im_screen_name_jabber' => '2_a_b_whare_kai_im_screen_name_jabber varchar(64)',
-      '2_a_b_whare_kai_im_screen_name_skype' => '2_a_b_whare_kai_im_screen_name_skype varchar(64)',
-      '2_a_b_whare_kai_im_screen_name_yahoo' => '2_a_b_whare_kai_im_screen_name_yahoo varchar(64)',
-      '8_a_b_whare_kai_im_screen_name' => '8_a_b_whare_kai_im_screen_name varchar(64)',
-      '8_a_b_whare_kai_im_screen_name_jabber' => '8_a_b_whare_kai_im_screen_name_jabber varchar(64)',
-      '8_a_b_whare_kai_im_screen_name_skype' => '8_a_b_whare_kai_im_screen_name_skype varchar(64)',
-      '8_a_b_whare_kai_im_screen_name_yahoo' => '8_a_b_whare_kai_im_screen_name_yahoo varchar(64)',
-      '5_a_b_whare_kai_im_screen_name' => '5_a_b_whare_kai_im_screen_name varchar(64)',
-      '5_a_b_whare_kai_im_screen_name_jabber' => '5_a_b_whare_kai_im_screen_name_jabber varchar(64)',
-      '5_a_b_whare_kai_im_screen_name_skype' => '5_a_b_whare_kai_im_screen_name_skype varchar(64)',
-      '5_a_b_whare_kai_im_screen_name_yahoo' => '5_a_b_whare_kai_im_screen_name_yahoo varchar(64)',
-    ], $sqlColumns);
-
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Updates some unit tests on export functionality to use preferred methodology

Before
----------------------------------------
Testing created temp table

After
----------------------------------------
Testing csv output

Technical Details
----------------------------------------
Because he is wiser than all of us @totten pointed out that we could throw an exception in the civiExit process for unit tests. This, combined with shipping phpleague csv package gave us a way to test the actual output. This upgrades some tests to do that. Testing thee csv output rather than the temptable details is preferred because the temp table is 'the workings' and in many cases would be better not created at all. Testing the columns created was REALLY useful when we were refactoring that but I don't believe removing that chunk now loses us any coverage


Comments
----------------------------------------

