### PR TITLE
[Import] [Cleanup] remove unused parameters

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -247,8 +247,8 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
             $defaults["mapper[$i]"] = [
               CRM_Utils_Array::value(0, $mappingHeader),
               ($softField) ? $softField : "",
-              (isset($locationId)) ? $locationId : "",
-              (isset($phoneType)) ? $phoneType : "",
+              "",
+              "",
             ];
             $jsSet = TRUE;
           }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup -remove some variables that only confuse

Before
----------------------------------------
<img width="647" alt="Screen Shot 2019-08-07 at 8 44 46 PM" src="https://user-images.githubusercontent.com/336308/62608772-9b92ee80-b954-11e9-9240-c40f315154e1.png">


After
----------------------------------------

Removed


As we can see the fields are not actually available in the UI for contribution import so no actual change
<img width="916" alt="Screen Shot 2019-08-07 at 8 42 01 PM" src="https://user-images.githubusercontent.com/336308/62608823-ba918080-b954-11e9-9563-a25fd5a03e26.png">


Technical Details
----------------------------------------
Looks like some copy & past put these vars here as they are never set & not exposed for
contribution import

Comments
----------------------------------------

