### PR TITLE
dev/core#439 [Export] [Ref] Convert custom data export test to use newer function.

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -541,7 +541,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           // Search table is used by query object searches..
           $fields[$dao->id]['search_table'] = ($fields[$dao->id]['extends_table'] == 'civicrm_contact') ? 'contact_a' : $fields[$dao->id]['extends_table'];
           self::getOptionsForField($fields[$dao->id], $dao->option_group_name);
-
         }
 
         Civi::cache('fields')->set("custom importableFields $cacheKey", $fields);

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1413,6 +1413,9 @@ class CRM_Export_BAO_ExportProcessor {
       switch ($fieldSpec['type']) {
         case CRM_Utils_Type::T_INT:
         case CRM_Utils_Type::T_BOOLEAN:
+          if (in_array(CRM_Utils_Array::value('data_type', $fieldSpec), ['Country', 'StateProvince', 'ContactReference'])) {
+            return "$fieldName varchar(255)";
+          }
           return "$fieldName varchar(16)";
 
         case CRM_Utils_Type::T_STRING:
@@ -1469,8 +1472,6 @@ class CRM_Export_BAO_ExportProcessor {
                 $length = max(512, CRM_Utils_Array::value('text_length', $queryFields[$columnName]));
                 return "$fieldName varchar($length)";
 
-              case 'Country':
-              case 'StateProvince':
               case 'Link':
                 return "$fieldName varchar(255)";
 

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -445,7 +445,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'custom_field_id' => $this->getCustomFieldID('country'),
         'options_per_line' => NULL,
         'text_length' => NULL,
-        'data_type' => 'Int',
+        'data_type' => 'Country',
         'html_type' => 'Select Country',
         'is_search_range' => '0',
         'id' => $this->getCustomFieldID('country'),
@@ -467,6 +467,12 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'where' => 'civicrm_value_custom_group_' . $customGroupID . '.country_' . $this->getCustomFieldID('country'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
+        'pseudoconstant' => [
+          'table' => 'civicrm_country',
+          'keyColumn' => 'id',
+          'labelColumn' => 'name',
+          'nameColumn' => 'iso_code',
+        ],
       ],
       $this->getCustomFieldName('file') => [
         'name' => $this->getCustomFieldName('file'),

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -142,7 +142,7 @@ trait CRMTraits_Custom_CustomDataTrait {
     $ids['file'] = $fileField['id'];
     $ids['country'] = $this->customFieldCreate([
       'custom_group_id' => $customGroupID,
-      'data_type' => 'Int',
+      'data_type' => 'Country',
       'html_type' => 'Select Country',
       'default_value' => '',
       'label' => 'Country',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the test & in the process fixes the handling for custom country fields to be where it is actually hit now. The code lines for custom fields are in a block that assumes 'type' will not be in the metadata for custom fields. That was one of these 'this is how the data is right this moment in time so I will build logic off it' type assumptions which riddles our code base.

Of course over time the metadata was fixed - leading to the assumption that custom fields would not have metadata being wrong. I have fixed it for the fields addressed in this test

Before
----------------------------------------
Old test helper

After
----------------------------------------
New test helper, parsing for country names longer than 16 chars

Technical Details
----------------------------------------
Part of general LeXIM cleanup to support extension leap on export UI

Comments
----------------------------------------

