### PR TITLE
dev/core#938 - remove duplicate lines

### DIFF
--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -349,8 +349,16 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
       'return' => ['content'],
     ]);
     $this->assertEquals($expectedContent, $getResult2['values'][$fileId]['content']);
+    // Do this again even though we just tested above to demonstrate that these fields should be returned even if you only ask to return 'content'.
     foreach (['id', 'entity_table', 'entity_id', 'url'] as $field) {
-      $this->assertEquals($createResult['values'][$fileId][$field], $getResult['values'][$fileId][$field], "Expect field $field to match");
+      if ($field == 'url') {
+        $this->assertEquals(substr($createResult['values'][$fileId][$field], 0, -15), substr($getResult2['values'][$fileId][$field], 0, -15));
+        $this->assertEquals(substr($createResult['values'][$fileId][$field], -3), substr($getResult2['values'][$fileId][$field], -3));
+        $this->assertApproxEquals(substr($createResult['values'][$fileId][$field], -14, 10), substr($getResult2['values'][$fileId][$field], -14, 10), 2);
+      }
+      else {
+        $this->assertEquals($createResult['values'][$fileId][$field], $getResult2['values'][$fileId][$field], "Expect field $field to match");
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/938#note_22580. There's some duplicate lines that were never noticed before because the only time they would fail was when the lines above it would fail, but that meant the test would end before hitting them. Now that the lines above it are worked-around this comes up.

Before
----------------------------------------
Test can still fail intermittently because of duplicated lines.

After
----------------------------------------
Lines removed.

Technical Details
----------------------------------------
These duplicate lines are comparing the results of the previous `get` call a second time. My guess is they were copy and paste.

Comments
----------------------------------------

