### PR TITLE
Remove ?last? instances of ->free() dev/core#562

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -234,26 +234,22 @@ class CRM_Core_DAO extends DB_DataObject {
       if ($fkDAO->find(TRUE)) {
         $this->$dbName = $fkDAO->id;
       }
-      $fkDAO->free();
     }
 
     elseif (in_array($FKClassName, CRM_Core_DAO::$_testEntitiesToSkip)) {
       $depObject = new $FKClassName();
       $depObject->find(TRUE);
       $this->$dbName = $depObject->id;
-      $depObject->free();
     }
     elseif ($daoName == 'CRM_Member_DAO_MembershipType' && $fieldName == 'member_of_contact_id') {
       // FIXME: the fields() metadata is not specific enough
       $depObject = CRM_Core_DAO::createTestObject($FKClassName, ['contact_type' => 'Organization']);
       $this->$dbName = $depObject->id;
-      $depObject->free();
     }
     else {
       //if it is required we need to generate the dependency object first
       $depObject = CRM_Core_DAO::createTestObject($FKClassName, CRM_Utils_Array::value($dbName, $params, 1));
       $this->$dbName = $depObject->id;
-      $depObject->free();
     }
   }
 

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -880,9 +880,6 @@ AND    u.status = 1
       else {
         $contactMatching++;
       }
-      if (is_object($match)) {
-        $match->free();
-      }
     }
 
     return [

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -836,9 +836,6 @@ AND    u.status = 1
       else {
         $contactMatching++;
       }
-      if (is_object($match)) {
-        $match->free();
-      }
     }
 
     return [

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -815,9 +815,6 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
       else {
         $contactMatching++;
       }
-      if (is_object($match)) {
-        $match->free();
-      }
     }
 
     return [

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -616,9 +616,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
       else {
         $contactMatching++;
       }
-      if (is_object($match)) {
-        $match->free();
-      }
     }
 
     return [

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -897,9 +897,6 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       else {
         $contactMatching++;
       }
-      if (is_object($match)) {
-        $match->free();
-      }
     }
 
     return [

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -847,9 +847,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       else {
         $contactMatching++;
       }
-      if (is_object($match)) {
-        $match->free();
-      }
     }
 
     return [

--- a/tools/scripts/solr/createSyncJSON.php
+++ b/tools/scripts/solr/createSyncJSON.php
@@ -133,7 +133,6 @@ SELECT $selectString, $whereField as contact_id
     }
     appendValue($values, $dao->contact_id, 'contact', $contact, $flat);
   }
-  $dao->free();
 }
 
 /**
@@ -187,7 +186,6 @@ AND   entity_table = 'civicrm_contact'
 
     appendValue($values, $dao->id, 'note', $note);
   }
-  $dao->free();
 }
 
 /**
@@ -225,7 +223,6 @@ AND        p.phone IS NOT NULL
 
     appendValue($values, $dao->id, 'phone', $phone);
   }
-  $dao->free();
 }
 
 /**
@@ -258,7 +255,6 @@ AND        e.email IS NOT NULL
     ];
     appendValue($values, $dao->id, 'email', $email);
   }
-  $dao->free();
 }
 
 /**
@@ -309,7 +305,6 @@ WHERE c.id IN ( $ids )
     }
     appendValue($values, $dao->id, 'address', $address);
   }
-  $dao->free();
 }
 
 /**
@@ -362,7 +357,6 @@ function getRelationshipInfo(&$contactIDs, &$values, &$allContactIDs, &$addition
       $allContactIDs, $additionalContacts
     );
   }
-  $dao->free();
 }
 
 /**
@@ -418,7 +412,6 @@ function getActivityInfo(&$contactIDs, &$values, &$allContactIDs, &$additionalCo
       $allContactIDs, $additionalContacts
     );
   }
-  $dao->free();
 
   if (empty($activityIDs)) {
     return;
@@ -439,7 +432,6 @@ function getActivityInfo(&$contactIDs, &$values, &$allContactIDs, &$additionalCo
     appendValue($values, $aaDAO->id, 'activity_assignment', $activityAssignee);
     $activityContacts[] = $aaDAO->assignee_contact_id;
   }
-  $aaDAO->free();
 
   $sql = "SELECT * FROM civicrm_activity_target WHERE activity_id IN ($activityIDString)";
   $atDAO = &CRM_Core_DAO::executeQuery($sql);
@@ -452,7 +444,6 @@ function getActivityInfo(&$contactIDs, &$values, &$allContactIDs, &$additionalCo
     appendValue($values, $atDAO->id, 'activity_target', $activityTarget);
     $activityContacts[] = $atDAO->target_contact_id;
   }
-  $atDAO->free();
 
   addAdditionalContacts($activityContacts, $allContactIDs, $additionalContacts);
 }


### PR DESCRIPTION
Overview
----------------------------------------
These are almost the last places where ->free is to be found. The remaining ones are in the dao
and perhaps out of scope / need more careful investigation

Before
----------------------------------------
$dao->free() used

After
----------------------------------------
$dao->free() removed

Technical Details
----------------------------------------
This is a deprecated method (replaced by $dao->__deconstruct()) which  in rare cases causes bugs - we've removed a tonne -  I think this might be the last batch

Comments
----------------------------------------
@seamuslee001 @aydun 
