### PR TITLE
dev/core#1158 mailing labels: explicitly set primary flag

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -179,9 +179,11 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
       $location = ['location' => ["{$locName}" => $address]];
       $returnProperties = array_merge($returnProperties, $location);
       $params[] = ['location_type', '=', [1 => $fv['location_type_id']], 0, 0];
+      $primaryLocationOnly = FALSE;
     }
     else {
       $returnProperties = array_merge($returnProperties, $address);
+      $primaryLocationOnly = TRUE;
     }
 
     $rows = [];
@@ -214,7 +216,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
     //get the total number of contacts to fetch from database.
     $numberofContacts = count($this->_contactIds);
     $query = new CRM_Contact_BAO_Query($params, $returnProperties);
-    $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts);
+    $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts, TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, $primaryLocationOnly);
 
     $messageToken = CRM_Utils_Token::getTokens($mailingFormat);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix mailing label primary location flag. Problem occurs if the global "Search Primary Details Only" option is turned off.

Before
----------------------------------------
Selecting primary location when generating mailing labels would not consistently export the correct address.

After
----------------------------------------
Selecting primary location works correctly.

Technical Details
----------------------------------------
The CRM_Contact_BAO_Query constructor (which is called by apiQuery) supports explicitly passing a parameter to search primary location only. If absent, it sets the value based on the global setting. The mailing label task called apiQuery and incorrectly assumed the primary record would be returned. This change explicitly sets that value if no location type is selected (i.e. the primary location is requested).