### PR TITLE
Fix upgrade for membership second reminder

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.14.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.14.alpha1.mysql.tpl
@@ -1,2 +1,1 @@
 {* file to handle db changes in 5.14.alpha1 during upgrade *}
-ALTER TABLE civicrm_action_log CHANGE COLUMN reference_date reference_date datetime;

--- a/CRM/Upgrade/Incremental/sql/5.17.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.17.alpha1.mysql.tpl
@@ -1,1 +1,2 @@
 {* file to handle db changes in 5.17.alpha1 during upgrade *}
+ALTER TABLE civicrm_action_log CHANGE COLUMN reference_date reference_date datetime;


### PR DESCRIPTION
Overview
----------------------------------------
Updates the upgrade from https://github.com/civicrm/civicrm-core/pull/13487 to apply to the merged civi version

Before
----------------------------------------
Wrong version targetted

After
----------------------------------------
Right version targetted

Technical Details
----------------------------------------
#13487 had languished - so the upgrade script was against the wrong version - this fixes

Comments
-----------
