### PR TITLE
Performance improvement on dedupe find

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -452,7 +452,7 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
       $validFieldsForRetrieval = civicrm_api3('Contact', 'getfields', ['action' => 'get'])['values'];
       if (!empty($criteria)) {
         $contacts = civicrm_api3('Contact', 'get', array_merge([
-          'options' => ['limit' => 0],
+          'options' => ['limit' => $searchLimit],
           'return' => 'id',
           'check_permissions' => TRUE,
         ], array_intersect_key($criteria['contact'], $validFieldsForRetrieval)));


### PR DESCRIPTION
Overview
----------------------------------------
Avoids an unlimited query when retrieving duplicates with a searchLimit set

Before
----------------------------------------
Unlimited query runs

After
----------------------------------------
Limited query runs

Technical Details
----------------------------------------
When we have a searchLimit this limits the number of contacts that we look for duplicates for.

  When we have a searchLimit this limits the number of contacts that we look for duplicates for
    however this is being ignored early on and we are retrieving an unlimited set of contacts
    matching the criteria - so a criteria of id > 10 might return the whole db
    to check against rather than the intended searchLimit of 50.
    
This is accessible via the api & the dedupetools extension leverages this for a  non-quickform
dedupe  experience but it's hitting  performance issues


Comments
----------------------------------------
@pfigel are you able to look at this - I'm just accessing it via Dedupe.getduplicates & seeing this

We have  been running this in production  for a while
