### PR TITLE
dev/core#1230 Dedupe permissions - allow safe mode merging based on 'merge duplicate contacts'

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1183,6 +1183,9 @@ class CRM_Core_Permission {
     $permissions['exception'] = [
       'default' => ['merge duplicate contacts'],
     ];
+    $permissions['job'] = [
+      'process_batch_merge' => ['merge duplicate contacts'],
+    ];
     // Loc block is only used for events
     $permissions['loc_block'] = $permissions['event'];
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -692,10 +692,15 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *  per comments on isSelected above.
    *
    * @return array|bool
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function batchMerge($rgid, $gid = NULL, $mode = 'safe', $batchLimit = 1, $isSelected = 2, $criteria = [], $checkPermissions = TRUE, $reloadCacheIfEmpty = NULL) {
     $redirectForPerformance = ($batchLimit > 1) ? TRUE : FALSE;
-
+    if ($mode === 'aggressive' && $checkPermissions && !CRM_Core_Permission::check('force merge duplicate contacts')) {
+      throw new CRM_Core_Exception(ts('Insufficient permissions for aggressive mode batch merge'));
+    }
     if (!isset($reloadCacheIfEmpty)) {
       $reloadCacheIfEmpty = (!$redirectForPerformance && $isSelected == 2);
     }

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -1112,7 +1112,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
    * @param $dataSet
    */
   public function testBatchMergeWorksCheckPermissionsTrue($dataSet) {
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'administer CiviCRM'];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'administer CiviCRM', 'merge duplicate contacts', 'force merge duplicate contacts'];
     foreach ($dataSet['contacts'] as $params) {
       $this->callAPISuccess('Contact', 'create', $params);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Perhaps batch mode merge contacts to users with 'merge duplicate contacts' (not just administer CiviCRM as before). Adds a check for  'force merge duplicate contacts' if mode is aggressive

Before
----------------------------------------
Administer CiviCRM permission required to access Job.process_batch_merge

After
----------------------------------------
'merge duplicate contacts' required to access Job.process_batch_merge but in aggressive mode 
'force merge duplicate contacts' is required

Technical Details
----------------------------------------
This is probably the first attempt to use  these api to  build access for users with  less than Administer CiviCRM -hence all the  things that have emerged

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/1230