### PR TITLE
core#1225 fix Event Info and Contribution Page Settings templates

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
@@ -153,16 +153,20 @@
         <td>&nbsp;</td>
         <td>{$form.is_share.html} {$form.is_share.label} {help id="id-is_share"}</td>
       </tr>
-    <tr class="crm-contribution-contributionpage-settings-form-block-is_active"><td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td><td>{$form.is_active.html} {$form.is_active.label}<br />
+        <tr class="crm-contribution-contributionpage-settings-form-block-is_active">
+        <td>&nbsp;</td>  
+        <td>{$form.is_active.html} {$form.is_active.label}</td>
+      </tr>
   {if $contributionPageID}
-        <span class="description">
+        <tr class="crm-contribution-contributionpage-settings-form-block-info_link">
+        <td>&nbsp;</td>  
+        <td class="description">
           {if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}
               {ts}When your page is active, you can link people to the page by copying and pasting the following URL:{/ts}<br />
               <strong>{crmURL a=1 fe=1 p='civicrm/contribute/transact' q="reset=1&id=`$contributionPageID`"}</strong>
           {elseif $config->userFramework EQ 'Joomla'}
               {ts 1=$title}When your page is active, create front-end links to the contribution page using the Menu Manager. Select <strong>Administer CiviCRM &raquo; CiviContribute &raquo; Manage Contribution Pages</strong> and select <strong>%1</strong> for the contribution page.{/ts}
           {/if}
-    </span>
       {/if}
   </td>
   </tr>

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -129,7 +129,7 @@
     </tr>
 
     {if $eventID}
-      <tr>
+      <tr class="crm-event-manage-eventinfo-form-block-info_link">
         <td>&nbsp;</td>
         <td class="description">
           {if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}


### PR DESCRIPTION
Overview
----------------------------------------
This makes some changes to templates that should **not** be visible to end users, but makes the underlying HTML less ugly.

Before
----------------------------------------
Elements are positioned by use of this line:
```html
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
```

After
----------------------------------------
We use sane rendering techniques to position our elements, and use the same positioning techniques on identical elements.

Technical Details
----------------------------------------
There's almost no technical detail to mention.

Comments
----------------------------------------
This started out as my adding a class to a table cell that had none on the event info template, but when I saw what the contribution page template looked like I expanded my scope to remove something rather hideous.
