### PR TITLE
dev/core#1187 Fix bug where import will not do 2 phone types of the same location

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -1207,6 +1207,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
       if (!array_key_exists($blockFieldName, $values)) {
         continue;
       }
+      $blockIndex = $values['location_type_id'] . (!empty($values['phone_type_id']) ? '_' . $values['phone_type_id'] : '');
 
       // block present in value array.
       if (!array_key_exists($blockFieldName, $params) || !is_array($params[$blockFieldName])) {
@@ -1221,13 +1222,13 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
       }
 
       _civicrm_api3_store_values($fields[$block], $values,
-        $params[$blockFieldName][$values['location_type_id']]
+        $params[$blockFieldName][$blockIndex]
       );
 
-      $this->fillPrimary($params[$blockFieldName][$values['location_type_id']], $values, $block, CRM_Utils_Array::value('id', $params));
+      $this->fillPrimary($params[$blockFieldName][$blockIndex], $values, $block, CRM_Utils_Array::value('id', $params));
 
       if (empty($params['id']) && (count($params[$blockFieldName]) == 1)) {
-        $params[$blockFieldName][$values['location_type_id']]['is_primary'] = TRUE;
+        $params[$blockFieldName][$blockIndex]['is_primary'] = TRUE;
       }
 
       // we only process single block at a time.

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -170,6 +170,8 @@ class CRM_Import_ImportProcessor {
   }
 
   /**
+   * Get the contact type for the import.
+   *
    * @return string
    */
   public function getContactType(): string {
@@ -212,9 +214,27 @@ class CRM_Import_ImportProcessor {
   }
 
   /**
+   * Set mapping fields.
+   *
+   * We do a little cleanup here too.
+   *
+   * We ensure that column numbers are set and that the fields are ordered by them.
+   *
+   * This would mean the fields could be loaded unsorted.
+   *
    * @param array $mappingFields
    */
   public function setMappingFields(array $mappingFields) {
+    $i = 0;
+    foreach ($mappingFields as &$mappingField) {
+      if (!isset($mappingField['column_number'])) {
+        $mappingField['column_number'] = $i;
+      }
+      if ($mappingField['column_number'] > $i) {
+        $i = $mappingField['column_number'];
+      }
+      $i++;
+    }
     $this->mappingFields = $this->rekeyBySortedColumnNumbers($mappingFields);
   }
 

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -464,6 +464,32 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test importing 2 phones of different types.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testImportTwoPhonesDifferentTypes() {
+    $processor = new CRM_Import_ImportProcessor();
+    $processor->setContactType('Individual');
+    $processor->setMappingFields(
+      [
+        ['name' => 'first_name'],
+        ['name' => 'last_name'],
+        ['name' => 'email'],
+        ['name' => 'phone', 'location_type_id' => 1, 'phone_type_id' => 2],
+        ['name' => 'phone', 'location_type_id' => 1, 'phone_type_id' => 1],
+      ]
+    );
+    $importer = $processor->getImporterObject();
+    $fields = ['First Name', 'new last name', 'bob@example.com', '1234', '5678'];
+    $importer->import(CRM_Import_Parser::DUPLICATE_UPDATE, $fields);
+    $contact = $this->callAPISuccessGetSingle('Contact', ['last_name' => 'new last name']);
+    $phones = $this->callAPISuccess('Phone', 'get', ['contact_id' => $contact['id']])['values'];
+    $this->assertCount(2, $phones);
+  }
+
+  /**
    * Test that the import parser adds the address to the primary location.
    *
    * @throws \Exception


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby one phone number is not imported if 2 of the same location type but different phone types are in an import

Before
----------------------------------------
Import as described in https://lab.civicrm.org/dev/core/issues/1187 does not result in 2 phones

After
----------------------------------------
2 phones created

Technical Details
----------------------------------------
The issue is the indexing is squishing them into one

Comments
----------------------------------------

