### PR TITLE
(dev/joomla#22) Fix deprecated JRequest for Joomla 4.0

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -265,8 +265,12 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
 
     if ($config->userFrameworkFrontend) {
       $script = 'index.php';
-      if (JRequest::getVar("Itemid") && (strpos($path, 'civicrm/payment/ipn') === FALSE)) {
-        $Itemid = "{$separator}Itemid=" . JRequest::getVar("Itemid");
+
+      // Get Itemid using JInput::get()
+      $input = Joomla\CMS\Factory::getApplication()->input;
+      $itemIdNum = $input->get("Itemid");
+      if ($itemIdNum && (strpos($path, 'civicrm/payment/ipn') === FALSE)) {
+        $Itemid = "{$separator}Itemid=" . $itemIdNum;
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Viewing any CiviCRM frontend page on Joomla 4.0 fails.
The error "Class 'JRequest' not found" is displayed. Ref: https://lab.civicrm.org/dev/joomla/issues/22
This PR replaces this deprecated class with JInput and its get() method.

Before
----------------------------------------
The error "Class 'JRequest' not found" is displayed and frontend pages fail to load.

After
----------------------------------------
Frontend pages load as expected.

Technical Details
----------------------------------------
The JRequest class is not present in Joomla 4.0. Use JInput::get() instead, ref: https://api.joomla.org/cms-3/classes/JRequest.html#method_getVar
See the example in the documentation: https://docs.joomla.org/Retrieving_request_data_using_JInput

> To use JInput you must first create an object of the Input class by using this code:
```
use Joomla\CMS\Factory;
$input = Factory::getApplication()->input;
// equivalent of the older format $input = JFactory::getApplication()->input;
```
> then to get the value of a specific parameter use
`$val = $input->get(param_name, default_value, filter);`

Comments
----------------------------------------

