### PR TITLE
Allow for the deselection of sorting filters

### DIFF
--- a/templates/CRM/Report/Form/Tabs/OrderBy.tpl
+++ b/templates/CRM/Report/Form/Tabs/OrderBy.tpl
@@ -82,7 +82,7 @@
       function hideRow(i) {
         showHideRow(i);
         // clear values on hidden field, so they're not saved
-        cj('select#order_bys_'+ i +'_column').val('');
+        cj('select#order_bys_'+ i +'_column').val('-');
         cj('select#order_bys_'+ i +'_order').val('ASC');
         cj('input#order_by_section_'+ i).prop('checked', false);
         cj('input#order_by_pagebreak_'+ i).prop('checked', false);

--- a/templates/CRM/Report/Form/Tabs/OrderBy.tpl
+++ b/templates/CRM/Report/Form/Tabs/OrderBy.tpl
@@ -82,8 +82,8 @@
       function hideRow(i) {
         showHideRow(i);
         // clear values on hidden field, so they're not saved
-        cj('select#order_by_column_'+ i).val('');
-        cj('select#order_by_order_'+ i).val('ASC');
+        cj('select#order_bys_'+ i +'_column').val('');
+        cj('select#order_bys_'+ i +'_order').val('ASC');
         cj('input#order_by_section_'+ i).prop('checked', false);
         cj('input#order_by_pagebreak_'+ i).prop('checked', false);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Unable to remove sorting filters on reports, "removing" them and refreshing the results would retain the sorting filters regardless.

Steps to Reproduce
----------------------------------------
1. Go to [CiviCRM dmaster](https://dmaster.demo.civicrm.org/civicrm/dashboard)
2. Navigate Reports -> Contact Reports
3. Select "Constituent Summary"
4. Open the "Sorting" tab
5. Add several Columns for sorting
6. Click "Refresh Results"
7. Open the "Sorting" tab
8. Delete several added Columns.
9. Click "Refresh Results"
10. Open the "Sorting" tab again, columns reappear.

![Bug](https://user-images.githubusercontent.com/7308809/62952816-49364f80-bde4-11e9-8148-291bf9581440.gif)

Before
----------------------------------------
The IDs of the Column and Order elements did not reflect the same element IDs used to reset the values.

After
----------------------------------------
The IDs of the Column and Order elements now reflect the same element IDs used to reset the values. Successfully able to remove sorting filters.

Technical Details
----------------------------------------
Fixes incorrect element IDs used in JavaScript.