### PR TITLE
Remove deprecated unused function.

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -626,27 +626,6 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * @deprecated Please use the Membership API
-   * Retrieve all Membership Types associated with an Organization
-   *
-   * @param int $orgID
-   *   Id of Organization.
-   *
-   * @return array
-   *   array of the details of membership types
-   */
-  public static function getMembershipTypesByOrg($orgID) {
-    CRM_Core_Error::deprecatedFunctionWarning('membership_type api');
-    $memberTypesSameParentOrg = civicrm_api3('MembershipType', 'get', [
-      'member_of_contact_id' => $orgID,
-      'options' => [
-        'limit' => 0,
-      ],
-    ]);
-    return CRM_Utils_Array::value('values', $memberTypesSameParentOrg, []);
-  }
-
-  /**
    * Retrieve all Membership Types with Member of Contact id.
    *
    * @param array $membershipTypes


### PR DESCRIPTION
Overview
----------------------------------------
I noticed this has been deprecated for over a year (& is unused). Removing

Before
----------------------------------------
<img width="912" alt="Screen Shot 2019-08-19 at 10 28 16 AM" src="https://user-images.githubusercontent.com/336308/63231192-4c11c400-c26c-11e9-9783-e98fc4654753.png">


After
----------------------------------------
Gone

Technical Details
----------------------------------------
We generally deprecate functions before removing them to ease the path of extensions calling BAO functions (which is not supported but this seems to reduce risk of pain). This removes

Comments
----------------------------------------
@mattwire 
