### PR TITLE
Add in Atomfeeds deprecation now that the extension has a new release…

### DIFF
--- a/CRM/Core/BAO/Cache/Psr16.php
+++ b/CRM/Core/BAO/Cache/Psr16.php
@@ -183,9 +183,6 @@ class CRM_Core_BAO_Cache_Psr16 {
     $groups = [
       // Universe
 
-      // be.chiro.civi.atomfeeds
-      'dashboard',
-
       // biz.jmaconsulting.lineitemedit
       'lineitem-editor',
 
@@ -215,6 +212,17 @@ class CRM_Core_BAO_Cache_Psr16 {
           ['civi.tag' => 'deprecated']
         );
         $groups[] = 'CiviCRM setting Spec';
+      }
+    }
+    $atomFeedsSettingExtensionStatus = $extensions->getStatus('be.chiro.civi.atomfeeds');
+    if ($atomFeedsSettingExtensionStatus == $extensions::STATUS_INSTALLED) {
+      $extension_version = civicrm_api3('Extension', 'get', ['key' => 'be.chiro.civi.atomfeeds'])['values'][0]['version'];
+      if (version_compare($extension_version, '0.1-alpha2', '<')) {
+        Civi::log()->warning(
+          'CRM_Core_BAO_Cache_PSR is deprecated for Atomfeeds extension, you should upgrade to the latest version to avoid this warning, this code will be removed at the end of 2019',
+          ['civi.tag' => 'deprecated']
+        );
+        $groups[] = 'dashboard';
       }
     }
     return $groups;


### PR DESCRIPTION
… with converted cache mechanism

Overview
----------------------------------------
Now that the Atomfeeds extension has a new release https://github.com/Chirojeugd-Vlaanderen/atomfeeds/releases/tag/0.1-alpha3 which incorporates a cache conversion we should implement the same deprecation here as with multisite and entity setting

Before
----------------------------------------
No deprecation

After
----------------------------------------
Deprecation as newer version of extension correctly uses newer cache mechanism

ping @eileenmcnaughton 