### PR TITLE
Fix thank-you date being lost

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -250,7 +250,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('action', $this->_action);
 
     // Get the contribution id if update
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     if (!empty($this->_id)) {
       $this->assignPaymentInfoBlock();
       $this->assign('contribID', $this->_id);


### PR DESCRIPTION
Overview
----------------------------------------
This reverts a change in 5.16.0 which creates a data loss scenario under very common circumstances.

Before
----------------------------------------
Editing a contribution caused the thank-you date to be lost on save.

After
----------------------------------------
Thank-you date remains, though presumably the issue in financial#50 is present again.

Comments
----------------------------------------
Probably the most urgent bug I've filed this year.