### PR TITLE
dev/event#8 Event Cart: save Participant custom field data

### DIFF
--- a/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
+++ b/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
@@ -301,6 +301,12 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
           $custom_fields = array_merge($participant->get_form()->get_participant_custom_data_fields());
 
           CRM_Contact_BAO_Contact::createProfileContact($this->_submitValues['field'][$participant_id], $custom_fields, $contact_id);
+
+          CRM_Core_BAO_CustomValueTable::postProcess($this->_submitValues['field'][$participant_id],
+            'civicrm_participant',
+            $participant_id,
+           'Participant'
+          );
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

How to reproduce:

* Create a custom group for Participants, add a custom field in it
* Create a profile for participants: first name, last name, your-participant-custom-field. Don't set a default value.
* Add an event to cart, checkout.

Result: the your-participant-custom-field will not have been saved.

https://lab.civicrm.org/dev/event/issues/8

Before
----------------------------------------

Custom Data fields for the "participant" record were not being saved.

After
----------------------------------------

works.

Technical Details
----------------------------------------

This probably never worked at all.

