### PR TITLE
 dev/financial#40 add missing financial item when altering a radio amount

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -547,6 +547,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID, 'participant');
     CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem);
     $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item'])['values'];
+    $this->assertCount(3, $actualResults);
     $expectedResults = [
       [
         'id' => 2,

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -538,4 +538,65 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * dev-financial-40: Test that partial payment entries in entity-financial-trxn table to ensure that reverse transaction is entered
+   */
+  public function testPartialPaymentEntries() {
+    $this->registerParticipantAndPay($this->_expensiveFee);
+    $priceSetParams['price_' . $this->priceSetFieldID] = $this->veryExpensiveFeeValueID;
+    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID, 'participant');
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem);
+    $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item', 'return' => ['amount', 'entity_id']])['values'];
+    $expectedResults = [
+      [
+        'id' => 2,
+        'amount' => 100.00,
+        'entity_id' => 1,
+      ],
+      [
+        'id' => 4,
+        'amount' => -100.00, // ensure that reverse entry is entered in the EntityFinancialTrxn table on fee change to greater amount
+        'entity_id' => 2,
+      ],
+      [
+        'id' => 5,
+        'amount' => 120.00,
+        'entity_id' => 3,
+      ],
+    ];
+    foreach ($expectedResults as $key => $expectedResult) {
+      $this->checkArrayEquals($expectedResult, $actualResults[$key]);
+    }
+  }
+  /**
+   * dev-financial-40: Test that refund payment entries in entity-financial-trxn table to ensure that reverse transaction is entered on fee change to lesser amount
+   */
+  public function testRefundPaymentEntries() {
+    $this->registerParticipantAndPay($this->_expensiveFee);
+    $priceSetParams['price_' . $this->priceSetFieldID] = $this->cheapFeeValueID;
+    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID, 'participant');
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem);
+    $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item', 'return' => ['amount', 'entity_id']])['values'];
+    $expectedResults = [
+      [
+        'id' => 2,
+        'amount' => 100.00,
+        'entity_id' => 1,
+      ],
+      [
+        'id' => 4,
+        'amount' => -100.00, // ensure that reverse entry is entered in the EntityFinancialTrxn table
+        'entity_id' => 2,
+      ],
+      [
+        'id' => 5,
+        'amount' => 80.00,
+        'entity_id' => 3,
+      ],
+    ];
+    foreach ($expectedResults as $key => $expectedResult) {
+      $this->checkArrayEquals($expectedResult, $actualResults[$key]);
+    }
+  }
+
 }

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -546,28 +546,36 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->veryExpensiveFeeValueID;
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID, 'participant');
     CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem);
-    $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item', 'return' => ['amount', 'entity_id']])['values'];
+    $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item'])['values'];
     $expectedResults = [
       [
         'id' => 2,
-        'amount' => 100.00,
+        'amount' => 100.0,
         'entity_id' => 1,
+        'financial_trxn_id' => 1,
+        'entity_table' => 'civicrm_financial_item',
       ],
       [
         'id' => 4,
-        'amount' => -100.00, // ensure that reverse entry is entered in the EntityFinancialTrxn table on fee change to greater amount
+        // ensure that reverse entry is entered in the EntityFinancialTrxn table on fee change to greater amount
+        'amount' => -100.0,
         'entity_id' => 2,
+        'financial_trxn_id' => 2,
+        'entity_table' => 'civicrm_financial_item',
       ],
       [
         'id' => 5,
         'amount' => 120.00,
         'entity_id' => 3,
+        'financial_trxn_id' => 2,
+        'entity_table' => 'civicrm_financial_item',
       ],
     ];
     foreach ($expectedResults as $key => $expectedResult) {
       $this->checkArrayEquals($expectedResult, $actualResults[$key]);
     }
   }
+
   /**
    * dev-financial-40: Test that refund payment entries in entity-financial-trxn table to ensure that reverse transaction is entered on fee change to lesser amount
    */
@@ -585,7 +593,8 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       ],
       [
         'id' => 4,
-        'amount' => -100.00, // ensure that reverse entry is entered in the EntityFinancialTrxn table
+        // ensure that reverse entry is entered in the EntityFinancialTrxn table
+        'amount' => -100.00,
         'entity_id' => 2,
       ],
       [

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -82,6 +82,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'financial_type_id' => 1,
       'contribution_status_id' => 2,
       'payment_instrument_id' => 1,
+      'receive_date' => date('Y-m-d'),
     ]);
     $participants = $this->callAPISuccess('Participant', 'get', []);
     $this->assertEquals(1, $participants['count']);


### PR DESCRIPTION
Overview
----------------------------------------
Updated non-stale version of https://github.com/civicrm/civicrm-core/pull/13521 - fixes a missing line item when adjusting a radio line item - refer to that PR for more detail

Before
----------------------------------------
When adjusting a line item of radio type the changed item doesn't have an entity_financial_item record & line item

After
----------------------------------------
The above are created

Technical Details
----------------------------------------
This is largely the same as the original one but it addresses the mislinking of the financial item with the wrong trxn_id

Comments
----------------------------------------
I had some doubts about bringing this back to life since most work in this areas is stalled on @monishdeb availability at the moment. However, I was reluctant to throw away the tests. There is ALSO a larger question which stalled that PR & might stall this one which comes down to 'do a big audit' - I think this gets us to a better position (better test cover, imbalance fixed) without addressing some larger questions, but if it stalls again I'll close & we can track through gitlab.

Note that the behaviour when changing a text field line item is different to a radio field. For text fields there is an adjustment amount, for the others a reversal  & a new row.


