### PR TITLE
Fix membership end date on confirming a pending contribution

### DIFF
--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -117,6 +117,8 @@ function civicrm_api3_membership_create($params) {
     }
     else {
       // This is an existing membership, calculate the membership dates after renewal
+      // num_terms is treated as a 'special sauce' for is_renewal but this
+      // isn't really helpful for completing pendings.
       $calcDates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType(
         $params['id'],
         NULL,

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -346,6 +346,8 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
 
   /**
    * Test submit with a membership block in place works with renewal.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testSubmitMembershipBlockNotSeparatePaymentProcessorInstantRenew() {
     $this->setUpMembershipContributionPage();


### PR DESCRIPTION
Overview
----------------------------------------
Replacement for https://github.com/civicrm/civicrm-core/pull/13706

When we create a Membership with 2 or more initial membership terms. The initial membership end date is set correctly in CiviCRM.

However, if the related Contribution has a status of Pending, when this Contribution status is changed to Completed then the membership end date is re-calculated and using the default term, causing the end date to change.

Put simply, when user sign up with pay later option for a 3 year membership. When the payment is received this membership is then changed to 1 year when Contribution is marked as Completed.

Before - Steps to Reproduce
----------------------------------------
1. Open a Contact Page
2. Go to Membership > Create a Membership with 2 or more terms with Contribution status of Pending.
3. Verify above steps created one pending membership and one pending contribution.
4. Go to Contributions tab > Click Record Payment of latest pending contribution
5. Record all the due payment
6. Go to Memberships tab
7. Membership is active but end_date is not correct. end_date is calculated for 1 term only.

After
----------------------------------------
On Step 7 Membership end_date is set according to the selected number of terms.

Technical Comments
--------------------------
Since #13706 had done the hard work of writing a test I did the easy work of putting in a more conservative fix for it. Per the code comments we are really just working around the assumptions the v3 api makes around what num_terms means. When we switch to apiv4 we can re-visit - but we will have a unit test to support that work


Comments
----------------------------------------
_Agileware Ref: CIVICRM-1148_
