### PR TITLE
[REF] [Import] extract function that sets field metadata

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -138,6 +138,33 @@ abstract class CRM_Import_Parser {
   protected $_fields;
 
   /**
+   * Metadata for all available fields, keyed by unique name.
+   *
+   * This is intended to supercede $_fields which uses a special sauce format which
+   * importableFieldsMetadata uses the standard getfields type format.
+   *
+   * @var array
+   */
+  protected $importableFieldsMetadata = [];
+
+  /**
+   * Get metadata for all importable fields in std getfields style format.
+   *
+   * @return array
+   */
+  public function getImportableFieldsMetadata(): array {
+    return $this->importableFieldsMetadata;
+  }
+
+  /**
+   * Set metadata for all importable fields in std getfields style format.
+   * @param array $importableFieldsMetadata
+   */
+  public function setImportableFieldsMetadata(array $importableFieldsMetadata) {
+    $this->importableFieldsMetadata = $importableFieldsMetadata;
+  }
+
+  /**
    * Array of the fields that are actually part of the import process
    * the position in the array also dictates their position in the import
    * file


### PR DESCRIPTION
Overview
----------------------------------------
Minor extraction

Before
----------------------------------------
Less readable

After
----------------------------------------
More readable - and ready for more cleanup

Technical Details
----------------------------------------
My thinking is that we want to migrate over to a new class (similar to export processor) that does a lot a metadata functions
- perhaps it might be importMetadata. A big part of the reason it's all so crazy appears to be that the functions to
wrangle the metadata are on the first class in the sequence (DataSource) and because they are not shared & do not have a shared
parent they are passed around instead via the form set &  get methods. In fact the metadata & array wrangling functions just
need to be available - hmm sounding like a trait - ok next commit....

Comments
----------------------------------------
I'm mostly cleaning this up because I have a couple of minor fixes to possibly do (although so far 2/2 have turned out not to be bugs & digging in the code pointed me to a non-code solution) - and because we learnt with export about how preparatory cleanup can lay the groundwork for a leap. The import code is nasty & perhaps it should just be dumped but it's hard to know what we are 'dumping' without some cleanup
