### PR TITLE
Fix hardcoded ID for Head of Household relationship

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -329,8 +329,17 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
 
     // check if the relationship type is Head of Household then update the
     // household's primary contact with this contact.
-    if ($relationshipTypeID == 6) {
-      CRM_Contact_BAO_Household::updatePrimaryContact($relationship->contact_id_b, $relationship->contact_id_a);
+    try {
+      $headOfHouseHoldID = civicrm_api3('RelationshipType', 'getvalue', [
+        'return' => "id",
+        'name_a_b' => "Head of Household for",
+      ]);
+      if ($relationshipTypeID == $headOfHouseHoldID) {
+        CRM_Contact_BAO_Household::updatePrimaryContact($relationship->contact_id_b, $relationship->contact_id_a);
+      }
+    }
+    catch (Exception $e) {
+      // No "Head of Household" relationship found so we skip specific processing
     }
 
     if (!empty($params['id']) && self::isCurrentEmployerNeedingToBeCleared($relationship->toArray(), $params['id'], $relationshipTypeID)) {


### PR DESCRIPTION
Overview
----------------------------------------
As identified by @demeritcowboy in #15103 which needs merge first.

Before
----------------------------------------
Hardcoded ID which isn't always the correct ID.

After
----------------------------------------
ID which is always the correct ID.

Technical Details
----------------------------------------
We dont have pseudoconstant on relationshiptype so using API getvalue.

Comments
----------------------------------------
Ping @demeritcowboy 
