### PR TITLE
Don't let optiongroup check crash

### DIFF
--- a/CRM/Utils/Check/Component/OptionGroups.php
+++ b/CRM/Utils/Check/Component/OptionGroups.php
@@ -48,8 +48,10 @@ class CRM_Utils_Check_Component_OptionGroups extends CRM_Utils_Check_Component {
         $values = CRM_Core_BAO_OptionValue::getOptionValuesArray($optionGroup['id']);
         if (count($values) > 0) {
           foreach ($values as $value) {
-            $validate = CRM_Utils_Type::validate($value['value'], $optionGroup['data_type'], FALSE);
-            if (is_null($validate)) {
+            try {
+              CRM_Utils_Type::validate($value['value'], $optionGroup['data_type'], FALSE, '', TRUE);
+            }
+            catch (Exception $e) {
               $problemValues[] = [
                 'group_name' => $optionGroup['title'],
                 'value_name' => $value['label'],


### PR DESCRIPTION
Overview
----------------------------------------
If the optiongroup datatype is incorrect the check can fail (I found this when data_type was set to 0 or 1 instead of NULL or a valid value).  This PR stops the check from ever being able to crash - which being a check it really shouldn't be doing as it'll hide other, more important checks.

Before
----------------------------------------
Optiongroup check can crash.

After
----------------------------------------
Optiongroup check can't crash, can only report back as a check is supposed to do...

Technical Details
----------------------------------------

Comments
----------------------------------------

