### PR TITLE
Fix recursion in crmInArray()

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -375,7 +375,7 @@ class CRM_Utils_Array {
   public static function crmInArray($value, $params, $caseInsensitive = TRUE) {
     foreach ($params as $item) {
       if (is_array($item)) {
-        $ret = crmInArray($value, $item, $caseInsensitive);
+        $ret = self::crmInArray($value, $item, $caseInsensitive);
       }
       else {
         $ret = ($caseInsensitive) ? strtolower($item) == strtolower($value) : $item == $value;


### PR DESCRIPTION
Overview
----------------------------------------
See [the issue on Lab](https://lab.civicrm.org/dev/core/issues/1196).

Before
----------------------------------------
Recursion does not take place as expected.

After
----------------------------------------
Recursion takes place as expected.

Technical Details
----------------------------------------
There's a minor error in CRM_Utils_Array::crmInArray() where the method is called with `crmInArray()` instead of with `self::crmInArray()`.