### PR TITLE
Remove unused method CRM_Contact_BAO_Contact_Utils::maxLocations

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -243,33 +243,6 @@ WHERE  id IN ( $idString )
   }
 
   /**
-   * Get the count of  contact loctions.
-   *
-   * @param int $contactId
-   *   Contact id.
-   *
-   * @return int
-   *   max locations for the contact
-   */
-  public static function maxLocations($contactId) {
-    $contactLocations = [];
-
-    // find number of location blocks for this contact and adjust value accordinly
-    // get location type from email
-    $query = "
-( SELECT location_type_id FROM civicrm_email   WHERE contact_id = {$contactId} )
-UNION
-( SELECT location_type_id FROM civicrm_phone   WHERE contact_id = {$contactId} )
-UNION
-( SELECT location_type_id FROM civicrm_im      WHERE contact_id = {$contactId} )
-UNION
-( SELECT location_type_id FROM civicrm_address WHERE contact_id = {$contactId} )
-";
-    $dao = CRM_Core_DAO::executeQuery($query);
-    return $dao->N;
-  }
-
-  /**
    * Create Current employer relationship for a individual.
    *
    * @param int $contactID


### PR DESCRIPTION
Overview
----------------------------------------
The \CRM_Contact_BAO_Contact_Utils::maxLocations method has no usages. I checked this using IDE tools and then by grepping the codebase for the 'maxLocations' string. I also tried grepping the commit log and didn't see any other references to it other than the declaration.

So let's remove it?

(The other option would be to deprecate it and remove it later...)