### PR TITLE
[clean up][ export] Remove membership_auto_renew from defaultReturn properties

### DIFF
--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -454,7 +454,6 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
         'membership_recur_id' => 1,
         'member_campaign_id' => 1,
         'member_is_override' => 1,
-        'member_auto_renew' => 1,
       ];
 
       if ($includeCustomFields) {

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -287,8 +287,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'membership_recur_id' => 1,
       'Campaign ID' => '',
       'member_is_override' => '',
-      // Nothing is returned for auto-renew - this is incorrect based on the intent - but we are adding a test to confirm not fix here.
-      'member_auto_renew' => '',
       'Total Amount' => '200.00',
       'Contribution Status' => 'Pending',
       'Date Received' => '2019-07-25 07:34:23',
@@ -1595,7 +1593,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'membership_recur_id' => 1,
       'member_campaign_id' => 1,
       'member_is_override' => 1,
-      'member_auto_renew' => 1,
     ];
   }
 
@@ -2367,7 +2364,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       92 => 'membership_recur_id',
       93 => 'Campaign ID',
       94 => 'member_is_override',
-      95 => 'member_auto_renew',
     ];
   }
 
@@ -2771,7 +2767,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'membership_recur_id' => 'membership_recur_id varchar(255)',
       'member_campaign_id' => 'member_campaign_id varchar(16)',
       'member_is_override' => 'member_is_override text',
-      'member_auto_renew' => 'member_auto_renew text',
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup - removes a false field from the Member_BAO_Query object which is not populated by that object

Before
----------------------------------------
Field 'appears' to be selectable but confusingly is not

After
----------------------------------------
Confusion reduced

Technical Details
----------------------------------------
This field is in the defaultReturnProperties for the BAO_Query object but it's a pseudofield and as demonstrated in this PR
https://github.com/civicrm/civicrm-core/pull/14956

the ability of the [search selector](https://github.com/civicrm/civicrm-core/pull/14956/files#diff-ce8713d2ed34e1061d2b3304ec3ff6bbR69)
to determine this value is unrelated to it's presence in the Query object (which always returns an empty value as we can
see in the [export test](https://github.com/civicrm/civicrm-core/pull/14956/files#diff-4686601201fee8a8402a894c1b7df226R291)
despite contribution_recur_id being calculated (as we see a few lines earlier)

This is not a query object the api accesses

Comments
----------------------------------------
Part of ensuring all export fields are meta-data defined
