### PR TITLE
dev/core#1230 [Dedupe] Do not geocode while merging, rely on existing values

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1181,7 +1181,11 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             $locations[$moniker][$blockName][$cnt] = $value;
             // Fix address display
             if ($blockName == 'address') {
+              // For performance avoid geocoding while merging https://issues.civicrm.org/jira/browse/CRM-21786
+              // we can expect existing geocode values to be retained.
+              $value['skip_geocode'] = TRUE;
               CRM_Core_BAO_Address::fixAddress($value);
+              unset($value['skip_geocode']);
               $locations[$moniker][$blockName][$cnt]['display'] = CRM_Utils_Address::format($value);
             }
             // Fix email display


### PR DESCRIPTION
Overview
----------------------------------------
This is a performance fix when merging - don't do geocoding when merging -  we already have
geocode data for the contacts. We also move the 'whole address' so shouldn't re-geocode for more info

https://issues.civicrm.org/jira/browse/CRM-21786

Before
----------------------------------------
Geocoding calls happen during merging

After
----------------------------------------
No calls (existing geocode info in use)

Technical Details
----------------------------------------

Comments
----------------------------------------
@pfigel @lcdservices 
