### PR TITLE
dev/core#1084 Contribution confirmation page: Translation won't work

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -296,13 +296,9 @@
     <div class="messages status continue_instructions-section">
       <p>
         {if $is_pay_later OR $amount LE 0.0}
-          {ts 1=$button}Your transaction will not be completed until you click the
-            <strong>%1</strong>
-            button. Please click the button one time only.{/ts}
+          {ts 1=$button}Your transaction will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
         {else}
-          {ts 1=$button}Your contribution will not be completed until you click the
-            <strong>%1</strong>
-            button. Please click the button one time only.{/ts}
+          {ts 1=$button}Your contribution will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
         {/if}
       </p>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
Quoting the issue description [CORE-1084](https://lab.civicrm.org/dev/core/issues/1084):

The message `{ts 1=$button}Your contribution will not be completed until you click the %1 button. Please click the button one time only.{/ts}` is not translated.
The reason is: The code is split over several lines and contains spaces, linebreaks and tab characters. This breaks the gettext translation.

Comments
----------------------------------------
Please credit [Detlev](https://lab.civicrm.org/Detlev) for this PR, I'm just submitting it for this regression to get resolved quickly.
