### PR TITLE
Enable view/revert delete action for detail logging

### DIFF
--- a/CRM/Report/Form/Contact/LoggingSummary.php
+++ b/CRM/Report/Form/Contact/LoggingSummary.php
@@ -271,7 +271,7 @@ class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
 
       $date = CRM_Utils_Date::isoToMysql($row['log_civicrm_entity_log_date']);
 
-      if ('Update' == CRM_Utils_Array::value('log_civicrm_entity_log_action', $row)) {
+      if (in_array(CRM_Utils_Array::value('log_civicrm_entity_log_action', $row), ['Update', 'Delete'])) {
         $row = $this->addDetailReportLinksToRow($baseQueryCriteria, $row);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Delete information was being recorded and the reports have all the necessary code to view/revert the information.  But it's impossible to view the deleted info via the "changelog" UI or revert.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/63091422-35125f80-bf56-11e9-8abe-ca301720105c.png)
it's impossible to view the deleted info via the "changelog" UI or revert.

After
----------------------------------------
View the deleted info via the "changelog" UI and/or revert.

![ew-001](https://user-images.githubusercontent.com/2052161/63091212-95ed6800-bf55-11e9-877e-99e99500eadb.png)
![ew-039](https://user-images.githubusercontent.com/2052161/63091229-a4d41a80-bf55-11e9-8664-6babf0a1c510.png)
![ew-094](https://user-images.githubusercontent.com/2052161/63091252-b5849080-bf55-11e9-89d9-5230373e0e29.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
One-line change - unclear why it's disabled in the first place as it makes the changelog a lot less useful if you can't actually see what was deleted!
