### PR TITLE
(dev/core#1226) Fix failure to save relative dates on legacy fields

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -437,9 +437,29 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     // This is required only until all fields are converted to datepicker fields as the new format is truer to the
     // form format and simply saves (e.g) custom_3_relative => "this.year"
     $relativeDates = ['relative_dates' => []];
-    $specialDateFields = ['event_relative', 'case_from_relative', 'case_to_relative', 'participant_relative', 'log_date_relative'];
+    $specialDateFields = [
+      'event_relative',
+      'case_from_relative',
+      'case_to_relative',
+      'participant_relative',
+      'log_date_relative',
+      'pledge_payment_date_relative',
+      'pledge_start_date_relative',
+      'pledge_end_date_relative',
+      'pledge_create_date_relative',
+      'member_join_date_relative',
+      'member_start_date_relative',
+      'member_end_date_relative',
+      'birth_date_relative',
+      'deceased_date_relative',
+      'mailing_date_relative',
+      'relation_date_relative',
+      'relation_start_date_relative',
+      'relation_end_date_relative',
+      'relation_action_date_relative',
+    ];
     foreach ($formValues as $id => $value) {
-      if ((preg_match('/_date$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
+      if (in_array($id, $specialDateFields) && !empty($value)) {
         $entityName = strstr($id, '_date', TRUE);
         if (empty($entityName)) {
           $entityName = strstr($id, '_relative', TRUE);

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -945,7 +945,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
     ]);
     $eventResult = $this->callAPISuccess('Event', 'getsingle', ['id' => $eventResult['id']]);
     foreach ($templateParams as $param => $value) {
-      $this->assertEquals($value, $eventResult[$param]);
+      $this->assertEquals($value, $eventResult[$param], print_r($eventResult, 1));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a 5.16 regression whereby smart groups relative dates are converted to fixed dates for smart groups created on 5.16 with one of the affected fields in them.

This is an expansion of the previous update https://github.com/civicrm/civicrm-core/pull/15169.

Before
----------------------------------------
Groups with the fields 
      'log_date_relative',
      'pledge_payment_date_relative',
      'member_join_date_relative',
      'member_start_date_relative',
      'member_end_date_relative',
      'birth_date_relative',
      'deceased_date_relative',
      'mailing_date_relative',
      'relation_date_relative',
      'relation_start_date_relative',
      'relation_end_date_relative',
      'relation_action_date_relative',

on 5.16 are created with the dates converted to fixed dates

After
----------------------------------------
Saves as relative dates

Technical Details
----------------------------------------
The regex was wrong in this change

https://github.com/civicrm/civicrm-core/commit/7f175707d67597717d72661c55878d6432f87736#diff-54576153cb6a72d6ea7e22a5e8ca63f2R442

This switches to a whitelist of remaining legacy dates

Once merged to master a PR on master would remove converted fields from the list


Comments
----------------------------------------
I noticed that the custom fields are added differently for Contact custom fields and non-contact custom fields & non contact custom fields are using the jcalendar dates & likely didn't work before or after this. We should fix them. The Contact_BAO_Query object and the others don't have a shared parent & hence have 2 different functions. I think they should have a shared parent & Contact_BAO_Query  should share with the others - if existing functions make that hard we can use a trait