### PR TITLE
[Code-quality] remove references to where_tables, where_clause

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -421,7 +421,6 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       $group->name = substr($group->name, 0, -4) . "_{$group->id}";
     }
 
-    $group->buildClause();
     $group->save();
 
     // add custom field values
@@ -499,25 +498,6 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       );
     }
     return $group;
-  }
-
-  /**
-   * Given a saved search compute the clause and the tables
-   * and store it for future use
-   */
-  public function buildClause() {
-    $params = [['group', 'IN', [$this->id], 0, 0]];
-
-    if (!empty($params)) {
-      $tables = $whereTables = [];
-      $this->where_clause = CRM_Contact_BAO_Query::getWhereClause($params, NULL, $tables, $whereTables);
-      if (!empty($tables)) {
-        $this->select_tables = serialize($tables);
-      }
-      if (!empty($whereTables)) {
-        $this->where_tables = serialize($whereTables);
-      }
-    }
   }
 
   /**

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -325,43 +325,6 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
   }
 
   /**
-   * Given a saved search compute the clause and the tables and store it for future use.
-   */
-  public function buildClause() {
-    $fv = unserialize($this->form_values);
-
-    if ($this->mapping_id) {
-      $params = CRM_Core_BAO_Mapping::formattedFields($fv);
-    }
-    else {
-      $params = CRM_Contact_BAO_Query::convertFormValues($fv);
-    }
-
-    if (!empty($params)) {
-      $tables = $whereTables = [];
-      $this->where_clause = CRM_Contact_BAO_Query::getWhereClause($params, NULL, $tables, $whereTables);
-      if (!empty($tables)) {
-        $this->select_tables = serialize($tables);
-      }
-      if (!empty($whereTables)) {
-        $this->where_tables = serialize($whereTables);
-      }
-    }
-  }
-
-  /**
-   * Save the search.
-   *
-   * @param bool $hook
-   */
-  public function save($hook = TRUE) {
-    // first build the computed fields
-    $this->buildClause();
-
-    parent::save($hook);
-  }
-
-  /**
    * Given an id, get the name of the saved search.
    *
    * @param int $id

--- a/sql/GenerateData.php
+++ b/sql/GenerateData.php
@@ -1119,8 +1119,6 @@ class CRM_GCD {
       $group->visibility = 'Public Pages';
       $group->is_active = 1;
       $group->save();
-      $group->buildClause();
-      $group->save();
     }
 
     // 60 are for newsletter

--- a/sql/GenerateReportData.php
+++ b/sql/GenerateReportData.php
@@ -1087,8 +1087,6 @@ class CRM_GCD {
       $group->visibility = 'Public Pages';
       $group->is_active  = 1;
       $group->save();
-      $group->buildClause();
-      $group->save();
     }
 
     // 60 are for newsletter


### PR DESCRIPTION
Overview
----------------------------------------
Removes confusion code

Before
----------------------------------------
The following are calculated & saved to the DB (at some php cost) but never used

where_clause
select_clause
where_tables 

After
----------------------------------------
Removed

Technical Details
----------------------------------------
I've long been of the impression that the where_tables & where_clause in the Smart group & group tables are not
actually used. On  going through I found places where they are saved to but not any where they are  used.

This removes them - next step would be to actually drop the fields but need Jenkins & another person to agree with me
first

Comments
----------------------------------------
@colemanw @seamuslee001 @mattwire  - am interested as to whether you have a different opinion on these