### PR TITLE
Display only own assignees contact(s) on batch activity form

### DIFF
--- a/CRM/Activity/Form/Task/Batch.php
+++ b/CRM/Activity/Form/Task/Batch.php
@@ -80,6 +80,7 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
     if (!empty($contactDetails)) {
       foreach ($contactDetails as $key => $value) {
         $assignee = CRM_Activity_BAO_ActivityAssignment::retrieveAssigneeIdsByActivityId($key);
+        $assigneeContact = [];
         foreach ($assignee as $values) {
           $assigneeContact[] = CRM_Contact_BAO_Contact::displayName($values);
         }


### PR DESCRIPTION
Overview
----------------------------------------
Activity profile always displays Added By, With Contact and Assigned to fields.
Assigned to contains own contact and contacts for previous processed activities.
https://lab.civicrm.org/dev/core/issues/1185

Before
----------------------------------------
1st -> only own contact(s)
2nd -> own contact(s) and previous contacts (from 1st)
3rd -> own contact(s) and previous contacts (from 1st and 2nd)
4th -> ...

After
----------------------------------------
1st -> only own contact(s)
2nd -> own contact(s)
3rd -> own contact(s)
4th -> ...

Technical Details
----------------------------------------
Simple reset $assigneeContact array before next activity

Comments
----------------------------------------
It's curious that such simple bug exists