### PR TITLE
dev/event#6 Follow the 'same email' participants config setting for backend participants

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -863,7 +863,12 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
 
       $eventId = CRM_Utils_Array::value('event_id', $values);
-      if (!empty($contactId) && !empty($eventId)) {
+
+      $event = new CRM_Event_DAO_Event();
+      $event->id = $eventId;
+      $event->find(TRUE);
+
+      if (!$event->allow_same_participant_emails && !empty($contactId) && !empty($eventId)) {
         $cancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Cancelled');
         $dupeCheck = new CRM_Event_BAO_Participant();
         $dupeCheck->contact_id = $contactId;


### PR DESCRIPTION
https://lab.civicrm.org/dev/event/issues/6

Overview
----------------------------------------

We have the following use-case:

* Organisation using CiviEvent for a box office, i.e. to sell tickets for concerts
* People may buy multiple tickets for concerts, and often not at the same time.

For example, they may have bought a ticket during pre-sales, then later bought a ticket as a gift for a friend.

The front-end allows this, thanks for the "allow same participant emails". However the backend does not validate this option. When adding a backend registration, if the participant has already bought a ticket, the admin will get an error message: "This contact has already been assigned to this event."

Looking at Stack Exchange, I found this thread:  
https://civicrm.stackexchange.com/questions/15826/enable-multiple-event-registration-for-same-purchaser-participant


Before
----------------------------------------

Cannot register a contact more than once to the same event.

After
----------------------------------------

Allow to register.

Technical Details
----------------------------------------

Needs a test? Also may need a documentation update.
