### PR TITLE
core#1176 - fix uncaught exception with missing extensions

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -334,7 +334,12 @@ class CRM_Extension_Mapper {
     foreach ($this->getModules() as $module) {
       /** @var $module CRM_Core_Module */
       if ($module->is_active) {
-        $urls[$module->name] = $this->keyToUrl($module->name);
+        try {
+          $urls[$module->name] = $this->keyToUrl($module->name);
+        }
+        catch (Exception $ex) {
+          // Do nothing, we're being called by AJAX.
+        }
       }
     }
     return $urls;


### PR DESCRIPTION
Overview
----------------------------------------
If you have a missing extension, several parts of CiviCRM break.  The easiest to replicate is the System Status screen.

Before
----------------------------------------
You get an error message instead of the status screen when an extension is missing.

After
----------------------------------------
Status screen appears normally (and shows the "missing extension" error).

Technical Details
----------------------------------------
I don't have experience fixing "uncaught exception" messages, but I think this is the right place in the call stack to catch the exception.  Would love feedback on if there's a more appropriate place.