### PR TITLE
[Ref] Import use process for relationship defaults, add test

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -864,23 +864,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       if ($mappingName[$i] != ts('- do not import -')) {
 
         if ($processor->getRelationshipKey($i)) {
-          $contactType = $processor->getContactType();
-          //CRM-5125
-          $contactSubType = NULL;
-          if ($this->get('contactSubType')) {
-            $contactSubType = $this->get('contactSubType');
-          }
-
-          $relations = CRM_Contact_BAO_Relationship::getContactRelationshipType(NULL, NULL, NULL, $contactType,
-            FALSE, 'label', TRUE, $contactSubType
-          );
-
-          foreach ($relations as $key => $var) {
-            if ($processor->getValidRelationshipKey($i)) {
-              $relation = $processor->getValidRelationshipKey($i);
-              break;
-            }
-          }
 
           $contactDetails = strtolower(str_replace(" ", "_", $mappingName[$i]));
           $websiteTypeId = $processor->getWebsiteTypeID($i);

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -886,14 +886,9 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           $locationId = $processor->getLocationTypeID($i);
           $phoneType = $processor->getPhoneTypeID($i);
           $imProvider = $processor->getIMProviderID($i);
-          $typeId = $processor->getPhoneOrIMTypeID($i);
 
-          if ($websiteTypeId) {
-            $defaults["mapper[$i]"] = [$relation, $contactDetails, $websiteTypeId];
-          }
-          else {
-
-            $defaults["mapper[$i]"] = [$relation, $contactDetails, $locationId, $typeId];
+          $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
+          if (!$websiteTypeId) {
             if (!$locationId) {
               $js .= "{$formName}['mapper[$i][2]'].style.display = 'none';\n";
             }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -400,6 +400,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $processor->setFormName($formName);
     $processor->setMetadata($this->getContactImportMetadata());
     $processor->setContactTypeByConstant($this->get('contactType'));
+    $processor->setContactSubType($this->get('contactSubType'));
 
     for ($i = 0; $i < $this->_columnCount; $i++) {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -513,6 +513,12 @@ class CRM_Import_ImportProcessor {
    * @throws \CiviCRM_API3_Exception
    */
   public function getSavedQuickformDefaultsForColumn($column) {
+    if ($this->getValidRelationshipKey($column)) {
+      if ($this->getWebsiteTypeID($column)) {
+        return [$this->getValidRelationshipKey($column), $this->getFieldName($column), $this->getWebsiteTypeID($column)];
+      }
+      return [$this->getValidRelationshipKey($column), $this->getFieldName($column), $this->getLocationTypeID($column), $this->getPhoneOrIMTypeID($column)];
+    }
     if ($this->getWebsiteTypeID($column)) {
       return [$this->getFieldName($column), $this->getWebsiteTypeID($column)];
     }

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -310,10 +310,14 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
       ],
       [
         // Yes, the relationship mapping really does use url whereas non relationship uses website because... legacy
-        ['name' => 'Url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id', 'relationship_type_id' => 1, 'relationship_direction' => 'a_b'],
-        "document.forms.MapField['mapper[0][2]'].style.display = 'none';
-document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
-        ['mapper[0]' => ['1_a_b', 'url', 0, NULL]],
+        ['name' => 'Url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id' => 1, 'relationship_type_id' => 1, 'relationship_direction' => 'a_b'],
+        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        ['mapper[0]' => ['1_a_b', 'url', 1]],
+      ],
+      [
+        ['name' => 'Phone', 'contact_type' => 'Individual', 'column_number' => 0, 'phone_type_id' => 1, 'relationship_type_id' => 1, 'relationship_direction' => 'b_a'],
+        '',
+        ['mapper[0]' => ['1_b_a', 'phone', 'Primary', 1]],
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Further code cleanup to use the processor class. In the process I discovered contact subtype is not yet set on the processor class - merging this in the same civi version as related cleanups would be safer.

Adds unit tests to cover

Before
----------------------------------------
Hard to read

After
----------------------------------------
Easier to read

Technical Details
----------------------------------------
Part of cleanup & adding unit tests

Comments
----------------------------------------

@colemanw @seamuslee001 I think we should merge this before 5.18rc is cut. Risk of edge case bug from not having set contactSubType is low but avoidable