### PR TITLE
dev/drupal#72 Ensure front end profile title is used in event confirmation screens & emails

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5890,7 +5890,7 @@ LIMIT 1;";
     $eventParams = [
       'id' => $eventID,
     ];
-    $values = ['event' =>[]];
+    $values = ['event' => []];
 
     CRM_Event_BAO_Event::retrieve($eventParams, $values['event']);
     // add custom fields for event

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -283,7 +283,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
    *
    * @return array
    *   The fields that belong to this ufgroup(s)
-   * @throws \Exception
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function getFields(
     $id,
@@ -366,7 +367,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     }
 
     if (empty($fields) && !$validGroup) {
-      CRM_Core_Error::fatal(ts('The requested Profile (gid=%1) is disabled OR it is not configured to be used for \'Profile\' listings in its Settings OR there is no Profile with that ID OR you do not have permission to access this profile. Please contact the site administrator if you need assistance.',
+      throw new CRM_Core_Exception(ts('The requested Profile (gid=%1) is disabled OR it is not configured to be used for \'Profile\' listings in its Settings OR there is no Profile with that ID OR you do not have permission to access this profile. Please contact the site administrator if you need assistance.',
         [1 => implode(',', $profileIds)]
       ));
     }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3627,4 +3627,18 @@ SELECT  group_id
     }
   }
 
+  /**
+   * Get the frontend_title for the profile, falling back on 'title' if none.
+   *
+   * @param int $profileID
+   *
+   * @return string
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getFrontEndTitle(int $profileID) {
+    $profile = civicrm_api3('UFGroup', 'getsingle', ['id' => $profileID, 'return' => ['title', 'frontend_title']]);
+    return $profile['frontend_title'] ?? $profile['title'];
+  }
+
 }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1455,8 +1455,7 @@ WHERE civicrm_event.is_active = 1
       }
 
       if (!empty($fields)) {
-        $profile = civicrm_api3('UFGroup', 'getsingle', ['id' => $gid, ['return' => ['title', 'frontend_title']]]);
-        $groupTitle['groupTitle'] = $profile['frontend_title'] ?? $profile['title'];
+        $groupTitle['groupTitle'] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $gid);
       }
 
       $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1431,6 +1431,10 @@ WHERE civicrm_event.is_active = 1
    *   Formatted array of key value.
    *
    * @param array $profileFields
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \API_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function displayProfile(&$params, $gid, &$groupTitle, &$values, &$profileFields = []) {
     if ($gid) {

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1450,11 +1450,9 @@ WHERE civicrm_event.is_active = 1
         $fields = CRM_Core_BAO_UFGroup::getFields($gid, FALSE, CRM_Core_Action::ADD);
       }
 
-      foreach ($fields as $v) {
-        if (!empty($v['groupTitle'])) {
-          $groupTitle['groupTitle'] = $v['groupTitle'];
-          break;
-        }
+      if (!empty($fields)) {
+        $profile = civicrm_api3('UFGroup', 'getsingle', ['id' => $gid, ['return' => ['title', 'frontend_title']]]);
+        $groupTitle['groupTitle'] = $profile['frontend_title'] ?? $profile['title'];
       }
 
       $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1050,7 +1050,9 @@ WHERE civicrm_event.is_active = 1
    * @param int $participantId
    * @param bool $isTest
    * @param bool $returnMessageText
+   *
    * @return array|null
+   * @throws \CiviCRM_API3_Exception
    */
   public static function sendMail($contactID, &$values, $participantId, $isTest = FALSE, $returnMessageText = FALSE) {
 
@@ -1110,43 +1112,44 @@ WHERE civicrm_event.is_active = 1
           $postProfileID = CRM_Utils_Array::value('additional_custom_post_id', $values, $postProfileID);
         }
 
-        self::buildCustomDisplay($preProfileID,
+        $profilePre = self::buildCustomDisplay($preProfileID,
           'customPre',
           $contactID,
           $template,
           $participantId,
           $isTest,
-          NULL,
+          TRUE,
           $participantParams
         );
 
-        self::buildCustomDisplay($postProfileID,
+        $profilePost = self::buildCustomDisplay($postProfileID,
           'customPost',
           $contactID,
           $template,
           $participantId,
           $isTest,
-          NULL,
+          TRUE,
           $participantParams
         );
 
         $sessions = CRM_Event_Cart_BAO_Conference::get_participant_sessions($participantId);
 
+        // @todo - the goal is that all params available to the message template are explicitly defined here rather than
+        // 'in a smattering of places'. Note that leakage can happen between mailings when not explicitly defined.
         $tplParams = array_merge($values, $participantParams, [
           'email' => $email,
           'confirm_email_text' => CRM_Utils_Array::value('confirm_email_text', $values['event']),
           'isShowLocation' => CRM_Utils_Array::value('is_show_location', $values['event']),
           // The concept of contributeMode is deprecated.
           'contributeMode' => CRM_Utils_Array::value('contributeMode', $template->_tpl_vars),
+          'customPre' => $profilePre[0],
+          'customPre_grouptitle' => empty($profilePre[1]) ? NULL : [CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $preProfileID)],
+          'customPost' => $profilePost[0],
+          'customPost_grouptitle' => empty($profilePost[1]) ? NULL : [CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $postProfileID)],
           'participantID' => $participantId,
           'conference_sessions' => $sessions,
-          'credit_card_number' =>
-          CRM_Utils_System::mungeCreditCard(
-              CRM_Utils_Array::value('credit_card_number', $participantParams)),
-          'credit_card_exp_date' =>
-          CRM_Utils_Date::mysqlToIso(
-              CRM_Utils_Date::format(
-                CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),
+          'credit_card_number' => CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $participantParams)),
+          'credit_card_exp_date' => CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format(CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),
         ]);
 
         // CRM-13890 : NOTE wait list condition need to be given so that
@@ -1242,10 +1245,11 @@ WHERE civicrm_event.is_active = 1
    * @param string $template
    * @param int $participantId
    * @param bool $isTest
-   * @param bool $isCustomProfile
+   * @param bool $returnResults
    * @param array $participantParams
    *
    * @return array|null
+   * @throws \CRM_Core_Exception
    */
   public static function buildCustomDisplay(
     $id,
@@ -1254,7 +1258,7 @@ WHERE civicrm_event.is_active = 1
     &$template,
     $participantId,
     $isTest,
-    $isCustomProfile = FALSE,
+    $returnResults = FALSE,
     $participantParams = []
   ) {
     if (!$id) {
@@ -1408,7 +1412,7 @@ WHERE civicrm_event.is_active = 1
     }
 
     //return if we only require array of participant's info.
-    if ($isCustomProfile) {
+    if ($returnResults) {
       if (count($val)) {
         return [$val, $groupTitles];
       }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1210,11 +1210,13 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
   }
 
   /**
-   * Assign Profiles.
+   * Assign Profiles to the template.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Event_Form_Registration_Confirm $form
+   *
+   * @throws \Exception
    */
-  public static function assignProfiles(&$form) {
+  public static function assignProfiles($form) {
     $participantParams = $form->_params;
     $formattedValues = $profileFields = [];
     $count = 1;
@@ -1227,7 +1229,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $prefix1 = '';
         $prefix2 = '';
       }
-      if ($participantValue != 'skip') {
+      if ($participantValue !== 'skip') {
         //get the customPre profile info
         if (!empty($form->_values[$prefix2 . 'custom_pre_id'])) {
           $values = $groupName = [];

--- a/api/api.php
+++ b/api/api.php
@@ -36,6 +36,7 @@ function civicrm_api($entity, $action, $params, $extra = NULL) {
  *   Array to be passed to function.
  *
  * @throws CiviCRM_API3_Exception
+ *
  * @return array
  */
 function civicrm_api3($entity, $action, $params = []) {

--- a/tests/phpunit/CRMTraits/Profile/ProfileTrait.php
+++ b/tests/phpunit/CRMTraits/Profile/ProfileTrait.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Trait PriceSetTrait
+ *
+ * Trait for working with Price Sets in tests
+ */
+trait CRMTraits_Financial_PriceSetTrait {
+
+  /**
+   * Create a contribution with 2 line items.
+   *
+   * This also involves creating t
+   *
+   * @param $params
+   * @param array $lineItemFinancialTypes
+   *   Financial Types, if an override is intended.
+   */
+  protected function createContributionWithTwoLineItemsAgainstPriceSet($params, $lineItemFinancialTypes = []) {
+    $params = array_merge(['total_amount' => 300, 'financial_type_id' => 'Donation'], $params);
+    $priceFields = $this->createPriceSet('contribution');
+    foreach ($priceFields['values'] as $key => $priceField) {
+      $financialTypeID = (!empty($lineItemFinancialTypes) ? array_shift($lineItemFinancialTypes) : $priceField['financial_type_id']);
+      $params['line_items'][]['line_item'][$key] = [
+        'price_field_id' => $priceField['price_field_id'],
+        'price_field_value_id' => $priceField['id'],
+        'label' => $priceField['label'],
+        'field_title' => $priceField['label'],
+        'qty' => 1,
+        'unit_price' => $priceField['amount'],
+        'line_total' => $priceField['amount'],
+        'financial_type_id' => $financialTypeID,
+        'entity_table' => 'civicrm_contribution',
+      ];
+    }
+    $this->callAPISuccess('order', 'create', $params);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby the front end profile title is not used in event confirm & thankyou screens & confirmation emails

Before
----------------------------------------
Register ...
<img width="629" alt="Screen Shot 2019-08-05 at 7 00 29 AM" src="https://user-images.githubusercontent.com/336308/62428684-48ece300-b758-11e9-9357-afeaf86ba3ef.png">

BUT
<img width="727" alt="Screen Shot 2019-08-05 at 7 00 51 AM" src="https://user-images.githubusercontent.com/336308/62428699-66ba4800-b758-11e9-8166-d5efa50db604.png">


Also in confirmation emails

After
----------------------------------------
<img width="653" alt="Screen Shot 2019-08-05 at 8 03 46 AM" src="https://user-images.githubusercontent.com/336308/62428694-5efaa380-b758-11e9-972f-d3cfa1916038.png">
<img width="471" alt="Screen Shot 2019-08-05 at 8 04 10 AM" src="https://user-images.githubusercontent.com/336308/62428695-5efaa380-b758-11e9-9a02-e1727bdd390a.png">

Technical Details
----------------------------------------
Incorporates https://github.com/civicrm/civicrm-core/pull/14958

Comments
----------------------------------------

https://lab.civicrm.org/dev/drupal/issues/72