### PR TITLE
Fixes inconsitency between constituency summary and constituency detail

### DIFF
--- a/templates/CRM/Report/Form/Contact/Detail.tpl
+++ b/templates/CRM/Report/Form/Contact/Detail.tpl
@@ -201,3 +201,10 @@
     {/if}
     {include file="CRM/Report/Form/ErrorMessage.tpl"}
 </div>
+
+
+{if $outputMode == 'print'}
+  <script type="text/javascript">
+    window.print();
+  </script>
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes inconsistency between Constituency Summary and Constituency Detail.
One has print to prompt show up the other one does not.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/54142191/64361755-1bb87c80-d005-11e9-9160-3e9950c13f7f.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/54142191/64361782-23782100-d005-11e9-84b0-ee933f748e76.png)


Steps to reproduce
----------------------------------------
1. Click "View contact record"
2. Click "Contacts" > "Contact Reports"
3. Click 3 dots for choosing an action near the "Constituent Detail" report
4. Click "Print Report"
