### PR TITLE
[Ref] [Import] move metadata calculations to a trait

### DIFF
--- a/CRM/Contact/Import/MetadataTrait.php
+++ b/CRM/Contact/Import/MetadataTrait.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Trait CRM_Contact_Import_MetadataTrait
+ *
+ * Trait for handling contact import specific metadata so it
+ * does not need to be passed from one form to the next.
+ */
+trait CRM_Contact_Import_MetadataTrait {
+
+  /**
+   * Get metadata for contact importable fields.
+   *
+   * @return array
+   */
+  protected function getContactImportMetadata(): array {
+    $cacheKey = 'importable_contact_field_metadata' . $this->getContactType() . $this->getContactSubType();
+    if (Civi::cache('fields')->has($cacheKey)) {
+      return Civi::cache('fields')->get($cacheKey);
+    }
+    $contactFields = CRM_Contact_BAO_Contact::importableFields($this->getContactType());
+    // exclude the address options disabled in the Address Settings
+    $fields = CRM_Core_BAO_Address::validateAddressOptions($contactFields);
+
+    //CRM-5125
+    //supporting import for contact subtypes
+    $csType = NULL;
+    if ($this->getContactSubType()) {
+      //custom fields for sub type
+      $subTypeFields = CRM_Core_BAO_CustomField::getFieldsForImport($this->getContactSubType());
+
+      if (!empty($subTypeFields)) {
+        foreach ($subTypeFields as $customSubTypeField => $details) {
+          $fields[$customSubTypeField] = $details;
+        }
+      }
+    }
+
+    foreach ($this->getRelationships() as $key => $var) {
+      list($type) = explode('_', $key);
+      $relationshipType[$key]['title'] = $var;
+      $relationshipType[$key]['headerPattern'] = '/' . preg_quote($var, '/') . '/';
+      $relationshipType[$key]['import'] = TRUE;
+      $relationshipType[$key]['relationship_type_id'] = $type;
+      $relationshipType[$key]['related'] = TRUE;
+    }
+
+    if (!empty($relationshipType)) {
+      $fields = array_merge($fields, [
+        'related' => [
+          'title' => ts('- related contact info -'),
+        ],
+      ], $relationshipType);
+    }
+    Civi::cache('fields')->set($cacheKey, $fields);
+    return $fields;
+  }
+
+  /**
+   * Get sorted available relationships.
+   *
+   * @return array
+   */
+  protected function getRelationships(): array {
+    $cacheKey = 'importable_contact_relationship_field_metadata' . $this->getContactType() . $this->getContactSubType();
+    if (Civi::cache('fields')->has($cacheKey)) {
+      return Civi::cache('fields')->get($cacheKey);
+    }
+    //Relationship importables
+    $relations = CRM_Contact_BAO_Relationship::getContactRelationshipType(
+      NULL, NULL, NULL, $this->getContactType(),
+      FALSE, 'label', TRUE, $this->getContactSubType()
+    );
+    asort($relations);
+    Civi::cache('fields')->set($cacheKey, $relations);
+    return $relations;
+  }
+
+  /**
+   * Get an array of header patterns for importable keys.
+   *
+   * @return array
+   */
+  public function getHeaderPatterns() {
+    return CRM_Utils_Array::collect('headerPattern', $this->getContactImportMetadata());
+  }
+
+  /**
+   * Get an array of header patterns for importable keys.
+   *
+   * @return array
+   */
+  public function getDataPatterns() {
+    return CRM_Utils_Array::collect('dataPattern', $this->getContactImportMetadata());
+  }
+
+  /**
+   * Get an array of header patterns for importable keys.
+   *
+   * @return array
+   */
+  public function getFieldTitles() {
+    return CRM_Utils_Array::collect('title', $this->getContactImportMetadata());
+  }
+
+  /**
+   * Get configured contact type.
+   */
+  protected function getContactType() {
+    return $this->_contactType ?? 'Individual';
+  }
+
+  /**
+   * Get configured contact sub type.
+   *
+   * @return string
+   */
+  protected function getContactSubType() {
+    return $this->_contactSubType ?? NULL;
+  }
+
+}

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -37,6 +37,9 @@ require_once 'api/v3/utils.php';
  * class to parse contact csv files
  */
 class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
+
+  use CRM_Contact_Import_MetadataTrait;
+
   protected $_mapperKeys = [];
   protected $_mapperLocType = [];
   protected $_mapperPhoneType;
@@ -2054,49 +2057,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
    * Set field metadata.
    */
   protected function setFieldMetadata() {
-    $contactFields = CRM_Contact_BAO_Contact::importableFields($this->_contactType);
-    // exclude the address options disabled in the Address Settings
-    $fields = CRM_Core_BAO_Address::validateAddressOptions($contactFields);
-
-    //CRM-5125
-    //supporting import for contact subtypes
-    $csType = NULL;
-    if (!empty($this->_contactSubType)) {
-      //custom fields for sub type
-      $subTypeFields = CRM_Core_BAO_CustomField::getFieldsForImport($this->_contactSubType);
-
-      if (!empty($subTypeFields)) {
-        foreach ($subTypeFields as $customSubTypeField => $details) {
-          $fields[$customSubTypeField] = $details;
-        }
-      }
-    }
-
-    //Relationship importables
-    $this->_relationships = $relations
-      = CRM_Contact_BAO_Relationship::getContactRelationshipType(
-      NULL, NULL, NULL, $this->_contactType,
-      FALSE, 'label', TRUE, $this->_contactSubType
-    );
-    asort($relations);
-
-    foreach ($relations as $key => $var) {
-      list($type) = explode('_', $key);
-      $relationshipType[$key]['title'] = $var;
-      $relationshipType[$key]['headerPattern'] = '/' . preg_quote($var, '/') . '/';
-      $relationshipType[$key]['import'] = TRUE;
-      $relationshipType[$key]['relationship_type_id'] = $type;
-      $relationshipType[$key]['related'] = TRUE;
-    }
-
-    if (!empty($relationshipType)) {
-      $fields = array_merge($fields, [
-        'related' => [
-          'title' => ts('- related contact info -'),
-        ],
-      ], $relationshipType);
-    }
-    $this->setImportableFieldsMetadata($fields);
+    $this->setImportableFieldsMetadata($this->getContactImportMetadata());
+    // Probably no longer needed but here for now.
+    $this->_relationships = $this->getRelationships();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Refactor to increase shared code

Before
----------------------------------------
Metadata passed around

After
----------------------------------------
Metadata retrieved from shared trait

Technical Details
----------------------------------------
A lot of the complexity of the import classes comes from complex & convoluted handling of metadata.

For reasons now obsolete the metadata is loaded & wrangled into various arrays on the first form and
then passed through storing the form in the session object to later forms (which don't have a shared parent).

We should be passing user form input around but not metadata as that can be retrieved as needed (and
cached for performance). This moves  couple of functions out to the metadata and adds a couple of calls to them
- more could be done but it would be hard going. Am also open to breaking this into 2 PRs so the first commit can be merged as a straight extraction per
reviewer preference

Comments
----------------------------------------

