### PR TITLE
[REF] [Test] [Export] Convert some more tests to use the newer function

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1397,11 +1397,6 @@ class CRM_Export_BAO_ExportProcessor {
       return "$fieldName varchar(128)";
     }
 
-    if (substr($fieldName, -11) == 'campaign_id') {
-      // CRM-14398
-      return "$fieldName varchar(128)";
-    }
-
     $queryFields = $this->getQueryFields();
     // @todo remove the enotice avoidance here, ensure all columns are declared.
     // tests will fail on the enotices until they all are & then all the 'else'


### PR DESCRIPTION
Overview
----------------------------------------
Converts some tests to new helper & also cleans up special handling on campaign_id fields

Before
----------------------------------------
Uses old helper, unnecessary handling

After
----------------------------------------
New helper, handling removed

Technical Details
----------------------------------------
In testing this I checked and all the exports export an integer in the campaign_id field. Contribution
ALSO exports campaign_title field - which is unaffected by the removed lines (& for contribution both are tested)

I see the reference to https://issues.civicrm.org/jira/browse/CRM-14398 is for contribution which is covered by the unit test


Comments
----------------------------------------

