### PR TITLE
dev/core#1204 Data import for custom membership fields is done as tex…

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -664,46 +664,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
       }
 
       // Handling Custom Data
-      if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        $values[$key] = $value;
-        $type = $customFields[$customFieldID]['html_type'];
-        if ($type == 'CheckBox' || $type == 'Multi-Select') {
-          $mulValues = explode(',', $value);
-          $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-          $values[$key] = [];
-          foreach ($mulValues as $v1) {
-            foreach ($customOption as $customValueID => $customLabel) {
-              $customValue = $customLabel['value'];
-              if ((strtolower($customLabel['label']) == strtolower(trim($v1))) ||
-                (strtolower($customValue) == strtolower(trim($v1)))
-              ) {
-                if ($type == 'CheckBox') {
-                  $values[$key][$customValue] = 1;
-                }
-                else {
-                  $values[$key][] = $customValue;
-                }
-              }
-            }
-          }
-        }
-        elseif ($type == 'Select' || $type == 'Radio' ||
-          ($type == 'Autocomplete-Select' &&
-            $customFields[$customFieldID]['data_type'] == 'String'
-          )
-        ) {
-          $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-          foreach ($customOption as $customFldID => $customValue) {
-            $val = CRM_Utils_Array::value('value', $customValue);
-            $label = CRM_Utils_Array::value('label', $customValue);
-            $label = strtolower($label);
-            $value = strtolower(trim($value));
-            if (($value == $label) || ($value == strtolower($val))) {
-              $values[$key] = $val;
-            }
-          }
-        }
-      }
+      $values = CRM_Import_Parser::formatCustomData($values, $key, $customFields, $value);
 
       switch ($key) {
         case 'contribution_contact_id':

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -525,42 +525,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
       }
 
       // Handling Custom Data
-      if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        $values[$key] = $value;
-        $type = $customFields[$customFieldID]['html_type'];
-        if ($type == 'CheckBox' || $type == 'Multi-Select') {
-          $mulValues = explode(',', $value);
-          $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-          $values[$key] = [];
-          foreach ($mulValues as $v1) {
-            foreach ($customOption as $customValueID => $customLabel) {
-              $customValue = $customLabel['value'];
-              if ((strtolower(trim($customLabel['label'])) == strtolower(trim($v1))) ||
-                (strtolower(trim($customValue)) == strtolower(trim($v1)))
-              ) {
-                if ($type == 'CheckBox') {
-                  $values[$key][$customValue] = 1;
-                }
-                else {
-                  $values[$key][] = $customValue;
-                }
-              }
-            }
-          }
-        }
-        elseif ($type == 'Select' || $type == 'Radio') {
-          $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-          foreach ($customOption as $customFldID => $customValue) {
-            $val = CRM_Utils_Array::value('value', $customValue);
-            $label = CRM_Utils_Array::value('label', $customValue);
-            $label = strtolower($label);
-            $value = strtolower(trim($value));
-            if (($value == $label) || ($value == strtolower($val))) {
-              $values[$key] = $val;
-            }
-          }
-        }
-      }
+      $values = CRM_Import_Parser::formatCustomData($values, $key, $customFields, $value);
 
       switch ($key) {
         case 'participant_contact_id':

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -572,7 +572,7 @@ abstract class CRM_Import_Parser {
     return '';
   }
 
-   /**
+  /**
    * format custom data for while doing impor for components membership,contribution,participants.
    *
    * @param $values
@@ -629,4 +629,5 @@ abstract class CRM_Import_Parser {
     }
     return $values;
   }
+
 }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -666,6 +666,17 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
             }
           }
         }
+        if ($type == 'Autocomplete-Select') {
+          //  Get Custom data value
+          $membershipData = civicrm_api3('OptionValue', 'get', [
+            'label' => $value,
+            'return' => ["value"],
+          ]);
+          if (empty($membershipData['values'])) {
+            throw new Exception("Invalid option for $key : $value");
+          }
+          $values['custom_'.$customFieldID ] = $membershipData['values'][$membershipData['id']]['value'];
+        }
       }
 
       switch ($key) {

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -642,42 +642,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
         continue;
       }
 
-      //Handling Custom Data
-      if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        $values[$key] = $value;
-        $type = $customFields[$customFieldID]['html_type'];
-        if ($type == 'CheckBox' || $type == 'Multi-Select') {
-          $mulValues = explode(',', $value);
-          $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-          $values[$key] = [];
-          foreach ($mulValues as $v1) {
-            foreach ($customOption as $customValueID => $customLabel) {
-              $customValue = $customLabel['value'];
-              if ((strtolower($customLabel['label']) == strtolower(trim($v1))) ||
-                (strtolower($customValue) == strtolower(trim($v1)))
-              ) {
-                if ($type == 'CheckBox') {
-                  $values[$key][$customValue] = 1;
-                }
-                else {
-                  $values[$key][] = $customValue;
-                }
-              }
-            }
-          }
-        }
-        if ($type == 'Autocomplete-Select') {
-          //  Get Custom data value
-          $membershipData = civicrm_api3('OptionValue', 'get', [
-            'label' => $value,
-            'return' => ["value"],
-          ]);
-          if (empty($membershipData['values'])) {
-            throw new Exception("Invalid option for $key : $value");
-          }
-          $values['custom_'.$customFieldID ] = $membershipData['values'][$membershipData['id']]['value'];
-        }
-      }
+      // Handling Custom Data
+      $values = CRM_Import_Parser::formatCustomData($values, $key, $customFields, $value);
 
       switch ($key) {
         case 'membership_contact_id':


### PR DESCRIPTION

Overview
----------------------------------------
Data import for custom membership fields is done as text Instead of value. 

* Create a custom data used for Membership having *Data Field* with Alphanumeric and *Field Type* Autocomplete-Select
* The values in the look up should be numeric.
* Try to update the membership record using import for the custom field with text not the value.

Before
----------------------------------------
Check the field in DB, the data is imported but stored as text not value - so this doesn't show up in the UI.

After
----------------------------------------
Check the field in DB, the data is imported and stored as value - so show up in the UI.


Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1204
