### PR TITLE
dev/core#1133 Payment method name is displayed instead of label in payment block for Manual payment

### DIFF
--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -173,7 +173,7 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    * @return string
    */
   public function getPaymentTypeLabel() {
-    return CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $this->getPaymentInstrumentID());
+    return CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $this->getPaymentInstrumentID());
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Payment method name is displayed instead of label in payment block for Manual payment

Before
----------------------------------------
Displays payment method name

After
----------------------------------------
Displays payment method label

Technical Details
----------------------------------------
Change method to `getLabel()` 