### PR TITLE
Fix search for case tags that are part of tag sets

### DIFF
--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -481,7 +481,14 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
         $tags = CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', ['onlyActive' => FALSE]);
 
         if (!empty($value)) {
-          $val = explode(',', $value);
+          if (is_array($value)) {
+            // Search tag(s) are part of a tag set
+            $val = array_keys($value);
+          }
+          else {
+            // Search tag(s) are part of the tag tree
+            $val = explode(',', $value);
+          }
           foreach ($val as $v) {
             if ($v) {
               $names[] = $tags[$v];


### PR DESCRIPTION
Overview
----------------------------------------
The current code only allows for searching tags that are part of the tag tree. A search for a tag that is part of a tag set will produce a DB Error. This fix allows for searching one or the other. 

Before
----------------------------------------
The search produces a DB Error.

![image](https://user-images.githubusercontent.com/32363067/64257610-a741e880-cef3-11e9-9d5c-c62c971aa6eb.png)

![image](https://user-images.githubusercontent.com/32363067/64255383-3f899e80-ceef-11e9-8c0f-0b5ec004a150.png)

After
----------------------------------------
The search is successful.

Comments
----------------------------------------
This fix does not offer a solution for searching both a case tag in the tag tree and a case tag in a tag set at the same time. But then again the Advanced Search on Contact Tags doesn't either.
