### PR TITLE
Fix an HTML error in Calculate.tpl

### DIFF
--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -25,15 +25,16 @@
 *}
 
 {assign var='hideTotal' value=$quickConfig+$noCalcValueDisplay}
+
 <div id="pricesetTotal" class="crm-section section-pricesetTotal">
-  <div class="label
-{if $hideTotal},  hiddenElement{/if}" id="pricelabel">
-    {if ( $extends eq 'Contribution' ) || ( $extends eq 'Membership' )}
-    <span id='amount_sum_label'>{ts}Total Amount{/ts}{else}{ts}Total Fee(s){/ts}</span>
-     {if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}
+  <div id="pricelabel" class="label {if $hideTotal}hiddenElement{/if}">
+    {if ($extends eq 'Contribution') || ($extends eq 'Membership')}
+      <span id='amount_sum_label'>{ts}Total Amount{/ts}</span>
+    {else}
+      <span id='amount_sum_label'>{ts}Total Fee(s){/ts}{if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}</span>
     {/if}
   </div>
-  <div class="content calc-value" {if $hideTotal}style="display:none;"{/if} id="pricevalue" ></div>
+  <div class="content calc-value" {if $hideTotal}style="display:none;"{/if} id="pricevalue"></div>
 </div>
 
 <script type="text/javascript">
@@ -44,25 +45,23 @@ var separator      = '{/literal}{$config->monetaryDecimalPoint}{literal}';
 var symbol         = '{/literal}{$currencySymbol}{literal}';
 var optionSep      = '|';
 
+// Recalculate the total fees based on user selection
 cj("#priceset [price]").each(function () {
+  var elementType = cj(this).attr('type');
+  if (this.tagName == 'SELECT') {
+    elementType = 'select-one';
+  }
 
-    var elementType =  cj(this).attr('type');
-    if ( this.tagName == 'SELECT' ) {
-      elementType = 'select-one';
-    }
-
-    switch(elementType) {
-      case 'checkbox':
-        //event driven calculation of element.
-        cj(this).click(function(){
-          calculateCheckboxLineItemValue(this);
-          display(calculateTotalFee());
-        });
+  switch(elementType) {
+    case 'checkbox':
+      cj(this).click(function(){
         calculateCheckboxLineItemValue(this);
+        display(calculateTotalFee());
+      });
+      calculateCheckboxLineItemValue(this);
       break;
 
     case 'radio':
-      //event driven calculation of element.
       cj(this).click( function(){
         calculateRadioLineItemValue(this);
         display(calculateTotalFee());
@@ -70,32 +69,26 @@ cj("#priceset [price]").each(function () {
       calculateRadioLineItemValue(this);
       break;
 
-  case 'text':
-
-    //event driven calculation of element.
-    cj(this).bind( 'keyup', function() {
+    case 'text':
+      cj(this).bind( 'keyup', function() {
+        calculateText(this);
+      }).bind( 'blur' , function() {
+        calculateText(this);
+      });
+      //default calculation of element.
       calculateText(this);
-    }).bind( 'blur' , function() {
-      calculateText(this);
-    });
-    //default calculation of element.
-    calculateText(this);
+      break;
 
-    break;
-
-  case 'select-one':
-    calculateSelectLineItemValue(this);
-
-    //event driven calculation of element.
-    cj(this).change( function() {
+    case 'select-one':
       calculateSelectLineItemValue(this);
-      display(calculateTotalFee());
-    });
 
-
-    break;
-
+      cj(this).change(function() {
+        calculateSelectLineItemValue(this);
+        display(calculateTotalFee());
+      });
+      break;
   }
+
   display(calculateTotalFee());
 });
 


### PR DESCRIPTION
Overview
----------------------------------------

There was an HTML error with a 'span' tag that was not closed correctly because the markup was outside the condition.

I also did a bit of code-style cleanup.

Most of it is NFC, except that I added the string "for this participant" now moved inside the span. It doesn't make sense to have it outside.


Before
----------------------------------------
```
<div id="pricesetTotal" class="crm-section section-pricesetTotal">
--
   <div class="label
   " id="pricelabel">
   Total Fee(s)</span>
   for this participant      </div>
   <div class="content calc-value"  id="pricevalue" ></div>
   </div>
```
<img width="474" alt="Screen Shot 2019-09-05 at 7 17 25 PM" src="https://user-images.githubusercontent.com/336308/64320056-d5b5e580-d011-11e9-9936-9c62532acf86.png">

```
After

<div id="pricesetTotal" class="crm-section section-pricesetTotal">
--
   <div id="pricelabel" class="label ">
   <span id='amount_sum_label'>Total Fee(s) for this participant</span>
   </div>
   <div class="content calc-value"  id="pricevalue"></div>
  </div>

```

And on a membership page

```
<div id="pricesetTotal" class="crm-section section-pricesetTotal">
--
<div id="pricelabel" class="label ">
   <span id='amount_sum_label'>Total Amount</span>
   </div>
   <div class="content calc-value"  id="pricevalue"></div>
   </div>

```

No  noticeable visible change