### PR TITLE
[REF] remove never-set, mispelt parameter

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -168,8 +168,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   public $_lineItemParticipantsCount;
   public $_availableRegistrations;
 
-  public $_forcePayement;
-
   /**
    * @var bool
    * @deprecated
@@ -233,8 +231,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     // check for waitlisting.
     $this->_allowWaitlist = $this->get('allowWaitlist');
 
-    $this->_forcePayement = $this->get('forcePayement');
-
     //get the additional participant ids.
     $this->_additionalParticipantIds = $this->get('additionalParticipantIds');
     $config = CRM_Core_Config::singleton();
@@ -252,7 +248,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
       // get all the values from the dao object
       $this->_values = $this->_fields = array();
-      $this->_forcePayement = FALSE;
 
       //retrieve event information
       $params = array('id' => $this->_eventId);

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -552,7 +552,6 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       CRM_Price_BAO_PriceSet::processAmount($self->_values['fee'], $fields, $lineItem);
       if ($fields['amount'] > 0) {
         $validatePayement = TRUE;
-        // $self->_forcePayement = true;
         // return false;
       }
     }

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -888,7 +888,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $isZeroAmount = TRUE;
       }
 
-      if ($isZeroAmount && !($form->_forcePayement && !empty($fields['additional_participants']))) {
+      if ($isZeroAmount) {
         $skipPaymentValidation = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
On digging into an issue around multiple payments I found the parameter $form->_forcePayement if never set to TRUE (the place where it was obviously expected to be possibly set was commented out) so it should go

Before
----------------------------------------
Parameter present

After
----------------------------------------
poof

Technical Details
----------------------------------------
Note I removed an 'if' that relies on it being TRUE since it never is

Comments
----------------------------------------
I am digging into https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/127 & I know that many years ago I wrote the code to move the payment block off the first page in this flow but abandoned it unreviewed (mostly because it was before LeXIM & it the processes were poorer back then).

 I suspect this might be part of that abandoned attempt
