### PR TITLE
dev/event#10 - Prevent old notes from being exposed in event confirmation email

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1358,6 +1358,15 @@ WHERE civicrm_event.is_active = 1
 
         CRM_Core_BAO_UFGroup::getValues($cid, $fields, $values, FALSE, $params);
 
+        //dev/event#10
+        //If the event profile includes a note field and the submitted value of
+        //that field is "", then remove the old note returned by getValues.
+        if (isset($participantParams['note']) && empty($participantParams['note'])) {
+          $noteKeyPos = array_search('note', array_keys($fields));
+          $valuesKeys = array_keys($values);
+          $values[$valuesKeys[$noteKeyPos]] = "";
+        }
+
         if (isset($fields['participant_status_id']['title']) &&
           isset($values[$fields['participant_status_id']['title']]) &&
           is_numeric($values[$fields['participant_status_id']['title']])

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1301,8 +1301,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     // This happens in buildQuickForm so emulate here.
     $form->_amount = $form->_totalAmount = CRM_Utils_Rule::cleanMoney(CRM_Utils_Array::value('totalAmount', $params));
     $form->set('params', $params['params']);
-    $form->_values['custom_pre_id'] = [];
-    $form->_values['custom_post_id'] = [];
+    $form->_values['custom_pre_id'] = CRM_Utils_Array::value('custom_pre_id', $params);
+    $form->_values['custom_post_id'] = CRM_Utils_Array::value('custom_post_id', $params);
     $form->_values['event'] = CRM_Utils_Array::value('event', $params);
     $form->_contributeMode = $params['contributeMode'];
     $eventParams = ['id' => $params['id']];


### PR DESCRIPTION
Overview
----------------------------------------
When submitting an event registration which contains a profile which contains a note field, if the note is left blank, then the confirmation/notification emails contain the most recent note in the contact's record, potentially exposing confidential information.

This PR corrects this issue and adds a test (testNoteSubmission) to confirm that the email works as expected for both blank and non-blank note submissions.

Before
----------------------------------------
Email shows last note in contact record upon the above conditions.

After
----------------------------------------
Email shows a blank for the note upon the above conditions.


Technical Details
----------------------------------------


Comments
----------------------------------------

