### PR TITLE
Add default location for API v3 creates of Address, IM, OpenID and Phone

### DIFF
--- a/api/v3/Address.php
+++ b/api/v3/Address.php
@@ -125,6 +125,10 @@ function _civicrm_api3_address_create_spec(&$params) {
     'name' => 'world_region',
     'type' => CRM_Utils_Type::T_TEXT,
   ];
+  $defaultLocation = CRM_Core_BAO_LocationType::getDefault();
+  if ($defaultLocation) {
+    $params['location_type_id']['api.default'] = $defaultLocation->id;
+  }
 }
 
 /**

--- a/api/v3/Im.php
+++ b/api/v3/Im.php
@@ -52,6 +52,10 @@ function civicrm_api3_im_create($params) {
  */
 function _civicrm_api3_im_create_spec(&$params) {
   $params['contact_id']['api.required'] = 1;
+  $defaultLocation = CRM_Core_BAO_LocationType::getDefault();
+  if ($defaultLocation) {
+    $params['location_type_id']['api.default'] = $defaultLocation->id;
+  }
 }
 
 /**

--- a/api/v3/OpenID.php
+++ b/api/v3/OpenID.php
@@ -53,6 +53,10 @@ function civicrm_api3_open_i_d_create($params) {
  */
 function _civicrm_api3_open_i_d_create_spec(&$params) {
   $params['contact_id']['api.required'] = 1;
+  $defaultLocation = CRM_Core_BAO_LocationType::getDefault();
+  if ($defaultLocation) {
+    $params['location_type_id']['api.default'] = $defaultLocation->id;
+  }
 }
 
 /**

--- a/api/v3/Phone.php
+++ b/api/v3/Phone.php
@@ -56,6 +56,10 @@ function _civicrm_api3_phone_create_spec(&$params) {
   $params['phone']['api.required'] = 1;
   // hopefully change to use handleprimary
   $params['is_primary']['api.default'] = 0;
+  $defaultLocation = CRM_Core_BAO_LocationType::getDefault();
+  if ($defaultLocation) {
+    $params['location_type_id']['api.default'] = $defaultLocation->id;
+  }
 }
 
 /**

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -122,6 +122,22 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   }
 
   /**
+   * If no location is specified when creating a new address, it should default to
+   * the LocationType default
+   *
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateAddressDefaultLocation($version) {
+    $this->_apiversion = $version;
+    $params = $this->_params;
+    unset($params['location_type_id']);
+    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
+    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
+  }
+
+  /**
    * FIXME: Api4
    */
   public function testCreateAddressTooLongSuffix() {

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -89,9 +89,9 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['location_type_id']);
-    $result = $this->callAPIAndDocument('email', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
     $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
-    $delresult = $this->callAPISuccess('email', 'delete', ['id' => $result['id']]);
+    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
   }
 
   /**

--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -72,6 +72,22 @@ class api_v3_ImTest extends CiviUnitTestCase {
   }
 
   /**
+   * If no location is specified when creating a new IM, it should default to
+   * the LocationType default
+   *
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateImDefaultLocation($version) {
+    $this->_apiversion = $version;
+    $params = $this->_params;
+    unset($params['location_type_id']);
+    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
+    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
+  }
+
+  /**
    * @param int $version
    *
    * @dataProvider versionThreeAndFour

--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -33,11 +33,8 @@
  * @group headless
  */
 class api_v3_ImTest extends CiviUnitTestCase {
-
-  protected $params;
-
+  protected $_params;
   protected $id;
-
   protected $_entity;
 
   public $DBResetRequired = FALSE;
@@ -48,7 +45,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
 
     $this->_entity = 'im';
     $this->_contactID = $this->organizationCreate();
-    $this->params = [
+    $this->_params = [
       'contact_id' => $this->_contactID,
       'name' => 'My Yahoo IM Handle',
       'location_type_id' => 1,
@@ -65,9 +62,9 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testCreateIm($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
-    $this->getAndCheck($this->params, $result['id'], $this->_entity);
+    $this->getAndCheck($this->_params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
 
@@ -94,8 +91,8 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testGetIm($version) {
     $this->_apiversion = $version;
-    $this->callAPISuccess($this->_entity, 'create', $this->params);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
@@ -108,7 +105,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testDeleteIm($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $deleteParams = ['id' => $result['id']];
     $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);
@@ -119,7 +116,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
    * Skip api4 test - delete behaves differently
    */
   public function testDeleteImInvalid() {
-    $this->callAPISuccess($this->_entity, 'create', $this->params);
+    $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $deleteParams = ['id' => 600];
     $this->callAPIFailure($this->_entity, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);

--- a/tests/phpunit/api/v3/OpenIDTest.php
+++ b/tests/phpunit/api/v3/OpenIDTest.php
@@ -67,6 +67,22 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
   }
 
   /**
+   * If no location is specified when creating a new openid, it should default to
+   * the LocationType default
+   *
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateOpenIDDefaultLocation($version) {
+    $this->_apiversion = $version;
+    $params = $this->_params;
+    unset($params['location_type_id']);
+    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
+    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
+  }
+
+  /**
    * @param int $version
    * @dataProvider versionThreeAndFour
    */

--- a/tests/phpunit/api/v3/OpenIDTest.php
+++ b/tests/phpunit/api/v3/OpenIDTest.php
@@ -35,7 +35,7 @@
 class api_v3_OpenIDTest extends CiviUnitTestCase {
 
   protected $_apiversion = 3;
-  protected $params;
+  protected $_params;
   protected $id;
   protected $_entity;
 
@@ -47,7 +47,7 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
 
     $this->_entity = 'OpenID';
     $this->_contactID = $this->organizationCreate();
-    $this->params = [
+    $this->_params = [
       'contact_id' => $this->_contactID,
       'openid' => 'My OpenID handle',
       'location_type_id' => 1,
@@ -60,9 +60,9 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
    */
   public function testCreateOpenID($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
-    $this->getAndCheck($this->params, $result['id'], $this->_entity);
+    $this->getAndCheck($this->_params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id'], 'In line ' . __LINE__);
   }
 
@@ -88,8 +88,8 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
    */
   public function testGetOpenID($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
     $this->assertNotNull($result['values'][$result['id']]['id'], 'In line ' . __LINE__);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
@@ -101,7 +101,7 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
    */
   public function testDeleteOpenID($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $deleteParams = ['id' => $result['id']];
     $result = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);
@@ -114,7 +114,7 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
    */
   public function testDeleteOpenIDInvalid($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $deleteParams = ['id' => 600];
     $result = $this->callAPIFailure($this->_entity, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);

--- a/tests/phpunit/api/v3/PhoneTest.php
+++ b/tests/phpunit/api/v3/PhoneTest.php
@@ -69,6 +69,22 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
   }
 
   /**
+   * If no location is specified when creating a new phone, it should default to
+   * the LocationType default
+   *
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreatePhoneDefaultLocation($version) {
+    $this->_apiversion = $version;
+    $params = $this->_params;
+    unset($params['location_type_id']);
+    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
+    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
+  }
+
+  /**
    * @param int $version
    * @dataProvider versionThreeAndFour
    */

--- a/tests/phpunit/api/v3/PhoneTest.php
+++ b/tests/phpunit/api/v3/PhoneTest.php
@@ -36,8 +36,10 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
   protected $_contactID;
   protected $_locationType;
   protected $_params;
+  protected $_entity;
 
   public function setUp() {
+    $this->_entity = 'Phone';
     parent::setUp();
     $this->useTransaction();
 


### PR DESCRIPTION
Has tests.

Default location was recently added for APIv3 Email.create
(https://github.com/civicrm/civicrm-core/pull/14489)
and for Address, Email, IM, OpenID and Phone in APIv4
(https://github.com/civicrm/org.civicrm.api4/pull/162)
so this brings consistency of behaviour for these entities between each other
and between APIv3 and APIv4

Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
