### PR TITLE
[REF] Move clone template functionality from api to bao

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -132,6 +132,13 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event {
         $params['created_id'] = $session->get('userID');
       }
       $params['created_date'] = date('YmdHis');
+
+      // Clone from template
+      if (!empty($params['template_id'])) {
+        $copy = self::copy($params['template_id']);
+        $params['id'] = $copy->id;
+        unset($params['template_id']);
+      }
     }
 
     $event = self::add($params);

--- a/api/v3/Event.php
+++ b/api/v3/Event.php
@@ -57,13 +57,6 @@ function civicrm_api3_event_create($params) {
     ]);
   }
 
-  // Clone event from template
-  if (!empty($params['template_id']) && empty($params['id'])) {
-    $copy = CRM_Event_BAO_Event::copy($params['template_id']);
-    $params['id'] = $copy->id;
-    unset($params['template_id']);
-  }
-
   _civicrm_api3_event_create_legacy_support_42($params);
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Event');
 }


### PR DESCRIPTION
Overview
----------------------------------------
Moves code block from one place to another, for better reusability in api4.

Before
----------------------------------------
Code in api.

After
----------------------------------------
Code in bao.
