### PR TITLE
(dev/joomla#21) [WIP] Do not call session_start() for Joomla as it can break cron.php

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -123,7 +123,8 @@ class CRM_Core_Session {
           }
           $_SESSION = array();
         }
-        else {
+        // Joomla will do its own session_start() so do not do it here
+        elseif ($config->userFramework !== 'Joomla') {
           session_start();
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/joomla/issues/21
On Joomla 3.8 and higher, PHP 7, and error reporting set to show warnings, cron.php does not work due to CiviCRM creating a PHP session and then Joomla attempting to do an ini_set().

Before
----------------------------------------
Warning: ini_set(): A session is active. You cannot change the session module's ini settings at this time in /var/www/html/membership/libraries/joomla/session/handler/joomla.php on line 48

After
----------------------------------------
No warning and cron.php executes successfully regardless of the error_reporting setting.

Technical Details
----------------------------------------
This PR eliminates the call to `session_start()` in `CRM_Core_Session::initialize()` if the user framework is Joomla on the basis that Joomla does that itself at the appropriate (later) time.

Comments
----------------------------------------

