### PR TITLE
dev/core#1123 - Changing the label for Inbound Email bypasses edit permission

### DIFF
--- a/CRM/Activity/BAO/ActivityType.php
+++ b/CRM/Activity/BAO/ActivityType.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ */
+
+/**
+ * This class is a wrapper that moves some boilerplate code out of the Form class and helps remove some ambiguity with name and label.
+ */
+class CRM_Activity_BAO_ActivityType {
+
+  /**
+   * key/value pair for this activity type
+   *
+   * @var array
+   *   machineName The internal name for lookups - matches up to option_value 'name' column in the database
+   *   displayLabel The label used for display/output - matches up to option_value 'label' column in the database
+   *   id The value used to initialize this object - matches up to the option_value 'value' column in the database
+   */
+  protected $_activityType = [
+    'machineName' => NULL,
+    'displayLabel' => NULL,
+    'id' => NULL,
+  ];
+
+  /**
+   * Constructor
+   *
+   * @param $activity_type_id int This matches up to the option_value 'value' column in the database.
+   */
+  public function __construct($activity_type_id) {
+    $this->setActivityType($activity_type_id);
+  }
+
+  /**
+   * Get the key/value pair representing this activity type.
+   *
+   * @return array
+   * @see $this->_activityType
+   */
+  public function getActivityType() {
+    return $this->_activityType;
+  }
+
+  /**
+   * Look up the key/value pair representing this activity type from the id.
+   * Generally called from constructor.
+   *
+   * @param $activity_type_id int This matches up to the option_value 'value' column in the database.
+   */
+  public function setActivityType($activity_type_id) {
+    if ($activity_type_id && is_numeric($activity_type_id)) {
+
+      /*
+       * These are pulled from CRM_Activity_Form_Activity.
+       * To avoid unexpectedly changing things like introducing hidden
+       * business logic or changing permission checks I've kept it using
+       * the same function call. It may or may not be desired to have
+       * that but this at least doesn't introduce anything that wasn't
+       * there before.
+       */
+      $machineNames = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $activity_type_id, 'name');
+      $displayLabels = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $activity_type_id, 'label');
+
+      $this->_activityType = [
+        'machineName' => CRM_Utils_Array::value($activity_type_id, $machineNames),
+        'displayLabel' => CRM_Utils_Array::value($activity_type_id, $displayLabels),
+        'id' => $activity_type_id,
+      ];
+    }
+  }
+
+}

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -1241,8 +1241,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $activityTypeDisplayLabels = $this->getActivityTypeDisplayLabels();
       if ($activityTypeDisplayLabels[$this->_activityTypeId]) {
         $this->_activityTypeName = $activityTypeDisplayLabels[$this->_activityTypeId];
-        // can't change this instance of activityTName yet - will come back to it dev/core#1116
-        $this->assign('activityTName', $activityTypeDisplayLabels[$this->_activityTypeId]);
+
+        // At the moment this is duplicating other code in this section, but refactoring in small steps.
+        $activityTypeObj = new CRM_Activity_BAO_ActivityType($this->_activityTypeId);
+        $this->assign('activityType', $activityTypeObj->getActivityType());
       }
       // Set title.
       if (isset($activityTypeDisplayLabels)) {

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -252,7 +252,7 @@
   {/if} {* End Delete vs. Add / Edit action *}
   </table>
   <div class="crm-submit-buttons">
-  {if $action eq 4 && ($activityTName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
+  {if $action eq 4 && ($activityType.machineName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
     {if !$context }
       {assign var="context" value='activity'}
     {/if}

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTypeTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Activity_BAO_ActivityTypeTest extends CiviUnitTestCase {
+
+  /**
+   * Test ActivityType
+   */
+  public function testActivityType() {
+    $actParams = [
+      'option_group_id' => 'activity_type',
+      'name' => 'abc123',
+      'label' => 'Write Unit Test',
+      'is_active' => 1,
+      'is_default' => 0,
+    ];
+    $result = $this->callAPISuccess('option_value', 'create', $actParams);
+
+    $activity_type_id = $result['values'][$result['id']]['value'];
+
+    // instantiate the thing we want to test and read it back
+    $activityTypeObj = new CRM_Activity_BAO_ActivityType($activity_type_id);
+    $keyValuePair = $activityTypeObj->getActivityType();
+
+    $this->assertEquals($keyValuePair['machineName'], 'abc123');
+    $this->assertEquals($keyValuePair['displayLabel'], 'Write Unit Test');
+
+    // cleanup
+    $this->callAPISuccess('option_value', 'delete', ['id' => $result['id']]);
+  }
+
+}

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -212,6 +212,44 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
     $form->assignActivityType();
 
     $this->assertEquals('Water Plants', $form->_activityTypeName);
+
+    // cleanup
+    $this->callAPISuccess('option_value', 'delete', ['id' => $result['id']]);
+  }
+
+  /**
+   * Test that the machineName and displayLabel are assigned correctly to the
+   * smarty template.
+   *
+   * See also testActivityTypeNameIsReallyLabel()
+   */
+  public function testActivityTypeAssignment() {
+    $form = new CRM_Activity_Form_Activity();
+
+    $form->_currentlyViewedContactId = $this->source;
+
+    // Let's make a new activity type that has a different name from its label just to be sure.
+    $actParams = [
+      'option_group_id' => 'activity_type',
+      'name' => '47395hc',
+      'label' => 'Hide Cookies',
+      'is_active' => 1,
+      'is_default' => 0,
+    ];
+    $result = $this->callAPISuccess('option_value', 'create', $actParams);
+
+    $form->_activityTypeId = $result['values'][$result['id']]['value'];
+
+    // Do the thing we want to test
+    $form->assignActivityType();
+
+    // Check the smarty template has the correct values assigned.
+    $keyValuePair = $form->getTemplate()->get_template_vars('activityType');
+    $this->assertEquals('47395hc', $keyValuePair['machineName']);
+    $this->assertEquals('Hide Cookies', $keyValuePair['displayLabel']);
+
+    // cleanup
+    $this->callAPISuccess('option_value', 'delete', ['id' => $result['id']]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This replaces the check in CRM/Activity/Form/Activity.tpl which was comparing against the activity type label instead of name, and removes the odd and incorrect variable `activityTName` that is only used once anywhere.

https://lab.civicrm.org/dev/core/issues/1123

Before
----------------------------------------
Less privileged users can edit inbound emails if they change the activity type label.

After
----------------------------------------
They still can if they know how, but that's a different bug...

Technical Details
----------------------------------------
This looks like a lot of code but:

* 2 files are tests.
* The changes to form/activity.php are two lines that add something new and then use that new correct thing instead of the old incorrect thing.
* The change to form/activity.tpl is one line that uses the new correct thing instead of the old incorrect thing.
* It's a continuation of the other PRs for dev/core#1116 and the general activity type name/label issue.

The 5th file is a new file, and I waffled a bit with some earlier variations:
* I started by just adding more stuff into form/activity.php, but that started to feel wrong.
* I looked at adding to bao/activity.php, but that also sort of felt wrong to be adding more static functions in there for this. It's an option, but it seemed cleaner to do it as a class.
* I looked at PseudoConstant::activityType, but it's deprecated, and it says to use buildOptions but that's for a different use-case that adds business logic and such. I really just wanted to pull out the existing call that gets the labels and put it somewhere where I could then also add in the names. I don't want to change the way that it gets those here.
* I also looked at api but again it adds stuff - I just wanted to keep everything the same here without introducing unexpected changes and put it somewhere more central.
* The meat of this new file is just lines 89-94 and everything around it is boilerplate.

Comments
----------------------------------------
To test the actual bug on the test site here is a bit difficult because there is no inbound email processor. Do like so:
* In the drupal permissions confirm that the edit inbound email permission is disabled for the non-admin user.
* Create a meeting activity or something.
* Using the api explorer, do an activity-create using the activity id of the activity you just created and change the activity_type_id to Inbound Email.
* Log in as the regular demo user.
* Visit the activity you made before and it should be type inbound email activity now. You'll note that on the activity view page there is no edit/delete button (not the action links, which are controlled separately, but on the actual view page).
* Change the activity type label for inbound email to something else (/civicrm/admin/options/activity_type?reset=1).
* Visit the inbound email activity and view it again. There should still be no edit/delete links. On an unpatched site there would have been, and it would let you edit and save.
