### PR TITLE
Stop adding a refund payment from creating extraneous financial items

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -385,31 +385,6 @@ class CRM_Financial_BAO_Payment {
     if ($updateStatus) {
       CRM_Core_DAO::setFieldValue('CRM_Contribute_BAO_Contribution', $contributionId, 'contribution_status_id', $completedStatusId);
     }
-    // add financial item entry
-    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contributionDAO->id);
-    if (!empty($lineItems)) {
-      foreach ($lineItems as $lineItemId => $lineItemValue) {
-        // don't record financial item for cancelled line-item
-        if ($lineItemValue['qty'] == 0) {
-          continue;
-        }
-        $paid = $financialTrxn->total_amount;
-        if (!empty(floatval($contributionDAO->total_amount))) {
-          $paid = $lineItemValue['line_total'] * ($financialTrxn->total_amount / $contributionDAO->total_amount);
-        }
-        $addFinancialEntry = [
-          'transaction_date' => $financialTrxn->trxn_date,
-          'contact_id' => $contributionDAO->contact_id,
-          'amount' => round($paid, 2),
-          'currency' => $contributionDAO->currency,
-          'status_id' => $paidStatus,
-          'entity_id' => $lineItemId,
-          'entity_table' => 'civicrm_line_item',
-        ];
-        $trxnIds = ['id' => $financialTrxn->id];
-        CRM_Financial_BAO_FinancialItem::create($addFinancialEntry, NULL, $trxnIds);
-      }
-    }
     return $financialTrxn;
   }
 

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -489,7 +489,28 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test update payment api
+   * Test update payment api.
+   *
+   * 1) create a contribution for $300 with a partial payment of $150
+   * - this results in 2 financial transactions. The accounts receivable transaction is linked
+   *   via entity_financial_trxns to the 2 line items. The $150 payment is not linked to the line items
+   *   so the line items are fully allocated even though they are only half paid.
+   *
+   * 2) add a payment of $50 -
+   *  This payment transaction IS linked to the line items so $350 of the $300 in line items is allocated
+   *  but $200 is paid
+   *
+   * 3) update that payment to be $100
+   *  This results in a negative and a positive payment ($50 & $100) - the negative payment results in
+   *  financial_items but the positive payment does not.
+   *
+   * The final result is we have
+   * - 1 partly paid contribution of $300
+   * -  payment financial_trxns totalling $250
+   * - 1 Accounts receivable financial_trxn totalling $300
+   * - 2 financial items totalling $300 linked to the Accounts receivable financial_trxn
+   * - 6 entries in the civicrm_entity_financial_trxn linked to line items - totalling $450.
+   * - 5 entries in the civicrm_entity_financial_trxn linked to contributions - totalling $550.
    */
   public function testUpdatePayment() {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute', 'edit contributions'];
@@ -522,7 +543,6 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     foreach ($eft['values'] as $value) {
       $this->assertEquals($value['amount'], array_pop($amounts));
     }
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute'];
 
     // update the amount for payment
     $params = [
@@ -531,9 +551,11 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'id' => $payment['id'],
       'check_permissions' => TRUE,
     ];
-    $payment = $this->callAPIFailure('payment', 'create', $params, 'API permission check failed for Payment/create call; insufficient permission: require access CiviCRM and access CiviContribute and edit contributions');
+    // @todo - move this permissions test to it's own test - it just confuses here.
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute'];
+    $this->callAPIFailure('payment', 'create', $params, 'API permission check failed for Payment/create call; insufficient permission: require access CiviCRM and access CiviContribute and edit contributions');
 
-    array_push(CRM_Core_Config::singleton()->userPermissionClass->permissions, 'access CiviCRM', 'edit contributions');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute', 'access CiviCRM', 'edit contributions'];
     $payment = $this->callAPIAndDocument('payment', 'create', $params, __FUNCTION__, __FILE__, 'Update Payment', 'UpdatePayment');
 
     // Check for proportional cancelled payment against lineitems.
@@ -559,6 +581,14 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     foreach ($eft['values'] as $value) {
       $this->assertEquals($value['amount'], array_pop($amounts));
     }
+    $items = $this->callAPISuccess('FinancialItem', 'get', [])['values'];
+    $this->assertCount(2, $items);
+    $itemSum = 0;
+    foreach ($items as $item) {
+      $this->assertEquals('civicrm_line_item', $item['entity_table']);
+      $itemSum += $item['amount'];
+    }
+    $this->assertEquals(300, $itemSum);
 
     $params = [
       'contribution_id' => $contribution['id'],


### PR DESCRIPTION
Overview
----------------------------------------
    Stop adding a refund payment from creating extraneous financial items
    
    Per
    https://github.com/civicrm/civicrm-core/pull/15143#issuecomment-527245150
    
    and https://github.com/civicrm/civicrm-core/pull/13114/files#diff-8967f6e57d6209aa277ded6512413608L326

Before
----------------------------------------
Financial items created when adding a refund to a contribution but @monishdeb - see  https://github.com/civicrm/civicrm-core/pull/13114/files#diff-8967f6e57d6209aa277ded6512413608L326 and @pradpnayak - see comment below - have both said they should not be. 

In this test we have the following events

1) Contribution is created for $300 with a partial payment of $150. Line items are $100 & $200
2) A payment is added for $50
3) the payment is update to be $100

These payments look as expected - 

**civicrm_financial_trxn**
<img width="836" alt="Screen Shot 2019-08-27 at 7 49 58 PM" src="https://user-images.githubusercontent.com/336308/63751641-dfe62e80-c903-11e9-8991-4b216e2d3160.png">


The final outcome is that the allocation in the civicrm_financial_item table is equal to the sum of payments $250 and the total of the entity_financial_trxns for this  exceeds the amount paid

**civicrm_financial_item**
<img width="812" alt="Screen Shot 2019-08-27 at 7 57 17 PM" src="https://user-images.githubusercontent.com/336308/63752180-e7f29e00-c904-11e9-9a18-df45eaca962a.png">

**However**, BEFORE we started adding payments the allocation was actually equal to the sum of the contribution.

**civicrm_entity_financial_trxn - entity_table = civicrm_financial_item**
<img width="771" alt="Screen Shot 2019-08-27 at 7 59 24 PM" src="https://user-images.githubusercontent.com/336308/63752340-3011c080-c905-11e9-9f62-d72dfddff820.png">


**civicrm_entity_financial_trxn - entity_table = civicrm_contribution**
<img width="763" alt="Screen Shot 2019-08-27 at 8 11 54 PM" src="https://user-images.githubusercontent.com/336308/63753328-f93caa00-c906-11e9-8a07-1367ed7b60d9.png">


So prior to adding payments the financial_items allocated the total amount to pay (paid and unpaid) to the line items via financial items but in the end we would up with only the amount paid allocated. This feels wonky.


After
----------------------------------------
Only the original 2 financial items created. Test locks this change in.

Technical Details
----------------------------------------



Comments
----------------------------------------

