### PR TITLE
[REF] Down with php4 compatibility

### DIFF
--- a/CRM/Core/Report/Excel.php
+++ b/CRM/Core/Report/Excel.php
@@ -38,11 +38,11 @@ class CRM_Core_Report_Excel {
    * Outputs a result set with a given header
    * in the string buffer result
    *
-   * @param string $header
-   *   (reference ) column headers.
-   * @param string $rows
-   *   (reference ) result set rows.
-   * @param null $titleHeader
+   * @param array $header
+   *   column headers.
+   * @param array $rows
+   *   result set rows.
+   * @param string $titleHeader
    * @param bool $print
    *   Should the output be printed.
    * @param bool $outputHeader
@@ -51,7 +51,7 @@ class CRM_Core_Report_Excel {
    *   empty if output is printed, else output
    *
    */
-  public static function makeCSVTable(&$header, &$rows, $titleHeader = NULL, $print = TRUE, $outputHeader = TRUE) {
+  public static function makeCSVTable($header, $rows, $titleHeader = NULL, $print = TRUE, $outputHeader = TRUE) {
     if ($titleHeader) {
       echo $titleHeader;
     }
@@ -159,7 +159,7 @@ class CRM_Core_Report_Excel {
    * @param null $titleHeader
    * @param bool $outputHeader
    */
-  public function writeHTMLFile($fileName, &$header, &$rows, $titleHeader = NULL, $outputHeader = TRUE) {
+  public function writeHTMLFile($fileName, $header, $rows, $titleHeader = NULL, $outputHeader = TRUE) {
     if ($outputHeader) {
       CRM_Utils_System::download(CRM_Utils_String::munge($fileName),
         'application/vnd.ms-excel',
@@ -206,7 +206,7 @@ class CRM_Core_Report_Excel {
    *
    * @return void
    */
-  public static function writeCSVFile($fileName, &$header, &$rows, $titleHeader = NULL, $outputHeader = TRUE, $saveFile = NULL) {
+  public static function writeCSVFile($fileName, $header, $rows, $titleHeader = NULL, $outputHeader = TRUE, $saveFile = NULL) {
     if ($outputHeader && !$saveFile) {
       CRM_Utils_System::download(CRM_Utils_String::munge($fileName),
         'text/x-csv',


### PR DESCRIPTION
Overview
----------------------------------------
Removes a few more cases where parameters are needlessly passed as references

Before
----------------------------------------
Better support for php4

After
----------------------------------------
Worse support for php 4

Technical Details
----------------------------------------
Part of ongoing cleanup removing unnecessary pass-by-references (which allows code simplication). The key is to check whether the parameters are changes anywhere in the function - if not we are not achieving anything by passing by ref

Comments
----------------------------------------

