### PR TITLE
5.17.0 release notes - initial run

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -15,6 +15,17 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 5.17.0
+
+Released September 4, 2019
+
+- **[Synopsis](release-notes/5.17.0.md#synopsis)**
+- **[Features](release-notes/5.17.0.md#features)**
+- **[Bugs resolved](release-notes/5.17.0.md#bugs)**
+- **[Miscellany](release-notes/5.17.0.md#misc)**
+- **[Credits](release-notes/5.17.0.md#credits)**
+- **[Feedback](release-notes/5.17.0.md#feedback)**
+
 ## CiviCRM 5.16.2
 
 Released August 14, 2019

--- a/release-notes/5.17.0.md
+++ b/release-notes/5.17.0.md
@@ -1,0 +1,511 @@
+# CiviCRM 5.17.0
+
+Released September 4, 2019;
+
+- **[Features](#features)**
+- **[Bugs resolved](#bugs)**
+- **[Miscellany](#misc)**
+- **[Credits](#credits)**
+
+## <a name="features"></a>Features
+
+### Core CiviCRM
+
+- **CRM-20455 Missing Summary ([259](https://github.com/civicrm/civicrm-packages/pull/259))**
+
+- **CRM-20445 Missing Summary ([180](https://github.com/civicrm/civicrm-packages/pull/180))**
+
+## <a name="bugs"></a>Bugs resolved
+
+### Core CiviCRM
+
+- **(dev/drupal#79) CRM_Upgrade_Form - Raise MINIMUM_PHP_VERSION from 5.6 to 7.0 ([15082](https://github.com/civicrm/civicrm-core/pull/15082))**
+
+- **Remove "Copy Case custom data" code (circa 2013) ([15051](https://github.com/civicrm/civicrm-core/pull/15051))**
+
+- **Fix unreleased regression on import ([15048](https://github.com/civicrm/civicrm-core/pull/15048))**
+
+- **dev/core#1186 add in unit test to lock in fix from dmeritcowboy in #1… ([15058](https://github.com/civicrm/civicrm-core/pull/15058))**
+
+- **dev/core#1186 - ignore exception if no description field ([15055](https://github.com/civicrm/civicrm-core/pull/15055))**
+
+- **dev/core#1190 Add pptx to safe file types ([15047](https://github.com/civicrm/civicrm-core/pull/15047))**
+
+- **Add release-notes/5.16.2.md ([15041](https://github.com/civicrm/civicrm-core/pull/15041))**
+
+- **dev/financial#65 - Revert recent changes that cause financial account edit form to be blank ([15037](https://github.com/civicrm/civicrm-core/pull/15037))**
+
+- **5.16.1 release notes ([15025](https://github.com/civicrm/civicrm-core/pull/15025))**
+
+- **core#1182 - revert crm.menubar.js changes ([15021](https://github.com/civicrm/civicrm-core/pull/15021))**
+
+- **core#1175 - fix custom searches ([15007](https://github.com/civicrm/civicrm-core/pull/15007))**
+
+- **Revert #14222 on RC branch ([14996](https://github.com/civicrm/civicrm-core/pull/14996))**
+
+- **Further e-notice regression fix ([14991](https://github.com/civicrm/civicrm-core/pull/14991))**
+
+- **Error log improvements: Provide severity level and use Civi::log() ([14222](https://github.com/civicrm/civicrm-core/pull/14222))**
+
+- **Issue 1170 ([14985](https://github.com/civicrm/civicrm-core/pull/14985))**
+
+- **dev/core#1109 - Fix merge not updating ContactReference fields ([14983](https://github.com/civicrm/civicrm-core/pull/14983))**
+
+- ** Fix (unreleased regression) e-notices on import form ([14978](https://github.com/civicrm/civicrm-core/pull/14978))**
+
+- **5.16 to master ([14987](https://github.com/civicrm/civicrm-core/pull/14987))**
+
+- **dev/drupal#72 Ensure front end profile title is used in event confirmation emails ([14960](https://github.com/civicrm/civicrm-core/pull/14960))**
+
+- **[REF] [Import] extract function that sets field metadata ([14979](https://github.com/civicrm/civicrm-core/pull/14979))**
+
+- **[REF][Import]   very minor cleanup - 3 lines of code to one ([14976](https://github.com/civicrm/civicrm-core/pull/14976))**
+
+- **[Test] Add test cover for Member_BAO_Query auto_renew field ([14956](https://github.com/civicrm/civicrm-core/pull/14956))**
+
+- **Add pseudoconstant metadata to mapping_field.location_type_id ([14975](https://github.com/civicrm/civicrm-core/pull/14975))**
+
+- **[NFC] code formatting only ([14977](https://github.com/civicrm/civicrm-core/pull/14977))**
+
+- **Use metadata for getOptions abbreviation & include currency symbol ([14969](https://github.com/civicrm/civicrm-core/pull/14969))**
+
+- **[REF] Update selfService in updateBilling to use shared function ([14965](https://github.com/civicrm/civicrm-core/pull/14965))**
+
+- **dev/core#1061 Ensure that custom data is not loaded on update subscription form when in self service mode and re-use shared function ([14964](https://github.com/civicrm/civicrm-core/pull/14964))**
+
+- **Translation 'ts' usage fixes. ([14971](https://github.com/civicrm/civicrm-core/pull/14971))**
+
+- **5.16.0 to master ([14974](https://github.com/civicrm/civicrm-core/pull/14974))**
+
+- **Minor cleanup around invoicing on event code ([14959](https://github.com/civicrm/civicrm-core/pull/14959))**
+
+- **[NFC] minor cleanup ([14957](https://github.com/civicrm/civicrm-core/pull/14957))**
+
+- **[NFC] dev/core#1116 - seek and document where activityTypeName is name and where it's label ([14970](https://github.com/civicrm/civicrm-core/pull/14970))**
+
+- **[REF] minor code cleanup on import mapping ([14962](https://github.com/civicrm/civicrm-core/pull/14962))**
+
+- **Fix removeNullContactTokens compatibility with custom tokens ([14943](https://github.com/civicrm/civicrm-core/pull/14943))**
+
+- **dev/core#1135 Participants having multiple roles affects maximum event registration count ([14844](https://github.com/civicrm/civicrm-core/pull/14844))**
+
+- **dev/core#470: Current employer disapears when disabling expired relationships ([14951](https://github.com/civicrm/civicrm-core/pull/14951))**
+
+- **[REF] Move Self service handlng to shared function to allow for use i… ([14963](https://github.com/civicrm/civicrm-core/pull/14963))**
+
+- **[REF] simple extraction of function to check required fields are present ([14961](https://github.com/civicrm/civicrm-core/pull/14961))**
+
+- **Core/dev#692 support for some additional url params ([14921](https://github.com/civicrm/civicrm-core/pull/14921))**
+
+- **Add serialization metadata for MembershipType api ([14954](https://github.com/civicrm/civicrm-core/pull/14954))**
+
+- **Add missing is_public flags to public paths ([14945](https://github.com/civicrm/civicrm-core/pull/14945))**
+
+- **[TEST] [REF] [Export] Convert a couple more tests ([14953](https://github.com/civicrm/civicrm-core/pull/14953))**
+
+- **Move the code to add employer from relationship backoffice form to BAO ([14950](https://github.com/civicrm/civicrm-core/pull/14950))**
+
+- **dev/core#439 [Export] [Ref] Convert custom data export test to use newer function. ([14937](https://github.com/civicrm/civicrm-core/pull/14937))**
+
+- **[REF] [Test] [Export] Convert some more tests to use the newer function ([14933](https://github.com/civicrm/civicrm-core/pull/14933))**
+
+- **core#1130 - allow search views to show contact subtype ([14840](https://github.com/civicrm/civicrm-core/pull/14840))**
+
+- **[NFC] dev/core#1116 - document where activityTypeName is name and where it's label ([14952](https://github.com/civicrm/civicrm-core/pull/14952))**
+
+- **Add test for failed payment ([14946](https://github.com/civicrm/civicrm-core/pull/14946))**
+
+- **[NFC] Formatting in BAO_Relationship class ([14949](https://github.com/civicrm/civicrm-core/pull/14949))**
+
+- **dev/core#1162 [TEST] [Mailing] add in unit test checking that no bulk email flag is re… ([14947](https://github.com/civicrm/civicrm-core/pull/14947))**
+
+- **5.16 to master ([14948](https://github.com/civicrm/civicrm-core/pull/14948))**
+
+- **dev/core#961 - Contribution page including 2 email fields does not re… ([14252](https://github.com/civicrm/civicrm-core/pull/14252))**
+
+- **Catch Payment Processor Exception if thrown when registering via bac… ([14930](https://github.com/civicrm/civicrm-core/pull/14930))**
+
+- **Fix mishandling of renamed membership status labels on membership import ([14940](https://github.com/civicrm/civicrm-core/pull/14940))**
+
+- **[REPORT] Allow extensions to join address, email and phone tables without limi… ([14941](https://github.com/civicrm/civicrm-core/pull/14941))**
+
+- **[Report] Fix handling of location type in Reports ([14942](https://github.com/civicrm/civicrm-core/pull/14942))**
+
+- **(dev/core#1104) make admin panels hookable ([14734](https://github.com/civicrm/civicrm-core/pull/14734))**
+
+- **dev/core#987 Reporthook ([14320](https://github.com/civicrm/civicrm-core/pull/14320))**
+
+- **Extend contribute search url parsing to advanced search ([14939](https://github.com/civicrm/civicrm-core/pull/14939))**
+
+- **5.16 ([14934](https://github.com/civicrm/civicrm-core/pull/14934))**
+
+- **[REF] [Export] Move writeToTable fn to exportProcessor ([14932](https://github.com/civicrm/civicrm-core/pull/14932))**
+
+- **[REF][Event]  Extract calculation of 'zero-ness' in form rule ([14917](https://github.com/civicrm/civicrm-core/pull/14917))**
+
+- **dev/financial#36 [IMPORT] fix & test mishandling on payment_instrument labels ([14881](https://github.com/civicrm/civicrm-core/pull/14881))**
+
+- **dev/core#1141 remove unused deprecated sql_calc_rows ([14877](https://github.com/civicrm/civicrm-core/pull/14877))**
+
+- **[Export] Convert testGender Export to new test format. ([14914](https://github.com/civicrm/civicrm-core/pull/14914))**
+
+- **[REF] [Export] Stop passing header rows around ([14913](https://github.com/civicrm/civicrm-core/pull/14913))**
+
+- **5.16 ([14925](https://github.com/civicrm/civicrm-core/pull/14925))**
+
+- **5.16 to master ([14922](https://github.com/civicrm/civicrm-core/pull/14922))**
+
+- **[REF] Add in cleanup function to prevnext service and utilise in clea… ([14911](https://github.com/civicrm/civicrm-core/pull/14911))**
+
+- **[REF] [Export] [Test] Update 2 more tests to use new helper ([14915](https://github.com/civicrm/civicrm-core/pull/14915))**
+
+- **[REF] [Export] Remove now redundant param ([14912](https://github.com/civicrm/civicrm-core/pull/14912))**
+
+- **dev/core#1050 - Delete repeat activities that are selected for deletion ([14784](https://github.com/civicrm/civicrm-core/pull/14784))**
+
+- **[REF] remove never-set, mispelt parameter ([14907](https://github.com/civicrm/civicrm-core/pull/14907))**
+
+- **Further deprecate use of $ids array in membership functions ([14887](https://github.com/civicrm/civicrm-core/pull/14887))**
+
+- **Improve performance on getSoftContribution details - only run one query instead of one per contribution ([14747](https://github.com/civicrm/civicrm-core/pull/14747))**
+
+- **Add unit test for net_amount when fee_amount is set ([14909](https://github.com/civicrm/civicrm-core/pull/14909))**
+
+- **[REF] [Export] Move fetch Relationship details to processor ([14898](https://github.com/civicrm/civicrm-core/pull/14898))**
+
+- **Remove unused standalone-mode code ([14910](https://github.com/civicrm/civicrm-core/pull/14910))**
+
+- **[NFC] comment fixes, function mis-casing fix ([14906](https://github.com/civicrm/civicrm-core/pull/14906))**
+
+- **dev/core#1149 - Make it clearer which record the logging report is displaying ([14889](https://github.com/civicrm/civicrm-core/pull/14889))**
+
+- **Fix membership end date on confirming a pending contribution ([14902](https://github.com/civicrm/civicrm-core/pull/14902))**
+
+- **5.16 ([14908](https://github.com/civicrm/civicrm-core/pull/14908))**
+
+- **[Test] [Import] Add test to demonstrate bug that turns out not to exist ([14880](https://github.com/civicrm/civicrm-core/pull/14880))**
+
+- **[NFC] reformat class ([14899](https://github.com/civicrm/civicrm-core/pull/14899))**
+
+- **Fixed event type id fetch ([14534](https://github.com/civicrm/civicrm-core/pull/14534))**
+
+- **[IMPORT] [code-quality] Remove instances of CRM_Core_Error::fatal from first import form ([14870](https://github.com/civicrm/civicrm-core/pull/14870))**
+
+- **Fix support for relative dates in urls ([14893](https://github.com/civicrm/civicrm-core/pull/14893))**
+
+- **Add default location for API v3 creates of Address, IM, OpenID and Phone ([14885](https://github.com/civicrm/civicrm-core/pull/14885))**
+
+- **dev/core#1108 [REF] use CRM_Core_DAO::executeQuery instead of ->query() ([14760](https://github.com/civicrm/civicrm-core/pull/14760))**
+
+- **Switch create MembershipPayment to use API ([14886](https://github.com/civicrm/civicrm-core/pull/14886))**
+
+- **EntityPageTrait: Set logged in contact ID as default if one is not specified - this allows permission checks etc. to work properly. ([14620](https://github.com/civicrm/civicrm-core/pull/14620))**
+
+- **Fix php7.x warning on count ([14896](https://github.com/civicrm/civicrm-core/pull/14896))**
+
+- **[REf] [Export] Remove deprecated componentPaymentFields function ([14874](https://github.com/civicrm/civicrm-core/pull/14874))**
+
+- **[Ref] [Export] Remove exportComponent function - it's not adding much here ([14875](https://github.com/civicrm/civicrm-core/pull/14875))**
+
+- **Do not launch raw js alert  jqueryValidation fails ([14854](https://github.com/civicrm/civicrm-core/pull/14854))**
+
+- **Don't let optiongroup check crash ([14895](https://github.com/civicrm/civicrm-core/pull/14895))**
+
+- **[REF] [Test] Add test to cover handling of 'gender_id' on import, remove unused code. ([14879](https://github.com/civicrm/civicrm-core/pull/14879))**
+
+- **dev/event#6 Follow the 'same email' participants config setting for backend participants ([14884](https://github.com/civicrm/civicrm-core/pull/14884))**
+
+- **Invalidate smart group cache for group following deletion of group_c… ([14672](https://github.com/civicrm/civicrm-core/pull/14672))**
+
+- **[test] Catch A.net exception & ignore ([14861](https://github.com/civicrm/civicrm-core/pull/14861))**
+
+- **Ensure that if present the HTTP_X_FORWARDED_FOR IP address is used in… ([14833](https://github.com/civicrm/civicrm-core/pull/14833))**
+
+- **5.16 to master ([14878](https://github.com/civicrm/civicrm-core/pull/14878))**
+
+- **Move log and compilation dirs from "Runtime" to "Paths" ([14718](https://github.com/civicrm/civicrm-core/pull/14718))**
+
+- **[REF] extract loadSavedMapping ([14873](https://github.com/civicrm/civicrm-core/pull/14873))**
+
+- **dev/event#9 Event Templates: do not set the Start/End dates ([14862](https://github.com/civicrm/civicrm-core/pull/14862))**
+
+- **[IMPORT] [code quality] [REF] Improve readability of variable assignment ([14871](https://github.com/civicrm/civicrm-core/pull/14871))**
+
+- **[IMPORT] [code-quality] Remove usage of nullArray ([14869](https://github.com/civicrm/civicrm-core/pull/14869))**
+
+- **[IMPORT] reduce php4 support, don't pass by ref when not required ([14872](https://github.com/civicrm/civicrm-core/pull/14872))**
+
+- **[EXPORT] Fix unreleased regression where postal addresses are not suppressed when empty ([14846](https://github.com/civicrm/civicrm-core/pull/14846))**
+
+- **[METADATA] Add titles to Mapping xml & DAOs ([14867](https://github.com/civicrm/civicrm-core/pull/14867))**
+
+- **5.16 to master ([14868](https://github.com/civicrm/civicrm-core/pull/14868))**
+
+- **[REF] [EXPORT] Use columns from processor instead of passing them ([14860](https://github.com/civicrm/civicrm-core/pull/14860))**
+
+- **NFC Update node module versions based on npm audit fix ([14859](https://github.com/civicrm/civicrm-core/pull/14859))**
+
+- **Add in Atomfeeds deprecation now that the extension has a new release… ([14856](https://github.com/civicrm/civicrm-core/pull/14856))**
+
+- **Autoformat /tests directory with php short array syntax ([14857](https://github.com/civicrm/civicrm-core/pull/14857))**
+
+- **(NFC) Fixing documentation links in readme. ([14855](https://github.com/civicrm/civicrm-core/pull/14855))**
+
+- **Multilingual test fix and cleanup ([14639](https://github.com/civicrm/civicrm-core/pull/14639))**
+
+- **Add unit test demonstrating attaching a listener to queries ([14716](https://github.com/civicrm/civicrm-core/pull/14716))**
+
+- **[REF] [Export] Move temp table creation function to the processor ([14851](https://github.com/civicrm/civicrm-core/pull/14851))**
+
+- **[NFC] code reformatting ([14853](https://github.com/civicrm/civicrm-core/pull/14853))**
+
+- **dev/core#538 fix advanced search on activity subject, detail to use wildcards like activity search does ([14703](https://github.com/civicrm/civicrm-core/pull/14703))**
+
+- **mail#46 - show label, not value, on contribution custom field tokens ([14658](https://github.com/civicrm/civicrm-core/pull/14658))**
+
+- **Remove use of deprecated path in function `CRM_Event_BAO_Event::checkPermission()` ([14735](https://github.com/civicrm/civicrm-core/pull/14735))**
+
+- **Switch priceset selector to addField method ([14843](https://github.com/civicrm/civicrm-core/pull/14843))**
+
+- **Changed the title and description of profile_add_to_group_double_optin ([14852](https://github.com/civicrm/civicrm-core/pull/14852))**
+
+- **dev/core#1118 correct filteration by case type, re-use parent where() ([14827](https://github.com/civicrm/civicrm-core/pull/14827))**
+
+- **Set profile greeting fields based on actual contact type ([14845](https://github.com/civicrm/civicrm-core/pull/14845))**
+
+- **[REF][TEST][EXPORT] minor test cleanup & minor cleanup of code it tests ([14848](https://github.com/civicrm/civicrm-core/pull/14848))**
+
+- **[NFC] [TEST] code formatting in test class ([14849](https://github.com/civicrm/civicrm-core/pull/14849))**
+
+- **[REF] [TEST] cleanup on export activity test ([14850](https://github.com/civicrm/civicrm-core/pull/14850))**
+
+- **[REF] [Export] Stop passing exportParams & sqlColumns around ([14838](https://github.com/civicrm/civicrm-core/pull/14838))**
+
+- **[REF] Down with php4 compatibility ([14847](https://github.com/civicrm/civicrm-core/pull/14847))**
+
+- **dev/core#1133 Payment method name is displayed instead of label in payment block for Manual payment ([14841](https://github.com/civicrm/civicrm-core/pull/14841))**
+
+- **Menubar - Improve flexibility & remove hardcoded values ([14839](https://github.com/civicrm/civicrm-core/pull/14839))**
+
+- **[REF] [Export] Simplify setting of address strings ([14835](https://github.com/civicrm/civicrm-core/pull/14835))**
+
+- **dev/core#1056 Remove unneded schema file ([14834](https://github.com/civicrm/civicrm-core/pull/14834))**
+
+- **dev/core#1120 remove multiple export handling ([14830](https://github.com/civicrm/civicrm-core/pull/14830))**
+
+- **[NFC] [TEST] Reformat arrays in test classes ([14831](https://github.com/civicrm/civicrm-core/pull/14831))**
+
+- **Use singleton to get session instead of relying on ->_session being set elsewhere ([14832](https://github.com/civicrm/civicrm-core/pull/14832))**
+
+- **Add in Deprecation warnings on Cache functons ([14828](https://github.com/civicrm/civicrm-core/pull/14828))**
+
+- **dev/core#1093 Make bulkSave defaults optional and ensure correct post hook is called ([14829](https://github.com/civicrm/civicrm-core/pull/14829))**
+
+- **[REF] Convert contribution_recur dates to datepicker from jcalendar ([14737](https://github.com/civicrm/civicrm-core/pull/14737))**
+
+- **dev/core#1115 - fix invalid url in singleton/max_instances warning in civicase ([14824](https://github.com/civicrm/civicrm-core/pull/14824))**
+
+- **[REF] [Export] remove another confusing parameter ([14822](https://github.com/civicrm/civicrm-core/pull/14822))**
+
+- **[REF] Cleanup up handling of dates for Recurring & Contribution date fields in query class ([14825](https://github.com/civicrm/civicrm-core/pull/14825))**
+
+- **Remove additional custom fields deletegroup functions ([14823](https://github.com/civicrm/civicrm-core/pull/14823))**
+
+- **Convert the contact fields cache group to standard cache backend ([14583](https://github.com/civicrm/civicrm-core/pull/14583))**
+
+- **Add unique names and unique title for recurrings. ([14820](https://github.com/civicrm/civicrm-core/pull/14820))**
+
+- **Convert Custom Data cache group to be using standard cache backend ([14582](https://github.com/civicrm/civicrm-core/pull/14582))**
+
+- **5.16 to master ([14821](https://github.com/civicrm/civicrm-core/pull/14821))**
+
+- **[REF] [Export] Stop passing export params to the merge function ([14819](https://github.com/civicrm/civicrm-core/pull/14819))**
+
+- **dev/event#8 Event Cart: save Participant custom field data ([14816](https://github.com/civicrm/civicrm-core/pull/14816))**
+
+- **Remove the only two defined fonts from selectors ([14815](https://github.com/civicrm/civicrm-core/pull/14815))**
+
+- **[REF] Cleanup usage of CRM_Core_BAO_PrevNextCache::setItem and deprec… ([14675](https://github.com/civicrm/civicrm-core/pull/14675))**
+
+- **Convert Navigation cache group to current cache defition system ([14581](https://github.com/civicrm/civicrm-core/pull/14581))**
+
+- **[TEST] export - add unit test covering merge to same address addressee handling ([14817](https://github.com/civicrm/civicrm-core/pull/14817))**
+
+- **MagicMerge - Fix ephemeral overrides for aliased properties ([14818](https://github.com/civicrm/civicrm-core/pull/14818))**
+
+- **[EXPORT] add getPreview function ([14782](https://github.com/civicrm/civicrm-core/pull/14782))**
+
+- **[REF] [Export] clean up incorporation of order by & group by into ExportProcessor ([14811](https://github.com/civicrm/civicrm-core/pull/14811))**
+
+- **[REF] [Export] More export Structure arrays to processor ([14812](https://github.com/civicrm/civicrm-core/pull/14812))**
+
+- **[REF] [TEST] [Export] Update export tests to reflect new format ([14813](https://github.com/civicrm/civicrm-core/pull/14813))**
+
+- **Fix upgrade for membership second reminder ([14810](https://github.com/civicrm/civicrm-core/pull/14810))**
+
+- **[REF] [Export] Further  cleanup - construct  sql more concisely ([14808](https://github.com/civicrm/civicrm-core/pull/14808))**
+
+- **[REF] [Export] move mergeSameAddress to processor class ([14809](https://github.com/civicrm/civicrm-core/pull/14809))**
+
+- **[TEST][EXPORT] Improve unit test on export. ([14793](https://github.com/civicrm/civicrm-core/pull/14793))**
+
+- **5.16 to master ([14807](https://github.com/civicrm/civicrm-core/pull/14807))**
+
+- **[REF] [Export] further code cleanup ([14806](https://github.com/civicrm/civicrm-core/pull/14806))**
+
+- **[REF] final cleanup - call bulkCreate from migrate_utils ([14728](https://github.com/civicrm/civicrm-core/pull/14728))**
+
+- **[REF] [EXPORT] Alter CRM_Export_BAO_Export::exportComponents ([14800](https://github.com/civicrm/civicrm-core/pull/14800))**
+
+- **(dev/core#285) Fixed second membership reminder ([13487](https://github.com/civicrm/civicrm-core/pull/13487))**
+
+- **[REF] [Export] move build master copy array to ExportProcessor ([14803](https://github.com/civicrm/civicrm-core/pull/14803))**
+
+- **[REF] [Export] Remove code that seems unused ([14804](https://github.com/civicrm/civicrm-core/pull/14804))**
+
+- **[REF] [Export] Move setting of household properties to processor ([14802](https://github.com/civicrm/civicrm-core/pull/14802))**
+
+- **5.16 to master ([14805](https://github.com/civicrm/civicrm-core/pull/14805))**
+
+- **[REF] [Export] Minor code relocation ([14801](https://github.com/civicrm/civicrm-core/pull/14801))**
+
+- **[REF] [Export] Move replace merge tokens to processor class ([14799](https://github.com/civicrm/civicrm-core/pull/14799))**
+
+- **[REF] [EXPORT] Stop passing return Properties ([14795](https://github.com/civicrm/civicrm-core/pull/14795))**
+
+- **[REF] [Export] Move function that parses tokens to address processor ([14797](https://github.com/civicrm/civicrm-core/pull/14797))**
+
+- **[REF] [EXPORT] Minor consolidation of weird mergeSameAddreess nightmare code ([14796](https://github.com/civicrm/civicrm-core/pull/14796))**
+
+- **dev/core#1093 add a bulkCreate action for many customFields in one go ([14694](https://github.com/civicrm/civicrm-core/pull/14694))**
+
+- **Use select2 to display field mappings ([14794](https://github.com/civicrm/civicrm-core/pull/14794))**
+
+- **[REF] [EXPORT] cleanup setting of additional postal fields ([14790](https://github.com/civicrm/civicrm-core/pull/14790))**
+
+- **[REF] [EXPORT] [TLA] Update handling of input fields so that the mapping format is accepted. ([14792](https://github.com/civicrm/civicrm-core/pull/14792))**
+
+- **[REF][Export] Minor cleanup on household merge properties ([14787](https://github.com/civicrm/civicrm-core/pull/14787))**
+
+- **[NFC] [REF] [TEST] [EXPORT] Update various export tests to test csv output with new functions ([14780](https://github.com/civicrm/civicrm-core/pull/14780))**
+
+- **[REF] [EXPORT] partial cleanup on adding fields to returnProperties based on usage ([14788](https://github.com/civicrm/civicrm-core/pull/14788))**
+
+- **[EXPORT] Minor fixes to the export form ([14785](https://github.com/civicrm/civicrm-core/pull/14785))**
+
+- **5.16 to master ([14786](https://github.com/civicrm/civicrm-core/pull/14786))**
+
+- ** [REF] [export] remove chunk of non-functional code ([14773](https://github.com/civicrm/civicrm-core/pull/14773))**
+
+- **[REF] [export] Cleaner handling of additional return properties ([14774](https://github.com/civicrm/civicrm-core/pull/14774))**
+
+- **dev/core#1108 Use api call to retrieve mailing_id ([14761](https://github.com/civicrm/civicrm-core/pull/14761))**
+
+- **[REF] initial extraction of loading saved mapping to qf format ([14767](https://github.com/civicrm/civicrm-core/pull/14767))**
+
+- **[REF] simplify & add tests on getMappingParams ([14769](https://github.com/civicrm/civicrm-core/pull/14769))**
+
+- **5.16 to master ([14781](https://github.com/civicrm/civicrm-core/pull/14781))**
+
+- **[ref] [export] [test] Improve csv test to test final output rather than the csv ([14779](https://github.com/civicrm/civicrm-core/pull/14779))**
+
+- **Fix enotice on formatting credit card details ([14750](https://github.com/civicrm/civicrm-core/pull/14750))**
+
+- **Finish removing references to Config.IDS.ini ([14770](https://github.com/civicrm/civicrm-core/pull/14770))**
+
+- **Migrate CivicrmHelper::parseUrl() to CRM_Utils_System_Drupal8::parseUrl(). ([14696](https://github.com/civicrm/civicrm-core/pull/14696))**
+
+- **GenCode, Cache::cleanKey() - Fix deploop during clean initialization ([14777](https://github.com/civicrm/civicrm-core/pull/14777))**
+
+- **(dev/cloud-native#3) CRM_Utils_File - Deprecate baseFilePath() et al ([14778](https://github.com/civicrm/civicrm-core/pull/14778))**
+
+- **dev/drupal#75 Drupal8: fix call to languageNegotiationURL() when called from cv ([14772](https://github.com/civicrm/civicrm-core/pull/14772))**
+
+- **[REF] [export] . Move greeting params retrieval to the place in the code where it is used ([14768](https://github.com/civicrm/civicrm-core/pull/14768))**
+
+- **[REF] Update export test to new function ([14765](https://github.com/civicrm/civicrm-core/pull/14765))**
+
+- **dev/core#578 follow up fix on activity summary report ([14745](https://github.com/civicrm/civicrm-core/pull/14745))**
+
+- **Set title using standard form method and use for success message on contributionpage ([14615](https://github.com/civicrm/civicrm-core/pull/14615))**
+
+- **[REF] Extract mapping converter function, kinda brutally ([14762](https://github.com/civicrm/civicrm-core/pull/14762))**
+
+- **expose smarty's compile_check to be overridden in civicrm.settings.php ([14706](https://github.com/civicrm/civicrm-core/pull/14706))**
+
+- **[REF] export code simplification ([14758](https://github.com/civicrm/civicrm-core/pull/14758))**
+
+- **[REF] Extract saveMapping Field ([14757](https://github.com/civicrm/civicrm-core/pull/14757))**
+
+- **e-notice fix & unit test ([14729](https://github.com/civicrm/civicrm-core/pull/14729))**
+
+- **Extract field wrangling to determineReturnProperties ([14756](https://github.com/civicrm/civicrm-core/pull/14756))**
+
+- **Fix obscure bug on updating custom fields (not necessarily hittable via UI) ([14754](https://github.com/civicrm/civicrm-core/pull/14754))**
+
+- **[REF] Remove call to getMappingFields in favour of api call. ([14755](https://github.com/civicrm/civicrm-core/pull/14755))**
+
+- **[REF] un-extract createProportionalFinancialEntities ([14742](https://github.com/civicrm/civicrm-core/pull/14742))**
+
+- **[REF] Move function onto the processor class ([14752](https://github.com/civicrm/civicrm-core/pull/14752))**
+
+- **dev/core#1015 Unit test for fix regression on exporting soft credits  ([14514](https://github.com/civicrm/civicrm-core/pull/14514))**
+
+- **[REF] Extract CRM_Core_BAO_Mapping::addComponentFields ([14751](https://github.com/civicrm/civicrm-core/pull/14751))**
+
+- **dev/report#17 fix postal_code_suffix col ([14744](https://github.com/civicrm/civicrm-core/pull/14744))**
+
+- **REF Simple cleanup of tabset code for contributionpages ([14616](https://github.com/civicrm/civicrm-core/pull/14616))**
+
+- **Removed hardcoded activity status and used Activity create ([14720](https://github.com/civicrm/civicrm-core/pull/14720))**
+
+- **5.16 to master ([14749](https://github.com/civicrm/civicrm-core/pull/14749))**
+
+- **dev/core/issues/577: Activity Summary report fix for db column count error with section header (without ONLY_FULL_GROUP_BY) ([13540](https://github.com/civicrm/civicrm-core/pull/13540))**
+
+- **[REF] Further cleanup & extraction in getMappingFieds ([14743](https://github.com/civicrm/civicrm-core/pull/14743))**
+
+- **[REF] Simple function extraction for buildMappingForm ([14741](https://github.com/civicrm/civicrm-core/pull/14741))**
+
+- **[REF] simple extraction of getFieldAlterSQL ([14727](https://github.com/civicrm/civicrm-core/pull/14727))**
+
+- ** Fix creation of additional zero value line item when changing fee selection in edge case ([14589](https://github.com/civicrm/civicrm-core/pull/14589))**
+
+- **[REF] extract portion that creates the custom field record ([14725](https://github.com/civicrm/civicrm-core/pull/14725))**
+
+- **5.16 to master ([14738](https://github.com/civicrm/civicrm-core/pull/14738))**
+
+- **Improve handling of 'Manage Event' title ([14614](https://github.com/civicrm/civicrm-core/pull/14614))**
+
+- **[REF] Cleanup fixSchemaDifferencesFor() ([14697](https://github.com/civicrm/civicrm-core/pull/14697))**
+
+- **[REF] clarify  variable (very minor change with good test cover) ([14724](https://github.com/civicrm/civicrm-core/pull/14724))**
+
+- **Fix some test leakage ([14731](https://github.com/civicrm/civicrm-core/pull/14731))**
+
+- **Updated Circle-Interactive developers info ([14736](https://github.com/civicrm/civicrm-core/pull/14736))**
+
+- **Activity search - convert priority_id to a metadata field and add location as a searchable field ([14701](https://github.com/civicrm/civicrm-core/pull/14701))**
+
+- **[REF] simple extraction of prepareCreateParams ([14726](https://github.com/civicrm/civicrm-core/pull/14726))**
+
+- **dev/core#1097 - Ensure consistent count on Groups tab ([14721](https://github.com/civicrm/civicrm-core/pull/14721))**
+
+- **Fix path for civicrm.settings.php when installed in profiles/ ([552](https://github.com/civicrm/civicrm-drupal/pull/552))**
+
+- **Update civicrmtheme module to use new isFrontEndPage function on user… ([581](https://github.com/civicrm/civicrm-drupal/pull/581))**
+
+- **(NFC) VERSIONS.php - Add discussion about how to migrate to composer ([261](https://github.com/civicrm/civicrm-packages/pull/261))**
+
+## <a name="misc"></a>Miscellany
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following code authors:
+
+AGH Strategies - Andrew Hunt, Eli Lisseck; Agileware - Alok Patel, Justin Freeman; Australian Greens - Seamus Lee; Circle Interactive - Dave Jenkins, Kirk Jackson, Pradeep Nayak; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; Coop SymbioTIC - Mathieu Lutfy; Dave D; Dawnthorn; Deepak Srivastava; Electronic Frontier Foundation - Mark Burdett; Freeform Solutions - Herb van den Dool; Fuzion - Jitendra Purohit; Greenpeace CEE - Patrick Figel; iXiam - Luciano Spiegel; JMA Consulting - Monish Deb; John Kingsnorth; Lighthouse Design and Consulting - Brian Shaughnessy; Megaphone Technology Consulting - Jon Goldberg; MillerTech - Chamil Wijesooriya; MJCO - Mikey O'Toole; MJW Consulting - Matthew Wire; Nicol Wistreich; Squiffle Consulting - Aidan Saunders; sushantpaste; Wikimedia Foundation - Eileen McNaughton
+
+Most authors also reviewed code for this release; in addition, the following
+reviewers contributed their comments:
+
+AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Justin Freeman; Australian Greens - Seamus Lee; Circle Interactive - Dave Jenkins, Kirk Jackson, Pradeep Nayak; civibot[bot]; CiviCoop - Jaap Jansma; civicrm-builder; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Nicolas Ganivet, Yashodha Chaku; CompuCorp - Alessandro Verdura; Coop SymbioTIC - Mathieu Lutfy; Dave D; Dawnthorn; Deepak Srivastava; Electronic Frontier Foundation - Mark Burdett; Freeform Solutions - Herb van den Dool; Fuzion - Jitendra Purohit, Luke Stewart; Greenpeace CEE - Patrick Figel; iXiam - Luciano Spiegel; JMA Consulting - Monish Deb; John Kingsnorth; Joseph Lacey; Lighthouse Design and Consulting - Brian Shaughnessy; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Richard van Oosterhout; ryanlrobinson; Skvare - Mark Hanna; Squiffle Consulting - Aidan Saunders; sushantpaste; Tadpole Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton

--- a/release-notes/5.17.0.md
+++ b/release-notes/5.17.0.md
@@ -1,11 +1,25 @@
 # CiviCRM 5.17.0
 
-Released September 4, 2019;
+Released September 4, 2019
 
+- **[Synopsis](#synopsis)**
 - **[Features](#features)**
 - **[Bugs resolved](#bugs)**
 - **[Miscellany](#misc)**
 - **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |         |
+|:--------------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                                   |         |
+| Change the database schema?                                     |         |
+| Alter the API?                                                  |         |
+| Require attention to configuration options?                     |         |
+| Fix problems installing or upgrading to a previous version?     |         |
+| Introduce features?                                             |         |
+| Fix bugs?                                                       |         |
 
 ## <a name="features"></a>Features
 
@@ -509,3 +523,9 @@ Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:
 
 AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Justin Freeman; Australian Greens - Seamus Lee; Circle Interactive - Dave Jenkins, Kirk Jackson, Pradeep Nayak; civibot[bot]; CiviCoop - Jaap Jansma; civicrm-builder; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Nicolas Ganivet, Yashodha Chaku; CompuCorp - Alessandro Verdura; Coop SymbioTIC - Mathieu Lutfy; Dave D; Dawnthorn; Deepak Srivastava; Electronic Frontier Foundation - Mark Burdett; Freeform Solutions - Herb van den Dool; Fuzion - Jitendra Purohit, Luke Stewart; Greenpeace CEE - Patrick Figel; iXiam - Luciano Spiegel; JMA Consulting - Monish Deb; John Kingsnorth; Joseph Lacey; Lighthouse Design and Consulting - Brian Shaughnessy; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire; Richard van Oosterhout; ryanlrobinson; Skvare - Mark Hanna; Squiffle Consulting - Aidan Saunders; sushantpaste; Tadpole Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Alice Frumin and Andrew Hunt.  If you'd like
+to provide feedback on them, please log in to https://chat.civicrm.org/civicrm
+and contact `@agh1`.


### PR DESCRIPTION
This is an initial run of the release notes script with boilerplate.  It's ready to merge now; as with 5.16 you can expect follow-up PRs from @alifrumin and me with the bulk of the edits and then the late changes and wrap-up.