### PR TITLE
Add missing is_public flags to public paths

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -275,7 +275,7 @@
   </item>
   <item>
      <path>civicrm/admin/scheduleReminders</path>
-     <title>Schedule Reminders</title>[A
+     <title>Schedule Reminders</title>
      <desc>Schedule Reminders.</desc>
      <page_callback>CRM_Admin_Page_ScheduleReminders</page_callback>
      <access_callback>1</access_callback>
@@ -719,6 +719,7 @@
      <path>civicrm/sms/callback</path>
      <page_callback>CRM_SMS_Page_Callback</page_callback>
      <access_callback>1</access_callback>
+     <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/admin/badgelayout</path>

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -203,6 +203,7 @@
     <path>civicrm/ajax/l10n-js</path>
     <page_callback>CRM_Core_Resources::outputLocalizationJS</page_callback>
     <access_callback>1</access_callback>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/shortcode</path>

--- a/CRM/Event/xml/Menu/Event.xml
+++ b/CRM/Event/xml/Menu/Event.xml
@@ -300,11 +300,13 @@
     <path>civicrm/ajax/event/add_participant_to_cart</path>
     <page_callback>CRM_Event_Cart_Page_CheckoutAJAX::add_participant_to_cart</page_callback>
     <access_callback>1</access_callback>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/ajax/event/remove_participant_from_cart</path>
     <page_callback>CRM_Event_Cart_Page_CheckoutAJAX::remove_participant_from_cart</page_callback>
     <access_callback>1</access_callback>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/event/add_to_cart</path>

--- a/CRM/Report/xml/Menu/Report.xml
+++ b/CRM/Report/xml/Menu/Report.xml
@@ -14,6 +14,7 @@
      <title>CiviCRM Reports</title>
      <page_callback>CRM_Report_Page_InstanceList</page_callback>
      <access_callback>1</access_callback>
+     <is_public>true</is_public>
   </item>
   <item>
      <path>civicrm/report/template/list</path>
@@ -43,6 +44,7 @@
      <title>Report</title>
      <page_callback>CRM_Report_Page_Instance</page_callback>
      <access_callback>1</access_callback>
+     <is_public>true</is_public>
   </item>
   <item>
      <path>civicrm/admin/report/template/list</path>


### PR DESCRIPTION
Overview
----------------------------------------
The menu definition has a flag for 'is_public' that defines if a path can be viewed by 'the public'. Sometimes this includes 'the public, but with the right permissions (eg: 'make online contribution' pages are still 'public').

This PR adds the is_public flag to all pages that have an access callback of '1', but are missing the 'is_public' flag.

The exception is the 'civicrm/admin/scheduleReminders' path. Although it has an access callback of 1 it is not a public page, and some weird logic has been implemented to make it visible in the correct circumstances (see https://github.com/civicrm/civicrm-core/pull/6126/files)

An additional fix included is a very old typo (by the looks of it) next to the 'scheduled reminders' title field.

Before
----------------------------------------
Public paths were missing the is_public flag

After
----------------------------------------
More paths are flagged as is_public

Technical Details
----------------------------------------
Changes to XML menu definitions that will be automatically rebuilt into the DB on a cache rebuild.
