### PR TITLE
Translation 'ts' usage fixes.

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -400,7 +400,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       $validate = CRM_Utils_Type::validate($fields['value'], $dataType, FALSE);
       if ($validate === FALSE) {
         CRM_Core_Session::setStatus(
-          ts('Data Type of the value field for this option value does not match ' . $dataType),
+          ts('Data Type of the value field for this option value does not match %1.', [1 => $dataType]),
           ts('Value field Data Type mismatch'));
       }
     }

--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -116,15 +116,15 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
         'title' => ts('Tax Display Settings'),
         'weight' => 8,
         'option_values' => [
-          'Do_not_show' => ts('Do not show breakdown, only show total -i.e ' .
-            CRM_Core_BAO_Country::defaultCurrencySymbol() . '120.00'),
-          'Inclusive' => ts('Show [tax term] inclusive price - i.e. ' .
-            CRM_Core_BAO_Country::defaultCurrencySymbol() .
-            '120.00 (includes [tax term] of ' .
-            CRM_Core_BAO_Country::defaultCurrencySymbol() . '20.00)'),
-          'Exclusive' => ts('Show [tax term] exclusive price - i.e. ' .
-            CRM_Core_BAO_Country::defaultCurrencySymbol() . '100.00 + ' .
-            CRM_Core_BAO_Country::defaultCurrencySymbol() . '20.00 [tax term]'),
+          'Do_not_show' => ts('Do not show breakdown, only show total - i.e %1', [
+            1 => CRM_Utils_Money::format(120),
+          ]),
+          'Inclusive' => ts('Show [tax term] inclusive price - i.e. %1', [
+            1 => ts('%1 (includes [tax term] of %2)', [1 => CRM_Utils_Money::format(120), 2 => CRM_Utils_Money::format(20)]),
+          ]),
+          'Exclusive' => ts('Show [tax term] exclusive price - i.e. %1', [
+            1 => ts('%1 + %2 [tax term]', [1 => CRM_Utils_Money::format(120), 2 => CRM_Utils_Money::format(20)]),
+          ]),
         ],
       ],
     ];

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -196,13 +196,13 @@ trait CRM_Admin_Form_SettingTrait {
           $this->$add(
             $props['html_type'],
             $setting,
-            ts($props['title']),
+            $props['title'],
             ($options !== NULL) ? $options : CRM_Utils_Array::value('html_attributes', $props, []),
             ($options !== NULL) ? CRM_Utils_Array::value('html_attributes', $props, []) : NULL
           );
         }
         elseif ($add == 'addSelect') {
-          $this->addElement('select', $setting, ts($props['title']), $options, CRM_Utils_Array::value('html_attributes', $props));
+          $this->addElement('select', $setting, $props['title'], $options, CRM_Utils_Array::value('html_attributes', $props));
         }
         elseif ($add == 'addCheckBox') {
           $this->addCheckBox($setting, '', $options, NULL, CRM_Utils_Array::value('html_attributes', $props), NULL, NULL, ['&nbsp;&nbsp;']);
@@ -224,23 +224,23 @@ trait CRM_Admin_Form_SettingTrait {
         }
         elseif ($add == 'addChainSelect') {
           $this->addChainSelect($setting, [
-            'label' => ts($props['title']),
+            'label' => $props['title'],
           ]);
         }
         elseif ($add == 'addMonthDay') {
-          $this->add('date', $setting, ts($props['title']), CRM_Core_SelectValues::date(NULL, 'M d'));
+          $this->add('date', $setting, $props['title'], CRM_Core_SelectValues::date(NULL, 'M d'));
         }
         elseif ($add === 'addEntityRef') {
-          $this->$add($setting, ts($props['title']), $props['entity_reference_options']);
+          $this->$add($setting, $props['title'], $props['entity_reference_options']);
         }
         elseif ($add === 'addYesNo' && ($props['type'] === 'Boolean')) {
-          $this->addRadio($setting, ts($props['title']), [1 => 'Yes', 0 => 'No'], NULL, '&nbsp;&nbsp;');
+          $this->addRadio($setting, $props['title'], [1 => 'Yes', 0 => 'No'], NULL, '&nbsp;&nbsp;');
         }
         elseif ($add === 'add') {
-          $this->add($props['html_type'], $setting, ts($props['title']), $options);
+          $this->add($props['html_type'], $setting, $props['title'], $options);
         }
         else {
-          $this->$add($setting, ts($props['title']), $options);
+          $this->$add($setting, $props['title'], $options);
         }
         // Migrate to using an array as easier in smart...
         $description = CRM_Utils_Array::value('description', $props);
@@ -281,7 +281,8 @@ trait CRM_Admin_Form_SettingTrait {
     // not made this change.
     $htmlType = $spec['html_type'];
     if ($htmlType !== strtolower($htmlType)) {
-      CRM_Core_Error::deprecatedFunctionWarning(ts('Settings fields html_type should be lower case - see https://docs.civicrm.org/dev/en/latest/framework/setting/ - this needs to be fixed for ' . $spec['name']));
+      // Avoiding 'ts' for obscure strings.
+      CRM_Core_Error::deprecatedFunctionWarning('Settings fields html_type should be lower case - see https://docs.civicrm.org/dev/en/latest/framework/setting/ - this needs to be fixed for ' . $spec['name']);
       $htmlType = strtolower($spec['html_type']);
     }
     $mapping = [

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -264,7 +264,8 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     // set an offset to account for other vars we are not counting
     $offset = 50;
     if ((count($this->_elementIndex) + $offset) > ini_get("max_input_vars")) {
-      CRM_Core_Error::fatal(ts('Batch size is too large. Increase value of php.ini setting "max_input_vars" (current val = ' . ini_get("max_input_vars") . ')'));
+      // Avoiding 'ts' for obscure messages.
+      CRM_Core_Error::fatal('Batch size is too large. Increase value of php.ini setting "max_input_vars" (current val = ' . ini_get("max_input_vars") . ')');
     }
 
     $this->assign('fields', $this->_fields);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -110,7 +110,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     $contributionID = CRM_Utils_Array::value('contribution', $ids, CRM_Utils_Array::value('id', $params));
     $duplicates = [];
     if (self::checkDuplicate($params, $duplicates, $contributionID)) {
-      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice ID. Contribution record ID(s) are: " . implode(', ', $duplicates));
+      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice ID. Contribution record ID(s) are: %1", [1 => implode(', ', $duplicates)]);
       throw new CRM_Core_Exception($message);
     }
 

--- a/CRM/Contribute/Exception/FutureContributionPageException.php
+++ b/CRM/Contribute/Exception/FutureContributionPageException.php
@@ -8,7 +8,7 @@ class CRM_Contribute_Exception_FutureContributionPageException extends Exception
    * @param int $id
    */
   public function __construct($message, $id) {
-    parent::__construct(ts($message));
+    parent::__construct($message);
     $this->id = $id;
     CRM_Core_Error::debug_log_message('Access to contribution page with start date in future attempted - page number ' . $id);
   }

--- a/CRM/Contribute/Exception/InactiveContributionPageException.php
+++ b/CRM/Contribute/Exception/InactiveContributionPageException.php
@@ -14,7 +14,7 @@ class CRM_Contribute_Exception_InactiveContributionPageException extends Excepti
    * @param int $id
    */
   public function __construct($message, $id) {
-    parent::__construct(ts($message));
+    parent::__construct($message);
     $this->id = $id;
     CRM_Core_Error::debug_log_message('inactive contribution page access attempted - page number ' . $id);
   }

--- a/CRM/Contribute/Exception/PastContributionPageException.php
+++ b/CRM/Contribute/Exception/PastContributionPageException.php
@@ -8,7 +8,7 @@ class CRM_Contribute_Exception_PastContributionPageException extends Exception {
    * @param int $id
    */
   public function __construct($message, $id) {
-    parent::__construct(ts($message));
+    parent::__construct($message);
     $this->id = $id;
     CRM_Core_Error::debug_log_message('Access to contribution page with past end date attempted - page number ' . $id);
   }

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -391,9 +391,9 @@ WHERE  contribution_id = {$id}
       // for some reason there was a need to filter here per commit history - but this indicates a problem
       // somewhere else.
       if ($processor['is_test'] == ($this->_mode == 'test')) {
-        $this->_processors[$id] = ts($processor['name']);
+        $this->_processors[$id] = $processor['name'];
         if (!empty($processor['description'])) {
-          $this->_processors[$id] .= ' : ' . ts($processor['description']);
+          $this->_processors[$id] .= ' : ' . $processor['description'];
         }
         if ($processor['is_recur']) {
           $this->_recurPaymentProcessors[$id] = $this->_processors[$id];

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -716,14 +716,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           $is_test
         );
 
-        $errorText = 'Your %1 membership was previously cancelled and can not be renewed online. Please contact the site administrator for assistance.';
         foreach ($self->_values['fee'] as $fieldKey => $fieldValue) {
           if ($fieldValue['html_type'] != 'Text' && CRM_Utils_Array::value('price_' . $fieldKey, $fields)) {
             if (!is_array($fields['price_' . $fieldKey]) && isset($fieldValue['options'][$fields['price_' . $fieldKey]])) {
               if (array_key_exists('membership_type_id', $fieldValue['options'][$fields['price_' . $fieldKey]])
                 && in_array($fieldValue['options'][$fields['price_' . $fieldKey]]['membership_type_id'], $currentMemberships)
               ) {
-                $errors['price_' . $fieldKey] = ts($errorText, [1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$fields['price_' . $fieldKey]]['membership_type_id'])]);
+                $errors['price_' . $fieldKey] = ts('Your %1 membership was previously cancelled and can not be renewed online. Please contact the site administrator for assistance.', [1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$fields['price_' . $fieldKey]]['membership_type_id'])]);
               }
             }
             else {
@@ -732,7 +731,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
                   if (array_key_exists('membership_type_id', $fieldValue['options'][$key])
                     && in_array($fieldValue['options'][$key]['membership_type_id'], $currentMemberships)
                   ) {
-                    $errors['price_' . $fieldKey] = ts($errorText, [1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$key]['membership_type_id'])]);
+                    $errors['price_' . $fieldKey] = ts('Your %1 membership was previously cancelled and can not be renewed online. Please contact the site administrator for assistance.', [1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$key]['membership_type_id'])]);
                   }
                 }
               }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -323,12 +323,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $endDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('end_date', $this->_values));
       $now = date('YmdHis');
       if ($endDate && $endDate < $now) {
-        throw new CRM_Contribute_Exception_PastContributionPageException(ts('The page you requested has past its end date on ' . CRM_Utils_Date::customFormat($endDate)), $this->_id);
+        throw new CRM_Contribute_Exception_PastContributionPageException(ts('The page you requested has past its end date on %1', [1 => CRM_Utils_Date::customFormat($endDate)]), $this->_id);
       }
 
       $startDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('start_date', $this->_values));
       if ($startDate && $startDate > $now) {
-        throw new CRM_Contribute_Exception_FutureContributionPageException(ts('The page you requested will be active from ' . CRM_Utils_Date::customFormat($startDate)), $this->_id);
+        throw new CRM_Contribute_Exception_FutureContributionPageException(ts('The page you requested will be active from %1', [1 => CRM_Utils_Date::customFormat($startDate)]), $this->_id);
       }
 
       $this->assignBillingType();
@@ -945,7 +945,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           }
         }
 
-        $form->assign('fieldSetTitle', ts(CRM_Core_BAO_UFGroup::getTitle($form->_values['onbehalf_profile_id'])));
+        $form->assign('fieldSetTitle', CRM_Core_BAO_UFGroup::getTitle($form->_values['onbehalf_profile_id']));
 
         if (CRM_Utils_Array::value('is_for_organization', $form->_values)) {
           if ($form->_values['is_for_organization'] == 2) {

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -218,9 +218,9 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     }
     // for front-end user show and use the basic three fields used to create a contact
     else {
-      $this->add('text', 'email', ts('To Email'), ts($this->_contact_email), TRUE);
-      $this->add('text', 'last_name', ts('To Last Name'), ts($this->_to_contact_last_name), TRUE);
-      $this->add('text', 'first_name', ts('To First Name'), ts($this->_to_contact_first_name), TRUE);
+      $this->add('text', 'email', ts('To Email'), $this->_contact_email, TRUE);
+      $this->add('text', 'last_name', ts('To Last Name'), $this->_to_contact_last_name, TRUE);
+      $this->add('text', 'first_name', ts('To First Name'), $this->_to_contact_first_name, TRUE);
     }
 
     $this->addButtons([

--- a/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
+++ b/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
@@ -100,12 +100,9 @@ LIMIT    $offset, $rowCount";
 
     $rows = [];
     $object = CRM_Core_DAO::executeQuery($query, $params);
-    $statusLookup = CRM_Event_PseudoConstant::participantStatus();
+    $statusLookup = CRM_Event_PseudoConstant::participantStatus(NULL, NULL, 'label');
     while ($object->fetch()) {
       $status = CRM_Utils_Array::value($object->status_id, $statusLookup);
-      if ($status) {
-        $status = ts($status);
-      }
       $row = [
         'id' => $object->contact_id,
         'participantID' => $object->participant_id,

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -153,7 +153,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
         }
       }
       if (!empty($tables)) {
-        $message = ts('The following tables have an entry for this financial type: %1', ['%1' => implode(', ', $tables)]);
+        $message = ts('The following tables have an entry for this financial type: %1', [1 => implode(', ', $tables)]);
 
         $errors = [];
         $errors['is_error'] = 1;
@@ -217,27 +217,32 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
       return FALSE;
     }
     $financialTypes = CRM_Contribute_PseudoConstant::financialType();
-    $prefix = ts('CiviCRM') . ': ';
-    $actions = ['add', 'view', 'edit', 'delete'];
+    $actions = [
+      'add' => ts('add'),
+      'view' => ts('view'),
+      'edit' => ts('edit'),
+      'delete' => ts('delete'),
+    ];
+
     foreach ($financialTypes as $id => $type) {
-      foreach ($actions as $action) {
+      foreach ($actions as $action => $action_ts) {
         if ($descriptions) {
           $permissions[$action . ' contributions of type ' . $type] = [
-            $prefix . ts($action . ' contributions of type ') . $type,
-            ts(ucfirst($action) . ' contributions of type ') . $type,
+            ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]),
+            ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
           ];
         }
         else {
-          $permissions[$action . ' contributions of type ' . $type] = $prefix . ts($action . ' contributions of type ') . $type;
+          $permissions[$action . ' contributions of type ' . $type] = ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]);
         }
       }
     }
     if (!$descriptions) {
-      $permissions['administer CiviCRM Financial Types'] = $prefix . ts('administer CiviCRM Financial Types');
+      $permissions['administer CiviCRM Financial Types'] = ts('CiviCRM: administer CiviCRM Financial Types');
     }
     else {
       $permissions['administer CiviCRM Financial Types'] = [
-        $prefix . ts('administer CiviCRM Financial Types'),
+        ts('CiviCRM: administer CiviCRM Financial Types'),
         ts('Administer access to Financial Types'),
       ];
     }

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -254,8 +254,8 @@ class CRM_Utils_Mail_Incoming {
    * @return string
    */
   public function formatUnrecognisedPart($part) {
-    CRM_Core_Error::debug_log_message(ts('CRM_Utils_Mail_Incoming: Unable to handle message part of type "%1".', ['%1' => get_class($part)]));
-    return ts('Unrecognised message part of type "%1".', ['%1' => get_class($part)]);
+    CRM_Core_Error::debug_log_message(ts('CRM_Utils_Mail_Incoming: Unable to handle message part of type "%1".', [1 => get_class($part)]));
+    return ts('Unrecognised message part of type "%1".', [1 => get_class($part)]);
   }
 
   /**

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -133,7 +133,7 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
 
     if (!empty($params['mail'])) {
       if (!valid_email_address($params['mail'])) {
-        $errors[$emailName] = ts('The e-mail address %1 is not valid.', ['%1' => $params['mail']]);
+        $errors[$emailName] = ts('The e-mail address %1 is not valid.', [1 => $params['mail']]);
       }
       else {
         $uid = db_query("SELECT uid FROM {users} WHERE mail = :mail", [':mail' => $params['mail']])->fetchField();

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -208,18 +208,22 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
     $this->setACL();
     CRM_Financial_BAO_FinancialType::permissionedFinancialTypes($permissions, TRUE);
     $financialTypes = CRM_Contribute_PseudoConstant::financialType();
-    $prefix = ts('CiviCRM') . ': ';
-    $actions = ['add', 'view', 'edit', 'delete'];
+    $actions = [
+      'add' => ts('add'),
+      'view' => ts('view'),
+      'edit' => ts('edit'),
+      'delete' => ts('delete'),
+    ];
     foreach ($financialTypes as $id => $type) {
-      foreach ($actions as $action) {
+      foreach ($actions as $action => $action_ts) {
         $checkPerms[$action . ' contributions of type ' . $type] = [
-          $prefix . ts($action . ' contributions of type ') . $type,
-          ts(ucfirst($action) . ' contributions of type ') . $type,
+          ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]),
+          ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
         ];
       }
     }
     $checkPerms['administer CiviCRM Financial Types'] = [
-      $prefix . ts('administer CiviCRM Financial Types'),
+      ts('CiviCRM: administer CiviCRM Financial Types'),
       ts('Administer access to Financial Types'),
     ];
     $this->assertEquals($permissions, $checkPerms, 'Verify that permissions for each financial type have been added');


### PR DESCRIPTION
Overview
----------------------------------------

Fixes how the gettext 'ts' translation function is called. Reduces the amount of warnings from the string extraction script.

https://docs.civicrm.org/dev/en/latest/translation/#best-practices