### PR TITLE
CRM-17182 Fix Search on fee_level_id and ensure that participant.fee_amount isn't updated when label changes

### DIFF
--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -54,13 +54,6 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
     $fieldValueBAO = new CRM_Price_BAO_PriceFieldValue();
     $fieldValueBAO->copyValues($params);
 
-    if ($id = CRM_Utils_Array::value('id', $ids)) {
-      $fieldValueBAO->id = $id;
-      $prevLabel = self::getOptionLabel($id);
-      if (!empty($params['label']) && $prevLabel != $params['label']) {
-        self::updateAmountAndFeeLevel($id, $prevLabel, $params['label']);
-      }
-    }
     // CRM-16189
     $priceFieldID = CRM_Utils_Array::value('price_field_id', $params);
     if (!$priceFieldID) {
@@ -314,41 +307,6 @@ cps.financial_type_id = %3
 WHERE cpse.id IS NOT NULL {$where}";
 
     CRM_Core_DAO::executeQuery($sql, $params);
-  }
-
-  /**
-   * Update price option label in line_item, civicrm_contribution and civicrm_participant.
-   *
-   * @param int $id - id of the price_field_value
-   * @param string $prevLabel
-   * @param string $newLabel
-   *
-   */
-  public static function updateAmountAndFeeLevel($id, $prevLabel, $newLabel) {
-    // update price field label in line item.
-    $lineItem = new CRM_Price_DAO_LineItem();
-    $lineItem->price_field_value_id = $id;
-    $lineItem->label = $prevLabel;
-    $lineItem->find();
-    while ($lineItem->fetch()) {
-      $lineItemParams['id'] = $lineItem->id;
-      $lineItemParams['label'] = $newLabel;
-      CRM_Price_BAO_LineItem::create($lineItemParams);
-
-      // update amount and fee level in civicrm_contribution and civicrm_participant
-      $params = [
-        1 => [CRM_Core_DAO::VALUE_SEPARATOR . $prevLabel . ' -', 'String'],
-        2 => [CRM_Core_DAO::VALUE_SEPARATOR . $newLabel . ' -', 'String'],
-      ];
-      // Update contribution
-      if (!empty($lineItem->contribution_id)) {
-        CRM_Core_DAO::executeQuery("UPDATE `civicrm_contribution` SET `amount_level` = REPLACE(amount_level, %1, %2) WHERE id = {$lineItem->contribution_id}", $params);
-      }
-      // Update participant
-      if ($lineItem->entity_table == 'civicrm_participant') {
-        CRM_Core_DAO::executeQuery("UPDATE `civicrm_participant` SET `fee_level` = REPLACE(fee_level, %1, %2) WHERE id = {$lineItem->entity_id}", $params);
-      }
-    }
   }
 
 }

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -56,6 +56,9 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
 
     // CRM-16189
     $priceFieldID = CRM_Utils_Array::value('price_field_id', $params);
+
+    $id = CRM_Utils_Array::value('id', $ids, CRM_Utils_Array::value('id', $params));
+
     if (!$priceFieldID) {
       $priceFieldID = CRM_Core_DAO::getFieldValue('CRM_Price_BAO_PriceFieldValue', $id, 'price_field_id');
     }

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -357,7 +357,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
       $params['visibility_id'] = CRM_Utils_Array::value('visibility_id', $params, FALSE);
       $ids = [];
       if ($this->_oid) {
-        $ids['id'] = $this->_oid;
+        $params['id'] = $this->_oid;
       }
       $optionValue = CRM_Price_BAO_PriceFieldValue::create($params, $ids);
 

--- a/tests/phpunit/CRM/Event/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Event/Form/SearchTest.php
@@ -8,48 +8,71 @@ class CRM_Event_Form_SearchTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
     $this->individualID = $this->individualCreate();
+    $this->event = $this->eventCreate();
+    $this->priceFieldValues = $this->createPriceSet('event', $this->event, [
+      'html_type'    => 'Radio',
+      'option_label' => ['1' => 'Radio Label A (inc. GST)', '2' => 'Radio Label B (inc. GST)'],
+      'option_name'  => ['1' => 'Radio Label A', '2' => 'Radio Label B'],
+    ]);
+
+    $this->priceFieldValues = $this->priceFieldValues['values'];
+    $this->participantPrice = NULL;
+    foreach ($this->priceFieldValues as $priceFieldValue) {
+      $this->participantPrice = $priceFieldValue;
+      break;
+    }
+
+    $today = new DateTime();
+    $this->participant = $this->participantCreate([
+      'event_id'  => $this->event['id'],
+      'contact_id' => $this->individualID,
+      'status_id' => 1,
+      'fee_level' => $this->participantPrice['label'],
+      'fee_amount' => $this->participantPrice['amount'],
+      'fee_currency' => 'USD',
+      'register_date' => $today->format('YmdHis'),
+    ]);
+  }
+
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**
    *  Test that search form returns correct number of rows for complex regex filters.
    */
   public function testSearch() {
-    $priceFieldValues = $this->createPriceSet('event', NULL, [
-      'html_type'    => 'Radio',
-      'option_label' => ['1' => 'Radio Label A (inc. GST)', '2' => 'Radio Label B (inc. GST)'],
-      'option_name'  => ['1' => 'Radio Label A', '2' => 'Radio Label B'],
-    ]);
-
-    $priceFieldValues = $priceFieldValues['values'];
-    $participantPrice = NULL;
-    foreach ($priceFieldValues as $priceFieldValue) {
-      $participantPrice = $priceFieldValue;
-      break;
-    }
-
-    $event = $this->eventCreate();
-    $individualID = $this->individualCreate();
-    $today = new DateTime();
-    $this->participantCreate([
-      'event_id'      => $event['id'],
-      'contact_id'    => $individualID,
-      'status_id'     => 1,
-      'fee_level'     => $participantPrice['label'],
-      'fee_amount'    => $participantPrice['amount'],
-      'fee_currency'  => 'USD',
-      'register_date' => $today->format('YmdHis'),
-    ]);
-
     $form = new CRM_Event_Form_Search();
     $form->controller = new CRM_Event_Controller_Search();
     $form->preProcess();
     $form->testSubmit([
       'participant_test' => 0,
       'participant_fee_id' => [
-        $participantPrice['id'],
+        $this->participantPrice['id'],
       ],
       'radio_ts'         => 'ts_all',
     ]);
+    $rows = $form->controller->get('rows');
+    $this->assertEquals(1, count($rows), 'Exactly one row should be returned for given price field value.');
+  }
+
+  public function testSearchWithPricelabelChange() {
+    $this->callAPISuccess('PriceFieldValue', 'create', [
+      'label' => 'Radio Label C',
+      'id' => $this->participantPrice['id'],
+    ]);
+    $form = new CRM_Event_Form_Search();
+    $form->controller = new CRM_Event_Controller_Search();
+    $form->preProcess();
+    $form->testSubmit([
+      'participant_test' => 0,
+      'participant_fee_id' => [
+        $this->participantPrice['id'],
+      ],
+      'radio_ts'         => 'ts_all',
+    ]);
+    // Confirm that even tho we have changed the label for the price field value the query still works
     $rows = $form->controller->get('rows');
     $this->assertEquals(1, count($rows), 'Exactly one row should be returned for given price field value.');
   }

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -573,6 +573,9 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $this->assertEquals(2, $lineItem['qty']);
     $this->assertEquals(20, $lineItem['unit_price']);
     $this->assertEquals('pricefieldvalue1', $lineItem['label']);
+    $this->callAPISuccess('PriceFieldValue', 'create', ['id' => $pfv2['id'], 'label' => 'Price FIeld Value 2 Label']);
+    $participantGet = $this->callAPISuccess('Participant', 'get', ['id' => $participant['id']]);
+    $this->assertEquals(["pricefieldvalue1 - 2", "pricefieldvalue2 - 2"], $participantGet['values'][$participant['id']]['participant_fee_level']);
 
     // Cleanup
     $this->callAPISuccess('participant', 'delete', ['id' => $participant['id']]);

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -576,6 +576,30 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $this->callAPISuccess('PriceFieldValue', 'create', ['id' => $pfv2['id'], 'label' => 'Price FIeld Value 2 Label']);
     $participantGet = $this->callAPISuccess('Participant', 'get', ['id' => $participant['id']]);
     $this->assertEquals(["pricefieldvalue1 - 2", "pricefieldvalue2 - 2"], $participantGet['values'][$participant['id']]['participant_fee_level']);
+    $conatactID4 = $this->individualCreate();
+    $myParams['contact_id'] = $conatactID4;
+    $myParams['participant_fee_level'] = CRM_Core_DAO::VALUE_SEPARATOR . "pricefieldvalue1 - 2" . CRM_Core_DAO::VALUE_SEPARATOR . "Price FIeld Value 2 Label - 2" . CRM_Core_DAO::VALUE_SEPARATOR;
+    $AdditionalParticipant = $this->callAPISuccess('Participant', 'create', $myParams);
+    $this->assertEquals(["pricefieldvalue1 - 2", "Price FIeld Value 2 Label - 2"], $AdditionalParticipant['values'][$AdditionalParticipant['id']]['fee_level']);
+    $lineItems = $this->callAPISuccess('LineItem', 'get', [
+      'entity_id' => $AdditionalParticipant['id'],
+      'entity_table' => 'civicrm_participant',
+    ]);
+    $this->assertEquals(2, $lineItems['count']);
+
+    // Check quantity, label and unit price of lines.
+    // TODO: These assertions depend on the order of the line items, which is
+    // technically incorrect.
+
+    $lineItem = array_pop($lineItems['values']);
+    $this->assertEquals(2, $lineItem['qty']);
+    $this->assertEquals(5, $lineItem['unit_price']);
+    $this->assertEquals('Price FIeld Value 2 Label', $lineItem['label']);
+
+    $lineItem = array_pop($lineItems['values']);
+    $this->assertEquals(2, $lineItem['qty']);
+    $this->assertEquals(20, $lineItem['unit_price']);
+    $this->assertEquals('pricefieldvalue1', $lineItem['label']);
 
     // Cleanup
     $this->callAPISuccess('participant', 'delete', ['id' => $participant['id']]);


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the issue in CRM-17182 by filtering on civicrm_line_item.price_field_value_id rather than civicrm_participant.fee_amount and remove the code introduced originally to fix CRM-17182 which changed the fee_amount column details based on label changes in price field values

Before
----------------------------------------
fee_amount changed whenever label is changed and searching done based on a regex on the fee_amount column

After
----------------------------------------
searching based on the price_field_value id and the fee_amount column is not changed

thoughts @JoeMurray @eileenmcnaughton @jitendrapurohit 