### PR TITLE
dev/core#1115 - fix invalid url in singleton/max_instances warning in civicase

### DIFF
--- a/CRM/Case/PseudoConstant.php
+++ b/CRM/Case/PseudoConstant.php
@@ -37,12 +37,6 @@
 class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
 
   /**
-   * Activity type
-   * @var array
-   */
-  public static $activityTypeList = [];
-
-  /**
    * Get all the case statues.
    *
    *
@@ -155,8 +149,8 @@ class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
   public static function &caseActivityType($indexName = TRUE, $all = FALSE) {
     $cache = (int) $indexName . '_' . (int) $all;
 
-    if (!array_key_exists($cache, self::$activityTypeList)) {
-      self::$activityTypeList[$cache] = [];
+    if (!isset(Civi::$statics[__CLASS__]['activityTypeList'][$cache])) {
+      Civi::$statics[__CLASS__]['activityTypeList'][$cache] = [];
 
       $query = "
               SELECT  v.label as label ,v.value as value, v.name as name, v.description as description, v.icon
@@ -194,9 +188,9 @@ class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
         $activityTypes[$index]['icon'] = $dao->icon;
         $activityTypes[$index]['description'] = $dao->description;
       }
-      self::$activityTypeList[$cache] = $activityTypes;
+      Civi::$statics[__CLASS__]['activityTypeList'][$cache] = $activityTypes;
     }
-    return self::$activityTypeList[$cache];
+    return Civi::$statics[__CLASS__]['activityTypeList'][$cache];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
1. Configure a case type so that some activity type (other than open case) has a max_instances set to 1.
2. On manage case, create a second activity of that type.
3. It will properly give you the warning that the singleton activity already exists, and provide a link to edit the existing one, but the link has id=0 instead of the actual activity id.
4. If you click the link, it gives a fatal error.

Before
----------------------------------------
The above, plus also if max_instances is greater than 1 the edit link is the empty string. The thinking was probably correct since it would be meaningless since what should it link to anyway, but then it shouldn't display an empty link.

After
----------------------------------------
The link in the warning is correct.
Also when max_instances is greater than 1 it now just has the warning without an empty link.

Technical Details
----------------------------------------
There was also an issue related to the fact that since the code is in a loop to support some kind of use case for multiple cases, an edge case was possible where it would end up using the edit link from a previous iteration, sending you to the wrong case.

Comments
----------------------------------------
I originally wanted to do this in multiple smaller PRs, but once I started pulling things out so I could write a test the logic in the block didn't make sense so I decided to just pull most of the block out. Added several test scenarios. Hopefully the block is easier to read now but feedback welcome.
