### PR TITLE
Better error handling in CRM_Utils_JS::decode

### DIFF
--- a/CRM/Utils/JS.php
+++ b/CRM/Utils/JS.php
@@ -143,11 +143,13 @@ class CRM_Utils_JS {
    */
   public static function decode($js) {
     $js = trim($js);
-    if ($js[0] === "'" || $js[0] === '"') {
+    $first = substr($js, 0, 1);
+    $last = substr($js, -1);
+    if ($last === $first && ($first === "'" || $first === '"')) {
       // Use a temp placeholder for escaped backslashes
       return str_replace(['\\\\', "\\'", '\\"', '\\&', '\\/', '**backslash**'], ['**backslash**', "'", '"', '&', '/', '\\'], substr($js, 1, -1));
     }
-    if ($js[0] === '{' || $js[0] === '[') {
+    if (($first === '{' && $last === '}') || ($first === '[' && $last === ']')) {
       $obj = self::getRawProps($js);
       foreach ($obj as $idx => $item) {
         $obj[$idx] = self::decode($item);

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -203,6 +203,7 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
     return [
       ['{a: \'Apple\', \'b\': "Banana", c: [1, 2, 3]}', ['a' => 'Apple', 'b' => 'Banana', 'c' => [1, 2, 3]]],
       ['true', TRUE],
+      [' ', NULL],
       ['false', FALSE],
       ['null', NULL],
       ['"true"', 'true'],
@@ -212,6 +213,10 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
       ["{  }", []],
       [" [   ]", []],
       [" [ 2   ]", [2]],
+      [
+        '{a: "parse error no closing bracket"',
+        NULL,
+      ],
       [
         '{a: ["foo", \'bar\'], "b": {a: [\'foo\', "bar"], b: {\'a\': ["foo", "bar"], b: {}}}}',
         ['a' => ['foo', 'bar'], 'b' => ['a' => ['foo', 'bar'], 'b' => ['a' => ['foo', 'bar'], 'b' => []]]],


### PR DESCRIPTION
Overview
----------------------------------------
Improves the function to better handle malformed js and adds tests.

Before
----------------------------------------
Malformed js caused php notices & possibly errors.

After
----------------------------------------
Malformed js passed to `json_decode` which simply outputs `NULL`.
