### PR TITLE
Remove "Copy Case custom data" code (circa 2013)

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2084,28 +2084,6 @@ HERESQL;
           continue;
         }
 
-        // CRM-11662 Copy Case custom data
-        $extends = array('case');
-        $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
-        if ($groupTree) {
-          foreach ($groupTree as $groupID => $group) {
-            $table[$groupTree[$groupID]['table_name']] = array('entity_id');
-            foreach ($group['fields'] as $fieldID => $field) {
-              $table[$groupTree[$groupID]['table_name']][] = $groupTree[$groupID]['fields'][$fieldID]['column_name'];
-            }
-          }
-
-          foreach ($table as $tableName => $tableColumns) {
-            $insert = 'INSERT INTO ' . $tableName . ' (' . implode(', ', $tableColumns) . ') ';
-            $tableColumns[0] = $mainCaseId;
-            $select = 'SELECT ' . implode(', ', $tableColumns);
-            $from = ' FROM ' . $tableName;
-            $where = " WHERE {$tableName}.entity_id = {$otherCaseId}";
-            $query = $insert . $select . $from . $where;
-            $dao = CRM_Core_DAO::executeQuery($query);
-          }
-        }
-
         $mainCaseIds[] = $mainCaseId;
         //insert record for case contact.
         $otherCaseContact = new CRM_Case_DAO_CaseContact();


### PR DESCRIPTION
Overview
----------------------------------------

Unable to merge Contacts and Cases with Case custom data, raises an error - DB Error: already exists (applies to CiviCRM 5.16.0 - CiviCRM 5.18.alpha1). See https://lab.civicrm.org/dev/core/issues/1183 for more details.

Before
----------------------------------------

Unable to merge Contacts and Cases with Case custom data, raises an error - DB Error: already exists.

Steps to reproduce:
1. Create Contact A and Contact B
1. Create custom fields for the Case Type
1. Create a Case for Contact A
1. Select the Case Type with the custom fields. Populate the custom fields.
1. Create a Case for Contact B
1. Select the Case Type with the custom fields. Populate the custom fields.
1. Search for Contact A/B
1. Merge Contact A/B
1. Observe the DB Error: already exists and merge fails to complete


After
----------------------------------------

Can merge Contacts and Cases with Case custom data without error.

Technical Details
----------------------------------------

Removes code introduced with https://github.com/civicrm/civicrm-core/pull/1204 - CRM-11662 Add missing logic to copy case custom fields in CRM_Case_BAO_C... #1204 

Comments
----------------------------------------

Happy to say goodbye to old code.

Agileware Ref: CIVICRM-1290 