### PR TITLE
Improve formatting for Tax Rate on price page template

### DIFF
--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -82,7 +82,7 @@
     {if $getTaxDetails}
       <td class="right">{$line.line_total|crmMoney:$currency}</td>
       {if $line.tax_rate != "" || $line.tax_amount != ""}
-        <td class="right">{$taxTerm} ({$line.tax_rate}%)</td>
+        <td class="right">{$taxTerm} ({$line.tax_rate|string_format:"%.2f"}%)</td>
         <td class="right">{$line.tax_amount|crmMoney:$currency}</td>
       {else}
         <td></td>


### PR DESCRIPTION
Overview
----------------------------------------
Improve "Tax Rate" format on price pages.

Before
----------------------------------------
![Tax_rate_before](https://user-images.githubusercontent.com/43451723/62469796-a126e380-b75e-11e9-9c2c-0a393fa1269b.png)


After
----------------------------------------
![Tax_rate_after](https://user-images.githubusercontent.com/43451723/62469795-a08e4d00-b75e-11e9-8f9b-efd8e3cb53cb.png)

Technical Details
----------------------------------------
This is only a template modification.

Comments
----------------------------------------
None.
