### PR TITLE
 Fix (unreleased regression) e-notices on import form

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -66,7 +66,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @return string
    */
-  public function defaultFromColumnName($columnName, &$patterns) {
+  public function defaultFromColumnName($columnName, $patterns) {
 
     if (!preg_match('/^[a-z0-9 ]$/i', $columnName)) {
       if ($columnKey = array_search($columnName, $this->_mapperFields)) {
@@ -541,7 +541,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @return array
    */
-  public function formatCustomFieldName(&$fields) {
+  public function formatCustomFieldName($fields) {
     //CRM-2676, replacing the conflict for same custom field name from different custom group.
     $fieldIds = $formattedFieldNames = [];
     foreach ($fields as $key => $value) {

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -400,7 +400,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
 
       if ($this->get('savedMapping')) {
-        list($mappingName, $key, $defaults, $js, $columnPatterns, $dataPatterns) = $this->loadSavedMapping($mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $defaults, $formName, $js, $hasColumnNames);
+        list($mappingName, $key, $defaults, $js) = $this->loadSavedMapping($mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $defaults, $formName, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
       }
       else {
         $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_0_');\n";
@@ -860,10 +860,12 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param string $formName
    * @param string $js
    * @param bool $hasColumnNames
+   * @param array $dataPatterns
+   * @param array $columnPatterns
    *
    * @return array
    */
-  protected function loadSavedMapping($mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $defaults, $formName, $js, $hasColumnNames) {
+  protected function loadSavedMapping($mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $defaults, $formName, $js, $hasColumnNames, $dataPatterns, $columnPatterns) {
     $jsSet = FALSE;
     if (isset($mappingName[$i])) {
       if ($mappingName[$i] != ts('- do not import -')) {
@@ -999,7 +1001,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         $defaults["mapper[$i]"] = [$this->defaultFromData($dataPatterns, $i)];
       }
     }
-    return [$mappingName, $key, $defaults, $js, $columnPatterns, $dataPatterns];
+    return [$mappingName, $key, $defaults, $js];
   }
 
 }

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -121,7 +121,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Core_Form {
    *
    * @return string
    */
-  public function defaultFromData(&$patterns, $index) {
+  public function defaultFromData($patterns, $index) {
     $best = '';
     $bestHits = 0;
     $n = count($this->_dataValues);


### PR DESCRIPTION
Overview
----------------------------------------
Fix enotices introduced in master & not in rc on import

Before
----------------------------------------
<img width="899" alt="Screen Shot 2019-08-07 at 2 35 02 PM" src="https://user-images.githubusercontent.com/336308/62593397-ae90c900-b92a-11e9-9bad-2ca00e1e2f78.png">


After
----------------------------------------
Not fully fixed - that will follow - but some fixed

Technical Details
----------------------------------------
When doing this extraction
0e3fc02

The function pass-by-reference calls hid the fact that the  &  needed to be passed in

causing e-notices.

In fact there are still some enotices after this which I'm still investigating but this partially fixes
& is mergeable in itself - the other can be follow up

Comments
----------------------------------------
