### PR TITLE
Add `pre` and `post` hooks to Domain create and edit operations

### DIFF
--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -127,10 +127,12 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    *   domain
    */
   public static function edit(&$params, &$id) {
+    CRM_Utils_Hook::pre('edit', 'Domain', CRM_Utils_Array::value('id', $params), $params);
     $domain = new CRM_Core_DAO_Domain();
     $domain->id = $id;
     $domain->copyValues($params);
     $domain->save();
+    CRM_Utils_Hook::post('edit', 'Domain', $domain->id, $domain);
     return $domain;
   }
 
@@ -143,9 +145,12 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    *   domain
    */
   public static function create($params) {
+    $hook = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($hook, 'Domain', CRM_Utils_Array::value('id', $params), $params);
     $domain = new CRM_Core_DAO_Domain();
     $domain->copyValues($params, TRUE);
     $domain->save();
+    CRM_Utils_Hook::post($hook, 'Domain', $domain->id, $domain);
     return $domain;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/core/issues/1203).

Before
----------------------------------------
There is no way detect when a new Domain has been created or when a Domain has been edited.

After
----------------------------------------
One can detect when a new Domain has been created or when a Domain has been edited with the usual `hook_civicrm_pre` and `hook_civicrm_post` callbacks.

Technical Details
----------------------------------------
Sample code to verify:

```php
/**
 * Implements hook_civicrm_config().
 *
 * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
 */
function mytest_civicrm_config(&$config) {

  // Hook into pre.
  Civi::service('dispatcher')->addListener(
    'hook_civicrm_pre',
    'mytest_civicrm_hook_callback',
    -100 // Default priority.
  );

  // Hook into post.
  Civi::service('dispatcher')->addListener(
    'hook_civicrm_post',
    'mytest_civicrm_hook_callback',
    -100 // Default priority.
  );

}

/**
 * Testing "hook_civicrm_pre" and  "hook_civicrm_post" callbacks.
 *
 * Implements hook_civicrm_pre() and hook_civicrm_post() via Symfony hook system.
 *
 * @param object $event The event object.
 * @param string $hook The hook name.
 */
function mytest_civicrm_hook_callback($event, $hook) {

  // Extract args for this hook.
  $params = $event->getHookValues();

  // Get values.
  $op = $params[0];
  $objectName = $params[1];
  
  // Bail if not of type "Domain".
  if ($objectName !== 'Domain') {
    return;
  }
  
  // Further values.
  $objectId = $params[2];
  $objectRef = $params[3];

  error_log( print_r( array(
    'method' => __METHOD__,
    'op' => $op,
    'objectName' => $objectName,
    'objectId' => $objectId,
    'objectRef' => $objectRef,
    'hook' => $hook,
  ), true ) );

}
```

Creating a new Domain now produces the following in my logs:

```

[22-Aug-2019 18:37:51 Europe/London] Array
(
    [method] => mytest_civicrm_hook_callback
    [op] => create
    [objectName] => Domain
    [objectId] => 
    [objectRef] => Array
        (
            [name] => My New Domain
            [domain_version] => 5.x
            [page] => CiviCRM
            [noheader] => 1
            [prettyprint] => 1
            [check_permissions] => 1
            [version] => 5.x
        )

    [hook] => hook_civicrm_pre
)

[22-Aug-2019 18:37:51 Europe/London] Array
(
    [method] => mytest_civicrm_hook_callback
    [op] => create
    [objectName] => Domain
    [objectId] => 5
    [objectRef] => CRM_Core_DAO_Domain Object
        (
            [id] => 5
            [name] => My New Domain
            [description] => 
            [config_backend] => 
            [version] => 5.16.2
            [contact_id] => 
            [locales] => 
            [locale_custom_strings] => 
            [resultCopies:protected] => 0
            [_options:protected] => Array
                (
                )

            [_DB_DataObject_version] => 1.8.12
            [__table] => civicrm_domain
            [N] => 0
            [_database_dsn] => 
            [_database_dsn_md5] => daac48f49d8f8ae4779f01eeb16dd31b
            [_database] => my_db_name
            [_query] => Array
                (
                    [condition] => 
                    [group_by] => 
                    [order_by] => 
                    [having] => 
                    [limit_start] => 
                    [limit_count] => 
                    [data_select] => *
                )

            [_DB_resultid] => 
            [_resultFields] => 
            [_link_loaded] => 
            [_join] => 
            [_lastError] => 
        )

    [hook] => hook_civicrm_post
)
```

I've skipped showing what happens when a Domain is edited since it's basically the same output -- this can easily be verified via the API Explorer.