### PR TITLE
dev/core#1230 [Dedupe] Add new api option to getduplicates, permitting a new search to be forced.

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1841,14 +1841,17 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @param int $searchLimit
    *   Limit to searching for matches against this many contacts.
    *
+   * @param int $isForceNewSearch
+   *   Should a new search be forced, bypassing any cache retrieval.
+   *
    * @return array
    *   Array of matches meeting the criteria.
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $includeConflicts = TRUE, $criteria = [], $checkPermissions = TRUE, $searchLimit = 0) {
-    $dupePairs = self::getCachedDuplicateMatches($rule_group_id, $group_id, $batchLimit, $isSelected, $includeConflicts, $criteria, $checkPermissions, $searchLimit);
+  public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $includeConflicts = TRUE, $criteria = [], $checkPermissions = TRUE, $searchLimit = 0, $isForceNewSearch = 0) {
+    $dupePairs = $isForceNewSearch ? [] : self::getCachedDuplicateMatches($rule_group_id, $group_id, $batchLimit, $isSelected, $includeConflicts, $criteria, $checkPermissions, $searchLimit);
     if (empty($dupePairs) && $reloadCacheIfEmpty) {
       // If we haven't found any dupes, probably cache is empty.
       // Try filling cache and give another try. We don't need to specify include conflicts here are there will not be any

--- a/api/v3/Dedupe.php
+++ b/api/v3/Dedupe.php
@@ -156,7 +156,7 @@ function _civicrm_api3_dedupe_getstatistics_spec(&$params) {
  */
 function civicrm_api3_dedupe_getduplicates($params) {
   $options = _civicrm_api3_get_options_from_params($params);
-  $dupePairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, TRUE, $options['limit'], FALSE, TRUE, $params['criteria'], CRM_Utils_Array::value('check_permissions', $params), CRM_Utils_Array::value('search_limit', $params, 0));
+  $dupePairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, TRUE, $options['limit'], FALSE, TRUE, $params['criteria'], CRM_Utils_Array::value('check_permissions', $params), CRM_Utils_Array::value('search_limit', $params, 0), CRM_Utils_Array::value('is_force_new_search', $params));
   return civicrm_api3_create_success($dupePairs);
 }
 
@@ -183,6 +183,10 @@ function _civicrm_api3_dedupe_getduplicates_spec(&$params) {
     'title' => ts('Number of contacts to look for matches for.'),
     'type' => CRM_Utils_Type::T_INT,
     'api.default' => (int) Civi::settings()->get('dedupe_default_limit'),
+  ];
+  $spec['is_force_new_search'] = [
+    'title' => ts('Force a new search, refreshing any cached search'),
+    'type' => CRM_Utils_Type::T_BOOLEAN,
   ];
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Extra parameter for Dedupe.getduplicates - is_force_new_search allows the api to force a refresh of cached results


Before
----------------------------------------
No way to force a refresh by api if the cache is invalidated

After
----------------------------------------
New api parameter

Technical Details
----------------------------------------
Per the inbuilt screen, sometimes there is a need to clear the cached duplicates & reload - e.g because more have been
created in the mean time.

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/issues/1230