### PR TITLE
dev/event#14 Fix excessive cache clearing on creating an event

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -83,7 +83,6 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event {
    * @return CRM_Event_DAO_Event
    */
   public static function add(&$params) {
-    CRM_Utils_System::flushCache();
     $financialTypeId = NULL;
     if (!empty($params['id'])) {
       CRM_Utils_Hook::pre('edit', 'Event', $params['id'], $params);


### PR DESCRIPTION
Overview
----------------------------------------
When creating or updating an event CiviCRM clears all caches.

Before
----------------------------------------
There seems to have been an issue with Memcache, CiviCRM, Drupal and Events. That when you create an event and press continue you will got a permission denied. See https://issues.civicrm.org/jira/browse/CRM-6734
The fix for that issue was simply clearing all caches. 

After
----------------------------------------
Removed the line for clearing the caches upon creating and updating events.
I have tested the fix with memcache enabled to see whether the permission denied problem reappeared but it did not.

Comments
----------------------------------------

This fix also improves performance

See related lab.civicrm.org issue: https://lab.civicrm.org/dev/event/issues/14
