### PR TITLE
Adjust permissions on dedupe exception api to 'merge duplicate contacts'

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1174,6 +1174,10 @@ class CRM_Core_Permission {
         'edit all events',
       ],
     ];
+    // Exception refers to dedupe_exception.
+    $permissions['exception'] = [
+      'default' => ['merge duplicate contacts'],
+    ];
     // Loc block is only used for events
     $permissions['loc_block'] = $permissions['event'];
 


### PR DESCRIPTION
Overview
----------------------------------------
The crud api for managing dedupe exceptions currently requires 'administer CiviCRM' permission - this alters it to require 'merge duplicate contacts'

Before
----------------------------------------
Need administer CiviCRM for Exception crud api actions

After
----------------------------------------
Need 'merge duplicate contacts'

Technical Details
----------------------------------------
@seamuslee001 @jusfreeman @pfigel open to other suggestions as to the appropriate permission but this api seems part & parcel of being allowed to dedupe to me

Comments
----------------------------------------

