### PR TITLE
dev/core#1188 Fix API v3  error Class or interface CiviCRM_API3_Exception does not exist 

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -205,6 +205,12 @@ class CRM_Core_ClassLoader {
    * @param $class
    */
   public function loadClass($class) {
+    if ($class === 'CiviCRM_API3_Exception') {
+      //call internal error class api/Exception first
+      // allow api/Exception class call external error class
+      // CiviCRM_API3_Exception
+      require_once 'api/Exception.php';
+    }
     if (
       // Only load classes that clearly belong to CiviCRM.
       // Note: api/v3 does not use classes, but api_v3's test-suite does


### PR DESCRIPTION
Overview
----------------------------------------
Static analysis tool Psalm reveals the above error, this is an attempt to fix it as a proof of concept that Psalm errors  within civi-core can actually be fixed

Before
----------------------------------------
Psalm autoloader cannot find CiviCRM_API3_Exception

After
----------------------------------------
Autoloader can find CiviCRM_API3_Exception

Technical Details
----------------------------------------
This is not a problem with runtime php because the API_Exception is invariably thrown before the CiviCRM_API3_Exception and since they are both in the same file the require_once for API_Exception also covers  CiviCRM_API3_Exception. However, for static code analysers (like Psalm) the processing order is not driven by the order of runtime events

Comments
----------------------------------------

