### PR TITLE
Ensure recently converted groups cache matches previous behaviour my …

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -159,14 +159,20 @@ class Container {
       'groups' => 'contact groups',
     ];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
+      $definitionParams = [
+        'name' => $cacheGrp,
+        'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
+      ];
+      // For Caches that we don't really care about the ttl for and/or maybe accessed
+      // fairly often we use the fastArrayDecorator which improves reads and writes, these
+      // caches should also not have concurrency risk.
+      $fastArrayCaches = ['groups'];
+      if (in_array($cacheSvc, $fastArrayCaches)) {
+        $definitionParams['withArray'] = 'fast';
+      }
       $container->setDefinition("cache.{$cacheSvc}", new Definition(
         'CRM_Utils_Cache_Interface',
-        [
-          [
-            'name' => $cacheGrp,
-            'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
-          ],
-        ]
+        [$definitionParams]
       ))->setFactory('CRM_Utils_Cache::create');
     }
 


### PR DESCRIPTION
…setting withArray as fast for it

Overview
----------------------------------------
Replicate previous behaviour by setting withArray to fast for contact groups cache

Before
----------------------------------------
Cache group didn't use fast array cache

After
----------------------------------------
Uses fastArrayCache if applicable

ping @eileenmcnaughton @totten 

FYI I didn't change the prevNextCache one because that has to be sqlBacked and sqlBacked Cache doesn't do anything in regards to fastArray