### PR TITLE
dev/financial#66 - Fix missing contribution ID for AdditionalInfo

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -364,7 +364,7 @@
     });
     // load panes function calls for snippet based on id of crm-accordion-header
     function loadPanes( id ) {
-      var url = "{/literal}{crmURL p='civicrm/contact/view/contribution' q='snippet=4&formType=' h=0}{literal}" + id;
+      var url = "{/literal}{crmURL p='civicrm/contact/view/contribution' q="snippet=4&id=`$entityID`&formType=" h=0}{literal}" + id;
       {/literal}
       {if $contributionMode}
         url = url + "&mode={$contributionMode}";


### PR DESCRIPTION
This fixes an issues where the contribution ID is not being passed
when the AdditionalInfo form block is retrieved in the contribution
form. This causes existing values of fields in this block to not be
loaded, leading to data loss when the form is saved.

Overview
----------------------------------------
Backport of #15105 for 5.16

ping @eileenmcnaughton @totten 