### PR TITLE
 Add ability to temporarily override logged in user

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -113,17 +113,17 @@ class CRM_ACL_API {
       }
     }
 
-    if (!$contactID) {
-      $contactID = CRM_Core_Session::getLoggedInContactID();
-    }
-    $contactID = (int) $contactID;
-
     // first see if the contact has edit / view all permission
     if (CRM_Core_Permission::check('edit all contacts', $contactID) ||
       ($type == self::VIEW && CRM_Core_Permission::check('view all contacts', $contactID))
     ) {
       return $deleteClause;
     }
+
+    if (is_null($contactID)) {
+      $contactID = CRM_Core_Session::getLoggedInContactID();
+    }
+    $contactID = (int) $contactID;
 
     $whereClause = CRM_ACL_BAO_ACL::whereClause($type,
       $tables,

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -118,6 +118,8 @@ class CRM_Core_Permission {
    */
   public static function check($permissions, $contactId = NULL) {
     $permissions = (array) $permissions;
+    // If the logged in contact id is being overridden, use the substitute contactId
+    $contactId = $contactId ?? CRM_Core_Session::getOverriddenUser();
     $userId = CRM_Core_BAO_UFMatch::getUFId($contactId);
     // If contact has no associated user, set to 0 for anonymous (logged-out)
     if ($contactId === 0 || ($contactId && !$userId)) {

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -111,6 +111,7 @@ class CRM_Core_Permission {
    *
    * @param int $contactId
    *   Contact id to check permissions for. Defaults to current logged-in user.
+   *   Pass 0 for no user (anonymous)
    *
    * @return bool
    *   true if contact has permission(s), else false
@@ -118,6 +119,10 @@ class CRM_Core_Permission {
   public static function check($permissions, $contactId = NULL) {
     $permissions = (array) $permissions;
     $userId = CRM_Core_BAO_UFMatch::getUFId($contactId);
+    // If contact has no associated user, set to 0 for anonymous (logged-out)
+    if ($contactId === 0 || ($contactId && !$userId)) {
+      $userId = 0;
+    }
 
     /** @var CRM_Core_Permission_Temp $tempPerm */
     $tempPerm = CRM_Core_Config::singleton()->userPermissionTemp;

--- a/CRM/Core/Permission/Backdrop.php
+++ b/CRM/Core/Permission/Backdrop.php
@@ -67,11 +67,10 @@ class CRM_Core_Permission_Backdrop extends CRM_Core_Permission_DrupalBase {
    *
    * @param string $str
    *   The permission to check.
-   *
    * @param int $userId
+   *   NULL = current user; 0 = anonymous (logged-out)
    *
    * @return bool
-   *   true if yes, else false
    */
   public function check($str, $userId = NULL) {
     $str = $this->translatePermission($str, 'Drupal', [
@@ -85,10 +84,7 @@ class CRM_Core_Permission_Backdrop extends CRM_Core_Permission_DrupalBase {
       return TRUE;
     }
     if (function_exists('user_access')) {
-      $account = NULL;
-      if ($userId) {
-        $account = user_load($userId);
-      }
+      $account = is_numeric($userId) ? user_load($userId) : NULL;
       return user_access($str, $account);
     }
     return TRUE;

--- a/CRM/Core/Permission/Drupal.php
+++ b/CRM/Core/Permission/Drupal.php
@@ -66,11 +66,10 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase {
    *
    * @param string $str
    *   The permission to check.
-   *
    * @param int $userId
+   *   NULL = current user; 0 = anonymous (logged-out)
    *
    * @return bool
-   *   true if yes, else false
    */
   public function check($str, $userId = NULL) {
     $str = $this->translatePermission($str, 'Drupal', [
@@ -84,10 +83,7 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase {
       return TRUE;
     }
     if (function_exists('user_access')) {
-      $account = NULL;
-      if ($userId) {
-        $account = user_load($userId);
-      }
+      $account = is_numeric($userId) ? user_load($userId) : NULL;
       return user_access($str, $account);
     }
     return TRUE;

--- a/CRM/Core/Permission/Drupal6.php
+++ b/CRM/Core/Permission/Drupal6.php
@@ -66,11 +66,10 @@ class CRM_Core_Permission_Drupal6 extends CRM_Core_Permission_DrupalBase {
    *
    * @param string $str
    *   The permission to check.
-   *
    * @param int $userId
+   *   NULL = current user; 0 = anonymous (logged-out)
    *
    * @return bool
-   *   true if yes, else false
    */
   public function check($str, $userId = NULL) {
     $str = $this->translatePermission($str, 'Drupal6', [
@@ -84,10 +83,7 @@ class CRM_Core_Permission_Drupal6 extends CRM_Core_Permission_DrupalBase {
       return TRUE;
     }
     if (function_exists('user_access')) {
-      $account = NULL;
-      if ($userId) {
-        $account = user_load($userId);
-      }
+      $account = is_numeric($userId) ? user_load($userId) : NULL;
       return user_access($str, $account);
     }
     return TRUE;

--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -43,8 +43,8 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
    *
    * @param string $str
    *   The permission to check.
-   *
    * @param int $userId
+   *   NULL = current user; 0 = anonymous (logged-out)
    *
    * @return bool
    */
@@ -59,7 +59,7 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
     if ($str == CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION) {
       return TRUE;
     }
-    $acct = $userId ? \Drupal\user\Entity\User::load($userId) : \Drupal::currentUser();
+    $acct = is_numeric($userId) ? \Drupal\user\Entity\User::load((int) $userId) : \Drupal::currentUser();
     return $acct->hasPermission($str);
   }
 

--- a/CRM/Core/Permission/Joomla.php
+++ b/CRM/Core/Permission/Joomla.php
@@ -44,16 +44,14 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
    * @param string $str
    *   The permission to check.
    * @param int $userId
+   *   NULL = current user; 0 = anonymous (logged-out)
    *
    * @return bool
-   *   true if yes, else false
    */
   public function check($str, $userId = NULL) {
     $config = CRM_Core_Config::singleton();
-    // JFactory::getUser does strict type checking, so convert falesy values to NULL
-    if (!$userId) {
-      $userId = NULL;
-    }
+    // JFactory::getUser does strict type checking, so convert non-numeric values to NULL
+    $userId = is_numeric($userId) ? (int) $userId : NULL;
 
     $translated = $this->translateJoomlaPermission($str);
     if ($translated === CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {

--- a/tests/phpunit/E2E/Core/UserOverrideTest.php
+++ b/tests/phpunit/E2E/Core/UserOverrideTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace E2E\Core;
+
+/**
+ * Class UserOverrideTest
+ *
+ * Check that overriding session user behaves as expected.
+ *
+ * @package E2E\Core
+ * @group e2e
+ */
+class UserOverrideTest extends \CiviEndToEndTestCase {
+
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  protected function tearDown() {
+    while (\CRM_Core_Session::singleton()->restoreCurrentUser()) {
+      // Loop until all overrides are cleared
+    }
+  }
+
+  public function testOverride() {
+    $session = \CRM_Core_Session::singleton();
+    $originalUser = $session::getLoggedInContactID();
+    // Set user CID to 2
+    $o1 = $session->overrideCurrentUser(2);
+    $this->assertEquals(2, $session::getLoggedInContactID());
+    // Set user CID to 3
+    $o2 = $session->overrideCurrentUser(3);
+    $this->assertEquals(3, $session::getLoggedInContactID());
+    // Set user CID to 4
+    $o3 = $session->overrideCurrentUser(4);
+    // Clear the second override
+    $this->assertTrue($session->restoreCurrentUser($o2));
+    // Latest override should still stand
+    $this->assertEquals(4, $session::getLoggedInContactID());
+    // Clear the last override, should revert to the one remaining override
+    $this->assertTrue($session->restoreCurrentUser());
+    $this->assertEquals(2, $session::getLoggedInContactID());
+    $this->assertEquals(2, $session->getOverriddenUser());
+    // Clear the final override
+    $this->assertTrue($session->restoreCurrentUser());
+    $this->assertEquals($originalUser, $session::getLoggedInContactID());
+    // Assert there are no overrides left to clear
+    $this->assertNull($session->getOverriddenUser());
+    $this->assertFalse($session->restoreCurrentUser());
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds a function in CRM_Core_Session to temporarily masquerade as a different user, which [api4 can use to specify the acting user for certain api calls](https://github.com/civicrm/org.civicrm.api4/pull/191).

Before
----------------------------------------
Current user taken from session, permissions always checked against current user.

After
----------------------------------------
Current user can be overridden, permission checks respect override, e.g.

```php
// Elevate privileges
$contactId = 300;
$handle = $session->overrideCurrentUser($contactId);

// ... Do something as $contactId, like
printf("Am I am an admin? %s",
  CRM_Core_Permission::check('administer CiviCRM') ? 'yes' : 'no');

// Restore privileges
$session->restoreCurrentUser($handle);
```

If the given `$contactId` does not have a corresponding user account (with permissions), then permissions will match the *anonymous user*.

Comments
----------------------------------------

Added a simple E2E test for the overrides.

This patch does not directly change the value of `userID` in the `CRM_Core_Session` - it does not intend to *persistently* change the active the user. Rather, this provides a momentary escalation. To accomplish this, it:

* Adds an additional static variable+function (`CRM_Core_Session::getOverriddenUser()`) which may be consulted on a bespoke basis to determine if there is an active override, and
* Modifies the behavior of `get('userID')` so to respect this value.