### PR TITLE
[WIP] dev/core#1123 and dev/core#1116 - Part 1 of I dunno yet -  replace confusing and misused activityTName

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -59,6 +59,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
   /**
    * The name of activity type.
+   * !!! NOTE: This is actually LABEL !!!
    *
    * @var string
    */
@@ -325,14 +326,18 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     // Assigning Activity type name.
     if ($this->_activityTypeId) {
-      $activityTName = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $this->_activityTypeId, 'label');
-      if ($activityTName[$this->_activityTypeId]) {
-        $this->_activityTypeName = $activityTName[$this->_activityTypeId];
-        $this->assign('activityTName', $activityTName[$this->_activityTypeId]);
+      $activityTypeLabels = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $this->_activityTypeId, 'label');
+      if ($activityTypeLabels[$this->_activityTypeId]) {
+        // yes it says Name but it's actually label
+        $this->_activityTypeName = $activityTypeLabels[$this->_activityTypeId];
+      }
+      $activityTypeNames = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $this->_activityTypeId, 'name');
+      if ($activityTypeNames[$this->_activityTypeId]) {
+        $this->assign('activityTypeInternalLookupName', $activityTypeNames[$this->_activityTypeId]);
       }
       // Set title.
-      if (isset($activityTName)) {
-        $activityName = CRM_Utils_Array::value($this->_activityTypeId, $activityTName);
+      if (isset($activityTypeLabels)) {
+        $activityName = CRM_Utils_Array::value($this->_activityTypeId, $activityTypeLabels);
 
         if ($this->_currentlyViewedContactId) {
           $displayName = CRM_Contact_BAO_Contact::displayName($this->_currentlyViewedContactId);

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -249,7 +249,7 @@
   {/if} {* End Delete vs. Add / Edit action *}
   </table>
   <div class="crm-submit-buttons">
-  {if $action eq 4 && ($activityTName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
+  {if $action eq 4 && ($activityTypeInternalLookupName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
     {if !$context }
       {assign var="context" value='activity'}
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
As described in the ticket if you change the activity type label for Inbound Email it doesn't properly do the check on if you can edit it. The problem is a variable that's really label instead of name and is only ever used in this one place.

Before
----------------------------------------
If you change the activity type label for Inbound Email it doesn't properly do the check on if you can edit it. 

After
----------------------------------------
Proper check. Confusing variable replaced.

Technical Details
----------------------------------------
All I've done in this part is replaced the word $activityTName with $activityTypeLabels, except in the one place where it needs to be `name`, where I've introduced a new variable $activityTypeInternalLookupName, which is actually `name`.

I'm flexible on what the variable is called and in general am also looking for feedback on the strategy for the next parts, which is to leave $this->_activityTypeName (not $activityTName) alone and just document that it is really label, and then in the places where it really should be name use the new $activityTypeInternalLookupName. A quick look through the code suggests that in many places activityTypeName is being used as a label (correctly), and so that's why I'm thinking to leave it alone despite the misnomer (or mislabler ?). Also, since activityTypeName is a form member and something that people might be referencing in form hooks, I'm hesitant to touch it.
