### PR TITLE
Add in Deprecation warnings on Cache functons

### DIFF
--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -73,6 +73,9 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function &getItem($group, $path, $componentID = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning(
+      'CRM_Core_BAO_Cache::getItem is deprecated and will be removed from core soon, use Civi::cache() facade or define cache group using hook_civicrm_container'
+    );
     if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       $value = $adapter::getItem($group, $path, $componentID);
       return $value;
@@ -116,6 +119,9 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function &getItems($group, $componentID = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning(
+      'CRM_Core_BAO_Cache::getItems is deprecated and will be removed from core soon, use Civi::cache() facade or define cache group using hook_civicrm_container'
+    );
     if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       return $adapter::getItems($group, $componentID);
     }
@@ -161,6 +167,9 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function setItem(&$data, $group, $path, $componentID = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning(
+      'CRM_Core_BAO_Cache::setItem is deprecated and will be removed from core soon, use Civi::cache() facade or define cache group using hook_civicrm_container'
+    );
     if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       return $adapter::setItem($data, $group, $path, $componentID);
     }
@@ -232,6 +241,9 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * @deprecated
    */
   public static function deleteGroup($group = NULL, $path = NULL, $clearAll = TRUE) {
+    CRM_Core_Error::deprecatedFunctionWarning(
+      'CRM_Core_BAO_Cache::deleteGroup is deprecated and will be removed from core soon, use Civi::cache() facade or define cache group using hook_civicrm_container'
+    );
     if (($adapter = CRM_Utils_Constant::value('CIVICRM_BAO_CACHE_ADAPTER')) !== NULL) {
       return $adapter::deleteGroup($group, $path);
     }

--- a/tests/phpunit/CRM/Core/BAO/CacheTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CacheTest.php
@@ -31,6 +31,20 @@
  */
 class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
 
+  /**
+   * @var CRM_Utils_Cache_Interface
+   */
+  protected $a;
+
+  public function createSimpleCache() {
+    return new CRM_Utils_Cache_FastArrayDecorator(
+      $this->a = CRM_Utils_Cache::create([
+        'name' => 'CRM_Core_BAO_CacheTest',
+        'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
+      ])
+    );
+  }
+
   public function testMultiVersionDecode() {
     $encoders = ['serialize', ['CRM_Core_BAO_Cache', 'encode']];
     $values = [NULL, 0, 1, TRUE, FALSE, [], ['abcd'], 'ab;cd', new stdClass()];
@@ -68,9 +82,10 @@ class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
    * @dataProvider exampleValues
    */
   public function testSetGetItem($originalValue) {
-    CRM_Core_BAO_Cache::setItem($originalValue, __CLASS__, 'testSetGetItem');
+    $this->createSimpleCache();
+    $this->a->set('testSetGetItem', $originalValue);
 
-    $return_1 = CRM_Core_BAO_Cache::getItem(__CLASS__, 'testSetGetItem');
+    $return_1 = $this->a->get('testSetGetItem');
     $this->assertEquals($originalValue, $return_1);
 
     // Wipe out any in-memory copies of the cache. Check to see if the SQL
@@ -78,7 +93,8 @@ class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
 
     CRM_Core_BAO_Cache::$_cache = NULL;
     CRM_Utils_Cache::$_singleton = NULL;
-    $return_2 = CRM_Core_BAO_Cache::getItem(__CLASS__, 'testSetGetItem');
+    $this->a->values = [];
+    $return_2 = $this->a->get('testSetGetItem');
     $this->assertEquals($originalValue, $return_2);
   }
 

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -54,17 +54,17 @@ class api_v3_SystemTest extends CiviUnitTestCase {
     // check all of them -- just enough to make sure that the API is doing
     // something
 
-    $this->assertTrue(NULL === CRM_Core_BAO_Cache::getItem(self::TEST_CACHE_GROUP, self::TEST_CACHE_PATH));
+    $this->assertTrue(NULL === Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
 
     $data = 'abc';
-    CRM_Core_BAO_Cache::setItem($data, self::TEST_CACHE_GROUP, self::TEST_CACHE_PATH);
+    Civi::cache()->set(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH), $data);
 
-    $this->assertEquals('abc', CRM_Core_BAO_Cache::getItem(self::TEST_CACHE_GROUP, self::TEST_CACHE_PATH));
+    $this->assertEquals('abc', Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
 
     $params = array();
     $result = $this->callAPIAndDocument('system', 'flush', $params, __FUNCTION__, __FILE__, "Flush all system caches", 'Flush');
 
-    $this->assertTrue(NULL === CRM_Core_BAO_Cache::getItem(self::TEST_CACHE_GROUP, self::TEST_CACHE_PATH));
+    $this->assertTrue(NULL === Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This adds deprecation warning notices on these functions as they aren't used by Core now

The following functions are deprected

```
CRM_Core_BAO_Cache::setItem
CRM_Core_BAO_Cache::getItem
CRM_Core_BAO_Cache::getItems
CRM_Core_BAO_Cache::deleteGroup
```

Developers shoud instead use something like the following instead

```
Civi::cache()->set()
CIvi::cache()->get()
Civi::cache()->flush()
```

If a developer wants to have their own Cache Group which might be useful if you are wanting to manage your cached data separate to the rest of data in a short cache then the following should be added in your extension.php file

```
/**
 * Implements hook_civicrm_container().
 */
function extensionshortname_civicrm_container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
  $container->setDefinition("cache.{groupname}", new Symfony\Component\DependencyInjection\Definition(
    'CRM_Utils_Cache_Interface',
    [
      [
        'name' => '{cache group name}',
        'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
        'withArray' => 'fast',
      ],
    ]
  ))->setFactory('CRM_Utils_Cache::create');
}
```
Then in your code use the following style of code

```
Civi::cache(<groupname>)->set()
Civi::cache(<groupname>)->get()
```

For more read https://docs.civicrm.org/dev/en/latest/framework/cache/

Before
----------------------------------------
No Warning

After
----------------------------------------
Warning

ping @eileenmcnaughton 