### PR TITLE
[REF] Add in cleanup function to prevnext service and utilise in clea…

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -296,7 +296,8 @@ FROM {$sql['from']}
 
       if (Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
         // SQL-backed prevnext cache uses an extra record for pruning the cache.
-        Civi::cache('prevNextCache')->set($cacheKey, $cacheKey);
+        // Also ensure that caches stay alive for 2 days a per previous code.
+        Civi::cache('prevNextCache')->set($cacheKey, $cacheKey, 60 * 60 * 24 * CRM_Core_PrevNextCache_Sql::cacheDays);
       }
     }
   }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1063,7 +1063,8 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     if (Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
       // SQL-backed prevnext cache uses an extra record for pruning the cache.
-      Civi::cache('prevNextCache')->set($cacheKey, $cacheKey);
+      // Also ensure that caches stay alive for 2 days as per previous code
+      Civi::cache('prevNextCache')->set($cacheKey, $cacheKey, 60 * 60 * 24 * CRM_Core_PrevNextCache_Sql::cacheDays);
     }
   }
 

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -467,22 +467,7 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
   }
 
   public static function cleanupCache() {
-    // clean up all prev next caches older than $cacheTimeIntervalDays days
-    $cacheTimeIntervalDays = 2;
-
-    // first find all the cacheKeys that match this
-    $sql = "
-DELETE     pn, c
-FROM       civicrm_cache c
-INNER JOIN civicrm_prevnext_cache pn ON c.path = pn.cachekey
-WHERE      c.group_name = %1
-AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
-";
-    $params = [
-      1 => [CRM_Utils_Cache::cleanKey('CiviCRM Search PrevNextCache'), 'String'],
-      2 => [$cacheTimeIntervalDays, 'Integer'],
-    ];
-    CRM_Core_DAO::executeQuery($sql, $params);
+    Civi::service('prevnext')->cleanup();
   }
 
   /**

--- a/CRM/Core/PrevNextCache/Interface.php
+++ b/CRM/Core/PrevNextCache/Interface.php
@@ -130,4 +130,9 @@ interface CRM_Core_PrevNextCache_Interface {
    */
   public function fetch($cacheKey, $offset, $rowCount);
 
+  /**
+   * Remove items from prev/next cache no longer current
+   */
+  public function cleanup();
+
 }

--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -252,4 +252,12 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     return [$allKey, $dataKey, $selKey, $maxScore];
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function cleanup() {
+    // Redis already handles cleaning up stale keys.
+    return;
+  }
+
 }


### PR DESCRIPTION
…nup cache situation

Overview
----------------------------------------
This is a split off from #14678 which seemed to get agreement generally

Before
----------------------------------------
No standard cleanup function as part of the prevnext cache service

After
----------------------------------------
Standard cleanup function ignored for redis as redis self cleans but migrates the SQL to the SQL service for cleanup purposes

ping @totten @eileenmcnaughton @mattwire 