### PR TITLE
[NFC] dev/core#1116 - seek and document where activityTypeName is name and where it's label

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -73,6 +73,8 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     // Set activity type name and description to template.
     list($activityTypeName, $activityTypeDescription) = CRM_Core_BAO_OptionValue::getActivityTypeDetails($defaults['activity_type_id']);
 
+    // activityTypeName - dev/core#1116-unknown-if-ok
+    // It seems like activityTypeName is no longer used? Description is still used though. See PR notes for more details.
     $this->assign('activityTypeName', $activityTypeName);
     $this->assign('activityTypeDescription', $activityTypeDescription);
 


### PR DESCRIPTION
Overview
----------------------------------------
This is part of a series. See also https://github.com/civicrm/civicrm-core/pull/14952

Before
----------------------------------------
Unused var

After
----------------------------------------
Still unused, but noted.

Technical Details
----------------------------------------
activityTypeName used to be used in ActivityView.tpl but was removed in

https://github.com/civicrm/civicrm-core/blame/06b69b1899b6304f7832f6d4d2f5af4a0acfde8c/templates/CRM/Activity/Form/ActivityView.tpl#L26

and

https://github.com/civicrm/civicrm-core/commit/b0a72b3b28baf264d37a47984ae229657ea9359f

Comments
----------------------------------------
It's possible it's still used in a customized override somewhere by somebody. But I couldn't find a reference in core or a reference where the tpl was `{include}'d` anywhere. I'm guessing it was just left during the rearrangement above. But it's commented now.