### PR TITLE
Extend contribute search url parsing to advanced search

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -731,7 +731,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     $controller->setDynamicAction($setDynamic);
 
     if ($this->_force) {
-
+      $this->loadMetadata();
       $this->postProcess();
 
       /*
@@ -907,6 +907,18 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
    */
   public function getTitle() {
     return ts('Search');
+  }
+
+  /**
+   * Load metadata for fields on the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function loadMetadata() {
+    // @todo - check what happens if the person does not have 'access civicontribute' - make sure they
+    // can't by pass acls by passing search criteria in the url.
+    $this->addSearchFieldMetadata(['Contribution' => CRM_Contribute_BAO_Query::getSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['ContributionRecur' => CRM_Contribute_BAO_ContributionRecur::getContributionRecurSearchFieldMetadata()]);
   }
 
 }

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -414,8 +414,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if (!$this->_force) {
       return;
     }
-    // Start by loading url defaults.
-    $this->_formValues = $this->setDefaultValues();
 
     $status = CRM_Utils_Request::retrieve('status', 'String');
     if ($status) {

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -133,7 +133,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    */
   public function setDefaultValues() {
     $defaults = (array) $this->_formValues;
-    foreach (['Contact', $this->getDefaultEntity()] as $entity) {
+    foreach (array_keys($this->getSearchFieldMetadata()) as $entity) {
       $defaults = array_merge($this->getEntityDefaults($entity), $defaults);
     }
     return $defaults;
@@ -141,10 +141,15 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
 
   /**
    * Set the form values based on input and preliminary processing.
+   *
+   * @throws \Exception
    */
   protected function setFormValues() {
     if (!empty($_POST) && !$this->_force) {
       $this->_formValues = $this->controller->exportValues($this->_name);
+    }
+    elseif ($this->_force) {
+      $this->_formValues = $this->setDefaultValues();
     }
     $this->convertTextStringsToUseLikeOperator();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Makes url search params that work in contribution search work in advanced search

Before
----------------------------------------
Params have no effect if passed in the url

After
----------------------------------------
<img width="807" alt="Screen Shot 2019-07-31 at 9 46 09 PM" src="https://user-images.githubusercontent.com/336308/62202037-a4c40e80-b3dc-11e9-91fd-f84a0acfa246.png">


Technical Details
----------------------------------------
@monishdeb this was where my train of thought was going when I drifted off in my other code comments - I was digging in the contribution search & seeing why it worked there & this seems like a more generic version of that. At this stage only the contribution metadata is added so only those fields work. I think the loadMetadata() function could load all entities - but I think this needs some permissions testing (which I haven't done yet) before extending.

However, once done it would just be a case of adding

```
$this->addSearchFieldMetadata(['Activity' => CRM_Activity_BAO_Activity::getActivitySearchFieldMetadata()]);
```

And then activity_date_time_high etc should also work

Comments
----------------------------------------

