### PR TITLE
dev/core#1192 - E_NOTICE on using Add Activity action on contact search results

### DIFF
--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -343,7 +343,7 @@ class CRM_Core_Form_RecurringEntity {
       $params['entity_id'] = self::$_entityId;
     }
     //Process this function only when you get this variable
-    if ($params['allowRepeatConfigToSubmit'] == 1) {
+    if (CRM_Utils_Array::value('allowRepeatConfigToSubmit', $params) == 1) {
       if (!empty($params['entity_table']) && !empty($params['entity_id']) && $type) {
         $params['used_for'] = $type;
         if (empty($params['parent_entity_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1192

E_NOTICE when using Add Activity from the actions dropdown for contact search results.

Before
----------------------------------------
Notice: Undefined index: allowRepeatConfigToSubmit in CRM_Core_Form_RecurringEntity::postProcess() (line 346 of /.../web/sites/all/modules/civicrm/CRM/Core/Form/RecurringEntity.php

After
----------------------------------------
No notice.

Technical Details
----------------------------------------

Comments
----------------------------------------

