### PR TITLE
Ensure that if present the HTTP_X_FORWARDED_FOR IP address is used in…

### DIFF
--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -247,10 +247,8 @@ class CRM_Core_IDS {
    * @return bool
    */
   private function log($result, $reaction = 0) {
-    $ip = (isset($_SERVER['SERVER_ADDR']) &&
-      $_SERVER['SERVER_ADDR'] != '127.0.0.1') ? $_SERVER['SERVER_ADDR'] : (
-      isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : '127.0.0.1'
-      );
+    // Include X_FORWARD_FOR ip address if set as per IDS patten.
+    $ip = $_SERVER['REMOTE_ADDR'] . (isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? ' (' . $_SERVER['HTTP_X_FORWARDED_FOR'] . ')' : '');
 
     $data = [];
     $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
…stead of the SERVER_ADDR when logging items from the IDS

Overview
----------------------------------------
This ensures that if present we use the `HTTP_X_FORWARDED_FOR` address as that is generally more accurate if behind a load balancer than `SERVER_ADDR`

Before
----------------------------------------
the `SERVER_ADDR` is always used even if behind a load balancer

After
----------------------------------------
The `SERVER_ADDR` is used only if we can't use `HTTP_X_FORWARDED_FOR`

https://www.chriswiegman.com/2014/05/getting-correct-ip-address-php
