### PR TITLE
dev/core#1123 - avoid possible variable name clash

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -1244,7 +1244,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
         // At the moment this is duplicating other code in this section, but refactoring in small steps.
         $activityTypeObj = new CRM_Activity_BAO_ActivityType($this->_activityTypeId);
-        $this->assign('activityType', $activityTypeObj->getActivityType());
+        $this->assign('activityTypeNameAndLabel', $activityTypeObj->getActivityType());
       }
       // Set title.
       if (isset($activityTypeDisplayLabels)) {

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -252,7 +252,7 @@
   {/if} {* End Delete vs. Add / Edit action *}
   </table>
   <div class="crm-submit-buttons">
-  {if $action eq 4 && ($activityType.machineName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
+  {if $action eq 4 && ($activityTypeNameAndLabel.machineName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
     {if !$context }
       {assign var="context" value='activity'}
     {/if}

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -244,7 +244,7 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
     $form->assignActivityType();
 
     // Check the smarty template has the correct values assigned.
-    $keyValuePair = $form->getTemplate()->get_template_vars('activityType');
+    $keyValuePair = $form->getTemplate()->get_template_vars('activityTypeNameAndLabel');
     $this->assertEquals('47395hc', $keyValuePair['machineName']);
     $this->assertEquals('Hide Cookies', $keyValuePair['displayLabel']);
 


### PR DESCRIPTION
Overview
----------------------------------------
As per the comment at https://github.com/civicrm/civicrm-core/pull/15147#discussion_r318358603 this avoids a possible smarty variable name clash with files that might get `{include}`'d, especially for custom activity types that have their custom templates automatically included. The variable name 'activityType' might be too common.

Comments
----------------------------------------
Putting against 5.18 because I meant to get to it earlier but was too slow and it got branched before I got to it.
