### PR TITLE
Use merge duplicate contacts as api permission for merging

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -971,6 +971,7 @@ class CRM_Core_Permission {
       'duplicatecheck' => [
         'access CiviCRM',
       ],
+      'merge' => ['merge duplicate contacts'],
     ];
 
     $permissions['dedupe'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Changes api permission on api call  Contact.merge

Before
----------------------------------------
Administer CiviCRM permission required

After
----------------------------------------
'merge duplicate contacts' permission required

Technical Details
----------------------------------------
This is a relatively new api  call so the permissions were not addressed when adding it

Comments
----------------------------------------

