### PR TITLE
core#1130 - allow search views to show contact subtype

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -842,7 +842,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
         );
 
         $row['contact_type_orig'] = $result->contact_sub_type ? $result->contact_sub_type : $result->contact_type;
-        $row['contact_sub_type'] = $result->contact_sub_type ? CRM_Contact_BAO_ContactType::contactTypePairs(FALSE, $result->contact_sub_type, ', ') : $result->contact_sub_type;
         $row['contact_id'] = $result->contact_id;
         $row['sort_name'] = $result->sort_name;
         // Surely this if should be if NOT - otherwise it's just wierd.

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -66,7 +66,7 @@
             <td>{$row.contact_type}</td>
             <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&key=`$qfKey`&context=`$context`"}">{$row.sort_name}</a></td>
             {foreach from=$row item=value key=key}
-               {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "contact_type_orig") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id")and ($key neq "contact_sub_type")}
+               {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "contact_type_orig") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id")}
               <td>
                 {if $key EQ "household_income_total" }
                     {$value|crmMoney}
@@ -133,7 +133,7 @@
               </td>
            {else}
               {foreach from=$row item=value key=key}
-                {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "contact_sub_type") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id") and ($key neq "contact_type_orig")}
+                {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id") and ($key neq "contact_type_orig")}
                  <td>{$value}&nbsp;</td>
                 {/if}
               {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Search views can't display contact subtype, because they're specifically blacklisted from display in the template.

Before
----------------------------------------
Can't use Contact Subtype as a result column in Search Views.

After
----------------------------------------
Can use Contact Subtype as a result column in Search Views.

Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1130.  It seems like whatever reason this field was originally added to the row has been lost to the mists of time.  I suspect it was replaced by `contact_type_orig`, which is necessary to display the correct icon.