### PR TITLE
Fix accidental move of sort_name field on advanced search

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -291,6 +291,8 @@ class CRM_Contact_Form_Search_Criteria {
   public static function getBasicSearchFields() {
     $userFramework = CRM_Core_Config::singleton()->userFramework;
     return [
+      // For now an empty array is still left in place for ordering.
+      'sort_name' => [],
       'email' => ['name' => 'email'],
       'contact_type' => ['name' => 'contact_type'],
       'group' => [


### PR DESCRIPTION
Overview
----------------------------------------
The code that made this field url-enterable ALSO re-ordered them by accident - this fixes

Before
----------------------------------------
<img width="602" alt="Screen Shot 2019-07-30 at 7 13 49 PM" src="https://user-images.githubusercontent.com/336308/62108511-580a0600-b2fe-11e9-9cdc-3cba49ec786b.png">


After
----------------------------------------
<img width="578" alt="Screen Shot 2019-07-30 at 7 15 18 PM" src="https://user-images.githubusercontent.com/336308/62108541-6526f500-b2fe-11e9-9f1a-adc16d48d38a.png">


Technical Details
----------------------------------------
The array is used in the template for rendering so the order matters. The array_merge fills the details but it needs to be in this array for ordering

Comments
----------------------------------------

