### PR TITLE
(dev/joomla#10) Remove Joomla-specific error display and use native CiviCRM

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -466,17 +466,12 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $template = CRM_Core_Smarty::singleton();
     $template->assign($vars);
     $content = $template->fetch('CRM/common/fatal.tpl');
+
     if ($config->backtrace) {
       $content = self::formatHtmlException($exception) . $content;
     }
-    if ($config->userFramework == 'Joomla' &&
-      class_exists('JError')
-    ) {
-      JError::raiseError('CiviCRM-001', $content);
-    }
-    else {
-      echo CRM_Utils_System::theme($content);
-    }
+
+    echo CRM_Utils_System::theme($content);
 
     // fin
     self::abend(CRM_Core_Error::FATAL_ERROR);

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -834,23 +834,6 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   }
 
   /**
-   * Output code from error function.
-   * @param string $content
-   */
-  public function outputError($content) {
-    if (class_exists('JErrorPage')) {
-      $error = new Exception($content);
-      JErrorPage::render($error);
-    }
-    elseif (class_exists('JError')) {
-      JError::raiseError('CiviCRM-001', $content);
-    }
-    else {
-      parent::outputError($content);
-    }
-  }
-
-  /**
    * @inheritDoc
    */
   public function synchronizeUsers() {

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {* error.tpl: Display page for fatal errors. Provides complete HTML doc.*}
-{if $config->userFramework != 'Joomla' and $config->userFramework != 'WordPress'}
+{if $config->userFramework != 'WordPress'}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
@@ -89,7 +89,7 @@ function toggle( element ) {
 }
 </script>
 {/literal}
-{if $config->userFramework != 'Joomla' and $config->userFramework != 'WordPress'}
+{if $config->userFramework != 'WordPress'}
 </body>
 </html>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/joomla/issues/10
CiviCRM fatal errors & unhandled exceptions are rendered very poorly on Joomla due to the inability of Joomla's exception handling to handle HTML in error messages. CiviCRM uses HTML in the error messages, plus inline script and CSS from the template and this is all displayed on the Joomla error page.

Because of these Joomla constraints (we can only use plain text and not even new line characters) it is better to remove the Joomla-specific way of rendering errors and display natively in CiviCRM as for Drupal.

Before
----------------------------------------
Fatal errors & unhandled exceptions are very dificult to read on Joomla:
![image](https://user-images.githubusercontent.com/25069773/63905488-973d8b00-ca53-11e9-85ff-0d0eeff9682a.png)

After
----------------------------------------
Fatal errors & unhandled exceptions are rendered natively by CiviCRM:
![image](https://user-images.githubusercontent.com/25069773/63908951-2cdf1780-ca60-11e9-884d-a560611b3c26.png)

Technical Details
----------------------------------------
This PR consists of:
-  Remove the Joomla-specific parts of `CRM_Core_Error::handleUnhandledExecption()`
-  Remove `if config->userFramework != 'Joomla'` from `templates/CRM/common/fatal.tpl` so that a full html page is output
-  Remove `CRM_Utils_System_Joomla::outputError()` altogether so that the parent `CRM_Utils_System::outputError()` is used instead.

Comments
----------------------------------------
Joomla's JError is deprecated so this also helps remove instances of its usage.