### PR TITLE
[NFC] dev/core#1116 - document where activityTypeName is name and where it's label

### DIFF
--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -235,6 +235,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
 
     // create activity.
     $activityParams = [
+      // activityTypeName - dev/core#1116-unknown-if-ok
       'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_type_id', $activityTypeName),
       'subject' => $batch->title . "- Batch",
       'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_status_id', 'Completed'),

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -150,10 +150,12 @@
   </tr>
   <tr class="crm-activity-form-block-details">
     <td class="label">{$form.details.label}</td>
+    {* activityTypeName means label here not name, but it should be name (dev/core#1116-fixme) *}
     {if $activityTypeName eq "Print PDF Letter"}
       <td class="view-value">
       {$form.details.html}
       </td>
+    {* activityTypeName means label here not name, but it should be name (dev/core#1116-fixme) *}
     {elseif $activityTypeName eq "Inbound Email"}
       <td class="view-value">
        {$form.details.html|crmStripAlternatives|nl2br}

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -36,8 +36,10 @@
   <div class="messages status no-popup">
     <i class="crm-i fa-info-circle"></i> &nbsp;
     {if $action eq 8}
+      {* activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label) *}
       {ts 1=$activityTypeName}Click Delete to move this &quot;%1&quot; activity to the Trash.{/ts}
     {else}
+      {* activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label) *}
       {ts 1=$activityTypeName}Click Restore to retrieve this &quot;%1&quot; activity from the Trash.{/ts}
     {/if}
   </div><br />
@@ -109,6 +111,7 @@
 
                 <tr class="crm-case-activity-form-block-activityTypeName">
                   <td class="label">{ts}Activity Type{/ts}</td>
+                  {* activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label) *}
                   <td class="view-value bold">{$activityTypeName|escape}</td>
                 </tr>
                 <tr class="crm-case-activity-form-block-source_contact_id">

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -21,6 +21,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $tplParams = [
       'isCaseActivity' => 1,
       'client_id' => $client_id,
+      // activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label)
       'activityTypeName' => 'Follow up',
       'activity' => [
         'fields' => [

--- a/tools/bin/scripts/testProcess.php
+++ b/tools/bin/scripts/testProcess.php
@@ -15,6 +15,7 @@ $params = [
   'clientID' => 104,
   'creatorID' => 108,
   'standardTimeline' => 1,
+  // activityTypeName means name here not label, and that is correct here (dev/core#1116-ok-name)
   'activityTypeName' => 'Open Case',
   'dueDateTime' => time(),
   'caseID' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
I'm trying to get a full sense of the scope of the use/misuse of activityTypeName, and I figured I'd document it as I go, and where possible add any missing tests for spots where it is used properly. This is part 1 of ... some.

Using the following legend/tagging, for grepping later.

* activityTypeName means name here not label, and that is correct here (dev/core#1116-ok-name)
* activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label)
* activityTypeName means label here not name, but it should be name (dev/core#1116-fixme)
* activityTypeName - dev/core#1116-unknown-if-ok

Before
----------------------------------------
Some spots good some bad.

After
----------------------------------------
Still some spots good some bad, but "triaged".

Comments
----------------------------------------
Why am I not just fixing the bad spots? It would be nice to replace the variable with something that is harder to misuse in the future and immune to confusion between name and label, but not sure exactly what that would be yet.