### PR TITLE
Do not launch raw js alert  jqueryValidation fails

### DIFF
--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -114,12 +114,12 @@
 
   // use civicrm notifications when there are errors
   params.invalidHandler = function(form, validator) {
+    // If there is no container for display then red text will still show next to the invalid fields
+    // but there will be no overall message. Currently the container is only available on backoffice pages.
     if ($('#crm-notification-container').length) {
       $.each(validator.errorList, function(k, error) {
         $(error.element).crmError(error.message);
       });
-    } else {
-      alert({/literal}"{ts escape='js'}Please review and correct the highlighted fields before continuing.{/ts}"{literal});
     }
   };
 


### PR DESCRIPTION
Overview
----------------------------------------
Jquery validation is not enabled much on front end forms but if you DO enable it you get very nasty pure js alert messages. This removes those - after discussion removal makes sense at this stage. You still see the red messages and it's still possible for extensions to capture & render the messages with some jquery foo.

To enable validation on contribution pages in an extension assign

```$form->assign('isJsValidate', TRUE);``` - it will kick in if you try to submit with an invalid email

Before
----------------------------------------
Cannot enable Validate without horrendous js alerts

After
----------------------------------------
Can....

Technical Details
----------------------------------------
This isn't my ultimate preference - per long discussion here
https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/pull/128

I think being able to output a summary of messages near, or in place of, the paypal
checkout button makes more sense - open to better options @colemanw

Comments
----------------------------------------

@colemanw this is what I've been kinda back-ground nagging you about - I had a go - much more detail on the link above