### PR TITLE
CRM-20455 - Allow CRM_Core_DAOTest to pass w/packages#259

### DIFF
--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -483,7 +483,10 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function testModifyQuery() {
-    $listener = function(\Symfony\Component\EventDispatcher\Event $e) {
+    /**
+     * @param \Civi\Core\Event\QueryEvent $e
+     */
+    $listener = function($e) {
       $e->query = '/* User :  hooked */' . $e->query;
     };
     Civi::dispatcher()->addListener('civi.db.query', $listener);
@@ -498,6 +501,9 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * Demonstrate it is modified showing the query now breaks.
    */
   public function testModifyAndBreakQuery() {
+    /**
+     * @param \Civi\Core\Event\QueryEvent $e
+     */
     $listener = function($e) {
       $e->query = '/* Forgot trailing comment marker' . $e->query;
     };

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -483,7 +483,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function testModifyQuery() {
-    $listener = function(\Civi\Core\Event\GenericHookEvent $e) {
+    $listener = function(\Symfony\Component\EventDispatcher\Event $e) {
       $e->query = '/* User :  hooked */' . $e->query;
     };
     Civi::dispatcher()->addListener('civi.db.query', $listener);
@@ -498,7 +498,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * Demonstrate it is modified showing the query now breaks.
    */
   public function testModifyAndBreakQuery() {
-    $listener = function(\Civi\Core\Event\GenericHookEvent $e) {
+    $listener = function($e) {
       $e->query = '/* Forgot trailing comment marker' . $e->query;
     };
     Civi::dispatcher()->addListener('civi.db.query', $listener);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -344,7 +344,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     CRM_Utils_System::flushCache();
 
     // initialize the object once db is loaded
-    \Civi::reset();
+    \Civi::$statics = array();
     // ugh, performance
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
 


### PR DESCRIPTION
Overview
----------------

This is a supplement to CRM-20455 and esp https://github.com/civicrm/civicrm-packages/pull/259.

Before
----------------

`CRM_Core_DAOTest` passes with current code, but it fails with packages#259 because:

1. A function signature needs changing.
2. `CiviUnitTestCase::setUp()` effectively calls `Civi\Core\Container::boot()` multiple times (once via `Civi::reset()` and then via `CRM_Core_Config::singleton()`), which initializes various services twice in a row. This creates a mismatch in the lifecycle of `Civi::$statics` and `dispatcher` (such that `Civi::$statics` may retain a stale copy of `dispatcher`).

After
----------------

`CRM_Core_DAOTest` passes with either current code or with packages#259

Comments
----------------

For sub-item `#1`, the changed tests/functions are new; the signature change occurs mid-dev-cycle.

For sub-item `#2`, any change to initialization in `CiviUnitTestCase::setUp()` makes me nervous on account of the code's centrality. But fortunately, the reinitialization still runs at the same time (just non-duplicatively), and the test-suite shows a green light.