### PR TITLE
Do not show Activity Separation on when viewing an Activity

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -747,7 +747,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     $this->assign('surveyActivity', $this->_isSurveyActivity);
 
     // Add the "Activity Separation" field
-    $actionIsAdd = $this->_action != CRM_Core_Action::UPDATE;
+    $actionIsAdd = ($this->_action != CRM_Core_Action::UPDATE && $this->_action != CRM_Core_Action::VIEW);
     $separationIsPossible = $this->supportsActivitySeparation;
     if ($actionIsAdd && $separationIsPossible) {
       $this->addRadio(

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -79,7 +79,7 @@
     </td>
   </tr>
 
-  {if $form.separation }
+  {if $form.separation}
     <tr class="crm-activity-form-block-separation crm-is-multi-activity-wrapper">
       <td class="label">{$form.separation.label}</td>
       <td>{$form.separation.html} {help id="separation"}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Activity separation fields show up when viewing an activity.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/54142191/63095209-9b04e400-bf62-11e9-8b14-8b99eb8f6b23.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/54142191/63095217-a0fac500-bf62-11e9-8bb6-1b46979b6146.png)

Steps to replicate
----------------------------------------
1.Find and open a profile of the contact from the precondition
2.Click "Actions" → "Meeting"
3.Click "Save"
4.Open the created meeting (Click "View")
5.Take a look at the "Activity Separation" field