### PR TITLE
[Ref] [Import] Use processor to determine website type, location type, test

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -209,13 +209,11 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     else {
       $savedMapping = $this->get('savedMapping');
 
-      list($mappingName, $mappingContactType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $mappingRelation, $mappingOperator, $mappingValue, $mappingWebsiteType) = CRM_Core_BAO_Mapping::getMappingFields($savedMapping, TRUE);
+      list($mappingName, $mappingContactType, $mappingLocation, $mappingPhoneType, $mappingImProvider, $mappingRelation) = CRM_Core_BAO_Mapping::getMappingFields($savedMapping, TRUE);
 
       //get loaded Mapping Fields
       $mappingName = CRM_Utils_Array::value(1, $mappingName);
-      $mappingLocation = CRM_Utils_Array::value(1, $mappingLocation);
       $mappingRelation = CRM_Utils_Array::value(1, $mappingRelation);
-      $mappingWebsiteType = CRM_Utils_Array::value(1, $mappingWebsiteType);
 
       $this->assign('loadedMapping', $savedMapping);
       $this->set('loadedMapping', $savedMapping);
@@ -407,7 +405,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
 
       if ($this->get('savedMapping')) {
-        list($defaults, $js) = $this->loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
+        list($defaults, $js) = $this->loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
       }
       else {
         $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_0_');\n";
@@ -849,9 +847,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param \CRM_Import_ImportProcessor $processor
    * @param $mappingName
    * @param int $i
-   * @param $mappingRelation
-   * @param $mappingWebsiteType
-   * @param $mappingLocation
+   * @param array $mappingRelation
    * @param array $defaults
    * @param string $js
    * @param bool $hasColumnNames
@@ -861,7 +857,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @return array
    * @throws \CiviCRM_API3_Exception
    */
-  public function loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $mappingWebsiteType, $mappingLocation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns) {
+  public function loadSavedMapping($processor, $mappingName, $i, $mappingRelation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns) {
     $jsSet = FALSE;
     $formName = $processor->getFormName();
     if (isset($mappingName[$i])) {
@@ -899,8 +895,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           }
 
           $contactDetails = strtolower(str_replace(" ", "_", $mappingName[$i]));
-          $websiteTypeId = isset($mappingWebsiteType[$i]) ? $mappingWebsiteType[$i] : NULL;
-          $locationId = isset($mappingLocation[$i]) ? $mappingLocation[$i] : 0;
+          $websiteTypeId = $processor->getWebsiteTypeID($i);
+          $locationId = $processor->getLocationTypeID($i);
           $phoneType = $processor->getPhoneTypeID($i);
           $imProvider = $processor->getIMProviderID($i);
 
@@ -941,8 +937,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         }
         else {
           $mappingHeader = array_keys((array) $this->_mapperFields, $mappingName[$i]);
-          $websiteTypeId = isset($mappingWebsiteType[$i]) ? $mappingWebsiteType[$i] : NULL;
-          $locationId = isset($mappingLocation[$i]) ? $mappingLocation[$i] : 0;
+          $websiteTypeId = $processor->getWebsiteTypeID($i);
+          $locationId = $processor->getLocationTypeID($i);
           $phoneType = $processor->getPhoneTypeID($i);
           $imProvider = $processor->getIMProviderID($i);
 

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -297,6 +297,12 @@ document.forms.MapField['mapper[1][3]'].style.display = 'none';\n",
         ['name' => 'Phone', 'contact_type' => 'Individual', 'column_number' => 0, 'im_provider_id' => 1, 'location_type_id' => 2],
         "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
       ],
+      [
+        ['name' => 'Website', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id'],
+        "document.forms.MapField['mapper[0][1]'].style.display = 'none';
+document.forms.MapField['mapper[0][2]'].style.display = 'none';
+document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+      ],
     ];
   }
 

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -342,7 +342,7 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
     $processor->setFormName('document.forms.MapField');
     $processor->setMetadata($this->getContactImportMetadata());
 
-    $return = $form->loadSavedMapping($processor, $mappingName, $columnNumber, $mappingRelation, $mappingWebsiteType, $mappingLocation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
+    $return = $form->loadSavedMapping($processor, $mappingName, $columnNumber, $mappingRelation, $defaults, $js, $hasColumnNames, $dataPatterns, $columnPatterns);
     return ['defaults' => $return[0], 'js' => $return[1]];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup on import

Before
----------------------------------------
Less readable

After
----------------------------------------
More readable

Technical Details
----------------------------------------
Part of a bigger cleanup - I'm slowly extending test cover & making the covered changes.

The way it DID work was an array like
[[0 => 1], [1 => ''],[2 =>''] 
was passed around as $mappingWebsiteType. These were basically the values from the column website_type_id from the table civicrm_mapping_field indexed by column number & they were passed around for eventual lookup. We now load the mapping_fields into the ImportProcessor class and use it's functions to look up the values (which are NOT stored in separate column-indexed arrays but in a single array that reflects the underlying data structure from civicrm_mapping_field)

Comments
----------------------------------------

