### PR TITLE
dev/financial#66 - Fix missing contribution ID for AdditionalInfo

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -364,7 +364,7 @@
     });
     // load panes function calls for snippet based on id of crm-accordion-header
     function loadPanes( id ) {
-      var url = "{/literal}{crmURL p='civicrm/contact/view/contribution' q='snippet=4&formType=' h=0}{literal}" + id;
+      var url = "{/literal}{crmURL p='civicrm/contact/view/contribution' q="snippet=4&id=`$entityID`&formType=" h=0}{literal}" + id;
       {/literal}
       {if $contributionMode}
         url = url + "&mode={$contributionMode}";


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a data loss issue in the contribution form for fields in the "Additional Details" and "Premium Information" blocks.

Before
----------------------------------------
When an existing contribution is edited, and values were previously stored in any of the fields within the "Additional Details" and "Premium Information" blocks, the existing values were not loaded, leading to data loss when the contribution is saved.

After
----------------------------------------
The contribution ID is passed when loading the `AdditionalInfo` snippet, causing existing values to be loaded.

Comments
----------------------------------------
This is an alternative fix for #15101.
