### PR TITLE
(dev/core#1226) Fix regression where new groups created on 5.16 with relative dates save 'fixed dates'

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -437,7 +437,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     // This is required only until all fields are converted to datepicker fields as the new format is truer to the
     // form format and simply saves (e.g) custom_3_relative => "this.year"
     $relativeDates = ['relative_dates' => []];
-    $specialDateFields = ['event_relative', 'case_from_relative', 'case_to_relative', 'participant_relative'];
+    $specialDateFields = ['event_relative', 'case_from_relative', 'case_to_relative', 'participant_relative', 'log_date_relative'];
     foreach ($formValues as $id => $value) {
       if ((preg_match('/_date$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
         $entityName = strstr($id, '_date', TRUE);

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -457,6 +457,13 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
       'relation_start_date_relative',
       'relation_end_date_relative',
       'relation_action_date_relative',
+      'contribution_recur_start_date_relative',
+      'contribution_recur_next_sched_contribution_date_relative',
+      'contribution_recur_cancel_date_relative',
+      'contribution_recur_end_date_relative',
+      'contribution_recur_create_date_relative',
+      'contribution_recur_modified_date_relative',
+      'contribution_recur_failure_retry_date_relative',
     ];
     foreach ($formValues as $id => $value) {
       if (in_array($id, $specialDateFields) && !empty($value)) {

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -437,9 +437,29 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     // This is required only until all fields are converted to datepicker fields as the new format is truer to the
     // form format and simply saves (e.g) custom_3_relative => "this.year"
     $relativeDates = ['relative_dates' => []];
-    $specialDateFields = ['event_relative', 'case_from_relative', 'case_to_relative', 'participant_relative', 'log_date_relative'];
+    $specialDateFields = [
+      'event_relative',
+      'case_from_relative',
+      'case_to_relative',
+      'participant_relative',
+      'log_date_relative',
+      'pledge_payment_date_relative',
+      'pledge_start_date_relative',
+      'pledge_end_date_relative',
+      'pledge_create_date_relative',
+      'member_join_date_relative',
+      'member_start_date_relative',
+      'member_end_date_relative',
+      'birth_date_relative',
+      'deceased_date_relative',
+      'mailing_date_relative',
+      'relation_date_relative',
+      'relation_start_date_relative',
+      'relation_end_date_relative',
+      'relation_action_date_relative',
+    ];
     foreach ($formValues as $id => $value) {
-      if ((preg_match('/_date$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
+      if (in_array($id, $specialDateFields) && !empty($value)) {
         $entityName = strstr($id, '_date', TRUE);
         if (empty($entityName)) {
           $entityName = strstr($id, '_relative', TRUE);

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -203,6 +203,30 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test if change log relative dates are stored correctly
+   * in civicrm_saved_search table.
+   */
+  public function testRelativeDateChangeLog() {
+    $savedSearch = new CRM_Contact_BAO_SavedSearch();
+    $formValues = [
+      'operator' => 'AND',
+      'log_date_relative' => 'this.month',
+      'radio_ts' => 'ts_all',
+    ];
+    $queryParams = [];
+    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
+    CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
+    $savedSearch->form_values = serialize($queryParams);
+    $savedSearch->save();
+
+    $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
+    $expectedResult = [
+      'log' => 'this.month',
+    ];
+    $this->checkArrayEquals($result['relative_dates'], $expectedResult);
+  }
+
+  /**
    * Test relative dates
    *
    * This is a slightly odd test because it was originally created to test that we DO create a

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -945,7 +945,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
     ));
     $eventResult = $this->callAPISuccess('Event', 'getsingle', array('id' => $eventResult['id']));
     foreach ($templateParams as $param => $value) {
-      $this->assertEquals($value, $eventResult[$param]);
+      $this->assertEquals($value, $eventResult[$param], print_r($eventResult, 1));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
FIxes a regression whereby creating new groups on 5.16 with a relative date on one of the below fields say it saved as a fixed date (e.g 'this.month' ended up as '_low' => '2019-09-01', _high => '2019-09-30')

It is not possible to repair these but we can prevent more being created.

      'log_date_relative',
      'pledge_payment_date_relative',
      'pledge_start_date_relative',
      'pledge_end_date_relative',
      'pledge_create_date_relative',
      'member_join_date_relative',
      'member_start_date_relative',
      'member_end_date_relative',
      'birth_date_relative',
      'deceased_date_relative',
      'mailing_date_relative',
      'relation_date_relative',
      'relation_start_date_relative',
      'relation_end_date_relative',
      'relation_action_date_relative',
      'contribution_recur_start_date_relative',
      'contribution_recur_next_sched_contribution_date_relative',
      'contribution_recur_cancel_date_relative',
      'contribution_recur_end_date_relative',
      'contribution_recur_create_date_relative',
      'contribution_recur_modified_date_relative',
      'contribution_recur_failure_retry_date_relative',

Before
----------------------------------------
Some groups created on civi 5.16 will not retain relative date information

After
----------------------------------------
Above is fixed

Technical Details
----------------------------------------
In the medium term all of these will be standardised as datepicker fields

Comments
----------------------------------------

This is a slightly modified backport of https://github.com/civicrm/civicrm-core/pull/15194