### PR TITLE
Catch Payment Processor Exception if thrown when registering via bac…

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1256,10 +1256,14 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       // CRM-15622: fix for incorrect contribution.fee_amount
       $paymentParams['fee_amount'] = NULL;
-      $result = $payment->doPayment($paymentParams);
-
-      if (is_a($result, 'CRM_Core_Error')) {
-        CRM_Core_Error::displaySessionError($result);
+      try {
+        $result = $payment->doPayment($paymentParams);
+      }
+      catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+        // @todo un comment the following line out when we are creating a contribution before we get to this point
+        // see dev/financial#53 about ensuring we create a pending contribution before we try processing payment
+        // CRM_Contribute_BAO_Contribution::failPayment($contributionID);
+        CRM_Core_Session::singleton()->setStatus($e->getMessage());
         CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view/participant',
           "reset=1&action=add&cid={$this->_contactId}&context=participant&mode={$this->_mode}"
         ));


### PR DESCRIPTION
…k office participant registration

Overview
----------------------------------------
This catches any Exception thrown by the Payment Processor as it doesn't appear to be caught anywhere else and then sets a standard style status message

Before
----------------------------------------
Payment Processor Exception not caught

After
----------------------------------------
Payment Processor Exception caught 

ping @eileenmcnaughton 