### PR TITLE
Unit test for custom date parsing

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -11,6 +11,14 @@
  */
 class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   protected $_tablesToTruncate = [];
+  use CRMTraits_Custom_CustomDataTrait;
+
+  /**
+   * Default entity for class.
+   *
+   * @var string
+   */
+  protected $entity = 'Contribution';
 
   /**
    * Setup function.
@@ -140,6 +148,29 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $values['contribution_status_id'] = 'just say no';
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::ERROR);
     $this->callAPISuccessGetCount('Contribution', ['contact_id' => $contactID], 2);
+  }
+
+  /**
+   * Test dates are parsed
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testParsedCustomDates() {
+    $this->createCustomGroupWithFieldOfType([], 'date');
+    $mapperKeys = [];
+    $form = new CRM_Contribute_Import_Parser_Contribution($mapperKeys);
+    $params = [$this->getCustomFieldName('date') => '20/10/2019'];
+    CRM_Core_Session::singleton()->set('dateTypes', 32);
+    $formatted = [];
+    $form->formatInput($params, $formatted);
+    // @todo I feel like we should work towards this actually parsing $params here -
+    // & dropping formatting but
+    // per https://github.com/civicrm/civicrm-core/pull/14986 for now $formatted is parsing
+    // The issue I hit was that when I tried to extend to checking they were correctly imported
+    // I was not actually sure what correct behaviour was for what dates were accepted since
+    // on one hand the custom fields have a date format & on the other there is an input format &
+    // it seems to ignore the latter in favour of the former - which seems wrong.
+    $this->assertEquals('20191020000000', $formatted[$this->getCustomFieldName('date')]);
   }
 
   /**

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -72,7 +72,7 @@ trait CRMTraits_Custom_CustomDataTrait {
    * @throws \CRM_Core_Exception
    */
   public function createCustomGroupWithFieldOfType($groupParams = [], $customFieldType = 'text', $identifier = '') {
-    $supported = ['text', 'select'];
+    $supported = ['text', 'select', 'date'];
     if (!in_array($customFieldType, $supported)) {
       throw new CRM_Core_Exception('we have not yet extracted other custom field types from createCustomFieldsOfAllTypes, Use consistent syntax when you do');
     }
@@ -85,6 +85,10 @@ trait CRMTraits_Custom_CustomDataTrait {
 
       case 'select':
         $customField = $this->createSelectCustomField(['custom_group_id' => $this->ids['CustomGroup'][$groupParams['title']]]);
+        break;
+
+      case 'date':
+        $customField = $this->createDateCustomField(['custom_group_id' => $this->ids['CustomGroup'][$groupParams['title']]]);
         break;
     }
     $this->ids['CustomField'][$identifier . $customFieldType] = $customField['id'];
@@ -102,18 +106,7 @@ trait CRMTraits_Custom_CustomDataTrait {
     $customField = $this->createSelectCustomField(['custom_group_id' => $customGroupID]);
     $ids['select_string'] = $customField['id'];
 
-    $params = [
-      'custom_group_id' => $customGroupID,
-      'name' => 'test_date',
-      'label' => 'test_date',
-      'html_type' => 'Select Date',
-      'data_type' => 'Date',
-      'default_value' => '20090711',
-      'weight' => 3,
-      'time_format' => 1,
-    ];
-
-    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    $customField = $this->createDateCustomField(['custom_group_id' => $customGroupID]);
 
     $ids['select_date'] = $customField['id'];
     $params = [
@@ -246,6 +239,28 @@ trait CRMTraits_Custom_CustomDataTrait {
       'is_searchable' => 0,
       'is_active' => 1,
       'option_values' => $optionValue,
+    ], $params);
+
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    return $customField['values'][$customField['id']];
+  }
+
+  /**
+   * Create a custom field of  type date.
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  protected function createDateCustomField($params): array {
+    $params = array_merge([
+      'name' => 'test_date',
+      'label' => 'test_date',
+      'html_type' => 'Select Date',
+      'data_type' => 'Date',
+      'default_value' => '20090711',
+      'weight' => 3,
+      'time_format' => 1,
     ], $params);
 
     $customField = $this->callAPISuccess('custom_field', 'create', $params);


### PR DESCRIPTION
Overview
----------------------------------------
Unit test for https://github.com/civicrm/civicrm-core/pull/14986
along with some code comments in the test about issues I hit doing what I thought was the right fix


Before
----------------------------------------
Test not included in fix

After
----------------------------------------
Test included

Technical Details
----------------------------------------
- Comments about issues I hit copied here for visibility

    // @todo I feel like we should work towards this actually parsing $params here -
    // & dropping formatting but
    // per https://github.com/civicrm/civicrm-core/pull/14986 for now $formatted is parsing
    // The issue I hit was that when I tried to extend to checking they were correctly imported
    // I was not actually sure what correct behaviour was for what dates were accepted since
    // it seems to ignore the latter in favour of the former - which seems wrong.

Comments
----------------------------------------

@lucianov88 FYI