### PR TITLE
Manage Group search message fix

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -109,7 +109,7 @@
     // on initial load of manage group page and
     // also to handle search filtering for initial load of same page.
     var parentsOnly = 1
-    var ZeroRecordText = {/literal}'{ts escape="js"}<div class="status messages">No Groups have been created for this site.{/ts}</div>'{literal};
+    var ZeroRecordText = {/literal}'{ts escape="js"}<div class="status messages">None found.{/ts}</div>'{literal};
     $('table.crm-group-selector').data({
       "ajax": {
         "url": {/literal}'{crmURL p="civicrm/ajax/grouplist" h=0 q="snippet=4"}'{literal},


### PR DESCRIPTION
Overview
----------------------------------------
When searching for group it looks like the search was performed by the site name.
New message is more user friendly

Before
----------------------------------------
![K2YbOSY](https://user-images.githubusercontent.com/54142191/63167060-15e40280-c028-11e9-889c-61c5ba718964.png)


After
----------------------------------------
![2y4BGTr](https://user-images.githubusercontent.com/54142191/63167073-1bd9e380-c028-11e9-95c7-f98a48c7e9f2.png)


Steps to reproduce
----------------------------------------
1.Click "View contact record"
2.Click "Contact" → "Manage Group"
3.Try to find some non-existent group
4.Take a look at the message: "No Groups have been created for this site."
