### PR TITLE
Respect calling code passing in 'null'  for creditnote_id.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -155,7 +155,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       if (($params['contribution_status_id'] == array_search('Refunded', $contributionStatus)
         || $params['contribution_status_id'] == array_search('Cancelled', $contributionStatus))
       ) {
-        if (empty($params['creditnote_id']) || $params['creditnote_id'] == "null") {
+        if (empty($params['creditnote_id'])) {
           $params['creditnote_id'] = self::createCreditNoteId();
         }
       }
@@ -1125,7 +1125,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         $isARefund = TRUE;
         // @todo we should stop passing $params by reference - splitting this out would be a step towards that.
         $params['trxnParams']['total_amount'] = -$params['total_amount'];
-        if (empty($params['contribution']->creditnote_id) || $params['contribution']->creditnote_id == "null") {
+        if (empty($params['contribution']->creditnote_id)) {
           $creditNoteId = self::createCreditNoteId();
           CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution']->id, 'creditnote_id', $creditNoteId);
         }
@@ -1140,7 +1140,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           // @todo we should stop passing $params by reference - splitting this out would be a step towards that.
           $params['trxnParams']['to_financial_account_id'] = $arAccountId;
           $params['trxnParams']['total_amount'] = -$params['total_amount'];
-          if (is_null($params['contribution']->creditnote_id) || $params['contribution']->creditnote_id == "null") {
+          if (empty($params['contribution']->creditnote_id)) {
             $creditNoteId = self::createCreditNoteId();
             CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution']->id, 'creditnote_id', $creditNoteId);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue where the contribution bao disregards 'null' when passed in for 'credit_note_id'. This has performance implications as the code to get the credit note id is very slow and there is no precedent anywhere in our code for the BAO to deliberately override efforts by
calling code to null out a value 

Before
----------------------------------------
The 'null' in the below query is ignored and the credit note id is calcluated anyway in a way that performs very badly, even on sites without the requirement for this particular calculation.

```
civicrm_api3('Contribution', 'create', [
  'id' => 'x',
 'contribution_status_id' => 'Refunded',
 'creditnote_id' => 'null'
);
```


After
----------------------------------------
The api call results in a credit note id of NULL and performance is not damaged.
```
civicrm_api3('Contribution', 'create', [
  'id' => 'x',
 'contribution_status_id' => 'Refunded',
 'creditnote_id' => 'null'
);
```

Technical Details
----------------------------------------
The credit note code was implemented in core quite a while ago, before we were really pushing these things
out to extensions. It was implemented such that it iterates through all credit notes & has performance
implications in order to meet a use case that is not common to all.

Ideally we would move it to an extension, but short of that we can at least respect
calling code setting the value to 'null' in order to override it.


Probably we should longer term simply have a hook

hook::getCreditNoteID() & more this function to an extension called by that hook

Comments
----------------------------------------
@JoeMurray @pfigel @jamienovick @lucianov88 it seems Patrick's fix mitigated the performance issue but it's still a thing - too much so for us to be able to have that code in production with hacking it out. This makes the credit note behaviour 'opt out' & makes our code more consistent - although per above - it should still be moved to an extension IMHO
