### PR TITLE
[NFC] Update the APIv3 documentation links.

### DIFF
--- a/tests/templates/documentFunction.tpl
+++ b/tests/templates/documentFunction.tpl
@@ -60,17 +60,17 @@ function {$function}_expectedresult() {literal}{{/literal}
 * https://github.com/civicrm/civicrm-core/blob/master/tests/phpunit/api/v3/{$testFile}
 *
 * You can see the outcome of the API tests at
-* https://test.civicrm.org/job/CiviCRM-master-git/
+* https://test.civicrm.org/job/CiviCRM-Core-Matrix/
 *
 * To Learn about the API read
-* http://wiki.civicrm.org/confluence/display/CRMDOC/Using+the+API
+* https://docs.civicrm.org/dev/en/latest/api/
 *
-* Browse the api on your own site with the api explorer
-* http://MYSITE.ORG/path/to/civicrm/api
+* Browse the API on your own site with the API Explorer. It is in the main
+* CiviCRM menu, under: Support > Development > API Explorer.
 *
 * Read more about testing here
-* http://wiki.civicrm.org/confluence/display/CRM/Testing
+* https://docs.civicrm.org/dev/en/latest/testing/
 *
 * API Standards documentation:
-* http://wiki.civicrm.org/confluence/display/CRM/API+Architecture+Standards
+* https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
 */


### PR DESCRIPTION
Overview
----------------------------------------

Many of the links in the API examples point to outdated resources (old wiki, non-existing Jenkins job).

Most (but not all) of the wiki links are still alive and with redirects, but they may disappear one day.

