### PR TITLE
(dev/drupal#79) Fail more gracefully when attempting to install on PHP 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
   },
   "include-path": ["vendor/tecnickcom"],
   "require": {
+    "php": "~7.0",
     "dompdf/dompdf" : "0.8.*",
     "electrolinux/phpquery": "^0.9.6",
     "symfony/config": "^2.8.44 || ~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "027475804731d7ef0bd3e0feb2139d3c",
+    "content-hash": "ffdac3f93564fe6edb467d3ac43c4869",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -2628,6 +2628,8 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "~7.0"
+    },
     "platform-dev": []
 }

--- a/install/index.php
+++ b/install/index.php
@@ -91,6 +91,15 @@ else {
   errorDisplayPage($errorTitle, $errorMsg, FALSE);
 }
 
+$composerJsonPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'composer.json';
+if (file_exists($composerJsonPath)) {
+  $composerJson = json_decode(file_get_contents($composerJsonPath), 1);
+  $minPhpVer = preg_replace(';[~^];', '', $composerJson['require']['php']);
+  if (!version_compare(phpversion(), $minPhpVer, '>=')) {
+    errorDisplayPage('PHP Version Requirement', sprintf("CiviCRM requires PHP %s+. The web server is running PHP %s.", $minPhpVer, phpversion()), FALSE);
+  }
+}
+
 $pkgPath = $crmPath . DIRECTORY_SEPARATOR . 'packages';
 
 require_once $crmPath . '/CRM/Core/ClassLoader.php';

--- a/tests/phpunit/CRM/Upgrade/FormTest.php
+++ b/tests/phpunit/CRM/Upgrade/FormTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Class CRM_Upgrade_FormTest
+ * @group headless
+ */
+class CRM_Upgrade_FormTest extends CiviUnitTestCase {
+
+  /**
+   * "php" requirement (composer.json) should match MINIMUM_PHP_VERSION (CRM/Upgrade/Form.php).
+   */
+  public function testComposerRequirementMatch() {
+    global $civicrm_root;
+    $composerJsonPath = "{$civicrm_root}/composer.json";
+    $this->assertFileExists($composerJsonPath);
+    $composerJson = json_decode(file_get_contents($composerJsonPath), 1);
+    $composerJsonRequirePhp = preg_replace(';[~^];', '', $composerJson['require']['php']);
+    $actualMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', $composerJsonRequirePhp);
+    $expectMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', \CRM_Upgrade_Form::MINIMUM_PHP_VERSION);
+    $this->assertEquals($expectMajorMinor, $actualMajorMinor, "The PHP version requirements in CRM_Upgrade_Form ($expectMajorMinor) and composer.json ($actualMajorMinor) should specify same major+minor versions.");
+  }
+
+}


### PR DESCRIPTION
See also: https://lab.civicrm.org/dev/drupal/issues/79

Before
------

If an admin stracts the code and navigates to `/sites/all/modules/civicrm/install/index.php`, it displays a syntax error.

After
-----

If an admin stracts the code and navigates to `/sites/all/modules/civicrm/install/index.php`, it displays the message:

> __PHP Version Requirement__
> CiviCRM requires PHP 7.0+. The web server is running PHP 5.6.38.

Comments
--------

This is similar to https://github.com/civicrm/civicrm-drupal/pull/583

The canonical representation of the minimum PHP version is in `$civicrm_root/CRM/Upgrade/Form.php`.  However, setting up the classloader triggers a syntax error, so we need to read this without having access to the classloader.

The approach herein has a few effects:

* The minimum PHP can be read from a JSON file.
* That JSON file is also used by `composer`, so you'll also get better errors when downloading that way.
* At some unknown future time, the minimum will probably bump up again (7.1 or 7.2 or whatever). When that happens, the unit-test will ensure we keep `CRM/Upgrade/Form.php` and `composer.json` in sync.

Note: I was little concerned that the `composer.json` file might not be available when normal installers run, so I checked the published tarballs for D7, BD, WP, and J - in all cases, the `composer.json` looks to be included at the expected location.

