### PR TITLE
dev/core#1230 Loosen permissions to Dedupe.getstatistics api

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -976,6 +976,7 @@ class CRM_Core_Permission {
 
     $permissions['dedupe'] = [
       'getduplicates' => ['access CiviCRM'],
+      'getstatistics' => ['access CiviCRM'],
     ];
 
     // CRM-16963 - Permissions for country.


### PR DESCRIPTION
Overview
----------------------------------------
This is a recently  added api & the permissions turn out to be too restrictive  (as I test with a less permissioned user)

This api should have the same level of permission as Dedupe.getduplicates - it gets data about
cached duplicates. Note that getduplicates has 'access CiviCRM' & relys on ACLs to  restrict
which contacts can be accessed through it

The results of the function are simply counts of the number of skipped  and merged rows from a given search set

Before
----------------------------------------
Dedupe.getstatistics requires Administer CiviCRM

After
----------------------------------------
Dedupe.getstatistics requires Access CiviCRM

Technical Details
----------------------------------------
This does not affect  core code as  this is only called from tests in core

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/1230