### PR TITLE
SMTP help text and URL are misleading to Organization Address and Contact Info instead of leading to From Email Addresses; see also #14055 and #14329

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -105,8 +105,8 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
 
         if (!$domainEmailAddress || $domainEmailAddress == 'info@EXAMPLE.ORG') {
-          $fixUrl = CRM_Utils_System::url("civicrm/admin/domain", 'action=update&reset=1');
-          CRM_Core_Error::statusBounce(ts('The site administrator needs to enter a valid email address in <a href="%1">Administer CiviCRM &raquo; Communications &raquo; Organization Address and Contact Info</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
+          $fixUrl = CRM_Utils_System::url("civicrm/admin/options/from_email_address", 'action=update&reset=1');
+          CRM_Core_Error::statusBounce(ts('The site administrator needs to enter a valid \'FROM Email Address\' in <a href="%1">Administer CiviCRM &raquo; System Settings &raquo; Option Groups &raquo; From Email Address</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
         }
         if (!$toEmail) {
           CRM_Core_Error::statusBounce(ts('Cannot send a test email because your user record does not have a valid email address.'));


### PR DESCRIPTION
Overview
----------------------------------------
This is about a help message that is being displayed when testing the SMTP configuration fails. It says the Email in the Organization Contact Information should be changed. This is wrong however as it appears because of wrongly configured from address.

Before
----------------------------------------
Text and link point to Organization Address and Contact Info

After
----------------------------------------
Text and link point to From Email Addresses

Technical Details
----------------------------------------
none

Comments
----------------------------------------
Issue explained [in erroneous pull request #14055](https://github.com/civicrm/civicrm-core/pull/14055#issuecomment-526360222), [related lab issue dev/core#879](https://lab.civicrm.org/dev/core/issues/879) should be closed
