### PR TITLE
dev/core#1061 Ensure that custom data is not loaded on update subscription form when in self service mode and re-use shared function

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -41,8 +41,6 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
 
   protected $_subscriptionDetails = NULL;
 
-  protected $_selfService = FALSE;
-
   public $_paymentProcessor = NULL;
 
   public $_paymentProcessorObj = NULL;
@@ -99,13 +97,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
       $this->assign('contactId', $this->_subscriptionDetails->contact_id);
     }
 
-    if (!CRM_Core_Permission::check('edit contributions')) {
-      if ($this->_subscriptionDetails->contact_id != $this->getContactID()) {
-        CRM_Core_Error::statusBounce(ts('You do not have permission to update subscription.'));
-      }
-      $this->_selfService = TRUE;
-    }
-    $this->assign('self_service', $this->_selfService);
+    $this->assign('self_service', $this->isSelfService());
 
     $this->editableScheduleFields = $this->_paymentProcessorObj->getEditableRecurringScheduleFields();
 
@@ -125,7 +117,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     }
 
     // when custom data is included in this page
-    if (!empty($_POST['hidden_custom'])) {
+    if (!empty($_POST['hidden_custom']) && !$this->isSelfService()) {
       CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'ContributionRecur', $this->contributionRecurID);
       CRM_Custom_Form_CustomData::buildQuickForm($this);
       CRM_Custom_Form_CustomData::setDefaultValues($this);
@@ -187,7 +179,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     }
 
     if (CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($this->contributionRecurID)) {
-      $this->addEntityRef('financial_type_id', ts('Financial Type'), ['entity' => 'FinancialType'], !$this->_selfService);
+      $this->addEntityRef('financial_type_id', ts('Financial Type'), ['entity' => 'FinancialType'], !$this->isSelfService());
     }
 
     // Add custom data
@@ -195,7 +187,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     $this->assign('entityID', $this->contributionRecurID);
 
     $type = 'next';
-    if ($this->_selfService) {
+    if ($this->isSelfService()) {
       $type = 'submit';
     }
 
@@ -220,7 +212,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     // store the submitted values in an array
     $params = $this->exportValues();
 
-    if ($this->_selfService && $this->_donorEmail) {
+    if ($this->isSelfService() && $this->_donorEmail) {
       // for self service force notify
       $params['is_notify'] = 1;
     }

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -52,7 +52,9 @@
     {/if}
   </table>
 
-  {include file="CRM/common/customDataBlock.tpl"}
+  {if !$self_service}
+    {include file="CRM/common/customDataBlock.tpl"}
+  {/if}
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This incorporates changes in #14963 but it makes it so that custom data is not loaded when we are in self service mode. This seems consistant with the cancel subscription form and is a small step towards the end goal of splitting front end and back end forms

Before
----------------------------------------
Popup shows because sometimes custom data is not able to be accessed

After
----------------------------------------
No popup and custom data only loaded in backend form

ping @eileenmcnaughton @mattwire 