### PR TITLE
[Export] Convert testGender Export to new test format.

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1403,18 +1403,17 @@ class CRM_Export_BAO_ExportProcessor {
     }
 
     $queryFields = $this->getQueryFields();
-    $lookUp = ['prefix_id', 'suffix_id'];
+    // @todo remove the enotice avoidance here, ensure all columns are declared.
+    // tests will fail on the enotices until they all are & then all the 'else'
+    // below can go.
+    $fieldSpec = $queryFields[$columnName] ?? [];
+
     // set the sql columns
-    if (isset($queryFields[$columnName]['type'])) {
-      switch ($queryFields[$columnName]['type']) {
+    if (isset($fieldSpec['type'])) {
+      switch ($fieldSpec['type']) {
         case CRM_Utils_Type::T_INT:
         case CRM_Utils_Type::T_BOOLEAN:
-          if (in_array($columnName, $lookUp)) {
-            return "$fieldName varchar(255)";
-          }
-          else {
-            return "$fieldName varchar(16)";
-          }
+          return "$fieldName varchar(16)";
 
         case CRM_Utils_Type::T_STRING:
           if (isset($queryFields[$columnName]['maxlength'])) {

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -522,12 +522,16 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * does NOT retain the gender of the former.
    *
    * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
    */
   public function testExportPseudoField() {
     $this->setUpContactExportData();
-    $selectedFields = [['Individual', 'gender_id']];
-    list($tableName, $sqlColumns) = $this->doExport($selectedFields, $this->contactIDs);
-    $this->assertEquals('Female,', CRM_Core_DAO::singleValueQuery("SELECT GROUP_CONCAT(gender_id) FROM {$tableName}"));
+    $this->callAPISuccess('OptionValue', 'create', ['option_group_id' => 'gender', 'name' => 'Really long string', 'value' => 678, 'label' => 'Really long string']);
+    $selectedFields = [['contact_type' => 'Individual', 'name' => 'gender_id']];
+    $this->callAPISuccess('Contact', 'create', ['id' => $this->contactIDs[0], 'gender_id' => 678]);
+    $this->doExportTest(['fields' => $selectedFields, 'ids' => $this->contactIDs]);
+    $row = $this->csv->fetchOne();
+    $this->assertEquals('Really long string', $row['Gender']);
   }
 
   /**
@@ -2484,12 +2488,12 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'prefix_id' => 'prefix_id varchar(255)',
       'suffix_id' => 'suffix_id varchar(255)',
       'formal_title' => 'formal_title varchar(64)',
-      'communication_style_id' => 'communication_style_id varchar(16)',
+      'communication_style_id' => 'communication_style_id varchar(255)',
       'email_greeting_id' => 'email_greeting_id varchar(16)',
       'postal_greeting_id' => 'postal_greeting_id varchar(16)',
       'addressee_id' => 'addressee_id varchar(16)',
       'job_title' => 'job_title varchar(255)',
-      'gender_id' => 'gender_id varchar(16)',
+      'gender_id' => 'gender_id varchar(255)',
       'birth_date' => 'birth_date varchar(32)',
       'is_deceased' => 'is_deceased varchar(16)',
       'deceased_date' => 'deceased_date varchar(32)',
@@ -2670,12 +2674,12 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'prefix_id' => 'prefix_id varchar(255)',
       'suffix_id' => 'suffix_id varchar(255)',
       'formal_title' => 'formal_title varchar(64)',
-      'communication_style_id' => 'communication_style_id varchar(16)',
+      'communication_style_id' => 'communication_style_id varchar(255)',
       'email_greeting_id' => 'email_greeting_id varchar(16)',
       'postal_greeting_id' => 'postal_greeting_id varchar(16)',
       'addressee_id' => 'addressee_id varchar(16)',
       'job_title' => 'job_title varchar(255)',
-      'gender_id' => 'gender_id varchar(16)',
+      'gender_id' => 'gender_id varchar(255)',
       'birth_date' => 'birth_date varchar(32)',
       'is_deceased' => 'is_deceased varchar(16)',
       'deceased_date' => 'deceased_date varchar(32)',


### PR DESCRIPTION
Overview
----------------------------------------
This is part of switching the tests to a new cleaner method

It includes a tangental cleanup & fix whereby I add test cover for a gender label longer than 16 char & consolidate the handling of gender & the other special case fields (prefix_id, suffix_id & communication_style_id)  by handling the special casing in the metadata declaration
on the query object

Before
----------------------------------------
Less std, gender labels longer than 16 char cause export fails

After
----------------------------------------
More std, long gender labels are supported

Technical Details
----------------------------------------
Early on in the switch to metadata handling for fields like gender_id, prefix_id the query object was updated to overwrite those fields with the label when processing out. More recently we adopted a pattern of outputting the original field AND a pseudofield with the field name being the option group name. This makes the handling of the first set clearer & means they are output correctly in export as a byproduct.

Comments
----------------------------------------

