### PR TITLE
Fix removeNullContactTokens compatibility with custom tokens

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1434,12 +1434,12 @@ class CRM_Utils_Token {
    * @param array $greetingTokens
    */
   private static function removeNullContactTokens(&$tokenString, $contactDetails, &$greetingTokens) {
-    
+
     // Only applies to contact tokens
     if (!array_key_exists('contact', $greetingTokens)) {
       return;
     }
-    
+
     $greetingTokensOriginal = $greetingTokens;
     $contactFieldList = CRM_Contact_DAO_Contact::fields();
     // Sometimes contactDetails are in a multidemensional array, sometimes a

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1434,6 +1434,12 @@ class CRM_Utils_Token {
    * @param array $greetingTokens
    */
   private static function removeNullContactTokens(&$tokenString, $contactDetails, &$greetingTokens) {
+    
+    // Only applies to contact tokens
+    if (!array_key_exists('contact', $greetingTokens)) {
+      return;
+    }
+    
     $greetingTokensOriginal = $greetingTokens;
     $contactFieldList = CRM_Contact_DAO_Contact::fields();
     // Sometimes contactDetails are in a multidemensional array, sometimes a

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -78,6 +78,11 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
     $escapeSmarty = TRUE;
     CRM_Utils_Token::replaceGreetingTokens($tokenString, $contactDetails, $contactId, $className, $escapeSmarty);
     $this->assertEquals($tokenString, 'First Name: Morticia Last Name: Addams Birth Date:  Prefix: Ms. Suffix: ');
+
+    // Test compatibility with custom tokens (#14943)
+    $tokenString = 'Custom {custom.custom}';
+    CRM_Utils_Token::replaceGreetingTokens($tokenString, $contactDetails, $contactId, $className, $escapeSmarty);
+    $this->assertEquals($tokenString, 'Custom ');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
removeNullContactTokens offers a performance improvement regarding tokens associated with greetings. In normal use case all these tokens belong to the 'contact' token group.

However, using took_civicrm_tokens, custom token groups can be defined.

This causes an error in removeNullContactTokens, because it is specifically looking for the 'contact' array when called:

```
Notice: Undefined index: contact in CRM_Utils_Token::removeNullContactTokens() (line 1472 of .../CRM/Utils/Token.php).
Warning: array_diff(): Argument #1 is not an array in CRM_Utils_Token::removeNullContactTokens() (line 1472 of .../CRM/Utils/Token.php).
Notice: Undefined index: contact in CRM_Utils_Token::removeNullContactTokens() (line 1475 of .../CRM/Utils/Token.php).
Warning: array_diff(): Argument #1 is not an array in CRM_Utils_Token::removeNullContactTokens() (line 1475 of .../CRM/Utils/Token.php).
```

This PR adds a simple check to ensure the array key is set, so the rest of the function can perform normally.

Before
----------------------------------------
PHP notices and warnings with custom tokens when updating a contact record.

After
----------------------------------------
No notices and warnings with custom tokens when updating a contact record.

Technical Details
----------------------------------------
Simple if with a return, formatted for readability rather than brevity.
