### PR TITLE
Remove template field if using Mosaico in non shoreditch mode

### DIFF
--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -6,7 +6,7 @@ It could perhaps be thinned by 30-60% by making more directives.
 -->
 <div class="crm-block" ng-form="subform" crm-ui-id-scope>
   <div class="crm-group">
-    <div crm-ui-field="{name: 'subform.msg_template_id', title: ts('Template')}">
+    <div crm-ui-field="{name: 'subform.msg_template_id', title: ts('Template')}" ng-if="mailing.template_type=='traditional'">
       <div crm-mailing-block-templates="{name: 'templates', id: 'subform.msg_template_id'}" crm-mailing="mailing"></div>
     </div>
     <div crm-ui-field="{name: 'subform.fromAddress', title: ts('From'), help: hs('from_email')}">

--- a/ang/crmMailingAB/BlockMailing.html
+++ b/ang/crmMailingAB/BlockMailing.html
@@ -14,56 +14,56 @@ processed by Angular; if false, the field will be hidden and completely ignored 
 <div class="crm-block" ng-form="subform" crm-ui-id-scope>
   <div class="crm-group">
 
-
-    <div crm-ui-field="{name: 'subform.msg_template_id', title: ts('Template')}" ng-if="fields.msg_template_id">
-      <div ng-controller="MsgTemplateCtrl">
-        <select
-          crm-ui-id="subform.msg_template_id"
-          name="msg_template_id"
-          class="fa-clipboard"
-          crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Message Template')}"
-          ng-model="abtest.mailings.a.msg_template_id"
-          ng-change="loadTemplate(abtest.mailings.a, abtest.mailings.a.msg_template_id)"
-          >
-          <option value=""></option>
-          <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
-        </select>
-        <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+    <div ng-if="abtest.mailings.a.template_type=='traditional'">
+      <div crm-ui-field="{name: 'subform.msg_template_id', title: ts('Template')}" ng-if="fields.msg_template_id">
+        <div ng-controller="MsgTemplateCtrl">
+          <select
+            crm-ui-id="subform.msg_template_id"
+            name="msg_template_id"
+            class="fa-clipboard"
+            crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Message Template')}"
+            ng-model="abtest.mailings.a.msg_template_id"
+            ng-change="loadTemplate(abtest.mailings.a, abtest.mailings.a.msg_template_id)"
+            >
+            <option value=""></option>
+            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
+          </select>
+          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+        </div>
+      </div>
+      <div crm-ui-field="{name: 'subform.msg_template_idA', title: ts('Template (A)')}" ng-if="fields.msg_template_idA">
+        <div ng-controller="MsgTemplateCtrl">
+          <select
+            crm-ui-id="subform.msg_template_idA"
+            name="msg_template_idA"
+            class="fa-clipboard"
+            crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Message Template')}"
+            ng-model="abtest.mailings.a.msg_template_id"
+            ng-change="loadTemplate(abtest.mailings.a, abtest.mailings.a.msg_template_id)"
+            >
+            <option value=""></option>
+            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
+          </select>
+          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+        </div>
+      </div>
+      <div crm-ui-field="{name: 'subform.msg_template_idB', title: ts('Template (B)')}" ng-if="fields.msg_template_idB">
+        <div ng-controller="MsgTemplateCtrl">
+          <select
+            crm-ui-id="subform.msg_template_idB"
+            name="msg_template_idB"
+            class="fa-clipboard"
+            crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Message Template')}"
+            ng-model="abtest.mailings.b.msg_template_id"
+            ng-change="loadTemplate(abtest.mailings.b, abtest.mailings.b.msg_template_id)"
+            >
+            <option value=""></option>
+            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
+          </select>
+          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.b)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+        </div>
       </div>
     </div>
-    <div crm-ui-field="{name: 'subform.msg_template_idA', title: ts('Template (A)')}" ng-if="fields.msg_template_idA">
-      <div ng-controller="MsgTemplateCtrl">
-        <select
-          crm-ui-id="subform.msg_template_idA"
-          name="msg_template_idA"
-          class="fa-clipboard"
-          crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Message Template')}"
-          ng-model="abtest.mailings.a.msg_template_id"
-          ng-change="loadTemplate(abtest.mailings.a, abtest.mailings.a.msg_template_id)"
-          >
-          <option value=""></option>
-          <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
-        </select>
-        <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
-      </div>
-    </div>
-    <div crm-ui-field="{name: 'subform.msg_template_idB', title: ts('Template (B)')}" ng-if="fields.msg_template_idB">
-      <div ng-controller="MsgTemplateCtrl">
-        <select
-          crm-ui-id="subform.msg_template_idB"
-          name="msg_template_idB"
-          class="fa-clipboard"
-          crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Message Template')}"
-          ng-model="abtest.mailings.b.msg_template_id"
-          ng-change="loadTemplate(abtest.mailings.b, abtest.mailings.b.msg_template_id)"
-          >
-          <option value=""></option>
-          <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
-        </select>
-        <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.b)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
-      </div>
-    </div>
-
 
     <div crm-ui-field="{name: 'subform.fromAddress', title: ts('From'), help: hs('from_email')}" ng-if="fields.fromAddress">
       <span ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="abtest.mailings.a">


### PR DESCRIPTION
Overview
----------------------------------------
This aims to accomplish something akin to what @agileware-pengyi was aiming to do in https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/pull/322. This does this by only showing the template field if the template_type is traditional

Before
----------------------------------------
Template field shown even if using Mosaico Template but not using shoreditch

After
----------------------------------------
Template field hidden in Mosicao

ping @eileenmcnaughton @agileware-pengyi @totten 