### PR TITLE
Add minimal test for testExportFinancialBatch

### DIFF
--- a/api/v3/Batch.php
+++ b/api/v3/Batch.php
@@ -37,6 +37,8 @@
  * @param array $params
  *
  * @return array
+ * @throws \API_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
  */
 function civicrm_api3_batch_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Batch');
@@ -56,8 +58,10 @@ function _civicrm_api3_batch_create_spec(&$params) {
   $params['entity_table']['api.default'] = "civicrm_batch";
   $params['entity_table']['type'] = CRM_Utils_Type::T_STRING;
   $params['entity_table']['title'] = 'Batch Entity Table - remove?';
-
-  $params['modified_date']['api.default'] = "now";
+  $params['created_id']['api.default'] = 'user_contact_id';
+  $params['created_date']['api.default'] = 'now';
+  $params['modified_id']['api.default'] = 'user_contact_id';
+  $params['modified_date']['api.default'] = 'now';
   $params['status_id']['api.required'] = 1;
   $params['title']['api.required'] = 1;
   $params['status_id']['api.required'] = 1;
@@ -82,6 +86,8 @@ function civicrm_api3_batch_get($params) {
  *
  * @return array
  *   Array of deleted values.
+ * @throws \API_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
  */
 function civicrm_api3_batch_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -32,6 +32,16 @@
 class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
 
   /**
+   * Cleanup after test.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function tearDown() {
+    parent::tearDown();
+    $this->quickCleanup(['civicrm_batch']);
+  }
+
+  /**
    * This test checks that a batch search
    * by payment method works.
    * This function could later be expanded to include
@@ -42,6 +52,8 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
    * card and one with payment method check.  After performing a
    * search by payment method for checks, it makes sure that the
    * results are only contributions made by check.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetBatchFinancialItems() {
 
@@ -102,6 +114,17 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
     ]);
     $result = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId, $returnvalues, $notPresent, $params, TRUE)->fetchAll();
     $this->assertEquals(count($result), 1, 'In line' . __LINE__);
+  }
+
+  /**
+   * Test testExportFinancialBatch.
+   */
+  public function testExportFinancialBatch() {
+    $this->createLoggedInUser();
+    $batchParams = ['title' => 'Test Batch'];
+    $batchParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Exported');
+    $batch = $this->callAPISuccess('Batch', 'create', $batchParams);
+    CRM_Batch_BAO_Batch::exportFinancialBatch([$batch['id']], 'CSV', NULL);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds the minimal test suggested as needed for https://github.com/civicrm/civicrm-core/pull/14621

In the process I needed to add some api defaults

Before
----------------------------------------
No test, no defaults

After
----------------------------------------
Test, defaults - note defaults only apply on create (not update) - ideally modified_id & modified_date WOULD do 'something' when updated by the api but not in scope

Technical Details
----------------------------------------
Once merged #14621 can be retested & merged

Comments
----------------------------------------
@pradpnayak I wrote it for you...
