### PR TITLE
[REF] Extract chunk of code relating to whether to disabled an inherited relationship

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
@@ -249,15 +249,18 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
       'relationship_type_id' => $orgToPersonTypeId2,
     ]);
 
+    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
+
+    // Disable the relationship & check the membership is removed.
+    $relationshipOne['is_active'] = 0;
+    $this->callAPISuccess('Relationship', 'create', array_merge($relationshipOne, ['is_active' => 0]));
+    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 0);
     /*
      * @todo this section not yet working due to bug in would-be-tested code.
-    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
     $relationshipTwo['is_active'] = 0;
     $this->callAPISuccess('Relationship', 'create', $relationshipTwo);
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
-    $relationshipOne['is_active'] = 0;
-    $this->callAPISuccess('Relationship', 'create', $relationshipOne);
-    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 0);
+
     $relationshipOne['is_active'] = 1;
     $this->callAPISuccess('Relationship', 'create', $relationshipOne);
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);


### PR DESCRIPTION
Overview
----------------------------------------
Fairly straight forward extraction along with a slight extension of what is enabled of the test @agilewarealok wrote for #14410

Before
----------------------------------------
Code less readable

After
----------------------------------------
Code more readable

Technical Details
----------------------------------------
#14410 stalled & is stale - I've now added the tests but the part that relates to the fix is commented out. This does not bring in any of the fix - it just extracts the code that is fixed for readability & extends the test to cover this codes original functionality. When I was looking through that PR I felt that without the code being broken out a bit I felt really uncomfortable reviewing it so cleaning up the code with an extraction seemed like a good first step towards getting it to a point where the patch could be written in a way that would not stall on getting reviewed. The next step IMHO is to add the early return / if handling into the extracted function & uncomment the next lines of code that cover it.

I did cleanup the test quite a bit in passing

Comments
----------------------------------------

will rebase once #14954 is merged