### PR TITLE
mysqli_get_client_info() may fail to return info in some environments

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -920,7 +920,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       );
     }
     // Ensure that the MySQL driver supports utf8mb4 encoding.
-    $version = mysqli_get_client_info(CRM_Core_DAO::getConnection()->connection);
+    $version = mysqli_get_client_info();
     if (strpos($version, 'mysqlnd') !== FALSE) {
       // The mysqlnd driver supports utf8mb4 starting at version 5.0.9.
       $version = preg_replace('/^\D+([\d.]+).*/', '$1', $version);

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -624,7 +624,7 @@ class Requirements {
     mysqli_query($conn, 'DROP TABLE civicrm_utf8mb4_test');
 
     // Ensure that the MySQL driver supports utf8mb4 encoding.
-    $version = mysqli_get_client_info($conn);
+    $version = mysqli_get_client_info();
     if (strpos($version, 'mysqlnd') !== FALSE) {
       // The mysqlnd driver supports utf8mb4 starting at version 5.0.9.
       $version = preg_replace('/^\D+([\d.]+).*/', '$1', $version);

--- a/install/index.php
+++ b/install/index.php
@@ -1411,7 +1411,7 @@ class InstallRequirements {
     $result = mysqli_query($conn, 'DROP TABLE civicrm_utf8mb4_test');
 
     // Ensure that the MySQL driver supports utf8mb4 encoding.
-    $version = mysqli_get_client_info($conn);
+    $version = mysqli_get_client_info();
     if (strpos($version, 'mysqlnd') !== FALSE) {
       // The mysqlnd driver supports utf8mb4 starting at version 5.0.9.
       $version = preg_replace('/^\D+([\d.]+).*/', '$1', $version);


### PR DESCRIPTION
Overview
----------------------------------------
we use mysqli_get_client_info() to get info about the mysql library in use. In some environments this may fail to return info if a parameter is passed in (no parameter is expected). Fixes https://lab.civicrm.org/dev/core/issues/1136

Before
----------------------------------------
Sites may get an incorrect warning re: utf8mb4 not being supported since library version could not be determined.

After
----------------------------------------
Library version can be detected and status is reported correctly.