### PR TITLE
membership#14 - detect lifetime memberships correctly

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2407,7 +2407,11 @@ WHERE      civicrm_membership.is_test = 0
 
     if ($onlyLifeTime) {
       $dao->whereAdd('end_date IS NULL');
+      // Membership#14 - a canceled membership that was only ever pending can have no end date, but will also have no join date.
+      $dao->whereAdd('join_date IS NOT NULL');
     }
+    //CRM-4297
+    $dao->orderBy('end_date DESC');
 
     $dao->find();
     while ($dao->fetch()) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1095,6 +1095,7 @@ WHERE  id = %1";
 
   /**
    * Check the current Membership having end date null.
+   * FIXME: This function isn't buggy but should be consolidated with other functions that check for lifetime memberships.
    *
    * @param array $options
    * @param int $userid


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM calculates whether a contact has a lifetime membership when they visit a contribution page with a membership component.  However, it also incorrectly identifies other memberships as lifetime memberships.

Also, the lifetime membership code is repeated in 3 different places, all with different logic!  This begins the consolidation process.

Before
----------------------------------------
Some non-pending memberships with no end date are considered a lifetime membership.

After
----------------------------------------
Memberships that are pending, then canceled are considered correctly.  Hardcoded variables are removed.  Performance is improved.

Technical Details
----------------------------------------
I couldn't find any code path that would lead to a membership that had no start OR end dates except for Pending (through the front-end form) and Pending, then Canceled (from a failed payment).

Comments
----------------------------------------
There are three places where this "lifetime membership logic" exists:
* `CRM_Member_BAO_Membership::getAllContactMembership()`.  This logic doesn't consider a cancelled membership, which is now fixed.
* `CRM_Contribute_Form_ContributionBase::buildMembershipBlock()` considers canceled memberships, but uses hardcoded variables, and makes a SQL read for each membership type.  I've replaced this code with the fixed code above.
* `CRM_Price_BAO_PriceSet`.  I couldn't figure out how to trigger this code - a price set seems to trigger the first set of code - but since it has none of the problems of the first two functions, I'm leaving it out of scope for now (it's repetitious but not buggy).

Replication steps
----------------------------------------
* Create a contribution page with memberships (or use an existing one) to create a pending membership ("Pay Later" is fine).
* Note that you've created a pending membership with no join/start/end date.
* Change the membership status id in the db for this membership to "Cancelled".  This simulates, e.g, a failed recurring payment.
* Reload the contribution page.
* If the page uses price sets, you should see the words, "You have a current Lifetime Membership which does not need to be renewed."
* Even if you don't use price sets, any attempt to create a new membership receives the error: "You already have a lifetime membership and cannot select a membership with a shorter term."