### PR TITLE
dev/core#1120 remove multiple export handling

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1889,12 +1889,11 @@ class CRM_Export_BAO_ExportProcessor {
    * Build array for merging same addresses.
    *
    * @param $sql
-   * @param array $exportParams
    * @param bool $sharedAddress
    *
    * @return array
    */
-  public function buildMasterCopyArray($sql, $exportParams, $sharedAddress = FALSE) {
+  public function buildMasterCopyArray($sql, $sharedAddress = FALSE) {
 
     $addresseeOptions = CRM_Core_OptionGroup::values('addressee');
     $postalOptions = CRM_Core_OptionGroup::values('postal_greeting');
@@ -1953,13 +1952,7 @@ class CRM_Export_BAO_ExportProcessor {
 
       if (!$sharedAddress && !array_key_exists($copyID, $merge[$masterID]['copy'])) {
 
-        if (!empty($exportParams['postal_greeting_other']) &&
-          count($merge[$masterID]['copy']) >= 1
-        ) {
-          // use static greetings specified if no of contacts > 2
-          $merge[$masterID]['postalGreeting'] = $exportParams['postal_greeting_other'];
-        }
-        elseif ($copyPostalGreeting) {
+        if ($copyPostalGreeting) {
           $this->trimNonTokensFromAddressString($copyPostalGreeting,
             $postalOptions[$dao->copy_postal_greeting_id],
             $this->getPostalGreetingTemplate()
@@ -1969,13 +1962,7 @@ class CRM_Export_BAO_ExportProcessor {
           $merge[$masterID]['postalGreeting'] = str_replace(" {$copyPostalGreeting},", "", $merge[$masterID]['postalGreeting']);
         }
 
-        if (!empty($exportParams['addressee_other']) &&
-          count($merge[$masterID]['copy']) >= 1
-        ) {
-          // use static greetings specified if no of contacts > 2
-          $merge[$masterID]['addressee'] = $exportParams['addressee_other'];
-        }
-        elseif ($copyAddressee) {
+        if ($copyAddressee) {
           $this->trimNonTokensFromAddressString($copyAddressee,
             $addresseeOptions[$dao->copy_addressee_id],
             $this->getAddresseeGreetingTemplate()
@@ -2041,7 +2028,7 @@ FROM      $tableName r1
 INNER JOIN civicrm_address adr ON r1.master_id   = adr.id
 INNER JOIN $tableName      r2  ON adr.contact_id = r2.civicrm_primary_id
 ORDER BY  r1.id";
-    $linkedMerge = $this->buildMasterCopyArray($sql, $exportParams, TRUE);
+    $linkedMerge = $this->buildMasterCopyArray($sql, TRUE);
 
     // find all the records that have the same street address BUT not in a household
     // require match on city and state as well
@@ -2068,7 +2055,7 @@ AND       ( r1.street_address != '' )
 AND       r2.id > r1.id
 ORDER BY  r1.id
 ";
-    $merge = $this->buildMasterCopyArray($sql, $exportParams);
+    $merge = $this->buildMasterCopyArray($sql);
 
     // unset ids from $merge already present in $linkedMerge
     foreach ($linkedMerge as $masterID => $values) {

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -291,7 +291,7 @@ FROM   {$this->_componentTable}
       $this->_greetingOptions = self::getGreetingOptions();
 
       foreach ($this->_greetingOptions as $key => $value) {
-        $fieldLabel = ts('%1 (merging > 2 contacts)', [1 => ucwords(str_replace('_', ' ', $key))]);
+        $fieldLabel = ts('%1 (when merging contacts)', [1 => ucwords(str_replace('_', ' ', $key))]);
         $this->addElement('select', $key, $fieldLabel,
           $value, ['onchange' => "showOther(this);"]
         );
@@ -361,7 +361,7 @@ FROM   {$this->_componentTable}
         if ((CRM_Utils_Array::value($otherOption, $self->_greetingOptions[$key]) == ts('Other')) && empty($params[$value])) {
 
           $label = ucwords(str_replace('_', ' ', $key));
-          $errors[$value] = ts('Please enter a value for %1 (merging > 2 contacts), or select a pre-configured option from the list.', [1 => $label]);
+          $errors[$value] = ts('Please enter a value for %1 (when merging contacts), or select a pre-configured option from the list.', [1 => $label]);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/1120 I'm not convinced the current merge code does 'what it says on the box'

It implies that both the drop down option or the 'other' string only kick in with > 2 contacts with the same address. In fact it seems that they both kick in with any merge but there is code that attempts to only apply the 'other' string for 2 or more (I'm not sure it succeeds since I wrote a unit test before I moved that code around & it seemed to show the 'other' string being used for 2 contacts). This simplifies to doing more or less what the code seems to do.

Before
----------------------------------------
<img width="921" alt="Screen Shot 2019-07-16 at 9 32 04 AM" src="https://user-images.githubusercontent.com/336308/61251496-b8e9f800-a7ae-11e9-8798-567d8c22c364.png">


After
----------------------------------------
<img width="902" alt="Screen Shot 2019-07-16 at 9 45 13 AM" src="https://user-images.githubusercontent.com/336308/61251484-b25b8080-a7ae-11e9-8308-cfac8ddaed15.png">


Technical Details
----------------------------------------

Comments
----------------------------------------
More discussion in https://lab.civicrm.org/dev/core/issues/1120 but I think at best it applies the 2 or more rule to the 'other' rather than the variants and 'other'

@lcdservices @Stoob @agh1 @colemanw @MegaphoneJon @petednz thoughts? I
