### PR TITLE
(dev/joomla#24) Stop CiviCRM's joomla.css from modifying Joomla 4 header background colour

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -155,9 +155,6 @@ br.clear {
 #header, #content {
   width: 100%;
 }
-#header {
-  background-color: #69c;
-}
 #logo {
   vertical-align: middle;
   border: 0;


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/joomla/issues/24.
This PR stops the Joomla 4 header from having its background colour modified to blue by CiviCRM's joomla.css

Before
----------------------------------------
When on a CiviCRM backend page the Joomla 4 header will change from white to blue background.
![image](https://user-images.githubusercontent.com/25069773/63664582-4c7b0380-c806-11e9-902b-bb23463266f5.png)

After
----------------------------------------
Joomla's header will have a white background as it does on non-CiviCRM pages.
![image](https://user-images.githubusercontent.com/25069773/63664633-97951680-c806-11e9-842c-ddf8fe97c565.png)


Technical Details
----------------------------------------
Removed `#header {   background-color: #69c; }` which seemed to have no purpose on earlier Joomla versions.

Comments
----------------------------------------

