### PR TITLE
WIP: ensure checksum include contact id.

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1592,7 +1592,7 @@ INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
     if ($entityArg != '') {
       // Add checksum argument
       if ($contactID != 0 && $userId != $contactID) {
-        $checksumValue = '&cs=' . CRM_Contact_BAO_Contact_Utils::generateChecksum($contactID, NULL, 'inf');
+        $checksumValue = '&cid=' . $contactID . '&cs=' . CRM_Contact_BAO_Contact_Utils::generateChecksum($contactID, NULL, 'inf');
       }
       return CRM_Utils_System::url($url, "reset=1&{$entityArg}={$entityID}{$checksumValue}", TRUE, NULL, FALSE, TRUE);
     }


### PR DESCRIPTION
Fix for https://lab.civicrm.org/dev/core/issues/760

Regression from: https://lab.civicrm.org/dev/core/issues/571

Overview
----------------------------------------

Ensure links to update or cancel recurring contributions succeed for users who are not logged in for authorize.net (and perhaps others).

Before
----------------------------------------

Clicking on a link to update or cancel a recurring contribution resulted in a permission denied error.

After
----------------------------------------

By ensuring the cid= argument is included in the link, the request succeeds without being logged in.


Comments
----------------------------------------

Seems to be a regression from: 

https://lab.civicrm.org/dev/core/issues/571