### PR TITLE
Fix mishandling of renamed membership status labels on membership import

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -1011,18 +1011,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
           ) {
             $realField = $fields[$key]['is_pseudofield_for'] ?? $key;
             $realFieldSpec = $fields[$realField];
-            /* @var \CRM_Core_DAO $bao */
-            $bao = $realFieldSpec['bao'];
-            // Get names & labels - we will try to match name first but if not available then see if
-            // we have a label that can be converted to a name.
-            // For historical reasons use validate as context - ie disabled name matches ARE permitted per prior to change.
-            $nameOptions = $bao::buildOptions($realField, 'validate');
-            if (!isset($nameOptions[$value])) {
-              $labelOptions = array_flip($bao::buildOptions($realField, 'match'));
-              if (isset($labelOptions[$params[$key]])) {
-                $values[$key] = $labelOptions[$params[$key]];
-              }
-            }
+            $values[$key] = $this->parsePseudoConstantField($value, $realFieldSpec);
           }
           break;
       }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -300,8 +300,8 @@ class CRM_Core_PseudoConstant {
         $cacheKey = $daoName . $fieldName . serialize($params);
 
         // Retrieve cached options
-        if (isset(self::$cache[$cacheKey]) && empty($params['fresh'])) {
-          $output = self::$cache[$cacheKey];
+        if (isset(\Civi::$statics[__CLASS__][$cacheKey]) && empty($params['fresh'])) {
+          $output = \Civi::$statics[__CLASS__][$cacheKey];
         }
         else {
           $daoName = CRM_Core_DAO_AllCoreTables::getClassForTable($pseudoconstant['table']);
@@ -386,7 +386,7 @@ class CRM_Core_PseudoConstant {
             }
           }
           CRM_Utils_Hook::fieldOptions($entity, $fieldName, $output, $params);
-          self::$cache[$cacheKey] = $output;
+          \Civi::$statics[__CLASS__][$cacheKey] = $output;
         }
         return $flip ? array_flip($output) : $output;
       }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -520,4 +520,29 @@ abstract class CRM_Import_Parser {
     return $error;
   }
 
+  /**
+   * Parse a field which could be represented by a label or name value rather than the DB value.
+   *
+   * We will try to match name first but if not available then see if we have a label that can be converted to a name.
+   *
+   * @param string|int|null $submittedValue
+   * @param array $fieldSpec
+   *   Metadata for the field
+   *
+   * @return mixed
+   */
+  protected function parsePseudoConstantField($submittedValue, $fieldSpec) {
+    /* @var \CRM_Core_DAO $bao */
+    $bao = $fieldSpec['bao'];
+    // For historical reasons use validate as context - ie disabled name matches ARE permitted.
+    $nameOptions = $bao::buildOptions($fieldSpec['name'], 'validate');
+    if (!isset($nameOptions[$submittedValue])) {
+      $labelOptions = array_flip($bao::buildOptions($fieldSpec['name'], 'match'));
+      if (isset($labelOptions[$submittedValue])) {
+        return array_search($labelOptions[$submittedValue], $nameOptions, TRUE);
+      }
+    }
+    return '';
+  }
+
 }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -49,6 +49,13 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
   private $_membershipStatusIndex;
 
   /**
+   * Array of metadata for all available fields.
+   *
+   * @var array
+   */
+  protected $fieldMetadata = [];
+
+  /**
    * Array of successfully imported membership id's
    *
    * @var array
@@ -59,12 +66,10 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
    * Class constructor.
    *
    * @param $mapperKeys
-   * @param null $mapperLocType
-   * @param null $mapperPhoneType
    */
-  public function __construct(&$mapperKeys, $mapperLocType = NULL, $mapperPhoneType = NULL) {
+  public function __construct($mapperKeys) {
     parent::__construct();
-    $this->_mapperKeys = &$mapperKeys;
+    $this->_mapperKeys = $mapperKeys;
   }
 
   /**
@@ -73,9 +78,10 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
    * @return void
    */
   public function init() {
-    $fields = CRM_Member_BAO_Membership::importableFields($this->_contactType, FALSE);
+    $this->fieldMetadata = CRM_Member_BAO_Membership::importableFields($this->_contactType, FALSE);
 
-    foreach ($fields as $name => $field) {
+    foreach ($this->fieldMetadata as $name => $field) {
+      // @todo - we don't really need to do all this.... fieldMetadata is just fine to use as is.
       $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
       $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
       $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
@@ -223,6 +229,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
             break;
 
           case 'membership_type_id':
+            // @todo - squish into membership status - can use same lines here too.
             $membershipTypes = CRM_Member_PseudoConstant::membershipType();
             if (!CRM_Utils_Array::crmInArray($val, $membershipTypes) &&
               !array_key_exists($val, $membershipTypes)
@@ -232,7 +239,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
             break;
 
           case 'status_id':
-            if (!CRM_Utils_Array::crmInArray($val, CRM_Member_PseudoConstant::membershipStatus())) {
+            if (!empty($val) && !$this->parsePseudoConstantField($val, $this->fieldMetadata[$key])) {
               CRM_Contact_Import_Parser_Contact::addToErrorMsg('Membership Status', $errorMessage);
             }
             break;
@@ -324,10 +331,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
               break;
 
             case 'status_id':
-              if (!is_numeric($val)) {
-                unset($params['status_id']);
-                $params['membership_status'] = $val;
-              }
+              // @todo - we can do this based on the presence of 'pseudoconstant' in the metadata rather than field specific.
+              $params[$key] = $this->parsePseudoConstantField($val, $this->fieldMetadata[$key]);
               break;
 
             case 'is_override':
@@ -346,12 +351,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
         }
       }
       //date-Format part ends
-
-      static $indieFields = NULL;
-      if ($indieFields == NULL) {
-        $tempIndieFields = CRM_Member_DAO_Membership::import();
-        $indieFields = $tempIndieFields;
-      }
 
       $formatValues = [];
       foreach ($params as $key => $field) {
@@ -719,30 +718,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
             throw new Exception('Invalid Membership Type');
           }
           $values['membership_type_id'] = $membershipTypeId;
-          break;
-
-        case 'status_id':
-          if (!CRM_Utils_Array::value($value, CRM_Member_PseudoConstant::membershipStatus())) {
-            throw new Exception('Invalid Membership Status Id');
-          }
-          $values[$key] = $value;
-          break;
-
-        case 'membership_status':
-          $membershipStatusId = CRM_Utils_Array::key(ucfirst($value),
-            CRM_Member_PseudoConstant::membershipStatus()
-          );
-          if ($membershipStatusId) {
-            if (!empty($values['status_id']) &&
-              $membershipStatusId != $values['status_id']
-            ) {
-              throw new Exception('Mismatched membership Status and Membership Status Id');
-            }
-          }
-          else {
-            throw new Exception('Invalid Membership Status');
-          }
-          $values['status_id'] = $membershipStatusId;
           break;
 
         default:

--- a/CRM/Member/PseudoConstant.php
+++ b/CRM/Member/PseudoConstant.php
@@ -132,6 +132,9 @@ class CRM_Member_PseudoConstant extends CRM_Core_PseudoConstant {
     if (isset(self::$$name)) {
       self::$$name = NULL;
     }
+    // The preferred source of membership pseudoconstants is in fact the Core class.
+    // which buildOptions accesses - better flush that too.
+    CRM_Core_PseudoConstant::flush();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug that especially affects multilingual sites where the 'Membership Status' is compared against the 'name' field but not the 'label'

https://github.com/civicrm/civicrm-core/pull/14881#issuecomment-515359860

Before
----------------------------------------
Cannot import with a renamed 'status'

After
----------------------------------------
Can

Technical Details
----------------------------------------
Builds on the recent fix for contribution payment instrument but makes it more generic

Comments
----------------------------------------
@sluc23 can you review?