### PR TITLE
Fix fatal when saving import mapping with a relationship but 'Primary' location type

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -700,7 +700,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
             elseif (CRM_Utils_Array::value('1', $mapperKeys[$i]) == 'im') {
               $updateMappingFields->im_provider_id = isset($mapperKeys[$i][3]) ? $mapperKeys[$i][3] : NULL;
             }
-            $updateMappingFields->location_type_id = isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
+            $updateMappingFields->location_type_id = isset($mapperKeys[$i][2]) && is_numeric($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
           }
         }
         else {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal error when saving an import mapping with field mapped to (for example) employer's phone with the location type set to primary

Mapping looks like this (bottom field is the issue)
<img width="600" alt="Screen Shot 2019-08-23 at 4 11 33 PM" src="https://user-images.githubusercontent.com/336308/63566322-befaa200-c5c0-11e9-8324-b8f2b7827c66.png">


Before

----------------------------------------
<img width="1226" alt="Screen Shot 2019-08-23 at 3 20 35 PM" src="https://user-images.githubusercontent.com/336308/63564728-5c9ea300-c5ba-11e9-99a8-c223916fbf4b.png">


After
----------------------------------------
Saves

Technical Details
----------------------------------------
This occurs because the correct value to save for location_type_id of Primary is '' but the current code winds up casting to 0
which won't save as it there is a foreign key involved.  Handling was previously added but only to the
(duplicate) code that deals with non-relationship fields

https://github.com/eileenmcnaughton/civicrm-core/blob/cd41fa5b5599b329bd6f54acf0a79dda85477804/CRM/Contact/Import/Form/MapField.php#L724

Comments
----------------------------------------

