### PR TITLE
core#1175 - fix custom searches

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1512,7 +1512,7 @@ FROM   civicrm_domain
    * @return string
    * @throws Exception
    */
-  public static function composeQuery($query, $params, $abort = TRUE) {
+  public static function composeQuery($query, $params = [], $abort = TRUE) {
     $tr = [];
     foreach ($params as $key => $item) {
       if (is_numeric($key)) {


### PR DESCRIPTION
Overview
----------------------------------------
Custom searches don't work on Civi 5.16.0.

Before
----------------------------------------
Custom searches result in a CMS error screen (e.g. "The website encountered an unexpected error. Please try again later.").

Drupal watchdog logs this error:
```
Too few arguments to function CRM_Core_DAO::composeQuery(), 1 passed in                                                                                                                      /home/jon/local/agbud8/htdocs/vendor/civicrm/civicrm-core/CRM/Contact/Form/Search/Custom/Base.php, 2 expected.
```

After
----------------------------------------
Custom searches work.

Technical Details
----------------------------------------
See the lab.c.o posting [core-1175](https://lab.civicrm.org/dev/core/issues/1175).  If you look at the commit that introduced this bug and you look at this fix, it should be pretty straightforward to review this.