### PR TITLE
Fix unreleased regression on import

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -185,7 +185,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
     $result = CRM_Core_DAO::executeQuery($query);
 
     while ($result->fetch()) {
-      $values = $result->toArray();
+      $values = array_values($result->toArray());
       $this->_rowCount++;
 
       /* trim whitespace around the values */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes unreleased bug where csv field  don't show


Before
----------------------------------------
<img width="893" alt="Screen Shot 2019-08-16 at 10 19 04 AM" src="https://user-images.githubusercontent.com/336308/63130718-892d4a80-c00f-11e9-93fb-6fdf5748a23a.png">

After
----------------------------------------
<img width="918" alt="Screen Shot 2019-08-16 at 10 19 36 AM" src="https://user-images.githubusercontent.com/336308/63130726-90545880-c00f-11e9-80b7-adc4c33844e3.png">


Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/commit/2adc819d0e59d71ffcf14c6799a379f108b07d60
made the code a little more readable but changed the indexing from 0-based to column based.

See https://pear.php.net/manual/en/package.database.db.db-common.setfetchmode.php

This can be replicated by trying to update an existing mapping

Comments
----------------------------------------
I actually found & solved this a few days ago & it's in my 'long-list' PR https://github.com/civicrm/civicrm-core/pull/15034 & once #15028 was merged I was going to rebase that & pull out the next one & try to fix https://lab.civicrm.org/dev/core/issues/1187 (which I've replicated) but it turns out this affects 5.17 so putting against the rc. Will remove from #15034 once this is merged
