### PR TITLE
Revert "[REF] use generic loadStandardSearchOptionsFromUrl". Fix search selections.

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -531,14 +531,17 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
      * driven by the wizard framework
      */
 
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
+
+    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean');
     $this->_groupID = CRM_Utils_Request::retrieve('gid', 'Positive', $this);
     $this->_amtgID = CRM_Utils_Request::retrieve('amtgID', 'Positive', $this);
+    $this->_ssID = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);
     $this->_sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter', 'String', $this);
     $this->_ufGroupID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     $this->_componentMode = CRM_Utils_Request::retrieve('component_mode', 'Positive', $this, FALSE, CRM_Contact_BAO_Query::MODE_CONTACTS, $_REQUEST);
     $this->_operator = CRM_Utils_Request::retrieve('operator', 'String', $this, FALSE, CRM_Contact_BAO_Query::SEARCH_OPERATOR_AND, 'REQUEST');
 
-    $this->loadStandardSearchOptionsFromUrl();
     /**
      * set the button names
      */
@@ -556,6 +559,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     }
 
     // assign context to drive the template display, make sure context is valid
+    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
     if (!CRM_Utils_Array::value($this->_context, self::validContext())) {
       $this->_context = 'search';
     }


### PR DESCRIPTION
Overview
-------------------

This reverts commit a5ca2ad8e16b145edf3a5604fab923d1e2386b37
and fixes a bug in management of the prev/next cache. The
bug is visible when following this procedure:

1. In browser, use "Quick search" to search for text "am"
2. In browser, select checkboxes next to two items
3. In MySQL CLI, run `select * from civicrm_prevnext_cache where is_selected =1;`. Observe that there are two selections.
4. In browser, continue to next page. **Observe that selection count drops to zero.**
5. In MySQL CLI, re-run SQL query. **Observe that the selections have disappeared.**

Before
-------------------

Proceeding to another page of search results causes loss of selections

After
-------------------

Selections are preserved
