### PR TITLE
dev/membership#13 Add handling for missing MembershipPayment record.

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -678,6 +678,7 @@ function civicrm_api3_contribution_repeattransaction($params) {
       'fee_amount',
       'financial_type_id',
       'contribution_status_id',
+      'membership_id',
     ];
     $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
 


### PR DESCRIPTION
Overview
----------------------------------------
We have an intermittent regression on extending memberships off paypal payments. This adds debug messages and handling / tests for the scenario I suspect may be in play.

In short it used  to be that the paypal request membershipID would override a lack of identifiable membership ids later on. This  causes the paypal id to have that dominance again

Before
----------------------------------------
If the  code could not determine the correct membership none would be extended.

After
----------------------------------------
The paypal request sets the membership id to be extended

Technical Details
----------------------------------------


The 'decision' the code makes about how to create recurring transactions is all dependent on the 'template transaction'
- if that is not correct the follow on payments will not be.

This PR allows the membershipID input from paypal to be passed through and used.  This will override any
intended changes - but that just restores previous behaviour and we do not have good handling for these

Comments
----------------------------------------
@MegaphoneJon @Stoob can you test

https://lab.civicrm.org/dev/membership/issues/13