### PR TITLE
dev/core#1230 Permission nuancing, fix another place where merge duplicate contacts should be enough

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1184,9 +1184,11 @@ class CRM_Core_Permission {
     $permissions['exception'] = [
       'default' => ['merge duplicate contacts'],
     ];
+
     $permissions['job'] = [
       'process_batch_merge' => ['merge duplicate contacts'],
     ];
+    $permissions['rule_group']['get'] = [['merge duplicate contacts', 'administer CiviCRM']];
     // Loc block is only used for events
     $permissions['loc_block'] = $permissions['event'];
 


### PR DESCRIPTION
Overview
----------------------------------------
Gives contacts with ''merge duplicate contacts'' permission to get dedupe rules

Before
----------------------------------------
'Administer CiviCRM' required

After
----------------------------------------
'Administer CiviCRM' or 'merge duplicate contacts' required

Technical Details
----------------------------------------

Per the example in the comment block on CRM_Core_Permission::check()
```
   * Ex 3: Must have 'access CiviCRM' or 'access Ajax API'
   *   [
   *     ['access CiviCRM', 'access Ajax API'],
   *   ],
```

It seems fine for Rule.create & delete to require administer CiviCRM but merge duplicate contacts should be enough for get

Comments
----------------------------------------
