### PR TITLE
Add ts() to deceased string

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -227,7 +227,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
         $displayName = CRM_Contact_BAO_Contact::displayName($this->_contactId);
         if ($defaults['is_deceased']) {
-          $displayName .= '  <span class="crm-contact-deceased">(deceased)</span>';
+          $displayName .= '  <span class="crm-contact-deceased">(' . ts('deceased') . ')</span>';
         }
         $displayName = ts('Edit %1', [1 => $displayName]);
 

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -323,7 +323,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     // set page title
     $title = "{$contactImage} {$displayName}";
     if ($contactDetails[$contactId]['isDeceased']) {
-      $title .= '  <span class="crm-contact-deceased">(deceased)</span>';
+      $title .= '  <span class="crm-contact-deceased">(' . ts('deceased') . ')</span>';
     }
     if ($isDeleted) {
       $title = "<del>{$title}</del>";


### PR DESCRIPTION
Overview
----------------------------------------
View contact page does not translate *deceased* string 

Before
----------------------------------------
On view contact page contact which is deceased has label *(deceased)* close to display name regardless of language version.

After
----------------------------------------
On view contact page contact which is deceased has translated label *(deceased)* close to display name

Technical Details
----------------------------------------
Just add missing ts() function.

Comments
----------------------------------------
No brainer