### PR TITLE
[EXPORT] Fix unreleased regression where postal addresses are not suppressed when empty

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -739,23 +739,8 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function runQuery($params, $order) {
     $returnProperties = $this->getReturnProperties();
-    $addressWhere = '';
     $params = array_merge($params, $this->getWhereParams());
-    if ($this->isPostalableOnly) {
-      if (array_key_exists('street_address', $returnProperties)) {
-        $addressWhere = " civicrm_address.street_address <> ''";
-        if (array_key_exists('supplemental_address_1', $returnProperties)) {
-          // We need this to be an OR rather than AND on the street_address so, hack it in.
-          $addressOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-            'address_options', TRUE, NULL, TRUE
-          );
-          if (!empty($addressOptions['supplemental_address_1'])) {
-            $addressWhere .= " OR civicrm_address.supplemental_address_1 <> ''";
-          }
-        }
-        $addressWhere = ' AND (' . $addressWhere . ')';
-      }
-    }
+
     $query = new CRM_Contact_BAO_Query($params, $returnProperties, NULL,
       FALSE, FALSE, $this->getQueryMode(),
       FALSE, TRUE, TRUE, NULL, $this->getQueryOperator()
@@ -778,6 +763,22 @@ class CRM_Export_BAO_ExportProcessor {
     foreach ($params as $value) {
       if ($value[0] == 'contact_is_deleted') {
         unset($whereClauses['trash_clause']);
+      }
+    }
+
+    if ($this->isPostalableOnly) {
+      if (array_key_exists('street_address', $returnProperties)) {
+        $addressWhere = " civicrm_address.street_address <> ''";
+        if (array_key_exists('supplemental_address_1', $returnProperties)) {
+          // We need this to be an OR rather than AND on the street_address so, hack it in.
+          $addressOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+            'address_options', TRUE, NULL, TRUE
+          );
+          if (!empty($addressOptions['supplemental_address_1'])) {
+            $addressWhere .= " OR civicrm_address.supplemental_address_1 <> ''";
+          }
+        }
+        $whereClauses['address'] = $addressWhere;
       }
     }
 

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1225,6 +1225,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * @param array $addressReason
    *
    * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
    */
   public function testExportDeceasedDoNotMail($reason, $addressReason) {
     $contactA = $this->callAPISuccess('contact', 'create', [
@@ -1261,37 +1262,21 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'is_primary' => 1,
     ], $addressReason));
 
-    //export and merge contacts with same address
-    list($tableName, $sqlColumns, $headerRows, $processor) = CRM_Export_BAO_Export::exportComponents(
-      TRUE,
-      [$contactA['id'], $contactB['id']],
-      [],
-      NULL,
-      NULL,
-      NULL,
-      CRM_Export_Form_Select::CONTACT_EXPORT,
-      "contact_a.id IN ({$contactA['id']}, {$contactB['id']})",
-      NULL,
-      TRUE,
-      FALSE,
-      [
-        'mergeOption' => TRUE,
-        'suppress_csv_for_testing' => TRUE,
+    $this->doExportTest([
+      'selectAll' => TRUE,
+      'ids' => [$contactA['id'], $contactB['id']],
+      'exportParams' => [
         'postal_mailing_export' => [
           'postal_mailing_export' => TRUE,
         ],
-      ]
-    );
+        'mergeSameAddress' => TRUE,
+      ],
+    ]);
+    $row = $this->csv->fetchOne(0);
 
-    $this->assertTrue(!in_array('state_province_id', $processor->getHeaderRows()));
-    $greeting = CRM_Core_DAO::singleValueQuery("SELECT email_greeting FROM {$tableName}");
-
-    //Assert email_greeting is not merged
-    $this->assertNotContains(',', (string) $greeting);
-
-    // delete the export temp table and component table
-    $sql = "DROP TABLE IF EXISTS {$tableName}";
-    CRM_Core_DAO::executeQuery($sql);
+    $this->assertTrue(!in_array('Stage', $this->processor->getHeaderRows()));
+    $this->assertEquals('Dear John', $row['Email Greeting']);
+    $this->assertCount(1, $this->csv);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an unreleased regression whereby rows with no address were not being suppressed from the export when postal_mailing was checked

Before
----------------------------------------
<img width="851" alt="Screen Shot 2019-07-20 at 1 55 13 PM" src="https://user-images.githubusercontent.com/336308/61572715-0f7c6c80-aaf6-11e9-86fc-d521ba076da8.png">

Row with no address still included

After
----------------------------------------
Rows with no address excluded

Technical Details
----------------------------------------
I had a suspicion about this as the variable showed as unused in my IDE so I upgraded the test that was failing to notice . and it started failing on this.

Bug is that the lines were not being added to the query to suppress empty addresses.

Comments
----------------------------------------
@totten @prondubuisi - psalm would have stopped this bug from getting in - I picked it up because of similar checks in my IDE

@colemanw now I understand the weird format for postal_mailing_export - it a QF 'advCheckbox' - I'm tempted to switch it to a radio & get it down to being just a value
