### PR TITLE
core#1182 - revert crm.menubar.js changes

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -27,13 +27,13 @@
 
       // Wait for crm-container present on the page as it's faster than document.ready
       function insert(markup) {
-        if ($('.crm-container').length) {
+        if ($('#crm-container').length) {
           render(markup);
         } else {
           new MutationObserver(function(mutations, observer) {
             _.each(mutations, function(mutant) {
               _.each(mutant.addedNodes, function(node) {
-                if ($(node).is('.crm-container')) {
+                if ($(node).is('#crm-container')) {
                   render(markup);
                   observer.disconnect();
                 }


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM 5.16.0 has a race condition that causes the menubar to not function.

Before
----------------------------------------
Menubar rarely works.

After
----------------------------------------
Menubar works.

Technical Details
----------------------------------------
[This commit](https://github.com/civicrm/civicrm-core/commit/f696fd924a73dff0987303cd5db8d60d0e61a4e1#diff-5d6e10b762b26e6116b7b88ab3be98c7) is the issue.  I note that there's only one HTML element with an id of `crm-container` but several with the class of `crm-container`.  I imagine that under certain circumstances one of those elements loads before the menubar, causing `crm.menubar.js` to not work.