### PR TITLE
dev/core#378 Determine front end pages in drupal

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -415,6 +415,19 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Is a front end page being accessed.
+   *
+   * Generally this would be a contribution form or other public page as opposed to a backoffice page (like contact edit).
+   *
+   * @todo Drupal uses the is_public setting - clarify & rationalise. See https://github.com/civicrm/civicrm-drupal/pull/546/files
+   *
+   * @return bool
+   */
+  public function isFrontEndPage() {
+    return CRM_Core_Config::singleton()->userFrameworkFrontend;
+  }
+
+  /**
    * Get user login URL for hosting CMS (method declared in each CMS system class)
    *
    * @param string $destination

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -663,4 +663,26 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return (!empty($language->language)) ? $language->language : $language;
   }
 
+  /**
+   * Is a front end page being accessed.
+   *
+   * Generally this would be a contribution form or other public page as opposed to a backoffice page (like contact edit).
+   *
+   * See https://github.com/civicrm/civicrm-drupal/pull/546/files
+   *
+   * @return bool
+   */
+  public function isFrontEndPage() {
+    // Get the menu items.
+    $args = explode('?', $_GET['q']);
+    $path = $args[0];
+
+    // Get the menu for above URL.
+    $item = CRM_Core_Menu::get($path);
+    if (!empty(CRM_Utils_Array::value('is_public', $item))) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -85,7 +85,7 @@ class Themes {
     if ($this->activeThemeKey === NULL) {
       // Ambivalent: is it better to use $config->userFrameworkFrontend or $template->get('urlIsPublic')?
       $config = \CRM_Core_Config::singleton();
-      $settingKey = $config->userFrameworkFrontend ? 'theme_frontend' : 'theme_backend';
+      $settingKey = $config->userSystem->isFrontEndPage() ? 'theme_frontend' : 'theme_backend';
 
       $themeKey = Civi::settings()->get($settingKey);
       if ($themeKey === 'default') {


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-drupal/pull/546/files that I think narrows the scope
since it means we are not changing an existing property

Before
----------------------------------------
Cannot assign to front end pages in drupal

After
--------------
Can

Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/378#note_20974 in 5.16 it's possible to designate front end page themes in Joomla! and WP but not drupal. @seamuslee001 proposed https://github.com/civicrm/civicrm-drupal/pull/546 to address that. However, it altered the config variable ```userFrameworkFrontend ``` for drupal & as @totten pointed out that is used for other things & might be unpredictable.

This gets around that by adding a function to retrieve whether it is a front end page which accesses the variable for Joomla! & WP but uses @seamuslee001's method for Drupal.

I don't know if there are any special concerns for D8 -but they are mitigated by the fact that front end themes are entirely new & will only affect those adjusting to the new setting.

Comments
----------------------------------------
I have targeted the 5.16rc as both the change this extends & the current shoreditch work target 5.16
(fyi @kcristiano )
