### PR TITLE
Open up permissions on Dedupe.getduplicates

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -973,6 +973,10 @@ class CRM_Core_Permission {
       ],
     ];
 
+    $permissions['dedupe'] = [
+      'getduplicates' => ['access CiviCRM'],
+    ];
+
     // CRM-16963 - Permissions for country.
     $permissions['country'] = [
       'get' => [


### PR DESCRIPTION
Overview
----------------------------------------
Less restrictive permissions on Dedupe.getduplicates api - currently only used from unit tests.

Currently the action Dedupe.getduplicates is defaulting to 'administer CiviCRM'.

The function manages permissions internally (ie. you can't retrieve contacts you don't have permission  to see) so the function itself can have fairly open  permissions - hence I went for  'access CiviCRM' rather than 'merge duplicate contacts' - it might even be argued this should be open & rely solely on contact ACLs but I have not gone that far


Before
----------------------------------------
Dedupe.getduplicates requires 'Administer CiviCRM'

After
----------------------------------------
Dedupe.getduplicates requires 'AccessCiviCRM'

Technical Details
----------------------------------------
This function is part of moving towards api based rather than form based logic. It is not in use in core yet outside tests.

Comments
----------------------------------------

