### PR TITLE
Fix php7.x warning on count

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -166,7 +166,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
             $defaults["additional_custom_post_id_multiple[$key]"] = $value;
           }
         }
-        $this->assign('profilePostMultipleAdd', CRM_Utils_Array::value('additional_custom_post', $defaults));
+        $this->assign('profilePostMultipleAdd', CRM_Utils_Array::value('additional_custom_post', $defaults, []));
       }
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a warning when php 7.2 tries to count on a null value
Before
----------------------------------------
<img width="878" alt="Screen Shot 2019-07-28 at 1 34 03 PM" src="https://user-images.githubusercontent.com/336308/62001149-b63bbb00-b13d-11e9-833e-70b7c70d2713.png">



After
----------------------------------------
Gone

Technical Details
----------------------------------------
This error occurs if you try to do count on a variable that is NULL

<img width="609" alt="Screen Shot 2019-07-28 at 1 33 55 PM" src="https://user-images.githubusercontent.com/336308/62001154-c9e72180-b13d-11e9-848e-f707c1ed92ae.png">


Comments
----------------------------------------

