### PR TITLE
[Report] Fix handling of location type in Reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5777,7 +5777,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'options' => CRM_Core_PseudoConstant::country(),
       ],
       $options['prefix'] . 'location_type_id' => [
-        'name' => 'is_primary',
+        'name' => 'location_type_id',
         'title' => $options['prefix_label'] . ts('Location Type'),
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,

--- a/tests/phpunit/CRM/Report/Form/ContactSummaryTest.php
+++ b/tests/phpunit/CRM/Report/Form/ContactSummaryTest.php
@@ -196,4 +196,36 @@ class CRM_Report_Form_ContactSummaryTest extends CiviReportTestCase {
     }
   }
 
+  /**
+   * Test that Loation Type prints out a sensible piece of data
+   */
+  public function testLocationTypeIdHandling() {
+    $customLocationType = $this->callAPISuccess('LocationType', 'create', [
+      'name' => 'Custom Location Type',
+      'display_name' => 'CiviTest Custom Location Type',
+      'is_active' => 1,
+    ]);
+    $this->individualCreate([
+      'api.Address.create' => [
+        'location_type_id' => $customLocationType['id'],
+        'is_primary' => 1,
+        'street_number' => 3,
+      ],
+    ]);
+    $input = [
+      'fields' => [
+        'address_street_number',
+        'address_odd_street_number',
+        'address_location_type_id',
+      ],
+    ];
+    $obj = $this->getReportObject('CRM_Report_Form_Contact_Summary', $input);
+    $obj->setParams($obj->getParams());
+    $sql = $obj->buildQuery(TRUE);
+    $rows = [];
+    $obj->buildRows($sql, $rows);
+    $obj->formatDisplay($rows);
+    $this->assertEquals('CiviTest Custom Location Type', $rows[0]['civicrm_address_address_location_type_id']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug in the processing of location_type_id field for addresses in reports. Because the array key's name is is_primary it is either reporting only blank or Home which is generally the label for location type id 1. 

Before
----------------------------------------
Wrong field queried for location_type_id

After
----------------------------------------
Correct field queried and test added to lock in handling

ping @eileenmcnaughton @mattwire 