### PR TITLE
dev/core#1186 - ignore exception if no description field

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1172,7 +1172,16 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
             // In other contexts show a paperclip icon
             if (CRM_Utils_Rule::integer($value)) {
               $icons = CRM_Core_BAO_File::paperIconAttachment('*', $value);
-              $display = $icons[$value] . civicrm_api3('File', 'getvalue', ['return' => "description", 'id' => $value]);
+
+              $file_description = '';
+              try {
+                $file_description = civicrm_api3('File', 'getvalue', ['return' => "description", 'id' => $value]);
+              }
+              catch (CiviCRM_API3_Exception $dontcare) {
+                // don't care
+              }
+
+              $display = "{$icons[$value]}{$file_description}";
             }
             else {
               //CRM-18396, if filename is passed instead


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1186

Before
----------------------------------------
Datatables error because of uncaught exception

After
----------------------------------------
Golden silence.

Technical Details
----------------------------------------

Comments
----------------------------------------
