### PR TITLE
Deprecate CRM_Core_Config::addressSequence()

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -442,9 +442,6 @@ WHERE id={$contactId}; ";
    *
    */
   public static function buildOnBehalfForm(&$form, $contactType, $countryID, $stateID, $title) {
-
-    $config = CRM_Core_Config::singleton();
-
     $form->assign('contact_type', $contactType);
     $form->assign('fieldSetTitle', $title);
     $form->assign('contactEditMode', TRUE);
@@ -482,7 +479,7 @@ WHERE id={$contactId}; ";
         );
     }
 
-    $addressSequence = $config->addressSequence();
+    $addressSequence = CRM_Utils_Address::sequence(\Civi::settings()->get('address_format'));
     $form->assign('addressSequence', array_fill_keys($addressSequence, 1));
 
     //Primary Phone

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -663,8 +663,7 @@ ORDER BY civicrm_address.is_primary DESC, civicrm_address.location_type_id DESC,
    *   Array of address sequence.
    */
   public static function addressSequence() {
-    $config = CRM_Core_Config::singleton();
-    $addressSequence = $config->addressSequence();
+    $addressSequence = CRM_Utils_Address::sequence(\Civi::settings()->get('address_format'));
 
     $countryState = $cityPostal = FALSE;
     foreach ($addressSequence as $key => $field) {

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -471,6 +471,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * @deprecated
    */
   public function addressSequence() {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Utils_Address::sequence(Civi::settings()->get(\'address_format\')');
     return CRM_Utils_Address::sequence(Civi::settings()->get('address_format'));
   }
 

--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -67,8 +67,7 @@ class CRM_Core_Page_AJAX_Location {
     $entityBlock = ['contact_id' => $cid];
     $location = CRM_Core_BAO_Location::getValues($entityBlock);
 
-    $config = CRM_Core_Config::singleton();
-    $addressSequence = array_flip($config->addressSequence());
+    $addressSequence = array_flip(CRM_Utils_Address::sequence(\Civi::settings()->get('address_format')));
 
     $profileFields = CRM_Core_BAO_UFGroup::getFields($ufId, FALSE, CRM_Core_Action::VIEW, NULL, NULL, FALSE,
       NULL, FALSE, NULL, CRM_Core_Permission::CREATE, NULL


### PR DESCRIPTION
Overview
----------------------------------------
Stop using deprecated CRM_Core_Config::addressSequence() in core and emit warnings if they are used.
Partial from #14576

Before
----------------------------------------
Deprecated functions used by core.

After
----------------------------------------
Deprecated functions not used by core.

Technical Details
----------------------------------------

Comments
----------------------------------------
