### PR TITLE
[IMPORT] reduce php4 support, don't pass by ref when not required

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -107,7 +107,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $tableName,
-    &$mapper,
+    $mapper = [],
     $mode = self::MODE_PREVIEW,
     $contactType = self::CONTACT_INDIVIDUAL,
     $primaryKeyName = '_id',


### PR DESCRIPTION
Overview
----------------------------------------
Removes a case where a variable is pointlessly passed by reference

Before
----------------------------------------
Passed by reference

After
----------------------------------------
Not passed by reference

Technical Details
----------------------------------------
I checked & it is not changed in the function

Comments
----------------------------------------

