### PR TITLE
Add unit test for net_amount when fee_amount is set

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1002,7 +1002,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     if (!$pending && $result) {
       $contribParams += [
         'fee_amount' => CRM_Utils_Array::value('fee_amount', $result),
-        'net_amount' => CRM_Utils_Array::value('net_amount', $result, $params['amount']),
         'trxn_id' => $result['trxn_id'],
         'receipt_date' => $receiptDate,
       ];

--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -105,6 +105,7 @@ class System {
    * @param int $id
    *
    * @return \CRM_Core_Payment|NULL
+   *
    * @throws \CiviCRM_API3_Exception
    */
   public function getById($id) {


### PR DESCRIPTION
Overview
----------------------------------------
This just improves testing & ensures fee_amount is used to set net amount.

I got some odd results on financial_trxn & financial_item but just adding checks for
what I found atm

Before
----------------------------------------
Less tests, net_amount not calculated off fee_amount

After
----------------------------------------
More tests, net_amount calculated

Technical Details
----------------------------------------
Preliminary digging towards https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/127

Comments
----------------------------------------
@mattwire I think this was something you were trying to tell me about - even though we say processors should only set fee_amount in this scenario that wasn't enough & without this patch they need to set net_amount too
