### PR TITLE
5.16.0 release notes - late changes

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1249,7 +1249,7 @@
 
 - github      : scoobird
   name        : Morgan Robinson
-  organization: Palante
+  organization: Palante Technology Cooperative
 
 - name        : Steve Binkowski
   jira        : s.bink

--- a/release-notes.md
+++ b/release-notes.md
@@ -26,6 +26,15 @@ Released August 7, 2019
 - **[Credits](release-notes/5.16.0.md#credits)**
 - **[Feedback](release-notes/5.16.0.md#feedback)**
 
+## CiviCRM 5.15.2
+
+Released July 30, 2019
+
+- **[Synopsis](release-notes/5.15.2.md#synopsis)**
+- **[Bugs resolved](release-notes/5.15.2.md#bugs)**
+- **[Credits](release-notes/5.15.2.md#credits)**
+- **[Feedback](release-notes/5.15.2.md#feedback)**
+
 ## CiviCRM 5.15.1
 
 Released July 10, 2019

--- a/release-notes.md
+++ b/release-notes.md
@@ -26,6 +26,15 @@ Released August 7, 2019
 - **[Credits](release-notes/5.16.0.md#credits)**
 - **[Feedback](release-notes/5.16.0.md#feedback)**
 
+## CiviCRM 5.15.1
+
+Released July 10, 2019
+
+- **[Synopsis](release-notes/5.15.1.md#synopsis)**
+- **[Bugs resolved](release-notes/5.15.1.md#bugs)**
+- **[Credits](release-notes/5.15.1.md#credits)**
+- **[Feedback](release-notes/5.15.1.md#feedback)**
+
 ## CiviCRM 5.15.0
 
 Released July 3, 2019

--- a/release-notes/5.15.1.md
+++ b/release-notes/5.15.1.md
@@ -1,0 +1,43 @@
+# CiviCRM 5.15.1
+
+Released July 10, 2019
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |         |
+|:--------------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                                   |   no    |
+| Change the database schema?                                     |   no    |
+| Alter the API?                                                  |   no    |
+| Require attention to configuration options?                     |   no    |
+| Fix problems installing or upgrading to a previous version?     |   no    |
+| Introduce features?                                             |   no    |
+| **Fix bugs?**                                                   | **yes** |
+
+## <a name="bugs"></a>Bugs resolved
+
+- **CiviContribute: Refund not recorded on additional payment form ([#14739](https://github.com/civicrm/civicrm-core/pull/14739))**
+- **CiviReport: Error sorting contributions on non-displayed column ([dev/core#1081](https://lab.civicrm.org/dev/core/issues/1081):
+  [#14771](https://github.com/civicrm/civicrm-core/pull/14771))**
+- **Drupal 8: `cv` reports "Cannot resolve path using "cms.root.url" ([dev/drupal#75](https://lab.civicrm.org/dev/drupal/issues/75),
+  [cv#48](https://github.com/civicrm/cv/issues/48): [#14776](https://github.com/civicrm/civicrm-core/pull/14776))**
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+Wikimedia Foundation - Eileen McNaughton; Tadpole Collective - Kevin
+Cristiano; Megaphone Technology Consulting - Jon Goldberg; JMA Consulting -
+Monish Deb; César; Coop SymbioTIC - Mathieu Lutfy; CiviCRM - Tim Otten;
+Blackfly Solutions - Alan Dixon
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Tim Otten and Andrew Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/release-notes/5.15.2.md
+++ b/release-notes/5.15.2.md
@@ -25,6 +25,7 @@ Released July 31, 2019
 - **CiviContribute: Fix translation of message ([dev/core#1084](https://lab.civicrm.org/dev/core/issues/1084), [#14935](https://github.com/civicrm/civicrm-core/pull/14935))**
 - **Search: Fix cross-page record selection ([#14929](https://github.com/civicrm/civicrm-core/pull/14929))**
 - **Status Check: Fix compatibility in new utf8mb4 check ([dev/core#1136](https://lab.civicrm.org/dev/core/issues/1136), [#14935](https://github.com/civicrm/civicrm-core/pull/14935))**
+- **Regression: Can't use operators to filter contact subtypes other than "Is One Of" ([dev/report#15](https://lab.civicrm.org/dev/report/issues/15): [14814](https://github.com/civicrm/civicrm-core/pull/14814))**
 
 ## <a name="credits"></a>Credits
 

--- a/release-notes/5.15.2.md
+++ b/release-notes/5.15.2.md
@@ -1,6 +1,6 @@
 # CiviCRM 5.15.2
 
-Released July 30, 2019
+Released July 31, 2019
 
 - **[Synopsis](#synopsis)**
 - **[Bugs resolved](#bugs)**

--- a/release-notes/5.15.2.md
+++ b/release-notes/5.15.2.md
@@ -1,0 +1,44 @@
+# CiviCRM 5.15.2
+
+Released July 30, 2019
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |         |
+|:--------------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                                   |   no    |
+| Change the database schema?                                     |   no    |
+| Alter the API?                                                  |   no    |
+| Require attention to configuration options?                     |   no    |
+| Fix problems installing or upgrading to a previous version?     |   no    |
+| Introduce features?                                             |   no    |
+| **Fix bugs?**                                                   | **yes** |
+
+## <a name="bugs"></a>Bugs resolved
+
+- **Activities: Fix duplicate custom data block ([dev/core#1042](https://lab.civicrm.org/dev/core/issues/1042): [#14936](https://github.com/civicrm/civicrm-core/pull/14936))**
+- **CiviContribute: Fix translation of message ([dev/core#1084](https://lab.civicrm.org/dev/core/issues/1084), [#14935](https://github.com/civicrm/civicrm-core/pull/14935))**
+- **Search: Fix cross-page record selection ([#14929](https://github.com/civicrm/civicrm-core/pull/14929))**
+- **Status Check: Fix compatibility in new utf8mb4 check ([dev/core#1136](https://lab.civicrm.org/dev/core/issues/1136), [#14935](https://github.com/civicrm/civicrm-core/pull/14935))**
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+Wikimedia Foundation - Eileen McNaughton; Pradeep Nayak; MJW Consulting -
+Matthew Wire; Jens Schuppe; JMA Consulting - Monish Deb; Electronic Frontier
+Foundation - Mark Burdett; Digitalcourage - Detlev Sieber; Dave D; CiviCoop -
+Jaap Jansma; CiviCRM - Tim Otten; Centrale Organisatie van Voetbal
+Scheidsrechters (COVS) - Ed van Leeuwen Blackfly Solutions - Alan Dixon;
+Australian Greens - Seamus Lee
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Tim Otten and Andrew Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/release-notes/5.16.0.md
+++ b/release-notes/5.16.0.md
@@ -1,7 +1,5 @@
 # CiviCRM 5.16.0
 
-In-progress, based upon commit 55086d4c32123382ce471afd2527469873120129
-
 Released August 7, 2019
 
 - **[Synopsis](#synopsis)**
@@ -57,6 +55,12 @@ Released August 7, 2019
   get_conflicts, the code doing this wrangling is moved from the api to the BAO
   layer.
 
+- **Better support for hookable menubar colors
+  ([14944](https://github.com/civicrm/civicrm-core/pull/14944))**
+
+  More colors in the menu, including the base color, highlight color, and text
+  color, can be modified with hooks.
+
 - **Add csv reader package
   ([14524](https://github.com/civicrm/civicrm-core/pull/14524))**
 
@@ -75,6 +79,31 @@ Released August 7, 2019
 
   Moves the logic for checking the api_key field permissions from the api layer
   to the BAO layer so it can be reused by api4 and other things.
+
+- **Add a configuration setting for when to load custom CSS (initial work for
+  [dev/core#378](https://lab.civicrm.org/dev/core/issues/378):
+  [14876](https://github.com/civicrm/civicrm-core/pull/14876))**
+
+  A new function, `CRM_Utils_System::isFrontEndPage()`, indicates whether a page
+  is considered "front-end".
+
+- **Permit sort_name as a url parameter on advanced search
+  ([14475](https://github.com/civicrm/civicrm-core/pull/14475) and
+  [14920](https://github.com/civicrm/civicrm-core/pull/14920))**
+
+  You can now set `sort_name=x` in the URL on the advanced search form.  In
+  doing this, the sort name field is now defined through metadata rather than
+  *ad hoc*.
+
+- **Menubar - Improve flexibility & remove hardcoded values
+  ([14924](https://github.com/civicrm/civicrm-core/pull/14924))**
+
+  The menu no longer relies on hardcoded pixel dimensions to determine mobile
+  appearance, and it replaces references to the ID selector `crm-container` with
+  the class selector of the same name (which is used more broadly).
+
+  This also resolves
+  [dev/core#1127](https://lab.civicrm.org/dev/core/issues/1127).
 
 - **Handle relative start & end dates passed to datepicker widget
   ([14632](https://github.com/civicrm/civicrm-core/pull/14632))**
@@ -223,6 +252,12 @@ Released August 7, 2019
 
   Ensures "SubmitOnce" functionality works with forms with multiple buttons.
 
+- **[regression] `cv` fails on CiviCRM 5.15.0
+  ([dev/drupal#75](https://lab.civicrm.org/dev/drupal/issues/75):
+  [14775](https://github.com/civicrm/civicrm-core/pull/14775))**
+
+  This fixes the return value of `CRM_Utils_System_Drupal8::languageNegotiationURL()`
+
 - **Errors exporting contributions on 5.13.2 (continues work for
   [dev/core#1015](https://lab.civicrm.org/dev/core/issues/1015):
   [14513](https://github.com/civicrm/civicrm-core/pull/14513))**
@@ -340,6 +375,18 @@ Released August 7, 2019
 - **Ensure that contact groups caches are cleared if memory backed
   ([14607](https://github.com/civicrm/civicrm-core/pull/14607))**
 
+- **Ensure recently converted groups cache matches previous behaviour by setting
+  `withArray` as fast for it
+  ([14789](https://github.com/civicrm/civicrm-core/pull/14789))**
+
+- **Does CiviCRM make it possible to specify which directories are private and
+  which are public-accessible? (continues work for
+  [dev/cloud-native#3](https://lab.civicrm.org/dev/cloud-native/issues/3):
+  [14717](https://github.com/civicrm/civicrm-core/pull/14717))**
+
+  Removes an unused cache-driver for storing cache records in the file system
+  (under CIVICRM_TEMPLATE_COMPILEDIR, using PHP serialize() format).
+
 ### CiviCampaign
 
 - **CiviCRM Campaign, the Revenue Goal field stores 0 if $5,000 or any other
@@ -439,6 +486,9 @@ Released August 7, 2019
 - **Ensure that completed status is selected by default on search contribution
   form ([14612](https://github.com/civicrm/civicrm-core/pull/14612))**
 
+- **Fix unreleased regression - fatal on financial account screen
+  ([14900](https://github.com/civicrm/civicrm-core/pull/14900))**
+
 ### CiviEvent
 
 - **When creating a new event using a template the new event screen is taking
@@ -462,15 +512,12 @@ Released August 7, 2019
 - **Removed hardcoded value for registered participant status
   ([14569](https://github.com/civicrm/civicrm-core/pull/14569))**
 
-### Cloud Native
+### CiviMail
 
-- **Does CiviCRM make it possible to specify which directories are private and
-  which are public-accessible? (continues work for
-  [dev/cloud-native#3](https://lab.civicrm.org/dev/cloud-native/issues/3):
-  [14717](https://github.com/civicrm/civicrm-core/pull/14717))**
-
-  Removes an unused cache-driver for storing cache records in the file system
-  (under CIVICRM_TEMPLATE_COMPILEDIR, using PHP serialize() format).
+- **Hashed mailing URLs do not work with view mailing links
+  ([dev/core#1037](https://lab.civicrm.org/dev/core/issues/1037):
+  [14508](https://github.com/civicrm/civicrm-core/pull/14508) and
+  [14722](https://github.com/civicrm/civicrm-core/pull/14722))**
 
 ### Drupal Integration
 
@@ -518,6 +565,9 @@ Released August 7, 2019
   correctly set on the civicrm base page.
 
 ## <a name="misc"></a>Miscellany
+
+- **Revert "[REF] use generic loadStandardSearchOptionsFromUrl". Fix search
+  selections. ([14918](https://github.com/civicrm/civicrm-core/pull/14918))**
 
 - **Remove duplicated code in contribution recur search build function
   ([14504](https://github.com/civicrm/civicrm-core/pull/14504))**

--- a/release-notes/5.16.0.md
+++ b/release-notes/5.16.0.md
@@ -767,23 +767,24 @@ Released August 7, 2019
 
 This release was developed by the following code authors:
 
-AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Alok Patel, Francis
-Whittle; Andrei Mondoc; Australian Greens - Seamus Lee; Christian Wach;
-CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; Coop  
-SymbioTIC - Mathieu Lutfy, Samuel Vanhove; Dave D; Fuzion - Jitendra Purohit;
-Greenpeace CEE - Patrick Figel; iXiam - César Ramos; JMA Consulting - Monish Deb;
-Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire;
-Nicol Wistreich; Pradeep Nayak; Squiffle Consulting - Aidan Saunders; Tadpole
-Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton
+AGH Strategies - Alice Frumin, Andrew Hunt, Eli Lisseck; Agileware - Alok Patel,
+Francis Whittle; Andrei Mondoc; Australian Greens - Seamus Lee; Christian Wach;
+CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; Coop SymbioTIC -
+Mathieu Lutfy, Samuel Vanhove; Dave D; Electronic Frontier Foundation - Mark
+Burdett; Fuzion - Jitendra Purohit; Greenpeace CEE - Patrick Figel; iXiam -
+César Ramos; JMA Consulting - Monish Deb; John Kingsnorth; Megaphone Technology
+Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Nicol Wistreich;
+Pradeep Nayak; Squiffle Consulting - Aidan Saunders; Tadpole Collective - Kevin
+Cristiano; Wikimedia Foundation - Eileen McNaughton
 
 Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:
 
 Agileware - Justin Freeman; CiviCoop - Jaap Jansma; CiviDesk - Sunil Pawar;
 Fuzion - Luke Stewart; JMA Consulting - Joe Murray; Korlon - Stuart Gaston;
-Lighthouse Design and Consulting - Brian Shaughnessy; National Urban League:
-Lisa Taliano; Palante - Morgan Robinson; Semper IT - Karin Gerritsen; Tech To
-The People - Xavier Dutoit
+Lighthouse Design and Consulting - Brian Shaughnessy; National Urban League -
+Lisa Taliano; Palante Technology Cooperative - Morgan Robinson; Semper IT -
+Karin Gerritsen; Tech To The People - Xavier Dutoit
 
 ## <a name="feedback"></a>Feedback
 


### PR DESCRIPTION
Here are the final changes for the 5.16.0 release notes.  In the process, I cherry-picked the 5.15.1 and 5.15.2 release notes into the branch since there were some edits to make for 5.16 changes that were backported there.