### PR TITLE
[Membership-backoffice] Reduce reliance on multiple specific but confusing class variables

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1132,20 +1132,21 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     //take the required membership recur values.
     if ($this->_mode && !empty($formValues['auto_renew'])) {
       $params['is_recur'] = $formValues['is_recur'] = TRUE;
-      $mapping = [
-        'frequency_interval' => 'duration_interval',
-        'frequency_unit' => 'duration_unit',
-      ];
 
       $count = 0;
       foreach ($this->_memTypeSelected as $memType) {
         $recurMembershipTypeValues = CRM_Utils_Array::value($memType,
-          $this->_recurMembershipTypes, []
+          $this->allMembershipTypeDetails, []
         );
-        foreach ($mapping as $mapVal => $mapParam) {
-          $membershipTypeValues[$memType][$mapVal] = CRM_Utils_Array::value($mapParam,
-            $recurMembershipTypeValues
-          );
+        if (!$recurMembershipTypeValues['auto_renew']) {
+          continue;
+        }
+        foreach ([
+          'frequency_interval' => 'duration_interval',
+          'frequency_unit' => 'duration_unit',
+        ] as $mapVal => $mapParam) {
+          $membershipTypeValues[$memType][$mapVal] = $recurMembershipTypeValues[$mapParam];
+
           if (!$count) {
             $formValues[$mapVal] = CRM_Utils_Array::value($mapParam,
               $recurMembershipTypeValues


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/14888 seeks to add auto_renew as a parameter on buildMembershipTypeValues
but on digging the results of that are not used much & could be used less.

It's only because we store them far away from where we use them that the relative silliness is kinda
hidden.

This PR removes one of the reliances.

Note that testSubmitRecurCompleteInstant is a good one for stepping through this

Before
----------------------------------------
Use of second class var just for this purpose

After
----------------------------------------
Re-use of generic var

Technical Details
----------------------------------------
@mattwire I'm reluctant to add $recurOnly to the function signature here  https://github.com/civicrm/civicrm-core/pull/14888/files#diff-f43c8498e32f5b2d68ab27bcd243ca36L1555 beca
because I think we are adding complexity to a function we'd rather deprecate & by-pass. I propose this & a similar one to remove the use of $this->membershipTypeRenewalStatus (which is used once) instead

Comments
----------------------------------------

