### PR TITLE
Agile fixFix inherited membership being deleted when there is still a valid …  …relationship

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -984,19 +984,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     }
 
     $contactType = $contact->contact_type;
-    // currently we only clear employer cache.
-    // we are now deleting inherited membership if any.
-    if ($contact->contact_type == 'Organization') {
-      $action = $restore ? CRM_Core_Action::ENABLE : CRM_Core_Action::DISABLE;
-      $relationshipDtls = CRM_Contact_BAO_Relationship::getRelationship($id);
-      if (!empty($relationshipDtls)) {
-        foreach ($relationshipDtls as $rId => $details) {
-          CRM_Contact_BAO_Relationship::disableEnableRelationship($rId, $action);
-        }
-      }
-      CRM_Contact_BAO_Contact_Utils::clearAllEmployee($id);
-    }
-
     if ($restore) {
       return self::contactTrashRestore($contact, TRUE);
     }
@@ -1044,6 +1031,18 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     }
     else {
       self::contactTrashRestore($contact);
+    }
+    // currently we only clear employer cache.
+    // we are now deleting inherited membership if any.
+    if ($contact->contact_type == 'Organization') {
+      $action = $restore ? CRM_Core_Action::ENABLE : CRM_Core_Action::DISABLE;
+      $relationshipDtls = CRM_Contact_BAO_Relationship::getRelationship($id);
+      if (!empty($relationshipDtls)) {
+        foreach ($relationshipDtls as $rId => $details) {
+          CRM_Contact_BAO_Relationship::disableEnableRelationship($rId, $action);
+        }
+      }
+      CRM_Contact_BAO_Contact_Utils::clearAllEmployee($id);
     }
 
     //delete the contact id from recently view

--- a/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
@@ -46,6 +46,8 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
    * Tears down the fixture, for example, closes a network connection.
    *
    * This method is called after a test is executed.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function tearDown() {
     $this->quickCleanup([
@@ -57,10 +59,15 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
+  /**
+   * Test Relationship Type Options Will Return Specified Type
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function testRelationshipTypeOptionsWillReturnSpecifiedType() {
     $orgToOrgType = 'A_B_relationship';
     $orgToOrgReverseType = 'B_A_relationship';
-    civicrm_api3('RelationshipType', 'create', [
+    $this->callAPISuccess('RelationshipType', 'create', [
       'name_a_b' => $orgToOrgType,
       'name_b_a' => $orgToOrgReverseType,
       'contact_type_a' => 'Organization',
@@ -251,19 +258,21 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
 
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $organisationID], 1);
-    // Disable the relationship & check the membership is removed.
+    // Disable the relationship & check the membership is not removed because the other relationship is still valid.
     $relationshipOne['is_active'] = 0;
     $this->callAPISuccess('Relationship', 'create', array_merge($relationshipOne, ['is_active' => 0]));
-    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 0);
-    /*
-     * @todo this section not yet working due to bug in would-be-tested code.
+    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
+
     $relationshipTwo['is_active'] = 0;
     $this->callAPISuccess('Relationship', 'create', $relationshipTwo);
-    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
+    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 0);
 
     $relationshipOne['is_active'] = 1;
     $this->callAPISuccess('Relationship', 'create', $relationshipOne);
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
+
+    /*
+     * @todo this section not yet working due to bug in would-be-tested code.
     $relationshipTwo['is_active'] = 1;
     $this->callAPISuccess('Relationship', 'create', $relationshipTwo);
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -516,6 +516,9 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    *
    * Test suite for CRM-14758: API ( contact, create ) does not always create related membership
    * and max_related property for Membership_Type and Membership entities
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testCreateWithRelationship() {
     // Create membership type: inherited through employment, max_related = 2
@@ -691,6 +694,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
   /**
    * We are checking for no e-notices + only id & end_date returned
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testMembershipGetWithReturn() {
     $this->contactMembershipCreate($this->_params);

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -1301,8 +1301,12 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Check for e-notices on enable & disable as reported in CRM-14350
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testSetActive($version) {
     $this->_apiversion = $version;
@@ -1313,8 +1317,12 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
   /**
    * Test creating related memberships.
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreateRelatedMembership($version) {
     $this->_apiversion = $version;


### PR DESCRIPTION
Overview
----------------------------------------
This is a recut of work by Agileware in #14410 - including enabling part of the already-merged-but-commented-out test from that PR which was previously merged.

It addresses one of the scenarios in that PR - ie. when a contact has 2 relationships with another contact and inherits a membership from them. If one relationship is disabled then the inheritance should persist

More details on the original PR

Before
----------------------------------------
Contact with 2 relationships to a member contacts loses their inherited relationship is only one is deleted

After
----------------------------------------
Relationship not lost

Technical Details
----------------------------------------
Note this relies on preliminary cleanup in #15061  - I will rebase when merged.

Comments
----------------------------------------
agileware-pengyi this is how I think we should progress the #14410 fix - ie  break it down into component bugs & cleanup the code to make the actual fix readable
