### PR TITLE
dev/core#1149 - Make it clearer which record the logging report is displaying

### DIFF
--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -134,7 +134,7 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
       'log_civicrm_activity_contact' => [
         'fk' => 'contact_id',
         'table_name' => 'log_civicrm_activity_contact',
-        'log_type' => 'Activity',
+        'log_type' => 'Activity Contact',
         'field' => 'activity_id',
         'extra_joins' => [
           'table' => 'log_civicrm_activity',


### PR DESCRIPTION
Overview
----------------------------------------
As described in https://lab.civicrm.org/dev/core/issues/1149 the report at "Reports - Contact Reports - Contact Logging Report (Summary)" says it's showing records for activities but it's actually showing activity_contact log records.

Before
----------------------------------------
Log type shows as "Activity"

After
----------------------------------------
Log type shows as "Activity Contact"

Comments
----------------------------------------
As described in the ticket there is additionally some grouping going on that prevents actually seeing the whole sequence of activity_contact transactions, and the logging itself doesn't seem to track the activity_contact when the activity itself is deleted. This PR doesn't attempt to fix any of that.

It also doesn't attempt to fix the word "Case" which is actually showing some combination of Case_Contact and I dunno what (maybe the contact whose id matches the case_type_id - I gave up looking).
