### PR TITLE
dev/core#860: discount not applied to line item: call buildAmount hook in CRM_Member_Form_Membership::submit().

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1162,6 +1162,26 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
     $lineItem = [$this->_priceSetId => []];
 
+    // BEGIN Fix for dev/core/issues/860
+    // Prepare $feeBlock for call to buildAmount hook - code based on
+    // CRM_Price_BAO_PriceSet::buildPriceSet().
+    $feeBlock = &$this->_priceSet['fields'];
+    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
+      foreach ($feeBlock as $key => $value) {
+        foreach ($value['options'] as $k => $options) {
+          if (!CRM_Core_Permission::check('add contributions of type ' . CRM_Contribute_PseudoConstant::financialType($options['financial_type_id']))) {
+            unset($feeBlock[$key]['options'][$k]);
+          }
+        }
+        if (empty($feeBlock[$key]['options'])) {
+          unset($feeBlock[$key]);
+        }
+      }
+    }
+    // Call buildAmount hook.
+    CRM_Utils_Hook::buildAmount('membership', $this, $feeBlock);
+    // END Fix for dev/core/issues/860
+
     CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],
       $formValues, $lineItem[$this->_priceSetId], NULL, $this->_priceSetId);
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1163,23 +1163,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $lineItem = [$this->_priceSetId => []];
 
     // BEGIN Fix for dev/core/issues/860
-    // Prepare $feeBlock for call to buildAmount hook - code based on
-    // CRM_Price_BAO_PriceSet::buildPriceSet().
-    $feeBlock = &$this->_priceSet['fields'];
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
-      foreach ($feeBlock as $key => $value) {
-        foreach ($value['options'] as $k => $options) {
-          if (!CRM_Core_Permission::check('add contributions of type ' . CRM_Contribute_PseudoConstant::financialType($options['financial_type_id']))) {
-            unset($feeBlock[$key]['options'][$k]);
-          }
-        }
-        if (empty($feeBlock[$key]['options'])) {
-          unset($feeBlock[$key]);
-        }
-      }
-    }
-    // Call buildAmount hook.
-    CRM_Utils_Hook::buildAmount('membership', $this, $feeBlock);
+    // Prepare fee block and call buildAmount hook - based on CRM_Price_BAO_PriceSet::buildPriceSet().
+    CRM_Price_BAO_PriceSet::applyACLFinancialTypeStatusToFeeBlock($this->_priceSet['fields']);
+    CRM_Utils_Hook::buildAmount('membership', $this, $this->_priceSet['fields']);
     // END Fix for dev/core/issues/860
 
     CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1008,19 +1008,9 @@ WHERE  id = %1";
     else {
       $feeBlock = &$form->_priceSet['fields'];
     }
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
-      foreach ($feeBlock as $key => $value) {
-        foreach ($value['options'] as $k => $options) {
-          if (!CRM_Core_Permission::check('add contributions of type ' . CRM_Contribute_PseudoConstant::financialType($options['financial_type_id']))) {
-            unset($feeBlock[$key]['options'][$k]);
-          }
-        }
-        if (empty($feeBlock[$key]['options'])) {
-          unset($feeBlock[$key]);
-        }
-      }
-    }
-    // call the hook.
+
+    self::applyACLFinancialTypeStatusToFeeBlock($feeBlock);
+    // Call the buildAmount hook.
     CRM_Utils_Hook::buildAmount($component, $form, $feeBlock);
 
     // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions
@@ -1069,6 +1059,29 @@ WHERE  id = %1";
             NULL,
             $options
           );
+        }
+      }
+    }
+  }
+
+  /**
+   * Apply ACLs on Financial Type to the price options in a fee block.
+   *
+   * @param array $feeBlock
+   *   Fee block: array of price fields.
+   *
+   * @return void
+   */
+  public static function applyACLFinancialTypeStatusToFeeBlock(&$feeBlock) {
+    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
+      foreach ($feeBlock as $key => $value) {
+        foreach ($value['options'] as $k => $options) {
+          if (!CRM_Core_Permission::check('add contributions of type ' . CRM_Contribute_PseudoConstant::financialType($options['financial_type_id']))) {
+            unset($feeBlock[$key]['options'][$k]);
+          }
+        }
+        if (empty($feeBlock[$key]['options'])) {
+          unset($feeBlock[$key]);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix for dev/core/issues/860 [Incorrect line item created for back-end membership sign-up using price set and CiviDiscount](https://lab.civicrm.org/dev/core/issues/860).

This is an alternative approach to the one in PR #14994, which caused test failures. See Technical Details below.

Before
----------------------------------------
When doing a back-end membership sign-up using a price set, with an additional item e.g. donation and with a CiviDiscount code applying to the membership, the line item created for the membership does not reflect the discount but the contribution total does. The problem does not occur without the additional item.

**Steps to replicate**
1. Create a CiviDiscount code for e.g. 25% off General membership.
2. Create a membership price set with 2 fields: Membership with options General & Student; Donation text field.
3. Create a contribution page using the price set (we don't use this here but in my testing, the discount did not work on back-end sign-ups until I did this step.)
4. Go to a contact's summary -> Memberships tab and click Add Membership.
5. Enter the discount code & Apply.
6. Choose price set -> select the above price set.
7. You may need to click Apply again to get the discount to show for General membership.
8. Select "General (Includes applied discount: 25% Test for General membership) - $ 75.00".
9. Enter a donation amount, e.g. $5.
10. Leave "Record Membership Payment?" ticked, leave other fields as default.
11. Click Save.

**Expected result**
Contribution created with total amount $80 and 2 line items:
- entity_table: civicrm_membership, line total $75.00
- entity_table: civicrm_contribution, line total $5.00

**Actual result**
Contribution created with total amount $80 and 2 line items:
- entity_table: civicrm_membership, line total $100.00
- entity_table: civicrm_contribution, line total $5.00

Note that the membership line item has the wrong amount and the sum of the line items is not equal to the contribution amount.

After
----------------------------------------
Actual result = Expected result

Technical Details
----------------------------------------
I traced the misbehaviour in a debugger and found that the price set was being instantiated twice, once with the discount, once without, causing the line items to be calculated without the discount. However if there was only one line item, a different route through the code kicked in, overriding the line item amount. I have some detailed notes from debugger sessions if those would be of interest.

I tried a couple of different approaches to fixing:

1. PR #14994: avoid instantiating the price set twice by checking, in CRM_Member_Form_Membership::submit(), whether $this->_priceSet is already set: if it is, we skip the call to $this->setPriceSetParameters(). This worked in my testing but led to unit test failures.

2. This PR: insert a call to the buildAmount hook when instantiating the price set for the second time. This also works in my testing. It
(a) requires duplicating some code for setting up the fee block, including checking isACLFinancialTypeStatus() and
(b) retains the second instantiation of the price set.
