### PR TITLE
dev/core#1042 fix  duplicate activities on custom data block

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -189,9 +189,10 @@
   <tr class="crm-activity-form-block-custom_data">
     <td colspan="2">
       {if $action eq 4}
-      {include file="CRM/Custom/Page/CustomDataView.tpl"}
-        {else}
+        {include file="CRM/Custom/Page/CustomDataView.tpl"}
+      {else}
         <div id="customData"></div>
+        {include file="CRM/common/customDataBlock.tpl"}
       {/if}
     </td>
   </tr>
@@ -293,8 +294,6 @@
       });
     </script>
     {/literal}
-
-    {include file="CRM/common/customDataBlock.tpl"}
   {/if}
   </div>{* end of form block*}
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes duplication of the custom data block

Before
----------------------------------------
Add a custom field set for activities.
Create an activity.
Go to search - find activities.
Click the View action link.
In the popup the custom field set appears twice, once in read mode and once in edit mode.

It doesn't happen when viewing the activity from a contact's activities tab.

After
----------------------------------------
Only appears once

Technical Details
----------------------------------------
@demeritcowboy I think your analysis of the cause is spot on - do you want to see if this seems to work for you?

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/1042