### PR TITLE
Make sure inherited memberships are not themselves inherited

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
@@ -250,7 +250,7 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
     ]);
 
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
-
+    $this->callAPISuccessGetCount('Membership', ['contact_id' => $organisationID], 1);
     // Disable the relationship & check the membership is removed.
     $relationshipOne['is_active'] = 0;
     $this->callAPISuccess('Relationship', 'create', array_merge($relationshipOne, ['is_active' => 0]));


### PR DESCRIPTION
Overview
----------------------------------------
Fixes weird scenario (encountered in tests, maybe not in the wild) whereby an inherited membership can be itself inherited

This scenario was created in the test setup (probably by accident) but it seems highly problematic - as shown in #15062 - the code is already pretty problematic.

Before
----------------------------------------
An inherited membership can itself be inherited

After
----------------------------------------
Inherited memberships are not inherited

Technical Details
----------------------------------------
In trying to make sense of the code / fix / test for https://github.com/civicrm/civicrm-core/pull/14410 (& isn't current spin off #15062)

I discovered the tests wouldn't pass due to a weird edge case where an individual inherited a membership and that membership was inherited in turn via a relationship the individual had (with the same organization)

Comments
----------------------------------------
@agh1 thoughts ? @agileware-pengyi  fyi

Will rebase once extraction is merged
