### PR TITLE
Fix support for relative dates in urls

### DIFF
--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -268,6 +268,8 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    * @param string $entity
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function getEntityDefaults($entity) {
     $defaults = [];
@@ -284,6 +286,12 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
             $defaults[$fieldName . '_relative'] = 0;
             $defaults[$fieldName . '_low'] = $low ? date('Y-m-d H:i:s', strtotime($low)) : NULL;
             $defaults[$fieldName . '_high'] = $high ? date('Y-m-d H:i:s', strtotime($high)) : NULL;
+          }
+          else {
+            $relative = CRM_Utils_Request::retrieveValue($fieldName . '_relative', 'String', NULL, NULL, 'GET');
+            if (!empty($relative) && isset(CRM_Core_OptionGroup::values('relative_date_filters')[$relative])) {
+              $defaults[$fieldName . '_relative'] = $relative;
+            }
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
This improves support for relative dates for fields that have been converted to use datepicker

For example

http://dmaster.local/civicrm/contribute/search?reset=1&receive_date_relative=this.year&force=1

Now works to render donations 'This Calendar Year'

Before
----------------------------------------
No URL support for relative dates

After
----------------------------------------
URL support for relative dates for fields that already supported high & low - e.g civicrm_activity.activity_date_time, contribution.receive_date - there are still some not converted

Technical Details
----------------------------------------
I was looking at https://github.com/civicrm/civicrm-core/pull/13440 & wondering whether the labels map correctly & I figured this was a good way to expose it - by default we have support for 
the following prefix (supports n means you can use any number eg. ending_6.year = from 6 years ago until today. You must add a value to civicrm_option_value in the 'relative_date_filters' group to support an 'n' that is not present by default)

prefix |meaning|e.g|supports 'n'
-- | --|--|--
this.x |the x of which right now is part|This Year|proposed -  at least partial https://github.com/civicrm/civicrm-core/pull/13440
previous.x |the x immediately before this.x|Last Year|some
previous_before.x|x prior to the previous x|The year before Last Year
greater|From the start of this x|Everything from the start of this year on
greater_previous.x|Everything from the end of previous X onwards|Everything from the start of last year on
earlier.x|all time up until the start of this.x|Everything before the start of this year
less.x|From start of time to end of current x|Everything to the end of this year
current|this x until now|From the start of this year until now
next|the x after this one|Next year
ending|1 x up until now|Last 12 months ending today|Yes
starting|from now for 1 x|One year from now including today

value | label
-- | --
this.year | This calendar year
this.week | This week
this.quarter | This quarter
this.month | This calendar month
this.fiscal_year | This fiscal year
this.day | Today
starting_2.month | Next 60 days including today
starting.year | Next 12 months including today
starting.week | Next 7 days including today
starting.quarter | Next 90 days including today
starting.month | Next 30 days including today
starting.day | Tomorrow
previous_before.year | Year prior to previous calendar year
previous_before.week | Week prior to previous week
previous_before.quarter | Quarter prior to previous quarter
previous_before.month | Month prior to previous calendar month
previous_before.day | Day prior to yesterday
previous_2.year | Previous 2 calendar years
previous_2.week | Previous 2 weeks
previous_2.quarter | Previous 2 quarters
previous_2.month | Previous 2 calendar months
previous_2.day | Previous 2 days
previous.year | Previous calendar year
previous.week | Previous week
previous.quarter | Previous quarter
previous.month | Previous calendar month
previous.fiscal_year | Previous fiscal year
previous.day | Yesterday
next.year | Next calendar year
next.week | Next week
next.quarter | Next quarter
next.month | Next calendar month
next.fiscal_year | Next fiscal year
less.year | To end of current calendar year
less.week | To end of current week
less.quarter | To end of current quarter
less.month | To end of current calendar month
greater_previous.year | From end of previous calendar year
greater_previous.week | From end of previous week
greater_previous.quarter | From end of previous quarter
greater_previous.month | From end of previous calendar month
greater.year | From start of current calendar year
greater.week | From start of current week
greater.quarter | From start of current quarter
greater.month | From start of current calendar month
greater.day | From start of current day
ending_90.day | Last 90 days including today
ending_60.day | Last 60 days including today
ending_30.day | Last 30 days including today
ending_3.year | Last 3 years including today
ending_2.year | Last 2 years including today
ending.year | Last 12 months including today
ending.week | Last 7 days including today
earlier.year | To end of previous calendar year
earlier.week | To end of previous week
earlier.quarter | To end of previous quarter
earlier.month | To end of previous calendar month
earlier.day | To end of yesterday
current.year | Current calendar year to-date
current.week | Current week to-date
current.quarter | Current quarter to-date
current.month | Current calendar month to-date






Comments
----------------------------------------

