### PR TITLE
Fix readability & caching on CRM_Contact_BAO_Relationship::isInheritedMembershipInvalidated

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -156,6 +156,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
     CRM_Member_PseudoConstant::membershipType(NULL, TRUE);
     civicrm_api3('membership', 'getfields', ['cache_clear' => 1, 'fieldname' => 'membership_type_id']);
     civicrm_api3('profile', 'getfields', ['action' => 'submit', 'cache_clear' => 1]);
+    Civi::cache('metadata')->clear();
   }
 
   /**
@@ -266,6 +267,8 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   /**
    * Get membership Types.
    *
+   * @deprecated  use getAllMembershipTypes.
+   *
    * @param bool $public
    *
    * @return array
@@ -287,6 +290,8 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
 
   /**
    * Get membership Type Details.
+   *
+   * @deprecated use getMembershipType.
    *
    * @param int $membershipTypeId
    *
@@ -839,6 +844,32 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
         CRM_Price_BAO_PriceFieldValue::add($updateParams);
       }
     }
+  }
+
+  /**
+   * Cached wrapper for membership types.
+   *
+   * Since this is used from the batched script caching helps.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getAllMembershipTypes() {
+    if (!Civi::cache('metadata')->has(__CLASS__ . __FUNCTION__)) {
+      Civi::cache('metadata')->set(__CLASS__ . __FUNCTION__, civicrm_api3('MembershipType', 'get', ['options' => ['limit' => 0, 'sort' => 'weight']])['values']);
+    }
+    return Civi::cache('metadata')->get(__CLASS__ . __FUNCTION__);
+  }
+
+  /**
+   * Get a specific membership type (leveraging the cache).
+   *
+   * @param int $id
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getMembershipType($id) {
+    return self::getAllMembershipTypes()[$id];
   }
 
 }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1443,6 +1443,7 @@ class CRM_Utils_System {
       Civi::cache('navigation')->flush();
       Civi::cache('customData')->flush();
       Civi::cache('contactTypes')->clear();
+      Civi::cache('metadata')->clear();
       CRM_Extension_System::singleton()->getCache()->flush();
       CRM_Cxn_CiviCxnHttp::singleton()->getCache()->flush();
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -160,6 +160,7 @@ class Container {
       'customData' => 'custom data',
       'fields' => 'contact fields',
       'contactTypes' => 'contactTypes',
+      'metadata' => 'metadata',
     ];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
@@ -169,7 +170,7 @@ class Container {
       // For Caches that we don't really care about the ttl for and/or maybe accessed
       // fairly often we use the fastArrayDecorator which improves reads and writes, these
       // caches should also not have concurrency risk.
-      $fastArrayCaches = ['groups', 'navigation', 'customData', 'fields', 'contactTypes'];
+      $fastArrayCaches = ['groups', 'navigation', 'customData', 'fields', 'contactTypes', 'metadata'];
       if (in_array($cacheSvc, $fastArrayCaches)) {
         $definitionParams['withArray'] = 'fast';
       }

--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -87,6 +87,7 @@ function civicrm_api3_membership_type_get($params) {
       // Workaround for fields using nonstandard serialization
       foreach (['relationship_type_id', 'relationship_direction'] as $field) {
         if (isset($item[$field]) && !is_array($item[$field])) {
+          // @todo - this should be handled by the serialization now...
           $item[$field] = (array) $item[$field];
         }
       }


### PR DESCRIPTION
Overview
Mostly code readability but also improves caching

Before
----------------------------------------
Sql query & some hard-to-read & unnecessary wrangling 

After
----------------------------------------
More readable. Introduction of a cached function improves performance

Technical Details
----------------------------------------
@seamuslee001 looking at this I was going to use the 'fields' cache but of course the name was wrong so I figured adding a generic 'metadata' cache would cover a lot of uses (including probably what 'fields' currently is....

Comments
----------------------------------------
