### PR TITLE
dev/core#1141 remove unused deprecated sql_calc_rows

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -610,7 +610,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
       $addWhere .= " AND {$this->_aliases['civicrm_contact']}.id IN ( SELECT DISTINCT cont.id FROM civicrm_contact cont, civicrm_contribution contri WHERE cont.id = contri.contact_id AND {$receive_date} = {$this->_referenceYear['this_year']} AND contri.is_test = 0 ) ";
     }
     $this->limit();
-    $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid, SUM({$this->_aliases['civicrm_contribution']}.total_amount) as civicrm_contribution_total_amount_sum {$this->_from} {$this->_where} {$addWhere} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_having} {$this->_limit}";
+    $getContacts = "SELECT {$this->_aliases['civicrm_contact']}.id as cid, SUM({$this->_aliases['civicrm_contribution']}.total_amount) as civicrm_contribution_total_amount_sum {$this->_from} {$this->_where} {$addWhere} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_having} {$this->_limit}";
 
     $dao = CRM_Core_DAO::executeQuery($getContacts);
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove an instance of SQL_CALC_ROWS for mysql 8 support. I just checked & in this case the count is never used so it can just go

Before
----------------------------------------
Unnecessary deprecated sql present

After
----------------------------------------
poof

Technical Details
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1141 - this is just one case I looked into for that & realised could just go

Comments
----------------------------------------
