### PR TITLE
Switch create MembershipPayment to use API

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1578,8 +1578,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         if (!empty($membershipContribution)) {
           // update recurring id for membership record
           CRM_Member_BAO_Membership::updateRecurMembership($membership, $membershipContribution);
-          // Next line is probably redundant. Checksprevent it happening twice.
-          CRM_Member_BAO_Membership::linkMembershipPayment($membership, $membershipContribution);
+          // Next line is probably redundant. Checks prevent it happening twice.
+          $membershipPaymentParams = [
+            'membership_id' => $membership->id,
+            'membership_type_id' => $membership->membership_type_id,
+            'contribution_id' => $membershipContribution->id,
+          ];
+          civicrm_api3('MembershipPayment', 'create', $membershipPaymentParams);
         }
         if ($membership) {
           CRM_Core_BAO_CustomValueTable::postProcess($form->_params, 'civicrm_membership', $membership->id, 'Membership');

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -397,11 +397,12 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     //insert payment record for this membership
     if (!empty($params['relate_contribution_id'])) {
-      CRM_Member_BAO_MembershipPayment::create(array(
+      $membershipPaymentParams = [
         'membership_id' => $membership->id,
         'membership_type_id' => $membership->membership_type_id,
         'contribution_id' => $params['relate_contribution_id'],
-      ));
+      ];
+      civicrm_api3('MembershipPayment', 'create', $membershipPaymentParams);
     }
 
     $transaction->commit();
@@ -1803,20 +1804,6 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
   }
 
   /**
-   * Create linkages between membership & contribution - note this is the wrong place for this code but this is a
-   * refactoring step. This should be BAO functionality
-   * @param $membership
-   * @param $membershipContribution
-   */
-  public static function linkMembershipPayment($membership, $membershipContribution) {
-    CRM_Member_BAO_MembershipPayment::create(array(
-      'membership_id' => $membership->id,
-      'membership_type_id' => $membership->membership_type_id,
-      'contribution_id' => $membershipContribution->id,
-    ));
-  }
-
-  /**
    * @param int $contactID
    * @param int $membershipTypeID
    * @param bool $is_test
@@ -2507,11 +2494,12 @@ WHERE      civicrm_membership.is_test = 0
 
     //insert payment record for this membership
     if (empty($ids['contribution']) || !empty($params['is_recur'])) {
-      CRM_Member_BAO_MembershipPayment::create(array(
+      civicrm_api3('MembershipPayment', 'create', [
         'membership_id' => $membershipId,
         'contribution_id' => $contribution->id,
-      ));
+      ]);
     }
+
     return $contribution;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This simplifies and standardises the creation of a MembershipPayment when using a "live" payment method.

Before
----------------------------------------
3 different ways of creating the MembershipPayment

After
----------------------------------------
Always call the API to create a MembershipPayment

Technical Details
----------------------------------------
We had a separate function `linkMembershipPayment()` called from one place but this wasn't very useful elsewhere because it required objects to be passed in which may/may not exist elsewhere.  So removed that in favour of the API too.

Comments
----------------------------------------
