### PR TITLE
Update select2 to latest 3.x + patches

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "jquery-ui": "~1.12",
     "lodash-compat": "~3.0",
     "google-code-prettify": "~1.0",
-    "select2": "colemanw/select2#stable/3.5",
+    "select2": "colemanw/select2#v3.5-civicrm-1.0",
     "jquery-validation": "~1.13",
     "datatables": "~1.10",
     "jstree": "~3",


### PR DESCRIPTION
Overview
----------------------------------------
This bumps up our patched version of Select2 to 3.5.4 and targets a tag instead of a branch for better composer integration.
