### PR TITLE
(dev/core#1167) Add new hook for summary overlay profile

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -97,6 +97,7 @@ class CRM_Contact_BAO_Contact_Utils {
       if (!$summaryOverlayProfileId) {
         $summaryOverlayProfileId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', 'summary_overlay', 'id', 'name');
       }
+      CRM_Utils_Hook::summaryOverlayProfile($summaryOverlayProfileId, $contactType);
 
       $profileURL = CRM_Utils_System::url('civicrm/profile/view',
         "reset=1&gid={$summaryOverlayProfileId}&id={$contactId}&snippet=4"

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2050,6 +2050,18 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called while preparing a summary overlay profile
+   *
+   * @param int $profileID
+   * @param string $contactType
+   * @return mixed
+   */
+  public static function summaryOverlayProfile(&$profileID, $contactType) {
+    return self::singleton()->invoke(array('profileID', 'contactType'), $profileID, $contactType, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, 'civicrm_summaryOverlayProfile');
+  }
+
+  /**
    * This hook is called while preparing a list of contacts (based on a profile)
    *
    * @param string $profileName


### PR DESCRIPTION
Overview
----------------------------------------
Currently, there is just one profile set for summary overlay.
This causes organisations/households to show demographics fields as well which is not relevant.
![summary_overlay](https://user-images.githubusercontent.com/3455173/62711747-35bb6b00-ba17-11e9-85d1-4f190f23fa61.png)

Add a new hook to change profile id used in summary overlay on search forms so that the extension can later decide which profile should be rendered for which contact type.

Before
----------------------------------------
No way to change profile if needed.

After
----------------------------------------
Hook can be used in extension to change the profile as per the contact type.