### PR TITLE
[test] Catch A.net exception & ignore

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1023,8 +1023,10 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    *   Contact ID
    *
    * @return bool|\CRM_Contribute_DAO_Contribution
+   *
    * @throws \CRM_Core_Exception
    * @throws \Civi\Payment\Exception\PaymentProcessorException
+   * @throws \CiviCRM_API3_Exception
    */
   protected function processCreditCard($submittedValues, $lineItem, $contactID) {
     $isTest = ($this->_mode == 'test') ? 1 : 0;
@@ -1287,7 +1289,11 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    * @param int $action
    * @param string|null $creditCardMode
    *
+   * @return CRM_Contribute_BAO_Contribution
+   *
+   * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function testSubmit($params, $action, $creditCardMode = NULL) {
     $defaults = [
@@ -1347,8 +1353,11 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    *
    * @param $pledgePaymentID
    *
-   * @return array
-   * @throws \Exception
+   * @return \CRM_Contribute_BAO_Contribution
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   protected function submit($submittedValues, $action, $pledgePaymentID) {
     $pId = $contribution = $isRelatedId = FALSE;

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -893,7 +893,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *   Is this recurring?
    *
    * @return \CRM_Contribute_DAO_Contribution
-   * @throws \Exception
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function processFormContribution(
     &$form,

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -135,7 +135,7 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
    *   (deprecated) associated array with note id - preferably set $params['id'].
    * @return null|object
    *   $note CRM_Core_BAO_Note object
-   * @throws \CRM_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function add(&$params, $ids = array()) {
     $dataExists = self::dataExists($params);
@@ -145,7 +145,7 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
 
     if (!empty($params['entity_table']) && $params['entity_table'] == 'civicrm_contact' && !empty($params['check_permissions'])) {
       if (!CRM_Contact_BAO_Contact_Permission::allow($params['entity_id'], CRM_Core_Permission::EDIT)) {
-        throw new CRM_Exception('Permission denied to modify contact record');
+        throw new CRM_Core_Exception('Permission denied to modify contact record');
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to reduce false negatives in the test suite

Before
----------------------------------------
Frequent false negatives outside our control

After
----------------------------------------
Mark skipped when a-net fails

Technical Details
----------------------------------------
Hopefully we can avoid false negatives like
https://test.civicrm.org/job/CiviCRM-Core-PR/27923/testReport/junit/(root)/CRM_Core_Payment_AuthorizeNetIPNTest/testIPNPaymentRecurNoReceipt/
without losing too much

A.net is easing into end of life now but these tests cause too much pain to be justified

Comments
----------------------------------------

