### PR TITLE
(dev/drupal#79) CRM_Upgrade_Form - Raise MINIMUM_PHP_VERSION from 5.6 to 7.0

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -50,10 +50,9 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   /**
    * Minimum php version required to run (equal to or lower than the minimum install version)
    *
-   * Even though 5.6 is no longer supported, this value is left here for a while
-   * so as not to block stragglers from upgrading.
+   * As of Civi 5.16, using PHP 5.x will lead to a hard crash during bootstrap.
    */
-  const MINIMUM_PHP_VERSION = '5.6';
+  const MINIMUM_PHP_VERSION = '7.0.0';
 
   /**
    * @var \CRM_Core_Config


### PR DESCRIPTION
This version requirement officially went up to PHP 7.0 circa Civi 5.14. However, at that time, the upgrade metadata was kept at PHP 5.6 to allow somewhat softer landing for stragglers. That's no longer possible in 5.16+, so this just updates the requirement.

Before
------

When upgrading via drush or Drupal web UI to Civi 5.16+ on PHP 5.6, the Civi class-loader fails to initialize.

```
Parse error: syntax error, unexpected ':', expecting '{' 
in /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/vendor/league/csv/src/functions.php on line 33
```

(Approximate call-path: `civicrm.drush.inc | civicrm.module` => `civicrm.settings.php` =>
`CRM_Core_ClassLoader` => `vendor/autoload.php` => `vendor/league/csv/src/functions.php`)

After
-----

It still fails, but at least the metadata is accurate.

There will be a separate PR for `civicrm-drupal.git` to use this metadata and present a clearer error-message.
