### PR TITLE
Further deprecate use of $ids array in membership functions

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -860,6 +860,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           unset($value['membership_start_date']);
           unset($value['membership_end_date']);
           $ids = [];
+          // @todo stop passing empty $ids
           $membership = CRM_Member_BAO_Membership::create($value, $ids);
         }
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1418,7 +1418,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         $paymentParams['contributionTypeID'] = $contribution->financial_type_id;
         $paymentParams['contributionPageID'] = $contribution->contribution_page_id;
         $paymentParams['contributionRecurID'] = $contribution->contribution_recur_id;
-        $ids['contribution'] = $contribution->id;
+        $params['contribution_id'] = $paymentParams['contributionID'];
         $params['contribution_recur_id'] = $paymentParams['contributionRecurID'];
       }
       $paymentStatus = NULL;
@@ -1522,6 +1522,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           unset($membershipParams['lineItems']);
         }
         $membershipParams['payment_instrument_id'] = $paymentInstrumentID;
+        // @todo stop passing $ids (membership and userId only are set above)
         $membership = CRM_Member_BAO_Membership::create($membershipParams, $ids);
         $params['contribution'] = CRM_Utils_Array::value('contribution', $membershipParams);
         unset($params['lineItems']);
@@ -1618,7 +1619,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           if (!empty($softParams)) {
             $membershipParams['soft_credit'] = $softParams;
           }
-
+          // @todo stop passing $ids (membership and userId only are set above)
           $membership = CRM_Member_BAO_Membership::create($membershipParams, $ids);
           $params['contribution'] = CRM_Utils_Array::value('contribution', $membershipParams);
           unset($params['lineItems']);

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -121,7 +121,6 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
         break;
 
       case 'create':
-        $ids = [];
         $params = [
           'contact_id' => CRM_Utils_Request::retrieve('rid', 'Positive', $this),
           'membership_type_id' => $owner['membership_type_id'],
@@ -136,6 +135,8 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
           'skipStatusCal' => TRUE,
           'createActivity' => TRUE,
         ];
+        // @todo stop passing $ids here (we are only doing so because of passbyreference)
+        $ids = [];
         CRM_Member_BAO_Membership::create($params, $ids);
         $relatedDisplayName = CRM_Contact_BAO_Contact::displayName($params['contact_id']);
         CRM_Core_Session::setStatus(ts('Related membership for %1 has been created.', [1 => $relatedDisplayName]),

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -395,15 +395,15 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
             'Membership'
           );
           if ($dao->find(TRUE)) {
-            $ids = [
-              'membership' => $formatValues['membership_id'],
-              'userId' => $session->get('userID'),
-            ];
-
             if (empty($params['line_item']) && !empty($formatted['membership_type_id'])) {
               CRM_Price_BAO_LineItem::getLineItemArray($formatted, NULL, 'membership', $formatted['membership_type_id']);
             }
 
+            // @todo stop passing $ids array (and put details in $formatted if required)
+            $ids = [
+              'membership' => $formatValues['membership_id'],
+              'userId' => $session->get('userID'),
+            ];
             $newMembership = CRM_Member_BAO_Membership::create($formatted, $ids, TRUE);
             if (civicrm_error($newMembership)) {
               array_unshift($values, $newMembership['is_error'] . ' for Membership ID ' . $formatValues['membership_id'] . '. Row was skipped.');

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -134,10 +134,10 @@ function civicrm_api3_membership_create($params) {
   }
 
   // Fixme: This code belongs in the BAO
+  $ids = [];
   if (empty($params['id'])) {
     $params['action'] = CRM_Core_Action::ADD;
     // we need user id during add mode
-    $ids = [];
     if (!empty($params['contact_id'])) {
       $ids['userId'] = $params['contact_id'];
     }
@@ -145,10 +145,11 @@ function civicrm_api3_membership_create($params) {
   else {
     // edit mode
     $params['action'] = CRM_Core_Action::UPDATE;
-    // $ids['membership'] is required in CRM_Price_BAO_LineItem::processPriceSet
+    // @todo remove $ids['membership'] is required in CRM_Price_BAO_LineItem::processPriceSet
     $ids['membership'] = $params['id'];
   }
 
+  // @todo stop passing $ids (membership and userId may be set above)
   $membershipBAO = CRM_Member_BAO_Membership::create($params, $ids, TRUE);
 
   if (array_key_exists('is_error', $membershipBAO)) {

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1206,6 +1206,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'skipStatusCal' => 1,
       'is_for_organization' => 1,
     ];
+    // @todo stop passing empty $ids
     $ids = [];
     $membership = CRM_Member_BAO_Membership::create($params, $ids);
 


### PR DESCRIPTION
Overview
----------------------------------------
Incremental progress towards removing deprecated code.

Before
----------------------------------------
`$ids` passed in more places.

After
----------------------------------------
`$ids` passed in less places.

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton per similar work you've done
