### PR TITLE
Improvements to copying events and contribution pages

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -666,9 +666,15 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
    * @return CRM_Contribute_DAO_ContributionPage
    */
   public static function copy($id) {
+    $session = CRM_Core_Session::singleton();
+
     $fieldsFix = [
       'prefix' => [
         'title' => ts('Copy of') . ' ',
+      ],
+      'replace' => [
+        'created_id' => $session->get('userID'),
+        'created_date' => date('YmdHis'),
       ],
     ];
     $copy = CRM_Core_DAO::copyGeneric('CRM_Contribute_DAO_ContributionPage', [

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -384,9 +384,18 @@ AND         cp.page_type = 'contribute'
       $this, TRUE, 0, 'GET'
     );
 
-    CRM_Contribute_BAO_ContributionPage::copy($gid);
+    $copy = CRM_Contribute_BAO_ContributionPage::copy($gid);
 
-    CRM_Utils_System::redirect(CRM_Utils_System::url(CRM_Utils_System::currentPath(), 'reset=1'));
+    $urlString = CRM_Utils_System::currentPath();
+    $urlParams = 'reset=1';
+
+    // Redirect to copied contribution page
+    if ($copy->id) {
+      $urlString = 'civicrm/admin/contribute/settings';
+      $urlParams .= '&action=update&id=' . $copy->id;
+    }
+
+    CRM_Utils_System::redirect(CRM_Utils_System::url($urlString, $urlParams));
   }
 
   /**

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -926,6 +926,7 @@ WHERE civicrm_event.is_active = 1
    * @throws \CRM_Core_Exception
    */
   public static function copy($id, $params = []) {
+    $session = CRM_Core_Session::singleton();
     $eventValues = [];
 
     //get the required event values.
@@ -940,7 +941,15 @@ WHERE civicrm_event.is_active = 1
 
     CRM_Core_DAO::commonRetrieve('CRM_Event_DAO_Event', $eventParams, $eventValues, $returnProperties);
 
-    $fieldsFix = ['prefix' => ['title' => ts('Copy of') . ' ']];
+    $fieldsFix = [
+      'prefix' => [
+        'title' => ts('Copy of') . ' ',
+      ],
+      'replace' => [
+        'created_id' => $session->get('userID'),
+        'created_date' => date('YmdHis'),
+      ],
+    ];
     if (empty($eventValues['is_show_location'])) {
       $fieldsFix['prefix']['is_show_location'] = 0;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Copying events and contribution pages currently preserves the original 'created date' and 'created by user ID' fields. This is a bit misleading when trying to track back through changes, particularly when you don't have detailed logging enabled.

So when copying events and contribution pages, use the current date and user ID for the fields instead.

Additionally, when copying contribution pages, you are redirected back to the list of contribution pages, which is annoying when you have a lot of them! Redirect to the newly copied page instead to match the behaviour when copying events.

Before
----------------------------------------
Original user created_date and created_id saved in DB when copying events and contribution pages.

You are redirected to the contribution page listing after copying a contribution page.

After
----------------------------------------
The current user ID and time are stored in created_date and created_id when copying events and contribution pages.

When copying a contribution page you are redirected to the 'edit' screen for the newly copied page.
