### PR TITLE
dev/core#1135 Participants having multiple roles affects maximum event registration count

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -388,7 +388,8 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
         $escapedRoles[] = CRM_Utils_Type::escape($participantRole, 'String');
       }
 
-      $where[] = " participant.role_id IN ( '" . implode("', '", $escapedRoles) . "' ) ";
+      $regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', $escapedRoles) . "([[:cntrl:]]|$)";
+      $where[] = " participant.role_id REGEXP '{$regexp}'";
     }
 
     $eventParams = [1 => [$eventId, 'Positive']];


### PR DESCRIPTION
Participants having multiple roles affects maximum event registration count

Overview
----------------------------------------
If you add multiple participant roles for a participant entry, it affects the event full count.

Steps to reproduce
----------------------------------------

1. On dmaster, create a new event
2. Enable online registration and set "Max Number of Participants" to 1
3. Go to live event registration page. You should be able to register
4. Now add a new registration to a different contact from backend.
5. Once again go to live event registration page. Now it should show the event full message.
6. Go back to the other contact's events. Edit the event participant entry and add another role such as "Host".
7. Now go to the event registration page and you will be able to register for the maxed out event

Technical Details
----------------------------------------
After inspecting `CRM_Event_BAO_Participant::eventFull()` the following line assumes there will only be one value in the field
````php
$where[] = " participant.role_id IN ( '" . implode("', '", $escapedRoles) . "' ) ";
````
Therefore when you have multiple values it won't work properly.

Solution
----------------------------------------
I used regular expression code that's used in `CRM_Event_BAO_Query::whereClauseSingle()` under `case 'participant_role_id'`. 
````php
$regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', $escapedRoles) . "([[:cntrl:]]|$)";
$where[] = " participant.role_id REGEXP '{$regexp}'";
````
Comments
----------------------------------------
This is a simple workaround I could think of. Haven't tested in all other scenarios.

https://lab.civicrm.org/dev/core/issues/1135