### PR TITLE
Fix php 7.2+ deprecation error

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -294,8 +294,7 @@ class civicrm_cli {
    * @return bool
    */
   private function _validateOptions() {
-    $required = $this->_required_arguments;
-    while (list(, $var) = each($required)) {
+    foreach ($this->_required_arguments as $var) {
       $index = '_' . $var;
       if (empty($this->$index)) {
         $missing_arg = '--' . $var;


### PR DESCRIPTION
Overview
----------------------------------------
FIxes 
  The each() function is deprecated. This message will be suppressed on further calls in /var/www/sln/wordpress/wp-content/plugins/civicrm/civicrm/bin/cli.class.php on line 298"
from wp cli

Before
----------------------------------------
Error on php 7.2+

After
----------------------------------------
No error

Technical Details
----------------------------------------
@kcristiano @seamuslee001 I haven't tested this - it's just off chat but I think this is the syntax for getting rid of each

Comments
----------------------------------------
