### PR TITLE
[Import] [REF] code cleanup & test on the code to  'guess the intended  field  from the column name'

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -70,7 +70,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   public function defaultFromColumnName($columnName, $patterns) {
 
     if (!preg_match('/^[a-z0-9 ]$/i', $columnName)) {
-      if ($columnKey = array_search($columnName, $this->_mapperFields)) {
+      if ($columnKey = array_search($columnName, $this->getFieldTitles())) {
         $this->_fieldUsed[$columnKey] = TRUE;
         return $columnKey;
       }

--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -578,6 +578,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
    * @return array
    */
   public function getColumnPatterns() {
+    CRM_Core_Error::deprecatedFunctionWarning('no  longer used- use   CRM_Contact_Import_MetadataTrait');
     $values = [];
     foreach ($this->_fields as $name => $field) {
       $values[$name] = $field->_columnPattern;
@@ -616,7 +617,6 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
     $store->set('fields', $this->getSelectValues());
     $store->set('fieldTypes', $this->getSelectTypes());
 
-    $store->set('columnPatterns', $this->getColumnPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());
     $store->set('columnCount', $this->_activeFieldCount);
 

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -323,6 +323,37 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
   }
 
   /**
+   * Test the MapField function getting defaults from column names.
+   *
+   * @dataProvider getHeaderMatchDataProvider
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testDefaultFromColumnNames($columnHeader, $mapsTo) {
+    $this->setUpMapFieldForm();
+    $this->assertEquals($mapsTo, $this->form->defaultFromColumnName($columnHeader, $this->getHeaderPatterns()));
+  }
+
+  /**
+   * Get data to use for default from column names.
+   *
+   * @return array
+   */
+  public function getHeaderMatchDataProvider() {
+    return [
+      ['Contact Id', 'id'],
+      ['Contact ID', 'id'],
+      ['contact id', 'id'],
+      ['contact_id', 'id'],
+      // Yes, really... id wins the day here.
+      ['external id', 'id'],
+      ['external ident', 'external_identifier'],
+      ['external idg', 'external_identifier'],
+    ];
+  }
+
+  /**
    * Wrapper for loadSavedMapping.
    *
    * This signature of the function we are calling is funky as a new extraction & will be refined.


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup 


Before
----------------------------------------
Less readable, untested

After
----------------------------------------
More  readable,  tested

Technical Details
----------------------------------------
This gets us away from using the form session to pass around metadata & makes the functio testable.

In this case the metadata i the 'header pattern' from the xml - it's a bit of regex intended to look at the incoming column header & see if it is a match for any of our fields. Neat idea. It would be cool to hone it a bit but this just standardises how it is loaded

Comments
----------------------------------------
