### PR TITLE
[REF] [EXPORT] Alter CRM_Export_BAO_Export::exportComponents

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -177,10 +177,6 @@ class CRM_Export_BAO_Export {
       isset($exportParams['postal_mailing_export']['postal_mailing_export']) &&
       $exportParams['postal_mailing_export']['postal_mailing_export'] == 1
     );
-    $mappedFields = [];
-    foreach ((array) $fields as $field) {
-      $mappedFields[] = CRM_Core_BAO_Mapping::getMappingParams([], $field);
-    }
 
     if (!$selectAll && $componentTable && !empty($exportParams['additional_group'])) {
       // If an Additional Group is selected, then all contacts in that group are
@@ -192,7 +188,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       );
     }
 
-    $processor = new CRM_Export_BAO_ExportProcessor($exportMode, $mappedFields, $queryOperator, $mergeSameHousehold, $isPostalOnly, $mergeSameAddress);
+    $processor = new CRM_Export_BAO_ExportProcessor($exportMode, $fields, $queryOperator, $mergeSameHousehold, $isPostalOnly, $mergeSameAddress);
     if ($moreReturnProperties) {
       $processor->setAdditionalRequestedReturnProperties($moreReturnProperties);
     }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1556,7 +1556,7 @@ class CRM_Export_BAO_ExportProcessor {
       $returnProperties = [];
       foreach ($this->getRequestedFields() as $key => $value) {
         $fieldName = $value['name'];
-        $locationName = CRM_Core_PseudoConstant::getName('CRM_Core_BAO_Address', 'location_type_id', $value['location_type_id']);
+        $locationName = !empty($value['location_type_id']) ? CRM_Core_PseudoConstant::getName('CRM_Core_BAO_Address', 'location_type_id', $value['location_type_id']) : NULL;
         $relationshipTypeKey = !empty($value['relationship_type_id']) ? $value['relationship_type_id'] . '_' . $value['relationship_direction'] : NULL;
         if (!$fieldName || $this->isHouseholdMergeRelationshipTypeKey($relationshipTypeKey)) {
           continue;

--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -183,14 +183,14 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
 
     $mapperKeys = $params['mapper'][1];
 
-    $checkEmpty = 0;
-    foreach ($mapperKeys as $value) {
-      if ($value[0]) {
-        $checkEmpty++;
+    $mappedFields = [];
+    foreach ((array) $mapperKeys as $field) {
+      if (!empty($field[1])) {
+        $mappedFields[] = CRM_Core_BAO_Mapping::getMappingParams([], $field);
       }
     }
 
-    if (!$checkEmpty) {
+    if (!$mappedFields) {
       $this->set('mappingId', NULL);
       CRM_Utils_System::redirect(CRM_Utils_System::url($currentPath, '_qf_Map_display=true' . $urlParams));
     }
@@ -220,7 +220,7 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
       $this->get('componentIds'),
       (array) $this->get('queryParams'),
       $this->get(CRM_Utils_Sort::SORT_ORDER),
-      $mapperKeys,
+      $mappedFields,
       $this->get('returnProperties'),
       $this->get('exportMode'),
       $this->get('componentClause'),


### PR DESCRIPTION
Overview
----------------------------------------
Refactors the function `CRM_Export_BAO_Export::exportComponents` to accept fields in a standard format, rather than the crazy thing we get back from Quickform. This allows the new ExportUi extension to work.

Before
----------------------------------------
Field format converted from qf to standard array inside function.

After
----------------------------------------
Field format converted from qf to standard array outside function.
