### PR TITLE
Extract function to create email activity when sending an email to contact

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -988,6 +988,56 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
   }
 
   /**
+   * @param int $userID
+   * @param string $subject
+   * @param string $html
+   * @param string $text
+   * @param string $additionalDetails
+   * @param int $campaignID
+   * @param array $attachments
+   *
+   * @return int
+   *   The created activity ID
+   * @throws \CRM_Core_Exception
+   */
+  public static function createEmailActivity($userID, $subject, $html, $text, $additionalDetails, $campaignID, $attachments) {
+    $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email');
+
+    // CRM-6265: save both text and HTML parts in details (if present)
+    if ($html and $text) {
+      $details = "-ALTERNATIVE ITEM 0-\n$html$additionalDetails\n-ALTERNATIVE ITEM 1-\n$text$additionalDetails\n-ALTERNATIVE END-\n";
+    }
+    else {
+      $details = $html ? $html : $text;
+      $details .= $additionalDetails;
+    }
+
+    $activityParams = [
+      'source_contact_id' => $userID,
+      'activity_type_id' => $activityTypeID,
+      'activity_date_time' => date('YmdHis'),
+      'subject' => $subject,
+      'details' => $details,
+      // FIXME: check for name Completed and get ID from that lookup
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed'),
+      'campaign_id' => $campaignID,
+    ];
+
+    // CRM-5916: strip [case #…] before saving the activity (if present in subject)
+    $activityParams['subject'] = preg_replace('/\[case #([0-9a-h]{7})\] /', '', $activityParams['subject']);
+
+    // add the attachments to activity params here
+    if ($attachments) {
+      // first process them
+      $activityParams = array_merge($activityParams, $attachments);
+    }
+
+    $activity = self::create($activityParams);
+
+    return $activity->id;
+  }
+
+  /**
    * Send the message to all the contacts.
    *
    * Also insert a contact activity in each contacts record.
@@ -1018,6 +1068,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    *
    * @return array
    *   ( sent, activityId) if any email is sent and activityId
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function sendEmail(
     &$contactDetails,
@@ -1061,45 +1113,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
 
     //create the meta level record first ( email activity )
-    $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email');
+    $activityID = self::createEmailActivity($userID, $subject, $html, $text, $additionalDetails, $campaignId, $attachments);
 
-    // CRM-6265: save both text and HTML parts in details (if present)
-    if ($html and $text) {
-      $details = "-ALTERNATIVE ITEM 0-\n$html$additionalDetails\n-ALTERNATIVE ITEM 1-\n$text$additionalDetails\n-ALTERNATIVE END-\n";
-    }
-    else {
-      $details = $html ? $html : $text;
-      $details .= $additionalDetails;
-    }
-
-    $activityParams = [
-      'source_contact_id' => $userID,
-      'activity_type_id' => $activityTypeID,
-      'activity_date_time' => date('YmdHis'),
-      'subject' => $subject,
-      'details' => $details,
-      // FIXME: check for name Completed and get ID from that lookup
-      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed'),
-      'campaign_id' => $campaignId,
-    ];
-
-    // CRM-5916: strip [case #…] before saving the activity (if present in subject)
-    $activityParams['subject'] = preg_replace('/\[case #([0-9a-h]{7})\] /', '', $activityParams['subject']);
-
-    // add the attachments to activity params here
-    if ($attachments) {
-      // first process them
-      $activityParams = array_merge($activityParams,
-        $attachments
-      );
-    }
-
-    $activity = self::create($activityParams);
-
-    // get the set of attachments from where they are stored
-    $attachments = CRM_Core_BAO_File::getEntityFile('civicrm_activity',
-      $activity->id
-    );
     $returnProperties = [];
     if (isset($messageToken['contact'])) {
       foreach ($messageToken['contact'] as $key => $value) {
@@ -1207,8 +1222,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         $tokenText,
         $tokenHtml,
         $emailAddress,
-        $activity->id,
-        $attachments,
+        $activityID,
+        // get the set of attachments from where they are stored
+        CRM_Core_BAO_File::getEntityFile('civicrm_activity', $activityID),
         $cc,
         $bcc
       )
@@ -1217,7 +1233,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
 
-    return [$sent, $activity->id];
+    return [$sent, $activityID];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Extract function that creates an email activity.

Background: I've had a number of requests to save the contents of an email *after* tokens have been parsed but the way it currently works is it saves a single activity pre-parsing and then creates activity contacts to link it to multiple contacts.  This is a more efficient use of the database but a lot less friendly to the end-user admin who can't see what was actually sent to the contact.  Note that this PR makes no changes - it just extracts the function that creates the activity so we can consider further refactoring.

Before
----------------------------------------
Create email activity embedded in main sendMessage function.

After
----------------------------------------
Create email activity extracted to it's own function.

Technical Details
----------------------------------------
There should be no functional change with this PR, just simplified/improved code.

Comments
----------------------------------------
