### PR TITLE
dev/core#1118 Case summary report filters incorrectly for case type

### DIFF
--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -340,7 +340,7 @@ inner join civicrm_contact $c2 on ${c2}.id=${ccc}.contact_id
                   $operator = 'NOT';
                 }
 
-                $regexp = "[[:cntrl:]]*" . implode('[[:>:]]*|[[:<:]]*', $value) . "[[:cntrl:]]*";
+                $regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', $value) . "([[:cntrl:]]|$)";
                 $clause = "{$field['dbAlias']} {$operator} REGEXP '{$regexp}'";
               }
               $op = NULL;


### PR DESCRIPTION
Case summary report filters incorrectly for case type
----------------------------------------

Overview
----------------------------------------
Case summary report uses REGEXP filtering for case type: `WHERE case_civireport.case_type_id REGEXP '[[:cntrl:]]*5[[:cntrl:]]*'` Which results in records where case type id consists of 5 (for this example).

![image](https://user-images.githubusercontent.com/33434409/61545348-2f9d2480-aa3f-11e9-8c49-82cdff7180d2.png)

Technical Details
----------------------------------------
Used regular expression used in `CRM_Event_BAO_Query::whereClauseSingle()`
````php
case 'participant_role_id':
        ...
        if (!strstr($op, 'NULL') && !strstr($op, 'EMPTY') && !strstr($op, 'LIKE')) {
          $regexOp = (strstr($op, '!') || strstr($op, 'NOT')) ? 'NOT REGEXP' : 'REGEXP';
          $regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', (array) $value) . "([[:cntrl:]]|$)";
        ...

````