### PR TITLE
dev/event#9 Event Templates: do not set the Start/End dates

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -274,6 +274,8 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       $defaults['is_template'] = $this->_isTemplate;
       $defaults['template_id'] = $defaults['id'];
       unset($defaults['id']);
+      unset($defaults['start_date']);
+      unset($defaults['end_date']);
     }
     else {
       $defaults['is_active'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------

When creating an event using an event template, the Start Date is automatically set to the date when the template was created.

To reproduce:

* Create an Event Template (Administer > Events > Event Templates)
* Wait one day, or set the `start_date` to some past date (templates are saved as regular events in the `civicrm_event` database table).
* Create a new Event, and use the template that was created.
* Notice how the start date is automatically set.

This might not sound like a big deal, but when the event template was created in 2015, it gets pretty annoying to have to also click to change the year (and it's easy to overlook).

This was also reported on Stack Exchange:  
https://civicrm.stackexchange.com/questions/28159/event-template-start-date

Gitlab issue: https://lab.civicrm.org/dev/event/issues/9

Before
----------------------------------------

Start Date is automatically set to some old date in the past.

After
----------------------------------------

Start Date is not set.

Technical Details
----------------------------------------

I also unset `end_date` as a precaution. It should not be set, but if someone created a template from an existing event, it could.
