### PR TITLE
dev/core#1146 Custom multi profile: file fields only show one delete attachme…

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -615,7 +615,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
                 "reset=1&id={$fileId}&eid=$entityId&fid={$key}&action=delete&fcs={$fileHash}"
               );
               $text = ts("Delete Attached File");
-              $customFiles[$field['name']]['deleteURL'] = "<a href=\"{$deleteURL}\" onclick = \"if (confirm( ' $deleteExtra ' )) this.href+='&amp;confirmed=1'; else return false;\">$text</a>";
+              $customFiles[$name]['deleteURL'] = "<a href=\"{$deleteURL}\" onclick = \"if (confirm( ' $deleteExtra ' )) this.href+='&amp;confirmed=1'; else return false;\">$text</a>";
 
               // also delete the required rule that we've set on the form element
               $this->removeFileRequiredRules($name);


### PR DESCRIPTION
…nt action

Overview
----------------------------------------
For a profile with multi record custom set including multiple file fields, display delete attachment option only for one file.

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
![image](https://user-images.githubusercontent.com/33451769/61667165-2c20cc00-acd1-11e9-98a8-2f71a3b98f8a.png)

After
----------------------------------------
Shows "Delete Attached File" option for both the files. 

