### PR TITLE
Add default domain to membershiptype API

### DIFF
--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -96,6 +96,18 @@ function civicrm_api3_membership_type_get($params) {
 }
 
 /**
+ * Adjust Metadata for Get action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_membership_type_get_spec(&$params) {
+  $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
+}
+
+/**
  * Adjust input for getlist action.
  *
  * We want to only return active membership types for getlist. It's a bit


### PR DESCRIPTION
Overview
----------------------------------------
As identified in https://github.com/civicrm/civicrm-core/pull/14888

Before
----------------------------------------
No default domain for MembershipType API

After
----------------------------------------
Default domain for MembershipType API

Technical Details
----------------------------------------

Comments
----------------------------------------
