### PR TITLE
Don't use random parameters to detect if we should create MembershipPayment

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2492,8 +2492,11 @@ WHERE      civicrm_membership.is_test = 0
     // store contribution id
     $params['contribution_id'] = $contribution->id;
 
-    //insert payment record for this membership
-    if (empty($ids['contribution']) || !empty($params['is_recur'])) {
+    // Create membership payment if it does not already exist
+    $membershipPayment = civicrm_api3('MembershipPayment', 'get', [
+      'contribution_id' => $contribution->id,
+    ]);
+    if (empty($membershipPayment['count'])) {
       civicrm_api3('MembershipPayment', 'create', [
         'membership_id' => $membershipId,
         'contribution_id' => $contribution->id,


### PR DESCRIPTION
Overview
----------------------------------------
Follow on from https://github.com/civicrm/civicrm-core/pull/14886

There are 3 places where a MembershipPayment may be created.  This bit uses 2 unrelated parameters to check if we've already hit one of those other places.  Instead, just check directly for a MembershipPayment using the API and don't rely on parameters which come from elsewhere and may change.

Before
----------------------------------------
Uses random parameters to decide whether a MembershipPayment should be created.

After
----------------------------------------
Use a proper check to decide whether a MembershipPayment should be created.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
@eileenmcnaughton Follow on from #14886 which should be merged first
