### PR TITLE
[Ref] [Import] Final round in the cleanup Load Mapping form epic

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -403,7 +403,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
 
       if ($this->get('savedMapping')) {
-        list($defaults, $js) = $this->loadSavedMapping($processor, $mappingName, $i, $defaults, $js, $hasColumnNames);
+        list($defaults, $js) = $this->loadSavedMapping($processor, $i, $defaults, $js, $hasColumnNames);
       }
       else {
         $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_0_');\n";
@@ -850,18 +850,11 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @return array
    * @throws \CiviCRM_API3_Exception
    */
-  public function loadSavedMapping($processor, $mappingName, $i, $defaults, $js, $hasColumnNames) {
+  public function loadSavedMapping($processor, $i, $defaults, $js, $hasColumnNames) {
     $formName = $processor->getFormName();
     if ($processor->getFieldName($i)) {
       $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
-      if ($mappingName[$i] != ts('- do not import -')) {
-        $js .= $processor->getQuickFormJSForField($i);
-      }
-      else {
-        for ($k = 1; $k < 4; $k++) {
-          $js .= "{$formName}['mapper[$i][$k]'].style.display = 'none';\n";
-        }
-      }
+      $js .= $processor->getQuickFormJSForField($i);
     }
     else {
       // this load section to help mapping if we ran out of saved columns when doing Load Mapping

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -198,39 +198,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   public function buildQuickForm() {
     $savedMappingID = (int) $this->get('savedMapping');
-    //to save the current mappings
-    if (!$savedMappingID) {
-      $saveDetailsName = ts('Save this field mapping');
-      $this->applyFilter('saveMappingName', 'trim');
-      $this->add('text', 'saveMappingName', ts('Name'));
-      $this->add('text', 'saveMappingDesc', ts('Description'));
-    }
-    else {
-      $savedMapping = $this->get('savedMapping');
-
-      list($mappingName) = CRM_Core_BAO_Mapping::getMappingFields($savedMapping, TRUE);
-
-      //get loaded Mapping Fields
-      $mappingName = CRM_Utils_Array::value(1, $mappingName);
-
-      $this->assign('loadedMapping', $savedMapping);
-      $this->set('loadedMapping', $savedMapping);
-
-      $params = ['id' => $savedMapping];
-      $temp = [];
-      $mappingDetails = CRM_Core_BAO_Mapping::retrieve($params, $temp);
-
-      $this->assign('savedName', $mappingDetails->name);
-
-      $this->add('hidden', 'mappingId', $savedMapping);
-
-      $this->addElement('checkbox', 'updateMapping', ts('Update this field mapping'), NULL);
-      $saveDetailsName = ts('Save as a new field mapping');
-      $this->add('text', 'saveMappingName', ts('Name'));
-      $this->add('text', 'saveMappingDesc', ts('Description'));
-    }
-
-    $this->addElement('checkbox', 'saveMapping', $saveDetailsName, NULL, ['onclick' => "showSaveDetails(this)"]);
+    $this->buildSavedMappingFields($savedMappingID);
 
     $this->addFormRule(['CRM_Contact_Import_Form_MapField', 'formRule']);
 

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -402,8 +402,9 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     for ($i = 0; $i < $this->_columnCount; $i++) {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
 
-      if ($this->get('savedMapping')) {
-        list($defaults, $js) = $this->loadSavedMapping($processor, $i, $defaults, $js, $hasColumnNames);
+      if ($this->get('savedMapping') && $processor->getFieldName($i)) {
+        $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
+        $js .= $processor->getQuickFormJSForField($i);
       }
       else {
         $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_0_');\n";
@@ -837,37 +838,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
     $saveMappingFields->save();
     return $saveMappingFields->mapping_id;
-  }
-
-  /**
-   * @param \CRM_Import_ImportProcessor $processor
-   * @param $mappingName
-   * @param int $i
-   * @param array $defaults
-   * @param string $js
-   * @param bool $hasColumnNames
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function loadSavedMapping($processor, $i, $defaults, $js, $hasColumnNames) {
-    $formName = $processor->getFormName();
-    if ($processor->getFieldName($i)) {
-      $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
-      $js .= $processor->getQuickFormJSForField($i);
-    }
-    else {
-      // this load section to help mapping if we ran out of saved columns when doing Load Mapping
-      $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_0_');\n";
-
-      if ($hasColumnNames) {
-        $defaults["mapper[$i]"] = [$this->defaultFromColumnName($this->_columnNames[$i])];
-      }
-      else {
-        $defaults["mapper[$i]"] = [$this->defaultFromData($this->getDataPatterns(), $i)];
-      }
-    }
-    return [$defaults, $js];
   }
 
 }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -852,13 +852,12 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   public function loadSavedMapping($processor, $mappingName, $i, $defaults, $js, $hasColumnNames) {
     $formName = $processor->getFormName();
-    if (isset($mappingName[$i])) {
+    if ($processor->getFieldName($i)) {
+      $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
       if ($mappingName[$i] != ts('- do not import -')) {
-        $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
         $js .= $processor->getQuickFormJSForField($i);
       }
       else {
-        $defaults["mapper[$i]"] = [];
         for ($k = 1; $k < 4; $k++) {
           $js .= "{$formName}['mapper[$i][$k]'].style.display = 'none';\n";
         }

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -545,6 +545,9 @@ class CRM_Import_ImportProcessor {
    * @throws \CiviCRM_API3_Exception
    */
   public function getSavedQuickformDefaultsForColumn($column) {
+    if ($this->getFieldName($column) === ts('- do not import -')) {
+      return [];
+    }
     if ($this->getValidRelationshipKey($column)) {
       if ($this->getWebsiteTypeID($column)) {
         return [$this->getValidRelationshipKey($column), $this->getFieldName($column), $this->getWebsiteTypeID($column)];

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -438,6 +438,10 @@ class CRM_Import_ImportProcessor {
       }
       else {
         // Honour legacy chaos factor.
+        if ($field['name'] === ts('- do not import -')) {
+          // This is why we save names not labels people....
+          $field['name'] = 'do_not_import';
+        }
         $fields[$index]['name'] = strtolower(str_replace(" ", "_", $field['name']));
         // fix for edge cases, CRM-4954
         if ($fields[$index]['name'] === 'image_url') {
@@ -508,7 +512,10 @@ class CRM_Import_ImportProcessor {
    */
   public function getQuickFormJSForField($column) {
     $columnNumbersToHide = [];
-    if ($this->getRelationshipKey($column)) {
+    if ($this->getFieldName($column) === 'do_not_import') {
+      $columnNumbersToHide = [1, 2, 3];
+    }
+    elseif ($this->getRelationshipKey($column)) {
       if (!$this->getWebsiteTypeID($column) && !$this->getLocationTypeID($column)) {
         $columnNumbersToHide[] = 2;
       }
@@ -545,7 +552,7 @@ class CRM_Import_ImportProcessor {
    * @throws \CiviCRM_API3_Exception
    */
   public function getSavedQuickformDefaultsForColumn($column) {
-    if ($this->getFieldName($column) === ts('- do not import -')) {
+    if ($this->getFieldName($column) === 'do_not_import') {
       return [];
     }
     if ($this->getValidRelationshipKey($column)) {

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -365,8 +365,6 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
    *
    * This signature of the function we are calling is funky as a new extraction & will be refined.
    *
-   * @param \CRM_Contact_Import_Form_MapField $form
-   *
    * @param int $mappingID
    * @param int $columnNumber
    *

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -176,7 +176,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
 
     $mapping = $this->callAPISuccess('Mapping', 'create', ['name' => 'my test']);
     $this->callAPISuccess('MappingField', 'create', array_merge(['mapping_id' => $mapping['id']], $fieldSpec));
-    $result = $this->loadSavedMapping($this->form, $mapping['id'], $fieldSpec['column_number']);
+    $result = $this->loadSavedMapping($mapping['id'], $fieldSpec['column_number']);
     $this->assertEquals($expectedJS, $result['js']);
     $this->assertEquals($expectedDefaults, $result['defaults']);
   }
@@ -374,19 +374,18 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
    *
    * @throws \CiviCRM_API3_Exception
    */
-  protected function loadSavedMapping($form, $mappingID, $columnNumber) {
-    $defaults = [];
-
-    $js = '';
-    $hasColumnNames = TRUE;
+  protected function loadSavedMapping($mappingID, $columnNumber) {
     $processor = new CRM_Import_ImportProcessor();
     $processor->setMappingID($mappingID);
     $processor->setFormName('document.forms.MapField');
     $processor->setMetadata($this->getContactImportMetadata());
     $processor->setContactTypeByConstant(CRM_Import_Parser::CONTACT_INDIVIDUAL);
 
-    $return = $form->loadSavedMapping($processor, $columnNumber, $defaults, $js, $hasColumnNames);
-    return ['defaults' => $return[0], 'js' => $return[1]];
+    $defaults = [];
+    $defaults["mapper[$columnNumber]"] = $processor->getSavedQuickformDefaultsForColumn($columnNumber);
+    $js = $processor->getQuickFormJSForField($columnNumber);
+
+    return ['defaults' => $defaults, 'js' => $js];
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -319,6 +319,13 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
         '',
         ['mapper[0]' => ['1_b_a', 'phone', 'Primary', 1]],
       ],
+      [
+        ['name' => '- do not import -', 'contact_type' => 'Individual', 'column_number' => 0],
+        "document.forms.MapField['mapper[0][1]'].style.display = 'none';
+document.forms.MapField['mapper[0][2]'].style.display = 'none';
+document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        ['mapper[0]' => []],
+      ],
     ];
   }
 
@@ -368,10 +375,6 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
    * @throws \CiviCRM_API3_Exception
    */
   protected function loadSavedMapping($form, $mappingID, $columnNumber) {
-    list($mappingName) = CRM_Core_BAO_Mapping::getMappingFields($mappingID, TRUE);
-
-    //get loaded Mapping Fields
-    $mappingName = CRM_Utils_Array::value(1, $mappingName);
     $defaults = [];
 
     $js = '';
@@ -382,7 +385,7 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
     $processor->setMetadata($this->getContactImportMetadata());
     $processor->setContactTypeByConstant(CRM_Import_Parser::CONTACT_INDIVIDUAL);
 
-    $return = $form->loadSavedMapping($processor, $mappingName, $columnNumber, $defaults, $js, $hasColumnNames);
+    $return = $form->loadSavedMapping($processor, $columnNumber, $defaults, $js, $hasColumnNames);
     return ['defaults' => $return[0], 'js' => $return[1]];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This removes all the now-obsolete code from the mapping cleanup
-94 + 30.... but that is just this PR

The final result is that the 134 lines here https://github.com/civicrm/civicrm-core/blob/5.16/CRM/Contact/Import/Form/MapField.php#L407-L543

are now just 2 lines

And these
https://github.com/civicrm/civicrm-core/blob/5.16/CRM/Contact/Import/Form/MapField.php#L202-L239

are 1

Before
----------------------------------------
Chaos

After
----------------------------------------
Calm

Technical Details
----------------------------------------
After all the cleanups & tests we can now remove some big chunks....

Comments
----------------------------------------
@seamuslee001 @colemanw so this is the final one in the series (the other 2 open PRs are sub-PRs of this for easier review)