### PR TITLE
[Test] Add test cover for Member_BAO_Query auto_renew field

### DIFF
--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Member_BAO_MembershipTest
+ *
+ * @group headless
+ */
+class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
+
+  /**
+   * Test results from getRows.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSelectorGetRows() {
+    $this->_contactID = $this->individualCreate();
+    $this->_invoiceID = 1234;
+    $this->_contributionPageID = NULL;
+    $this->_paymentProcessorID = $this->paymentProcessorCreate();
+    $this->setupMembershipRecurringPaymentProcessorTransaction();
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_contactID]);
+    $membershipID = $membership['id'];
+    $params = [];
+    $selector = new CRM_Member_Selector_Search($params);
+    $rows = $selector->getRows(CRM_Core_Permission::VIEW, 0, 25, NULL);
+    $this->assertEquals([
+      'contact_id' => $this->_contactID,
+      'membership_id' => $membershipID,
+      'contact_type' => '<a href="/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=' . $this->_contactID . '&amp;snippet=4" class="crm-summary-link"><div class="icon crm-icon Individual-icon"></div></a>',
+      'sort_name' => 'Anderson, Anthony',
+      'membership_type' => 'General',
+      'join_date' => date('Y-m-d'),
+      'membership_start_date' => date('Y-m-d'),
+      'membership_end_date' => $membership['end_date'],
+      'membership_source' => 'Payment',
+      'member_is_test' => '0',
+      'owner_membership_id' => NULL,
+      'membership_status' => 'New',
+      'member_campaign_id' => NULL,
+      'campaign' => NULL,
+      'campaign_id' => NULL,
+      'checkbox' => 'mark_x_1',
+      'action' => '<span><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;id=1&amp;cid=' . $this->_contactID . '&amp;action=view&amp;context=search&amp;selectedChild=member&amp;compContext=membership" class="action-item crm-hover-button" title=\'View Membership\' >View</a><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=update&amp;id=' . $membershipID . '&amp;cid=' . $this->_contactID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Edit Membership\' >Edit</a></span><span class=\'btn-slide crm-hover-button\'>Renew...<ul class=\'panel\'><li><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=delete&amp;id=' . $membershipID . '&amp;cid=' . $this->_contactID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button small-popup" title=\'Delete Membership\' >Delete</a></li><li><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=renew&amp;id=' . $membershipID . '&amp;cid=' . $this->_contactID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Renew Membership\' >Renew</a></li><li><a href="/index.php?q=civicrm/contribute/unsubscribe&amp;reset=1&amp;mid=' . $membershipID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Cancel Auto Renew Subscription\' >Cancel Auto-renewal</a></li></ul></span>',
+      'auto_renew' => 1,
+    ], $rows[0]);
+    $this->assertCount(1, $rows);
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2396,6 +2396,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'contribution_page_id' => $this->_contributionPageID,
       'payment_processor_id' => $this->_paymentProcessorID,
       'is_test' => 0,
+      'receive_date' => '2019-07-25 07:34:23',
       'skipCleanMoney' => TRUE,
     ], $contributionParams);
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge(array(
@@ -2439,6 +2440,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
         'financial_type_id' => 1,
         'invoice_id' => 'abcd',
         'trxn_id' => 345,
+        'receive_date' => '2019-07-25 07:34:23',
       ));
     }
     $this->setupRecurringPaymentProcessorTransaction($recurParams);
@@ -2448,6 +2450,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'membership_type_id' => $this->ids['membership_type'],
       'contribution_recur_id' => $this->_contributionRecurID,
       'format.only_id' => TRUE,
+      'source' => 'Payment',
     ));
     //CRM-15055 creates line items we don't want so get rid of them so we can set up our own line items
     CRM_Core_DAO::executeQuery("TRUNCATE civicrm_line_item");


### PR DESCRIPTION
Overview
----------------------------------------
Adds test cover to support removal of an unused parameter

Before
----------------------------------------
Less cover

After
----------------------------------------
More cover

Technical Details
----------------------------------------
This adds test coverage to demonstrate that the auto_renew field in the Member_BAO_Query::defaultReturnProperties
achieves nothing.

auto_renew is NOT returned for the export - regardless of it's presence. It IS returned for getRows
but tha is calculated there now in the query object.

Once this is merged I will put up the commit to remove auto_renew from defaultReturnProperties


Comments
----------------------------------------
Relates to https://github.com/civicrm/civicrm-core/pull/14916 - proves one portion of that change
