### PR TITLE
Core/dev#692 support for some additional url params

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -402,7 +402,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
      * id of the tagset.
      */
     if (isset($defaults['contact_tags'])) {
-      foreach ($defaults['contact_tags'] as $key => $tagId) {
+      foreach ((array) $defaults['contact_tags'] as $key => $tagId) {
         if (!is_array($tagId)) {
           $parentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $tagId, 'parent_id');
           $element = "contact_taglist[$parentId]";

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -104,9 +104,6 @@ class CRM_Contact_Form_Search_Criteria {
       }
     }
 
-    // add text box for last name, first name, street name, city
-    $form->add('text', 'email', ts('Complete OR Partial Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
-
     //added contact source
     $form->add('text', 'contact_source', ts('Contact Source'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'contact_source'));
 
@@ -257,10 +254,14 @@ class CRM_Contact_Form_Search_Criteria {
 
   /**
    * Get the metadata for fields to be included on the contact search form.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getSearchFieldMetadata() {
     $fields = [
       'sort_name' => ['title' => ts('Complete OR Partial Name'), 'template_grouping' => 'basic'],
+      'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
+      'contact_tags' => ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'template_grouping' => 'basic'],
     ];
     $metadata = civicrm_api3('Contact', 'getfields', [])['values'];
     foreach ($fields as $fieldName => $field) {

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -187,12 +187,17 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
     $this->_action = CRM_Core_Action::ADVANCED;
     foreach ($this->getSearchFieldMetadata() as $entity => $fields) {
       foreach ($fields as $fieldName => $fieldSpec) {
-        if ($fieldSpec['type'] === CRM_Utils_Type::T_DATE || $fieldSpec['type'] === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)) {
+        $fieldType = $fieldSpec['type'] ?? '';
+        if ($fieldType === CRM_Utils_Type::T_DATE || $fieldType === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)) {
           $title = empty($fieldSpec['unique_title']) ? $fieldSpec['title'] : $fieldSpec['unique_title'];
-          $this->addDatePickerRange($fieldName, $title, ($fieldSpec['type'] === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)));
+          $this->addDatePickerRange($fieldName, $title, ($fieldType === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)));
         }
         else {
-          $props = ['entity' => $entity];
+          // Not quite sure about moving to a mix of keying by entity vs permitting entity to
+          // be passed in. The challenge of the former is that it doesn't permit ordering.
+          // Perhaps keying was the wrong starting point & we should do a flat array as all
+          // fields eventually need to be unique.
+          $props = ['entity' => $fieldSpec['entity'] ?? $entity];
           if (isset($fields[$fieldName]['unique_title'])) {
             $props['label'] = $fields[$fieldName]['unique_title'];
           }


### PR DESCRIPTION
Overview
----------------------------------------
Opening this to indicate the direction I think https://github.com/civicrm/civicrm-core/pull/14418 needs to go in.

We already have url support for several params through metadata & a methodology for adding more.

However, as we see from https://github.com/civicrm/civicrm-core/pull/14918 there is an underlying challenge to get the url params respected when force=1 - and where we do get it working it doesn't always stay working.

It seems like 

Before
----------------------------------------
No url support for contact_tags or email

After
----------------------------------------
http://dmaster.local/civicrm/contact/search/advanced?reset=1&sort_name=p&email=p&contact_tags=4 preloads the fields - but force=1 still not working :-(

Technical Details
----------------------------------------
This extends our general metadata based approach to the search forms. 

The metadata is currently being defined in functions on the relevant BAO_Query objects - eg

```
  /**
   * Get the metadata for fields to be included on the activity search form.
   *
   * @todo ideally this would be a trait included on the activity search & advanced search
   * rather than a static function.
   */
  public static function getSearchFieldMetadata() {
    $fields = ['activity_type_id', 'activity_date_time', 'priority_id', 'activity_location'];
    $metadata = civicrm_api3('Activity', 'getfields', [])['values'];
    $metadata = array_intersect_key($metadata, array_flip($fields));
    $metadata['activity_text'] = [
      'title' => ts('Activity Text'),
      'type' => CRM_Utils_Type::T_STRING,
      'is_pseudofield' => TRUE,
    ];
    return $metadata;
  }
```

By virtue of being defined there those forms are 
- available for url searching
- use wildcards for like searches for text fields (e.g activity_date)
- use datepicker if appropriate
- fields are added without being separately added

Currently they are added like
```
    $form->addSearchFieldMetadata(['Activity' => self::getSearchFieldMetadata()]);
```

from the buildSearchForm function 

However, perhaps calling from preProcess makes more sense. I'm not wedded to them being on the Query objects- I would have rathered it was ALL from the forms.

In the medium term we want to stop altering advanced search & freeze it & switch to [something sane](https://lab.civicrm.org/dev/core/issues/1106) IMHO but working towards it now the more we define what it already DOES do in std-ised metadata based ways the more it helps us to take that to a better framework

Comments
----------------------------------------
Documentation for urls is here https://github.com/civicrm/civicrm-dev-docs/issues/624 - keep adding

Needs rebasing after https://github.com/civicrm/civicrm-core/pull/14920