### PR TITLE
dev/core#1116 - refactor/rename activityTypeName

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -323,32 +323,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       );
     }
 
-    // Assigning Activity type name.
-    if ($this->_activityTypeId) {
-      $activityTypeDisplayLabels = $this->getActivityTypeDisplayLabels();
-      if ($activityTypeDisplayLabels[$this->_activityTypeId]) {
-        $this->_activityTypeName = $activityTypeDisplayLabels[$this->_activityTypeId];
-        // can't change this instance of activityTName yet - will come back to it dev/core#1116
-        $this->assign('activityTName', $activityTypeDisplayLabels[$this->_activityTypeId]);
-      }
-      // Set title.
-      if (isset($activityTypeDisplayLabels)) {
-        // FIXME - it's not clear why the if line just above is needed here and why we can't just set this once above and re-use. What is interesting, but can't possibly be the reason, is that the first if block will fail if the label is the string '0', whereas this one won't. But who would have an activity type called '0'?
-        $activityTypeDisplayLabel = CRM_Utils_Array::value($this->_activityTypeId, $activityTypeDisplayLabels);
-
-        if ($this->_currentlyViewedContactId) {
-          $displayName = CRM_Contact_BAO_Contact::displayName($this->_currentlyViewedContactId);
-          // Check if this is default domain contact CRM-10482.
-          if (CRM_Contact_BAO_Contact::checkDomainContact($this->_currentlyViewedContactId)) {
-            $displayName .= ' (' . ts('default organization') . ')';
-          }
-          CRM_Utils_System::setTitle($displayName . ' - ' . $activityTypeDisplayLabel);
-        }
-        else {
-          CRM_Utils_System::setTitle(ts('%1 Activity', [1 => $activityTypeDisplayLabel]));
-        }
-      }
-    }
+    $this->assignActivityType();
 
     // Check the mode when this form is called either single or as
     // search task action.
@@ -1256,6 +1231,37 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    */
   public function getActivityTypeDisplayLabels() {
     return CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $this->_activityTypeId, 'label');
+  }
+
+  /**
+   * For the moment this is just pulled from preProcess
+   */
+  public function assignActivityType() {
+    if ($this->_activityTypeId) {
+      $activityTypeDisplayLabels = $this->getActivityTypeDisplayLabels();
+      if ($activityTypeDisplayLabels[$this->_activityTypeId]) {
+        $this->_activityTypeName = $activityTypeDisplayLabels[$this->_activityTypeId];
+        // can't change this instance of activityTName yet - will come back to it dev/core#1116
+        $this->assign('activityTName', $activityTypeDisplayLabels[$this->_activityTypeId]);
+      }
+      // Set title.
+      if (isset($activityTypeDisplayLabels)) {
+        // FIXME - it's not clear why the if line just above is needed here and why we can't just set this once above and re-use. What is interesting, but can't possibly be the reason, is that the first if block will fail if the label is the string '0', whereas this one won't. But who would have an activity type called '0'?
+        $activityTypeDisplayLabel = CRM_Utils_Array::value($this->_activityTypeId, $activityTypeDisplayLabels);
+
+        if ($this->_currentlyViewedContactId) {
+          $displayName = CRM_Contact_BAO_Contact::displayName($this->_currentlyViewedContactId);
+          // Check if this is default domain contact CRM-10482.
+          if (CRM_Contact_BAO_Contact::checkDomainContact($this->_currentlyViewedContactId)) {
+            $displayName .= ' (' . ts('default organization') . ')';
+          }
+          CRM_Utils_System::setTitle($displayName . ' - ' . $activityTypeDisplayLabel);
+        }
+        else {
+          CRM_Utils_System::setTitle(ts('%1 Activity', [1 => $activityTypeDisplayLabel]));
+        }
+      }
+    }
   }
 
 }

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -186,4 +186,32 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
     $form->postProcess();
   }
 
+  /**
+   * This is a bit messed up having a variable called name that means label but we don't want to fix it because it's a form member variable _activityTypeName that might be used in form hooks, so just make sure it doesn't flip between name and label. dev/core#1116
+   */
+  public function testActivityTypeNameIsReallyLabel() {
+    $form = new CRM_Activity_Form_Activity();
+
+    // the actual value is irrelevant we just need something for the tested function to act on
+    $form->_currentlyViewedContactId = $this->source;
+
+    // Let's make a new activity type that has a different name from its label just to be sure.
+    $actParams = [
+      'option_group_id' => 'activity_type',
+      'name' => 'wp1234',
+      'label' => 'Water Plants',
+      'is_active' => 1,
+      'is_default' => 0,
+    ];
+    $result = $this->callAPISuccess('option_value', 'create', $actParams);
+
+    $form->_activityTypeId = $result['values'][$result['id']]['value'];
+    $this->assertNotEmpty($form->_activityTypeId);
+
+    // Do the thing we want to test
+    $form->assignActivityType();
+
+    $this->assertEquals('Water Plants', $form->_activityTypeName);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Continuation of https://github.com/civicrm/civicrm-core/pull/15032 which brings this back in line with https://github.com/civicrm/civicrm-core/pull/14972 but with naming changes 

Before
----------------------------------------
Block of code is inside preProcess()

After
----------------------------------------
Block of code is on its own and has test. No changes were made inside the block that was moved.

Technical Details
----------------------------------------

Comments
----------------------------------------
Next steps:
Add in machineName and use it where needed.
Physically add some visual separation between displayName(for contact) and displayLabel(for activityType) so it's not confusing.

