### PR TITLE
Swap CRM_Utils_Array::value for empty() in conditionals

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -312,9 +312,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
 
     // Set priority to Normal for Auto-populated activities (for Cases)
-    if (CRM_Utils_Array::value('priority_id', $params) === NULL &&
+    if (!isset($params['priority_id']) &&
       // if not set and not 0
-      !CRM_Utils_Array::value('id', $params)
+      empty($params['id'])
     ) {
       $priority = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id');
       $params['priority_id'] = array_search('Normal', $priority);

--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -205,7 +205,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
         'version' => 3,
         'key' => $this->_key,
       ]);
-      if (!CRM_Utils_Array::value('is_error', $result, FALSE)) {
+      if (empty($result['is_error'])) {
         CRM_Core_Session::setStatus("", ts('Extension Upgraded'), "success");
       }
       else {

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -523,7 +523,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       'end_date',
     ];
 
-    if (!CRM_Utils_Array::value('absolute_date', $params)) {
+    if (empty($params['absolute_date'])) {
       $params['absolute_date'] = 'null';
     }
     foreach ($moreKeys as $mkey) {
@@ -577,7 +577,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
     $params['is_active'] = CRM_Utils_Array::value('is_active', $values, 0);
 
-    if (CRM_Utils_Array::value('is_repeat', $values) == 0) {
+    if (empty($values['is_repeat'])) {
       $params['repetition_frequency_unit'] = 'null';
       $params['repetition_frequency_interval'] = 'null';
       $params['end_frequency_unit'] = 'null';

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -220,7 +220,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     }
 
     // add a new db locale if the requested language is not yet supported by the db
-    if (!CRM_Utils_Array::value('makeSinglelingual', $values) and CRM_Utils_Array::value('addLanguage', $values)) {
+    if (empty($values['makeSinglelingual']) && !empty($values['addLanguage'])) {
       $domain = new CRM_Core_DAO_Domain();
       $domain->find(TRUE);
       if (!substr_count($domain->locales, $values['addLanguage'])) {

--- a/CRM/Badge/BAO/Badge.php
+++ b/CRM/Badge/BAO/Badge.php
@@ -225,8 +225,8 @@ class CRM_Badge_BAO_Badge {
           break;
       }
       $this->pdf->Image($formattedRow['participant_image'], $x + $imageAlign, $y + $startOffset, CRM_Utils_Array::value('width_participant_image', $formattedRow), CRM_Utils_Array::value('height_participant_image', $formattedRow));
-      if ($startOffset == NULL && CRM_Utils_Array::value('height_participant_image', $formattedRow)) {
-        $startOffset = CRM_Utils_Array::value('height_participant_image', $formattedRow);
+      if ($startOffset == NULL && !empty($formattedRow['height_participant_image'])) {
+        $startOffset = $formattedRow['height_participant_image'];
       }
     }
 

--- a/CRM/Case/Form/Activity/ChangeCaseType.php
+++ b/CRM/Case/Form/Activity/ChangeCaseType.php
@@ -119,7 +119,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
       $params['id'] = $form->_id;
     }
 
-    if (CRM_Utils_Array::value('is_reset_timeline', $params) == 0) {
+    if (empty($params['is_reset_timeline'])) {
       unset($params['reset_date_time']);
     }
   }

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -62,7 +62,7 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     // check if $contactType is valid
     $contactTypes = civicrm_api3('Contact', 'getOptions', ['field' => "contact_type", 'context' => "validate"]);
     $contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
-    if (CRM_Utils_Array::value($contactType, $contactTypes['values'])) {
+    if (!empty($contactTypes['values'][$contactType])) {
       $this->_contactType = $contactType;
     }
     elseif (!empty($contactType)) {

--- a/CRM/Contact/Form/Task/ProximityCommon.php
+++ b/CRM/Contact/Form/Task/ProximityCommon.php
@@ -107,9 +107,7 @@ class CRM_Contact_Form_Task_ProximityCommon {
       if (empty($fields['prox_state_province_id']) || empty($fields['prox_country_id'])) {
         $errors["prox_state_province_id"] = ts("Country AND State/Province are required to search by distance.");
       }
-      if (!CRM_Utils_Array::value('prox_postal_code', $fields) and
-        !CRM_Utils_Array::value('prox_city', $fields)
-      ) {
+      if (empty($fields['prox_postal_code']) && empty($fields['prox_city'])) {
         $errors["prox_distance"] = ts("City OR Postal Code are required to search by distance.");
       }
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2962,7 +2962,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         if (!empty($lineItems)) {
           $firstLineItem = reset($lineItems);
           $priceSet = [];
-          if (CRM_Utils_Array::value('price_set_id', $firstLineItem)) {
+          if (!empty($firstLineItem['price_set_id'])) {
             $priceSet = civicrm_api3('PriceSet', 'getsingle', [
               'id' => $firstLineItem['price_set_id'],
               'return' => 'is_quick_config, id',
@@ -4013,7 +4013,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $baseTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contributionId);
       $baseTrxnId = $baseTrxnId['financialTrxnId'];
     }
-    if (!CRM_Utils_Array::value('total_amount', $total) || $usingLineTotal) {
+    if (empty($total['total_amount']) || $usingLineTotal) {
       $total = CRM_Price_BAO_LineItem::getLineTotal($contributionId);
     }
     else {
@@ -4538,7 +4538,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $contributionResult = civicrm_api3('Contribution', 'create', $contributionParams);
 
     // Add new soft credit against current $contribution.
-    if (CRM_Utils_Array::value('contributionRecur', $objects) && $objects['contributionRecur']->id) {
+    if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id) {
       CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($objects['contributionRecur']->id, $contribution->id);
     }
 
@@ -5046,7 +5046,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   public static function checkContributeSettings($name = NULL, $checkInvoicing = FALSE) {
     $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
 
-    if ($checkInvoicing && !CRM_Utils_Array::value('invoicing', $contributeSettings)) {
+    if ($checkInvoicing && empty($contributeSettings['invoicing'])) {
       return NULL;
     }
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -665,10 +665,10 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $componentDetails = [];
     if ($this->_id) {
       $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
-      if (CRM_Utils_Array::value('membership', $componentDetails)) {
+      if (!empty($componentDetails['membership'])) {
         $component = 'membership';
       }
-      elseif (CRM_Utils_Array::value('participant', $componentDetails)) {
+      elseif (!empty($componentDetails['participant'])) {
         $component = 'participant';
       }
     }
@@ -831,8 +831,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
       $isCancelledStatus = ($this->_values['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled'));
 
-      if (CRM_Utils_Array::value('membership', $componentDetails) ||
-        CRM_Utils_Array::value('participant', $componentDetails) ||
+      if (!empty($componentDetails['membership']) ||
+        !empty($componentDetails['participant']) ||
         // if status is Cancelled freeze Amount, Payment Instrument, Check #, Financial Type,
         // Net and Fee Amounts are frozen in AdditionalInfo::buildAdditionalDetail
         $isCancelledStatus
@@ -1710,7 +1710,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   protected function invoicingPostProcessHook($submittedValues, $action, $lineItem) {
 
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    if (!CRM_Utils_Array::value('invoicing', $invoiceSettings)) {
+    if (empty($invoiceSettings['invoicing'])) {
       return;
     }
     $taxRate = [];

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -117,7 +117,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $pledgeParams['frequency_day'] = 1;
       }
       $pledgeParams['create_date'] = $pledgeParams['start_date'] = $pledgeParams['scheduled_date'] = date("Ymd");
-      if (CRM_Utils_Array::value('start_date', $params)) {
+      if (!empty($params['start_date'])) {
         $pledgeParams['frequency_day'] = intval(date("d", strtotime(CRM_Utils_Array::value('start_date', $params))));
         $pledgeParams['start_date'] = $pledgeParams['scheduled_date'] = date('Ymd', strtotime(CRM_Utils_Array::value('start_date', $params)));
       }
@@ -1942,7 +1942,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $form->_fields['billing_first_name'] = 1;
     $form->_fields['billing_last_name'] = 1;
     // CRM-18854 - Set form values to allow pledge to be created for api test.
-    if (CRM_Utils_Array::value('pledge_block_id', $params)) {
+    if (!empty($params['pledge_block_id'])) {
       $form->_values['pledge_id'] = CRM_Utils_Array::value('pledge_id', $params, NULL);
       $form->_values['pledge_block_id'] = $params['pledge_block_id'];
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($params['id']);

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -631,9 +631,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   public static function formRule($fields, $files, $self) {
     $errors = [];
     $amount = self::computeAmount($fields, $self->_values);
-    if (CRM_Utils_Array::value('auto_renew', $fields) &&
-      CRM_Utils_Array::value('payment_processor_id', $fields) == 0
-    ) {
+    if (!empty($fields['auto_renew']) && empty($fields['payment_processor_id'])) {
       $errors['auto_renew'] = ts('You cannot have auto-renewal on if you are paying later.');
     }
 
@@ -876,15 +874,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     //CRM-16285 - Function to handle validation errors on form, for recurring contribution field.
     CRM_Contribute_BAO_ContributionRecur::validateRecurContribution($fields, $files, $self, $errors);
 
-    if (!empty($fields['is_recur']) &&
-      CRM_Utils_Array::value('payment_processor_id', $fields) == 0
-    ) {
+    if (!empty($fields['is_recur']) && empty($fields['payment_processor_id'])) {
       $errors['_qf_default'] = ts('You cannot set up a recurring contribution if you are not paying online by credit card.');
     }
 
     // validate PCP fields - if not anonymous, we need a nick name value
     if ($self->_pcpId && !empty($fields['pcp_display_in_roll']) &&
-      (CRM_Utils_Array::value('pcp_is_anonymous', $fields) == 0) &&
+      empty($fields['pcp_is_anonymous']) &&
       CRM_Utils_Array::value('pcp_roll_nickname', $fields) == ''
     ) {
       $errors['pcp_roll_nickname'] = ts('Please enter a name to include in the Honor Roll, or select \'contribute anonymously\'.');
@@ -915,13 +911,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           $errors['pledge_installments'] = ts('Please enter a valid number of pledge installments.');
         }
         else {
-          if (CRM_Utils_Array::value('pledge_installments', $fields) == NULL) {
+          if (!isset($fields['pledge_installments'])) {
             $errors['pledge_installments'] = ts('Pledge Installments is required field.');
           }
           elseif (CRM_Utils_Array::value('pledge_installments', $fields) == 1) {
             $errors['pledge_installments'] = ts('Pledges consist of multiple scheduled payments. Select one-time contribution if you want to make your gift in a single payment.');
           }
-          elseif (CRM_Utils_Array::value('pledge_installments', $fields) == 0) {
+          elseif (empty($fields['pledge_installments'])) {
             $errors['pledge_installments'] = ts('Pledge Installments field must be > 1.');
           }
         }
@@ -931,10 +927,10 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           $errors['pledge_frequency_interval'] = ts('Please enter a valid Pledge Frequency Interval.');
         }
         else {
-          if (CRM_Utils_Array::value('pledge_frequency_interval', $fields) == NULL) {
+          if (!isset($fields['pledge_frequency_interval'])) {
             $errors['pledge_frequency_interval'] = ts('Pledge Frequency Interval. is required field.');
           }
-          elseif (CRM_Utils_Array::value('pledge_frequency_interval', $fields) == 0) {
+          elseif (empty($fields['pledge_frequency_interval'])) {
             $errors['pledge_frequency_interval'] = ts('Pledge frequency interval field must be > 0');
           }
         }
@@ -947,7 +943,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       return $errors;
     }
 
-    if (CRM_Utils_Array::value('payment_processor_id', $fields) === NULL) {
+    if (!isset($fields['payment_processor_id'])) {
       $errors['payment_processor_id'] = ts('Payment Method is a required field.');
     }
     else {
@@ -1192,7 +1188,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if ($params['amount'] != 0 && (($this->_values['is_pay_later'] &&
           empty($this->_paymentProcessor) &&
           !array_key_exists('hidden_processor', $params)) ||
-        (CRM_Utils_Array::value('payment_processor_id', $params) == 0))
+        empty($params['payment_processor_id']))
     ) {
       $params['is_pay_later'] = 1;
     }

--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -306,7 +306,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       ];
       foreach ($pledgeBlock as $key) {
         $defaults[$key] = CRM_Utils_Array::value($key, $pledgeBlockDefaults);
-        if ($key == 'pledge_start_date' && CRM_Utils_Array::value($key, $pledgeBlockDefaults)) {
+        if ($key == 'pledge_start_date' && !empty($pledgeBlockDefaults[$key])) {
           $defaultPledgeDate = (array) json_decode($pledgeBlockDefaults['pledge_start_date']);
           $pledgeDateFields = [
             'pledge_calendar_date' => 'calendar_date',

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -95,10 +95,10 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
         if ($id != 0) {
           $paymentProcessor[$id] = $processor['name'];
         }
-        if (CRM_Utils_Array::value('is_recur', $processor)) {
+        if (!empty($processor['is_recur'])) {
           $recurringPaymentProcessor[] = $id;
         }
-        if (CRM_Utils_Array::value('object', $processor) && $processor['object']->supports('FutureRecurStartDate')) {
+        if (!empty($processor['object']) && $processor['object']->supports('FutureRecurStartDate')) {
           $futurePaymentProcessor[] = $id;
         }
       }
@@ -345,7 +345,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     }
 
     // CRM-18854 Check if recurring start date is in the future.
-    if (CRM_Utils_Array::value('pledge_calendar_date', $fields)) {
+    if (!empty($fields['pledge_calendar_date'])) {
       if (date('Ymd') > date('Ymd', strtotime($fields['pledge_calendar_date']))) {
         $errors['pledge_calendar_date'] = ts('The recurring start date cannot be prior to the current date.');
       }
@@ -506,7 +506,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       $params['is_recur_installments'] = CRM_Utils_Array::value('is_recur_installments', $params, FALSE);
     }
 
-    if (CRM_Utils_Array::value('adjust_recur_start_date', $params)) {
+    if (!empty($params['adjust_recur_start_date'])) {
       $fieldValue = '';
       $pledgeDateFields = [
         'calendar_date' => 'pledge_calendar_date',
@@ -517,7 +517,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       }
       else {
         foreach ($pledgeDateFields as $key => $pledgeDateField) {
-          if (CRM_Utils_Array::value($pledgeDateField, $params) && $params['pledge_default_toggle'] == $key) {
+          if (!empty($params[$pledgeDateField]) && $params['pledge_default_toggle'] == $key) {
             $fieldValue = json_encode([$key => $params[$pledgeDateField]]);
             break;
           }
@@ -531,10 +531,10 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       $params['is_pledge_start_date_visible'] = 0;
       $params['is_pledge_start_date_editable'] = 0;
     }
-    if (!CRM_Utils_Array::value('is_pledge_start_date_visible', $params)) {
+    if (empty($params['is_pledge_start_date_visible'])) {
       $params['is_pledge_start_date_visible'] = 0;
     }
-    if (!CRM_Utils_Array::value('is_pledge_start_date_editable', $params)) {
+    if (empty($params['is_pledge_start_date_editable'])) {
       $params['is_pledge_start_date_editable'] = 0;
     }
 

--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -84,7 +84,7 @@ class CRM_Core_BAO_Location extends CRM_Core_DAO {
       // when we come from a form which displays all the location elements (like the edit form or the inline block
       // elements, we can skip the below check. The below check adds quite a feq queries to an already overloaded
       // form
-      if (!CRM_Utils_Array::value('updateBlankLocInfo', $params, FALSE)) {
+      if (empty($params['updateBlankLocInfo'])) {
         // make sure contact should have only one primary block, CRM-5051
         self::checkPrimaryBlocks(CRM_Utils_Array::value('contact_id', $params));
       }

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -917,7 +917,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
         }
       }
       if ($formParams['repeats_by'] == 2) {
-        if (CRM_Utils_Array::value('entity_status_1', $formParams) && CRM_Utils_Array::value('entity_status_2', $formParams)) {
+        if (!empty($formParams['entity_status_1']) && !empty($formParams['entity_status_2'])) {
           $dbParams['entity_status'] = $formParams['entity_status_1'] . " " . $formParams['entity_status_2'];
         }
       }

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -496,7 +496,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
   public static function isAPIJobAllowedToRun($params) {
     $environment = CRM_Core_Config::environment(NULL, TRUE);
     if ($environment != 'Production') {
-      if (CRM_Utils_Array::value('runInNonProductionEnvironment', $params)) {
+      if (!empty($params['runInNonProductionEnvironment'])) {
         $mailing = Civi::settings()->get('mailing_backend_store');
         if ($mailing) {
           Civi::settings()->set('mailing_backend', $mailing);

--- a/CRM/Core/BAO/StatusPreference.php
+++ b/CRM/Core/BAO/StatusPreference.php
@@ -66,7 +66,7 @@ class CRM_Core_BAO_StatusPreference extends CRM_Core_DAO_StatusPreference {
     }
 
     // Check if this StatusPreference already exists.
-    if (empty($params['id']) && CRM_Utils_Array::value('name', $params)) {
+    if (empty($params['id']) && !empty($params['name'])) {
       $statusPreference->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
       $statusPreference->name = $params['name'];
 

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -827,7 +827,7 @@ SELECT  id
       if (in_array($field['field_name'], $validBillingFields)) {
         $validProfileFields[] = $field['field_name'];
       }
-      if (CRM_Utils_Array::value('is_required', $field)) {
+      if (!empty($field['is_required'])) {
         $requiredProfileFields[] = $field['field_name'];
       }
     }

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -300,7 +300,7 @@ class CRM_Core_DAO_AllCoreTables {
       $fields = $dao::fields();
 
       foreach ($fields as $name => $field) {
-        if (CRM_Utils_Array::value('export', $field)) {
+        if (!empty($field['export'])) {
           if ($prefix) {
             $exports[$labelName] = & $fields[$name];
           }
@@ -340,7 +340,7 @@ class CRM_Core_DAO_AllCoreTables {
       $fields = $dao::fields();
 
       foreach ($fields as $name => $field) {
-        if (CRM_Utils_Array::value('import', $field)) {
+        if (!empty($field['import'])) {
           if ($prefix) {
             $imports[$labelName] = & $fields[$name];
           }

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -369,7 +369,7 @@ class CRM_Core_Form_RecurringEntity {
 
         //exclude dates
         $excludeDateList = [];
-        if (CRM_Utils_Array::value('exclude_date_list', $params) && CRM_Utils_Array::value('parent_entity_id', $params) && $actionScheduleObj->entity_value) {
+        if (!empty($params['exclude_date_list']) && !empty($params['parent_entity_id']) && $actionScheduleObj->entity_value) {
           //Since we get comma separated values lets get them in array
           $excludeDates = explode(",", $params['exclude_date_list']);
 

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -337,7 +337,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
     $this->addElement('checkbox', 'toggleSelect', NULL, NULL, ['class' => 'select-rows']);
     if (!empty($rows)) {
       foreach ($rows as $row) {
-        if (CRM_Utils_Array::value('checkbox', $row)) {
+        if (!empty($row['checkbox'])) {
           $this->addElement('checkbox', $row['checkbox'], NULL, NULL, ['class' => 'select-row']);
         }
       }

--- a/CRM/Core/Page/AJAX.php
+++ b/CRM/Core/Page/AJAX.php
@@ -269,7 +269,7 @@ class CRM_Core_Page_AJAX {
     }
 
     foreach ($optionalParams as $param => $type) {
-      if (CRM_Utils_Array::value($param, $_GET)) {
+      if (!empty($_GET[$param])) {
         if (!is_array($_GET[$param])) {
           $params[$param] = CRM_Utils_Type::validate(CRM_Utils_Array::value($param, $_GET), $type);
         }

--- a/CRM/Core/Page/AJAX/RecurringEntity.php
+++ b/CRM/Core/Page/AJAX/RecurringEntity.php
@@ -14,7 +14,7 @@ class CRM_Core_Page_AJAX_RecurringEntity {
 
   public static function updateMode() {
     $finalResult = [];
-    if (CRM_Utils_Array::value('mode', $_REQUEST) && CRM_Utils_Array::value('entityId', $_REQUEST) && CRM_Utils_Array::value('entityTable', $_REQUEST)) {
+    if (!empty($_REQUEST['mode']) && !empty($_REQUEST['entityId']) && !empty($_REQUEST['entityTable'])) {
       $mode = CRM_Utils_Type::escape($_REQUEST['mode'], 'Integer');
       $entityId = CRM_Utils_Type::escape($_REQUEST['entityId'], 'Integer');
       $entityTable = CRM_Utils_Type::escape($_REQUEST['entityTable'], 'String');

--- a/CRM/Custom/Form/Preview.php
+++ b/CRM/Custom/Form/Preview.php
@@ -71,7 +71,7 @@ class CRM_Custom_Form_Preview extends CRM_Core_Form {
       if (!empty($defaults['is_view'])) {
         CRM_Core_Error::statusBounce(ts('This field is view only so it will not display on edit form.'));
       }
-      elseif (CRM_Utils_Array::value('is_active', $defaults) == 0) {
+      elseif (empty($defaults['is_active'])) {
         CRM_Core_Error::statusBounce(ts('This field is inactive so it will not display on edit form.'));
       }
 

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -47,7 +47,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     if ($participant->must_wait) {
       $participant_status = 'On waitlist';
     }
-    elseif (CRM_Utils_Array::value('is_pay_later', $params, FALSE)) {
+    elseif (!empty($params['is_pay_later'])) {
       $participant_status = 'Pending from pay later';
     }
     else {

--- a/CRM/Event/Form/ManageEvent/Repeat.php
+++ b/CRM/Event/Form/ManageEvent/Repeat.php
@@ -207,7 +207,7 @@ class CRM_Event_Form_ManageEvent_Repeat extends CRM_Event_Form_ManageEvent {
       $participantDetails = CRM_Event_Form_ManageEvent_Repeat::getParticipantCountforEvent($getRelatedEntities);
       //Check if participants exists for events
       foreach ($getRelatedEntities as $key => $value) {
-        if (!CRM_Utils_Array::value($value['id'], $participantDetails['countByID']) && $value['id'] != $eventID) {
+        if (empty($participantDetails['countByID'][$value['id']]) && $value['id'] != $eventID) {
           //CRM_Event_BAO_Event::del($value['id']);
           $eventIdsWithNoRegistration[] = $value['id'];
         }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -476,7 +476,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
           $this->assign($v, $params[$v]);
         }
       }
-      elseif (CRM_Utils_Array::value('amount', $params) == 0) {
+      elseif (empty($params['amount'])) {
         $this->assign($v, CRM_Utils_Array::value($v, $params));
       }
     }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -457,7 +457,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $participantCount[$participantNum] = 'participant';
       }
       $totalTaxAmount += CRM_Utils_Array::value('tax_amount', $record, 0);
-      if (CRM_Utils_Array::value('is_primary', $record)) {
+      if (!empty($record['is_primary'])) {
         $taxAmount = &$params[$participantNum]['tax_amount'];
       }
       //lets get additional participant id to cancel.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -103,7 +103,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   protected static function isZeroAmount($fields, $form): bool {
     $isZeroAmount = FALSE;
     if (!empty($fields['priceSetId'])) {
-      if (CRM_Utils_Array::value('amount', $fields) == 0) {
+      if (empty($fields['amount'])) {
         $isZeroAmount = TRUE;
       }
     }
@@ -1155,7 +1155,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           "_qf_Register_display=1&qfKey={$this->controller->_key}",
           TRUE, NULL, FALSE
         );
-        if (CRM_Utils_Array::value('additional_participants', $params, FALSE)) {
+        if (!empty($params['additional_participants'])) {
           $urlArgs = "_qf_Participant_1_display=1&rfp=1&qfKey={$this->controller->_key}";
         }
         else {
@@ -1194,7 +1194,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
 
     // If registering > 1 participant, give status message
-    if (CRM_Utils_Array::value('additional_participants', $params, FALSE)) {
+    if (!empty($params['additional_participants'])) {
       $statusMsg = ts('Registration information for participant 1 has been saved.');
       CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
     }

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -487,7 +487,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
       $realSetting = \Civi::$statics[__CLASS__]['is_acl_enabled'] = Civi::settings()->get('acl_financial_type');
       if (!$realSetting) {
         $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
-        if (CRM_Utils_Array::value('acl_financial_type', $contributeSettings)) {
+        if (!empty($contributeSettings['acl_financial_type'])) {
           \Civi::$statics[__CLASS__]['is_acl_enabled'] = TRUE;
         }
       }

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -88,7 +88,7 @@ class CRM_Financial_BAO_Payment {
       $trxn = CRM_Core_BAO_FinancialTrxn::create($balanceTrxnParams);
 
       // @todo - this is just weird & historical & inconsistent - why 2 tracks?
-      if (CRM_Utils_Array::value('line_item', $params) && !empty($trxn)) {
+      if (!empty($params['line_item']) && !empty($trxn)) {
         foreach ($params['line_item'] as $values) {
           foreach ($values as $id => $amount) {
             $p = ['id' => $id];

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -143,7 +143,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
       if ($values['financial_account_type_id'] != $financialAccountTypeId) {
         $errorMsg['financial_account_type_id'] = ts('Taxable accounts should have Financial Account Type set to Liability.');
       }
-      if (CRM_Utils_Array::value('tax_rate', $values) == NULL) {
+      if (!isset($values['tax_rate'])) {
         $errorMsg['tax_rate'] = ts('Please enter value for tax rate');
       }
     }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -381,14 +381,14 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       foreach ($params['line_item'] as $priceSetId => $lineItems) {
         foreach ($lineItems as $lineIndex => $lineItem) {
           $lineMembershipType = CRM_Utils_Array::value('membership_type_id', $lineItem);
-          if (CRM_Utils_Array::value('contribution', $params)) {
+          if (!empty($params['contribution'])) {
             $params['line_item'][$priceSetId][$lineIndex]['contribution_id'] = $params['contribution']->id;
           }
           if ($lineMembershipType && $lineMembershipType == CRM_Utils_Array::value('membership_type_id', $params)) {
             $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $membership->id;
             $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_membership';
           }
-          elseif (!$lineMembershipType && CRM_Utils_Array::value('contribution', $params)) {
+          elseif (!$lineMembershipType && !empty($params['contribution'])) {
             $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $params['contribution']->id;
             $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_contribution';
           }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1165,7 +1165,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],
       $formValues, $lineItem[$this->_priceSetId], NULL, $this->_priceSetId);
 
-    if (CRM_Utils_Array::value('tax_amount', $formValues)) {
+    if (!empty($formValues['tax_amount'])) {
       $params['tax_amount'] = $formValues['tax_amount'];
     }
     $params['total_amount'] = CRM_Utils_Array::value('amount', $formValues);
@@ -1739,7 +1739,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     // if selected membership doesn't match with earlier membership
       !in_array($this->_memType, $this->_memTypeSelected)
     ) {
-      if (CRM_Utils_Array::value('is_recur', $inputParams)) {
+      if (!empty($inputParams['is_recur'])) {
         CRM_Core_Session::setStatus(ts('Associated recurring contribution cannot be updated on membership type change.', ts('Error'), 'error'));
         return;
       }

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -1200,7 +1200,7 @@ SELECT  pledge.contact_id              as contact_id,
   public static function getPledgeStartDate($date, $pledgeBlock) {
     $startDate = (array) json_decode($pledgeBlock['pledge_start_date']);
     foreach ($startDate as $field => $value) {
-      if (!empty($date) && !CRM_Utils_Array::value('is_pledge_start_date_editable', $pledgeBlock)) {
+      if (!empty($date) && empty($pledgeBlock['is_pledge_start_date_editable'])) {
         return $date;
       }
       if (empty($date)) {

--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -301,8 +301,8 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       }
       $form->addElement('select', 'pledge_frequency_unit', NULL, $freqUnits, ['aria-label' => ts('Frequency Units')]);
       // CRM-18854
-      if (CRM_Utils_Array::value('is_pledge_start_date_visible', $pledgeBlock)) {
-        if (CRM_Utils_Array::value('pledge_start_date', $pledgeBlock)) {
+      if (!empty($pledgeBlock['is_pledge_start_date_visible'])) {
+        if (!empty($pledgeBlock['pledge_start_date'])) {
           $defaults = array();
           $date = (array) json_decode($pledgeBlock['pledge_start_date']);
           foreach ($date as $field => $value) {
@@ -335,7 +335,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
             $form->setDefaults($defaults);
             $form->assign('start_date_display', $paymentDate);
             $form->assign('start_date_editable', FALSE);
-            if (CRM_Utils_Array::value('is_pledge_start_date_editable', $pledgeBlock)) {
+            if (!empty($pledgeBlock['is_pledge_start_date_editable'])) {
               $form->assign('start_date_editable', TRUE);
               if ($field == 'calendar_month') {
                 $form->assign('is_date', FALSE);

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -70,7 +70,7 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
         $params['unit_price'] = 0;
       }
     }
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && CRM_Utils_Array::value('check_permissions', $params)) {
+    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !empty($params['check_permissions'])) {
       if (empty($params['financial_type_id'])) {
         throw new Exception('Mandatory key(s) missing from params array: financial_type_id');
       }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -727,7 +727,7 @@ WHERE  id = %1";
               $field['options'][$optionValueId]['tax_amount'] = round($taxAmount['tax_amount'], 2);
             }
           }
-          if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
+          if (!empty($field['options'][$optionValueId]['tax_rate'])) {
             $lineItem = self::setLineItem($field, $lineItem, $optionValueId, $totalTax);
           }
           $totalPrice += $lineItem[$firstOption['id']]['line_total'] + CRM_Utils_Array::value('tax_amount', $lineItem[key($field['options'])]);
@@ -742,7 +742,7 @@ WHERE  id = %1";
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, $amount_override);
-          if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
+          if (!empty($field['options'][$optionValueId]['tax_rate'])) {
             $lineItem = self::setLineItem($field, $lineItem, $optionValueId, $totalTax);
             if ($amount_override) {
               $lineItem[$optionValueId]['line_total'] = $lineItem[$optionValueId]['unit_price'] = CRM_Utils_Rule::cleanMoney($lineItem[$optionValueId]['line_total'] - $lineItem[$optionValueId]['tax_amount']);
@@ -765,7 +765,7 @@ WHERE  id = %1";
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, CRM_Utils_Array::value('partial_payment_total', $params));
-          if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
+          if (!empty($field['options'][$optionValueId]['tax_rate'])) {
             $lineItem = self::setLineItem($field, $lineItem, $optionValueId, $totalTax);
           }
           $totalPrice += $lineItem[$optionValueId]['line_total'] + CRM_Utils_Array::value('tax_amount', $lineItem[$optionValueId]);
@@ -782,7 +782,7 @@ WHERE  id = %1";
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, CRM_Utils_Array::value('partial_payment_total', $params));
           foreach ($params["price_{$id}"] as $optionId => $option) {
-            if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionId])) {
+            if (!empty($field['options'][$optionId]['tax_rate'])) {
               $lineItem = self::setLineItem($field, $lineItem, $optionId, $totalTax);
             }
             $totalPrice += $lineItem[$optionId]['line_total'] + CRM_Utils_Array::value('tax_amount', $lineItem[$optionId]);

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -422,7 +422,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     }
 
     if ((is_numeric(CRM_Utils_Array::value('count', $fields)) &&
-        CRM_Utils_Array::value('count', $fields) == 0
+        empty($fields['count'])
       ) &&
       (CRM_Utils_Array::value('html_type', $fields) == 'Text')
     ) {

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -380,7 +380,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
     $contributionOrSoftVal = $this->getElementValue('contribution_or_soft_value');
     if ($contributionOrSoftVal[0] == 'contributions_only') {
       $groupBySoft = $this->getElementValue('group_bys');
-      if (CRM_Utils_Array::value('soft_credit_id', $groupBySoft)) {
+      if (!empty($groupBySoft['soft_credit_id'])) {
         $this->setElementError('group_bys', ts('You cannot group by soft credit when displaying contributions only.  Please uncheck "Soft Credit" in the Grouping tab.'));
       }
     }

--- a/CRM/Report/Form/Event/Summary.php
+++ b/CRM/Report/Form/Event/Summary.php
@@ -349,7 +349,7 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form {
           $rows[$key]['civicrm_event_id'] . ") ";
       }
 
-      if (CRM_Utils_Array::value('totalAmount', $rows[$key]) == 0) {
+      if (empty($rows[$key]['totalAmount'])) {
         $countEvent = count($rows);
       }
 

--- a/CRM/Utils/API/ReloadOption.php
+++ b/CRM/Utils/API/ReloadOption.php
@@ -76,7 +76,7 @@ class CRM_Utils_API_ReloadOption implements API_Wrapper {
   public function toApiOutput($apiRequest, $result) {
     $reloadMode = NULL;
     if ($apiRequest['action'] === 'create' && isset($apiRequest['params'], $apiRequest['params']['options']) && is_array($apiRequest['params']['options']) && isset($apiRequest['params']['options']['reload'])) {
-      if (!CRM_Utils_Array::value('is_error', $result, FALSE)) {
+      if (empty($result['is_error'])) {
         $reloadMode = $apiRequest['params']['options']['reload'];
       }
       $id = (!empty($apiRequest['params']['sequential'])) ? 0 : $result['id'];

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -343,7 +343,7 @@ class CRM_Utils_Address {
         $alternateName = $alternate2;
       }
       //Include values which prepend 'billing_' to country and state_province.
-      if (CRM_Utils_Array::value($alternateName, $params)) {
+      if (!empty($params[$alternateName])) {
         if (empty($value) || !is_numeric($value)) {
           $value = $params[$alternateName];
         }

--- a/api/v3/LineItem.php
+++ b/api/v3/LineItem.php
@@ -78,7 +78,7 @@ function _civicrm_api3_line_item_create_spec(&$params) {
  *   Array of matching line_items
  */
 function civicrm_api3_line_item_get($params) {
-  if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && CRM_Utils_Array::value('check_permissions', $params)) {
+  if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !empty($params['check_permissions'])) {
     CRM_Price_BAO_LineItem::getAPILineItemParams($params);
   }
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -95,7 +95,7 @@ function civicrm_api3_line_item_get($params) {
  * @throws API_Exception
  */
 function civicrm_api3_line_item_delete($params) {
-  if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && CRM_Utils_Array::value('check_permissions', $params)) {
+  if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !empty($params['check_permissions'])) {
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, CRM_Core_Action::DELETE);
     if (empty($params['financial_type_id'])) {
       $params['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_LineItem', $params['id'], 'financial_type_id');

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -45,7 +45,7 @@ function civicrm_api3_order_get($params) {
   $contributions = [];
   $params['api.line_item.get'] = ['qty' => ['<>' => 0]];
   $isSequential = FALSE;
-  if (CRM_Utils_Array::value('sequential', $params)) {
+  if (!empty($params['sequential'])) {
     $params['sequential'] = 0;
     $isSequential = TRUE;
   }
@@ -88,7 +88,7 @@ function civicrm_api3_order_create($params) {
 
   $entity = NULL;
   $entityIds = [];
-  if (CRM_Utils_Array::value('line_items', $params) && is_array($params['line_items'])) {
+  if (!empty($params['line_items']) && is_array($params['line_items'])) {
     $priceSetID = NULL;
     CRM_Contribute_BAO_Contribution::checkLineItems($params);
     foreach ($params['line_items'] as $lineItems) {
@@ -124,7 +124,7 @@ function civicrm_api3_order_create($params) {
   }
   $contribution = civicrm_api3('Contribution', 'create', $params);
   // add payments
-  if ($entity && CRM_Utils_Array::value('id', $contribution)) {
+  if ($entity && !empty($contribution['id'])) {
     foreach ($entityIds as $entityId) {
       $paymentParams = [
         'contribution_id' => $contribution['id'],

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -43,7 +43,7 @@
 function civicrm_api3_payment_get($params) {
   $financialTrxn = [];
   $limit = '';
-  if (isset($params['options']) && CRM_Utils_Array::value('limit', $params['options'])) {
+  if (isset($params['options']) && !empty($params['options']['limit'])) {
     $limit = CRM_Utils_Array::value('limit', $params['options']);
   }
   $params['options']['limit'] = 0;
@@ -132,7 +132,7 @@ function civicrm_api3_payment_cancel($params) {
  */
 function civicrm_api3_payment_create($params) {
   // Check if it is an update
-  if (CRM_Utils_Array::value('id', $params)) {
+  if (!empty($params['id'])) {
     $amount = $params['total_amount'];
     civicrm_api3('Payment', 'cancel', $params);
     $params['total_amount'] = $amount;


### PR DESCRIPTION
Overview
----------------------------------------
When the output of `CRM_Utils_Array::value` is immediately cast to boolean by a conditional, then it's better to use `empty()` as it's faster & more readable.
If the output is being compared to `NULL` in the conditional then it's better to use `isset()`.

Technical Details
----------------------------------------
The before/after statements are identical in every scenario I can think of.

Comments
----------------------------------------
I did a mass regex replace of these 5 years ago with no ill-effects, this is just catching some stragglers that didn't get converted with that first pass.