### PR TITLE
dev/core#1198 mailing view when hash enabled

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -555,6 +555,12 @@ function civicrm_api3_mailing_preview($params) {
 
   $mailing = new CRM_Mailing_BAO_Mailing();
   $mailingID = CRM_Utils_Array::value('id', $params);
+
+  //id may be a hash; need to lookup actual id
+  if ($mailingID && !is_int($mailingID)) {
+    $mailingID = CRM_Core_DAO::getFieldValue('CRM_Mailing_BAO_Mailing', $mailingID, 'id', 'hash');
+  }
+
   if ($mailingID) {
     $mailing->id = $mailingID;
     $mailing->find(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce:

1. go to CiviMail > CiviMail Component Settings
2. select option for Hashed Mailing URL's
3. create and send a mailing
4. go to a contact who has received the mailing, click the Mailings tab, and View the mailing

Before
----------------------------------------
Unable to view mailing.

After
----------------------------------------
Able to view mailing.

Technical Details
----------------------------------------
The preview is handled through the API and expects the Mailing ID to be the actual mailing table ID. If hashed ID's is enabled, it fails the variable type validation check.
