### PR TITLE
[Import] [ref] - minor cleanup to reduce code complexity

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -214,8 +214,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       //get loaded Mapping Fields
       $mappingName = CRM_Utils_Array::value(1, $mappingName);
       $mappingLocation = CRM_Utils_Array::value(1, $mappingLocation);
-      $mappingPhoneType = CRM_Utils_Array::value(1, $mappingPhoneType);
-      $mappingImProvider = CRM_Utils_Array::value(1, $mappingImProvider);
       $mappingRelation = CRM_Utils_Array::value(1, $mappingRelation);
       $mappingWebsiteType = CRM_Utils_Array::value(1, $mappingWebsiteType);
 
@@ -409,7 +407,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
 
       if ($this->get('savedMapping')) {
-        list($defaults, $js) = $this->loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
+        list($defaults, $js) = $this->loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
       }
       else {
         $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_0_');\n";
@@ -854,8 +852,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param $mappingRelation
    * @param $mappingWebsiteType
    * @param $mappingLocation
-   * @param $mappingPhoneType
-   * @param $mappingImProvider
    * @param array $defaults
    * @param string $js
    * @param bool $hasColumnNames
@@ -863,8 +859,9 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param array $columnPatterns
    *
    * @return array
+   * @throws \CiviCRM_API3_Exception
    */
-  public function loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns) {
+  public function loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns) {
     $jsSet = FALSE;
     $formName = $processor->getFormName();
     if (isset($mappingName[$i])) {
@@ -904,9 +901,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           $contactDetails = strtolower(str_replace(" ", "_", $mappingName[$i]));
           $websiteTypeId = isset($mappingWebsiteType[$i]) ? $mappingWebsiteType[$i] : NULL;
           $locationId = isset($mappingLocation[$i]) ? $mappingLocation[$i] : 0;
-          $phoneType = isset($mappingPhoneType[$i]) ? $mappingPhoneType[$i] : NULL;
-          //get provider id from saved mappings
-          $imProvider = isset($mappingImProvider[$i]) ? $mappingImProvider[$i] : NULL;
+          $phoneType = $processor->getPhoneTypeID($i);
+          $imProvider = $processor->getIMProviderID($i);
 
           if ($websiteTypeId) {
             $defaults["mapper[$i]"] = [$relation, $contactDetails, $websiteTypeId];
@@ -947,9 +943,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           $mappingHeader = array_keys((array) $this->_mapperFields, $mappingName[$i]);
           $websiteTypeId = isset($mappingWebsiteType[$i]) ? $mappingWebsiteType[$i] : NULL;
           $locationId = isset($mappingLocation[$i]) ? $mappingLocation[$i] : 0;
-          $phoneType = isset($mappingPhoneType[$i]) ? $mappingPhoneType[$i] : NULL;
-          // get IM service provider id
-          $imProvider = isset($mappingImProvider[$i]) ? $mappingImProvider[$i] : NULL;
+          $phoneType = $processor->getPhoneTypeID($i);
+          $imProvider = $processor->getIMProviderID($i);
 
           if ($websiteTypeId) {
             $defaults["mapper[$i]"] = [$mappingHeader[0], $websiteTypeId];

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -452,7 +452,7 @@ class CRM_Import_ImportProcessor {
   protected function rekeyBySortedColumnNumbers(array $mappingFields) {
     $this->mappingFields = CRM_Utils_Array::rekey($mappingFields, 'column_number');
     ksort($this->mappingFields);
-    return array_values($this->mappingFields);
+    return $this->mappingFields;
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -336,7 +336,7 @@ document.forms.MapField['mapper[1][3]'].style.display = 'none';\n",
     $processor->setFormName('document.forms.MapField');
     $processor->setMetadata($this->getContactImportMetadata());
 
-    $return = $form->loadSavedMapping($processor, $mappingName, $columnNumber, $mappingRelation, $mappingWebsiteType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
+    $return = $form->loadSavedMapping($processor, $mappingName, $columnNumber, $mappingRelation, $mappingWebsiteType, $mappingLocation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
     return ['defaults' => $return[0], 'js' => $return[1]];
   }
 

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -293,6 +293,10 @@ document.forms.MapField['mapper[1][3]'].style.display = 'none';\n",
         ['name' => 'Phone', 'contact_type' => 'Individual', 'column_number' => 8, 'phone_type_id' => 1, 'location_type_id' => 2],
         "document.forms.MapField['mapper[8][3]'].style.display = 'none';\n",
       ],
+      [
+        ['name' => 'Phone', 'contact_type' => 'Individual', 'column_number' => 0, 'im_provider_id' => 1, 'location_type_id' => 2],
+        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+      ],
     ];
   }
 

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -344,10 +344,10 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   public function testPrefixLabel() {
     $this->callAPISuccess('OptionValue', 'create', ['option_group_id' => 'individual_prefix', 'name' => 'new_one', 'label' => 'special', 'value' => 70]);
     $mapping = [
-      ['name' => 'first_name', 'column_number' => 1],
-      ['name' => 'last_name', 'column_number' => 2],
-      ['name' => 'email', 'column_number' => 3, 'location_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Email', 'location_type_id', 'Home')],
-      ['name' => 'prefix_id', 'column_number' => 5],
+      ['name' => 'first_name', 'column_number' => 0],
+      ['name' => 'last_name', 'column_number' => 1],
+      ['name' => 'email', 'column_number' => 2, 'location_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Email', 'location_type_id', 'Home')],
+      ['name' => 'prefix_id', 'column_number' => 3],
       ['name' => 'suffix_id', 'column_number' => 4],
     ];
     $processor = new CRM_Import_ImportProcessor();
@@ -359,12 +359,13 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'Bill',
       'Gates',
       'bill.gates@microsoft.com',
-      'III',
       'special',
+      'III',
     ];
     $importer->import(CRM_Import_Parser::DUPLICATE_NOCHECK, $contactValues);
 
     $contact = $this->callAPISuccessGetSingle('Contact', ['first_name' => 'Bill', 'prefix_id' => 'new_one', 'suffix_id' => 'III']);
+    $this->assertEquals('special Bill Gates III', $contact['display_name']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Use Processor to determine the phone_type_id & im_provider_id + add a test

Before
----------------------------------------
Code more crazy, less tested

After
----------------------------------------
Less crazy, more tested

Technical Details
----------------------------------------


What we are doing here is actually very simple - despite the code being kinda insane - we are just getting the  fields from the database for  each column in the mapping.

The fields are all loaded into the processor already & those functions are tested. This switches to  using them and to passing around less variables...

Follow ons will do the same for other fields (website_type_id, location_type_id but I will add more tests as I do that

Comments
----------------------------------------

