### PR TITLE
dev/core#1118 correct filteration by case type, re-use parent where()

### DIFF
--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -309,66 +309,11 @@ inner join civicrm_contact $c2 on ${c2}.id=${ccc}.contact_id
     }
   }
 
-  public function where() {
-    $clauses = [];
+  public function storeWhereHavingClauseArray() {
     if (!empty($this->_params['fields']['label_b_a']) && $this->_params['fields']['label_b_a'] == 1) {
-      $clauses[] = 'contact_civireport.sort_name !=  c2_civireport.sort_name';
+      $this->_whereClauses[] = '(contact_civireport.sort_name != c2_civireport.sort_name)';
     }
-    $this->_having = '';
-    foreach ($this->_columns as $tableName => $table) {
-      if (array_key_exists('filters', $table)) {
-        foreach ($table['filters'] as $fieldName => $field) {
-          $clause = NULL;
-          if (CRM_Utils_Array::value("operatorType", $field) & CRM_Report_Form::OP_DATE
-          ) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
-
-            $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to,
-              CRM_Utils_Array::value('type', $field)
-            );
-          }
-          else {
-
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
-            if ($fieldName == 'case_type_id') {
-              $value = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
-              if (!empty($value)) {
-                $operator = '';
-                if ($op == 'notin') {
-                  $operator = 'NOT';
-                }
-
-                $regexp = "[[:cntrl:]]*" . implode('[[:>:]]*|[[:<:]]*', $value) . "[[:cntrl:]]*";
-                $clause = "{$field['dbAlias']} {$operator} REGEXP '{$regexp}'";
-              }
-              $op = NULL;
-            }
-
-            if ($op) {
-              $clause = $this->whereClause($field,
-                $op,
-                CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
-              );
-            }
-          }
-
-          if (!empty($clause)) {
-            $clauses[] = $clause;
-          }
-        }
-      }
-    }
-
-    if (empty($clauses)) {
-      $this->_where = "WHERE ( 1 ) ";
-    }
-    else {
-      $this->_where = "WHERE " . implode(' AND ', $clauses);
-    }
+    parent::storeWhereHavingClauseArray();
   }
 
   public function groupBy() {

--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -131,6 +131,7 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
             'title' => ts('Case Type'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Case_BAO_Case::buildOptions('case_type_id', 'search'),
+            'type' => CRM_Utils_Type::T_INT,
           ],
           'status_id' => [
             'title' => ts('Status'),


### PR DESCRIPTION
Overview
----------------------------------------
Applying the case type filter in the case summary report CRM_Report_Form_Case_Summary is resulting in two case types being reported where only one is selected in the case type filter.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/3448551/61213373-c5ae1380-a6fc-11e9-8930-34daac6ac89c.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/3448551/61213473-0a39af00-a6fd-11e9-9013-b3a3a53fba19.png)


Technical Details
----------------------------------------
REGEXP filtering for case type:
> WHERE case_civireport.case_type_id REGEXP '[[:cntrl:]]*5[[:cntrl:]]*'

Results in records where case type id consists of 5 (for this example).

The clause looks old and appears to be based on assumption that case could be based on multiple case types. Case type however is an integer column and could use where() clause of CRM/Report/Form.php.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
