### PR TITLE
Remove the only two defined fonts from selectors

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -334,7 +334,6 @@ input.crm-form-entityref {
 
 .crm-container fieldset legend {
   display: block;
-  font-family: Arial, Helvetica, sans-serif;
   font-size: 14px;
   font-weight: bold;
   padding: 4px;
@@ -720,7 +719,6 @@ input.crm-form-entityref {
   /* h3 used as table header for civicrm */
   background-color: #CDE8FE;
   font-size: 15px;
-  font-family: Arial, Helvetica, sans-serif;
   font-weight: bold;
   color: #121A2D;
   padding: 4px 6px;


### PR DESCRIPTION
For some reason, two selectors (form legends and H3) sets Arial/Helvetica/sans-serif - while the rest of CiviCRM inherits whatever fonts are set by the parent theme. In other words, when a front-end contribution page or profile inherits the site fonts, in these two instances it will still use 'Arial/etc' . 

This can be overriden by the user with custom css, but given that there is no other use of Arial in CiviCRM, it doesn't seem to make much sense. When theming front-end CiviCRM forms/pages these two elements have to be reset with "font-family: inherit". My guess is it's legacy from an earlier version - but in making this reques,t perhaps the real reason will emerge.

Overview
----------------------------------------
Front-end form legends & H3 tags inherit 'Arial, Helvetica, sans-serif' regardless what the base theme font is. Front-end custom CivICRM theming can override this easily enough, but it's likely that many users won't do this, so end up with multiple fonts on their theme, which may conflict (especially if close, such as with Source Sans Pro in the example below).

Before
----------------------------------------
Front-end form legends & H3 tags inherit 'Arial, Helvetica, sans-serif' regardless what the base theme font is. 
![image](https://user-images.githubusercontent.com/1175967/61145662-ee04fa80-a4cf-11e9-971d-a220a6e00211.png)


After
----------------------------------------
Front-end form legends & H3 tags inherits the font from the theme. 
![image](https://user-images.githubusercontent.com/1175967/61146511-24dc1000-a4d2-11e9-8cb3-5cad3c43f1c7.png)



Technical Details
----------------------------------------
In terms of backwards incompatibility, the problem would be where someone has a front-end theme setting `body {font-family: Times, serif;)` or  `h3 {font-family: cursive;}` say, but they like - for whatever reason - the way that front-end Civi forms use Arial for H3s and Legends - even tho the rest of the forms would be Times or Cursive. Then on upgrading CiviCRM, the Arial will vanish and Times or Cursive will appear instead. My instinct is that's an edge case - but worth flagging as the risk.

There also might be a reason why those fonts are hard-coded in relation to the back-end of CiviCRM, but in years of overriding them in front-end themes, and three months of using back-end overrides, I've not seen it yet.
