### PR TITLE
Fix wrong variable in check for profiles on contributionpage

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -328,8 +328,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       if ($preID = CRM_Utils_Array::value('custom_pre_id', $values)) {
         if (!empty($values['related_contact'])) {
           $preProfileTypes = CRM_Core_BAO_UFGroup::profileGroups($preID);
-          //@todo - following line should not refer to undefined $postProfileTypes? figure out way to test
-          if (in_array('Individual', $preProfileTypes) || in_array('Contact', $postProfileTypes)) {
+          if (in_array('Individual', $preProfileTypes) || in_array('Contact', $preProfileTypes)) {
             //Take Individual contact ID
             $userID = CRM_Utils_Array::value('related_contact', $values);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Copy/paste error means we're checking an undefined variable.

Before
----------------------------------------
Undefined variable being checked for preProfile types.

After
----------------------------------------
Correct variable being checked for preProfile types.

Technical Details
----------------------------------------

Comments
----------------------------------------

