### PR TITLE
distmaker - Finish migrating bower.json => composer.json

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -235,13 +235,10 @@ if [ -d "$DM_SOURCEDIR/drupal" ]; then
   GENCODE_CMS=Drupal
 fi
 
-## Get latest dependencies
+## Get fresh dependencies
+[ -d "$DM_SOURCEDIR/vendor" ] && rm -rf $DM_SOURCEDIR/vendor
+[ -d "$DM_SOURCEDIR/bower_components" ] && rm -rf $DM_SOURCEDIR/bower_components
 dm_generate_vendor "$DM_SOURCEDIR"
-## if we already have a bower_compoents dir empty it.
-if [ -d "$DM_SOURCEDIR/bower_components" ]; then
-  rm -rf $DM_SOURCEDIR/bower_components/* 
-fi
-dm_generate_bower "$DM_SOURCEDIR"
 
 # Before anything - regenerate DAOs
 

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -70,7 +70,7 @@ function dm_install_core() {
   done
 
   dm_install_files "$repo" "$to" {agpl-3.0,agpl-3.0.exception,gpl,CONTRIBUTORS}.txt
-  dm_install_files "$repo" "$to" composer.json composer.lock bower.json package.json Civi.php README.md release-notes.md extension-compatibility.json
+  dm_install_files "$repo" "$to" composer.json composer.lock package.json Civi.php README.md release-notes.md extension-compatibility.json
 
   mkdir -p "$to/sql"
   pushd "$repo" >> /dev/null
@@ -190,17 +190,6 @@ function dm_install_wordpress() {
   ## Need --exclude=civicrm for self-building on WP site
 
   dm_preg_edit '/^Version: [0-9\.]+/m' "Version: $DM_VERSION" "$to/civicrm.php"
-}
-
-
-## Generate the "bower_components" folder.
-## usage: dm_generate_bower <repo_path>
-function dm_generate_bower() {
-  local repo="$1"
-  pushd "$repo"
-    ${DM_NPM:-npm} install
-    ${DM_NODE:-node} node_modules/bower/bin/bower install
-  popd
 }
 
 ## Generate the composer "vendor" folder


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #15044 - since we don't have/need `bower.json`, it doesn't make sense for `distmaker` to call `bower install`.

Before
----------------------------------------
* `distmaker` tries to call `bower install` and publish `bower.json`

After
----------------------------------------
* `distmaker` omits `bower install` and `bower.json`

