### PR TITLE
[REF] Swap CRM_Utils_Array::value for ??

### DIFF
--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -264,7 +264,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
     }
     else {
       $params = $this->controller->exportValues($this->_name);
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
       $params['deny'] = 0;
       $params['entity_table'] = 'civicrm_acl_role';
 

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -380,7 +380,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $assignmentParams = ['activity_id' => $activityId];
 
       if (is_array($params['assignee_contact_id'])) {
-        if (CRM_Utils_Array::value('deleteActivityAssignment', $params, TRUE)) {
+        if (!empty($params['deleteActivityAssignment'])) {
           // first delete existing assignments if any
           self::deleteActivityContact($activityId, $assigneeID);
         }
@@ -416,7 +416,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
     else {
-      if (CRM_Utils_Array::value('deleteActivityAssignment', $params, TRUE)) {
+      if (!empty($params['deleteActivityAssignment'])) {
         self::deleteActivityContact($activityId, $assigneeID);
       }
     }
@@ -433,7 +433,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $targetParams = ['activity_id' => $activityId];
       $resultTarget = [];
       if (is_array($params['target_contact_id'])) {
-        if (CRM_Utils_Array::value('deleteActivityTarget', $params, TRUE)) {
+        if (!empty($params['deleteActivityTarget'])) {
           // first delete existing targets if any
           self::deleteActivityContact($activityId, $targetID);
         }
@@ -469,7 +469,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
     else {
-      if (CRM_Utils_Array::value('deleteActivityTarget', $params, TRUE)) {
+      if (!empty($params['deleteActivityTarget'])) {
         self::deleteActivityContact($activityId, $targetID);
       }
     }
@@ -764,13 +764,13 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         'activity_id' => $activity['id'],
         'activity_date_time' => CRM_Utils_Array::value('activity_date_time', $activity),
         'subject' => CRM_Utils_Array::value('subject', $activity),
-        'assignee_contact_name' => CRM_Utils_Array::value('assignee_contact_sort_name', $activity, []),
+        'assignee_contact_name' => $activity['assignee_contact_sort_name'] ?? [],
         'source_contact_id' => CRM_Utils_Array::value('source_contact_id', $activity),
         'source_contact_name' => CRM_Utils_Array::value('source_contact_sort_name', $activity),
       ];
       $activities[$id]['activity_type_name'] = CRM_Core_PseudoConstant::getName('CRM_Activity_BAO_Activity', 'activity_type_id', $activity['activity_type_id']);
       $activities[$id]['activity_type'] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $activity['activity_type_id']);
-      $activities[$id]['target_contact_count'] = CRM_Utils_Array::value('target_contact_count', $activity, 0);
+      $activities[$id]['target_contact_count'] = $activity['target_contact_count'] ?? 0;
       if (!empty($activity['target_contact_count'])) {
         $displayedTarget = civicrm_api3('ActivityContact', 'get', [
           'activity_id' => $id,
@@ -1329,7 +1329,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         $smsProviderParams['To'] = '';
       }
 
-      $doNotSms = CRM_Utils_Array::value('do_not_sms', $contact, 0);
+      $doNotSms = $contact['do_not_sms'] ?? 0;
 
       if ($doNotSms) {
         $errMsgs[] = PEAR::raiseError('Contact Does not accept SMS', NULL, PEAR_ERROR_RETURN);
@@ -2427,7 +2427,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
       'activity_date_time' => CRM_Utils_Array::value('activity_date_time', $params),
       'check_permissions' => 1,
       'options' => [
-        'offset' => CRM_Utils_Array::value('offset', $params, 0),
+        'offset' => $params['offset'] ?? 0,
       ],
     ];
 

--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -682,7 +682,7 @@ class CRM_Activity_BAO_Query {
   public static function whereClauseSingleActivityText(&$values, &$query) {
     list($name, $op, $value, $grouping, $wildcard) = $values;
     $activityOptionValues = $query->getWhereValues('activity_option', $grouping);
-    $activityOption = CRM_Utils_Array::value(2, $activityOptionValues, 6);
+    $activityOption = $activityOptionValues[2] ?? 6;
 
     $query->_useDistinct = TRUE;
 

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -541,7 +541,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     if ($this->_action & CRM_Core_Action::VIEW) {
       $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$this->_activityId}&action=view&cid={$this->_values['source_contact_id']}");
-      CRM_Utils_Recent::add(CRM_Utils_Array::value('subject', $this->_values, ts('(no subject)')),
+      CRM_Utils_Recent::add($this->_values['subject'] ?? ts('(no subject)'),
         $url,
         $this->_values['id'],
         'Activity',

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -105,7 +105,7 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     }
     if ($engagementLevel = CRM_Utils_Array::value('engagement_level', $defaults)) {
       $engagementLevels = CRM_Campaign_PseudoConstant::engagementLevel();
-      $values['engagement_level'] = CRM_Utils_Array::value($engagementLevel, $engagementLevels, $engagementLevel);
+      $values['engagement_level'] = $engagementLevels[$engagementLevel] ?? $engagementLevel;
     }
 
     $values['attachment'] = CRM_Core_BAO_File::attachmentInfo('civicrm_activity', $activityId);

--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -90,9 +90,9 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
     ]);
 
     foreach ($fields as $name => $field) {
-      $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
-      $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
-      $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
+      $field['type'] = $field['type'] ?? CRM_Utils_Type::T_INT;
+      $field['dataPattern'] = $field['dataPattern'] ?? '//';
+      $field['headerPattern'] = $field['headerPattern'] ?? '//';
       $this->addField($name, $field['title'], $field['type'], $field['headerPattern'], $field['dataPattern']);
     }
 

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -450,7 +450,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
       $row['status'] = $row['status_id'] ? $activityStatus[$row['status_id']] : NULL;
 
       if ($engagementLevel = CRM_Utils_Array::value('engagement_level', $row)) {
-        $row['engagement_level'] = CRM_Utils_Array::value($engagementLevel, $engagementLevels, $engagementLevel);
+        $row['engagement_level'] = $engagementLevels[$engagementLevel] ?? $engagementLevel;
       }
 
       // CRM-3553

--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -205,7 +205,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
         'version' => 3,
         'key' => $this->_key,
       ]);
-      if (!CRM_Utils_Array::value('is_error', $result, FALSE)) {
+      if (empty($result['is_error'])) {
         CRM_Core_Session::setStatus("", ts('Extension Upgraded'), "success");
       }
       else {

--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -201,7 +201,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
     $dao->api_entity = $values['api_entity'];
     $dao->api_action = $values['api_action'];
     $dao->description = $values['description'];
-    $dao->is_active = CRM_Utils_Array::value('is_active', $values, 0);
+    $dao->is_active = $values['is_active'] ?? 0;
 
     // CRM-17686
     $ts = strtotime($values['scheduled_run_date']);

--- a/CRM/Admin/Form/LocationType.php
+++ b/CRM/Admin/Form/LocationType.php
@@ -96,8 +96,8 @@ class CRM_Admin_Form_LocationType extends CRM_Admin_Form {
 
     // store the submitted values in an array
     $params = $this->exportValues();
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
+    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['is_default'] = $params['is_default'] ?? FALSE;
 
     // action is taken depending upon the mode
     $locationType = new CRM_Core_DAO_LocationType();

--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -170,7 +170,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
         'is_default',
         'is_ssl',
       ])) {
-        $params[$f] = CRM_Utils_Array::value($f, $formValues, FALSE);
+        $params[$f] = $formValues[$f] ?? FALSE;
       }
       else {
         $params[$f] = CRM_Utils_Array::value($f, $formValues);

--- a/CRM/Admin/Form/ParticipantStatusType.php
+++ b/CRM/Admin/Form/ParticipantStatusType.php
@@ -105,8 +105,8 @@ class CRM_Admin_Form_ParticipantStatusType extends CRM_Admin_Form {
       'name' => CRM_Utils_Array::value('name', $formValues),
       'label' => CRM_Utils_Array::value('label', $formValues),
       'class' => CRM_Utils_Array::value('class', $formValues),
-      'is_active' => CRM_Utils_Array::value('is_active', $formValues, FALSE),
-      'is_counted' => CRM_Utils_Array::value('is_counted', $formValues, FALSE),
+      'is_active' => $formValues['is_active'] ?? FALSE,
+      'is_counted' => $formValues['is_counted'] ?? FALSE,
       'weight' => CRM_Utils_Array::value('weight', $formValues),
       'visibility_id' => CRM_Utils_Array::value('visibility_id', $formValues),
     ];

--- a/CRM/Admin/Form/PaymentProcessorType.php
+++ b/CRM/Admin/Form/PaymentProcessorType.php
@@ -157,7 +157,7 @@ class CRM_Admin_Form_PaymentProcessorType extends CRM_Admin_Form {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_PaymentProcessorType');
 
     foreach ($this->_fields as $field) {
-      $required = CRM_Utils_Array::value('required', $field, FALSE);
+      $required = $field['required'] ?? FALSE;
       $this->add('text', $field['name'],
         $field['label'], $attributes['name'], $required
       );
@@ -221,9 +221,9 @@ UPDATE civicrm_payment_processor SET is_default = 0";
     $dao = new CRM_Financial_DAO_PaymentProcessorType();
 
     $dao->id = $this->_id;
-    $dao->is_default = CRM_Utils_Array::value('is_default', $values, 0);
-    $dao->is_active = CRM_Utils_Array::value('is_active', $values, 0);
-    $dao->is_recur = CRM_Utils_Array::value('is_recur', $values, 0);
+    $dao->is_default = $values['is_default'] ?? 0;
+    $dao->is_active = $values['is_active'] ?? 0;
+    $dao->is_recur = $values['is_recur'] ?? 0;
 
     $dao->name = $values['name'];
     $dao->description = $values['description'];

--- a/CRM/Admin/Form/Preferences.php
+++ b/CRM/Admin/Form/Preferences.php
@@ -110,7 +110,7 @@ class CRM_Admin_Form_Preferences extends CRM_Core_Form {
     foreach ($this->_varNames as $groupName => $settings) {
       CRM_Core_Error::deprecatedFunctionWarning('deprecated use of preferences form. This will be removed from core soon');
       foreach ($settings as $settingName => $settingDetails) {
-        $this->_defaults[$settingName] = isset($this->_config->$settingName) ? $this->_config->$settingName : CRM_Utils_Array::value('default', $settingDetails, NULL);
+        $this->_defaults[$settingName] = $this->_config->$settingName ?? $settingDetails['default'] ?? NULL;
       }
     }
 
@@ -218,7 +218,7 @@ class CRM_Admin_Form_Preferences extends CRM_Core_Form {
               break;
 
             case 'entity_reference':
-              $this->addEntityRef($fieldName, $fieldValue['title'], CRM_Utils_Array::value('options', $fieldValue, []));
+              $this->addEntityRef($fieldName, $fieldValue['title'], $fieldValue['options'] ?? []);
           }
         }
 

--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -191,7 +191,7 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
     // too. This means that saving from api will not have the desired core effect.
     // but we should fix that elsewhere - ie. stop abusing the settings
     // and fix the code repetition associated with invoicing
-    $invoiceParams['invoicing'] = CRM_Utils_Array::value('invoicing', $params, 0);
+    $invoiceParams['invoicing'] = $params['invoicing'] ?? 0;
     Civi::settings()->set('contribution_invoice_settings', $invoiceParams);
     parent::postProcess();
   }

--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -181,7 +181,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
     else {
       // store the submitted values in an array
       $params = $this->exportValues();
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -320,7 +320,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $errors['entity'] = ts('Please select appropriate value');
     }
 
-    $mode = CRM_Utils_Array::value('mode', $fields, FALSE);
+    $mode = $fields['mode'] ?? FALSE;
     if (!empty($fields['is_active']) &&
       CRM_Utils_System::isNull($fields['subject']) && (!$mode || $mode != 'SMS')
     ) {
@@ -508,7 +508,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $params[$key] = CRM_Utils_Array::value($key, $values);
     }
 
-    $params['is_repeat'] = CRM_Utils_Array::value('is_repeat', $values, 0);
+    $params['is_repeat'] = $values['is_repeat'] ?? 0;
 
     $moreKeys = [
       'start_action_offset',
@@ -569,13 +569,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
         $params['limit_to'] = 1;
       }
 
-      $entity_value = CRM_Utils_Array::value(1, $values['entity'], []);
-      $entity_status = CRM_Utils_Array::value(2, $values['entity'], []);
+      $entity_value = $values['entity'][1] ?? [];
+      $entity_status = $values['entity'][2] ?? [];
       $params['entity_value'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $entity_value);
       $params['entity_status'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $entity_status);
     }
 
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $values, 0);
+    $params['is_active'] = $values['is_active'] ?? 0;
 
     if (CRM_Utils_Array::value('is_repeat', $values) == 0) {
       $params['repetition_frequency_unit'] = 'null';
@@ -587,9 +587,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     }
 
     // multilingual options
-    $params['filter_contact_language'] = CRM_Utils_Array::value('filter_contact_language', $values, []);
+    $params['filter_contact_language'] = $values['filter_contact_language'] ?? [];
     $params['filter_contact_language'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['filter_contact_language']);
-    $params['communication_language'] = CRM_Utils_Array::value('communication_language', $values, NULL);
+    $params['communication_language'] = $values['communication_language'] ?? NULL;
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -197,8 +197,8 @@ trait CRM_Admin_Form_SettingTrait {
             $props['html_type'],
             $setting,
             $props['title'],
-            ($options !== NULL) ? $options : CRM_Utils_Array::value('html_attributes', $props, []),
-            ($options !== NULL) ? CRM_Utils_Array::value('html_attributes', $props, []) : NULL
+            ($options !== NULL) ? $options : $props['html_attributes'] ?? [],
+            ($options !== NULL) ? $props['html_attributes'] ?? [] : NULL
           );
         }
         elseif ($add == 'addSelect') {

--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -357,7 +357,7 @@ class CRM_Admin_Page_AJAX {
    * Used by jstree to incrementally load tags
    */
   public static function getTagTree() {
-    $parent = CRM_Utils_Type::escape(CRM_Utils_Array::value('parent_id', $_GET, 0), 'Integer');
+    $parent = CRM_Utils_Type::escape($_GET['parent_id'] ?? 0, 'Integer');
     $substring = CRM_Utils_Type::escape(CRM_Utils_Array::value('str', $_GET), 'String');
     $result = [];
 

--- a/CRM/Admin/Page/CKEditorConfig.php
+++ b/CRM/Admin/Page/CKEditorConfig.php
@@ -69,7 +69,7 @@ class CRM_Admin_Page_CKEditorConfig extends CRM_Core_Page {
    * @return string
    */
   public function run() {
-    $this->preset = CRM_Utils_Array::value('preset', $_REQUEST, 'default');
+    $this->preset = $_REQUEST['preset'] ?? 'default';
 
     // If the form was submitted, take appropriate action.
     if (!empty($_POST['revert'])) {

--- a/CRM/Badge/BAO/Layout.php
+++ b/CRM/Badge/BAO/Layout.php
@@ -87,9 +87,9 @@ class CRM_Badge_BAO_Layout extends CRM_Core_DAO_PrintLabel {
    * @return object
    */
   public static function create(&$params) {
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
-    $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['is_default'] = $params['is_default'] ?? FALSE;
+    $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
 
     $params['label_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_PrintLabel', 'label_type_id', 'Event Badge');
 

--- a/CRM/Badge/Form/Layout.php
+++ b/CRM/Badge/Form/Layout.php
@@ -153,7 +153,7 @@ class CRM_Badge_Form_Layout extends CRM_Admin_Form {
   public function setDefaultValues() {
     if (isset($this->_id)) {
       $defaults = array_merge($this->_values,
-        CRM_Badge_BAO_Layout::getDecodedData(CRM_Utils_Array::value('data', $this->_values, '[]')));
+        CRM_Badge_BAO_Layout::getDecodedData($this->_values['data'] ?? '[]'));
     }
     else {
       for ($i = 1; $i <= self::FIELD_ROWCOUNT; $i++) {

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -306,7 +306,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       $params['created_date'] = date('YmdHis');
     }
     // format params
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+    $params['is_active'] = $params['is_active'] ?? FALSE;
     $params['last_modified_id'] = $session->get('userID');
     $params['last_modified_date'] = date('YmdHis');
     $result = self::submit($params, $this);

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -307,7 +307,7 @@ WHERE  $whereClause
 
     $params['last_modified_id'] = $session->get('userID');
     $params['last_modified_date'] = date('YmdHis');
-    $params['is_share'] = CRM_Utils_Array::value('is_share', $params, FALSE);
+    $params['is_share'] = $params['is_share'] ?? FALSE;
 
     if ($this->_surveyId) {
 
@@ -325,9 +325,9 @@ WHERE  $whereClause
       $params['created_date'] = date('YmdHis');
     }
 
-    $params['bypass_confirm'] = CRM_Utils_Array::value('bypass_confirm', $params, 0);
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, 0);
-    $params['is_default'] = CRM_Utils_Array::value('is_default', $params, 0);
+    $params['bypass_confirm'] = $params['bypass_confirm'] ?? 0;
+    $params['is_active'] = $params['is_active'] ?? 0;
+    $params['is_default'] = $params['is_default'] ?? 0;
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->getEntityId(), $this->getDefaultEntity());
 

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -183,8 +183,8 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
       $params['created_date'] = date('YmdHis');
     }
 
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, 0);
-    $params['is_default'] = CRM_Utils_Array::value('is_default', $params, 0);
+    $params['is_active'] = $params['is_active'] ?? 0;
+    $params['is_default'] = $params['is_default'] ?? 0;
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->getEntityId(), $this->getDefaultEntity());
 

--- a/CRM/Campaign/Form/Task/Reserve.php
+++ b/CRM/Campaign/Form/Task/Reserve.php
@@ -312,7 +312,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
     }
 
     $params = $this->controller->exportValues($this->_name);
-    $groups = CRM_Utils_Array::value('groups', $params, []);
+    $groups = $params['groups'] ?? [];
     $newGroupName = CRM_Utils_Array::value('newGroupName', $params);
     $newGroupDesc = CRM_Utils_Array::value('newGroupDesc', $params);
 

--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -476,7 +476,7 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
       ->addSetting([
         'tabSettings' => [
-          'active' => strtolower(CRM_Utils_Array::value('subPage', $_GET, 'campaign')),
+          'active' => strtolower($_GET['subPage'] ?? 'campaign'),
         ],
       ]);
   }

--- a/CRM/Campaign/Page/Vote.php
+++ b/CRM/Campaign/Page/Vote.php
@@ -95,7 +95,7 @@ class CRM_Campaign_Page_Vote extends CRM_Core_Page {
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
       ->addSetting([
         'tabSettings' => [
-          'active' => strtolower(CRM_Utils_Array::value('subPage', $_GET, 'reserve')),
+          'active' => strtolower($_GET['subPage'] ?? 'reserve'),
         ],
       ]);
   }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -524,7 +524,7 @@ HERESQL;
       return Civi::$statics[__CLASS__]['totalCount'];
     }
 
-    $type = CRM_Utils_Array::value('type', $params, 'upcoming');
+    $type = $params['type'] ?? 'upcoming';
     $userID = CRM_Core_Session::singleton()->get('userID');
 
     // validate access for all cases.
@@ -622,7 +622,7 @@ HERESQL;
         $casesList[$key]['case_status'] = sprintf('<strong>%s</strong>', strtoupper($casesList[$key]['case_status']));
       }
       $casesList[$key]['case_type'] = CRM_Utils_Array::value($case['case_type_id'], $caseTypeTitles);
-      $casesList[$key]['case_role'] = CRM_Utils_Array::value('case_role', $case, '---');
+      $casesList[$key]['case_role'] = $case['case_role'] ?? '---';
       $casesList[$key]['manager'] = self::getCaseManagerContact($caseTypes[$case['case_type_id']], $case['case_id']);
 
       $casesList[$key]['date'] = CRM_Utils_Array::value($case['activity_type_id'], $activityTypeLabels);

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -61,7 +61,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     $caseTypeDAO = new CRM_Case_DAO_CaseType();
 
     // form the name only if missing: CRM-627
-    $nameParam = CRM_Utils_Array::value('name', $params, NULL);
+    $nameParam = $params['name'] ?? NULL;
     if (!$nameParam && empty($params['id'])) {
       $params['name'] = CRM_Utils_String::titleToVar($params['title']);
     }

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -149,7 +149,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
    */
   public function processStandardTimeline($activitySetXML, &$params) {
     if ('Change Case Type' == CRM_Utils_Array::value('activityTypeName', $params)
-      && CRM_Utils_Array::value('resetTimeline', $params, TRUE)
+      && !empty($params['resetTimeline'])
     ) {
       // delete all existing activities which are non-empty
       $this->deleteEmptyActivity($params);

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -184,7 +184,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
     ) {
       $allNull = FALSE;
       foreach (self::$_commPrefs as $name) {
-        $contact->$name = CRM_Utils_Array::value($name, $privacy, FALSE);
+        $contact->$name = $privacy[$name] ?? FALSE;
       }
     }
 
@@ -2023,8 +2023,8 @@ ORDER BY civicrm_email.is_primary DESC";
 
     // manage is_opt_out
     if (array_key_exists('is_opt_out', $fields) && array_key_exists('is_opt_out', $params)) {
-      $wasOptOut = CRM_Utils_Array::value('is_opt_out', $contactDetails, FALSE);
-      $isOptOut = CRM_Utils_Array::value('is_opt_out', $params, FALSE);
+      $wasOptOut = $contactDetails['is_opt_out'] ?? FALSE;
+      $isOptOut = $params['is_opt_out'] ?? FALSE;
       $data['is_opt_out'] = $isOptOut;
       // on change, create new civicrm_subscription_history entry
       if (($wasOptOut != $isOptOut) && !empty($contactDetails['contact_id'])) {
@@ -3715,13 +3715,13 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
       ];
       foreach ($retrieved['values'] as $id => $profile) {
         if (in_array($profile['name'], $profiles)) {
-          $links[] = array(
+          $links[] = [
             'label' => $profile['title'],
             'url' => CRM_Utils_System::url('civicrm/profile/create', "reset=1&context=dialog&gid=$id",
               NULL, NULL, FALSE, FALSE, TRUE),
             'type' => ucfirst(str_replace('new_', '', $profile['name'])),
-            'icon' => CRM_Utils_Array::value(str_replace('new_', '', $profile['name']), $icons),
-          );
+            'icon' => $icons[str_replace('new_', '', $profile['name'])] ?? NULL,
+          ];
         }
         else {
           $append[] = $id;

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -646,7 +646,7 @@ WHERE name = %1";
     $contactType = new CRM_Contact_DAO_ContactType();
     $contactType->copyValues($params);
     $contactType->id = CRM_Utils_Array::value('id', $params);
-    $contactType->is_active = CRM_Utils_Array::value('is_active', $params, 0);
+    $contactType->is_active = $params['is_active'] ?? 0;
 
     $contactType->save();
     if ($contactType->find(TRUE)) {

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -360,12 +360,12 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
           'is_active' => 1,
         ]);
         if (count($parentIds) >= 1 && $activeParentsCount <= 1) {
-          $setDisable = self::setIsActive($childValue, CRM_Utils_Array::value('is_active', $params, 1));
+          $setDisable = self::setIsActive($childValue, $params['is_active'] ?? 1);
         }
       }
     }
     // form the name only if missing: CRM-627
-    $nameParam = CRM_Utils_Array::value('name', $params, NULL);
+    $nameParam = $params['name'] ?? NULL;
     if (!$nameParam && empty($params['id'])) {
       $params['name'] = CRM_Utils_String::titleToVar($params['title']);
     }
@@ -714,8 +714,8 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       //create group only when new saved search.
       $groupParams = [
         'title' => "Hidden Smart Group {$ssId}",
-        'is_active' => CRM_Utils_Array::value('is_active', $params, 1),
-        'is_hidden' => CRM_Utils_Array::value('is_hidden', $params, 1),
+        'is_active' => $params['is_active'] ?? 1,
+        'is_hidden' => $params['is_hidden'] ?? 1,
         'group_type' => CRM_Utils_Array::value('group_type', $params),
         'visibility' => CRM_Utils_Array::value('visibility', $params),
         'saved_search_id' => $ssId,

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -551,7 +551,7 @@ WHERE  id IN ( $groupIDs )
             TRUE, TRUE,
             FALSE,
             CRM_Utils_Array::value('display_relationship_type', $formValues),
-            CRM_Utils_Array::value('operator', $formValues, 'AND')
+            $formValues['operator'] ?? 'AND'
           );
         $query->_useDistinct = FALSE;
         $query->_useGroupBy = FALSE;

--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -66,13 +66,13 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
     }
 
     $sortName = $displayName = '';
-    $firstName = CRM_Utils_Array::value('first_name', $params, '');
-    $middleName = CRM_Utils_Array::value('middle_name', $params, '');
-    $lastName = CRM_Utils_Array::value('last_name', $params, '');
-    $nickName = CRM_Utils_Array::value('nick_name', $params, '');
-    $prefix_id = CRM_Utils_Array::value('prefix_id', $params, '');
-    $suffix_id = CRM_Utils_Array::value('suffix_id', $params, '');
-    $formalTitle = CRM_Utils_Array::value('formal_title', $params, '');
+    $firstName = $params['first_name'] ?? '';
+    $middleName = $params['middle_name'] ?? '';
+    $lastName = $params['last_name'] ?? '';
+    $nickName = $params['nick_name'] ?? '';
+    $prefix_id = $params['prefix_id'] ?? '';
+    $suffix_id = $params['suffix_id'] ?? '';
+    $formalTitle = $params['formal_title'] ?? '';
 
     // get prefix and suffix names
     $prefix = $suffix = NULL;
@@ -83,7 +83,7 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
       $params['individual_suffix'] = $suffix = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'suffix_id', $suffix_id);
     }
 
-    $params['is_deceased'] = CRM_Utils_Array::value('is_deceased', $params, FALSE);
+    $params['is_deceased'] = $params['is_deceased'] ?? FALSE;
 
     $individual = NULL;
     if ($contact->id) {

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1436,7 +1436,7 @@ class CRM_Contact_BAO_Query {
         // make sure there is only one element
         // this is used when we are running under smog and need to know
         // how the contact was added (CRM-1203)
-        $groups = (array) CRM_Utils_Array::value($this->_paramLookup['group'][0][1], $this->_paramLookup['group'][0][2], $this->_paramLookup['group'][0][2]);
+        $groups = (array) ($this->_paramLookup['group'][0][2][$this->_paramLookup['group'][0][1]] ?? $this->_paramLookup['group'][0][2]);
         if ((count($this->_paramLookup['group']) == 1) &&
           (count($groups) == 1)
         ) {
@@ -2641,7 +2641,7 @@ class CRM_Contact_BAO_Query {
       $k = 99;
       if (strpos($key, '-') !== FALSE) {
         $keyArray = explode('-', $key);
-        $k = CRM_Utils_Array::value('civicrm_' . $keyArray[1], $info, 99);
+        $k = $info['civicrm_' . $keyArray[1]] ?? 99;
       }
       elseif (strpos($key, '_') !== FALSE) {
         $keyArray = explode('_', $key);
@@ -2649,11 +2649,11 @@ class CRM_Contact_BAO_Query {
           $k = CRM_Utils_Array::value(implode('_', $keyArray), $info, 99);
         }
         else {
-          $k = CRM_Utils_Array::value($key, $info, 99);
+          $k = $info[$key] ?? 99;
         }
       }
       else {
-        $k = CRM_Utils_Array::value($key, $info, 99);
+        $k = $info[$key] ?? 99;
       }
       $tempTable[$k . ".$key"] = $key;
     }
@@ -3033,7 +3033,7 @@ class CRM_Contact_BAO_Query {
     }
 
     if (isset($value)) {
-      $value = CRM_Utils_Array::value($op, $value, $value);
+      $value = $value[$op] ?? $value;
     }
 
     if ($name == 'group_type') {
@@ -3404,7 +3404,7 @@ WHERE  $smartGroupClause
     list($name, $op, $value, $grouping, $wildcard) = $values;
 
     $noteOptionValues = $this->getWhereValues('note_option', $grouping);
-    $noteOption = CRM_Utils_Array::value('2', $noteOptionValues, '6');
+    $noteOption = $noteOptionValues['2'] ?? '6';
     $noteOption = ($name == 'note_body') ? 2 : (($name == 'note_subject') ? 3 : $noteOption);
 
     $this->_useDistinct = TRUE;
@@ -4722,8 +4722,8 @@ civicrm_relationship.start_date > {$today}
         return;
       }
 
-      $from = CRM_Utils_Array::value($customFieldName . '_from', $formValues, NULL);
-      $to = CRM_Utils_Array::value($customFieldName . '_to', $formValues, NULL);
+      $from = $formValues[$customFieldName . '_from'] ?? NULL;
+      $to = $formValues[$customFieldName . '_to'] ?? NULL;
 
       if (self::isCustomDateField($customFieldName)) {
         list($from, $to) = CRM_Utils_Date::getFromTo(NULL, $from, $to);
@@ -6008,7 +6008,7 @@ AND   displayRelType.is_active = 1
             $dao->$key = CRM_Core_PseudoConstant::getLabel($value['bao'], $value['idCol'], $val);
           }
         }
-        elseif ($baoName = CRM_Utils_Array::value('bao', $value, NULL)) {
+        elseif ($baoName = $value['bao'] ?? NULL) {
           //preserve id value
           $idColumn = "{$key}_id";
           $dao->$idColumn = $val;
@@ -6159,7 +6159,7 @@ AND   displayRelType.is_active = 1
 
     // if Operator chosen is NULL/EMPTY then
     if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) {
-      return [CRM_Utils_Array::value($op, $qillOperators, $op), ''];
+      return [$qillOperators[$op] ?? $op, ''];
     }
 
     if ($fieldName == 'activity_type_id') {
@@ -6175,7 +6175,7 @@ AND   displayRelType.is_active = 1
       $pseudoOptions = CRM_Core_PseudoConstant::worldRegion();
     }
     elseif ($daoName == 'CRM_Event_DAO_Event' && $fieldName == 'id') {
-      $checkPermission = CRM_Utils_Array::value('check_permission', $pseudoExtraParam, TRUE);
+      $checkPermission = $pseudoExtraParam['check_permission'] ?? TRUE;
       $pseudoOptions = CRM_Event_BAO_Event::getEvents(0, $fieldValue, TRUE, $checkPermission, TRUE);
     }
     elseif ($fieldName == 'contribution_product_id') {
@@ -6195,7 +6195,7 @@ AND   displayRelType.is_active = 1
       $qillString = [];
       if (!empty($pseudoOptions)) {
         foreach ((array) $fieldValue as $val) {
-          $qillString[] = CRM_Utils_Array::value($val, $pseudoOptions, $val);
+          $qillString[] = $pseudoOptions[$val] ?? $val;
         }
         $fieldValue = implode(', ', $qillString);
       }
@@ -6222,7 +6222,7 @@ AND   displayRelType.is_active = 1
       $fieldValue = CRM_Utils_Date::customFormat($fieldValue);
     }
 
-    return [CRM_Utils_Array::value($op, $qillOperators, $op), $fieldValue];
+    return [$qillOperators[$op] ?? $op, $fieldValue];
   }
 
   /**
@@ -6395,14 +6395,14 @@ AND   displayRelType.is_active = 1
       // is not declared for them.
       // @todo so far only integer fields are being handled. If we add string fields we need to look at
       // escaping.
-      $pseudoConstantMetadata = CRM_Utils_Array::value('pseudoconstant', $fieldSpec, FALSE);
+      $pseudoConstantMetadata = $fieldSpec['pseudoconstant'] ?? FALSE;
       if (!empty($pseudoConstantMetadata)
       ) {
         if (!empty($pseudoConstantMetadata['optionGroupName'])
           || $this->isPseudoFieldAnFK($fieldSpec)
         ) {
           $sortedOptions = $fieldSpec['bao']::buildOptions($fieldSpec['name'], NULL, [
-            'orderColumn' => CRM_Utils_Array::value('labelColumn', $pseudoConstantMetadata, 'label'),
+            'orderColumn' => $pseudoConstantMetadata['labelColumn'] ?? 'label',
           ]);
           $fieldIDsInOrder = implode(',', array_keys($sortedOptions));
           // Pretty sure this validation ALSO happens in the order clause & this can't be reached but...
@@ -6844,7 +6844,7 @@ AND   displayRelType.is_active = 1
     if (!empty($field) && empty($field['name'])) {
       // standardising field formatting here - over time we can phase out variants.
       // all paths using this currently unit tested
-      $field['name'] = CRM_Utils_Array::value('field_name', $field, CRM_Utils_Array::value('idCol', $field, $fieldName));
+      $field['name'] = $field['field_name'] ?? $field['idCol'] ?? $fieldName;
     }
     return $field;
   }

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -61,7 +61,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     $extendedParams = self::loadExistingRelationshipDetails($params);
     // When id is specified we always wan't to update, so we don't need to
     // check for duplicate relations.
-    if (!isset($params['id']) && self::checkDuplicateRelationship($extendedParams, $extendedParams['contact_id_a'], $extendedParams['contact_id_b'], CRM_Utils_Array::value('id', $extendedParams, 0))) {
+    if (!isset($params['id']) && self::checkDuplicateRelationship($extendedParams, $extendedParams['contact_id_a'], $extendedParams['contact_id_b'], $extendedParams['id'] ?? 0)) {
       throw new CRM_Core_Exception('Duplicate Relationship');
     }
     $params = $extendedParams;
@@ -1046,7 +1046,7 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
     ]);
 
     if (is_array($result) && !empty($result['is_error']) && $result['error_message'] != 'Duplicate Relationship') {
-      throw new CiviCRM_API3_Exception($result['error_message'], CRM_Utils_Array::value('error_code', $result, 'undefined'), $result);
+      throw new CiviCRM_API3_Exception($result['error_message'], $result['error_code'] ?? 'undefined', $result);
     }
 
     return TRUE;
@@ -1517,7 +1517,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     // Check the end date and set the status of the relationship
     // accordingly.
     $status = self::CURRENT;
-    $targetContact = $targetContact = CRM_Utils_Array::value('contact_check', $params, []);
+    $targetContact = $targetContact = $params['contact_check'] ?? [];
     $today = date('Ymd');
 
     // If a relationship hasn't yet started, just return for now
@@ -1664,7 +1664,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         continue;
       }
 
-      $relatedContacts = array_keys(CRM_Utils_Array::value('relatedContacts', $details, []));
+      $relatedContacts = array_keys($details['relatedContacts'] ?? []);
       $mainRelatedContactId = reset($relatedContacts);
 
       foreach ($details['memberships'] as $membershipId => $membershipValues) {
@@ -1767,7 +1767,7 @@ SELECT count(*)
  WHERE membership_type_id = {$membershipValues['membership_type_id']} AND owner_membership_id = {$membershipValues['owner_membership_id']}
     AND is_current_member = 1";
             $result = CRM_Core_DAO::singleValueQuery($query);
-            if ($result < CRM_Utils_Array::value('max_related', $membershipValues, PHP_INT_MAX)) {
+            if ($result < $membershipValues['max_related'] ?? PHP_INT_MAX) {
               CRM_Member_BAO_Membership::create($membershipValues);
             }
           }
@@ -2134,7 +2134,7 @@ AND cc.sort_name LIKE '%$name%'";
             'civicrm/contact/view',
             "reset=1&cid={$values['cid']}");
 
-        $relationship['relation'] = CRM_Utils_Array::value('case', $values, '') . CRM_Utils_System::href(
+        $relationship['relation'] = $values['case'] ?? '' . CRM_Utils_System::href(
             $values['relation'],
             'civicrm/contact/view/rel',
             "action=view&reset=1&cid={$values['cid']}&id={$values['id']}&rtype={$values['rtype']}");
@@ -2225,7 +2225,7 @@ AND cc.sort_name LIKE '%$name%'";
    */
   public static function buildRelationshipTypeOptions($params = []) {
     $contactId = CRM_Utils_Array::value('contact_id', $params);
-    $direction = CRM_Utils_Array::value('relationship_direction', $params, 'a_b');
+    $direction = $params['relationship_direction'] ?? 'a_b';
     $relationshipId = CRM_Utils_Array::value('relationship_id', $params);
     $contactType = CRM_Utils_Array::value('contact_type', $params);
     $isForm = CRM_Utils_Array::value('is_form', $params);

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -399,10 +399,10 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
       $savedSearch->form_values = NULL;
     }
 
-    $savedSearch->is_active = CRM_Utils_Array::value('is_active', $params, 1);
-    $savedSearch->mapping_id = CRM_Utils_Array::value('mapping_id', $params, 'null');
-    $savedSearch->custom_search_id = CRM_Utils_Array::value('custom_search_id', $params, 'null');
-    $savedSearch->id = CRM_Utils_Array::value('id', $params, NULL);
+    $savedSearch->is_active = $params['is_active'] ?? 1;
+    $savedSearch->mapping_id = $params['mapping_id'] ?? 'null';
+    $savedSearch->custom_search_id = $params['custom_search_id'] ?? 'null';
+    $savedSearch->id = $params['id'] ?? NULL;
 
     $savedSearch->save();
 

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -927,8 +927,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       // process membership status for deceased contact
       $deceasedParams = [
         'contact_id' => CRM_Utils_Array::value('contact_id', $params),
-        'is_deceased' => CRM_Utils_Array::value('is_deceased', $params, FALSE),
-        'deceased_date' => CRM_Utils_Array::value('deceased_date', $params, NULL),
+        'is_deceased' => $params['is_deceased'] ?? FALSE,
+        'deceased_date' => $params['deceased_date'] ?? NULL,
       ];
       $updateMembershipMsg = $this->updateMembershipStatus($deceasedParams);
     }
@@ -960,7 +960,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     if (array_key_exists('CommunicationPreferences', $this->_editOptions)) {
       // this is a chekbox, so mark false if we dont get a POST value
-      $params['is_opt_out'] = CRM_Utils_Array::value('is_opt_out', $params, FALSE);
+      $params['is_opt_out'] = $params['is_opt_out'] ?? FALSE;
     }
 
     // process shared contact address.

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -217,7 +217,7 @@ UPDATE civicrm_dedupe_rule_group
     }
 
     $rgDao->title = $values['title'];
-    $rgDao->is_reserved = CRM_Utils_Array::value('is_reserved', $values, FALSE);
+    $rgDao->is_reserved = $values['is_reserved'] ?? FALSE;
     $rgDao->used = $values['used'];
     $rgDao->contact_type = $this->_contactType;
     $rgDao->threshold = $values['threshold'];

--- a/CRM/Contact/Form/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Inline/CommunicationPreferences.php
@@ -90,7 +90,7 @@ class CRM_Contact_Form_Inline_CommunicationPreferences extends CRM_Contact_Form_
     // Process / save communication preferences
 
     // this is a chekbox, so mark false if we dont get a POST value
-    $params['is_opt_out'] = CRM_Utils_Array::value('is_opt_out', $params, FALSE);
+    $params['is_opt_out'] = $params['is_opt_out'] ?? FALSE;
     $params['contact_type'] = $this->_contactType;
     $params['contact_id'] = $this->_contactId;
 

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -214,7 +214,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         // on the form.
         if (substr($element[1], 0, 13) === 'move_location') {
           $element[4] = array_merge(
-            (array) CRM_Utils_Array::value(4, $element, []),
+            (array) $element[4] ?? [],
             [
               'data-location' => substr($element[1], 14),
               'data-is_location' => TRUE,
@@ -223,7 +223,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         if (substr($element[1], 0, 15) === 'location_blocks') {
           // @todo We could add some data elements here to make jquery manipulation more straight-forward
           // @todo consider enabling if it is an add & defaulting to true.
-          $element[4] = array_merge((array) CRM_Utils_Array::value(4, $element, []), ['disabled' => TRUE]);
+          $element[4] = array_merge((array) $element[4] ?? [], ['disabled' => TRUE]);
         }
         $this->addElement($element[0],
           $element[1],

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -594,8 +594,8 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     }
 
     // If this is a b_a relationship these form elements are flipped
-    $params['is_permission_a_b'] = CRM_Utils_Array::value("is_permission_{$a}_{$b}", $values, 0);
-    $params['is_permission_b_a'] = CRM_Utils_Array::value("is_permission_{$b}_{$a}", $values, 0);
+    $params['is_permission_a_b'] = $values["is_permission_{$a}_{$b}"] ?? 0;
+    $params['is_permission_b_a'] = $values["is_permission_{$b}_{$a}"] ?? 0;
 
     return [$params, $a];
   }

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -584,15 +584,15 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       $this->_returnProperties = &$this->returnProperties();
 
       // also get the uf group id directly from the post value
-      $this->_ufGroupID = CRM_Utils_Array::value('uf_group_id', $_POST, $this->_ufGroupID);
+      $this->_ufGroupID = $_POST['uf_group_id'] ?? $this->_ufGroupID;
       $this->_formValues['uf_group_id'] = $this->_ufGroupID;
       $this->set('id', $this->_ufGroupID);
 
       // also get the object mode directly from the post value
-      $this->_componentMode = CRM_Utils_Array::value('component_mode', $_POST, $this->_componentMode);
+      $this->_componentMode = $_POST['component_mode'] ?? $this->_componentMode;
 
       // also get the operator from the post value if set
-      $this->_operator = CRM_Utils_Array::value('operator', $_POST, $this->_operator);
+      $this->_operator = $_POST['operator'] ?? $this->_operator;
       $this->_formValues['operator'] = $this->_operator;
       $this->set('operator', $this->_operator);
     }
@@ -672,7 +672,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     $this->assign('id',
       CRM_Utils_Array::value('uf_group_id', $this->_formValues)
     );
-    $operator = CRM_Utils_Array::value('operator', $this->_formValues, CRM_Contact_BAO_Query::SEARCH_OPERATOR_AND);
+    $operator = $this->_formValues['operator'] ?? CRM_Contact_BAO_Query::SEARCH_OPERATOR_AND;
     $this->set('queryOperator', $operator);
     if ($operator == CRM_Contact_BAO_Query::SEARCH_OPERATOR_OR) {
       $this->assign('operator', ts('OR'));
@@ -684,8 +684,8 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     // show the context menu only when we’re not searching for deleted contacts; CRM-5673
     if (empty($this->_formValues['deleted_contacts'])) {
       $menuItems = CRM_Contact_BAO_Contact::contextMenu();
-      $primaryActions = CRM_Utils_Array::value('primaryActions', $menuItems, []);
-      $this->_contextMenu = CRM_Utils_Array::value('moreActions', $menuItems, []);
+      $primaryActions = $menuItems['primaryActions'] ?? [];
+      $this->_contextMenu = $menuItems['moreActions'] ?? [];
       $this->assign('contextMenu', $primaryActions + $this->_contextMenu);
     }
 

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -265,7 +265,7 @@ class CRM_Contact_Form_Search_Criteria {
     ];
     $metadata = civicrm_api3('Contact', 'getfields', [])['values'];
     foreach ($fields as $fieldName => $field) {
-      $fields[$fieldName] = array_merge(CRM_Utils_Array::value($fieldName, $metadata, []), $field);
+      $fields[$fieldName] = array_merge($metadata[$fieldName] ?? [], $field);
     }
     return $fields;
   }
@@ -389,7 +389,7 @@ class CRM_Contact_Form_Search_Criteria {
       'street_unit' => [ts('Apt/Unit/Suite'), $attributes['street_unit'], NULL, NULL],
     ];
 
-    $parseStreetAddress = CRM_Utils_Array::value('street_address_parsing', $addressOptions, 0);
+    $parseStreetAddress = $addressOptions['street_address_parsing'] ?? 0;
     $form->assign('parseStreetAddress', $parseStreetAddress);
     foreach ($elements as $name => $v) {
       list($title, $attributes, $select, $multiSelect) = $v;

--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -78,7 +78,7 @@ class CRM_Contact_Form_Search_Custom_ContribSYBNT extends CRM_Contact_Form_Searc
     }
 
     foreach ($this->_checkboxes as $name => $title) {
-      $this->{$name} = CRM_Utils_Array::value($name, $this->_formValues, FALSE);
+      $this->{$name} = $this->_formValues[$name] ?? FALSE;
     }
 
     foreach ($this->_dates as $name => $title) {

--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -197,7 +197,7 @@ civicrm_contact AS contact_a {$this->_aclFrom}
     ];
     $metadata = civicrm_api3('Contribution', 'getfields', [])['values'];
     foreach ($fields as $fieldName => $field) {
-      $fields[$fieldName] = array_merge(CRM_Utils_Array::value($fieldName, $metadata, []), $field);
+      $fields[$fieldName] = array_merge($metadata[$fieldName] ?? [], $field);
     }
     return $fields;
   }

--- a/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -47,8 +47,8 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
   public function __construct(&$formValues) {
     $this->_formValues = self::formatSavedSearchFields($formValues);
 
-    $this->_includeGroups = CRM_Utils_Array::value('includeGroups', $formValues, []);
-    $this->_excludeGroups = CRM_Utils_Array::value('excludeGroups', $formValues, []);
+    $this->_includeGroups = $formValues['includeGroups'] ?? [];
+    $this->_excludeGroups = $formValues['excludeGroups'] ?? [];
 
     $this->_columns = [
       ts('Contact ID') => 'contact_id',
@@ -139,9 +139,9 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
     $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
 
-    $this->_includeGroups = CRM_Utils_Array::value('includeGroups', $this->_formValues, []);
+    $this->_includeGroups = $this->_formValues['includeGroups'] ?? [];
 
-    $this->_excludeGroups = CRM_Utils_Array::value('excludeGroups', $this->_formValues, []);
+    $this->_excludeGroups = $this->_formValues['excludeGroups'] ?? [];
 
     $this->_allSearch = FALSE;
     $this->_groups = FALSE;

--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -121,8 +121,8 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
       // 1. this custom search has slightly different structure ,
       // 2. we are in constructor right now,
       // we 'll use a small hack -
-      $rowCount = CRM_Utils_Array::value('crmRowCount', $_REQUEST, CRM_Utils_Pager::ROWCOUNT);
-      $pageId = CRM_Utils_Array::value('crmPID', $_REQUEST, 1);
+      $rowCount = $_REQUEST['crmRowCount'] ?? CRM_Utils_Pager::ROWCOUNT;
+      $pageId = $_REQUEST['crmPID'] ?? 1;
       $offset = ($pageId - 1) * $rowCount;
       $this->_limitClause = NULL;
       $this->_limitRowClause = [$rowCount, NULL];

--- a/CRM/Contact/Form/Search/Custom/Group.php
+++ b/CRM/Contact/Form/Search/Custom/Group.php
@@ -56,10 +56,10 @@ class CRM_Contact_Form_Search_Custom_Group extends CRM_Contact_Form_Search_Custo
       ts('Tag Name') => 'tname',
     ];
 
-    $this->_includeGroups = CRM_Utils_Array::value('includeGroups', $this->_formValues, []);
-    $this->_excludeGroups = CRM_Utils_Array::value('excludeGroups', $this->_formValues, []);
-    $this->_includeTags = CRM_Utils_Array::value('includeTags', $this->_formValues, []);
-    $this->_excludeTags = CRM_Utils_Array::value('excludeTags', $this->_formValues, []);
+    $this->_includeGroups = $this->_formValues['includeGroups'] ?? [];
+    $this->_excludeGroups = $this->_formValues['excludeGroups'] ?? [];
+    $this->_includeTags = $this->_formValues['includeTags'] ?? [];
+    $this->_excludeTags = $this->_formValues['excludeTags'] ?? [];
 
     //define variables
     $this->_allSearch = FALSE;

--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -191,7 +191,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
    */
   public function postProcess() {
     $params = $this->controller->exportValues();
-    $groupOption = CRM_Utils_Array::value('group_option', $params, NULL);
+    $groupOption = $params['group_option'] ?? NULL;
     if ($groupOption) {
       $groupParams = [];
       $groupParams['title'] = $params['title'];

--- a/CRM/Contact/Form/Task/AlterPreferences.php
+++ b/CRM/Contact/Form/Task/AlterPreferences.php
@@ -95,7 +95,7 @@ class CRM_Contact_Form_Task_AlterPreferences extends CRM_Contact_Form_Task {
     //get the submitted values in an array
     $params = $this->controller->exportValues($this->_name);
 
-    $actionTypeOption = CRM_Utils_Array::value('actionTypeOption', $params, NULL);
+    $actionTypeOption = $params['actionTypeOption'] ?? NULL;
     // If remove option has been selected set new privacy value to "false"
     $privacyValueNew = empty($actionTypeOption);
 

--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -67,7 +67,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     }
 
     // Get Task name
-    $modeValue = CRM_Contact_Form_Search::getModeValue(CRM_Utils_Array::value('component_mode', $values, CRM_Contact_BAO_Query::MODE_CONTACTS));
+    $modeValue = CRM_Contact_Form_Search::getModeValue($values['component_mode'] ?? CRM_Contact_BAO_Query::MODE_CONTACTS);
     $className = $modeValue['taskClassName'];
     $taskList = $className::taskTitles();
     $this->_task = CRM_Utils_Array::value('task', $values);

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -69,7 +69,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     $errorFiles = ['sqlImport.errors', 'sqlImport.conflicts', 'sqlImport.duplicates', 'sqlImport.mismatch'];
 
     // check for post max size avoid when called twice
-    $snippet = CRM_Utils_Array::value('snippet', $_GET, 0);
+    $snippet = $_GET['snippet'] ?? 0;
     if (empty($snippet)) {
       CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -215,7 +215,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       $this->_updateWithId = TRUE;
     }
 
-    $this->_parseStreetAddress = CRM_Utils_Array::value('street_address_parsing', CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'address_options'), FALSE);
+    $this->_parseStreetAddress = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME['street_address_parsing'] ?? 'address_options', FALSE);
   }
 
   /**

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -259,7 +259,7 @@ class CRM_Contact_Page_AJAX {
         // first check if there is any existing relationship present with same parameters.
         // If yes then update the relationship by setting active and start date to current time
         $relationship = civicrm_api3('Relationship', 'get', $params)['values'];
-        $params = array_merge(CRM_Utils_Array::value(0, $relationship, $params), [
+        $params = array_merge($relationship[0] ?? $params, [
           'start_date' => 'now',
           'is_active' => TRUE,
           'end_date' => '',
@@ -403,7 +403,7 @@ class CRM_Contact_Page_AJAX {
 
       if ($queryString) {
         $result = [];
-        $offset = CRM_Utils_Array::value('offset', $_GET, 0);
+        $offset = $_GET['offset'] ?? 0;
         $rowCount = Civi::settings()->get('search_autocomplete_count');
 
         $offset = CRM_Utils_Type::escape($offset, 'Int');
@@ -986,10 +986,10 @@ LIMIT {$offset}, {$rowCount}
   public static function selectUnselectContacts() {
     $name = CRM_Utils_Array::value('name', $_REQUEST);
     $cacheKey = CRM_Utils_Array::value('qfKey', $_REQUEST);
-    $state = CRM_Utils_Array::value('state', $_REQUEST, 'checked');
-    $variableType = CRM_Utils_Array::value('variableType', $_REQUEST, 'single');
+    $state = $_REQUEST['state'] ?? 'checked';
+    $variableType = $_REQUEST['variableType'] ?? 'single';
 
-    $actionToPerform = CRM_Utils_Array::value('action', $_REQUEST, 'select');
+    $actionToPerform = $_REQUEST['action'] ?? 'select';
 
     if ($variableType == 'multiple') {
       // action post value only works with multiple type variable

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -214,7 +214,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     }
 
     $displayRelationshipType = CRM_Utils_Array::value('display_relationship_type', $this->_formValues);
-    $operator = CRM_Utils_Array::value('operator', $this->_formValues, 'AND');
+    $operator = $this->_formValues['operator'] ?? 'AND';
 
     // rectify params to what proximity search expects if there is a value for prox_distance
     // CRM-7021

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1163,7 +1163,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         }
         // @todo we should stop passing $params by reference - splitting this out would be a step towards that.
         // This is an update so original currency if none passed in.
-        $params['trxnParams']['currency'] = CRM_Utils_Array::value('currency', $params, $params['prevContribution']->currency);
+        $params['trxnParams']['currency'] = $params['currency'] ?? $params['prevContribution']->currency;
 
         self::recordAlwaysAccountsReceivable($params['trxnParams'], $params);
         $trxn = CRM_Core_BAO_FinancialTrxn::create($params['trxnParams']);
@@ -2138,7 +2138,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
                 $membership->membership_type_id,
                 (array) $membership
               );
-              $membership->status_id = CRM_Utils_Array::value('id', $status, $membership->status_id);
+              $membership->status_id = $status['id'] ?? $membership->status_id;
               $membership->save();
             }
 
@@ -2619,7 +2619,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $this->_component = 'event';
       }
       else {
-        $this->_component = strtolower(CRM_Utils_Array::value('component', $input, 'contribute'));
+        $this->_component = strtolower($input['component'] ?? 'contribute');
       }
     }
 
@@ -3446,14 +3446,14 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'trxn_date' => !empty($params['contribution']->receive_date) ? $params['contribution']->receive_date : date('YmdHis'),
         'total_amount' => $totalAmount,
         'fee_amount' => CRM_Utils_Array::value('fee_amount', $params),
-        'net_amount' => CRM_Utils_Array::value('net_amount', $params, $totalAmount),
+        'net_amount' => $params['net_amount'] ?? $totalAmount,
         'currency' => $params['contribution']->currency,
         'trxn_id' => $params['contribution']->trxn_id,
         // @todo - this is getting the status id from the contribution - that is BAD - ie the contribution could be partially
         // paid but each payment is completed. The work around is to pass in the status_id in the trxn_params but
         // this should really default to completed (after discussion).
         'status_id' => $statusId,
-        'payment_instrument_id' => CRM_Utils_Array::value('payment_instrument_id', $params, $params['contribution']->payment_instrument_id),
+        'payment_instrument_id' => $params['payment_instrument_id'] ?? $params['contribution']->payment_instrument_id,
         'check_number' => CRM_Utils_Array::value('check_number', $params),
         'pan_truncation' => CRM_Utils_Array::value('pan_truncation', $params),
         'card_type_id' => CRM_Utils_Array::value('card_type_id', $params),
@@ -3811,7 +3811,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     ];
 
     if (!in_array($contributionStatuses[$fields['contribution_status_id']],
-      CRM_Utils_Array::value($contributionStatuses[$values['contribution_status_id']], $checkStatus, []))
+      $checkStatus[$contributionStatuses[$values['contribution_status_id']]] ?? [])
     ) {
       $errors['contribution_status_id'] = ts("Cannot change contribution status from %1 to %2.", [
         1 => $contributionStatuses[$values['contribution_status_id']],
@@ -3865,7 +3865,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             'version' => 3,
             'id' => ($props['contribution_page_id']),
           ]);
-          $types = (array) CRM_Utils_Array::value('payment_processor', $page, 0);
+          $types = (array) $page['payment_processor'] ?? 0;
           $params['condition'] = 'id IN (' . implode(',', $types) . ')';
         }
         break;
@@ -4474,7 +4474,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     if ($recurringContributionID) {
       $contributionParams['contribution_recur_id'] = $recurringContributionID;
     }
-    $changeDate = CRM_Utils_Array::value('trxn_date', $input, date('YmdHis'));
+    $changeDate = $input['trxn_date'] ?? date('YmdHis');
 
     if (empty($contributionParams['receive_date']) && $changeDate) {
       $contributionParams['receive_date'] = $changeDate;
@@ -4654,7 +4654,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // Use input value if supplied.
     if (!empty($input['receipt_from_email'])) {
       return [
-        CRM_Utils_Array::value('receipt_from_name', $input, ''),
+        $input['receipt_from_name'] ?? '',
         $input['receipt_from_email'],
       ];
     }
@@ -4723,7 +4723,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       FROM   civicrm_membership_payment
       WHERE  contribution_id = %1 ";
     $params = [1 => [$this->id, 'Integer']];
-    $ids['membership'] = (array) CRM_Utils_Array::value('membership', $ids, []);
+    $ids['membership'] = (array) $ids['membership'] ?? [];
 
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     while ($dao->fetch()) {
@@ -4765,13 +4765,13 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $balanceTrxnParams['from_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($contribution['financial_type_id'], 'Accounts Receivable Account is');
     $balanceTrxnParams['total_amount'] = $params['total_amount'];
     $balanceTrxnParams['contribution_id'] = $params['contribution_id'];
-    $balanceTrxnParams['trxn_date'] = CRM_Utils_Array::value('trxn_date', $params, CRM_Utils_Array::value('contribution_receive_date', $params, date('YmdHis')));
+    $balanceTrxnParams['trxn_date'] = $params['trxn_date'] ?? $params['contribution_receive_date'] ?? date('YmdHis');
     $balanceTrxnParams['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
     $balanceTrxnParams['net_amount'] = CRM_Utils_Array::value('total_amount', $params);
     $balanceTrxnParams['currency'] = $contribution['currency'];
-    $balanceTrxnParams['trxn_id'] = CRM_Utils_Array::value('contribution_trxn_id', $params, NULL);
+    $balanceTrxnParams['trxn_id'] = $params['contribution_trxn_id'] ?? NULL;
     $balanceTrxnParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'status_id', 'Completed');
-    $balanceTrxnParams['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $params, $contribution['payment_instrument_id']);
+    $balanceTrxnParams['payment_instrument_id'] = $params['payment_instrument_id'] ?? $contribution['payment_instrument_id'];
     $balanceTrxnParams['check_number'] = CRM_Utils_Array::value('check_number', $params);
     $balanceTrxnParams['is_payment'] = 1;
 
@@ -4896,7 +4896,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         if (empty($item['financial_type_id'])) {
           $item['financial_type_id'] = $params['financial_type_id'];
         }
-        $lineItemAmount += $item['line_total'] + CRM_Utils_Array::value('tax_amount', $item, 0.00);
+        $lineItemAmount += $item['line_total'] + $item['tax_amount'] ?? 0.00;
       }
     }
 
@@ -4904,7 +4904,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $params['total_amount'] = $lineItemAmount;
     }
     else {
-      $currency = CRM_Utils_Array::value('currency', $params, '');
+      $currency = $params['currency'] ?? '';
 
       if (empty($currency)) {
         $currency = CRM_Core_Config::singleton()->defaultCurrency;
@@ -5202,7 +5202,7 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
     elseif ($context == 'changedStatus') {
       $cancelledTaxAmount = 0;
       if ($isARefund) {
-        $cancelledTaxAmount = CRM_Utils_Array::value('tax_amount', $lineItemDetails, '0.00');
+        $cancelledTaxAmount = $lineItemDetails['tax_amount'] ?? '0.00';
       }
       return self::getMultiplier($params['contribution']->contribution_status_id, $context) * ((float) $lineItemDetails['line_total'] + (float) $cancelledTaxAmount);
     }
@@ -5372,7 +5372,7 @@ LIMIT 1;";
       );
 
       unset($dates['end_date']);
-      $membershipParams['status_id'] = CRM_Utils_Array::value('id', $calcStatus, 'New');
+      $membershipParams['status_id'] = $calcStatus['id'] ?? 'New';
       //we might be renewing membership,
       //so make status override false.
       $membershipParams['is_override'] = FALSE;
@@ -5629,7 +5629,7 @@ LIMIT 1;";
       if (!$amount) {
         $amount = $params['total_amount'];
         if ($context === NULL) {
-          $amount -= CRM_Utils_Array::value('tax_amount', $params, 0);
+          $amount -= $params['tax_amount'] ?? 0;
         }
       }
     }

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -413,7 +413,7 @@ INNER JOIN   civicrm_contact contact ON ( contact.id = contrib.contact_id )
     }
 
     if (($type == 'paypal') && (!isset($transaction['net_amount']))) {
-      $transaction['net_amount'] = $transaction['total_amount'] - CRM_Utils_Array::value('fee_amount', $transaction, 0);
+      $transaction['net_amount'] = $transaction['total_amount'] - ($transaction['fee_amount'] ?? 0);
     }
 
     if (!isset($transaction['invoice_id'])) {
@@ -649,7 +649,7 @@ LIMIT 1
    */
   public static function overrideDefaultCurrency($params) {
     $config = CRM_Core_Config::singleton();
-    $config->defaultCurrency = CRM_Utils_Array::value('currency', $params, $config->defaultCurrency);
+    $config->defaultCurrency = $params['currency'] ?? $config->defaultCurrency;
   }
 
 }

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -513,9 +513,9 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
           }
           // suppress all file fields from display and formatting fields
           if (
-            CRM_Utils_Array::value('data_type', $v, '') == 'File' ||
-            CRM_Utils_Array::value('name', $v, '') == 'image_URL' ||
-            CRM_Utils_Array::value('field_type', $v) == 'Formatting'
+            ($v['data_type'] ?? '') == 'File' ||
+            ($v['name'] ?? '') == 'image_URL' ||
+            ($v['field_type'] ?? '') == 'Formatting'
           ) {
             unset($fields[$k]);
           }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -197,7 +197,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       'id' => $recurID,
       'return' => ['payment_processor_id'],
     ]);
-    return (int) CRM_Utils_Array::value('payment_processor_id', $recur, 0);
+    return (int) $recur['payment_processor_id'] ?? 0;
   }
 
   /**
@@ -306,7 +306,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
           'source_contact_id' => $dao->contact_id,
           'source_record_id' => $dao->recur_id,
           'activity_type_id' => 'Cancel Recurring Contribution',
-          'subject' => CRM_Utils_Array::value('subject', $activityParams, ts('Recurring contribution cancelled')),
+          'subject' => $activityParams['subject'] ?? ts('Recurring contribution cancelled'),
           'details' => $details,
           'status_id' => 'Completed',
         ];

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -178,8 +178,8 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     }
     $pseudoExtraParam = [];
     $fieldName = str_replace(['_high', '_low'], '', $name);
-    $fieldSpec = CRM_Utils_Array::value($fieldName, $fields, []);
-    $tableName = CRM_Utils_Array::value('table_name', $fieldSpec, 'civicrm_contribution');
+    $fieldSpec = $fields[$fieldName] ?? [];
+    $tableName = $fieldSpec['table_name'] ?? 'civicrm_contribution';
     $dataType = CRM_Utils_Type::typeToString(CRM_Utils_Array::value('type', $fieldSpec));
     if ($dataType === 'Timestamp' || $dataType === 'Date') {
       $title = empty($fieldSpec['unique_title']) ? $fieldSpec['title'] : $fieldSpec['unique_title'];

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -307,7 +307,7 @@ class CRM_Contribute_Form_AdditionalInfo {
       )
     );
     $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      CRM_Utils_Array::value('id', $params, NULL),
+      $params['id'] ?? NULL,
       'Contribution'
     );
   }

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -294,7 +294,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     if ($self->_paymentType == 'refund' && $fields['total_amount'] != abs($self->_refund)) {
       $errors['total_amount'] = ts('Refund amount must equal refund due amount.');
     }
-    $netAmt = (float) $fields['total_amount'] - (float) CRM_Utils_Array::value('fee_amount', $fields, 0);
+    $netAmt = (float) $fields['total_amount'] - (float) ($fields['fee_amount'] ?? 0);
     if (!empty($fields['net_amount']) && $netAmt != $fields['net_amount']) {
       $errors['net_amount'] = ts('Net amount should be equal to the difference between payment amount and fee amount.');
     }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -576,7 +576,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $paneNames[ts('Premium Information')] = 'Premium';
     }
 
-    $this->payment_instrument_id = CRM_Utils_Array::value('payment_instrument_id', $defaults, $this->getDefaultPaymentInstrumentId());
+    $this->payment_instrument_id = $defaults['payment_instrument_id'] ?? $this->getDefaultPaymentInstrumentId();
     if (CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->payment_instrument_id) == TRUE) {
       if (!empty($this->_recurPaymentProcessors)) {
         $buildRecurBlock = TRUE;
@@ -1518,7 +1518,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $submittedValues['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_values);
       // Avoid tax amount deduction on edit form and keep it original, because this will lead to error described in CRM-20676
       if (!$this->_id) {
-        $submittedValues['total_amount'] -= CRM_Utils_Array::value('tax_amount', $this->_values, 0);
+        $submittedValues['total_amount'] -= $this->_values['tax_amount'] ?? 0;
       }
     }
     $this->assign('lineItem', !empty($lineItem) && !$isQuickConfig ? $lineItem : FALSE);

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -177,14 +177,14 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       'amount_level' => CRM_Utils_Array::value('amount_level', $params),
       'invoice_id' => $params['invoiceID'],
       'currency' => $params['currencyID'],
-      'is_pay_later' => CRM_Utils_Array::value('is_pay_later', $params, 0),
+      'is_pay_later' => $params['is_pay_later'] ?? 0,
       //configure cancel reason, cancel date and thankyou date
       //from 'contribution' type profile if included
-      'cancel_reason' => CRM_Utils_Array::value('cancel_reason', $params, 0),
+      'cancel_reason' => $params['cancel_reason'] ?? 0,
       'cancel_date' => isset($params['cancel_date']) ? CRM_Utils_Date::format($params['cancel_date']) : NULL,
       'thankyou_date' => isset($params['thankyou_date']) ? CRM_Utils_Date::format($params['thankyou_date']) : NULL,
       //setting to make available to hook - although seems wrong to set on form for BAO hook availability
-      'skipLineItem' => CRM_Utils_Array::value('skipLineItem', $params, 0),
+      'skipLineItem' => $params['skipLineItem'] ?? 0,
     ];
 
     if ($paymentProcessorOutcome) {
@@ -1111,7 +1111,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $recurParams['is_email_receipt'] = CRM_Utils_Array::value('is_email_receipt', $params);
     // we need to add a unique trxn_id to avoid a unique key error
     // in paypal IPN we reset this when paypal sends us the real trxn id, CRM-2991
-    $recurParams['trxn_id'] = CRM_Utils_Array::value('trxn_id', $params, $params['invoiceID']);
+    $recurParams['trxn_id'] = $params['trxn_id'] ?? $params['invoiceID'];
     $recurParams['financial_type_id'] = $contributionType->id;
 
     $campaignId = CRM_Utils_Array::value('campaign_id', $params, CRM_Utils_Array::value('campaign_id', $form->_values));
@@ -1434,7 +1434,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $isProcessSeparateMembershipTransaction, $financialTypeID, $unprocessedLineItems, $isPending) {
 
     $membershipContribution = NULL;
-    $isTest = CRM_Utils_Array::value('is_test', $membershipParams, FALSE);
+    $isTest = $membershipParams['is_test'] ?? FALSE;
     $errors = $paymentResults = [];
     $form->_values['isMembership'] = TRUE;
     $isRecurForFirstTransaction = CRM_Utils_Array::value('is_recur', $form->_params, CRM_Utils_Array::value('is_recur', $membershipParams));
@@ -1487,7 +1487,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           unset($membershipParams['is_recur']);
         }
         list($membershipContribution, $secondPaymentResult) = $this->processSecondaryFinancialTransaction($contactID, $form, array_merge($membershipParams, ['skipLineItem' => 1]),
-          $isTest, $unprocessedLineItems, CRM_Utils_Array::value('minimum_fee', $membershipDetails, 0), CRM_Utils_Array::value('financial_type_id', $membershipDetails));
+          $isTest, $unprocessedLineItems, $membershipDetails['minimum_fee'] ?? 0, CRM_Utils_Array::value('financial_type_id', $membershipDetails));
         $paymentResults[] = ['contribution_id' => $membershipContribution->id, 'result' => $secondPaymentResult];
         $totalAmount = $membershipContribution->total_amount;
       }
@@ -1508,7 +1508,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     //@todo it should no longer be possible for it to get to this point & membership to not be an array
     if (is_array($membershipTypeIDs) && !empty($membershipContributionID)) {
-      $typesTerms = CRM_Utils_Array::value('types_terms', $membershipParams, []);
+      $typesTerms = $membershipParams['types_terms'] ?? [];
 
       $membershipLines = $nonMembershipLines = [];
       foreach ($unprocessedLineItems as $priceSetID => $lines) {
@@ -1531,7 +1531,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $membershipLineItems = $unprocessedLineItems;
         }
         $i++;
-        $numTerms = CRM_Utils_Array::value($memType, $typesTerms, 1);
+        $numTerms = $typesTerms[$memType] ?? 1;
         if (!empty($membershipContribution)) {
           $pendingStatus = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
           $pending = ($membershipContribution->contribution_status_id == $pendingStatus) ? TRUE : FALSE;
@@ -1943,7 +1943,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $form->_fields['billing_last_name'] = 1;
     // CRM-18854 - Set form values to allow pledge to be created for api test.
     if (CRM_Utils_Array::value('pledge_block_id', $params)) {
-      $form->_values['pledge_id'] = CRM_Utils_Array::value('pledge_id', $params, NULL);
+      $form->_values['pledge_id'] = $params['pledge_id'] ?? NULL;
       $form->_values['pledge_block_id'] = $params['pledge_block_id'];
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($params['id']);
       $form->_values['max_reminders'] = $pledgeBlock['max_reminders'];
@@ -2069,7 +2069,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($this->_id);
       if (CRM_Utils_Array::value('start_date', $this->_params) || !CRM_Utils_Array::value('is_pledge_start_date_visible', $pledgeBlock)
           || !CRM_Utils_Array::value('is_pledge_start_date_editable', $pledgeBlock)) {
-        $pledgeStartDate = CRM_Utils_Array::value('start_date', $this->_params, NULL);
+        $pledgeStartDate = $this->_params['start_date'] ?? NULL;
         $this->_params['receive_date'] = CRM_Pledge_BAO_Pledge::getPledgeStartDate($pledgeStartDate, $pledgeBlock);
         $recurParams = CRM_Pledge_BAO_Pledge::buildRecurParams($this->_params);
         $this->_params = array_merge($this->_params, $recurParams);
@@ -2464,7 +2464,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         civicrm_api3('contribution', 'completetransaction', [
           'id' => $contributionID,
           'trxn_id' => CRM_Utils_Array::value('trxn_id', $result),
-          'payment_processor_id' => CRM_Utils_Array::value('payment_processor_id', $result, $this->_paymentProcessor['id']),
+          'payment_processor_id' => $result['payment_processor_id'] ?? $this->_paymentProcessor['id'],
           'is_transactional' => FALSE,
           'fee_amount' => CRM_Utils_Array::value('fee_amount', $result),
           'receive_date' => CRM_Utils_Array::value('receive_date', $result),

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -764,7 +764,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           }
         }
         // $membershipFieldId is set and additional amount is 'No thank you' or NULL then throw error
-        if ($membershipFieldId && !(CRM_Utils_Array::value('price_' . $contributionFieldId, $fields, -1) > 0) && empty($fields['price_' . $otherFieldId])) {
+        if ($membershipFieldId && !(($fields['price_' . $contributionFieldId] ?? -1) > 0) && empty($fields['price_' . $otherFieldId])) {
           $errors["price_{$errorKey}"] = ts('Additional Contribution is required.');
         }
       }
@@ -1203,7 +1203,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     // Would be nice to someday understand the point of this set.
     $this->set('is_pay_later', $params['is_pay_later']);
     // assign pay later stuff
-    $this->_params['is_pay_later'] = CRM_Utils_Array::value('is_pay_later', $params, FALSE);
+    $this->_params['is_pay_later'] = $params['is_pay_later'] ?? FALSE;
     $this->assign('is_pay_later', $params['is_pay_later']);
     if ($params['is_pay_later']) {
       $this->assign('pay_later_text', $this->_values['pay_later_text']);

--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -115,7 +115,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
       }
 
       foreach ($abbrMonthNames as $monthKey => $monthName) {
-        $val = CRM_Utils_Array::value($monthKey, $chartInfoMonthly['By Month'], 0);
+        $val = $chartInfoMonthly['By Month'][$monthKey] ?? 0;
 
         // don't include zero value month.
         if (!$val && ($chartType != 'bvg')) {

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -483,7 +483,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     }
 
     foreach ($fields as $field => $defaultVal) {
-      $val = CRM_Utils_Array::value($field, $params, $defaultVal);
+      $val = $params[$field] ?? $defaultVal;
       if (in_array($field, $resetFields)) {
         $val = $defaultVal;
       }
@@ -502,8 +502,8 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       $params['recur_frequency_unit'] = implode(CRM_Core_DAO::VALUE_SEPARATOR,
         array_keys($params['recur_frequency_unit'])
       );
-      $params['is_recur_interval'] = CRM_Utils_Array::value('is_recur_interval', $params, FALSE);
-      $params['is_recur_installments'] = CRM_Utils_Array::value('is_recur_installments', $params, FALSE);
+      $params['is_recur_interval'] = $params['is_recur_interval'] ?? FALSE;
+      $params['is_recur_installments'] = $params['is_recur_installments'] ?? FALSE;
     }
 
     if (CRM_Utils_Array::value('adjust_recur_start_date', $params)) {

--- a/CRM/Contribute/Form/ContributionPage/Premium.php
+++ b/CRM/Contribute/Form/ContributionPage/Premium.php
@@ -135,8 +135,8 @@ class CRM_Contribute_Form_ContributionPage_Premium extends CRM_Contribute_Form_C
       $params['id'] = $premiumID;
     }
 
-    $params['premiums_active'] = CRM_Utils_Array::value('premiums_active', $params, FALSE);
-    $params['premiums_display_min_contribution'] = CRM_Utils_Array::value('premiums_display_min_contribution', $params, FALSE);
+    $params['premiums_active'] = $params['premiums_active'] ?? FALSE;
+    $params['premiums_display_min_contribution'] = $params['premiums_display_min_contribution'] ?? FALSE;
     $params['entity_table'] = 'civicrm_contribution_page';
     $params['entity_id'] = $this->_id;
 

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -333,12 +333,12 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
       $params['currency'] = $config->defaultCurrency;
     }
 
-    $params['is_confirm_enabled'] = CRM_Utils_Array::value('is_confirm_enabled', $params, FALSE);
-    $params['is_share'] = CRM_Utils_Array::value('is_share', $params, FALSE);
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['is_credit_card_only'] = CRM_Utils_Array::value('is_credit_card_only', $params, FALSE);
-    $params['honor_block_is_active'] = CRM_Utils_Array::value('honor_block_is_active', $params, FALSE);
-    $params['is_for_organization'] = !empty($params['is_organization']) ? CRM_Utils_Array::value('is_for_organization', $params, FALSE) : 0;
+    $params['is_confirm_enabled'] = $params['is_confirm_enabled'] ?? FALSE;
+    $params['is_share'] = $params['is_share'] ?? FALSE;
+    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['is_credit_card_only'] = $params['is_credit_card_only'] ?? FALSE;
+    $params['honor_block_is_active'] = $params['honor_block_is_active'] ?? FALSE;
+    $params['is_for_organization'] = !empty($params['is_organization']) ? $params['is_for_organization'] ?? FALSE : 0;
     $params['goal_amount'] = CRM_Utils_Rule::cleanMoney($params['goal_amount']);
 
     if (!$params['honor_block_is_active']) {

--- a/CRM/Contribute/Form/ContributionPage/ThankYou.php
+++ b/CRM/Contribute/Form/ContributionPage/ThankYou.php
@@ -108,7 +108,7 @@ class CRM_Contribute_Form_ContributionPage_ThankYou extends CRM_Contribute_Form_
     $params = $this->controller->exportValues($this->_name);
 
     $params['id'] = $this->_id;
-    $params['is_email_receipt'] = CRM_Utils_Array::value('is_email_receipt', $params, FALSE);
+    $params['is_email_receipt'] = $params['is_email_receipt'] ?? FALSE;
     if (!$params['is_email_receipt']) {
       $params['receipt_from_name'] = NULL;
       $params['receipt_from_email'] = NULL;

--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -253,7 +253,7 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
       $params['id'] = $this->_widget->id;
     }
     $params['contribution_page_id'] = $this->_id;
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+    $params['is_active'] = $params['is_active'] ?? FALSE;
     $params['url_homepage'] = 'null';
 
     $widget = new CRM_Contribute_DAO_Widget();

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -124,7 +124,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     }
 
     $contactIds = array_keys($contacts);
-    self::createActivities($form, $html_message, $contactIds, CRM_Utils_Array::value('subject', $formValues, ts('Thank you letter')), CRM_Utils_Array::value('campaign_id', $formValues), $contactHtml);
+    self::createActivities($form, $html_message, $contactIds, $formValues['subject'] ?? ts('Thank you letter'), CRM_Utils_Array::value('campaign_id', $formValues), $contactHtml);
     $html = array_diff_key($html, $emailedHtml);
 
     if (!empty($formValues['is_unit_test'])) {

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -99,9 +99,9 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
       $fields = array_merge($fields, $pledgeFields);
     }
     foreach ($fields as $name => $field) {
-      $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
-      $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
-      $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
+      $field['type'] = $field['type'] ?? CRM_Utils_Type::T_INT;
+      $field['dataPattern'] = $field['dataPattern'] ?? '//';
+      $field['headerPattern'] = $field['headerPattern'] ?? '//';
       $this->addField($name, $field['title'], $field['type'], $field['headerPattern'], $field['dataPattern']);
     }
 

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -492,7 +492,7 @@ ORDER BY is_active desc, title asc
       }
 
       //build the configure links.
-      $sectionsInfo = CRM_Utils_Array::value($dao->id, $contriPageSectionInfo, array());
+      $sectionsInfo = $contriPageSectionInfo[$dao->id] ?? array();
       $contribution[$dao->id]['configureActionLinks'] = CRM_Core_Action::formLink(self::formatConfigureLinks($sectionsInfo),
         $action,
         array('id' => $dao->id),

--- a/CRM/Contribute/Page/DashBoard.php
+++ b/CRM/Contribute/Page/DashBoard.php
@@ -84,7 +84,7 @@ class CRM_Contribute_Page_DashBoard extends CRM_Core_Page {
     }
 
     //for contribution tabular View
-    $buildTabularView = CRM_Utils_Array::value('showtable', $_GET, FALSE);
+    $buildTabularView = $_GET['showtable'] ?? FALSE;
     $this->assign('buildTabularView', $buildTabularView);
     if ($buildTabularView) {
       return;

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -175,7 +175,7 @@ class CRM_Core_Action {
       self::$_description = array_flip(self::$_names);
     }
 
-    return CRM_Utils_Array::value($mask, self::$_description, 'NO DESCRIPTION SET');
+    return self::$_description[$mask] ?? 'NO DESCRIPTION SET';
   }
 
   /**
@@ -240,7 +240,7 @@ class CRM_Core_Action {
           );
         }
         else {
-          $urlPath = CRM_Utils_Array::value('url', $link, '#');
+          $urlPath = $link['url'] ?? '#';
         }
 
         $classes = 'action-item crm-hover-button';

--- a/CRM/Core/BAO/ActionLog.php
+++ b/CRM/Core/BAO/ActionLog.php
@@ -48,7 +48,7 @@ class CRM_Core_BAO_ActionLog extends CRM_Core_DAO_ActionLog {
   public static function create($params) {
     $actionLog = new CRM_Core_DAO_ActionLog();
 
-    $params['action_date_time'] = CRM_Utils_Array::value('action_date_time', $params, date('YmdHis'));
+    $params['action_date_time'] = $params['action_date_time'] ?? date('YmdHis');
 
     $actionLog->copyValues($params);
 

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -58,7 +58,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
     $addresses = [];
     $contactId = NULL;
 
-    $updateBlankLocInfo = CRM_Utils_Array::value('updateBlankLocInfo', $params, FALSE);
+    $updateBlankLocInfo = $params['updateBlankLocInfo'] ?? FALSE;
     if (!$entity) {
       $contactId = $params['contact_id'];
       //get all the addresses for this contact

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -241,8 +241,8 @@ class CRM_Core_BAO_Block {
       $contactId = $params['contact_id'];
     }
 
-    $updateBlankLocInfo = CRM_Utils_Array::value('updateBlankLocInfo', $params, FALSE);
-    $isIdSet = CRM_Utils_Array::value('isIdSet', $params[$blockName], FALSE);
+    $updateBlankLocInfo = $params['updateBlankLocInfo'] ?? FALSE;
+    $isIdSet = $params[$blockName]['isIdSet'] ?? FALSE;
 
     //get existing block ids.
     $blockIds = self::getBlockIds($blockName, $contactId, $entityElements);

--- a/CRM/Core/BAO/Country.php
+++ b/CRM/Core/BAO/Country.php
@@ -143,7 +143,7 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
           'labelColumn' => 'symbol',
           'orderColumn' => TRUE,
         ]);
-        $cachedSymbol = CRM_Utils_Array::value($currency, $currencySymbols, '');
+        $cachedSymbol = $currencySymbols[$currency] ?? '';
       }
       else {
         $cachedSymbol = '$';

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1117,7 +1117,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $display = implode(', ', $v);
         }
         else {
-          $display = CRM_Utils_Array::value($value, $field['options'], '');
+          $display = $field['options'][$value] ?? '';
         }
         break;
 
@@ -1886,7 +1886,7 @@ WHERE  id IN ( %1, %2 )
       }
 
       $optionValue->weight = $params['option_weight'][$optionName];
-      $optionValue->is_active = CRM_Utils_Array::value($optionName, $params['option_status'], FALSE);
+      $optionValue->is_active = $params['option_status'][$optionName] ?? FALSE;
       $optionValue->save();
     }
   }
@@ -2463,7 +2463,7 @@ WHERE      f.id IN ($ids)";
       }
       $dataType = $field->data_type;
 
-      $profileField = CRM_Utils_Array::value($key, $profileFields, array());
+      $profileField = $profileFields[$key] ?? array();
       $fieldTitle = CRM_Utils_Array::value('title', $profileField);
       $isRequired = CRM_Utils_Array::value('is_required', $profileField);
       if (!$fieldTitle) {

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -61,7 +61,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
       $group->title = $params['title'];
     }
 
-    $extends = CRM_Utils_Array::value('extends', $params, []);
+    $extends = $params['extends'] ?? [];
     $extendsEntity = CRM_Utils_Array::value(0, $extends);
 
     $participantEntities = [
@@ -113,7 +113,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     else {
       $oldWeight = 0;
     }
-    $group->weight = CRM_Utils_Weight::updateOtherWeights('CRM_Core_DAO_CustomGroup', $oldWeight, CRM_Utils_Array::value('weight', $params, FALSE));
+    $group->weight = CRM_Utils_Weight::updateOtherWeights('CRM_Core_DAO_CustomGroup', $oldWeight, $params['weight'] ?? FALSE);
     $fields = [
       'style',
       'collapse_display',

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -478,7 +478,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     foreach ($params as $dashboardIDs) {
       $contactID = CRM_Utils_Array::value('contact_id', $dashboardIDs);
       $dashboardID = CRM_Utils_Array::value('dashboard_id', $dashboardIDs);
-      $column = CRM_Utils_Array::value('column_no', $dashboardIDs, 0);
+      $column = $dashboardIDs['column_no'] ?? 0;
       $columns[$column][$dashboardID] = 0;
     }
     self::saveDashletChanges($columns, $contactID);

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -480,7 +480,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
       // TODO: This will only work when api.entity is "entity_tag". What about others?
       if ($context == 'search' || $context == 'create') {
         $dummyArray = [];
-        return CRM_Core_BAO_Tag::getTags(CRM_Utils_Array::value('entity_table', $props, 'civicrm_contact'), $dummyArray, CRM_Utils_Array::value('parent_id', $params), '- ');
+        return CRM_Core_BAO_Tag::getTags($props['entity_table'] ?? 'civicrm_contact', $dummyArray, CRM_Utils_Array::value('parent_id', $params), '- ');
       }
     }
 

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -576,7 +576,7 @@ AND       CEF.entity_id    = %2";
         $extraParams = [
           'description' => $formValues[$attachDesc],
           'tag' => $tagParams,
-          'attachment_taglist' => CRM_Utils_Array::value($attachFreeTags, $formValues, []),
+          'attachment_taglist' => $formValues[$attachFreeTags] ?? [],
         ];
 
         CRM_Utils_File::formatFile($formValues, $attachName, $extraParams);

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -68,7 +68,7 @@ class CRM_Core_BAO_FinancialTrxn extends CRM_Financial_DAO_FinancialTrxn {
 
     // Save to entity_financial_trxn table.
     $entityFinancialTrxnParams = [
-      'entity_table' => CRM_Utils_Array::value('entity_table', $params, 'civicrm_contribution'),
+      'entity_table' => $params['entity_table'] ?? 'civicrm_contribution',
       'entity_id' => CRM_Utils_Array::value('entity_id', $params, CRM_Utils_Array::value('contribution_id', $params)),
       'financial_trxn_id' => $trxn->id,
       'amount' => $params['total_amount'],

--- a/CRM/Core/BAO/LabelFormat.php
+++ b/CRM/Core/BAO/LabelFormat.php
@@ -395,7 +395,7 @@ class CRM_Core_BAO_LabelFormat extends CRM_Core_DAO_OptionValue {
     if (array_key_exists($field, self::$optionValueFields)) {
       switch (self::$optionValueFields[$field]['type']) {
         case CRM_Utils_Type::T_INT:
-          return (int) CRM_Utils_Array::value($field, $values, $default);
+          return (int) $values[$field] ?? $default;
 
         case CRM_Utils_Type::T_FLOAT:
           // Round float values to three decimal places and trim trailing zeros.
@@ -405,7 +405,7 @@ class CRM_Core_BAO_LabelFormat extends CRM_Core_DAO_OptionValue {
           $f = rtrim($f, '.');
           return (float) (empty($f) ? '0' : $f);
       }
-      return CRM_Utils_Array::value($field, $values, $default);
+      return $values[$field] ?? $default;
     }
     return $default;
   }
@@ -494,7 +494,7 @@ class CRM_Core_BAO_LabelFormat extends CRM_Core_DAO_OptionValue {
     }
     // copy the supplied form values to the corresponding Option Value fields in the base class
     foreach ($this->fields() as $name => $field) {
-      $this->$name = trim(CRM_Utils_Array::value($name, $values, $this->$name));
+      $this->$name = trim($values[$name] ?? $this->$name);
       if (empty($this->$name)) {
         $this->$name = 'null';
       }

--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -84,7 +84,7 @@ class CRM_Core_BAO_Location extends CRM_Core_DAO {
       // when we come from a form which displays all the location elements (like the edit form or the inline block
       // elements, we can skip the below check. The below check adds quite a feq queries to an already overloaded
       // form
-      if (!CRM_Utils_Array::value('updateBlankLocInfo', $params, FALSE)) {
+      if (!$params['updateBlankLocInfo'] ?? FALSE) {
         // make sure contact should have only one primary block, CRM-5051
         self::checkPrimaryBlocks(CRM_Utils_Array::value('contact_id', $params));
       }

--- a/CRM/Core/BAO/LocationType.php
+++ b/CRM/Core/BAO/LocationType.php
@@ -124,9 +124,9 @@ class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType {
    */
   public static function create(&$params) {
     if (empty($params['id'])) {
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
-      $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_default'] = $params['is_default'] ?? FALSE;
+      $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
     }
 
     $locationType = new CRM_Core_DAO_LocationType();

--- a/CRM/Core/BAO/MailSettings.php
+++ b/CRM/Core/BAO/MailSettings.php
@@ -144,8 +144,8 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
     }
 
     if (empty($params['id'])) {
-      $params['is_ssl'] = CRM_Utils_Array::value('is_ssl', $params, FALSE);
-      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
+      $params['is_ssl'] = $params['is_ssl'] ?? FALSE;
+      $params['is_default'] = $params['is_default'] ?? FALSE;
     }
 
     //handle is_default.

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -68,9 +68,9 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
   public static function add(&$params) {
     $navigation = new CRM_Core_DAO_Navigation();
     if (empty($params['id'])) {
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['has_separator'] = CRM_Utils_Array::value('has_separator', $params, FALSE);
-      $params['domain_id'] = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
+      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['has_separator'] = $params['has_separator'] ?? FALSE;
+      $params['domain_id'] = $params['domain_id'] ?? CRM_Core_Config::domainID();
     }
 
     if (!isset($params['id']) ||

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -74,16 +74,16 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    * @param array $params
    */
   public static function setDefaults(&$params) {
-    if (CRM_Utils_Array::value('label', $params, NULL) === NULL) {
+    if (!isset($params['label'])) {
       $params['label'] = $params['name'];
     }
-    if (CRM_Utils_Array::value('name', $params, NULL) === NULL) {
+    if (!isset($params['name'])) {
       $params['name'] = $params['label'];
     }
-    if (CRM_Utils_Array::value('weight', $params, NULL) === NULL) {
+    if (!isset($params['weight'])) {
       $params['weight'] = self::getDefaultWeight($params);
     }
-    if (CRM_Utils_Array::value('value', $params, NULL) === NULL) {
+    if (!isset($params['value'])) {
       $params['value'] = self::getDefaultValue($params);
     }
   }
@@ -177,10 +177,10 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
     // complex defaults like the domain id below would make sense in the setDefauls function
     // but unclear what other ways this function is being used
     if (!$id) {
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
-      $params['is_optgroup'] = CRM_Utils_Array::value('is_optgroup', $params, FALSE);
-      $params['filter'] = CRM_Utils_Array::value('filter', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_default'] = $params['is_default'] ?? FALSE;
+      $params['is_optgroup'] = $params['is_optgroup'] ?? FALSE;
+      $params['filter'] = $params['filter'] ?? FALSE;
     }
     // Update custom field data to reflect the new value
     elseif (isset($params['value'])) {

--- a/CRM/Core/BAO/PaperSize.php
+++ b/CRM/Core/BAO/PaperSize.php
@@ -209,7 +209,7 @@ class CRM_Core_BAO_PaperSize extends CRM_Core_DAO_OptionValue {
     if (array_key_exists($field, self::$optionValueFields)) {
       switch (self::$optionValueFields[$field]['type']) {
         case CRM_Utils_Type::T_INT:
-          return (int) CRM_Utils_Array::value($field, $values, $default);
+          return (int) $values[$field] ?? $default;
 
         case CRM_Utils_Type::T_FLOAT:
           // Round float values to three decimal places and trim trailing zeros.
@@ -219,7 +219,7 @@ class CRM_Core_BAO_PaperSize extends CRM_Core_DAO_OptionValue {
           $f = rtrim($f, '.');
           return (float) (empty($f) ? '0' : $f);
       }
-      return CRM_Utils_Array::value($field, $values, $default);
+      return $values[$field] ?? $default;
     }
     return $default;
   }
@@ -291,7 +291,7 @@ class CRM_Core_BAO_PaperSize extends CRM_Core_DAO_OptionValue {
     }
     // copy the supplied form values to the corresponding Option Value fields in the base class
     foreach ($this->fields() as $name => $field) {
-      $this->$name = trim(CRM_Utils_Array::value($name, $values, $this->$name));
+      $this->$name = trim($values[$name] ?? $this->$name);
       if (empty($this->$name)) {
         $this->$name = 'null';
       }

--- a/CRM/Core/BAO/PdfFormat.php
+++ b/CRM/Core/BAO/PdfFormat.php
@@ -266,7 +266,7 @@ class CRM_Core_BAO_PdfFormat extends CRM_Core_DAO_OptionValue {
     if (array_key_exists($field, self::$optionValueFields)) {
       switch (self::$optionValueFields[$field]['type']) {
         case CRM_Utils_Type::T_INT:
-          return (int) CRM_Utils_Array::value($field, $values, $default);
+          return (int) $values[$field] ?? $default;
 
         case CRM_Utils_Type::T_FLOAT:
           // Round float values to three decimal places and trim trailing zeros.
@@ -276,7 +276,7 @@ class CRM_Core_BAO_PdfFormat extends CRM_Core_DAO_OptionValue {
           $f = rtrim($f, '.');
           return (float) (empty($f) ? '0' : $f);
       }
-      return CRM_Utils_Array::value($field, $values, $default);
+      return $values[$field] ?? $default;
     }
     return $default;
   }
@@ -344,7 +344,7 @@ class CRM_Core_BAO_PdfFormat extends CRM_Core_DAO_OptionValue {
     }
     // copy the supplied form values to the corresponding Option Value fields in the base class
     foreach ($this->fields() as $name => $field) {
-      $this->$name = trim(CRM_Utils_Array::value($name, $values, $this->$name));
+      $this->$name = trim($values[$name] ?? $this->$name);
       if (empty($this->$name)) {
         $this->$name = 'null';
       }

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -307,7 +307,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
             $linkedObj = CRM_Core_BAO_RecurringEntity::copyCreateEntity($linkedInfo['table'],
               $linkedInfo['findCriteria'],
               $newCriteria,
-              CRM_Utils_Array::value('isRecurringEntityRecord', $linkedInfo, TRUE)
+              $linkedInfo['isRecurringEntityRecord'] ?? TRUE
             );
 
             if (is_a($linkedObj, 'CRM_Core_DAO') && $linkedObj->id) {

--- a/CRM/Core/BAO/StatusPreference.php
+++ b/CRM/Core/BAO/StatusPreference.php
@@ -67,7 +67,7 @@ class CRM_Core_BAO_StatusPreference extends CRM_Core_DAO_StatusPreference {
 
     // Check if this StatusPreference already exists.
     if (empty($params['id']) && CRM_Utils_Array::value('name', $params)) {
-      $statusPreference->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
+      $statusPreference->domain_id = $params['domain_id'] ?? CRM_Core_Config::domainID();
       $statusPreference->name = $params['name'];
 
       $statusPreference->find(TRUE);

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -98,7 +98,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
     }
 
     //@todo why is this even optional? Surely weight should just be 'managed' ??
-    if (CRM_Utils_Array::value('option.autoweight', $params, TRUE)) {
+    if ($params['option.autoweight'] ?? TRUE) {
       $params['weight'] = CRM_Core_BAO_UFField::autoWeight($params);
     }
 
@@ -196,7 +196,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
     $ufField->field_type = CRM_Utils_Array::value('field_type', $params);
     $ufField->field_name = CRM_Utils_Array::value('field_name', $params);
     $ufField->website_type_id = CRM_Utils_Array::value('website_type_id', $params);
-    if (is_null(CRM_Utils_Array::value('location_type_id', $params, ''))) {
+    if (array_key_exists('location_type_id', $params) && is_null($params['location_type_id'])) {
       // primary location type have NULL value in DB
       $ufField->whereAdd("location_type_id IS NULL");
     }
@@ -273,7 +273,7 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
       $oldWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFField', !empty($params['id']) ? $params['id'] : $params['field_id'], 'weight', 'id');
     }
     $fieldValues = ['uf_group_id' => !empty($params['uf_group_id']) ? $params['uf_group_id'] : $params['group_id']];
-    return CRM_Utils_Weight::updateOtherWeights('CRM_Core_DAO_UFField', $oldWeight, CRM_Utils_Array::value('weight', $params, 0), $fieldValues);
+    return CRM_Utils_Weight::updateOtherWeights('CRM_Core_DAO_UFField', $oldWeight, $params['weight'] ?? 0, $fieldValues);
   }
 
   /**

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -480,7 +480,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     if (isset($field->phone_type_id)) {
       $name .= "-{$field->phone_type_id}";
     }
-    $fieldMetaData = CRM_Utils_Array::value($name, $importableFields, (isset($importableFields[$field->field_name]) ? $importableFields[$field->field_name] : []));
+    $fieldMetaData = $importableFields[$name] ?? $importableFields[$field->field_name] ?? [];
 
     // No lie: this is bizarre; why do we need to mix so many UFGroup properties into UFFields?
     // I guess to make field self sufficient with all the required data and avoid additional calls
@@ -1462,7 +1462,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       'is_cms_user',
     ];
     foreach ($fields as $field) {
-      $params[$field] = CRM_Utils_Array::value($field, $params, FALSE);
+      $params[$field] = $params[$field] ?? FALSE;
     }
 
     $params['limit_listings_group_id'] = CRM_Utils_Array::value('group', $params);
@@ -1822,7 +1822,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     $view = $field['is_view'];
     $required = ($mode == CRM_Profile_Form::MODE_SEARCH) ? FALSE : $field['is_required'];
     $search = ($mode == CRM_Profile_Form::MODE_SEARCH) ? TRUE : FALSE;
-    $isShared = CRM_Utils_Array::value('is_shared', $field, 0);
+    $isShared = $field['is_shared'] ?? 0;
 
     // do not display view fields in drupal registration form
     // CRM-4632

--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -105,9 +105,9 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
       //get logged in user ids, and set to session.
       if ($isUserLoggedIn) {
         $userIds = self::getUFValues();
-        $session->set('ufID', CRM_Utils_Array::value('uf_id', $userIds, ''));
-        $session->set('userID', CRM_Utils_Array::value('contact_id', $userIds, ''));
-        $session->set('ufUniqID', CRM_Utils_Array::value('uf_name', $userIds, ''));
+        $session->set('ufID', $userIds['uf_id'] ?? '');
+        $session->set('userID', $userIds['contact_id'] ?? '');
+        $session->set('ufUniqID', $userIds['uf_name'] ?? '');
       }
     }
 
@@ -130,9 +130,9 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
       //are we processing logged in user.
       if ($loggedInUserUfID && $loggedInUserUfID != $ufID) {
         $userIds = self::getUFValues($loggedInUserUfID);
-        $ufID = CRM_Utils_Array::value('uf_id', $userIds, '');
-        $userID = CRM_Utils_Array::value('contact_id', $userIds, '');
-        $ufUniqID = CRM_Utils_Array::value('uf_name', $userIds, '');
+        $ufID = $userIds['uf_id'] ?? '';
+        $userID = $userIds['contact_id'] ?? '';
+        $ufUniqID = $userIds['uf_name'] ?? '';
       }
     }
 

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -93,7 +93,7 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement {
     $wordReplacement->id = $id;
     $wordReplacement->copyValues($params);
     $wordReplacement->save();
-    if (!isset($params['options']) || CRM_Utils_Array::value('wp-rebuild', $params['options'], TRUE)) {
+    if (!isset($params['options']) || $params['options']['wp-rebuild'] ?? TRUE) {
       self::rebuild();
     }
     return $wordReplacement;
@@ -113,7 +113,7 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement {
     $wordReplacement = new CRM_Core_DAO_WordReplacement();
     $wordReplacement->copyValues($params);
     $wordReplacement->save();
-    if (!isset($params['options']) || CRM_Utils_Array::value('wp-rebuild', $params['options'], TRUE)) {
+    if (!isset($params['options']) || $params['options']['wp-rebuild'] ?? TRUE) {
       self::rebuild();
     }
     return $wordReplacement;
@@ -131,7 +131,7 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement {
     $dao = new CRM_Core_DAO_WordReplacement();
     $dao->id = $id;
     $dao->delete();
-    if (!isset($params['options']) || CRM_Utils_Array::value('wp-rebuild', $params['options'], TRUE)) {
+    if (!isset($params['options']) || $params['options']['wp-rebuild'] ?? TRUE) {
       self::rebuild();
     }
     return $dao;

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -434,7 +434,7 @@ class CRM_Core_Block {
 
     foreach ($values as $key => $val) {
       if (!empty($val['title'])) {
-        $values[$key]['name'] = CRM_Utils_Array::value('name', $val, $val['title']);
+        $values[$key]['name'] = $val['name'] ?? $val['title'];
       }
     }
 

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -175,8 +175,8 @@ class CRM_Core_Component {
     $info = self::_info();
     $config = CRM_Core_Config::singleton();
 
-    $firstArg = CRM_Utils_Array::value(1, $args, '');
-    $secondArg = CRM_Utils_Array::value(2, $args, '');
+    $firstArg = $args[1] ?? '';
+    $secondArg = $args[2] ?? '';
     foreach ($info as $name => $comp) {
       if (in_array($name, $config->enableComponents) &&
         (($comp->info['url'] === $firstArg && $type == 'main') ||

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -158,11 +158,11 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
         // e.g. one codebase, multi database
         parse_url(CIVICRM_DSN, PHP_URL_PATH),
         // e.g. CMS vs extern vs installer
-        \CRM_Utils_Array::value('SCRIPT_FILENAME', $_SERVER, ''),
+        $_SERVER['SCRIPT_FILENAME'] ?? '',
         // e.g. name-based vhosts
-        \CRM_Utils_Array::value('HTTP_HOST', $_SERVER, ''),
+        $_SERVER['HTTP_HOST'] ?? '',
         // e.g. port-based vhosts
-        \CRM_Utils_Array::value('SERVER_PORT', $_SERVER, ''),
+        $_SERVER['SERVER_PORT'] ?? '',
         // Depending on deployment arch, these signals *could* be redundant, but who cares?
       ]));
     }

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -300,7 +300,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       return NULL;
     }
 
-    $key = CRM_Utils_Array::value('qfKey', $_REQUEST, NULL);
+    $key = $_REQUEST['qfKey'] ?? NULL;
     if (!$key && $_SERVER['REQUEST_METHOD'] === 'GET') {
       $key = CRM_Core_Key::get($name, $addSequence);
     }
@@ -432,7 +432,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   public function addPages(&$stateMachine, $action = CRM_Core_Action::NONE) {
     $pages = $stateMachine->getPages();
     foreach ($pages as $name => $value) {
-      $className = CRM_Utils_Array::value('className', $value, $name);
+      $className = $value['className'] ?? $name;
       $title = CRM_Utils_Array::value('title', $value);
       $options = CRM_Utils_Array::value('options', $value);
       $stateName = CRM_Utils_String::getClassName($className);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -248,7 +248,7 @@ class CRM_Core_DAO extends DB_DataObject {
     }
     else {
       //if it is required we need to generate the dependency object first
-      $depObject = CRM_Core_DAO::createTestObject($FKClassName, CRM_Utils_Array::value($dbName, $params, 1));
+      $depObject = CRM_Core_DAO::createTestObject($FKClassName, $params[$dbName] ?? 1);
       $this->$dbName = $depObject->id;
     }
   }
@@ -2254,7 +2254,7 @@ SELECT contact_id
           $className::getTableName(),
           $field['name'],
           'civicrm_option_value',
-          CRM_Utils_Array::value('keyColumn', $field['pseudoconstant'], 'value'),
+          $field['pseudoconstant']['keyColumn'] ?? 'value',
           $field['pseudoconstant']['optionGroupName']
         );
       }

--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -50,7 +50,7 @@ function _civicrm_api3_permissions($entity, $action, &$params) {
   CRM_Utils_Hook::alterAPIPermissions($entity, $action, $params, $permissions);
 
   // Merge permissions for this entity with the defaults
-  $perm = CRM_Utils_Array::value($entity, $permissions, []) + $permissions['default'];
+  $perm = ($permissions[$entity] ?? []) + $permissions['default'];
 
   // Return exact match if permission for this action has been declared
   if (isset($perm[$action])) {

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -824,8 +824,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
 
       $ret[] = sprintf(
         "%s(%s): %s%s(%s)",
-        CRM_Utils_Array::value('file', $trace, '[internal function]'),
-        CRM_Utils_Array::value('line', $trace, ''),
+        $trace['file'] ?? '[internal function]',
+        $trace['line'] ?? '',
         $className,
         $fnName,
         implode(", ", $args)

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -406,7 +406,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $attributes = ($attributes ? $attributes : []);
       $attributes['data-crm-datepicker'] = json_encode((array) $extra);
       if (!empty($attributes['aria-label']) || $label) {
-        $attributes['aria-label'] = CRM_Utils_Array::value('aria-label', $attributes, $label);
+        $attributes['aria-label'] = $attributes['aria-label'] ?? $label;
       }
       $type = "text";
     }
@@ -692,7 +692,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         if (in_array($button['type'], ['next', 'upload', 'done']) && $button['name'] === ts('Save')) {
           $attrs['accesskey'] = 'S';
         }
-        $icon = CRM_Utils_Array::value('icon', $button, $defaultIcon);
+        $icon = $button['icon'] ?? $defaultIcon;
         if ($icon) {
           $attrs['crm-icon'] = $icon;
         }
@@ -710,7 +710,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       }
 
       // hack - addGroup uses an array to express variable spacing, read from the last element
-      $spacing[] = CRM_Utils_Array::value('spacing', $button, self::ATTR_SPACING);
+      $spacing[] = $button['spacing'] ?? self::ATTR_SPACING;
     }
     $this->addGroup($prevnext, 'buttons', '', $spacing, FALSE);
   }
@@ -1438,7 +1438,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         if (
           $uniqueName === $props['field'] ||
           CRM_Utils_Array::value('name', $fieldSpec) === $props['field'] ||
-          in_array($props['field'], CRM_Utils_Array::value('api.aliases', $fieldSpec, []))
+          in_array($props['field'], $fieldSpec['api.aliases'] ?? [])
         ) {
           break;
         }
@@ -1509,7 +1509,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $fieldSpec = civicrm_api3($props['entity'], 'getfield', $props);
     $fieldSpec = $fieldSpec['values'];
     $fieldSpecLabel = isset($fieldSpec['html']['label']) ? $fieldSpec['html']['label'] : CRM_Utils_Array::value('title', $fieldSpec);
-    $label = CRM_Utils_Array::value('label', $props, $fieldSpecLabel);
+    $label = $props['label'] ?? $fieldSpecLabel;
 
     $widget = isset($props['type']) ? $props['type'] : $fieldSpec['html']['type'];
     if ($widget == 'TextArea' && $context == 'search') {
@@ -1534,7 +1534,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       }
       if ($context == 'search') {
         $widget = $widget == 'Select2' ? $widget : 'Select';
-        $props['multiple'] = CRM_Utils_Array::value('multiple', $props, TRUE);
+        $props['multiple'] = $props['multiple'] ?? TRUE;
       }
 
       // Add data for popup link.
@@ -1552,7 +1552,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $props['data-api-field'] = $props['name'];
       }
     }
-    $props += CRM_Utils_Array::value('html', $fieldSpec, []);
+    $props += $fieldSpec['html'] ?? [];
     CRM_Utils_Array::remove($props, 'entity', 'name', 'context', 'label', 'action', 'type', 'option_url', 'options');
 
     // TODO: refactor switch statement, to separate methods.
@@ -1610,7 +1610,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
       case 'Select':
       case 'Select2':
-        $props['class'] = CRM_Utils_Array::value('class', $props, 'big') . ' crm-select2';
+        $props['class'] = ($props['class'] ?? 'big') . ' crm-select2';
         if (!array_key_exists('placeholder', $props)) {
           $props['placeholder'] = $required ? ts('- select -') : ($context == 'search' ? ts('- any -') : ts('- none -'));
         }
@@ -1977,9 +1977,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public function addEntityRef($name, $label = '', $props = [], $required = FALSE) {
     // Default properties
-    $props['api'] = CRM_Utils_Array::value('api', $props, []);
-    $props['entity'] = CRM_Utils_String::convertStringToCamel(CRM_Utils_Array::value('entity', $props, 'Contact'));
-    $props['class'] = ltrim(CRM_Utils_Array::value('class', $props, '') . ' crm-form-entityref');
+    $props['api'] = $props['api'] ?? [];
+    $props['entity'] = CRM_Utils_String::convertStringToCamel($props['entity'] ?? 'Contact');
+    $props['class'] = ltrim(($props['class'] ?? '') . ' crm-form-entityref');
 
     if (array_key_exists('create', $props) && empty($props['create'])) {
       unset($props['create']);
@@ -1991,7 +1991,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if (!empty($props['multiple'])) {
       $defaults['multiple'] = TRUE;
     }
-    $props['select'] = CRM_Utils_Array::value('select', $props, []) + $defaults;
+    $props['select'] = $props['select'] ?? [] + $defaults;
 
     $this->formatReferenceFieldAttributes($props, get_class($this));
     return $this->add('text', $name, $label, $props, $required);

--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -278,8 +278,8 @@ class CRM_Core_JobManager {
    */
   private function _apiResultToMessage($apiResult) {
     $status = $apiResult['is_error'] ? ts('Failure') : ts('Success');
-    $msg = CRM_Utils_Array::value('error_message', $apiResult, 'empty error_message!');
-    $vals = CRM_Utils_Array::value('values', $apiResult, 'empty values!');
+    $msg = $apiResult['error_message'] ?? 'empty error_message!';
+    $vals = $apiResult['values'] ?? 'empty values!';
     if (is_array($msg)) {
       $msg = serialize($msg);
     }

--- a/CRM/Core/LegacyErrorHandler.php
+++ b/CRM/Core/LegacyErrorHandler.php
@@ -18,7 +18,7 @@ class CRM_Core_LegacyErrorHandler {
       $session->setStatus(
         $message,
         CRM_Utils_Array::value('message_title', $params),
-        CRM_Utils_Array::value('message_type', $params, 'error')
+        $params['message_type'] ?? 'error'
       );
 
       // @todo remove this code - legacy redirect path is an interim measure for moving redirects out of BAO

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -253,7 +253,7 @@ class CRM_Core_ManagedEntities {
    *   Entity specification (per hook_civicrm_managedEntities).
    */
   public function updateExistingEntity($dao, $todo) {
-    $policy = CRM_Utils_Array::value('update', $todo, 'always');
+    $policy = $todo['update'] ?? 'always';
     $doUpdate = ($policy == 'always');
 
     if ($doUpdate) {

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -388,7 +388,6 @@ class CRM_Core_Menu {
         $values[$item['adminGroup']] = array();
         $values[$item['adminGroup']]['fields'] = array();
       }
-      $weight = CRM_Utils_Array::value('weight', $item, 0);
       $values[$item['adminGroup']]['fields']["{weight}.{$item['title']}"] = $value;
       $values[$item['adminGroup']]['component_id'] = $item['component_id'];
     }

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -153,7 +153,7 @@ class CRM_Core_OptionValue {
 
       $optionValue[$dao->id]['label'] = htmlspecialchars($optionValue[$dao->id]['label']);
       $optionValue[$dao->id]['order'] = $optionValue[$dao->id]['weight'];
-      $optionValue[$dao->id]['icon'] = CRM_Utils_Array::value('icon', $optionValue[$dao->id], '');
+      $optionValue[$dao->id]['icon'] = $optionValue[$dao->id]['icon'] ?? '';
       $optionValue[$dao->id]['action'] = CRM_Core_Action::formLink($links, $action,
         [
           'id' => $dao->id,
@@ -197,7 +197,7 @@ class CRM_Core_OptionValue {
    *
    */
   public static function addOptionValue(&$params, $optionGroupName, $action, $optionValueID) {
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+    $params['is_active'] = $params['is_active'] ?? FALSE;
     // checking if the group name with the given id or name (in $groupParams) exists
     $groupParams = ['name' => $optionGroupName, 'is_active' => 1];
     $optionGroup = CRM_Core_BAO_OptionGroup::retrieve($groupParams, $defaults);

--- a/CRM/Core/Page/Redirect.php
+++ b/CRM/Core/Page/Redirect.php
@@ -55,9 +55,9 @@ class CRM_Core_Page_Redirect extends CRM_Core_Page {
     $urlParts = parse_url($urlString);
     $url = CRM_Utils_System::url(
       $urlParts['path'],
-      CRM_Utils_Array::value('query', $urlParts, NULL),
+      $urlParts['query'] ?? NULL,
       $absolute,
-      CRM_Utils_Array::value('fragment', $urlParts, NULL)
+      $urlParts['fragment'] ?? NULL
     );
 
     return $url;

--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -547,7 +547,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
    *   not set
    */
   public function _getParam($field, $xmlSafe = FALSE) {
-    $value = CRM_Utils_Array::value($field, $this->_params, '');
+    $value = $this->_params[$field] ?? '';
     if ($xmlSafe) {
       $value = str_replace(['&', '"', "'", '<', '>'], '', $value);
     }

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -745,7 +745,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    */
   public static function handlePaymentNotification() {
     $params = array_merge($_GET, $_REQUEST);
-    $q = explode('/', CRM_Utils_Array::value('q', $params, ''));
+    $q = explode('/', $params['q'] ?? '');
     $lastParam = array_pop($q);
     if (is_numeric($lastParam)) {
       $params['processor_id'] = $lastParam;

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -568,7 +568,7 @@ class CRM_Core_Permission {
       $item['access_callback'][0] == 'CRM_Core_Permission' &&
       $item['access_callback'][1] == 'checkMenu'
     ) {
-      $op = CRM_Utils_Array::value(1, $item['access_arguments'], 'and');
+      $op = $item['access_arguments'][1] ?? 'and';
       return self::checkMenu($item['access_arguments'][0], $op);
     }
     else {

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -66,7 +66,7 @@ class CRM_Core_Permission_Base {
 
       // pass through
       case 'cms':
-        return CRM_Utils_Array::value($name, $map, CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+        return $map[$name] ?? CRM_Core_Permission::ALWAYS_DENY_PERMISSION;
 
       case NULL:
         return $name;

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -228,7 +228,7 @@ class CRM_Core_PseudoConstant {
     $fieldSpec = $dao->getFieldSpec($fieldName);
 
     // Ensure we have the canonical name for this field
-    $fieldName = CRM_Utils_Array::value('name', $fieldSpec, $fieldName);
+    $fieldName = $fieldSpec['name'] ?? $fieldName;
 
     // Return false if field doesn't exist.
     if (empty($fieldSpec)) {
@@ -248,7 +248,7 @@ class CRM_Core_PseudoConstant {
 
       // Merge params with schema defaults
       $params += [
-        'condition' => CRM_Utils_Array::value('condition', $pseudoconstant, []),
+        'condition' => $pseudoconstant['condition'] ?? [],
         'keyColumn' => CRM_Utils_Array::value('keyColumn', $pseudoconstant),
         'labelColumn' => CRM_Utils_Array::value('labelColumn', $pseudoconstant),
       ];
@@ -593,12 +593,12 @@ class CRM_Core_PseudoConstant {
    */
   public static function &activityType() {
     $args = func_get_args();
-    $all = CRM_Utils_Array::value(0, $args, TRUE);
-    $includeCaseActivities = CRM_Utils_Array::value(1, $args, FALSE);
-    $reset = CRM_Utils_Array::value(2, $args, FALSE);
-    $returnColumn = CRM_Utils_Array::value(3, $args, 'label');
-    $includeCampaignActivities = CRM_Utils_Array::value(4, $args, FALSE);
-    $onlyComponentActivities = CRM_Utils_Array::value(5, $args, FALSE);
+    $all = $args[0] ?? TRUE;
+    $includeCaseActivities = $args[1] ?? FALSE;
+    $reset = $args[2] ?? FALSE;
+    $returnColumn = $args[3] ?? 'label';
+    $includeCampaignActivities = $args[4] ?? FALSE;
+    $onlyComponentActivities = $args[5] ?? FALSE;
     $index = (int) $all . '_' . $returnColumn . '_' . (int) $includeCaseActivities;
     $index .= '_' . (int) $includeCampaignActivities;
     $index .= '_' . (int) $onlyComponentActivities;

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -635,7 +635,7 @@ class CRM_Core_SelectValues {
         }
         else {
           // Support legacy token names
-          $tokenName = CRM_Utils_Array::value($val, $legacyTokenNames, $val);
+          $tokenName = $legacyTokenNames[$val] ?? $val;
           $tokens["{contact.$tokenName}"] = $exportFields[$val]['title'];
         }
       }

--- a/CRM/Core/Smarty/plugins/block.crmButton.php
+++ b/CRM/Core/Smarty/plugins/block.crmButton.php
@@ -54,7 +54,7 @@ function smarty_block_crmButton($params, $text, &$smarty) {
   // Always add class 'button' - fixme probably should be crm-button
   $params['class'] = empty($params['class']) ? 'button' : 'button ' . $params['class'];
   // Any FA icon works
-  $icon = CRM_Utils_Array::value('icon', $params, 'pencil');
+  $icon = $params['icon'] ?? 'pencil';
   // All other params are treated as html attributes
   CRM_Utils_Array::remove($params, 'icon', 'p', 'q', 'a', 'f', 'h', 'fb', 'fe');
   $attributes = CRM_Utils_String::htmlAttributes($params);

--- a/CRM/Core/Smarty/plugins/block.crmRegion.php
+++ b/CRM/Core/Smarty/plugins/block.crmRegion.php
@@ -23,7 +23,7 @@ function smarty_block_crmRegion($params, $content, &$smarty, &$repeat) {
   require_once 'CRM/Core/Region.php';
   $region = CRM_Core_Region::instance($params['name'], FALSE);
   if ($region) {
-    $result = $region->render($content, CRM_Utils_Array::value('allowCmsOverride', $params, TRUE));
+    $result = $region->render($content, $params['allowCmsOverride'] ?? TRUE);
     return $result;
   }
   else {

--- a/CRM/Core/Smarty/plugins/function.crmAPI.php
+++ b/CRM/Core/Smarty/plugins/function.crmAPI.php
@@ -45,8 +45,8 @@ function smarty_function_crmAPI($params, &$smarty) {
   }
   $errorScope = CRM_Core_TemporaryErrorScope::create(['CRM_Utils_REST', 'fatal']);
   $entity = $params['entity'];
-  $action = CRM_Utils_Array::value('action', $params, 'get');
-  $params['sequential'] = CRM_Utils_Array::value('sequential', $params, 1);
+  $action = $params['action'] ?? 'get';
+  $params['sequential'] = $params['sequential'] ?? 1;
   $var = CRM_Utils_Array::value('var', $params);
   CRM_Utils_Array::remove($params, 'entity', 'action', 'var');
   $params['version'] = 3;

--- a/CRM/Core/Smarty/plugins/function.crmCrudLink.php
+++ b/CRM/Core/Smarty/plugins/function.crmCrudLink.php
@@ -60,7 +60,7 @@ function smarty_function_crmCrudLink($params, &$smarty) {
   if ($link) {
     return sprintf('<a href="%s">%s</a>',
       htmlspecialchars($link['url']),
-      htmlspecialchars(CRM_Utils_Array::value('title', $params, $link['title']))
+      htmlspecialchars($params['title'] ?? $link['title'])
     );
   }
   else {

--- a/CRM/Core/Smarty/plugins/function.crmKey.php
+++ b/CRM/Core/Smarty/plugins/function.crmKey.php
@@ -47,6 +47,6 @@
 function smarty_function_crmKey($params, &$smarty) {
   return CRM_Core_Key::get(
       $params['name'],
-      CRM_Utils_Array::value('addSequence', $params, 0)
+      $params['addSequence'] ?? 0
     );
 }

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -407,7 +407,7 @@ SELECT count(*)
     $customOption->weight = $params['weight'];
     $customOption->description = $params['description'];
     $customOption->value = $params['value'];
-    $customOption->is_active = CRM_Utils_Array::value('is_active', $params, FALSE);
+    $customOption->is_active = $params['is_active'] ?? FALSE;
 
     $oldWeight = NULL;
     if ($this->_id) {

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -50,9 +50,9 @@ class CRM_Custom_Import_Parser_Api extends CRM_Custom_Import_Parser {
     $hasLocationType = FALSE;
 
     foreach ($fields as $name => $field) {
-      $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
-      $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
-      $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
+      $field['type'] = $field['type'] ?? CRM_Utils_Type::T_INT;
+      $field['dataPattern'] = $field['dataPattern'] ?? '//';
+      $field['headerPattern'] = $field['headerPattern'] ?? '//';
       $this->addField($name, $field['title'], $field['type'], $field['headerPattern'], $field['dataPattern'], $hasLocationType);
     }
     $this->setActiveFields($this->_mapperKeys);

--- a/CRM/Dedupe/BAO/QueryBuilder/IndividualGeneral.php
+++ b/CRM/Dedupe/BAO/QueryBuilder/IndividualGeneral.php
@@ -16,9 +16,9 @@ class CRM_Dedupe_BAO_QueryBuilder_IndividualGeneral extends CRM_Dedupe_BAO_Query
     $civicrm_address = CRM_Utils_Array::value('civicrm_address', $rg->params);
 
     // Since definitely have first and last name, escape them upfront.
-    $first_name = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('first_name', $civicrm_contact, ''));
-    $last_name = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('last_name', $civicrm_contact, ''));
-    $street_address = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('street_address', $civicrm_address, ''));
+    $first_name = CRM_Core_DAO::escapeString($civicrm_contact['first_name'] ?? '');
+    $last_name = CRM_Core_DAO::escapeString($civicrm_contact['last_name'] ?? '');
+    $street_address = CRM_Core_DAO::escapeString($civicrm_address['street_address'] ?? '');
 
     $query = "
             SELECT contact1.id id1, {$rg->threshold} as weight
@@ -30,15 +30,15 @@ class CRM_Dedupe_BAO_QueryBuilder_IndividualGeneral extends CRM_Dedupe_BAO_Query
               AND address1.street_address = '$street_address'
               ";
 
-    if ($birth_date = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('birth_date', $civicrm_contact, ''))) {
+    if ($birth_date = CRM_Core_DAO::escapeString($civicrm_contact['birth_date'] ?? '')) {
       $query .= " AND (contact1.birth_date IS NULL or contact1.birth_date = '$birth_date')\n";
     }
 
-    if ($suffix_id = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('suffix_id', $civicrm_contact, ''))) {
+    if ($suffix_id = CRM_Core_DAO::escapeString($civicrm_contact['suffix_id'] ?? '')) {
       $query .= " AND (contact1.suffix_id IS NULL or contact1.suffix_id = $suffix_id)\n";
     }
 
-    if ($middle_name = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('middle_name', $civicrm_contact, ''))) {
+    if ($middle_name = CRM_Core_DAO::escapeString($civicrm_contact['middle_name'] ?? '')) {
       $query .= " AND (contact1.middle_name IS NULL or contact1.middle_name = '$middle_name')\n";
     }
 

--- a/CRM/Dedupe/BAO/QueryBuilder/IndividualSupervised.php
+++ b/CRM/Dedupe/BAO/QueryBuilder/IndividualSupervised.php
@@ -15,20 +15,20 @@ class CRM_Dedupe_BAO_QueryBuilder_IndividualSupervised extends CRM_Dedupe_BAO_Qu
    */
   public static function record($rg) {
 
-    $civicrm_contact = CRM_Utils_Array::value('civicrm_contact', $rg->params, []);
-    $civicrm_email = CRM_Utils_Array::value('civicrm_email', $rg->params, []);
+    $civicrm_contact = $rg->params['civicrm_contact'] ?? [];
+    $civicrm_email = $rg->params['civicrm_email'] ?? [];
 
     $params = [
       1 => [
-        CRM_Utils_Array::value('first_name', $civicrm_contact, ''),
+        $civicrm_contact['first_name'] ?? '',
         'String',
       ],
       2 => [
-        CRM_Utils_Array::value('last_name', $civicrm_contact, ''),
+        $civicrm_contact['last_name'] ?? '',
         'String',
       ],
       3 => [
-        CRM_Utils_Array::value('email', $civicrm_email, ''),
+        $civicrm_email['email'] ?? '',
         'String',
       ],
     ];

--- a/CRM/Dedupe/BAO/QueryBuilder/IndividualUnsupervised.php
+++ b/CRM/Dedupe/BAO/QueryBuilder/IndividualUnsupervised.php
@@ -36,10 +36,10 @@ class CRM_Dedupe_BAO_QueryBuilder_IndividualUnsupervised extends CRM_Dedupe_BAO_
    * @return array
    */
   public static function record($rg) {
-    $civicrm_email = CRM_Utils_Array::value('civicrm_email', $rg->params, []);
+    $civicrm_email = $rg->params['civicrm_email'] ?? [];
 
     $params = [
-      1 => [CRM_Utils_Array::value('email', $civicrm_email, ''), 'String'],
+      1 => [$civicrm_email['email'] ?? '', 'String'],
     ];
 
     return [

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -125,7 +125,7 @@ class CRM_Dedupe_Finder {
     if (!$params) {
       return [];
     }
-    $checkPermission = CRM_Utils_Array::value('check_permission', $params, TRUE);
+    $checkPermission = $params['check_permission'] ?? TRUE;
     // This may no longer be required - see https://github.com/civicrm/civicrm-core/pull/13176
     $params = array_filter($params);
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2004,7 +2004,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
         foreach ($block as $blkCount => $values) {
           $otherBlockId = CRM_Utils_Array::value('id', $migrationInfo['other_details']['location_blocks'][$name][$blkCount]);
-          $mainBlockId = CRM_Utils_Array::value('mainContactBlockId', $migrationInfo['location_blocks'][$name][$blkCount], 0);
+          $mainBlockId = $migrationInfo['location_blocks'][$name][$blkCount]['mainContactBlockId'] ?? 0;
           if (!$otherBlockId) {
             continue;
           }
@@ -2050,7 +2050,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             $otherBlockDAO->is_billing = 0;
           }
 
-          $operation = CRM_Utils_Array::value('operation', $values, 2);
+          $operation = $values['operation'] ?? 2;
           // overwrite - need to delete block which belongs to main-contact.
           if (!empty($mainBlockId) && ($operation == 2)) {
             $deleteDAO = new $daoName();

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1063,7 +1063,7 @@ WHERE civicrm_event.is_active = 1
     ];
 
     //get the params submitted by participant.
-    $participantParams = CRM_Utils_Array::value($participantId, $values['params'], []);
+    $participantParams = $values['params'][$participantId] ?? [];
 
     if (!$returnMessageText) {
       //send notification email if field values are set (CRM-1941)
@@ -1108,8 +1108,8 @@ WHERE civicrm_event.is_active = 1
         $postProfileID = CRM_Utils_Array::value('custom_post_id', $values);
 
         if (!empty($values['params']['additionalParticipant'])) {
-          $preProfileID = CRM_Utils_Array::value('additional_custom_pre_id', $values, $preProfileID);
-          $postProfileID = CRM_Utils_Array::value('additional_custom_post_id', $values, $postProfileID);
+          $preProfileID = $values['additional_custom_pre_id'] ?? $preProfileID;
+          $postProfileID = $values['additional_custom_post_id'] ?? $postProfileID;
         }
 
         $profilePre = self::buildCustomDisplay($preProfileID,
@@ -1318,9 +1318,9 @@ WHERE civicrm_event.is_active = 1
           }
           // suppress all file fields from display
           if (
-            CRM_Utils_Array::value('data_type', $v, '') == 'File' ||
-            CRM_Utils_Array::value('name', $v, '') == 'image_URL' ||
-            CRM_Utils_Array::value('field_type', $v) == 'Formatting'
+            ($v['data_type'] ?? '') == 'File' ||
+            ($v['name'] ?? '') == 'image_URL' ||
+            ($v['field_type'] ?? '') == 'Formatting'
           ) {
             unset($fields[$k]);
           }
@@ -1347,9 +1347,7 @@ WHERE civicrm_event.is_active = 1
             while ($grp->fetch()) {
               $grpTitles[] = $grp->title;
             }
-            if (!empty($grpTitles) &&
-              CRM_Utils_Array::value('title', CRM_Utils_Array::value('group', $fields))
-            ) {
+            if (!empty($grpTitles) && !empty($fields['group']['title'])) {
               $values[$fields['group']['title']] = implode(', ', $grpTitles);
             }
             unset($fields['group']);
@@ -1777,7 +1775,7 @@ WHERE  id = $cfID
           //get the params submitted by participant.
           $participantParams = NULL;
           if (isset($values['params'])) {
-            $participantParams = CRM_Utils_Array::value($pId, $values['params'], []);
+            $participantParams = $values['params'][$pId] ?? [];
           }
 
           list($profilePre, $groupTitles) = self::buildCustomDisplay($preProfileID,
@@ -1998,7 +1996,7 @@ WHERE  ce.loc_block_id = $locBlockId";
     $participant = new CRM_Event_DAO_Participant();
     $participant->copyValues($params);
 
-    $participant->is_test = CRM_Utils_Array::value('is_test', $params, 0);
+    $participant->is_test = $params['is_test'] ?? 0;
     $participant->selectAdd();
     $participant->selectAdd('status_id');
     if ($participant->find(TRUE) && array_key_exists($participant->status_id, $statusTypes)) {

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -563,7 +563,7 @@ INNER JOIN  civicrm_price_field field       ON ( value.price_field_id = field.id
       if ($lineItem->html_type == 'Text') {
         $count *= $lineItem->qty;
       }
-      $optionsCount[$lineItem->valueId] = $count + CRM_Utils_Array::value($lineItem->valueId, $optionsCount, 0);
+      $optionsCount[$lineItem->valueId] = $count + ($optionsCount[$lineItem->valueId] ?? 0);
     }
 
     return $optionsCount;

--- a/CRM/Event/Cart/Form/Cart.php
+++ b/CRM/Event/Cart/Form/Cart.php
@@ -144,10 +144,10 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
       return $contact_id;
     }
     $contact_params = [
-      'email-Primary' => CRM_Utils_Array::value('email', $fields, NULL),
-      'first_name' => CRM_Utils_Array::value('first_name', $fields, NULL),
-      'last_name' => CRM_Utils_Array::value('last_name', $fields, NULL),
-      'is_deleted' => CRM_Utils_Array::value('is_deleted', $fields, TRUE),
+      'email-Primary' => $fields['email'] ?? NULL,
+      'first_name' => $fields['first_name'] ?? NULL,
+      'last_name' => $fields['last_name'] ?? NULL,
+      'is_deleted' => $fields['is_deleted'] ?? TRUE,
     ];
     $no_fields = [];
     $contact_id = CRM_Contact_BAO_Contact::createProfileContact($contact_params, $no_fields, NULL);

--- a/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
+++ b/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
@@ -128,7 +128,7 @@ EOS;
     foreach ($this->events_by_slot as $slot_name => $events) {
       $slot_index++;
       $field_name = "slot_$slot_index";
-      $session_event_id = CRM_Utils_Array::value($field_name, $params, NULL);
+      $session_event_id = $params[$field_name] ?? NULL;
       if (!$session_event_id) {
         continue;
       }

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -35,10 +35,10 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
       'id' => $participant->id,
       'event_id' => $event->id,
       'register_date' => $registerDate,
-      'source' => CRM_Utils_Array::value('participant_source', $params, $this->description),
+      'source' => $params['participant_source'] ?? $this->description,
       //'fee_level'     => $participant->fee_level,
       'is_pay_later' => $this->is_pay_later,
-      'fee_amount' => CRM_Utils_Array::value('amount', $params, 0),
+      'fee_amount' => $params['amount'] ?? 0,
       //XXX why is this a ref to participant and not contact?:
       //'registered_by_id' => $this->payer_contact_id,
       'fee_currency' => CRM_Utils_Array::value('currencyID', $params),
@@ -47,7 +47,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     if ($participant->must_wait) {
       $participant_status = 'On waitlist';
     }
-    elseif (CRM_Utils_Array::value('is_pay_later', $params, FALSE)) {
+    elseif (!empty($params['is_pay_later'])) {
       $participant_status = 'Pending from pay later';
     }
     else {
@@ -445,7 +445,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
    */
   public function preProcess() {
     $params = $this->_submitValues;
-    $this->is_pay_later = CRM_Utils_Array::value('is_pay_later', $params, FALSE) && !CRM_Utils_Array::value('payment_completed', $params);
+    $this->is_pay_later = !empty($params['is_pay_later']) && empty($params['payment_completed']);
 
     parent::preProcess();
   }
@@ -664,7 +664,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
       'trxn_id' => "{$params['trxn_id']}-{$this->sub_trxn_index}",
       'currency' => CRM_Utils_Array::value('currencyID', $params),
       'source' => $event->title,
-      'is_pay_later' => CRM_Utils_Array::value('is_pay_later', $params, 0),
+      'is_pay_later' => $params['is_pay_later'] ?? 0,
       'contribution_status_id' => $params['contribution_status_id'],
       'payment_instrument_id' => $params['payment_instrument_id'],
       'check_number' => CRM_Utils_Array::value('check_number', $params),

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -112,9 +112,9 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->assign('description', CRM_Utils_Array::value('description', $defaults));
 
     // Provide suggested text for event full and waitlist messages if they're empty
-    $defaults['event_full_text'] = CRM_Utils_Array::value('event_full_text', $defaults, ts('This event is currently full.'));
+    $defaults['event_full_text'] = $defaults['event_full_text'] ?? ts('This event is currently full.');
 
-    $defaults['waitlist_text'] = CRM_Utils_Array::value('waitlist_text', $defaults, ts('This event is currently full. However you can register now and get added to a waiting list. You will be notified if spaces become available.'));
+    $defaults['waitlist_text'] = $defaults['waitlist_text'] ?? ts('This event is currently full. However you can register now and get added to a waiting list. You will be notified if spaces become available.');
     $defaults['template_id'] = $this->_templateId;
     return $defaults;
   }
@@ -233,12 +233,12 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     //format params
     $params['start_date'] = CRM_Utils_Array::value('start_date', $params);
     $params['end_date'] = CRM_Utils_Array::value('end_date', $params);
-    $params['has_waitlist'] = CRM_Utils_Array::value('has_waitlist', $params, FALSE);
-    $params['is_map'] = CRM_Utils_Array::value('is_map', $params, FALSE);
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['is_public'] = CRM_Utils_Array::value('is_public', $params, FALSE);
-    $params['is_share'] = CRM_Utils_Array::value('is_share', $params, FALSE);
-    $params['default_role_id'] = CRM_Utils_Array::value('default_role_id', $params, FALSE);
+    $params['has_waitlist'] = $params['has_waitlist'] ?? FALSE;
+    $params['is_map'] = $params['is_map'] ?? FALSE;
+    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['is_public'] = $params['is_public'] ?? FALSE;
+    $params['is_share'] = $params['is_share'] ?? FALSE;
+    $params['default_role_id'] = $params['default_role_id'] ?? FALSE;
     $params['id'] = $this->_id;
 
     //merge params with defaults from templates

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -563,8 +563,8 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       $params['payment_processor'] = 'null';
     }
 
-    $params['is_pay_later'] = CRM_Utils_Array::value('is_pay_later', $params, 0);
-    $params['is_billing_required'] = CRM_Utils_Array::value('is_billing_required', $params, 0);
+    $params['is_pay_later'] = $params['is_pay_later'] ?? 0;
+    $params['is_billing_required'] = $params['is_billing_required'] ?? 0;
 
     if ($this->_id) {
 

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -49,10 +49,10 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $this->_addProfileBottom = CRM_Utils_Array::value('addProfileBottom', $_GET, FALSE);
-    $this->_profileBottomNum = CRM_Utils_Array::value('addProfileNum', $_GET, 0);
-    $this->_addProfileBottomAdd = CRM_Utils_Array::value('addProfileBottomAdd', $_GET, FALSE);
-    $this->_profileBottomNumAdd = CRM_Utils_Array::value('addProfileNumAdd', $_GET, 0);
+    $this->_addProfileBottom = $_GET['addProfileBottom'] ?? FALSE;
+    $this->_profileBottomNum = $_GET['addProfileNum'] ?? 0;
+    $this->_addProfileBottomAdd = $_GET['addProfileBottomAdd'] ?? FALSE;
+    $this->_profileBottomNumAdd = $_GET['addProfileNumAdd'] ?? 0;
 
     parent::preProcess();
     $this->setSelectedChild('registration');
@@ -166,7 +166,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
             $defaults["additional_custom_post_id_multiple[$key]"] = $value;
           }
         }
-        $this->assign('profilePostMultipleAdd', CRM_Utils_Array::value('additional_custom_post', $defaults, []));
+        $this->assign('profilePostMultipleAdd', $defaults['additional_custom_post'] ?? []);
       }
     }
     else {
@@ -174,9 +174,9 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     }
 
     // provide defaults for required fields if empty (and as a 'hint' for approval message field)
-    $defaults['registration_link_text'] = CRM_Utils_Array::value('registration_link_text', $defaults, ts('Register Now'));
-    $defaults['confirm_title'] = CRM_Utils_Array::value('confirm_title', $defaults, ts('Confirm Your Registration Information'));
-    $defaults['thankyou_title'] = CRM_Utils_Array::value('thankyou_title', $defaults, ts('Thank You for Registering'));
+    $defaults['registration_link_text'] = $defaults['registration_link_text'] ?? ts('Register Now');
+    $defaults['confirm_title'] = $defaults['confirm_title'] ?? ts('Confirm Your Registration Information');
+    $defaults['thankyou_title'] = $defaults['thankyou_title'] ?? ts('Thank You for Registering');
     $defaults['approval_req_text'] = CRM_Utils_Array::value('approval_req_text', $defaults, ts('Participation in this event requires approval. Submit your registration request here. Once approved, you will receive an email with a link to a web page where you can complete the registration process.'));
 
     return $defaults;
@@ -793,12 +793,12 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $params['id'] = $this->_id;
 
     // format params
-    $params['is_online_registration'] = CRM_Utils_Array::value('is_online_registration', $params, FALSE);
+    $params['is_online_registration'] = $params['is_online_registration'] ?? FALSE;
     // CRM-11182
-    $params['is_confirm_enabled'] = CRM_Utils_Array::value('is_confirm_enabled', $params, FALSE);
-    $params['is_multiple_registrations'] = CRM_Utils_Array::value('is_multiple_registrations', $params, FALSE);
-    $params['allow_same_participant_emails'] = CRM_Utils_Array::value('allow_same_participant_emails', $params, FALSE);
-    $params['requires_approval'] = CRM_Utils_Array::value('requires_approval', $params, FALSE);
+    $params['is_confirm_enabled'] = $params['is_confirm_enabled'] ?? FALSE;
+    $params['is_multiple_registrations'] = $params['is_multiple_registrations'] ?? FALSE;
+    $params['allow_same_participant_emails'] = $params['allow_same_participant_emails'] ?? FALSE;
+    $params['requires_approval'] = $params['requires_approval'] ?? FALSE;
 
     // reset is_email confirm if not online reg
     if (!$params['is_online_registration']) {
@@ -932,7 +932,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     self::addMultipleProfiles($additionalProfileIds, $params, 'additional_custom_post_id_multiple');
 
     $cantDedupe = FALSE;
-    $rgId = CRM_Utils_Array::value('dedupe_rule_group_id', $params, 0);
+    $rgId = $params['dedupe_rule_group_id'] ?? 0;
 
     switch (self::canProfilesDedupe($profileIds, $rgId)) {
       case 0:

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1030,7 +1030,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         //also add additional participant's fee level/priceset
         if (CRM_Event_BAO_Participant::isPrimaryParticipant($this->_id)) {
           $additionalIds = CRM_Event_BAO_Participant::getAdditionalParticipantIds($this->_id);
-          $hasLineItems = CRM_Utils_Array::value('priceSetId', $params, FALSE);
+          $hasLineItems = $params['priceSetId'] ?? FALSE;
           $additionalParticipantDetails = CRM_Event_BAO_Participant::getFeeDetails($additionalIds,
             $hasLineItems
           );
@@ -1396,7 +1396,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $contributionParams['non_deductible_amount'] = 'null';
         $contributionParams['receipt_date'] = !empty($params['send_receipt']) ? CRM_Utils_Array::value('receive_date', $params) : 'null';
         $contributionParams['contact_id'] = $this->_contactID;
-        $contributionParams['receive_date'] = CRM_Utils_Array::value('receive_date', $params, 'null');
+        $contributionParams['receive_date'] = $params['receive_date'] ?? 'null';
 
         $recordContribution = [
           'financial_type_id',
@@ -1519,7 +1519,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
               }
               $lineItem[$this->_priceSetId][$lineKey] = $line;
             }
-            CRM_Price_BAO_LineItem::processPriceSet($participants[$num]->id, $lineItem, CRM_Utils_Array::value($num, $contributions, NULL), 'civicrm_participant');
+            CRM_Price_BAO_LineItem::processPriceSet($participants[$num]->id, $lineItem, $contributions[$num] ?? NULL, 'civicrm_participant');
             CRM_Contribute_BAO_Contribution::addPayments($contributions);
           }
         }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -502,7 +502,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
 
     // assign pay later stuff
-    $params['is_pay_later'] = CRM_Utils_Array::value('is_pay_later', $params, FALSE);
+    $params['is_pay_later'] = $params['is_pay_later'] ?? FALSE;
     $this->assign('is_pay_later', $params['is_pay_later']);
     if ($params['is_pay_later']) {
       $this->assign('pay_later_text', $this->_values['event']['pay_later_text']);
@@ -732,7 +732,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       'Participant'
     );
 
-    $createPayment = (CRM_Utils_Array::value('amount', $this->_params, 0) != 0) ? TRUE : FALSE;
+    $createPayment = !empty($this->_params['amount']);
 
     // force to create zero amount payment, CRM-5095
     // we know the amout is zero since createPayment is false
@@ -835,7 +835,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $participantFields['participant_source']['maxlength']
       ),
       'fee_level' => CRM_Utils_Array::value('amount_level', $params),
-      'is_pay_later' => CRM_Utils_Array::value('is_pay_later', $params, 0),
+      'is_pay_later' => $params['is_pay_later'] ?? 0,
       'fee_amount' => CRM_Utils_Array::value('fee_amount', $params),
       'registered_by_id' => CRM_Utils_Array::value('registered_by_id', $params),
       'discount_id' => CRM_Utils_Array::value('discount_id', $params),
@@ -1103,7 +1103,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
             $currentCount = $priceSetFields[$priceFieldId]['options'][$optId] * $optVal;
           }
 
-          $optionsCount[$optId] = $currentCount + CRM_Utils_Array::value($optId, $optionsCount, 0);
+          $optionsCount[$optId] = $currentCount + ($optionsCount[$optId] ?? 0);
         }
       }
     }
@@ -1385,10 +1385,10 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     //validate for option max value.
     foreach ($optionMaxValues as $fieldId => $values) {
-      $options = CRM_Utils_Array::value('options', $feeBlock[$fieldId], array());
+      $options = $feeBlock[$fieldId]['options'] ?? [];
       foreach ($values as $optId => $total) {
         $optMax = $optionsMaxValueDetails[$fieldId]['options'][$optId];
-        $opDbCount = CRM_Utils_Array::value('db_total_count', $options[$optId], 0);
+        $opDbCount = $options[$optId]['db_total_count'] ?? 0;
         $total += $opDbCount;
         if ($optMax && ($total > $optMax)) {
           if ($opDbCount && ($opDbCount >= $optMax)) {

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -103,7 +103,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
           continue;
         }
 
-        $optionsFull = CRM_Utils_Array::value('option_full_ids', $val, []);
+        $optionsFull = $val['option_full_ids'] ?? [];
         foreach ($val['options'] as $keys => $values) {
           if ($values['is_default'] && !in_array($keys, $optionsFull)) {
             if ($val['html_type'] == 'CheckBox') {
@@ -259,7 +259,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
       //truly spaces are greater than required.
       if (is_numeric($spaces) && $spaces >= ($processedCnt + $currentPageMaxCount)) {
-        if (CRM_Utils_Array::value('amount', $this->_params[0], 0) == 0 || $this->_requireApproval) {
+        if (empty($this->_params[0]['amount']) || $this->_requireApproval) {
           $this->_allowWaitlist = FALSE;
           $this->set('allowWaitlist', $this->_allowWaitlist);
           if ($this->_requireApproval) {
@@ -285,9 +285,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
         CRM_Core_Session::setStatus($statusMessage, ts('Registration Error'), 'error');
       }
       elseif ($processedCnt == $spaces) {
-        if (CRM_Utils_Array::value('amount', $this->_params[0], 0) == 0
-          || $realPayLater || $this->_requireApproval
-        ) {
+        if (empty($this->_params[0]['amount']) || $realPayLater || $this->_requireApproval) {
           $this->_resetAllowWaitlist = TRUE;
           if ($this->_requireApproval) {
             $statusMessage = ts("If you skip this participant there will be enough spaces in the event for your group (you will not be wait listed). Registration for this event requires approval. You will receive an email once your registration has been reviewed.");
@@ -335,7 +333,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
           !$this->_allowWaitlist &&
           !$realPayLater &&
           !$this->_requireApproval &&
-          !(CRM_Utils_Array::value('amount', $this->_params[0], 0) == 0)
+          !empty($this->_params[0]['amount'])
         ) {
           $paymentBypassed = ts('Please go back to the main registration page, to complete payment information.');
         }
@@ -472,7 +470,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
         //validate price field params.
         $priceSetErrors = self::validatePriceSet($self, $allParticipantParams);
-        $errors = array_merge($errors, CRM_Utils_Array::value($addParticipantNum, $priceSetErrors, []));
+        $errors = array_merge($errors, $priceSetErrors[$addParticipantNum] ?? []);
 
         if (!$self->_allowConfirmation &&
           is_numeric($self->_availableRegistrations)
@@ -481,7 +479,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
             !$self->_allowWaitlist &&
             !$realPayLater &&
             !$self->_requireApproval &&
-            !(CRM_Utils_Array::value('amount', $self->_params[0], 0) == 0) &&
+            !empty($self->_params[0]['amount']) &&
             $totalParticipants < $self->_availableRegistrations
           ) {
             $errors['_qf_default'] = ts("Your event registration will be confirmed. Please go back to the main registration page, to complete payment information.");
@@ -509,7 +507,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
         !$self->_allowWaitlist &&
         !$realPayLater &&
         !$self->_requireApproval &&
-        !(CRM_Utils_Array::value('amount', $self->_params[0], 0) == 0)
+        !empty($self->_params[0]['amount'])
       ) {
         $errors['_qf_default'] = ts("You are going to skip the last participant, your event registration will be confirmed. Please go back to the main registration page, to complete payment information.");
       }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -155,7 +155,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $rfp = CRM_Utils_Request::retrieve('rfp', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, NULL, 'GET');
 
     //we lost rfp in case of additional participant. So set it explicitly.
-    if ($rfp || CRM_Utils_Array::value('additional_participants', $this->_params[0], FALSE)) {
+    if ($rfp || !empty($this->_params[0]['additional_participants'])) {
       if (!empty($this->_paymentProcessor) &&  $this->_paymentProcessor['object']->supports('preApproval')) {
         $preApprovalParams = $this->_paymentProcessor['object']->getPreApprovalDetails($this->get('pre_approval_parameters'));
         $params = array_merge($this->_params, $preApprovalParams);
@@ -456,7 +456,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       elseif ($participantNum) {
         $participantCount[$participantNum] = 'participant';
       }
-      $totalTaxAmount += CRM_Utils_Array::value('tax_amount', $record, 0);
+      $totalTaxAmount += $record['tax_amount'] ?? 0;
       if (CRM_Utils_Array::value('is_primary', $record)) {
         $taxAmount = &$params[$participantNum]['tax_amount'];
       }
@@ -981,7 +981,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       'invoice_id' => $params['invoiceID'],
       'currency' => $params['currencyID'],
       'source' => !empty($params['participant_source']) ? $params['participant_source'] : $params['description'],
-      'is_pay_later' => CRM_Utils_Array::value('is_pay_later', $params, 0),
+      'is_pay_later' => $params['is_pay_later'] ?? 0,
       'campaign_id' => CRM_Utils_Array::value('campaign_id', $params),
       'card_type_id' => CRM_Utils_Array::value('card_type_id', $params),
       'pan_truncation' => CRM_Utils_Array::value('pan_truncation', $params),

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -274,7 +274,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         if (empty($val['options'])) {
           continue;
         }
-        $optionFullIds = CRM_Utils_Array::value('option_full_ids', $val, []);
+        $optionFullIds = $val['option_full_ids'] ?? [];
         foreach ($val['options'] as $keys => $values) {
           if ($values['is_default'] && empty($values['is_full'])) {
 
@@ -297,7 +297,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     if ($this->_allowConfirmation) {
       $this->_contactId = $contactID;
       $this->_discountId = $discountId;
-      $forcePayLater = CRM_Utils_Array::value('is_pay_later', $this->_defaults, FALSE);
+      $forcePayLater = $this->_defaults['is_pay_later'] ?? FALSE;
       $this->_defaults = array_merge($this->_defaults, CRM_Event_Form_EventFees::setDefaultValues($this));
       $this->_defaults['is_pay_later'] = $forcePayLater;
 
@@ -647,14 +647,14 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
             $adminVisibilityID = CRM_Price_BAO_PriceField::getVisibilityOptionID('admin');
 
             foreach ($options as $key => $currentOption) {
-              $optionVisibility = CRM_Utils_Array::value('visibility_id', $currentOption, $publicVisibilityID);
+              $optionVisibility = $currentOption['visibility_id'] ?? $publicVisibilityID;
               if ($optionVisibility == $adminVisibilityID) {
                 unset($options[$key]);
               }
             }
           }
 
-          $optionFullIds = CRM_Utils_Array::value('option_full_ids', $field, []);
+          $optionFullIds = $field['option_full_ids'] ?? [];
 
           //soft suppress required rule when option is full.
           if (!empty($optionFullIds) && (count($options) == count($optionFullIds))) {
@@ -760,10 +760,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       }
       foreach ($field['options'] as & $option) {
         $optId = $option['id'];
-        $count = CRM_Utils_Array::value('count', $option, 0);
-        $maxValue = CRM_Utils_Array::value('max_value', $option, 0);
-        $dbTotalCount = CRM_Utils_Array::value($optId, $recordedOptionsCount, 0);
-        $currentTotalCount = CRM_Utils_Array::value($optId, $currentOptionsCount, 0);
+        $count = $option['count'] ?? 0;
+        $maxValue = $option['max_value'] ?? 0;
+        $dbTotalCount = $recordedOptionsCount[$optId] ?? 0;
+        $currentTotalCount = $currentOptionsCount[$optId] ?? 0;
 
         $totalCount = $currentTotalCount + $dbTotalCount;
         $isFull = FALSE;
@@ -876,7 +876,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $primaryParticipantCount = self::getParticipantCount($form, $ppParams);
 
       //get price set fields errors in.
-      $errors = array_merge($errors, CRM_Utils_Array::value(0, $priceSetErrors, []));
+      $errors = array_merge($errors, $priceSetErrors[0] ?? []);
 
       $totalParticipants = $primaryParticipantCount;
       if (!empty($fields['additional_participants'])) {
@@ -988,7 +988,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $this->set('is_pay_later', $params['is_pay_later']);
 
     // assign pay later stuff
-    $this->_params['is_pay_later'] = CRM_Utils_Array::value('is_pay_later', $params, FALSE);
+    $this->_params['is_pay_later'] = $params['is_pay_later'] ?? FALSE;
     $this->assign('is_pay_later', $params['is_pay_later']);
     if ($params['is_pay_later']) {
       $this->assign('pay_later_text', $this->_values['event']['pay_later_text']);
@@ -1155,7 +1155,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           "_qf_Register_display=1&qfKey={$this->controller->_key}",
           TRUE, NULL, FALSE
         );
-        if (CRM_Utils_Array::value('additional_participants', $params, FALSE)) {
+        if ($params['additional_participants'] ?? FALSE) {
           $urlArgs = "_qf_Participant_1_display=1&rfp=1&qfKey={$this->controller->_key}";
         }
         else {
@@ -1194,7 +1194,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
 
     // If registering > 1 participant, give status message
-    if (CRM_Utils_Array::value('additional_participants', $params, FALSE)) {
+    if ($params['additional_participants'] ?? FALSE) {
       $statusMsg = ts('Registration information for participant 1 has been saved.');
       CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
     }

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -291,10 +291,10 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     }
     if (empty($errors) && empty($contact_id)) {
       $params = [
-        'email-Primary' => CRM_Utils_Array::value('email', $fields, NULL),
-        'first_name' => CRM_Utils_Array::value('first_name', $fields, NULL),
-        'last_name' => CRM_Utils_Array::value('last_name', $fields, NULL),
-        'is_deleted' => CRM_Utils_Array::value('is_deleted', $fields, FALSE),
+        'email-Primary' => $fields['email'] ?? NULL,
+        'first_name' => $fields['first_name'] ?? NULL,
+        'last_name' => $fields['last_name'] ?? NULL,
+        'is_deleted' => $fields['is_deleted'] ?? FALSE,
       ];
       //create new contact for this name/email pair
       //if new contact, no need to check for contact already registered

--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -205,7 +205,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
    */
   public function postProcess() {
     $params = $this->controller->exportValues();
-    $groupOption = CRM_Utils_Array::value('group_option', $params, NULL);
+    $groupOption = $params['group_option'] ?? NULL;
     if ($groupOption) {
       $groupParams = [];
       $groupParams['title'] = $params['title'];

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -76,9 +76,9 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
     $fields['event_title'] = $eventfields['event_title'];
 
     foreach ($fields as $name => $field) {
-      $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
-      $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
-      $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
+      $field['type'] = $field['type'] ?? CRM_Utils_Type::T_INT;
+      $field['dataPattern'] = $field['dataPattern'] ?? '//';
+      $field['headerPattern'] = $field['headerPattern'] ?? '//';
       $this->addField($name, $field['title'], $field['type'], $field['headerPattern'], $field['dataPattern']);
     }
 

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1140,7 +1140,7 @@ class CRM_Export_BAO_ExportProcessor {
         'componentPaymentField_transaction_id' => 'trxn_id',
         'componentPaymentField_received_date' => 'receive_date',
       ];
-      return CRM_Utils_Array::value($payFieldMapper[$field], $paymentData, '');
+      return $paymentData[$payFieldMapper[$field]] ?? '';
     }
     else {
       // if field is empty or null
@@ -1321,8 +1321,8 @@ class CRM_Export_BAO_ExportProcessor {
     $relIMProviderId = NULL;
     $relLocTypeId = CRM_Utils_Array::value('location_type_id', $value);
     $locationName = CRM_Core_PseudoConstant::getName('CRM_Core_BAO_Address', 'location_type_id', $relLocTypeId);
-    $relPhoneTypeId = CRM_Utils_Array::value('phone_type_id', $value, ($locationName ? 'Primary' : NULL));
-    $relIMProviderId = CRM_Utils_Array::value('im_provider_id', $value, ($locationName ? 'Primary' : NULL));
+    $relPhoneTypeId = $value['phone_type_id'] ?? ($locationName ? 'Primary' : NULL);
+    $relIMProviderId = $value['im_provider_id'] ?? ($locationName ? 'Primary' : NULL);
     if (in_array($relationField, $this->getValidLocationFields()) && $locationName) {
       if ($relationField === 'phone') {
         $this->relationshipReturnProperties[$relationshipKey]['location'][$locationName]['phone-' . $relPhoneTypeId] = 1;

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -97,11 +97,11 @@ class CRM_Extension_System {
    */
   public function __construct($parameters = []) {
     $config = CRM_Core_Config::singleton();
-    $parameters['extensionsDir'] = CRM_Utils_Array::value('extensionsDir', $parameters, $config->extensionsDir);
-    $parameters['extensionsURL'] = CRM_Utils_Array::value('extensionsURL', $parameters, $config->extensionsURL);
-    $parameters['resourceBase'] = CRM_Utils_Array::value('resourceBase', $parameters, $config->resourceBase);
-    $parameters['uploadDir'] = CRM_Utils_Array::value('uploadDir', $parameters, $config->uploadDir);
-    $parameters['userFrameworkBaseURL'] = CRM_Utils_Array::value('userFrameworkBaseURL', $parameters, $config->userFrameworkBaseURL);
+    $parameters['extensionsDir'] = $parameters['extensionsDir'] ?? $config->extensionsDir;
+    $parameters['extensionsURL'] = $parameters['extensionsURL'] ?? $config->extensionsURL;
+    $parameters['resourceBase'] = $parameters['resourceBase'] ?? $config->resourceBase;
+    $parameters['uploadDir'] = $parameters['uploadDir'] ?? $config->uploadDir;
+    $parameters['userFrameworkBaseURL'] = $parameters['userFrameworkBaseURL'] ?? $config->userFrameworkBaseURL;
     if (!array_key_exists('civicrm_root', $parameters)) {
       $parameters['civicrm_root'] = $GLOBALS['civicrm_root'];
     }

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -84,11 +84,11 @@ class CRM_Financial_BAO_FinancialAccount extends CRM_Financial_DAO_FinancialAcco
    */
   public static function add(&$params) {
     if (empty($params['id'])) {
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['is_deductible'] = CRM_Utils_Array::value('is_deductible', $params, FALSE);
-      $params['is_tax'] = CRM_Utils_Array::value('is_tax', $params, FALSE);
-      $params['is_header_account'] = CRM_Utils_Array::value('is_header_account', $params, FALSE);
-      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_deductible'] = $params['is_deductible'] ?? FALSE;
+      $params['is_tax'] = $params['is_tax'] ?? FALSE;
+      $params['is_header_account'] = $params['is_header_account'] ?? FALSE;
+      $params['is_default'] = $params['is_default'] ?? FALSE;
     }
     if (!empty($params['id'])
       && !empty($params['financial_account_type_id'])

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -97,9 +97,9 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    */
   public static function add(&$params, &$ids = []) {
     if (empty($params['id'])) {
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['is_deductible'] = CRM_Utils_Array::value('is_deductible', $params, FALSE);
-      $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_deductible'] = $params['is_deductible'] ?? FALSE;
+      $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
     }
 
     // action is taken depending upon the mode

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -69,13 +69,13 @@ class CRM_Financial_BAO_Payment {
       $balanceTrxnParams['from_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($contribution['financial_type_id'], 'Accounts Receivable Account is');
       $balanceTrxnParams['total_amount'] = $params['total_amount'];
       $balanceTrxnParams['contribution_id'] = $params['contribution_id'];
-      $balanceTrxnParams['trxn_date'] = CRM_Utils_Array::value('trxn_date', $params, CRM_Utils_Array::value('contribution_receive_date', $params, date('YmdHis')));
+      $balanceTrxnParams['trxn_date'] = $params['trxn_date'] ?? $params['contribution_receive_date'] ?? date('YmdHis');
       $balanceTrxnParams['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
       $balanceTrxnParams['net_amount'] = CRM_Utils_Array::value('total_amount', $params);
       $balanceTrxnParams['currency'] = $contribution['currency'];
-      $balanceTrxnParams['trxn_id'] = CRM_Utils_Array::value('contribution_trxn_id', $params, NULL);
+      $balanceTrxnParams['trxn_id'] = $params['contribution_trxn_id'] ?? NULL;
       $balanceTrxnParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'status_id', 'Completed');
-      $balanceTrxnParams['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $params, $contribution['payment_instrument_id']);
+      $balanceTrxnParams['payment_instrument_id'] = $params['payment_instrument_id'] ?? $contribution['payment_instrument_id'];
       $balanceTrxnParams['check_number'] = CRM_Utils_Array::value('check_number', $params);
       $balanceTrxnParams['is_payment'] = 1;
 

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -205,7 +205,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
         'is_tax',
         'is_default',
       ] as $field) {
-        $params[$field] = CRM_Utils_Array::value($field, $params, FALSE);
+        $params[$field] = $params[$field] ?? FALSE;
       }
       $financialAccount = CRM_Financial_BAO_FinancialAccount::add($params);
       CRM_Core_Session::setStatus(ts('The Financial Account \'%1\' has been saved.', [1 => $financialAccount->name]), ts('Saved'), 'success');

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -148,7 +148,7 @@ class CRM_Financial_Form_FinancialType extends CRM_Contribute_Form {
         'is_reserved',
         'is_deductible',
       ] as $field) {
-        $params[$field] = CRM_Utils_Array::value($field, $params, FALSE);
+        $params[$field] = $params[$field] ?? FALSE;
       }
       $financialType = civicrm_api3('FinancialType', 'create', $params);
       if ($this->_action & CRM_Core_Action::UPDATE) {

--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -167,7 +167,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
       'id' => $this->_id,
       'payment_instrument_id' => $this->_submitValues['payment_instrument_id'],
       'trxn_id' => CRM_Utils_Array::value('trxn_id', $this->_submitValues),
-      'trxn_date' => CRM_Utils_Array::value('trxn_date', $this->_submitValues, date('YmdHis')),
+      'trxn_date' => $this->_submitValues['trxn_date'] ?? date('YmdHis'),
     ];
 
     $paymentInstrumentName = CRM_Core_PseudoConstant::getName('CRM_Financial_DAO_FinancialTrxn', 'payment_instrument_id', $params['payment_instrument_id']);
@@ -204,7 +204,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
       $previousFinanciaTrxn = $this->_values;
       $newFinancialTrxn = $submittedValues;
       unset($previousFinanciaTrxn['id'], $newFinancialTrxn['id']);
-      $previousFinanciaTrxn['trxn_date'] = CRM_Utils_Array::value('trxn_date', $submittedValues, date('YmdHis'));
+      $previousFinanciaTrxn['trxn_date'] = $submittedValues['trxn_date'] ?? date('YmdHis');
       $previousFinanciaTrxn['total_amount'] = -$previousFinanciaTrxn['total_amount'];
       $previousFinanciaTrxn['net_amount'] = -$previousFinanciaTrxn['net_amount'];
       $previousFinanciaTrxn['fee_amount'] = -$previousFinanciaTrxn['fee_amount'];

--- a/CRM/Friend/BAO/Friend.php
+++ b/CRM/Friend/BAO/Friend.php
@@ -353,7 +353,7 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
   public static function addTellAFriend(&$params) {
     $friendDAO = new CRM_Friend_DAO_Friend();
     $friendDAO->copyValues($params);
-    $friendDAO->is_active = CRM_Utils_Array::value('is_active', $params, FALSE);
+    $friendDAO->is_active = $params['is_active'] ?? FALSE;
     $friendDAO->save();
 
     return $friendDAO;

--- a/CRM/Friend/Form/Contribute.php
+++ b/CRM/Friend/Form/Contribute.php
@@ -112,7 +112,7 @@ class CRM_Friend_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
     $formValues['entity_table'] = 'civicrm_contribution_page';
     $formValues['entity_id'] = $this->_id;
     $formValues['title'] = $formValues['tf_title'];
-    $formValues['is_active'] = CRM_Utils_Array::value('tf_is_active', $formValues, FALSE);
+    $formValues['is_active'] = $formValues['tf_is_active'] ?? FALSE;
     $formValues['thankyou_title'] = CRM_Utils_Array::value('tf_thankyou_title', $formValues);
     $formValues['thankyou_text'] = CRM_Utils_Array::value('tf_thankyou_text', $formValues);
 

--- a/CRM/Friend/Form/Event.php
+++ b/CRM/Friend/Form/Event.php
@@ -121,7 +121,7 @@ class CRM_Friend_Form_Event extends CRM_Event_Form_ManageEvent {
     $formValues['entity_table'] = 'civicrm_event';
     $formValues['entity_id'] = $this->_id;
     $formValues['title'] = $formValues['tf_title'];
-    $formValues['is_active'] = CRM_Utils_Array::value('tf_is_active', $formValues, FALSE);
+    $formValues['is_active'] = $formValues['tf_is_active'] ?? FALSE;
     $formValues['thankyou_title'] = CRM_Utils_Array::value('tf_thankyou_title', $formValues);
     $formValues['thankyou_text'] = CRM_Utils_Array::value('tf_thankyou_text', $formValues);
 

--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -249,7 +249,7 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
     if (!$id) {
       $id = CRM_Utils_Array::value('contact_id', $params);
     }
-    if (!empty($params['note']) || CRM_Utils_Array::value('id', CRM_Utils_Array::value('note', $ids))) {
+    if (!empty($params['note']) || !empty($ids['note']['id'])) {
       $noteParams = [
         'entity_table' => 'civicrm_grant',
         'note' => $params['note'] = $params['note'] ? $params['note'] : "null",

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -386,8 +386,8 @@ WHERE  title = %1
         $params['group_type'] = array();
       }
 
-      $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+      $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
+      $params['is_active'] = $params['is_active'] ?? FALSE;
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
         $this->_id,
         'Group'

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -95,7 +95,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     $file = $params['uploadFile']['name'];
     $result = self::_CsvToTable($db,
       $file,
-      CRM_Utils_Array::value('skipColumnHeader', $params, FALSE),
+      $params['skipColumnHeader'] ?? FALSE,
       CRM_Utils_Array::value('import_table_name', $params),
       CRM_Utils_Array::value('fieldSeparator', $params, ',')
     );

--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -193,7 +193,7 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
       if (empty($metadata[$table])) {
         list($metadata[$table]['titles'], $metadata[$table]['values']) = $this->differ->titlesAndValuesForTable($table, $diff['log_date']);
       }
-      $values = CRM_Utils_Array::value('values', $metadata[$diff['table']], []);
+      $values = $metadata[$diff['table']]['values'] ?? [];
       $titles = $metadata[$diff['table']]['titles'];
       $field = $diff['field'];
       $from = $diff['from'];

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -784,7 +784,7 @@ COLS;
     $query = preg_replace("/^CREATE TABLE `$table`/i", "CREATE TABLE `{$this->db}`.log_$table", $query);
     $query = preg_replace("/ AUTO_INCREMENT/i", '', $query);
     $query = preg_replace("/^  [^`].*$/m", '', $query);
-    $engine = strtoupper(CRM_Utils_Array::value('engine', $this->logTableSpec[$table], self::ENGINE));
+    $engine = strtoupper($this->logTableSpec[$table]['engine'] ?? self::ENGINE);
     $engine .= " " . CRM_Utils_Array::value('engine_config', $this->logTableSpec[$table]);
     $query = preg_replace("/^\) ENGINE=[^ ]+ /im", ') ENGINE=' . $engine . ' ', $query);
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1482,7 +1482,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $mailing->id = $id;
       $mailing->find(TRUE);
     }
-    $mailing->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
+    $mailing->domain_id = $params['domain_id'] ?? CRM_Core_Config::domainID();
 
     if (((!$id && empty($params['replyto_email'])) || !isset($params['replyto_email'])) &&
       isset($params['from_email'])
@@ -2907,9 +2907,9 @@ ORDER BY civicrm_mailing.name";
       $mailing['start_date'] = CRM_Utils_Date::customFormat($values['start_date']);
       //CRM-12814
       $mailing['openstats'] = "Opens: " .
-        CRM_Utils_Array::value($values['mailing_id'], $openCounts, 0) .
+        $openCounts[$values['mailing_id']] ?? 0 .
         "<br />Clicks: " .
-        CRM_Utils_Array::value($values['mailing_id'], $clickCounts, 0);
+        $clickCounts[$values['mailing_id']] ?? 0;
 
       $actionLinks = [
         CRM_Core_Action::VIEW => [

--- a/CRM/Mailing/BAO/MailingAB.php
+++ b/CRM/Mailing/BAO/MailingAB.php
@@ -92,7 +92,7 @@ class CRM_Mailing_BAO_MailingAB extends CRM_Mailing_DAO_MailingAB {
     $mailingab = new CRM_Mailing_DAO_MailingAB();
     $mailingab->id = $id;
     if (!$id) {
-      $mailingab->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
+      $mailingab->domain_id = $params['domain_id'] ?? CRM_Core_Config::domainID();
     }
 
     $mailingab->copyValues($params);

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -923,7 +923,7 @@ AND    status IN ( 'Scheduled', 'Running', 'Paused' )
         'Canceled' => ts('Canceled'),
       ];
     }
-    return CRM_Utils_Array::value($status, $translation, ts('Not scheduled'));
+    return $translation[$status] ?? ts('Not scheduled');
   }
 
   /**

--- a/CRM/Mailing/Event/BAO/Queue.php
+++ b/CRM/Mailing/Event/BAO/Queue.php
@@ -68,7 +68,7 @@ class CRM_Mailing_Event_BAO_Queue extends CRM_Mailing_Event_DAO_Queue {
    */
   public static function hash($params) {
     $jobId = $params['job_id'];
-    $emailId = CRM_Utils_Array::value('email_id', $params, '');
+    $emailId = $params['email_id'] ?? '';
     $contactId = $params['contact_id'];
 
     return substr(sha1("{$jobId}:{$emailId}:{$contactId}:" . time()),

--- a/CRM/Mailing/PseudoConstant.php
+++ b/CRM/Mailing/PseudoConstant.php
@@ -206,7 +206,7 @@ class CRM_Mailing_PseudoConstant extends CRM_Core_PseudoConstant {
         self::$defaultComponent[$dao->component_type] = $dao->id;
       }
     }
-    $value = CRM_Utils_Array::value($type, self::$defaultComponent, $undefined);
+    $value = self::$defaultComponent[$type] ?? $undefined;
     return $value;
   }
 

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -140,7 +140,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
     $activityParams = array(
-      'status_id' => CRM_Utils_Array::value('membership_activity_status', $params, 'Completed'),
+      'status_id' => $params['membership_activity_status'] ?? 'Completed',
     );
     if (in_array($allStatus[$membership->status_id], array('Pending', 'Grace'))) {
       $activityParams['status_id'] = 'Scheduled';
@@ -277,7 +277,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       }
 
       //fix for CRM-3570, during import exclude the statuses those having is_admin = 1
-      $excludeIsAdmin = CRM_Utils_Array::value('exclude_is_admin', $params, FALSE);
+      $excludeIsAdmin = $params['exclude_is_admin'] ?? FALSE;
 
       //CRM-3724 always skip is_admin if is_override != true.
       if (!$excludeIsAdmin && empty($params['is_override'])) {
@@ -859,7 +859,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
             'limit' => 0,
           ),
         ));
-        $memberTypesSameParentOrgList = implode(',', array_keys(CRM_Utils_Array::value('values', $memberTypesSameParentOrg, array())));
+        $memberTypesSameParentOrgList = implode(',', array_keys($memberTypesSameParentOrg['values'] ?? []));
         $dao->whereAdd('membership_type_id IN (' . $memberTypesSameParentOrgList . ')');
       }
     }
@@ -1211,7 +1211,7 @@ AND civicrm_membership.is_test = %2";
           $format
         ),
         'membership_type_id' => $currentMembership['membership_type_id'],
-        'max_related' => CRM_Utils_Array::value('max_related', $currentMembership, 0),
+        'max_related' => $currentMembership['max_related'] ?? 0,
       );
 
       $session = CRM_Core_Session::singleton();
@@ -1936,7 +1936,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
         // Insert renewed dates for CURRENT membership
         $memParams = array();
         $memParams['join_date'] = CRM_Utils_Date::isoToMysql($membership->join_date);
-        $memParams['start_date'] = CRM_Utils_Array::value('start_date', $formDates, CRM_Utils_Date::isoToMysql($membership->start_date));
+        $memParams['start_date'] = $formDates['start_date'] ?? CRM_Utils_Date::isoToMysql($membership->start_date);
         $memParams['end_date'] = CRM_Utils_Array::value('end_date', $formDates);
         if (empty($memParams['end_date'])) {
           $memParams['end_date'] = CRM_Utils_Array::value('end_date', $dates);
@@ -2483,7 +2483,7 @@ WHERE      civicrm_membership.is_test = 0
     if (!empty($params['processPriceSet']) &&
       !empty($params['lineItems'])
     ) {
-      $contributionParams['line_item'] = CRM_Utils_Array::value('lineItems', $params, NULL);
+      $contributionParams['line_item'] = $params['lineItems'] ?? NULL;
     }
 
     $contribution = CRM_Contribute_BAO_Contribution::create($contributionParams);

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -643,7 +643,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
         'limit' => 0,
       ],
     ]);
-    return CRM_Utils_Array::value('values', $memberTypesSameParentOrg, []);
+    return $memberTypesSameParentOrg['values'] ?? [];
   }
 
   /**

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -441,7 +441,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           continue;
         }
         foreach ($pField['options'] as $opId => $opValues) {
-          $optionsMembershipTypes[$opId] = CRM_Utils_Array::value('membership_type_id', $opValues, 0);
+          $optionsMembershipTypes[$opId] = $opValues['membership_type_id'] ?? 0;
         }
       }
 
@@ -1223,7 +1223,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $calcDates = [];
     foreach ($this->_memTypeSelected as $memType) {
       if (empty($memTypeNumTerms)) {
-        $memTypeNumTerms = CRM_Utils_Array::value($memType, $termsByType, 1);
+        $memTypeNumTerms = $termsByType[$memType] ?? 1;
       }
       $calcDates[$memType] = CRM_Member_BAO_MembershipType::getDatesForMembershipType($memType,
         $joinDate, $startDate, $endDate, $memTypeNumTerms
@@ -1329,7 +1329,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     }
     $createdMemberships = [];
     if ($this->_mode) {
-      $params['total_amount'] = CRM_Utils_Array::value('total_amount', $formValues, 0);
+      $params['total_amount'] = $formValues['total_amount'] ?? 0;
 
       //CRM-20264 : Store CC type and number (last 4 digit) during backoffice or online payment
       $params['card_type_id'] = CRM_Utils_Array::value('card_type_id', $this->_params);

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -433,7 +433,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
           }
           $membetype = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($memType);
           $fieldParams['option_label'][$rowCount] = CRM_Utils_Array::value('name', $membetype);
-          $fieldParams['option_amount'][$rowCount] = CRM_Utils_Array::value('minimum_fee', $membetype, 0);
+          $fieldParams['option_amount'][$rowCount] = $membetype['minimum_fee'] ?? 0;
           $fieldParams['option_weight'][$rowCount] = CRM_Utils_Array::value('weight', $membetype);
           $fieldParams['option_description'][$rowCount] = CRM_Utils_Array::value('description', $membetype);
           $fieldParams['default_option'] = CRM_Utils_Array::value('membership_type_default', $params);
@@ -452,15 +452,15 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         $deletePriceSet = 1;
       }
 
-      $params['is_required'] = CRM_Utils_Array::value('is_required', $params, FALSE);
-      $params['is_active'] = CRM_Utils_Array::value('member_is_active', $params, FALSE);
+      $params['is_required'] = $params['is_required'] ?? FALSE;
+      $params['is_active'] = $params['member_is_active'] ?? FALSE;
 
       if ($priceSetID) {
         $params['membership_types'] = 'null';
-        $params['membership_type_default'] = CRM_Utils_Array::value('membership_type_default', $params, 'null');
+        $params['membership_type_default'] = $params['membership_type_default'] ?? 'null';
         $params['membership_types'] = serialize($membershipTypes);
-        $params['display_min_fee'] = CRM_Utils_Array::value('display_min_fee', $params, FALSE);
-        $params['is_separate_payment'] = CRM_Utils_Array::value('is_separate_payment', $params, FALSE);
+        $params['display_min_fee'] = $params['display_min_fee'] ?? FALSE;
+        $params['is_separate_payment'] = $params['is_separate_payment'] ?? FALSE;
       }
       $params['entity_table'] = 'civicrm_contribution_page';
       $params['entity_id'] = $this->_id;
@@ -473,7 +473,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         CRM_Price_BAO_PriceSet::addTo('civicrm_contribution_page', $this->_id, $priceSetID);
       }
 
-      if ($deletePriceSet || !CRM_Utils_Array::value('member_is_active', $params, FALSE)) {
+      if ($deletePriceSet || empty($params['member_is_active'])) {
 
         if ($this->_memPriceSetId) {
           $pFIDs = [];
@@ -489,7 +489,6 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
             CRM_Price_BAO_PriceSet::setIsQuickConfig($this->_memPriceSetId, '0');
           }
           else {
-
             CRM_Price_BAO_PriceField::setIsActive($params['mem_price_field_id'], '0');
           }
         }

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -493,12 +493,12 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->storeContactFields($this->_params);
     $this->beginPostProcess();
     $now = CRM_Utils_Date::getToday(NULL, 'YmdHis');
-    $this->assign('receive_date', CRM_Utils_Array::value('receive_date', $this->_params, date('Y-m-d H:i:s')));
+    $this->assign('receive_date', $this->_params['receive_date'] ?? date('Y-m-d H:i:s'));
     $this->processBillingAddress();
     list($userName) = CRM_Contact_BAO_Contact_Location::getEmailDetails(CRM_Core_Session::singleton()->get('userID'));
-    $this->_params['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_params,
-      CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'minimum_fee')
-    );
+    if (!isset($this->_params['total_amount'])) {
+      $this->_params['total_amount'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'minimum_fee');
+    }
     $this->_membershipId = $this->_id;
     $customFieldsFormatted = CRM_Core_BAO_CustomField::postProcess($this->_params,
       $this->_id,

--- a/CRM/Member/Form/MembershipStatus.php
+++ b/CRM/Member/Form/MembershipStatus.php
@@ -176,10 +176,10 @@ class CRM_Member_Form_MembershipStatus extends CRM_Core_Form {
     else {
       // store the submitted values in an array
       $params = $this->exportValues();
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['is_current_member'] = CRM_Utils_Array::value('is_current_member', $params, FALSE);
-      $params['is_admin'] = CRM_Utils_Array::value('is_admin', $params, FALSE);
-      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_current_member'] = $params['is_current_member'] ?? FALSE;
+      $params['is_admin'] = $params['is_admin'] ?? FALSE;
+      $params['is_default'] = $params['is_default'] ?? FALSE;
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->getEntityId();

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -251,7 +251,7 @@ END AS 'relType'
       if (!empty($membershipType['relationship_type_id']) && empty($values['owner_membership_id'])) {
         // display related contacts/membership block
         $this->assign('has_related', TRUE);
-        $this->assign('max_related', CRM_Utils_Array::value('max_related', $values, ts('Unlimited')));
+        $this->assign('max_related', $values['max_related'] ?? ts('Unlimited'));
         // split the relations in 2 arrays based on direction
         $relTypeId = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_type_id']);
         $relDirection = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_direction']);
@@ -283,7 +283,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
         $query .= " ORDER BY is_current_member DESC";
         $dao = CRM_Core_DAO::executeQuery($query);
         $related = [];
-        $relatedRemaining = CRM_Utils_Array::value('max_related', $values, PHP_INT_MAX);
+        $relatedRemaining = $values['max_related'] ?? PHP_INT_MAX;
         $rowElememts = [
           'id',
           'cid',

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -82,9 +82,9 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
 
     foreach ($this->fieldMetadata as $name => $field) {
       // @todo - we don't really need to do all this.... fieldMetadata is just fine to use as is.
-      $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
-      $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
-      $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
+      $field['type'] = $field['type'] ?? CRM_Utils_Type::T_INT;
+      $field['dataPattern'] = $field['dataPattern'] ?? '//';
+      $field['headerPattern'] = $field['headerPattern'] ?? '//';
       $this->addField($name, $field['title'], $field['type'], $field['headerPattern'], $field['dataPattern']);
     }
 

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -197,7 +197,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
         'limit' => 0,
       ],
     ]);
-    $membershipTypes = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
+    $membershipTypes = $membershipTypesResult['values'] ?? NULL;
 
     foreach ($membershipTypes as $key => $value) {
       $membershipTypes[$key]['action'] = CRM_Core_Action::formLink(self::membershipTypeslinks(),

--- a/CRM/Note/Form/Note.php
+++ b/CRM/Note/Form/Note.php
@@ -75,7 +75,7 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
     $this->_entityTable = $this->get('entityTable');
     $this->_entityId = $this->get('entityId');
     $this->_id = $this->get('id');
-    $this->_parentId = CRM_Utils_Array::value('parentId', $_GET, 0);
+    $this->_parentId = $_GET['parentId'] ?? 0;
     if ($this->_parentId) {
       $this->assign('parentId', $this->_parentId);
     }

--- a/CRM/PCP/Form/Contribute.php
+++ b/CRM/PCP/Form/Contribute.php
@@ -155,7 +155,7 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
     $params['entity_id'] = $this->_id;
 
     // Target
-    $params['target_entity_type'] = CRM_Utils_Array::value('target_entity_type', $params, 'contribute');
+    $params['target_entity_type'] = $params['target_entity_type'] ?? 'contribute';
     $params['target_entity_id'] = $this->_id;
 
     $dao = new CRM_PCP_DAO_PCPBlock();
@@ -163,9 +163,9 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
     $dao->entity_id = $this->_id;
     $dao->find(TRUE);
     $params['id'] = $dao->id;
-    $params['is_active'] = CRM_Utils_Array::value('pcp_active', $params, FALSE);
-    $params['is_approval_needed'] = CRM_Utils_Array::value('is_approval_needed', $params, FALSE);
-    $params['is_tellfriend_enabled'] = CRM_Utils_Array::value('is_tellfriend_enabled', $params, FALSE);
+    $params['is_active'] = $params['pcp_active'] ?? FALSE;
+    $params['is_approval_needed'] = $params['is_approval_needed'] ?? FALSE;
+    $params['is_tellfriend_enabled'] = $params['is_tellfriend_enabled'] ?? FALSE;
 
     CRM_PCP_BAO_PCPBlock::create($params);
 

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -185,12 +185,12 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
     $params['entity_id'] = $this->_id;
 
     // Target
-    $params['target_entity_type'] = CRM_Utils_Array::value('target_entity_type', $params, 'event');
+    $params['target_entity_type'] = $params['target_entity_type'] ?? 'event';
     if ($params['target_entity_type'] == 'event') {
       $params['target_entity_id'] = $this->_id;
     }
     else {
-      $params['target_entity_id'] = CRM_Utils_Array::value('target_entity_id', $params, $this->_id);
+      $params['target_entity_id'] = $params['target_entity_id'] ?? $this->_id;
     }
 
     $dao = new CRM_PCP_DAO_PCPBlock();
@@ -198,9 +198,9 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
     $dao->entity_id = $this->_id;
     $dao->find(TRUE);
     $params['id'] = $dao->id;
-    $params['is_active'] = CRM_Utils_Array::value('pcp_active', $params, FALSE);
-    $params['is_approval_needed'] = CRM_Utils_Array::value('is_approval_needed', $params, FALSE);
-    $params['is_tellfriend_enabled'] = CRM_Utils_Array::value('is_tellfriend_enabled', $params, FALSE);
+    $params['is_active'] = $params['pcp_active'] ?? FALSE;
+    $params['is_approval_needed'] = $params['is_approval_needed'] ?? FALSE;
+    $params['is_tellfriend_enabled'] = $params['is_tellfriend_enabled'] ?? FALSE;
 
     CRM_PCP_BAO_PCPBlock::create($params);
 

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -211,7 +211,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
         'actual_amount',
       );
       foreach ($paymentKeys as $key) {
-        $paymentParams[$key] = CRM_Utils_Array::value($key, $params, NULL);
+        $paymentParams[$key] = $params[$key] ?? NULL;
       }
       CRM_Pledge_BAO_PledgePayment::create($paymentParams);
     }
@@ -851,7 +851,7 @@ GROUP BY  currency
 
     $returnMessages = array();
 
-    $sendReminders = CRM_Utils_Array::value('send_reminders', $params, FALSE);
+    $sendReminders = $params['send_reminders'] ?? FALSE;
 
     $allStatus = array_flip(CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name'));
     $allPledgeStatus = CRM_Core_OptionGroup::values('pledge_status',

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -361,7 +361,7 @@ WHERE li.contribution_id = %1";
     foreach ($params["price_{$fid}"] as $oid => $qty) {
       $price = $amount_override === NULL ? $options[$oid]['amount'] : $amount_override;
 
-      $participantsPerField = CRM_Utils_Array::value('count', $options[$oid], 0);
+      $participantsPerField = $options[$oid]['count'] ?? 0;
 
       $values[$oid] = [
         'price_field_id' => $fid,

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -190,7 +190,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
       elseif (!empty($optionsIds) && !empty($optionsIds['id'])) {
         $optionsLoad = civicrm_api3('price_field_value', 'get', ['id' => $optionsIds['id']]);
         $options = $optionsLoad['values'][$optionsIds['id']];
-        $options['is_active'] = CRM_Utils_Array::value('is_active', $params, 1);
+        $options['is_active'] = $params['is_active'] ?? 1;
         try {
           CRM_Price_BAO_PriceFieldValue::create($options, $optionsIds);
         }
@@ -342,8 +342,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     switch ($field->html_type) {
       case 'Text':
         $optionKey = key($customOption);
-        $count = CRM_Utils_Array::value('count', $customOption[$optionKey], '');
-        $max_value = CRM_Utils_Array::value('max_value', $customOption[$optionKey], '');
+        $count = $customOption[$optionKey]['count'] ?? '';
+        $max_value = $customOption[$optionKey]['max_value'] ?? '';
         $taxAmount = CRM_Utils_Array::value('tax_amount', $customOption[$optionKey]);
         if (isset($taxAmount) && $displayOpt && $invoicing) {
           $qf->assign('displayOpt', $displayOpt);
@@ -439,8 +439,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             }
             $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
           }
-          $count = CRM_Utils_Array::value('count', $opt, '');
-          $max_value = CRM_Utils_Array::value('max_value', $opt, '');
+          $count = $opt['count'] ?? '';
+          $max_value = $opt['max_value'] ?? '';
           $priceVal = implode($seperator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
           if (isset($opt['visibility_id'])) {
             $visibility_id = $opt['visibility_id'];
@@ -524,8 +524,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         foreach ($customOption as $opt) {
           $taxAmount = CRM_Utils_Array::value('tax_amount', $opt);
-          $count = CRM_Utils_Array::value('count', $opt, '');
-          $max_value = CRM_Utils_Array::value('max_value', $opt, '');
+          $count = $opt['count'] ?? '';
+          $max_value = $opt['max_value'] ?? '';
 
           if ($field->is_display_amounts) {
             $opt['label'] .= '&nbsp;-&nbsp;';
@@ -580,8 +580,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $check = [];
         foreach ($customOption as $opId => $opt) {
           $taxAmount = CRM_Utils_Array::value('tax_amount', $opt);
-          $count = CRM_Utils_Array::value('count', $opt, '');
-          $max_value = CRM_Utils_Array::value('max_value', $opt, '');
+          $count = $opt['count'] ?? '';
+          $max_value = $opt['max_value'] ?? '';
 
           if ($field->is_display_amounts) {
             $preHelpText = $postHelpText = '';

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -106,7 +106,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
       if ($id) {
         $oldWeight = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $id, 'weight', 'id');
       }
-      $fieldValues = ['price_field_id' => CRM_Utils_Array::value('price_field_id', $params, 0)];
+      $fieldValues = ['price_field_id' => $params['price_field_id'] ?? 0];
       $params['weight'] = CRM_Utils_Weight::updateOtherWeights('CRM_Price_DAO_PriceFieldValue', $oldWeight, $params['weight'], $fieldValues);
     }
     else {
@@ -118,7 +118,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
       }
     }
 
-    $financialType = CRM_Utils_Array::value('financial_type_id', $params, NULL);
+    $financialType = $params['financial_type_id'] ?? NULL;
     if (!$financialType && $id) {
       $financialType = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $id, 'financial_type_id', 'id');
     }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -631,7 +631,7 @@ WHERE  id = %1";
           if (!empty($form->_priceSet['fields'])) {
             foreach ($form->_priceSet['fields'] as $field) {
               foreach ($field['options'] as $option) {
-                $count = CRM_Utils_Array::value('count', $option, 0);
+                $count = $option['count'] ?? 0;
                 $optionsCountDetails['fields'][$field['id']]['options'][$option['id']] = $count;
               }
             }
@@ -646,7 +646,7 @@ WHERE  id = %1";
         if (!empty($form->_priceSet['fields'])) {
           foreach ($form->_priceSet['fields'] as $field) {
             foreach ($field['options'] as $option) {
-              $maxVal = CRM_Utils_Array::value('max_value', $option, 0);
+              $maxVal = $option['max_value'] ?? 0;
               $optionsMaxValueDetails['fields'][$field['id']]['options'][$option['id']] = $maxVal;
               $optionsMaxValueTotal += $maxVal;
             }
@@ -1065,7 +1065,7 @@ WHERE  id = %1";
             'price_' . $field['id'],
             $field['id'],
             FALSE,
-            CRM_Utils_Array::value('is_required', $field, FALSE),
+            $field['is_required'] ?? FALSE,
             NULL,
             $options
           );

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -629,12 +629,12 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     // store the submitted values in an array
     $params = $this->controller->exportValues('Field');
 
-    $params['is_display_amounts'] = CRM_Utils_Array::value('is_display_amounts', $params, FALSE);
-    $params['is_required'] = CRM_Utils_Array::value('is_required', $params, FALSE);
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $params, FALSE);
-    $params['visibility_id'] = CRM_Utils_Array::value('visibility_id', $params, FALSE);
-    $params['count'] = CRM_Utils_Array::value('count', $params, FALSE);
+    $params['is_display_amounts'] = $params['is_display_amounts'] ?? FALSE;
+    $params['is_required'] = $params['is_required'] ?? FALSE;
+    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['financial_type_id'] = $params['financial_type_id'] ?? FALSE;
+    $params['visibility_id'] = $params['visibility_id'] ?? FALSE;
+    $params['count'] = $params['count'] ?? FALSE;
 
     // need the FKEY - price set id
     $params['price_set_id'] = $this->_sid;
@@ -652,7 +652,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     if (isset($params['option_name'])) {
       $params['option_value'] = $params['option_name'];
     }
-    $params['is_enter_qty'] = CRM_Utils_Array::value('is_enter_qty', $params, FALSE);
+    $params['is_enter_qty'] = $params['is_enter_qty'] ?? FALSE;
 
     if ($params['html_type'] == 'Text') {
       // if html type is Text, force is_enter_qty on
@@ -673,7 +673,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       $params['id'] = $this->_fid;
     }
 
-    $params['membership_num_terms'] = (!empty($params['membership_type_id'])) ? CRM_Utils_Array::value('membership_num_terms', $params, 1) : NULL;
+    $params['membership_num_terms'] = !empty($params['membership_type_id']) ? ($params['membership_num_terms'] ?? 1) : NULL;
 
     $priceField = CRM_Price_BAO_PriceField::create($params);
 

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -352,9 +352,9 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
         $params[$field] = CRM_Utils_Rule::cleanMoney(trim($params[$field]));
       }
       $params['price_field_id'] = $this->_fid;
-      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['visibility_id'] = CRM_Utils_Array::value('visibility_id', $params, FALSE);
+      $params['is_default'] = $params['is_default'] ?? FALSE;
+      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['visibility_id'] = $params['visibility_id'] ?? FALSE;
       $ids = [];
       if ($this->_oid) {
         $ids['id'] = $this->_oid;

--- a/CRM/Price/Form/Set.php
+++ b/CRM/Price/Form/Set.php
@@ -283,8 +283,8 @@ class CRM_Price_Form_Set extends CRM_Core_Form {
     // get the submitted form values.
     $params = $this->controller->exportValues('Set');
     $nameLength = CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceSet', 'name');
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $params, FALSE);
+    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['financial_type_id'] = $params['financial_type_id'] ?? FALSE;
 
     $compIds = [];
     $extends = CRM_Utils_Array::value('extends', $params);

--- a/CRM/Profile/Page/Router.php
+++ b/CRM/Profile/Page/Router.php
@@ -50,7 +50,7 @@ class CRM_Profile_Page_Router extends CRM_Core_Page {
       return NULL;
     }
 
-    $secondArg = CRM_Utils_Array::value(2, $args, '');
+    $secondArg = $args[2] ?? '';
 
     if ($secondArg == 'map') {
       $controller = new CRM_Core_Controller_Simple(

--- a/CRM/Queue/Queue/Sql.php
+++ b/CRM/Queue/Queue/Sql.php
@@ -97,7 +97,7 @@ class CRM_Queue_Queue_Sql extends CRM_Queue_Queue {
     $dao->queue_name = $this->getName();
     $dao->submit_time = CRM_Utils_Time::getTime('YmdHis');
     $dao->data = serialize($data);
-    $dao->weight = CRM_Utils_Array::value('weight', $options, 0);
+    $dao->weight = $options['weight'] ?? 0;
     $dao->save();
   }
 

--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -108,13 +108,13 @@ class CRM_Queue_Runner {
    *     default: 'civicrm/queue'.
    */
   public function __construct($runnerSpec) {
-    $this->title = CRM_Utils_Array::value('title', $runnerSpec, ts('Queue Runner'));
+    $this->title = $runnerSpec['title'] ?? ts('Queue Runner');
     $this->queue = $runnerSpec['queue'];
-    $this->errorMode = CRM_Utils_Array::value('errorMode', $runnerSpec, self::ERROR_ABORT);
-    $this->isMinimal = CRM_Utils_Array::value('isMinimal', $runnerSpec, FALSE);
-    $this->onEnd = CRM_Utils_Array::value('onEnd', $runnerSpec, NULL);
-    $this->onEndUrl = CRM_Utils_Array::value('onEndUrl', $runnerSpec, NULL);
-    $this->pathPrefix = CRM_Utils_Array::value('pathPrefix', $runnerSpec, 'civicrm/queue');
+    $this->errorMode = $runnerSpec['errorMode'] ?? self::ERROR_ABORT;
+    $this->isMinimal = $runnerSpec['isMinimal'] ?? FALSE;
+    $this->onEnd = $runnerSpec['onEnd'] ?? NULL;
+    $this->onEndUrl = $runnerSpec['onEndUrl'] ?? NULL;
+    $this->pathPrefix = $runnerSpec['pathPrefix'] ?? 'civicrm/queue';
     $this->buttons = CRM_Utils_Array::value('buttons', $runnerSpec, ['retry' => TRUE, 'skip' => TRUE]);
     // perhaps this value should be randomized?
     $this->qrid = $this->queue->getName();

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -63,8 +63,8 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
     }
 
     if (!$instanceID || !isset($params['id'])) {
-      $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
-      $params['domain_id'] = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
+      $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
+      $params['domain_id'] = $params['domain_id'] ?? CRM_Core_Config::domainID();
       // CRM-17256 set created_id on report creation.
       $params['created_id'] = isset($params['created_id']) ? $params['created_id'] : CRM_Core_Session::getLoggedInContactID();
     }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1017,8 +1017,8 @@ class CRM_Report_Form extends CRM_Core_Form {
           ) {
             $order_by = [
               'column' => $fieldName,
-              'order' => CRM_Utils_Array::value('default_order', $field, 'ASC'),
-              'section' => CRM_Utils_Array::value('default_is_section', $field, 0),
+              'order' => $field['default_order'] ?? 'ASC',
+              'section' => $field['default_is_section'] ?? 0,
             ];
 
             if (!empty($field['default_weight'])) {
@@ -2997,7 +2997,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
           }
           elseif (array_key_exists('extends', $table)) {
             // For custom fields referenced in $this->_customGroupExtends
-            $fields = CRM_Utils_Array::value('fields', $table, []);
+            $fields = $table['fields'] ?? [];
           }
           else {
             continue;
@@ -3340,7 +3340,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
                 $this->setEntityRefDefaults($field, $tableName);
                 $result = civicrm_api3($field['attributes']['entity'], 'getlist',
                   ['id' => $val] +
-                  CRM_Utils_Array::value('api', $field['attributes'], []));
+                  $field['attributes']['api'] ?? []);
                 $values = [];
                 foreach ($result['values'] as $v) {
                   $values[] = $v['label'];
@@ -3351,7 +3351,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
                 $value = $pair[$op];
               }
               elseif (is_array($val) && (!empty($val))) {
-                $options = CRM_Utils_Array::value('options', $field, []);
+                $options = $field['options'] ?? [];
                 foreach ($val as $key => $valIds) {
                   if (isset($options[$valIds])) {
                     $val[$key] = $options[$valIds];
@@ -3367,7 +3367,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
                 is_array($field['options']) && !empty($field['options'])
               ) {
                 $value = CRM_Utils_Array::value($op, $pair) . " " .
-                  CRM_Utils_Array::value($val, $field['options'], $val);
+                  $field['options'][$val] ?? $val;
               }
               elseif ($val) {
                 $value = CRM_Utils_Array::value($op, $pair) . " " . $val;
@@ -4052,7 +4052,7 @@ ORDER BY cg.weight, cf.weight";
       }
 
       if (!array_key_exists('type', $curFields[$fieldName])) {
-        $curFields[$fieldName]['type'] = CRM_Utils_Array::value('type', $curFilters[$fieldName], []);
+        $curFields[$fieldName]['type'] = $curFilters[$fieldName]['type'] ?? [];
       }
 
       if ($addFields) {
@@ -4093,7 +4093,7 @@ ORDER BY cg.weight, cf.weight";
         if ((!$this->isFieldSelected($prop)) || ($joinsForFiltersOnly && !$this->isFieldFiltered($prop))) {
           continue;
         }
-        $baseJoin = CRM_Utils_Array::value($prop['extends'], $this->_customGroupExtendsJoin, "{$this->_aliases[$extendsTable]}.id");
+        $baseJoin = $this->_customGroupExtendsJoin[$prop['extends']] ?? "{$this->_aliases[$extendsTable]}.id";
 
         $customJoin = is_array($this->_customGroupJoin) ? $this->_customGroupJoin[$table] : $this->_customGroupJoin;
         $this->_from .= "
@@ -4418,7 +4418,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'fields' => [
           'address_name' => [
             'title' => ts('Address Name'),
-            'default' => CRM_Utils_Array::value('name', $defaults, FALSE),
+            'default' => $defaults['name'] ?? FALSE,
             'name' => 'name',
           ],
         ],
@@ -4428,7 +4428,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
     foreach ($defaultAddressFields as $fieldName => $fieldLabel) {
       $addressFields['civicrm_address']['fields'][$fieldName] = [
         'title' => $fieldLabel,
-        'default' => CRM_Utils_Array::value($fieldName, $defaults, FALSE),
+        'default' => $defaults[$fieldName] ?? FALSE,
       ];
     }
 
@@ -4978,7 +4978,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       'is_deceased' => [
         'title' => ts('Deceased'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
-        'default' => CRM_Utils_Array::value('deceased', $defaults, 0),
+        'default' => $defaults['deceased'] ?? 0,
       ],
       'do_not_email' => [
         'title' => ts('Do not email'),

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -403,7 +403,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
         if (!empty($field['isSurveyResponseField'])) {
           $fldId = substr($name, 7);
           $fieldIds[$fldId] = $fldId;
-          $title = CRM_Utils_Array::value('label', $field, $field['title']);
+          $title = $field['label'] ?? $field['title'];
           $surveyResponseFields[$name] = array(
             'id' => $fldId,
             'title' => $title,
@@ -547,7 +547,7 @@ INNER JOIN  civicrm_survey survey ON ( survey.result_id = grp.id )
       if (!empty($row['civicrm_activity_survey_id'])) {
         $surveyId = $row['civicrm_activity_survey_id'];
       }
-      $result = CRM_Utils_Array::value($surveyId, $resultSet, array());
+      $result = $resultSet[$surveyId] ?? [];
       $resultLabel = CRM_Utils_Array::value('civicrm_activity_result', $row);
       if ($respondentStatus == 'Reserved') {
         $row['civicrm_activity_result'] = implode(' | ', array_keys($result));
@@ -672,7 +672,7 @@ INNER JOIN  civicrm_custom_group cg ON ( cg.id = cf.custom_group_id )
           in_array($this->_outputMode, array('print', 'pdf'))
         ) {
           $optGrpId = CRM_Utils_Array::value('option_group_id', $responseFields[$name]);
-          $options = CRM_Utils_Array::value($optGrpId, $fieldValueMap, array());
+          $options = $fieldValueMap[$optGrpId] ?? [];
           $value = implode(' | ', array_keys($options));
         }
         else {

--- a/CRM/Report/Form/Contact/LoggingSummary.php
+++ b/CRM/Report/Form/Contact/LoggingSummary.php
@@ -309,7 +309,7 @@ class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
     $entity = $this->currentLogTable;
 
     $detail = $this->_logTables[$entity];
-    $tableName = CRM_Utils_Array::value('table_name', $detail, $entity);
+    $tableName = $detail['table_name'] ?? $entity;
     $clause = CRM_Utils_Array::value('entity_table', $detail);
     $clause = $clause ? "AND entity_log_civireport.entity_table = 'civicrm_contact'" : NULL;
 

--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -654,7 +654,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
       $total = [];
       $total['civicrm_contact_sort_name'] = ts('Total');
       foreach ($summaryYears as $year) {
-        $total[$year] = CRM_Utils_Array::value($year, $primaryRow, 0);
+        $total[$year] = $primaryRow[$year] ?? 0;
       }
 
       $relatedContact = FALSE;
@@ -666,7 +666,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
         $relatedContact = TRUE;
         $relatedRow = $relatedContributions[$relcid];
         foreach ($summaryYears as $year) {
-          $total[$year] += CRM_Utils_Array::value($year, $relatedRow, 0);
+          $total[$year] += $relatedRow[$year] ?? 0;
         }
 
         foreach (array_keys($this->_relationshipColumns) as $col) {

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -451,7 +451,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
    * @return string
    */
   public function getYearFilterType() {
-    return CRM_Utils_Array::value('yid_op', $this->_params, 'calendar');
+    return $this->_params['yid_op'] ?? 'calendar';
   }
 
   /**

--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -105,7 +105,7 @@ class CRM_Report_Utils_Get {
    * @param $defaults
    */
   public static function stringParam($fieldName, &$field, &$defaults) {
-    $fieldOP = CRM_Utils_Array::value("{$fieldName}_op", $_GET, 'like');
+    $fieldOP = $_GET["{$fieldName}_op"] ?? 'like';
 
     switch ($fieldOP) {
       case 'has':
@@ -145,7 +145,7 @@ class CRM_Report_Utils_Get {
    * @param $defaults
    */
   public static function intParam($fieldName, &$field, &$defaults) {
-    $fieldOP = CRM_Utils_Array::value("{$fieldName}_op", $_GET, 'eq');
+    $fieldOP = $_GET["{$fieldName}_op"] ?? 'eq';
 
     switch ($fieldOP) {
       case 'lte':

--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -411,11 +411,11 @@ WHERE  inst.report_id = %1";
 
     // hack for now, CRM-8358
     $_REQUEST['instanceId'] = $instanceId;
-    $_REQUEST['sendmail'] = CRM_Utils_Array::value('sendmail', $params, 1);
+    $_REQUEST['sendmail'] = $params['sendmail'] ?? 1;
 
     // if cron is run from terminal --output is reserved, and therefore we would provide another name 'format'
-    $_REQUEST['output'] = CRM_Utils_Array::value('format', $params, CRM_Utils_Array::value('output', $params, 'pdf'));
-    $_REQUEST['reset'] = CRM_Utils_Array::value('reset', $params, 1);
+    $_REQUEST['output'] = $params['format'] ?? $params['output'] ?? 'pdf';
+    $_REQUEST['reset'] = $params['reset'] ?? 1;
 
     $optionVal = self::getValueFromUrl($instanceId);
     $messages = ["Report Mail Triggered..."];

--- a/CRM/SMS/BAO/Provider.php
+++ b/CRM/SMS/BAO/Provider.php
@@ -109,10 +109,10 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
       $provider->find(TRUE);
     }
     if ($id) {
-      $provider->domain_id = CRM_Utils_Array::value('domain_id', $params, $provider->domain_id);
+      $provider->domain_id = $params['domain_id'] ?? $provider->domain_id;
     }
     else {
-      $provider->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
+      $provider->domain_id = $params['domain_id'] ?? CRM_Core_Config::domainID();
     }
     $provider->copyValues($params);
     $result = $provider->save();
@@ -185,12 +185,12 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
         // Replace the api_type ID with the string value
         $apiTypes = CRM_Core_OptionGroup::values('sms_api_type');
         $apiTypeId = $providerInfo[$providerID]['api_type'];
-        $providerInfo[$providerID]['api_type'] = CRM_Utils_Array::value($apiTypeId, $apiTypes, $apiTypeId);
+        $providerInfo[$providerID]['api_type'] = $apiTypes[$apiTypeId] ?? $apiTypeId;
       }
     }
 
     if ($returnParam) {
-      return CRM_Utils_Array::value($returnParam, $providerInfo[$providerID], $returnDefaultString);
+      return $providerInfo[$providerID][$returnParam] ?? $returnDefaultString;
     }
     return $providerInfo[$providerID];
   }

--- a/CRM/SMS/Form/Provider.php
+++ b/CRM/SMS/Form/Provider.php
@@ -168,8 +168,8 @@ class CRM_SMS_Form_Provider extends CRM_Core_Form {
     }
 
     $recData = $values = $this->controller->exportValues($this->_name);
-    $recData['is_active'] = CRM_Utils_Array::value('is_active', $recData, 0);
-    $recData['is_default'] = CRM_Utils_Array::value('is_default', $recData, 0);
+    $recData['is_active'] = $recData['is_active'] ?? 0;
+    $recData['is_default'] = $recData['is_default'] ?? 0;
 
     if ($this->_action && (CRM_Core_Action::UPDATE || CRM_Core_Action::ADD)) {
       if ($this->_id) {

--- a/CRM/Tag/Page/Tag.php
+++ b/CRM/Tag/Page/Tag.php
@@ -61,7 +61,7 @@ class CRM_Tag_Page_Tag extends CRM_Core_Page {
       'options' => ['limit' => 0],
     ]);
     foreach ($result['values'] as $id => $tagset) {
-      $used = explode(',', CRM_Utils_Array::value('used_for', $tagset, ''));
+      $used = explode(',', $tagset['used_for'] ?? '');
       $tagset['used_for_label'] = array_values(array_intersect_key($usedFor, array_flip($used)));
       if (isset($tagset['created_id.display_name'])) {
         $tagset['display_name'] = $tagset['created_id.display_name'];

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -532,7 +532,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     }
 
     // If field_name is missing, it's formatting
-    $fieldName = CRM_Utils_Array::value(1, $params['field_name'], 'formatting');
+    $fieldName = $params['field_name'][1] ?? 'formatting';
 
     //check for duplicate fields
     $apiFormattedParams = $params;
@@ -747,11 +747,11 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
    *   list of errors to be posted back to the form
    */
   public static function formRule($fields, $files, $self) {
-    $is_required = CRM_Utils_Array::value('is_required', $fields, FALSE);
-    $is_registration = CRM_Utils_Array::value('is_registration', $fields, FALSE);
-    $is_view = CRM_Utils_Array::value('is_view', $fields, FALSE);
-    $in_selector = CRM_Utils_Array::value('in_selector', $fields, FALSE);
-    $is_active = CRM_Utils_Array::value('is_active', $fields, FALSE);
+    $is_required = $fields['is_required'] ?? FALSE;
+    $is_registration = $fields['is_registration'] ?? FALSE;
+    $is_view = $fields['is_view'] ?? FALSE;
+    $in_selector = $fields['in_selector'] ?? FALSE;
+    $is_active = $fields['is_active'] ?? FALSE;
 
     $errors = [];
     if ($is_view && $is_registration) {

--- a/CRM/Upgrade/Incremental/php/FiveFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFour.php
@@ -105,7 +105,7 @@ class CRM_Upgrade_Incremental_php_FiveFour extends CRM_Upgrade_Incremental_Base 
         'option_group_id' => 'activity_default_assignee',
         'name' => $option['name'],
         'label' => $option['label'],
-        'is_default' => CRM_Utils_Array::value('is_default', $option, 0),
+        'is_default' => $option['is_default'] ?? 0,
         'is_active' => TRUE,
       ]);
     }

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -67,7 +67,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
       CRM_Utils_System::url('civicrm/dashboard', 'reset=1')
     );
 
-    $action = CRM_Utils_Array::value('action', $_REQUEST, 'intro');
+    $action = $_REQUEST['action'] ?? 'intro';
     switch ($action) {
       case 'intro':
         $this->runIntro();

--- a/CRM/Utils/API/MatchOption.php
+++ b/CRM/Utils/API/MatchOption.php
@@ -187,7 +187,7 @@ class CRM_Utils_API_MatchOption implements API_Wrapper {
   public function createGetParams($origParams, $keys) {
     $params = ['version' => 3];
     foreach ($keys as $key) {
-      $params[$key] = CRM_Utils_Array::value($key, $origParams, '');
+      $params[$key] = $origParams[$key] ?? '';
     }
     return $params;
   }

--- a/CRM/Utils/API/ReloadOption.php
+++ b/CRM/Utils/API/ReloadOption.php
@@ -76,7 +76,7 @@ class CRM_Utils_API_ReloadOption implements API_Wrapper {
   public function toApiOutput($apiRequest, $result) {
     $reloadMode = NULL;
     if ($apiRequest['action'] === 'create' && isset($apiRequest['params'], $apiRequest['params']['options']) && is_array($apiRequest['params']['options']) && isset($apiRequest['params']['options']['reload'])) {
-      if (!CRM_Utils_Array::value('is_error', $result, FALSE)) {
+      if (empty($result['is_error'])) {
         $reloadMode = $apiRequest['params']['options']['reload'];
       }
       $id = (!empty($apiRequest['params']['sequential'])) ? 0 : $result['id'];

--- a/CRM/Utils/Address/USPS.php
+++ b/CRM/Utils/Address/USPS.php
@@ -82,7 +82,7 @@ class CRM_Utils_Address_USPS {
 
     $address2 = str_replace(',', '', $values['street_address']);
 
-    $XMLQuery = '<AddressValidateRequest USERID="' . $userID . '"><Address ID="0"><Address1>' . CRM_Utils_Array::value('supplemental_address_1', $values, '') . '</Address1><Address2>' . $address2 . '</Address2><City>' . $values['city'] . '</City><State>' . $values['state_province'] . '</State><Zip5>' . $values['postal_code'] . '</Zip5><Zip4>' . CRM_Utils_Array::value('postal_code_suffix', $values, '') . '</Zip4></Address></AddressValidateRequest>';
+    $XMLQuery = '<AddressValidateRequest USERID="' . $userID . '"><Address ID="0"><Address1>' . ($values['supplemental_address_1'] ?? '') . '</Address1><Address2>' . $address2 . '</Address2><City>' . $values['city'] . '</City><State>' . $values['state_province'] . '</State><Zip5>' . $values['postal_code'] . '</Zip5><Zip4>' . ($values['postal_code_suffix'] ?? '') . '</Zip4></Address></AddressValidateRequest>';
 
     require_once 'HTTP/Request.php';
     $request = new HTTP_Request();

--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -71,7 +71,7 @@ class CRM_Utils_Cache {
       // a generic method for utilizing any of the available db caches.
       $dbCacheClass = 'CRM_Utils_Cache_' . $className;
       $settings = self::getCacheSettings($className);
-      $settings['prefix'] = CRM_Utils_Array::value('prefix', $settings, '') . self::DELIMITER . 'default' . self::DELIMITER;
+      $settings['prefix'] = ($settings['prefix'] ?? '') . self::DELIMITER . 'default' . self::DELIMITER;
       self::$_singleton = new $dbCacheClass($settings);
     }
     return self::$_singleton;
@@ -192,7 +192,7 @@ class CRM_Utils_Cache {
           if (defined('CIVICRM_DB_CACHE_CLASS') && in_array(CIVICRM_DB_CACHE_CLASS, ['Memcache', 'Memcached', 'Redis'])) {
             $dbCacheClass = 'CRM_Utils_Cache_' . CIVICRM_DB_CACHE_CLASS;
             $settings = self::getCacheSettings(CIVICRM_DB_CACHE_CLASS);
-            $settings['prefix'] = CRM_Utils_Array::value('prefix', $settings, '') . self::DELIMITER . $params['name'] . self::DELIMITER;
+            $settings['prefix'] = ($settings['prefix'] ?? '') . self::DELIMITER . $params['name'] . self::DELIMITER;
             $cache = new $dbCacheClass($settings);
             if (!empty($params['withArray'])) {
               $cache = $params['withArray'] === 'fast' ? new CRM_Utils_Cache_FastArrayDecorator($cache) : new CRM_Utils_Cache_ArrayDecorator($cache);
@@ -205,7 +205,7 @@ class CRM_Utils_Cache {
           if (defined('CIVICRM_DSN') && CIVICRM_DSN) {
             return new CRM_Utils_Cache_SqlGroup([
               'group' => $params['name'],
-              'prefetch' => CRM_Utils_Array::value('prefetch', $params, FALSE),
+              'prefetch' => $params['prefetch'] ?? FALSE,
             ]);
           }
           break;

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -106,7 +106,7 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
       $this->componentID = NULL;
     }
     $this->valueCache = [];
-    if (CRM_Utils_Array::value('prefetch', $config, TRUE)) {
+    if (!empty($config['prefetch'])) {
       $this->prefetch();
     }
   }

--- a/CRM/Utils/Check/Message.php
+++ b/CRM/Utils/Check/Message.php
@@ -274,7 +274,7 @@ class CRM_Utils_Check_Message {
     ];
     // Check if there's a StatusPreference matching this name/domain.
     $statusPreference = civicrm_api3('StatusPreference', 'get', $statusPreferenceParams);
-    $prefs = CRM_Utils_Array::value('values', $statusPreference, []);
+    $prefs = $statusPreference['values'] ?? [];
     if ($prefs) {
       // If so, compare severity to StatusPreference->severity.
       if ($this->level <= $prefs[0]['ignore_severity']) {

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -216,7 +216,7 @@ class CRM_Utils_Mail {
     $headers['Content-Type'] = $htmlMessage ? 'multipart/mixed; charset=utf-8' : 'text/plain; charset=utf-8';
     $headers['Content-Disposition'] = 'inline';
     $headers['Content-Transfer-Encoding'] = '8bit';
-    $headers['Return-Path'] = CRM_Utils_Array::value('returnPath', $params, $defaultReturnPath);
+    $headers['Return-Path'] = $params['returnPath'] ?? $defaultReturnPath;
 
     // CRM-11295: Omit reply-to headers if empty; this avoids issues with overzealous mailservers
     $replyTo = CRM_Utils_Array::value('replyTo', $params, CRM_Utils_Array::value('from', $params));

--- a/CRM/Utils/Migrate/ExportJSON.php
+++ b/CRM/Utils/Migrate/ExportJSON.php
@@ -539,7 +539,7 @@ WHERE ac.contact_id IN ( $ids )
         $_fieldsRetrieved[$daoName][$value['name']] = [
           'uniqueName' => $key,
           'type' => $value['type'],
-          'title' => CRM_Utils_Array::value('title', $value, NULL),
+          'title' => $value['title'] ?? NULL,
         ];
       }
     }

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -114,7 +114,7 @@ class CRM_Utils_Money {
     $replacements = [
       '%a' => $amount,
       '%C' => $currency,
-      '%c' => CRM_Utils_Array::value($currency, self::$_currencySymbols, $currency),
+      '%c' => self::$_currencySymbols[$currency] ?? $currency,
     ];
     return strtr($format, $replacements);
   }

--- a/CRM/Utils/OpenFlashChart.php
+++ b/CRM/Utils/OpenFlashChart.php
@@ -123,7 +123,7 @@ class CRM_Utils_OpenFlashChart {
       }
 
       // get the currency to set in tooltip.
-      $tooltip = CRM_Utils_Array::value('tip', $params, "$symbol #val#");
+      $tooltip = $params['tip'] ?? "$symbol #val#";
       $bars[$barCount]->set_tooltip($tooltip);
     }
 
@@ -228,7 +228,7 @@ class CRM_Utils_OpenFlashChart {
     $pie->add_animation(new pie_bounce(2));
 
     // set the tooltip.
-    $tooltip = CRM_Utils_Array::value('tip', $params, "Amount is $symbol #val# of $symbol #total# <br>#percent#");
+    $tooltip = $params['tip'] ?? "Amount is $symbol #val# of $symbol #total# <br>#percent#";
     $pie->set_tooltip($tooltip);
 
     // set colours.
@@ -282,8 +282,8 @@ class CRM_Utils_OpenFlashChart {
 
       $xValueLabels[] = (string) $xVal;
       foreach ($criteria as $criteria) {
-        $xReferences[$criteria][$xVal] = (double) CRM_Utils_Array::value($criteria, $yVal, 0);
-        $yValues[] = (double) CRM_Utils_Array::value($criteria, $yVal, 0);
+        $xReferences[$criteria][$xVal] = (double) ($yVal[$criteria] ?? 0);
+        $yValues[] = (double) ($yVal[$criteria] ?? 0);
       }
     }
 
@@ -297,14 +297,14 @@ class CRM_Utils_OpenFlashChart {
     $symbol = CRM_Core_BAO_Country::defaultCurrencySymbol();
 
     // set the tooltip.
-    $tooltip = CRM_Utils_Array::value('tip', $params, "$symbol #val#");
+    $tooltip = $params['tip'] ?? "$symbol #val#";
 
     $count = 0;
     foreach ($xReferences as $criteria => $values) {
       $toolTipVal = $tooltip;
       // for separate tooltip for each criteria
       if (is_array($tooltip)) {
-        $toolTipVal = CRM_Utils_Array::value($criteria, $tooltip, "$symbol #val#");
+        $toolTipVal = $tooltip[$criteria] ?? "$symbol #val#";
       }
 
       // create bar_3d object
@@ -448,15 +448,15 @@ class CRM_Utils_OpenFlashChart {
         $graph[$key] = array_combine($dateKeys, $rows['multiValue'][$key]);
       }
       $chartData = [
-        'legend' => "$legend " . CRM_Utils_Array::value('legend', $rows, ts('Contribution')) . ' ' . ts('Summary'),
+        'legend' => "$legend " . ($rows['legend'] ?? ts('Contribution')) . ' ' . ts('Summary'),
         'values' => $graph[0],
         'multiValues' => $graph,
-        'barKeys' => CRM_Utils_Array::value('barKeys', $rows, []),
+        'barKeys' => $rows['barKeys'] ?? [],
       ];
     }
 
     // rotate the x labels.
-    $chartData['xLabelAngle'] = CRM_Utils_Array::value('xLabelAngle', $rows, 0);
+    $chartData['xLabelAngle'] = $rows['xLabelAngle'] ?? 0;
     if (!empty($rows['tip'])) {
       $chartData['tip'] = $rows['tip'];
     }
@@ -500,7 +500,7 @@ class CRM_Utils_OpenFlashChart {
     ];
 
     // rotate the x labels.
-    $chartData['xLabelAngle'] = CRM_Utils_Array::value('xLabelAngle', $chartInfo, 20);
+    $chartData['xLabelAngle'] = $chartInfo['xLabelAngle'] ?? 20;
     if (!empty($chartInfo['tip'])) {
       $chartData['tip'] = $chartInfo['tip'];
     }
@@ -534,10 +534,10 @@ class CRM_Utils_OpenFlashChart {
       $openFlashChart = [];
       if ($chartObj) {
         // calculate chart size.
-        $xSize = CRM_Utils_Array::value('xSize', $params, 400);
-        $ySize = CRM_Utils_Array::value('ySize', $params, 300);
+        $xSize = $params['xSize'] ?? 400;
+        $ySize = $params['ySize'] ?? 300;
         if ($chart == 'barChart') {
-          $ySize = CRM_Utils_Array::value('ySize', $params, 250);
+          $ySize = $params['ySize'] ?? 250;
           $xSize = 60 * count($params['values']);
           // hack to show tooltip.
           if ($xSize < 200) {

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -583,7 +583,7 @@ class CRM_Utils_REST {
         $call[0],
         $call[1],
       ];
-      $output[$key] = self::process($args, CRM_Utils_Array::value(2, $call, []));
+      $output[$key] = self::process($args, $call[2] ?? []);
     }
     return $output;
   }

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -136,7 +136,7 @@ class CRM_Utils_Recent {
         'contact_id' => $contactId,
         'contactName' => $contactName,
         'subtype' => CRM_Utils_Array::value('subtype', $others),
-        'isDeleted' => CRM_Utils_Array::value('isDeleted', $others, FALSE),
+        'isDeleted' => $others['isDeleted'] ?? FALSE,
         'image_url' => CRM_Utils_Array::value('imageUrl', $others),
         'edit_url' => CRM_Utils_Array::value('editUrl', $others),
         'delete_url' => CRM_Utils_Array::value('deleteUrl', $others),

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -785,7 +785,7 @@ class CRM_Utils_Rule {
       $name = $options[2];
     }
 
-    return CRM_Core_DAO::objectExists($value, CRM_Utils_Array::value(0, $options), CRM_Utils_Array::value(1, $options), CRM_Utils_Array::value(2, $options, $name), CRM_Utils_Array::value(3, $options));
+    return CRM_Core_DAO::objectExists($value, CRM_Utils_Array::value(0, $options), CRM_Utils_Array::value(1, $options), $options[2] ?? $name, CRM_Utils_Array::value(3, $options));
   }
 
   /**
@@ -795,7 +795,7 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function optionExists($value, $options) {
-    return CRM_Core_OptionValue::optionExists($value, $options[0], $options[1], $options[2], CRM_Utils_Array::value(3, $options, 'name'), CRM_Utils_Array::value(4, $options, FALSE));
+    return CRM_Core_OptionValue::optionExists($value, $options[0], $options[1], $options[2], $options[3] ?? 'name', $options[4] ?? FALSE);
   }
 
   /**

--- a/CRM/Utils/Sort.php
+++ b/CRM/Utils/Sort.php
@@ -182,7 +182,7 @@ class CRM_Utils_Sort {
    *   The sort order to use by default.
    */
   public function initSortID($defaultSortOrder) {
-    $url = CRM_Utils_Array::value(self::SORT_ID, $_GET, $defaultSortOrder);
+    $url = $_GET[self::SORT_ID] ?? $defaultSortOrder;
 
     if (empty($url)) {
       return;

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -364,11 +364,11 @@ class CRM_Utils_System {
     return self::url(
       $p,
       CRM_Utils_Array::value('q', $params),
-      CRM_Utils_Array::value('a', $params, FALSE),
+      $params['a'] ?? FALSE,
       CRM_Utils_Array::value('f', $params),
-      CRM_Utils_Array::value('h', $params, TRUE),
-      CRM_Utils_Array::value('fe', $params, FALSE),
-      CRM_Utils_Array::value('fb', $params, FALSE)
+      $params['h'] ?? TRUE,
+      $params['fe'] ?? FALSE,
+      $params['fb'] ?? FALSE
     );
   }
 
@@ -1837,7 +1837,7 @@ class CRM_Utils_System {
    *   - url: string
    */
   public static function createDefaultCrudLink($crudLinkSpec) {
-    $crudLinkSpec['action'] = CRM_Utils_Array::value('action', $crudLinkSpec, CRM_Core_Action::VIEW);
+    $crudLinkSpec['action'] = $crudLinkSpec['action'] ?? CRM_Core_Action::VIEW;
     $daoClass = CRM_Core_DAO_AllCoreTables::getClassForTable($crudLinkSpec['entity_table']);
     if (!$daoClass) {
       return NULL;

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -582,9 +582,9 @@ AND    u.status = 1
 
     $uid = CRM_Utils_Array::value('uid', $params);
     if (!$uid) {
-      // Load the user we need to check Backdrop permissions.
-      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      // Load the user, we need to check Backdrop permissions.
+      $name = $params['name'] ?? trim($_REQUEST['name'] ?? '');
+      $pass = $params['pass'] ?? trim($_REQUEST['pass'] ?? '');
 
       if ($name) {
         $uid = user_authenticate($name, $pass);

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -529,9 +529,9 @@ AND    u.status = 1
 
     $uid = CRM_Utils_Array::value('uid', $params);
     if (!$uid) {
-      //load user, we need to check drupal permissions.
-      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      // Load user, we need to check drupal permissions.
+      $name = $params['name'] ?? trim($_REQUEST['name'] ?? '');
+      $pass = $params['pass'] ?? trim($_REQUEST['pass'] ?? '');
 
       if ($name) {
         $uid = user_authenticate($name, $pass);

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -353,7 +353,7 @@ class CRM_Utils_VersionCheck {
       'api_action' => "version_check",
       'api_entity' => "job",
     ]);
-    $this->cronJob = CRM_Utils_Array::value(0, $jobs['values'], []);
+    $this->cronJob = $jobs['values'][0] ?? [];
   }
 
 }

--- a/CRM/Utils/Wrapper.php
+++ b/CRM/Utils/Wrapper.php
@@ -91,7 +91,7 @@ class CRM_Utils_Wrapper {
           $sessionVar = CRM_Utils_Array::value('sessionVar', $params);
           $type = CRM_Utils_Array::value('type', $params);
           $default = CRM_Utils_Array::value('default', $params);
-          $abort = CRM_Utils_Array::value('abort', $params, FALSE);
+          $abort = $params['abort'] ?? FALSE;
 
           $value = NULL;
           $value = CRM_Utils_Request::retrieve(

--- a/Civi/API/Api3SelectQuery.php
+++ b/Civi/API/Api3SelectQuery.php
@@ -174,7 +174,7 @@ class Api3SelectQuery extends SelectQuery {
     foreach ($this->apiFieldSpec as $field) {
       if (
         $fieldName == \CRM_Utils_Array::value('uniqueName', $field) ||
-        array_search($fieldName, \CRM_Utils_Array::value('api.aliases', $field, [])) !== FALSE
+        array_search($fieldName, $field['api.aliases'] ?? []) !== FALSE
       ) {
         return $field;
       }

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -344,7 +344,7 @@ class Kernel {
     $data['entity'] = \CRM_Utils_Array::value('entity', $apiRequest);
     $data['action'] = \CRM_Utils_Array::value('action', $apiRequest);
 
-    if (\CRM_Utils_Array::value('debug', \CRM_Utils_Array::value('params', $apiRequest))
+    if (!empty($apiRequest['params']['debug'])
       // prevent recursion
       && empty($data['trace'])
     ) {

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -228,7 +228,7 @@ abstract class SelectQuery {
       }
       $fieldInfo = \CRM_Utils_Array::value($fieldName, $fkField['FKApiSpec']);
 
-      $keyColumn = \CRM_Utils_Array::value('FKKeyColumn', $fkField, 'id');
+      $keyColumn = $fkField['FKKeyColumn'] ?? 'id';
       if (!$fieldInfo || !isset($fkField['FKApiSpec'][$keyColumn])) {
         // Join doesn't exist - might be another param with a dot in it for some reason, we'll just ignore it.
         return NULL;
@@ -409,7 +409,7 @@ abstract class SelectQuery {
       $words = preg_split("/[\s]+/", $item);
       if ($words) {
         // Direction defaults to ASC unless DESC is specified
-        $direction = strtoupper(\CRM_Utils_Array::value(1, $words, '')) == 'DESC' ? ' DESC' : '';
+        $direction = strtoupper($words[1] ?? '') == 'DESC' ? ' DESC' : '';
         $field = $this->getField($words[0]);
         if ($field) {
           $this->query->orderBy(self::MAIN_TABLE_ALIAS . '.' . $field['name'] . $direction, NULL, $index);

--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -70,7 +70,7 @@ class ChainSubscriber implements EventSubscriberInterface {
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] < 4) {
       $result = $event->getResponse();
-      if (\CRM_Utils_Array::value('is_error', $result, 0) == 0) {
+      if (empty($result['is_error'])) {
         $this->callNestedApi($event->getApiKernel(), $apiRequest['params'], $result, $apiRequest['action'], $apiRequest['entity'], $apiRequest['version']);
         $event->setResponse($result);
       }

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -185,7 +185,7 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
         $this->authorizeDelegate(
           $apiRequest['action'],
           $apiRequest['params']['entity_table'],
-          \CRM_Utils_Array::value('entity_id', $apiRequest['params'], NULL),
+          $apiRequest['params']['entity_id'] ?? NULL,
           $apiRequest
         );
         return;

--- a/Civi/API/WhitelistRule.php
+++ b/Civi/API/WhitelistRule.php
@@ -197,7 +197,7 @@ class WhitelistRule {
         // Kind'a silly we need to (re(re))parse here for each rule; would be more
         // performant if pre-parsed by Request::create().
         $options = _civicrm_api3_get_options_from_params($apiRequest['params'], TRUE, $apiRequest['entity'], 'get');
-        $return = \CRM_Utils_Array::value('return', $options, []);
+        $return = $options['return'] ?? [];
         $activatedFields = array_merge($activatedFields, array_keys($return));
       }
 

--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -170,7 +170,7 @@ class SettingsMetadata {
         $spec['options'] = Resolver::singleton()->call($spec['pseudoconstant']['callback'], []);
       }
       elseif (!empty($spec['pseudoconstant']['optionGroupName'])) {
-        $keyColumn = \CRM_Utils_Array::value('keyColumn', $spec['pseudoconstant'], 'value');
+        $keyColumn = $spec['pseudoconstant']['keyColumn'] ?? 'value';
         $spec['options'] = \CRM_Core_OptionGroup::values($spec['pseudoconstant']['optionGroupName'], FALSE, FALSE, TRUE, NULL, 'label', TRUE, FALSE, $keyColumn);
       }
     }

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -344,7 +344,7 @@ trait Api3TestTrait {
         if (!empty($v3Params['name'])) {
           $v3Params['filters']['name'] = $v3Params['name'];
         }
-        foreach (\CRM_Utils_Array::value('filters', $v3Params, []) as $filter => $val) {
+        foreach ($v3Params['filters'] ?? [] as $filter => $val) {
           $v4Params['where'][] = [$filter, '=', $val];
         }
       }
@@ -371,7 +371,7 @@ trait Api3TestTrait {
 
     foreach ($v3Fields as $name => $field) {
       // Resolve v3 aliases
-      foreach (\CRM_Utils_Array::value('api.aliases', $field, []) as $alias) {
+      foreach ($field['api.aliases'] ?? [] as $alias) {
         if (isset($v3Params[$alias])) {
           $v3Params[$field['name']] = $v3Params[$alias];
           unset($v3Params[$alias]);
@@ -665,7 +665,7 @@ trait Api3TestTrait {
       'Im' => 'IM',
       'Acl' => 'ACL',
     ];
-    return \CRM_Utils_Array::value($api4Name, $map, $api4Name);
+    return $map[$api4Name] ?? $api4Name;
   }
 
 }

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -141,7 +141,7 @@ class TokenRow {
       'return' => $customFieldName,
       'id' => $entityID,
     ]);
-    $fieldValue = \CRM_Utils_Array::value($customFieldName, $record, '');
+    $fieldValue = $record[$customFieldName] ?? '';
 
     // format the raw custom field value into proper display value
     if (isset($fieldValue)) {
@@ -230,7 +230,7 @@ class TokenRow {
               }
               elseif (\CRM_Utils_Array::value('data_type', \CRM_Utils_Array::value($field, $entityFields['values'])) == 'Memo') {
                 // Memo fields aka custom fields of type Note are html.
-                $htmlTokens[$entity][$field] = CRM_Utils_String::purifyHTML($value);
+                $htmlTokens[$entity][$field] = \CRM_Utils_String::purifyHTML($value);
               }
               else {
                 $htmlTokens[$entity][$field] = htmlentities($value);

--- a/api/api.php
+++ b/api/api.php
@@ -43,7 +43,7 @@ function civicrm_api3($entity, $action, $params = []) {
   $params['version'] = 3;
   $result = \Civi::service('civi_api_kernel')->runSafe($entity, $action, $params);
   if (is_array($result) && !empty($result['is_error'])) {
-    throw new CiviCRM_API3_Exception($result['error_message'], CRM_Utils_Array::value('error_code', $result, 'undefined'), $result);
+    throw new CiviCRM_API3_Exception($result['error_message'], $result['error_code'] ?? 'undefined', $result);
   }
   return $result;
 }

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -122,8 +122,8 @@ function civicrm_api3_activity_create($params) {
   }
 
   // this should all be handled at the BAO layer
-  $params['deleteActivityAssignment'] = CRM_Utils_Array::value('deleteActivityAssignment', $params, $deleteActivityAssignment);
-  $params['deleteActivityTarget'] = CRM_Utils_Array::value('deleteActivityTarget', $params, $deleteActivityTarget);
+  $params['deleteActivityAssignment'] = $params['deleteActivityAssignment'] ?? $deleteActivityAssignment;
+  $params['deleteActivityTarget'] = $params['deleteActivityTarget'] ?? $deleteActivityTarget;
 
   if ($case_id && $createRevision) {
     // This is very similar to the copy-to-case action.

--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -219,9 +219,9 @@ function _civicrm_api3_attachment_delete_spec(&$spec) {
   unset($spec['id']['api.required']);
   $entityFileFields = CRM_Core_DAO_EntityFile::fields();
   $spec['entity_table'] = $entityFileFields['entity_table'];
-  $spec['entity_table']['title'] = CRM_Utils_Array::value('title', $spec['entity_table'], 'Entity Table') . ' (write-once)';
+  $spec['entity_table']['title'] .= ' (write-once)';
   $spec['entity_id'] = $entityFileFields['entity_id'];
-  $spec['entity_id']['title'] = CRM_Utils_Array::value('title', $spec['entity_id'], 'Entity ID') . ' (write-once)';
+  $spec['entity_id']['title'] .= ' (write-once)';
 }
 
 /**
@@ -352,7 +352,7 @@ function __civicrm_api3_attachment_find($params, $id, $file, $entityFile, $isTru
  * @throws API_Exception validation errors
  */
 function _civicrm_api3_attachment_parse_params($params) {
-  $id = CRM_Utils_Array::value('id', $params, NULL);
+  $id = $params['id'] ?? NULL;
   if ($id && !is_numeric($id)) {
     throw new API_Exception("Malformed id");
   }
@@ -479,10 +479,10 @@ function _civicrm_api3_attachment_getfields() {
   $spec['upload_date'] = $fileFields['upload_date'];
   $spec['entity_table'] = $entityFileFields['entity_table'];
   // Would be hard to securely handle changes.
-  $spec['entity_table']['title'] = CRM_Utils_Array::value('title', $spec['entity_table'], 'Entity Table') . ' (write-once)';
+  $spec['entity_table']['title'] .= ' (write-once)';
   $spec['entity_id'] = $entityFileFields['entity_id'];
   // would be hard to securely handle changes
-  $spec['entity_id']['title'] = CRM_Utils_Array::value('title', $spec['entity_id'], 'Entity ID') . ' (write-once)';
+  $spec['entity_id']['title'] .= ' (write-once)';
   $spec['url'] = [
     'title' => 'URL (read-only)',
     'description' => 'URL for downloading the file (not searchable, expire-able)',

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -587,7 +587,7 @@ function civicrm_api3_case_delete($params) {
   //check parameters
   civicrm_api3_verify_mandatory($params, NULL, ['id']);
 
-  if (CRM_Case_BAO_Case::deleteCase($params['id'], CRM_Utils_Array::value('move_to_trash', $params, FALSE))) {
+  if (CRM_Case_BAO_Case::deleteCase($params['id'], $params['move_to_trash'] ?? FALSE)) {
     return civicrm_api3_create_success($params, $params, 'Case', 'delete');
   }
   else {

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1585,7 +1585,7 @@ function civicrm_api3_contact_duplicatecheck($params) {
     $params['match'],
     $params['match']['contact_type'],
     $params['rule_type'],
-    CRM_Utils_Array::value('exclude', $params, []),
+    $params['exclude'] ?? [],
     CRM_Utils_Array::value('check_permissions', $params),
     CRM_Utils_Array::value('dedupe_rule_id', $params)
   );

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -435,7 +435,7 @@ function civicrm_api3_contribution_transact($params) {
   }
 
   // Some payment processors expect a unique invoice_id - generate one if not supplied
-  $params['invoice_id'] = CRM_Utils_Array::value('invoice_id', $params, md5(uniqid(rand(), TRUE)));
+  $params['invoice_id'] = $params['invoice_id'] ?? md5(uniqid(rand(), TRUE));
 
   $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($params['payment_processor'], $params['payment_processor_mode']);
   $paymentProcessor['object']->doPayment($params);
@@ -721,8 +721,8 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
     if (empty($domainFromEmail) && (empty($params['receipt_from_name']) || empty($params['receipt_from_email']))) {
       list($domainFromName, $domainFromEmail) = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
     }
-    $input['receipt_from_name'] = CRM_Utils_Array::value('receipt_from_name', $params, $domainFromName);
-    $input['receipt_from_email'] = CRM_Utils_Array::value('receipt_from_email', $params, $domainFromEmail);
+    $input['receipt_from_name'] = $params['receipt_from_name'] ?? $domainFromName;
+    $input['receipt_from_email'] = $params['receipt_from_email'] ?? $domainFromEmail;
   }
   $input['card_type_id'] = CRM_Utils_Array::value('card_type_id', $params);
   $input['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $params);

--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -136,7 +136,7 @@ function civicrm_api3_custom_value_get($params) {
 
   $getParams = [
     'entityID' => $params['entity_id'],
-    'entityType' => CRM_Utils_Array::value('entity_table', $params, ''),
+    'entityType' => $params['entity_table'] ?? '',
   ];
   if (strstr($getParams['entityType'], 'civicrm_')) {
     $getParams['entityType'] = ucfirst(substr($getParams['entityType'], 8));
@@ -356,7 +356,7 @@ function civicrm_api3_custom_value_gettree($params) {
       }
     }
   }
-  $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], $toReturn, $params['entity_id'], NULL, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));
+  $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], $toReturn, $params['entity_id'], NULL, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, $params['check_permissions'] ?? TRUE);
   unset($tree['info']);
   $result = [];
   foreach ($tree as $group) {

--- a/api/v3/Cxn.php
+++ b/api/v3/Cxn.php
@@ -139,7 +139,7 @@ function civicrm_api3_cxn_unregister($params) {
 
   /** @var \Civi\Cxn\Rpc\RegistrationClient $client */
   $client = \Civi::service('cxn_reg_client');
-  list($cxnId, $result) = $client->unregister($appMeta, CRM_Utils_Array::value('force', $params, FALSE));
+  list($cxnId, $result) = $client->unregister($appMeta, $params['force'] ?? FALSE);
 
   return $result;
 }

--- a/api/v3/DashboardContact.php
+++ b/api/v3/DashboardContact.php
@@ -89,7 +89,7 @@ function _civicrm_api3_dashboard_contact_create_spec(&$params) {
 function _civicrm_api3_dashboard_contact_check_params(&$params) {
   $dashboard_id = CRM_Utils_Array::value('dashboard_id', $params);
   if ($dashboard_id) {
-    $allDashlets = CRM_Core_BAO_Dashboard::getDashlets(TRUE, CRM_Utils_Array::value('check_permissions', $params, 0));
+    $allDashlets = CRM_Core_BAO_Dashboard::getDashlets(TRUE, $params['check_permissions'] ?? 0);
     if (!isset($allDashlets[$dashboard_id])) {
       return civicrm_api3_create_error('Invalid or inaccessible dashboard ID');
     }

--- a/api/v3/Dedupe.php
+++ b/api/v3/Dedupe.php
@@ -106,8 +106,8 @@ function civicrm_api3_dedupe_getstatistics($params) {
   $stats = CRM_Dedupe_Merger::getMergeStats(CRM_Dedupe_Merger::getMergeCacheKeyString(
     $params['rule_group_id'],
     CRM_Utils_Array::value('group_id', $params),
-    CRM_Utils_Array::value('criteria', $params, []),
-    CRM_Utils_Array::value('check_permissions', $params, [])
+    $params['criteria'] ?? [],
+    $params['check_permissions'] ?? []
   ));
   return civicrm_api3_create_success($stats);
 }
@@ -150,7 +150,7 @@ function _civicrm_api3_dedupe_getstatistics_spec(&$params) {
  */
 function civicrm_api3_dedupe_getduplicates($params) {
   $options = _civicrm_api3_get_options_from_params($params);
-  $dupePairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, TRUE, $options['limit'], FALSE, TRUE, $params['criteria'], CRM_Utils_Array::value('check_permissions', $params), CRM_Utils_Array::value('search_limit', $params, 0));
+  $dupePairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, TRUE, $options['limit'], FALSE, TRUE, $params['criteria'], CRM_Utils_Array::value('check_permissions', $params), $params['search_limit'] ?? 0);
   return civicrm_api3_create_success($dupePairs);
 }
 

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -254,7 +254,7 @@ function civicrm_api3_extension_download($params) {
   }
   CRM_Extension_System::singleton()->getCache()->flush();
   CRM_Extension_System::singleton(TRUE);
-  if (CRM_Utils_Array::value('install', $params, TRUE)) {
+  if (!empty($params['install'])) {
     CRM_Extension_System::singleton()->getManager()->install([$params['key']]);
   }
 
@@ -400,7 +400,7 @@ function civicrm_api3_extension_getremote($params) {
     $info = array_merge($info, (array) $obj);
     $result[] = $info;
   }
-  return _civicrm_api3_basic_array_get('Extension', $params, $result, 'id', CRM_Utils_Array::value('return', $params, []));
+  return _civicrm_api3_basic_array_get('Extension', $params, $result, 'id', $params['return'] ?? []);
 }
 
 /**

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -79,8 +79,8 @@ function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
   $subentity    = CRM_Utils_Array::value('contact_type', $apiRequest['params']);
   $action = CRM_Utils_Array::value('action', $apiRequest['params']);
   $sequential = empty($apiRequest['params']['sequential']) ? 0 : 1;
-  $apiRequest['params']['options'] = CRM_Utils_Array::value('options', $apiRequest['params'], []);
-  $optionsToResolve = (array) CRM_Utils_Array::value('get_options', $apiRequest['params']['options'], []);
+  $apiRequest['params']['options'] = $apiRequest['params']['options'] ?? [];
+  $optionsToResolve = (array) ($apiRequest['params']['options']['get_options'] ?? []);
 
   if (!$action || $action == 'getvalue' || $action == 'getcount') {
     $action = 'get';
@@ -472,7 +472,7 @@ function _civicrm_api3_generic_getoptions_spec(&$params, $apiRequest) {
     $params['field']['options'] = [];
     foreach ($fields['values'] as $name => $field) {
       if (isset($field['pseudoconstant']) || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_BOOLEAN) {
-        $params['field']['options'][$name] = CRM_Utils_Array::value('title', $field, $name);
+        $params['field']['options'][$name] = $field['title'] ?? $name;
       }
     }
   }

--- a/api/v3/Generic/Setvalue.php
+++ b/api/v3/Generic/Setvalue.php
@@ -72,7 +72,7 @@ function civicrm_api3_generic_setValue($apiRequest) {
   }
 
   $def = $fields[$fieldKey];
-  $title = CRM_Utils_Array::value('title', $def, ts('Field'));
+  $title = $def['title'] ?? ts('Field');
   // Disallow empty values except for the number zero.
   // TODO: create a utility for this since it's needed in many places
   if (!empty($def['required']) || !empty($def['is_required'])) {

--- a/api/v3/GroupContact.php
+++ b/api/v3/GroupContact.php
@@ -66,7 +66,7 @@ function civicrm_api3_group_contact_get($params) {
     //ie. id passed in so we have to return something
     return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
-  $status = CRM_Utils_Array::value('status', $params, 'Added');
+  $status = $params['status'] ?? 'Added';
 
   $groupId = CRM_Utils_Array::value('group_id', $params);
   $values = CRM_Contact_BAO_GroupContact::getContactGroup($params['contact_id'], $status, NULL, FALSE, TRUE, FALSE, TRUE, $groupId);
@@ -132,7 +132,7 @@ function civicrm_api3_group_contact_create($params) {
       $params['contact_id'] = $info['values'][$params['id']]['contact_id'];
     }
   }
-  $action = CRM_Utils_Array::value('status', $params, 'Added');
+  $action = $params['status'] ?? 'Added';
   return _civicrm_api3_group_contact_common($params, $action);
 }
 
@@ -164,7 +164,7 @@ function civicrm_api3_group_contact_delete($params) {
   if ($groupContact['count'] == 0 && $groupContact2['count'] == 0) {
     throw new API_Exception('Cannot Delete GroupContact');
   }
-  $params['status'] = CRM_Utils_Array::value('status', $params, empty($params['skip_undelete']) ? 'Removed' : 'Deleted');
+  $params['status'] = $params['status'] ?? (empty($params['skip_undelete']) ? 'Removed' : 'Deleted');
   // "Deleted" isn't a real option so skip the api wrapper to avoid pseudoconstant validation
   return civicrm_api3_group_contact_create($params);
 }
@@ -233,8 +233,8 @@ function _civicrm_api3_group_contact_common($params, $op = 'Added') {
     }
   }
 
-  $method = CRM_Utils_Array::value('method', $params, 'API');
-  $status = CRM_Utils_Array::value('status', $params, $op);
+  $method = $params['method'] ?? 'API';
+  $status = $params['status'] ?? $op;
   $tracking = CRM_Utils_Array::value('tracking', $params);
 
   if ($op == 'Added' || $op == 'Pending') {
@@ -290,7 +290,7 @@ function civicrm_api3_group_contact_update_status($params) {
   CRM_Contact_BAO_GroupContact::addContactsToGroup(
     [$params['contact_id']],
     $params['group_id'],
-    CRM_Utils_Array::value('method', $params, 'API'),
+    $params['method'] ?? 'API',
     'Added',
     CRM_Utils_Array::value('tracking', $params)
   );

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -539,9 +539,9 @@ function civicrm_api3_job_process_batch_merge($params) {
   }
   $rgid = CRM_Utils_Array::value('rgid', $params);
   $gid = CRM_Utils_Array::value('gid', $params);
-  $mode = CRM_Utils_Array::value('mode', $params, 'safe');
+  $mode = $params['mode'] ?? 'safe';
 
-  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, 1, 2, CRM_Utils_Array::value('criteria', $params, []), CRM_Utils_Array::value('check_permissions', $params));
+  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, 1, 2, $params['criteria'] ?? [], !empty($params['check_permissions']));
 
   return civicrm_api3_create_success($result, $params);
 }
@@ -617,15 +617,15 @@ function civicrm_api3_job_run_payment_cron($params) {
  *   Sends in various config parameters to decide what needs to be cleaned.
  */
 function civicrm_api3_job_cleanup($params) {
-  $session   = CRM_Utils_Array::value('session', $params, TRUE);
-  $tempTable = CRM_Utils_Array::value('tempTables', $params, TRUE);
-  $jobLog    = CRM_Utils_Array::value('jobLog', $params, TRUE);
-  $expired   = CRM_Utils_Array::value('expiredDbCache', $params, TRUE);
-  $prevNext  = CRM_Utils_Array::value('prevNext', $params, TRUE);
-  $dbCache   = CRM_Utils_Array::value('dbCache', $params, FALSE);
-  $memCache  = CRM_Utils_Array::value('memCache', $params, FALSE);
-  $tplCache  = CRM_Utils_Array::value('tplCache', $params, FALSE);
-  $wordRplc  = CRM_Utils_Array::value('wordRplc', $params, FALSE);
+  $session   = $params['session'] ?? TRUE;
+  $tempTable = $params['tempTables'] ?? TRUE;
+  $jobLog    = $params['jobLog'] ?? TRUE;
+  $expired   = $params['expiredDbCache'] ?? TRUE;
+  $prevNext  = $params['prevNext'] ?? TRUE;
+  $dbCache   = $params['dbCache'] ?? FALSE;
+  $memCache  = $params['memCache'] ?? FALSE;
+  $tplCache  = $params['tplCache'] ?? FALSE;
+  $wordRplc  = $params['wordRplc'] ?? FALSE;
 
   if ($session || $tempTable || $prevNext || $expired) {
     CRM_Core_BAO_Cache::cleanup($session, $tempTable, $prevNext, $expired);
@@ -688,7 +688,7 @@ function civicrm_api3_job_group_rebuild($params) {
     throw new API_Exception('Could not acquire lock, another GroupRebuild process is running');
   }
 
-  $limit = CRM_Utils_Array::value('limit', $params, 0);
+  $limit = $params['limit'] ?? 0;
 
   CRM_Contact_BAO_GroupContactCache::loadAll(NULL, $limit);
   $lock->release();

--- a/api/v3/LocBlock.php
+++ b/api/v3/LocBlock.php
@@ -70,7 +70,7 @@ function civicrm_api3_loc_block_create($params) {
         }
         // Bother calling the api.
         else {
-          $info['contact_id'] = CRM_Utils_Array::value('contact_id', $info, 'null');
+          $info['contact_id'] = $info['contact_id'] ?? 'null';
           $result = civicrm_api3($item, 'create', $info);
           $entities[$key] = $result['values'][$result['id']];
           $params[$key . '_id'] = $result['id'];

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -319,7 +319,7 @@ function civicrm_api3_mailing_submit($params) {
   if (isset($params['approval_date'])) {
     $updateParams['approval_date'] = $params['approval_date'];
     $updateParams['approver_id'] = CRM_Core_Session::getLoggedInContactID();
-    $updateParams['approval_status_id'] = CRM_Utils_Array::value('approval_status_id', $updateParams, CRM_Core_OptionGroup::getDefaultValue('mail_approval_status'));
+    $updateParams['approval_status_id'] = $updateParams['approval_status_id'] ?? CRM_Core_OptionGroup::getDefaultValue('mail_approval_status');
   }
   if (isset($params['approval_note'])) {
     $updateParams['approval_note'] = $params['approval_note'];
@@ -808,8 +808,8 @@ function civicrm_api3_mailing_stats($params) {
  */
 function civicrm_api3_mailing_update_email_resetdate($params) {
   CRM_Mailing_Event_BAO_Delivered::updateEmailResetDate(
-    CRM_Utils_Array::value('minDays', $params, 3),
-    CRM_Utils_Array::value('maxDays', $params, 3)
+    $params['minDays'] ?? 3,
+    $params['maxDays'] ?? 3
   );
   return civicrm_api3_create_success();
 }

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -112,7 +112,7 @@ function civicrm_api3_membership_create($params) {
         CRM_Utils_Array::value('join_date', $params),
         CRM_Utils_Array::value('start_date', $params),
         CRM_Utils_Array::value('end_date', $params),
-        CRM_Utils_Array::value('num_terms', $params, 1)
+        $params['num_terms'] ?? 1
       );
     }
     else {
@@ -230,7 +230,7 @@ function civicrm_api3_membership_get($params) {
     $activeOnly = $params['filters']['is_current'];
     unset($params['filters']['is_current']);
   }
-  $activeOnly = CRM_Utils_Array::value('active_only', $params, $activeOnly);
+  $activeOnly = $params['active_only'] ?? $activeOnly;
   if ($activeOnly && empty($params['status_id'])) {
     $params['status_id'] = ['IN' => CRM_Member_BAO_MembershipStatus::getMembershipStatusCurrent()];
   }

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -92,7 +92,7 @@ function civicrm_api3_order_create($params) {
     $priceSetID = NULL;
     CRM_Contribute_BAO_Contribution::checkLineItems($params);
     foreach ($params['line_items'] as $lineItems) {
-      $entityParams = CRM_Utils_Array::value('params', $lineItems, []);
+      $entityParams = $lineItems['params'] ?? [];
       if (!empty($entityParams) && !empty($lineItems['line_item'])) {
         $item = reset($lineItems['line_item']);
         $entity = str_replace('civicrm_', '', $item['entity_table']);

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -71,7 +71,7 @@ function civicrm_api3_payment_get($params) {
       }
     }
   }
-  return civicrm_api3_create_success(CRM_Utils_Array::value('values', $financialTrxn, []), $params, 'Payment', 'get');
+  return civicrm_api3_create_success($financialTrxn['values'] ?? [], $params, 'Payment', 'get');
 }
 
 /**
@@ -108,7 +108,7 @@ function civicrm_api3_payment_cancel($params) {
   $paymentParams = [
     'total_amount' => -$entity['amount'],
     'contribution_id' => $entity['entity_id'],
-    'trxn_date' => CRM_Utils_Array::value('trxn_date', $params, 'now'),
+    'trxn_date' => $params['trxn_date'] ?? 'now',
   ];
 
   foreach (['trxn_id', 'payment_instrument_id'] as $permittedParam) {

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -378,7 +378,7 @@ function civicrm_api3_profile_apply($params) {
     CRM_Utils_Array::value('contact_id', $params),
     $params['profile_id'],
     CRM_Utils_Array::value('contact_type', $params),
-    CRM_Utils_Array::value('skip_custom', $params, FALSE)
+    $params['skip_custom'] ?? FALSE
   );
 
   if (empty($data)) {

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -62,9 +62,9 @@ function civicrm_api3_setting_getfields($params) {
   }
   $result = CRM_Core_BAO_Setting::getSettingSpecification(
     CRM_Utils_Array::value('component_id', $params),
-    CRM_Utils_Array::value('filters', $params, []),
-    CRM_Utils_Array::value('domain_id', $params, NULL),
-    CRM_Utils_Array::value('profile', $params, NULL)
+    $params['filters'] ?? [],
+    $params['domain_id'] ?? NULL,
+    $params['profile'] ?? NULL
   );
   // find any supplemental information
   if (!empty($params['action'])) {
@@ -301,7 +301,7 @@ function _civicrm_api3_setting_create_spec(&$params) {
  */
 function civicrm_api3_setting_get($params) {
   $domains = _civicrm_api3_setting_getDomainArray($params);
-  $result = CRM_Core_BAO_Setting::getItems($params, $domains, CRM_Utils_Array::value('return', $params, []));
+  $result = CRM_Core_BAO_Setting::getItems($params, $domains, $params['return'] ?? []);
   return civicrm_api3_create_success($result, $params, 'Setting', 'get');
 }
 

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -45,8 +45,8 @@
  */
 function civicrm_api3_system_flush($params) {
   CRM_Core_Invoke::rebuildMenuAndCaches(
-    CRM_Utils_Array::value('triggers', $params, FALSE),
-    CRM_Utils_Array::value('session', $params, FALSE)
+    $params['triggers'] ?? FALSE,
+    $params['session'] ?? FALSE
   );
   return civicrm_api3_create_success();
 }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -521,12 +521,12 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
   $options = _civicrm_api3_get_options_from_params($params, TRUE);
 
   $inputParams = array_merge(
-    CRM_Utils_Array::value('input_params', $options, []),
-    CRM_Utils_Array::value('input_params', $additional_options, [])
+    $options['input_params'] ?? [],
+    $additional_options['input_params'] ?? []
   );
   $returnProperties = array_merge(
-    CRM_Utils_Array::value('return', $options, []),
-    CRM_Utils_Array::value('return', $additional_options, [])
+    $options['return'] ?? [],
+    $additional_options['return'] ?? []
   );
   if (empty($returnProperties)) {
     $returnProperties = $defaultReturnProperties;
@@ -549,9 +549,9 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
     }
   }
   $options = array_merge($options, $additional_options);
-  $sort             = CRM_Utils_Array::value('sort', $options, NULL);
-  $offset             = CRM_Utils_Array::value('offset', $options, NULL);
-  $limit             = CRM_Utils_Array::value('limit', $options, NULL);
+  $sort             = $options['sort'] ?? NULL;
+  $offset             = $options['offset'] ?? NULL;
+  $limit             = $options['limit'] ?? NULL;
   $smartGroupCache  = CRM_Utils_Array::value('smartGroupCache', $params);
 
   if ($getCount) {
@@ -600,11 +600,11 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
  */
 function _civicrm_api3_get_query_object($params, $mode, $entity) {
   $options = _civicrm_api3_get_options_from_params($params, TRUE, $entity, 'get');
-  $sort = CRM_Utils_Array::value('sort', $options, NULL);
+  $sort = $options['sort'] ?? NULL;
   $offset = CRM_Utils_Array::value('offset', $options);
   $rowCount = CRM_Utils_Array::value('limit', $options);
-  $inputParams = CRM_Utils_Array::value('input_params', $options, []);
-  $returnProperties = CRM_Utils_Array::value('return', $options, NULL);
+  $inputParams = $options['input_params'] ?? [];
+  $returnProperties = $options['return'] ?? NULL;
   if (empty($returnProperties)) {
     $returnProperties = CRM_Contribute_BAO_Query::defaultReturnProperties($mode);
   }
@@ -786,25 +786,25 @@ function _civicrm_api3_apply_filters_to_dao($filterField, $filterValue, &$dao) {
 function _civicrm_api3_get_options_from_params($params, $queryObject = FALSE, $entity = '', $action = '') {
   $lowercase_entity = _civicrm_api_get_entity_name_from_camel($entity);
   $is_count = FALSE;
-  $sort = CRM_Utils_Array::value('sort', $params, 0);
-  $sort = CRM_Utils_Array::value('option.sort', $params, $sort);
-  $sort = CRM_Utils_Array::value('option_sort', $params, $sort);
+  $sort = $params['sort'] ?? 0;
+  $sort = $params['option.sort'] ?? $sort;
+  $sort = $params['option_sort'] ?? $sort;
 
-  $offset = CRM_Utils_Array::value('offset', $params, 0);
-  $offset = CRM_Utils_Array::value('option.offset', $params, $offset);
+  $offset = $params['offset'] ?? 0;
+  $offset = $params['option.offset'] ?? $offset;
   // dear PHP thought it would be a good idea to transform a.b into a_b in the get/post
-  $offset = CRM_Utils_Array::value('option_offset', $params, $offset);
+  $offset = $params['option_offset'] ?? $offset;
 
-  $limit = CRM_Utils_Array::value('rowCount', $params, 25);
-  $limit = CRM_Utils_Array::value('option.limit', $params, $limit);
-  $limit = CRM_Utils_Array::value('option_limit', $params, $limit);
+  $limit = $params['rowCount'] ?? 25;
+  $limit = $params['option.limit'] ?? $limit;
+  $limit = $params['option_limit'] ?? $limit;
 
   if (is_array(CRM_Utils_Array::value('options', $params))) {
     // is count is set by generic getcount not user
     $is_count = CRM_Utils_Array::value('is_count', $params['options']);
-    $offset = CRM_Utils_Array::value('offset', $params['options'], $offset);
-    $limit  = CRM_Utils_Array::value('limit', $params['options'], $limit);
-    $sort   = CRM_Utils_Array::value('sort', $params['options'], $sort);
+    $offset = $params['options']['offset'] ?? $offset;
+    $limit  = $params['options']['limit'] ?? $limit;
+    $sort   = $params['options']['sort'] ?? $sort;
   }
 
   $returnProperties = [];
@@ -959,7 +959,7 @@ function _civicrm_api3_build_fields_array(&$bao, $unique = TRUE) {
 function _civicrm_api3_get_unique_name_array(&$bao) {
   $fields = $bao->fields();
   foreach ($fields as $field => $values) {
-    $uniqueFields[$field] = CRM_Utils_Array::value('name', $values, $field);
+    $uniqueFields[$field] = $values['name'] ?? $field;
   }
   return $uniqueFields;
 }
@@ -1246,7 +1246,7 @@ function _civicrm_api3_basic_get($bao_name, $params, $returnAsSuccess = TRUE, $e
   $entity = $entity ?: CRM_Core_DAO_AllCoreTables::getBriefName(str_replace('_BAO_', '_DAO_', $bao_name));
   $options = _civicrm_api3_get_options_from_params($params);
 
-  $query = new \Civi\API\Api3SelectQuery($entity, CRM_Utils_Array::value('check_permissions', $params, FALSE));
+  $query = new \Civi\API\Api3SelectQuery($entity, $params['check_permissions'] ?? FALSE);
   $query->where = $params;
   if ($options['is_count']) {
     $query->select = ['count_rows'];
@@ -1985,7 +1985,7 @@ function _civicrm_api_get_custom_fields($entity, &$params) {
     // Regular fields have a 'name' property
     $value['name'] = 'custom_' . $key;
     $value['title'] = $value['label'];
-    if ($value['data_type'] == 'Date' && CRM_Utils_Array::value('time_format', $value, 0) > 0) {
+    if ($value['data_type'] == 'Date' && $value['time_format'] ?? 0 > 0) {
       $value['data_type'] = 'DateTime';
     }
     $value['type'] = CRM_Utils_Array::value($value['data_type'], CRM_Core_BAO_CustomField::dataToType());
@@ -2300,7 +2300,7 @@ function _civicrm_api3_api_match_pseudoconstant(&$fieldValue, $entity, $fieldNam
     }
     $options = civicrm_api($entity, 'getoptions', $options_lookup_params);
 
-    $options = CRM_Utils_Array::value('values', $options, []);
+    $options = $options['values'] ?? [];
   }
 
   // If passed a value-separated string, explode to an array, then re-implode after matching values.
@@ -2412,7 +2412,7 @@ function _civicrm_api3_api_resolve_alias($entity, $fieldName, $action = 'create'
     if ($fieldName == $info['name'] || $fieldName == CRM_Utils_Array::value('uniqueName', $info)) {
       return $info['name'];
     }
-    if (array_search($fieldName, CRM_Utils_Array::value('api.aliases', $info, [])) !== FALSE) {
+    if (array_search($fieldName, $info['api.aliases'] ?? []) !== FALSE) {
       return $info['name'];
     }
   }
@@ -2491,7 +2491,7 @@ function _civicrm_api3_field_value_check(&$params, $fieldName, $type = NULL) {
  */
 function _civicrm_api3_basic_array_get($entity, $params, $records, $idCol, $filterableFields) {
   $options = _civicrm_api3_get_options_from_params($params, TRUE, $entity, 'get');
-  // TODO // $sort = CRM_Utils_Array::value('sort', $options, NULL);
+  // TODO // $sort = $options['sort'] ?? NULL;
   $offset = CRM_Utils_Array::value('offset', $options);
   $limit = CRM_Utils_Array::value('limit', $options);
 
@@ -2523,7 +2523,7 @@ function _civicrm_api3_basic_array_get($entity, $params, $records, $idCol, $filt
     }
   }
 
-  $return = CRM_Utils_Array::value('return', $options, []);
+  $return = $options['return'] ?? [];
   if (!empty($return)) {
     $return['id'] = 1;
     $matches = CRM_Utils_Array::filterColumns($matches, array_keys($return));

--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -431,7 +431,7 @@ class CiviContributeProcessor {
     }
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      CRM_Utils_Array::value('id', $params, NULL),
+      $params['id'] ?? NULL,
       'Contribution'
     );
     // create contribution

--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -336,7 +336,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     $freq = [];
     for ($i = 0; $i < $trials; $i++) {
       $message = $communityMessages->pick();
-      $freq[$message['markup']] = CRM_Utils_Array::value($message['markup'], $freq, 0) + 1;
+      $freq[$message['markup']] = $freq[$message['markup']] ?? 0 + 1;
     }
 
     // assert the probabilities
@@ -364,7 +364,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     $freq = [];
     for ($i = 0; $i < $trials; $i++) {
       $message = $communityMessages->pick();
-      $freq[$message['markup']] = CRM_Utils_Array::value($message['markup'], $freq, 0) + 1;
+      $freq[$message['markup']] = $freq[$message['markup']] ?? 0 + 1;
     }
 
     $this->assertEquals($trials, $freq['<h1>Two</h1>']);

--- a/tests/phpunit/CRM/Core/FieldOptionsTest.php
+++ b/tests/phpunit/CRM/Core/FieldOptionsTest.php
@@ -95,7 +95,7 @@ class CRM_Core_FieldOptionsTest extends CiviUnitTestCase {
       foreach ($baoFields as $field) {
         $message = "BAO name: '{$baoName}', field: '{$field['fieldName']}'";
 
-        $props = CRM_Utils_Array::value('props', $field, []);
+        $props = $field['props'] ?? [];
         $optionValues = $baoName::buildOptions($field['fieldName'], 'create', $props);
         $this->assertNotEmpty($optionValues, $message);
 
@@ -108,7 +108,7 @@ class CRM_Core_FieldOptionsTest extends CiviUnitTestCase {
         }
 
         // Ensure count of optionValues is not extraordinarily high.
-        $max = CRM_Utils_Array::value('max', $field, 10);
+        $max = $field['max'] ?? 10;
         $this->assertLessThanOrEqual($max, count($optionValues), $message);
       }
     }

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -1056,7 +1056,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
         }
 
         // Ensure count of optionValues is not extraordinarily high.
-        $max = CRM_Utils_Array::value('max', $field, 20);
+        $max = $field['max'] ?? 20;
         $this->assertLessThanOrEqual($max, count($optionValues), $message);
       }
     }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -2807,22 +2807,22 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   protected function doExportTest($params) {
     $this->startCapturingOutput();
     try {
-      $exportMode = CRM_Utils_Array::value('exportMode', $params, CRM_Export_Form_Select::CONTACT_EXPORT);
-      $ids = CRM_Utils_Array::value('ids', $params, ($exportMode === CRM_Export_Form_Select::CONTACT_EXPORT ? $this->contactIDs : []));
+      $exportMode = $params['exportMode'] ?? CRM_Export_Form_Select::CONTACT_EXPORT;
+      $ids = $params['ids'] ?? ($exportMode === CRM_Export_Form_Select::CONTACT_EXPORT ? $this->contactIDs : []);
       $defaultClause = (empty($ids) ? NULL : "contact_a.id IN (" . implode(',', $ids) . ")");
       CRM_Export_BAO_Export::exportComponents(
-        CRM_Utils_Array::value('selectAll', $params, (empty($params['fields']))),
+        $params['selectAll'] ?? (empty($params['fields'])),
         $ids,
-        CRM_Utils_Array::value('params', $params, []),
+        $params['params'] ?? [],
         CRM_Utils_Array::value('order', $params),
-        CRM_Utils_Array::value('fields', $params, []),
+        $params['fields'] ?? [],
         CRM_Utils_Array::value('moreReturnProperties', $params),
         $exportMode,
-        CRM_Utils_Array::value('componentClause', $params, $defaultClause),
+        $params['componentClause'] ?? $defaultClause,
         CRM_Utils_Array::value('componentTable', $params),
-        CRM_Utils_Array::value('mergeSameAddress', $params, FALSE),
-        CRM_Utils_Array::value('mergeSameHousehold', $params, FALSE),
-        CRM_Utils_Array::value('exportParams', $params, [])
+        $params['mergeSameAddress'] ?? FALSE,
+        $params['mergeSameHousehold'] ?? FALSE,
+        $params['exportParams'] ?? []
       );
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {

--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -364,7 +364,7 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
         'limit' => 0,
       ],
     ]);
-    $result = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
+    $result = $membershipTypesResult['values'] ?? NULL;
     $this->assertEquals(empty($result), FALSE, 'Verify membership types for organization.');
 
     $membershipTypesResult = civicrm_api3('MembershipType', 'get', [
@@ -373,7 +373,7 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
         'limit' => 0,
       ],
     ]);
-    $result = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
+    $result = $membershipTypesResult['values'] ?? NULL;
     $this->assertEquals(empty($result), TRUE, 'Verify membership types for organization.');
 
     $this->membershipTypeDelete(['id' => $membershipType->id]);

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -53,7 +53,7 @@ class CRM_Utils_MailTest extends CiviUnitTestCase {
     foreach ($values as $value) {
       $result = CRM_Utils_Mail::formatRFC822Email($value['name'],
         $value['email'],
-        CRM_Utils_Array::value('useQuote', $value, FALSE)
+        $value['useQuote'] ?? FALSE
       );
       $this->assertEquals($result, $value['result'], 'Expected encoding does not match');
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1852,7 +1852,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
         $keys[CRM_Utils_Array::Value('name', $settings, $field)] = $field;
       }
       else {
-        $keys[CRM_Utils_Array::Value('name', $settings, $field)] = CRM_Utils_Array::value('name', $settings, $field);
+        $keys[CRM_Utils_Array::Value('name', $settings, $field)] = $settings['name'] ?? $field;
       }
       $type = CRM_Utils_Array::value('type', $settings);
       if ($type == CRM_Utils_Type::T_DATE) {
@@ -2811,7 +2811,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     if ($context != 'online' && $context != 'payLater') {
       $compareParams = array(
         'to_financial_account_id' => 6,
-        'total_amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'total_amount' => $params['total_amount'] ?? 100,
         'status_id' => 1,
       );
     }
@@ -2821,15 +2821,15 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     elseif ($context == 'online') {
       $compareParams = array(
         'to_financial_account_id' => 12,
-        'total_amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'total_amount' => $params['total_amount'] ?? 100,
         'status_id' => 1,
-        'payment_instrument_id' => CRM_Utils_Array::value('payment_instrument_id', $params, 1),
+        'payment_instrument_id' => $params['payment_instrument_id'] ?? 1,
       );
     }
     elseif ($context == 'payLater') {
       $compareParams = array(
         'to_financial_account_id' => 7,
-        'total_amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'total_amount' => $params['total_amount'] ?? 100,
         'status_id' => 2,
       );
     }
@@ -2843,15 +2843,15 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'id' => $entityTrxn['entity_id'],
     );
     $compareParams = array(
-      'amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+      'amount' => $params['total_amount'] ?? 100,
       'status_id' => 1,
-      'financial_account_id' => CRM_Utils_Array::value('financial_account_id', $params, 1),
+      'financial_account_id' => $params['financial_account_id'] ?? 1,
     );
     if ($context == 'payLater') {
       $compareParams = array(
-        'amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'amount' => $params['total_amount'] ?? 100,
         'status_id' => 3,
-        'financial_account_id' => CRM_Utils_Array::value('financial_account_id', $params, 1),
+        'financial_account_id' => $params['financial_account_id'] ?? 1,
       );
     }
     $this->assertDBCompareValues('CRM_Financial_DAO_FinancialItem', $fitemParams, $compareParams);

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -303,7 +303,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
       $membetype = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($type);
       $fieldParams['option_id'] = [1 => $priceFieldValue['id']];
       $fieldParams['option_label'][$rowCount] = CRM_Utils_Array::value('name', $membetype);
-      $fieldParams['option_amount'][$rowCount] = CRM_Utils_Array::value('minimum_fee', $membetype, 0);
+      $fieldParams['option_amount'][$rowCount] = $membetype['minimum_fee'] ?? 0;
       $fieldParams['option_weight'][$rowCount] = CRM_Utils_Array::value('weight', $membetype);
       $fieldParams['option_description'][$rowCount] = CRM_Utils_Array::value('description', $membetype);
       $fieldParams['option_financial_type_id'][$rowCount] = CRM_Utils_Array::value('financial_type_id', $membetype);

--- a/tests/phpunit/api/v3/SelectQueryTest.php
+++ b/tests/phpunit/api/v3/SelectQueryTest.php
@@ -75,7 +75,7 @@ class api_v3_SelectQueryTest extends CiviUnitTestCase {
   public function hook_civicrm_selectWhereClause($entity, &$clauses) {
     if ($entity == $this->hookEntity) {
       foreach ($this->hookCondition as $field => $clause) {
-        $clauses[$field] = array_merge(CRM_Utils_Array::value($field, $clauses, []), $clause);
+        $clauses[$field] = array_merge($clauses[$field] ?? [], $clause);
       }
     }
   }

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1472,7 +1472,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           $entity[$field] = 'warm.beer.com';
       }
       if (empty($specs['FKClassName']) && (!empty($specs['pseudoconstant']) || !empty($specs['options']))) {
-        $options = CRM_Utils_Array::value('options', $specs, []);
+        $options = $specs['options'] ?? [];
         if (!$options) {
           //eg. pdf_format id doesn't ship with any
           if (isset($specs['pseudoconstant']['optionGroupName'])) {
@@ -1482,7 +1482,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
               'sequential' => 1,
             ]);
             $optionValue = $optionValue['values'];
-            $keyColumn = CRM_Utils_Array::value('keyColumn', $specs['pseudoconstant'], 'value');
+            $keyColumn = $specs['pseudoconstant']['keyColumn'] ?? 'value';
             $options[$optionValue[0][$keyColumn]] = 'new option value';
           }
         }

--- a/tools/scripts/solr/createSyncJSON.php
+++ b/tools/scripts/solr/createSyncJSON.php
@@ -490,7 +490,7 @@ function getDBFields($daoName) {
       $_fieldsRetrieved[$daoName][$value['name']] = [
         'uniqueName' => $key,
         'type' => $value['type'],
-        'title' => CRM_Utils_Array::value('title', $value, NULL),
+        'title' => $value['title'] ?? NULL,
       ];
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
PHP 7 finally has a built-in language construct that does basically the same thing as our homebrew function. Swapping the two is more efficient and easier to read.

Before
----------------------------------------
Less efficient: `CRM_Utils_Array::value($key, $array, $default)`

After
----------------------------------------
More efficient: `$array[$key] ?? $default`

Notes
-----------
I did this with a regex but then manually checked the results and tweaked some of them that were particularly weird or that could be further simplified (for example within an `if()` statement the whole thing could be swapped for `!empty()`.

Technical Details
----------------------------------------
The difference in functionality between these two constructs is negligible. Technically there is one difference: if the item exists in the array but has a value of `null`, then `CRM_Utils_Array::value()` would return `null` whereas ?? would return the default. However I think it's unlikely any developer was relying on this quirk.