### PR TITLE
Add freeform relative date for 'This Fiscal Year'

### DIFF
--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -97,15 +97,23 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     Civi::settings()->set('fiscalYearStart', ['M' => 7, 'd' => 1]);
     $fiscalYearStartYear = (strtotime('now') > strtotime((date('Y-07-01')))) ? date('Y') : (date('Y') - 1);
 
+    //  this_2 = 'These  2 Fiscal  years'
+    $date = CRM_Utils_Date::relativeToAbsolute('this_2', 'fiscal_year');
+    $this->assertEquals([
+      'from' => ($fiscalYearStartYear - 1) . '0701000000',
+      'to' => ($fiscalYearStartYear + 1) . '0630235959',
+    ], $date, 'relative term is this_2.fiscal_year');
+
     foreach ($sequence as $relativeString) {
       $date = CRM_Utils_Date::relativeToAbsolute($relativeString, 'fiscal_year');
       $this->assertEquals([
         'from' => $fiscalYearStartYear . '0701',
-        'to' => ($fiscalYearStartYear + 1) . '0630',
+        'to' => ($fiscalYearStartYear + 1) . '0630235959',
       ], $date, 'relative term is ' . $relativeString);
 
       $fiscalYearStartYear--;
     }
+
   }
 
   /**
@@ -126,6 +134,14 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
 
       $year--;
     }
+
+    //  this_2 = 'These  2 years'
+    $date = CRM_Utils_Date::relativeToAbsolute('this_2', 'year');
+    $thisYear = date('Y');
+    $this->assertEquals([
+      'from' => ($thisYear - 1) . '0101',
+      'to' => $thisYear . '1231',
+    ], $date, 'relative term is this_2 year');
   }
 
   /**
@@ -134,6 +150,43 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
    * Go backwards one year at a time through the sequence.
    */
   public function testRelativeEnding() {
+    $relativeDateValues = [
+      'ending.week' => '- 6 days',
+      'ending_30.day' => '- 29 days',
+      'ending.year' => '- 1 year + 1 day',
+      'ending_90.day' => '- 89 days',
+      'ending_60.day' => '- 59 days',
+      'ending_2.year' => '- 2 years + 1 day',
+      'ending_3.year' => '- 3 years + 1 day',
+      'ending_18.year' => '- 18 years + 1 day',
+      'ending_18.quarter' => '- 54 months + 1 day',
+      'ending_18.week' => '- 18 weeks + 1 day',
+      'ending_18.month' => '- 18 months + 1 day',
+      'ending_18.day' => '- 17 days',
+    ];
+
+    foreach ($relativeDateValues as $key => $value) {
+      $parts = explode('.', $key);
+      $date = CRM_Utils_Date::relativeToAbsolute($parts[0], $parts[1]);
+      $this->assertEquals([
+        'from' => date('Ymd000000', strtotime($value)),
+        'to' => date('Ymd235959'),
+      ], $date, 'relative term is ' . $key);
+    }
+
+    $date = CRM_Utils_Date::relativeToAbsolute('ending', 'month');
+    $this->assertEquals([
+      'from' => date('Ymd000000', strtotime('- 29 days')),
+      'to' => date('Ymd235959'),
+    ], $date, 'relative term is ending.week');
+  }
+
+  /**
+   * Test relativeToAbsolute function on a range of year options.
+   *
+   * Go backwards one year at a time through the sequence.
+   */
+  public function testRelativeThisFiscal() {
     $relativeDateValues = [
       'ending.week' => '- 6 days',
       'ending_30.day' => '- 29 days',
@@ -205,7 +258,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       $offset = (substr($relativeString, -1, 1));
       $this->assertEquals([
         'from' => $lastFiscalYearEnd - $offset . '0701',
-        'to' => $lastFiscalYearEnd . '0630',
+        'to' => $lastFiscalYearEnd . '0630235959',
       ], $date, 'relative term is ' . $relativeString);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Added support for this_n.year & this_n.fiscal_year

Before
----------------------------------------
No support for 'Last year & this year' or 'Last fiscal year & this fiscal year' ('These 2 years')

After
----------------------------------------
Support at the code level - as with https://github.com/civicrm/civicrm-core/pull/12682 it is necessary to add an option value to the relative_date_filters custom group to expose any new options

Technical Details
----------------------------------------
@magnolia61 I decided to add a test for yours to finish it - but I found I had a slightly different assumption ie

this_2.fiscal_year = 'these 2 fiscal years' - ie. last year & this year. I think your assumption was that this_2 would actually be 2 years.

Comments
----------------------------------------
