### PR TITLE
reporting#18: participant listing report filters by role incorrectly

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -572,7 +572,7 @@ ORDER BY  cv.label
                   $operator = 'NOT';
                 }
 
-                $regexp = "[[:cntrl:]]*" . implode('[[:>:]]*|[[:<:]]*', $value) . "[[:cntrl:]]*";
+                $regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', (array) $value) . "([[:cntrl:]]|$)";
                 $clause = "{$field['dbAlias']} {$operator} REGEXP '{$regexp}'";
               }
               $op = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
This issue is identical to [CRM-18803](https://issues.civicrm.org/jira/browse/CRM-18803) except that CRM-18803 affected all other CiviReports with fields that stored values separated by `CRM_Core_DAO::VALUE_SEPARATOR`.  Those were fixed everywhere else by [this PR](https://github.com/civicrm/civicrm-core/pull/8650).  However, since the `where()` in this report is overridden, it has its own copy of the regex which wasn't fixed.

I grepped and confirmed this is the only place where this needs to be fixed, and applied the same regex as the commit above.

To replicate this bug, you need at least ten participant roles.  The first one's value should be `1`.  Searching on this value will return any participant whose role BEGINS with a `1` (i.e. `10`, `11`, `100`, etc.) rather than just records whose participant role value IS 1.

Before
----------------------------------------
Searching for a participant role will return all participants whose value begins with the value you're searching for.

After
----------------------------------------
Participant list is filtered correctly.

Comments
----------------------------------------
This fix is identical to the one listed in the PR above, which is used on many reports; this is just an overridden method where it wasn't changed.
