### PR TITLE
dev/core#1179 Default Contact Search Profile should be respected for contact searches including Edit Smart Group Criteria

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -612,7 +612,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           $this->_ssID = $ssId;
         }
       }
-      // set the uf group id if not already present
+      // set the uf group id for smart group search default profile view.
       if (isset($this->_ufGroupID)) {
         $this->_formValues['uf_group_id'] = $this->_ufGroupID;
       }

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -612,26 +612,27 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           $this->_ssID = $ssId;
         }
       }
-
+      // set the uf group id if not already present
+      if (isset($this->_ufGroupID)) {
+        $this->_formValues['uf_group_id'] = $this->_ufGroupID;
+      }
       // fix for CRM-1907
       if (isset($this->_ssID) && $this->_context != 'smog') {
-        // we only retrieve the saved search values if out current values are null
-        $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
+        if (!isset($this->_ufGroupID)) {
+          // we only retrieve the saved search values if out current values are null
+          $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
 
-        //fix for CRM-1505
-        if (CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch', $this->_ssID, 'mapping_id')) {
-          $this->_params = CRM_Contact_BAO_SavedSearch::getSearchParams($this->_ssID);
-        }
-        else {
-          $this->_params = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
+          //fix for CRM-1505
+          if (CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch', $this->_ssID, 'mapping_id')) {
+            $this->_params = CRM_Contact_BAO_SavedSearch::getSearchParams($this->_ssID);
+          }
+          else {
+            $this->_params = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
+          }
         }
         $this->_returnProperties = &$this->returnProperties();
       }
       else {
-        if (isset($this->_ufGroupID)) {
-          // also set the uf group id if not already present
-          $this->_formValues['uf_group_id'] = $this->_ufGroupID;
-        }
         if (isset($this->_componentMode)) {
           $this->_formValues['component_mode'] = $this->_componentMode;
         }


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/1179

Default Contact Search Profile should be respected for contact searches including Edit Smart Group Criteria.

* Create a profile configured to be used in Search Views.
* Make this profile as Default Contact Search Profile. From Administrator - Search Preferences - Default Contact Search Profile.
* Go to Basic, Advanced Search/Builer, all the results have profile fields listed as column headers if use force=1
* Create a smart search and go to Contacts and use force=1. Profile fields not shown.

Before:

<img width="775" alt="before-patch-view" src="https://user-images.githubusercontent.com/445545/63507445-601c2680-c4f5-11e9-9e2a-d098495adddc.png">

After:

Smart group advance search will also show the default Search profile fields.

<img width="694" alt="after-patch-view" src="https://user-images.githubusercontent.com/445545/63507456-68746180-c4f5-11e9-90e8-6fe9c4e65099.png">
