### PR TITLE
[IMPORT] [code-quality] Remove instances of CRM_Core_Error::fatal from first import form

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -46,6 +46,8 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
 
   /**
    * Set variables up before form is built.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
 
@@ -58,7 +60,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     unset($errorScope);
 
     if ($daoTestPrivilege->_lastError) {
-      CRM_Core_Error::fatal(ts('Database Configuration Error: Insufficient permissions. Import requires that the CiviCRM database user has permission to create temporary tables. Contact your site administrator for assistance.'));
+      $this->invalidConfig(ts('Database Configuration Error: Insufficient permissions. Import requires that the CiviCRM database user has permission to create temporary tables. Contact your site administrator for assistance.'));
     }
 
     $results = [];
@@ -81,7 +83,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     }
     closedir($handler);
     if (!empty($results)) {
-      CRM_Core_Error::fatal(ts('<b>%1</b> file(s) in %2 directory are not writable. Listed file(s) might be used during the import to log the errors occurred during Import process. Contact your site administrator for assistance.', [
+      $this->invalidConfig(ts('<b>%1</b> file(s) in %2 directory are not writable. Listed file(s) might be used during the import to log the errors occurred during Import process. Contact your site administrator for assistance.', [
         1 => implode(', ', $results),
         2 => $config->uploadDir,
       ]));
@@ -121,7 +123,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
       $this->assign('dataSourceFormTemplateFile', $templateFile);
     }
     elseif ($this->_dataSource) {
-      throw new \CRM_Core_Exception("Invalid data source");
+      $this->invalidConfig('Invalid data source');
     }
   }
 
@@ -269,10 +271,10 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     $dataSourceDir = $civicrm_root . DIRECTORY_SEPARATOR . 'CRM' . DIRECTORY_SEPARATOR . 'Import' . DIRECTORY_SEPARATOR . 'DataSource' . DIRECTORY_SEPARATOR;
     $dataSources = [];
     if (!is_dir($dataSourceDir)) {
-      CRM_Core_Error::fatal("Import DataSource directory $dataSourceDir does not exist");
+      $this->invalidConfig("Import DataSource directory $dataSourceDir does not exist");
     }
     if (!$dataSourceHandle = opendir($dataSourceDir)) {
-      CRM_Core_Error::fatal("Unable to access DataSource directory $dataSourceDir");
+      $this->invalidConfig("Unable to access DataSource directory $dataSourceDir");
     }
 
     while (($dataSourceFile = readdir($dataSourceHandle)) !== FALSE) {
@@ -363,7 +365,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
       $parser->set($this);
     }
     else {
-      CRM_Core_Error::fatal("Invalid DataSource on form post. This shouldn't happen!");
+      $this->invalidConfig("Invalid DataSource on form post. This shouldn't happen!");
     }
   }
 
@@ -404,6 +406,21 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     $db->query($alterQuery);
 
     return ['status' => $statusFieldName, 'pk' => $primaryKeyName];
+  }
+
+  /**
+   * General function for handling invalid configuration.
+   *
+   * I was going to statusBounce them all but when I tested I was 'bouncing' to weird places
+   * whereas throwing an exception gave no behaviour change. So, I decided to centralise
+   * and we can 'flip the switch' later.
+   *
+   * @param $message
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function invalidConfig($message) {
+    throw new CRM_Core_Exception($message);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup towards removing CRM_Core_Error::fatal

Before
----------------------------------------
<img width="1351" alt="Screen Shot 2019-07-24 at 4 27 14 PM" src="https://user-images.githubusercontent.com/336308/61766261-4921e000-ae34-11e9-81f5-c42563794d20.png">


After
----------------------------------------
UI appearance is unchanged but a CRM_Core_Exception is thrown.

Technical Details
----------------------------------------
Per the comments I was going to go with a bounce - which is preferred for user facing issues (despite them really being sysadmin errors that still kinda made sense) but when I tested I bounced some weird places - ie. never to the main civicrm page. Not sure why but rather than dig deeper I did this as an step in the right direction / aid to future improvements

Comments
----------------------------------------

