### PR TITLE
[REF] [EXPORT] [TLA] Update handling of input fields so that the mapping format is accepted.

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -921,9 +921,8 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
    *
    * @return array
    */
-  protected static function getMappingParams($defaults, $v) {
+  public static function getMappingParams($defaults, $v) {
     $locationTypeId = NULL;
-    $phoneTypeId = NULL;
     $saveMappingFields = $defaults;
 
     $saveMappingFields['name'] = CRM_Utils_Array::value('1', $v);
@@ -958,14 +957,18 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
         }
 
         if (is_numeric(CRM_Utils_Array::value('4', $v))) {
-          $phoneTypeId = CRM_Utils_Array::value('4', $v);
+          if ($saveMappingFields['name'] === 'im') {
+            $saveMappingFields['im_provider_id'] = $v[4];
+          }
+          else {
+            $saveMappingFields['phone_type_id'] = CRM_Utils_Array::value('4', $v);
+          }
         }
         elseif (is_numeric(CRM_Utils_Array::value('6', $v))) {
-          $phoneTypeId = CRM_Utils_Array::value('6', $v);
+          $saveMappingFields['phone_type_id'] = CRM_Utils_Array::value('6', $v);
         }
 
         $saveMappingFields['location_type_id'] = is_numeric($locationTypeId) ? $locationTypeId : NULL;
-        $saveMappingFields['phone_type_id'] = is_numeric($phoneTypeId) ? $phoneTypeId : NULL;
         $saveMappingFields['relationship_type_id'] = $id;
         $saveMappingFields['relationship_direction'] = "{$first}_{$second}";
       }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -178,8 +178,12 @@ class CRM_Export_BAO_Export {
       isset($exportParams['postal_mailing_export']['postal_mailing_export']) &&
       $exportParams['postal_mailing_export']['postal_mailing_export'] == 1
     );
+    $mappedFields = [];
+    foreach ((array) $fields as $field) {
+      $mappedFields[] = CRM_Core_BAO_Mapping::getMappingParams([], $field);
+    }
 
-    $processor = new CRM_Export_BAO_ExportProcessor($exportMode, $fields, $queryOperator, $mergeSameHousehold, $isPostalOnly, $mergeSameAddress);
+    $processor = new CRM_Export_BAO_ExportProcessor($exportMode, $mappedFields, $queryOperator, $mergeSameHousehold, $isPostalOnly, $mergeSameAddress);
     if ($moreReturnProperties) {
       $processor->setAdditionalRequestedReturnProperties($moreReturnProperties);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup on export - make it cleaner

Before
----------------------------------------
Confusing array format used

After
----------------------------------------
Sane array format used

Technical Details
----------------------------------------
Updates the export processor to accept the field mapping format from the civicrm_mapping_field table

The current situation is that a weird and wonderful format is used on the Mapping form quickform. This is converted to a sane format when saved to the civicrm_mapping_field table. However, the export processor currently expects the insane format - leading to complexity & lack of re-usablity.

This pr updates the workings of the export processor to use the sane format - as of this PR that are still received in the insane format but they are converted before they are actually  used.

This sets us up to change the format received by the . function . & re-instate sanity (instate perhaps)

Comments
----------------------------------------
Although there is a lot of code in this PR it is very heavily tested. In fact every single change was made as part of stepping through a unit test because each changed line is specifically tested. We built up a lot of tests on this on the IM part of LeXIM over the last year 
