### PR TITLE
Fix dedupe bug whereby the result of passing in criteria with no matches is to have it ignored

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -457,6 +457,11 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
           'check_permissions' => TRUE,
         ], array_intersect_key($criteria['contact'], $validFieldsForRetrieval)));
         $contactIDs = array_keys($contacts['values']);
+        if (empty($contactIDs)) {
+          // If there is criteria but no contacts were found then we should return now
+          // since we have no contacts to match.
+          return [];
+        }
       }
       $foundDupes = CRM_Dedupe_Finder::dupes($rgid, $contactIDs, $checkPermissions, $searchLimit);
     }

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -12,6 +12,15 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
   protected $_contactIds = [];
 
   /**
+   * Contacts created for the test.
+   *
+   * Overlaps contactIds....
+   *
+   * @var array
+   */
+  protected $contacts = [];
+
+  /**
    * Tear down.
    *
    * @throws \Exception
@@ -319,6 +328,27 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
         'canMerge' => TRUE,
       ],
     ], $pairs);
+  }
+
+  /**
+   * Test that if criteria are passed and there are no matching contacts no matches are returned.
+   */
+  public function testGetMatchesCriteriaNotMatched() {
+    $this->setupMatchData();
+
+    $pairs = $this->callAPISuccess('Dedupe', 'getduplicates', [
+      'rule_group_id' => 1,
+      'criteria' => ['contact' => ['id' => ['>' => 1]]],
+    ])['values'];
+
+    $this->assertCount(2, $pairs);
+
+    $pairs = $this->callAPISuccess('Dedupe', 'getduplicates', [
+      'rule_group_id' => 1,
+      'criteria' => ['contact' => ['id' => ['>' => 100000]]],
+    ])['values'];
+
+    $this->assertCount(0, $pairs);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug that can be replicated using Dedupe.getduplicates api call. The api call accepts criteria intended to limit the contacts that are returned. However, if the criteria return no results the result is for them to be dropped - this fixes with an early return

Before
----------------------------------------
```
 $pairs = $this->callAPISuccess('Dedupe', 'getduplicates', [
      'rule_group_id' => 1,
      'criteria' => ['contact' => ['id' => ['>' => 1000000000]]],
    ])
```
returns results if no contacts in the DB match the criteria

After
----------------------------------------
Above only returns results if contacts in the DB match the criteria

Technical Details
----------------------------------------

Comments
----------------------------------------

