### PR TITLE
Issue 329 workaround disabling sample case types

### DIFF
--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -266,9 +266,13 @@ class CRM_Case_XMLRepository {
     $result = [];
 
     $p = new CRM_Case_XMLProcessor_Process();
-    foreach ($this->getAllCaseTypes() as $caseTypeName) {
-      $caseTypeXML = $this->retrieve($caseTypeName);
-      $result = array_merge($result, $p->getDeclaredRelationshipTypes($caseTypeXML));
+       foreach ($this->getAllCaseTypes() as $caseTypeId => $caseTypeName) {
+      $query = "SELECT is_active FROM civicrm_case_type WHERE id = %1";
+      $isActive = (int) CRM_Core_DAO::singleValueQuery($query, [1 => [$caseTypeId, 'Integer']]);
+      if ($isActive) {
+        $caseTypeXML = $this->retrieve($caseTypeName);
+        $result = array_merge($result, $p->getDeclaredRelationshipTypes($caseTypeXML));
+      }
     }
 
     $result = array_unique($result);

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -264,9 +264,8 @@ class CRM_Case_XMLRepository {
    */
   public function getAllDeclaredRelationshipTypes() {
     $result = [];
-
     $p = new CRM_Case_XMLProcessor_Process();
-       foreach ($this->getAllCaseTypes() as $caseTypeId => $caseTypeName) {
+    foreach ($this->getAllCaseTypes() as $caseTypeId => $caseTypeName) {
       $query = "SELECT is_active FROM civicrm_case_type WHERE id = %1";
       $isActive = (int) CRM_Core_DAO::singleValueQuery($query, [1 => [$caseTypeId, 'Integer']]);
       if ($isActive) {
@@ -274,7 +273,6 @@ class CRM_Case_XMLRepository {
         $result = array_merge($result, $p->getDeclaredRelationshipTypes($caseTypeXML));
       }
     }
-
     $result = array_unique($result);
     sort($result);
     return $result;


### PR DESCRIPTION
check if the case type is actually enabled? This does not fix the root problem but at least provides a workaround by disabling the relationship type

Overview
----------------------------------------
Workaround for the long standing API error: DB error when enabling CiviCase

Before
----------------------------------------
At the moment when you enable the CiviCase component, there are lots of instances where API error:DB error shows up because the managed entities tries to create the relationship types associated with the sample case types but they already exist...(https://lab.civicrm.org/dev/core/issues/329)

After
----------------------------------------
Function to get the declared relationship types now only does so if the case types are enabled. So the workaround (because the deeper root issue is complicated) is then to disable the sample case types and the error message will not show up again


