### PR TITLE
5.16.0 release notes first run

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1514,7 +1514,7 @@
 
 - github      : wadelson
   organization: Webstanz
-  name:       : Adelson
+  name        : Adelson
 
 - github      : wdecraene
   organization: Wim De Craene

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -261,6 +261,10 @@
   name        : Chandana Bandara
   organization: CompuCorp
 
+- github      : CsarRamos
+  name        : César Ramos
+  organization: iXiam
+
 - github      : chrisfromredfin
   name        : Chris Wells
   organization: Redfin Solutions

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,6 +15,17 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 5.16.0
+
+Released August 7, 2019
+
+- **[Synopsis](release-notes/5.16.0.md#synopsis)**
+- **[Features](release-notes/5.16.0.md#features)**
+- **[Bugs resolved](release-notes/5.16.0.md#bugs)**
+- **[Miscellany](release-notes/5.16.0.md#misc)**
+- **[Credits](release-notes/5.16.0.md#credits)**
+- **[Feedback](release-notes/5.16.0.md#feedback)**
+
 ## CiviCRM 5.15.0
 
 Released July 3, 2019

--- a/release-notes/5.16.0.md
+++ b/release-notes/5.16.0.md
@@ -1,0 +1,391 @@
+# CiviCRM 5.16.0
+
+Released August 7, 2019;
+
+- **[Features](#features)**
+- **[Bugs resolved](#bugs)**
+- **[Miscellany](#misc)**
+- **[Credits](#credits)**
+
+## <a name="features"></a>Features
+
+### Core CiviCRM
+
+- **[CRM-18792](https://issues.civicrm.org/jira/browse/CRM-18792)  ([14551](https://github.com/civicrm/civicrm-core/pull/14551) and [12929](https://github.com/civicrm/civicrm-core/pull/12929))**
+
+## <a name="bugs"></a>Bugs resolved
+
+### Core CiviCRM
+
+- **dev/drupal#75 Drupal8: fix call to languageNegotiationURL() when called from cv ([14775](https://github.com/civicrm/civicrm-core/pull/14775))**
+
+- **dev/core#1081 fix for error on contribution detail when using custom data order by without select ([14746](https://github.com/civicrm/civicrm-core/pull/14746))**
+
+- **dev/report#16 Unreleased regression - fee levels incorrectly show sol… ([14732](https://github.com/civicrm/civicrm-core/pull/14732))**
+
+- **Fix refund payment not recording from additional payment form ([14733](https://github.com/civicrm/civicrm-core/pull/14733))**
+
+- **Extract code converting a date object to local timezone object to own… ([14723](https://github.com/civicrm/civicrm-core/pull/14723))**
+
+- **(dev/cloud-native#3) SerializeCache - Remove unused, incomplete cache-driver ([14717](https://github.com/civicrm/civicrm-core/pull/14717))**
+
+- **5.15 to master ([14714](https://github.com/civicrm/civicrm-core/pull/14714))**
+
+- **Grab contribution status id from database ([14713](https://github.com/civicrm/civicrm-core/pull/14713))**
+
+- ** [test] convert export test to handle exception rather than early return ([14608](https://github.com/civicrm/civicrm-core/pull/14608))**
+
+- **dev/joomla#13 - followup 2 - Some class names have wrong upper/lower case spelling ([14707](https://github.com/civicrm/civicrm-core/pull/14707))**
+
+- **dev/joomla#13 - followup 3 - Some class names have wrong upper/lower case spelling ([14708](https://github.com/civicrm/civicrm-core/pull/14708))**
+
+- **dev/joomla#13 - followup 4 - Some class names have wrong upper/lower case spelling ([14709](https://github.com/civicrm/civicrm-core/pull/14709))**
+
+- **dev/joomla#13 - followup 5 - Some class names have wrong upper/lower case spelling ([14710](https://github.com/civicrm/civicrm-core/pull/14710))**
+
+- **Grab contribution status id from database ([14704](https://github.com/civicrm/civicrm-core/pull/14704))**
+
+- **Consolidate handling of conflicts between the batch job and get_conflicts api ([14685](https://github.com/civicrm/civicrm-core/pull/14685))**
+
+- **[REF] remove instances of pass-by-reference where no change takes place ([14693](https://github.com/civicrm/civicrm-core/pull/14693))**
+
+- **$this->_selectedTables is not populated incase of boleen filters ([14503](https://github.com/civicrm/civicrm-core/pull/14503))**
+
+- **dev/joomla#13 - followup - Some class names have wrong upper/lower case spelling ([14702](https://github.com/civicrm/civicrm-core/pull/14702))**
+
+- **[REF] extract prepareCreate from CustomField.create ([14689](https://github.com/civicrm/civicrm-core/pull/14689))**
+
+- **[NFC][test] reformat activity search test ([14699](https://github.com/civicrm/civicrm-core/pull/14699))**
+
+- **[NFC][test] code formatting only ([14700](https://github.com/civicrm/civicrm-core/pull/14700))**
+
+- **Remove failing assertion ([14695](https://github.com/civicrm/civicrm-core/pull/14695))**
+
+- **5.15 to master ([14698](https://github.com/civicrm/civicrm-core/pull/14698))**
+
+- ** Fix erroneous variable passed to callAPISuccessGetValue ([14688](https://github.com/civicrm/civicrm-core/pull/14688))**
+
+- **[REF] transform the setting of defaults in CustomField::create to be like (some) other entities ([14671](https://github.com/civicrm/civicrm-core/pull/14671))**
+
+- **Deprecate some deprecated address functions: defaultCurrencySymbol ([14687](https://github.com/civicrm/civicrm-core/pull/14687))**
+
+- **dev/financial#50 - Fix contributions and participants getting overwritten ([14244](https://github.com/civicrm/civicrm-core/pull/14244))**
+
+- **Fixing the display of checkboxes in event confirm / thank you (dev/core#1058) ([14587](https://github.com/civicrm/civicrm-core/pull/14587))**
+
+- **Fix failing test by changing expected date format ([14686](https://github.com/civicrm/civicrm-core/pull/14686))**
+
+- **dev-core#1079: Improper character encoding breaks xml processor ([14654](https://github.com/civicrm/civicrm-core/pull/14654))**
+
+- **dev/core#1086 - Mismatched div and /div tags in caseTypeDetails.html ([14682](https://github.com/civicrm/civicrm-core/pull/14682))**
+
+- **Block classes in unserialize field for IDE cheer ([14683](https://github.com/civicrm/civicrm-core/pull/14683))**
+
+- **[NFC][test] reformat jobTest class ([14681](https://github.com/civicrm/civicrm-core/pull/14681))**
+
+- **Improve protected field metadata ([14679](https://github.com/civicrm/civicrm-core/pull/14679))**
+
+- **5.15 to master ([14677](https://github.com/civicrm/civicrm-core/pull/14677))**
+
+- **[REF] do not receive  by reference in CustomField::create ([14670](https://github.com/civicrm/civicrm-core/pull/14670))**
+
+- **URL support for some params in event search  ([14477](https://github.com/civicrm/civicrm-core/pull/14477))**
+
+- **dev/core#389 Fix custom data relative date searching ([14625](https://github.com/civicrm/civicrm-core/pull/14625))**
+
+- **5.15 ([14669](https://github.com/civicrm/civicrm-core/pull/14669))**
+
+- **dev/core#663 - Use InnoDB engine for extended log tables ([14256](https://github.com/civicrm/civicrm-core/pull/14256))**
+
+- **Add in Andrei Mondoc(mecachisenros) to contributor key ([14665](https://github.com/civicrm/civicrm-core/pull/14665))**
+
+- **dev/core#1082 - test demonstrating message template mixup ([14666](https://github.com/civicrm/civicrm-core/pull/14666))**
+
+- **Fix incorrect display of Line Items created via API when printing invoice (for Participants) ([13477](https://github.com/civicrm/civicrm-core/pull/13477))**
+
+- **5.15 ([14664](https://github.com/civicrm/civicrm-core/pull/14664))**
+
+- ** Move api_key read/write permission checks from api to BAO ([14660](https://github.com/civicrm/civicrm-core/pull/14660))**
+
+- **[REF] Copy assignProportional Line items back into Payment.create function ([14622](https://github.com/civicrm/civicrm-core/pull/14622))**
+
+- **[REF] minor code cleanup - move indexExist calculation to the only place in the code that needs it ([14650](https://github.com/civicrm/civicrm-core/pull/14650))**
+
+- **[REF] Remove columnName field ([14651](https://github.com/civicrm/civicrm-core/pull/14651))**
+
+- **Remove superfluous pass-by-ref in api3 ([14645](https://github.com/civicrm/civicrm-core/pull/14645))**
+
+- **[REF + test] extract buildFieldChangeSql and add unit test ([14653](https://github.com/civicrm/civicrm-core/pull/14653))**
+
+- **[Test] Add in unit test attempting to demonstrate issue caused by dev… ([14637](https://github.com/civicrm/civicrm-core/pull/14637))**
+
+- **[NFC] formatting on test class cleanup ([14649](https://github.com/civicrm/civicrm-core/pull/14649))**
+
+- **[REF] extract createOptionValue function in CustomField::create ([14652](https://github.com/civicrm/civicrm-core/pull/14652))**
+
+- **Removing unused spec function ([14646](https://github.com/civicrm/civicrm-core/pull/14646))**
+
+- **Remove a few places where pass by reference is used but does not need to be ([14643](https://github.com/civicrm/civicrm-core/pull/14643))**
+
+- **5.15 ([14642](https://github.com/civicrm/civicrm-core/pull/14642))**
+
+- **Scheduled jobs: replace outdated wiki link ([14641](https://github.com/civicrm/civicrm-core/pull/14641))**
+
+- **dev/core#1067 Clean Money before creating Campaign record and add test ([14601](https://github.com/civicrm/civicrm-core/pull/14601))**
+
+- **Fix notice on editing contribution ([14626](https://github.com/civicrm/civicrm-core/pull/14626))**
+
+- **REF Extract getDefaultRoleID for add participant ([14499](https://github.com/civicrm/civicrm-core/pull/14499))**
+
+- **Add checklist-model angular module ([14634](https://github.com/civicrm/civicrm-core/pull/14634))**
+
+- **Partially revert "Update example dates from 2009 to current year" ([14636](https://github.com/civicrm/civicrm-core/pull/14636))**
+
+- **Reset language at end of localized api call ([14597](https://github.com/civicrm/civicrm-core/pull/14597))**
+
+- **5.15 to master ([14638](https://github.com/civicrm/civicrm-core/pull/14638))**
+
+- **dev/core#1059 Fix contribution search to work with url parameters in force mode ([14624](https://github.com/civicrm/civicrm-core/pull/14624))**
+
+- **Handle relative start & end dates passed to datepicker widget ([14632](https://github.com/civicrm/civicrm-core/pull/14632))**
+
+- **Update example dates from 2009 to current year ([14635](https://github.com/civicrm/civicrm-core/pull/14635))**
+
+- **Activity formRule status check cleanup ([14630](https://github.com/civicrm/civicrm-core/pull/14630))**
+
+- **Ensure that contact groups caches are cleared if memory backed ([14607](https://github.com/civicrm/civicrm-core/pull/14607))**
+
+- **Remove handling for legacy PrevNextCache group as it has now been con… ([14631](https://github.com/civicrm/civicrm-core/pull/14631))**
+
+- **Follow up to receive_date convert to datepicker - update test ([14627](https://github.com/civicrm/civicrm-core/pull/14627))**
+
+- **Improve utilities & tests for working with js notation ([14588](https://github.com/civicrm/civicrm-core/pull/14588))**
+
+- **[TEST] Update Email Common Test to incorporate testing for the fix fo… ([14629](https://github.com/civicrm/civicrm-core/pull/14629))**
+
+- **Add a helper function to ensure we always set the correct tab for manage events ([14602](https://github.com/civicrm/civicrm-core/pull/14602))**
+
+- **Ensure that completed status is selected by default on search contrib… ([14612](https://github.com/civicrm/civicrm-core/pull/14612))**
+
+- **dev/core#1059 Replace deprecated start and end url params with receiv… ([14613](https://github.com/civicrm/civicrm-core/pull/14613))**
+
+- **Follow up fix on start as a url parameter ([14611](https://github.com/civicrm/civicrm-core/pull/14611))**
+
+- **Reduce deadlocks on inserting custom data by only using 'ON DUPLICATE' when it is not a new row ([14605](https://github.com/civicrm/civicrm-core/pull/14605))**
+
+- **Add query object support for receive_date_high & receive_date_low and generically date fields ([14623](https://github.com/civicrm/civicrm-core/pull/14623))**
+
+- **NFC These pseudoconstant functions return array or string ([14619](https://github.com/civicrm/civicrm-core/pull/14619))**
+
+- **[NFC] code formatting ([14606](https://github.com/civicrm/civicrm-core/pull/14606))**
+
+- **Fix url support for receive_date_high & receive_date_low ([14594](https://github.com/civicrm/civicrm-core/pull/14594))**
+
+- **Convert prevNextCache to standard Cache Defintiion format ([14580](https://github.com/civicrm/civicrm-core/pull/14580))**
+
+- **[REF] Add in utility function for resetting ACL and System Level Caches ([14600](https://github.com/civicrm/civicrm-core/pull/14600))**
+
+- **NFC Cleanup comments on BAO event ([14603](https://github.com/civicrm/civicrm-core/pull/14603))**
+
+- **Decommission recordPartialPayment function ([14599](https://github.com/civicrm/civicrm-core/pull/14599))**
+
+- **[REF] do not pass  by reference to store & create functions ([14598](https://github.com/civicrm/civicrm-core/pull/14598))**
+
+- **Convert Contact Groups cache group to standard cache definition ([14584](https://github.com/civicrm/civicrm-core/pull/14584))**
+
+- **Fix setup.sh crash when using the -a flag ([14595](https://github.com/civicrm/civicrm-core/pull/14595))**
+
+- **Towards Convert receive_date to use datepicker in search  ([14593](https://github.com/civicrm/civicrm-core/pull/14593))**
+
+- **Support api3 & 4 language syntax & improve test ([14590](https://github.com/civicrm/civicrm-core/pull/14590))**
+
+- **5.15 to master ([14592](https://github.com/civicrm/civicrm-core/pull/14592))**
+
+- **Add default receive_date for contributions at BAO level ([14460](https://github.com/civicrm/civicrm-core/pull/14460))**
+
+- **dev/core#553: Creating new event takes value from default value not from saved template for custom fields ([14480](https://github.com/civicrm/civicrm-core/pull/14480))**
+
+- **i18n - Improve multilingual popup for text and wysiwyg fields ([14578](https://github.com/civicrm/civicrm-core/pull/14578))**
+
+- **dev/core#914 rewrite submitOnce function ([14519](https://github.com/civicrm/civicrm-core/pull/14519))**
+
+- **Update Owner Membership ID label in reports to be Primary Membership … ([14585](https://github.com/civicrm/civicrm-core/pull/14585))**
+
+- **Utils_JS - add fn to get props of js object without parsing them ([14586](https://github.com/civicrm/civicrm-core/pull/14586))**
+
+- **5.15 ([14579](https://github.com/civicrm/civicrm-core/pull/14579))**
+
+- **Fix use of cached schema information in SchemaHandler ([14568](https://github.com/civicrm/civicrm-core/pull/14568))**
+
+- **dev/core#1049: Use FrontEndPaymentFormTrait to assign line items… ([14562](https://github.com/civicrm/civicrm-core/pull/14562))**
+
+- **Removed hardcoded value for registered participant status ([14569](https://github.com/civicrm/civicrm-core/pull/14569))**
+
+- **[TEST] add assert to ensure nullArray & nullObject are not contaminated ([14543](https://github.com/civicrm/civicrm-core/pull/14543))**
+
+- **5.15 to master ([14566](https://github.com/civicrm/civicrm-core/pull/14566))**
+
+- **Remove more uses of CRM_Core_DAO::$_nullArray that are unncessary ([14564](https://github.com/civicrm/civicrm-core/pull/14564))**
+
+- **Remove unncessary $_nullArray usage when calling createProfileContact function ([14560](https://github.com/civicrm/civicrm-core/pull/14560))**
+
+- **Remove unneeded use of CRM_Core_DAO::$_nullArray in executeQuery or s… ([14561](https://github.com/civicrm/civicrm-core/pull/14561))**
+
+- **[REF] Remove more instances of _nullArray ([14558](https://github.com/civicrm/civicrm-core/pull/14558))**
+
+- **Alter PSR16 code to take into account of new entitysetting release wi… ([14559](https://github.com/civicrm/civicrm-core/pull/14559))**
+
+- **Support button elements in ajax popups ([14136](https://github.com/civicrm/civicrm-core/pull/14136))**
+
+- **Add buttons to 'Cleanup caches and update paths' in standard way ([14509](https://github.com/civicrm/civicrm-core/pull/14509))**
+
+- **5.15 to master ([14557](https://github.com/civicrm/civicrm-core/pull/14557))**
+
+- **dev/core#1047 Fix instance of null contamination ([14556](https://github.com/civicrm/civicrm-core/pull/14556))**
+
+- **dev/core#1047 Fix instance of null contamination ([14555](https://github.com/civicrm/civicrm-core/pull/14555))**
+
+- **[test] Call parent tearDown more consistently ([14552](https://github.com/civicrm/civicrm-core/pull/14552))**
+
+- **dev/core#1047 Fix instance of NULL contamination ([14550](https://github.com/civicrm/civicrm-core/pull/14550))**
+
+- **Fix duplicate households on 'Merge same household' exports ([14443](https://github.com/civicrm/civicrm-core/pull/14443))**
+
+- **5.15 ([14549](https://github.com/civicrm/civicrm-core/pull/14549))**
+
+- **[TEST] Fix intermittent test fail on NULL array getting contaminated  ([14542](https://github.com/civicrm/civicrm-core/pull/14542))**
+
+- **[NFC] Fix Test function delcaration to match change in CiviUnitTestCa… ([14548](https://github.com/civicrm/civicrm-core/pull/14548))**
+
+- **5.15 to master ([14547](https://github.com/civicrm/civicrm-core/pull/14547))**
+
+- **Fix A.net to resolve time when using default ([14540](https://github.com/civicrm/civicrm-core/pull/14540))**
+
+- **Deprecate contribution_date as a parameter ([14533](https://github.com/civicrm/civicrm-core/pull/14533))**
+
+- **Add CRM_Utils_JS::decode function for decoding js objects ([14537](https://github.com/civicrm/civicrm-core/pull/14537))**
+
+- **Add csv reader package ([14524](https://github.com/civicrm/civicrm-core/pull/14524))**
+
+- **[test] truncate pledge block when cleaning up financial entities ([14538](https://github.com/civicrm/civicrm-core/pull/14538))**
+
+- **Address BAO - Handle standard 'custom' param as well as individual fields ([14535](https://github.com/civicrm/civicrm-core/pull/14535))**
+
+- **5.15 to master ([14541](https://github.com/civicrm/civicrm-core/pull/14541))**
+
+- **5.15 to master ([14536](https://github.com/civicrm/civicrm-core/pull/14536))**
+
+- **ActivityForm - Redirect to contact page or activity view in standalone mode ([14522](https://github.com/civicrm/civicrm-core/pull/14522))**
+
+- **[REF] CRM_Case_BAO_Case::addcaseActivityLinks to CRM_Case_Selector_Search ([14512](https://github.com/civicrm/civicrm-core/pull/14512))**
+
+- **[REF] dev/core#561 Convert Contribution Date field to use date picker… ([14486](https://github.com/civicrm/civicrm-core/pull/14486))**
+
+- **Php 7.2 notices fix on import ([14531](https://github.com/civicrm/civicrm-core/pull/14531))**
+
+- **Expose Primary member only/Non primary member only filter in membersh… ([14530](https://github.com/civicrm/civicrm-core/pull/14530))**
+
+- **Adding myself to the contributors file ([14532](https://github.com/civicrm/civicrm-core/pull/14532))**
+
+- **CiviDist fails on BSD flavor of 'cp' with '-r -p' switch to '-R -p' ([14523](https://github.com/civicrm/civicrm-core/pull/14523))**
+
+- **5.15 ([14528](https://github.com/civicrm/civicrm-core/pull/14528))**
+
+- **[NFC] Fix indenting in Misc Setting Template ([14526](https://github.com/civicrm/civicrm-core/pull/14526))**
+
+- **Update PSR16 handling for multisite extension legacy caching group ([14505](https://github.com/civicrm/civicrm-core/pull/14505))**
+
+- **Display description next to 'paperclip' file icon - usually the filename ([14501](https://github.com/civicrm/civicrm-core/pull/14501))**
+
+- **dev/core#1015 fix regression on exporting soft credits - more robust … ([14513](https://github.com/civicrm/civicrm-core/pull/14513))**
+
+- **dev/core#965 Fix destination in payment edit ([14518](https://github.com/civicrm/civicrm-core/pull/14518))**
+
+- **Fix test which fails when run in isolation. ([14517](https://github.com/civicrm/civicrm-core/pull/14517))**
+
+- **[NFC] test cleanup. Uses CRM_Core_Exceptions, properly outputs unfiltered results ([14471](https://github.com/civicrm/civicrm-core/pull/14471))**
+
+- **5.15 ([14520](https://github.com/civicrm/civicrm-core/pull/14520))**
+
+- **Improve I18n schema by including comments and default and NOT NULL or… ([14484](https://github.com/civicrm/civicrm-core/pull/14484))**
+
+- **Fix placeholder font in Quicksearch ([14154](https://github.com/civicrm/civicrm-core/pull/14154))**
+
+- **Fixed visibility logic on Price field options. ([13966](https://github.com/civicrm/civicrm-core/pull/13966))**
+
+- **CRM_Utils_SQL_* - Properly interpolate NULL values ([14250](https://github.com/civicrm/civicrm-core/pull/14250))**
+
+- **dev/core#1039 Make the contact details in the contact summary screen … ([14506](https://github.com/civicrm/civicrm-core/pull/14506))**
+
+- **Civi\Angular\ChangeSet - Relax debug-mode consistency check ([14510](https://github.com/civicrm/civicrm-core/pull/14510))**
+
+- **dev/drupal#63 Drupal8: override setMessage(), because drupal_set_message is deprecated ([13959](https://github.com/civicrm/civicrm-core/pull/13959))**
+
+- **Expose Primary member only/Non primary member only filter in membersh… ([14507](https://github.com/civicrm/civicrm-core/pull/14507))**
+
+- **REF Deduplicate recaptcha handling code ([14500](https://github.com/civicrm/civicrm-core/pull/14500))**
+
+- **Remove duplicated code in contribution recur search build function ([14504](https://github.com/civicrm/civicrm-core/pull/14504))**
+
+- **Fix deletion of contact sub_type in api4 ([14492](https://github.com/civicrm/civicrm-core/pull/14492))**
+
+- **REF Extract override default currency function ([14496](https://github.com/civicrm/civicrm-core/pull/14496))**
+
+- **[REF] Minor code cleanup on string concatenation ([14444](https://github.com/civicrm/civicrm-core/pull/14444))**
+
+- **Fix proportional test to test Payment.create & for the test to make more sense ([14436](https://github.com/civicrm/civicrm-core/pull/14436))**
+
+- **REF: Extract preProcess paypalexpress ([14498](https://github.com/civicrm/civicrm-core/pull/14498))**
+
+- **NFC Comments and formatting only ([14497](https://github.com/civicrm/civicrm-core/pull/14497))**
+
+- **dev/drupal#21 Remove asterisks from placeholder url ([14474](https://github.com/civicrm/civicrm-core/pull/14474))**
+
+- **Add a couple customField pseudoconstants ([14494](https://github.com/civicrm/civicrm-core/pull/14494))**
+
+- **dev/core#530 Make a_b relationships available as case roles ([13916](https://github.com/civicrm/civicrm-core/pull/13916))**
+
+- **Create payment activity when creating a payment via the api, test ([14452](https://github.com/civicrm/civicrm-core/pull/14452))**
+
+- **[REF] Move sort_name definition to searchFieldMetadata ([14478](https://github.com/civicrm/civicrm-core/pull/14478))**
+
+- **Remove more free calls ([14493](https://github.com/civicrm/civicrm-core/pull/14493))**
+
+- **Add in uniqueness to cache keys to mitigate clashes on multisite inst… ([14485](https://github.com/civicrm/civicrm-core/pull/14485))**
+
+- **dev/core#561 Convert pledge search form to use metadata functions ([14431](https://github.com/civicrm/civicrm-core/pull/14431))**
+
+- **financial#55: support IPN logging on processors that send JSON data as POST ([14290](https://github.com/civicrm/civicrm-core/pull/14290))**
+
+- **Fix core#1026 where an email address synced from a CMS contact is created with no location field. ([14489](https://github.com/civicrm/civicrm-core/pull/14489))**
+
+- **Object id is always NULL in ore hook in update activity mode ([14491](https://github.com/civicrm/civicrm-core/pull/14491))**
+
+- **dev/core#889 Add test for changing fee selection to 0 and then record… ([14488](https://github.com/civicrm/civicrm-core/pull/14488))**
+
+- **dev/core#889 - Refund throws a fatal error if the main contribution a… ([14103](https://github.com/civicrm/civicrm-core/pull/14103))**
+
+- **[Form cleanup] remove form classes & tpls for Event Component settings & Multisite ([14425](https://github.com/civicrm/civicrm-core/pull/14425))**
+
+- **5.15 ([14483](https://github.com/civicrm/civicrm-core/pull/14483))**
+
+- **Add WP-oriented E2E test suite, with HookTest as an example ([159](https://github.com/civicrm/civicrm-wordpress/pull/159))**
+
+- **Recreate rewrite rules when basepage setting is updated ([157](https://github.com/civicrm/civicrm-wordpress/pull/157))**
+
+- **Implement "document_title_parts" filter to apply CiviCRM title on basepage ([158](https://github.com/civicrm/civicrm-wordpress/pull/158))**
+
+- **5.15 ([256](https://github.com/civicrm/civicrm-packages/pull/256))**
+
+## <a name="misc"></a>Miscellany
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following code authors:
+
+AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Alok Patel, Francis Whittle; Andrei Mondoc; Australian Greens - Seamus Lee; Christian Wach; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; Coop SymbioTIC - Mathieu Lutfy, Samuel Vanhove; Dave D; Fuzion - Jitendra Purohit; Greenpeace CEE - Patrick Figel; JMA Consulting - Monish Deb; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Nicol Wistreich; Pradeep Nayak; Squiffle Consulting - Aidan Saunders; Tadpole Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton
+
+Most authors also reviewed code for this release; in addition, the following
+reviewers contributed their comments:
+
+AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Francis Whittle, Justin Freeman; Andrei Mondoc; Australian Greens - Seamus Lee; Christian Wach; civibot[bot]; CiviCoop - Jaap Jansma; civicrm-builder; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Sunil Pawar, Yashodha Chaku; Coop SymbioTIC - Mathieu Lutfy, Samuel Vanhove; Dave D; Fuzion - Jitendra Purohit, Luke Stewart; Greenpeace CEE - Patrick Figel; JMA Consulting - Joe Murray, Monish Deb; Korlon - Stuart Gaston; Lighthouse Design and Consulting - Brian Shaughnessy; ltaliano; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Nicol Wistreich; Palante - Morgan Robinson; Pradeep Nayak; Semper IT - Karin Gerritsen; Squiffle Consulting - Aidan Saunders; Tadpole Collective - Kevin Cristiano; Tech To The People - Xavier Dutoit; Wikimedia Foundation - Eileen McNaughton

--- a/release-notes/5.16.0.md
+++ b/release-notes/5.16.0.md
@@ -399,7 +399,7 @@ Released August 7, 2019
 
 This release was developed by the following code authors:
 
-AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Alok Patel, Francis Whittle; Andrei Mondoc; Australian Greens - Seamus Lee; Christian Wach; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; Coop SymbioTIC - Mathieu Lutfy, Samuel Vanhove; Dave D; Fuzion - Jitendra Purohit; Greenpeace CEE - Patrick Figel; JMA Consulting - Monish Deb; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Nicol Wistreich; Pradeep Nayak; Squiffle Consulting - Aidan Saunders; Tadpole Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton
+AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Alok Patel, Francis Whittle; Andrei Mondoc; Australian Greens - Seamus Lee; Christian Wach; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; Coop SymbioTIC - Mathieu Lutfy, Samuel Vanhove; Dave D; Fuzion - Jitendra Purohit; Greenpeace CEE - Patrick Figel; iXiam - César Ramos; JMA Consulting - Monish Deb; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Nicol Wistreich; Pradeep Nayak; Squiffle Consulting - Aidan Saunders; Tadpole Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton
 
 Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:

--- a/release-notes/5.16.0.md
+++ b/release-notes/5.16.0.md
@@ -1,11 +1,27 @@
 # CiviCRM 5.16.0
 
-Released August 7, 2019;
+In-progress, based upon commit 55086d4c32123382ce471afd2527469873120129
 
+Released August 7, 2019
+
+- **[Synopsis](#synopsis)**
 - **[Features](#features)**
 - **[Bugs resolved](#bugs)**
 - **[Miscellany](#misc)**
 - **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |         |
+|:--------------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                                   |         |
+| Change the database schema?                                     |         |
+| Alter the API?                                                  |         |
+| Require attention to configuration options?                     |         |
+| Fix problems installing or upgrading to a previous version?     |         |
+| Introduce features?                                             |         |
+| Fix bugs?                                                       |         |
 
 ## <a name="features"></a>Features
 
@@ -389,3 +405,9 @@ Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:
 
 AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Francis Whittle, Justin Freeman; Andrei Mondoc; Australian Greens - Seamus Lee; Christian Wach; civibot[bot]; CiviCoop - Jaap Jansma; civicrm-builder; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Sunil Pawar, Yashodha Chaku; Coop SymbioTIC - Mathieu Lutfy, Samuel Vanhove; Dave D; Fuzion - Jitendra Purohit, Luke Stewart; Greenpeace CEE - Patrick Figel; JMA Consulting - Joe Murray, Monish Deb; Korlon - Stuart Gaston; Lighthouse Design and Consulting - Brian Shaughnessy; ltaliano; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Nicol Wistreich; Palante - Morgan Robinson; Pradeep Nayak; Semper IT - Karin Gerritsen; Squiffle Consulting - Aidan Saunders; Tadpole Collective - Kevin Cristiano; Tech To The People - Xavier Dutoit; Wikimedia Foundation - Eileen McNaughton
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Alice Frumin and Andrew Hunt.  If you'd like
+to provide feedback on them, please log in to https://chat.civicrm.org/civicrm
+and contact `@agh1`.


### PR DESCRIPTION
Per @eileenmcnaughton's comment on https://github.com/civicrm/civicrm-core/pull/14490#issuecomment-504806876 we're trying a series of PRs for release notes.  I expect that we'd normally have three, each merged relatively promptly:

- Early in the month, a PR that has the raw change list based upon the script output, plus some boilerplate stuff (that's this one)
- One or more PRs over the course of the month as @alifrumin and/or I document the changes, reorganize items, and so forth
- A PR soon before the release that incorporates late changes and final edits

Hopefully this will make it easier by having an in-progress set of release notes in the repo at any given point.

However, I probably would discourage people from making their own changes to the release notes prior to that last PR.  Because it's a single file, the content isn't very atomic, and items are liable to be rearranged heavily, it's ripe for merge conflicts.  Instead, contributors can put suggested language in the PRs that got merged, or the can just contact us directly.

(As always, after that last PR gets merged, the reverse is the case--if you make a late change, you should update the notes yourself to document it.)