### PR TITLE
Ensure all report templates switch the filter field_name from join_da…

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveEighteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveEighteen.php
@@ -110,6 +110,7 @@ class CRM_Upgrade_Incremental_php_FiveEighteen extends CRM_Upgrade_Incremental_B
       ],
     ]);
     $this->addTask('Update civicrm_mapping_field and civicrm_uf_field for change in join_date name', 'updateJoinDateMappingUF');
+    $this->addTask('Update civicrm_report_instances for change in filter from join_date to membership_join_date', 'joinDateReportUpdate');
   }
 
   public static function removeDomainIDFK() {
@@ -131,6 +132,41 @@ class CRM_Upgrade_Incremental_php_FiveEighteen extends CRM_Upgrade_Incremental_B
   public static function updateJoinDateMappingUF() {
     CRM_Core_DAO::executeQuery("UPDATE civicrm_mapping_field SET name = 'membership_join_date' WHERE name = 'join_date' AND contact_type = 'Membership'");
     CRM_Core_DAO::executeQuery("UPDATE civicrm_uf_field SET field_name = 'membership_join_date' WHERE field_name = 'join_date' AND field_type = 'Membership'");
+    return TRUE;
+  }
+
+  public static function joinDateReportUpdate() {
+    $report_templates = ['member/contributionDetail', 'member/Detail', 'member/Summary'];
+    $substitutions = [
+      'join_date_relative' => 'membership_join_date_relative',
+      'join_date_from' => 'membership_join_date_from',
+      'join_date_to' => 'membership_join_date_to',
+    ];
+    foreach ($report_templates as $report_template) {
+      $reports = civicrm_api3('ReportInstance', 'get', [
+        'report_id' => $report_template,
+        'options' => ['limit' => 0],
+      ])['values'];
+      foreach ($reports as $report) {
+        if (!is_array($report['form_values'])) {
+          $form_values = unserialize($report['form_values']);
+        }
+        else {
+          $form_values = $report['form_values'];
+        }
+        foreach ($form_values as $key => $value) {
+          if (array_key_exists($key, $substitutions)) {
+            $form_values[$substitutions[$key]] = $value;
+            unset($form_values[$key]);
+          }
+        }
+        $form_values = serialize($form_values);
+        CRM_Core_DAO::executeQuery("UPDATE civicrm_report_instance SET form_values = %1 WHERE id = %2", [
+          1 => [$form_values, 'String'],
+          2 => [$report['id'], 'Positive'],
+        ]);
+      }
+    }
     return TRUE;
   }
 


### PR DESCRIPTION
…te to be membership_join_date

Overview
----------------------------------------
As part of #15177 we switched some report filter keys to be membership_join_date rather than join_date to match the new metadata, this PR aims to update that in the stored form_values in civicrm_report_instance

Before
----------------------------------------
stored form values using old filter key

After
----------------------------------------
stored form values using new filter key

ping @eileenmcnaughton 