### PR TITLE
Menubar - Improve flexibility & remove hardcoded values

### DIFF
--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -203,7 +203,7 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   /* hide the button in desktop view */
   #civicrm-menu-nav .crm-menubar-toggle-btn {
     position: absolute;
-    top: -99999px;
+    top: -99999px; /* do not edit this without updating the isMobile() function in crm.menubar.js */
   }
 
   #civicrm-menu {

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -27,13 +27,13 @@
 
       // Wait for crm-container present on the page as it's faster than document.ready
       function insert(markup) {
-        if ($('#crm-container').length) {
+        if ($('.crm-container').length) {
           render(markup);
         } else {
           new MutationObserver(function(mutations, observer) {
             _.each(mutations, function(mutant) {
               _.each(mutant.addedNodes, function(node) {
-                if ($(node).is('#crm-container')) {
+                if ($(node).is('.crm-container')) {
                   render(markup);
                   observer.disconnect();
                 }

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -244,7 +244,7 @@
         }
       })
         .on('resize', function() {
-          if ($(window).width() >= 768 && $mainMenuState[0].checked) {
+          if (!isMobile() && $mainMenuState[0].checked) {
             $mainMenuState[0].click();
           }
           handleResize();
@@ -438,11 +438,16 @@
   }
 
   function handleResize() {
-    if ($(window).width() >= 768 && $('#civicrm-menu').height() > 50) {
+    if (!isMobile() && ($('#civicrm-menu').height() >= (2 * $('#civicrm-menu > li').height()))) {
       $('body').addClass('crm-menubar-wrapped');
     } else {
       $('body').removeClass('crm-menubar-wrapped');
     }
+  }
+
+  // Figure out if we've hit the mobile breakpoint, based on the rule in crm-menubar.css
+  function isMobile() {
+    return $('.crm-menubar-toggle-btn', '#civicrm-menu-nav').css('top') !== '-99999px';
   }
 
   function traverse(items, itemName, op) {


### PR DESCRIPTION
Overview
----------------------------------------
Minor tweak to `crm.menubar.js` to make it less reliant on the presence of a `<div id="crm-container">` which may not be present on non-civicrm pages.
Also tweaks the js to remove hardcoded pixel values to work better with theme overrides.

Before
----------------------------------------
Problems loading on non-civicrm pages.
Hardcoded values interfere with theme overrides.

After
----------------------------------------
Works better on non-civicrm pages.
Works better with theme overrides to the menu size & breakpoints.

Comments
----------------------------------------
Fixes https://www.drupal.org/project/civimenu/issues/3068607
Fixes https://lab.civicrm.org/dev/core/issues/1127