### PR TITLE
Move the code to add employer from relationship backoffice form to BAO

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -392,10 +392,7 @@ UNION
       $query = "UPDATE civicrm_contact contact_a,civicrm_contact contact_b
 SET contact_a.employer_id=contact_b.id, contact_a.organization_name=contact_b.organization_name
 WHERE contact_a.id ={$contactId} AND contact_b.id={$orgId}; ";
-
-      //FIXME : currently civicrm mysql_query support only single statement
-      //execution, though mysql 5.0 support multiple statement execution.
-      $dao = CRM_Core_DAO::executeQuery($query);
+      CRM_Core_DAO::executeQuery($query);
     }
   }
 

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -416,8 +416,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     $note = !empty($params['note']) ? $params['note'] : '';
     $this->saveRelationshipNotes($relationshipIds, $note);
 
-    $this->setEmploymentRelationship($params, $relationshipIds);
-
     // Refresh contact tabs which might have been affected
     $this->ajaxResponse = [
       'reloadBlocks' => ['#crm-contactinfo-content'],
@@ -635,29 +633,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       if (!empty($action)) {
         civicrm_api3('note', $action, $noteParams);
       }
-    }
-  }
-
-  /**
-   * Sets current employee/employer relationship
-   *
-   * @param $params
-   * @param array $relationshipIds
-   */
-  private function setEmploymentRelationship($params, $relationshipIds) {
-    $employerParams = [];
-    foreach ($relationshipIds as $id) {
-      if (!CRM_Contact_BAO_Relationship::isCurrentEmployerNeedingToBeCleared($params, $id)
-        //don't think this is required to check again.
-        && $this->_allRelationshipNames[$params['relationship_type_id']]["name_a_b"] == 'Employee of') {
-        // Fixme this is dumb why do we have to look this up again?
-        $rel = CRM_Contact_BAO_Relationship::getRelationshipByID($id);
-        $employerParams[$rel->contact_id_a] = $rel->contact_id_b;
-      }
-    }
-    if (!empty($employerParams)) {
-      // @todo this belongs in the BAO.
-      CRM_Contact_BAO_Contact_Utils::setCurrentEmployer($employerParams);
     }
   }
 

--- a/api/v3/Relationship.php
+++ b/api/v3/Relationship.php
@@ -58,6 +58,11 @@ function _civicrm_api3_relationship_create_spec(&$params) {
   $params['contact_id_b']['api.required'] = 1;
   $params['relationship_type_id']['api.required'] = 1;
   $params['is_active']['api.default'] = 1;
+  $params['is_current_employer'] = [
+    'title' => 'Is Current Employer?',
+    'description' => 'This is a optional parameter used to add employer contact when \'Employee Of\' relationship is created',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  ];
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Replacement PR for tested portion of https://github.com/civicrm/civicrm-core/pull/13331 (which stalled on QA & is thoroughly stale)

The Relationship back office form has a core function ```setEmploymentRelationship()``` responsible for adding data to an individual contact when a 'Employee of' relationship is added/updated. This moves that code to the BAO

Before
----------------------------------------
Relationship.create API cannot add the employer contact after a current 'Employee of' relationship is created

After
----------------------------------------
Code more logical,
Added an optional relationship.create API parameter ```is_current_employer```

Technical Details
----------------------------------------
The added UT ensures that it doesn't break the logic in API or at form level.
