### PR TITLE
[REF] Move Self service handlng to shared function to allow for use i…

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -54,13 +54,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
   }
 
   /**
-   * Is the from being accessed by a front end user to update their own recurring.
-   *
-   * @var bool
-   */
-  protected $selfService;
-
-  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Core_Exception
@@ -337,25 +330,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         "reset=1&task=cancel&result=1"));
       }
     }
-  }
-
-  /**
-   * Is this being used by a front end user to update their own recurring.
-   *
-   * @return bool
-   */
-  protected function isSelfService() {
-    if (!is_null($this->selfService)) {
-      return $this->selfService;
-    }
-    $this->selfService = FALSE;
-    if (!CRM_Core_Permission::check('edit contributions')) {
-      if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
-        CRM_Core_Error::statusBounce(ts('You do not have permission to cancel this recurring contribution.'));
-      }
-      $this->selfService = TRUE;
-    }
-    return $this->selfService;
   }
 
 }

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -108,6 +108,13 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   protected $subscriptionDetails = [];
 
   /**
+   * Is the from being accessed by a front end user to update their own recurring.
+   *
+   * @var bool
+   */
+  protected $selfService;
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -202,6 +209,25 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   protected function getSubscriptionContactID() {
     $sub = $this->getSubscriptionDetails();
     return isset($sub->contact_id) ? $sub->contact_id : FALSE;
+  }
+
+  /**
+   * Is this being used by a front end user to update their own recurring.
+   *
+   * @return bool
+   */
+  protected function isSelfService() {
+    if (!is_null($this->selfService)) {
+      return $this->selfService;
+    }
+    $this->selfService = FALSE;
+    if (!CRM_Core_Permission::check('edit contributions')) {
+      if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
+        CRM_Core_Error::statusBounce(ts('You do not have permission to cancel this recurring contribution.'));
+      }
+      $this->selfService = TRUE;
+    }
+    return $this->selfService;
   }
 
 }


### PR DESCRIPTION
…n other contribution recur functions

Overview
----------------------------------------
This moves the selfSerivice function so that it can be used by other ContributionRecur forms

Before
----------------------------------------
Function on one specfic form

After
----------------------------------------
Function on shared form

ping @eileenmcnaughton 