### PR TITLE
Declare metadata for component payment fields on export

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -589,7 +589,10 @@ class CRM_Export_BAO_ExportProcessor {
    * @return array
    */
   public function getQueryFields() {
-    return $this->queryFields;
+    return array_merge(
+      $this->queryFields,
+      $this->getComponentPaymentFields()
+    );
   }
 
   /**
@@ -725,7 +728,7 @@ class CRM_Export_BAO_ExportProcessor {
       return $this->getQueryFields()[$field]['title'];
     }
     elseif ($this->isExportPaymentFields() && array_key_exists($field, $this->getcomponentPaymentFields())) {
-      return CRM_Utils_Array::value($field, $this->getcomponentPaymentFields());
+      return CRM_Utils_Array::value($field, $this->getcomponentPaymentFields())['title'];
     }
     else {
       return $field;
@@ -1257,11 +1260,11 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function getComponentPaymentFields() {
     return [
-      'componentPaymentField_total_amount' => ts('Total Amount'),
-      'componentPaymentField_contribution_status' => ts('Contribution Status'),
-      'componentPaymentField_received_date' => ts('Date Received'),
-      'componentPaymentField_payment_instrument' => ts('Payment Method'),
-      'componentPaymentField_transaction_id' => ts('Transaction ID'),
+      'componentPaymentField_total_amount' => ['title' => ts('Total Amount'), 'type' => CRM_Utils_Type::T_MONEY],
+      'componentPaymentField_contribution_status' => ['title' => ts('Contribution Status'), 'type' => CRM_Utils_Type::T_STRING],
+      'componentPaymentField_received_date' => ['title' => ts('Date Received'), 'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME],
+      'componentPaymentField_payment_instrument' => ['title' => ts('Payment Method'), 'type' => CRM_Utils_Type::T_STRING],
+      'componentPaymentField_transaction_id' => ['title' => ts('Transaction ID'), 'type' => CRM_Utils_Type::T_STRING],
     ];
   }
 
@@ -1273,7 +1276,7 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function getPaymentHeaders() {
     if ($this->isExportPaymentFields() && !$this->isExportSpecifiedPaymentFields()) {
-      return $this->getcomponentPaymentFields();
+      return CRM_Utils_Array::collect('title', $this->getcomponentPaymentFields());
     }
     return [];
   }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1818,9 +1818,9 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     return [
       'participant_campaign_id' => 'participant_campaign_id varchar(16)',
       'participant_contact_id' => 'participant_contact_id varchar(16)',
-      'componentpaymentfield_contribution_status' => 'componentpaymentfield_contribution_status text',
+      'componentpaymentfield_contribution_status' => 'componentpaymentfield_contribution_status varchar(255)',
       'currency' => 'currency varchar(3)',
-      'componentpaymentfield_received_date' => 'componentpaymentfield_received_date text',
+      'componentpaymentfield_received_date' => 'componentpaymentfield_received_date varchar(32)',
       'default_role_id' => 'default_role_id varchar(16)',
       'participant_discount_name' => 'participant_discount_name varchar(16)',
       'event_id' => 'event_id varchar(16)',
@@ -1843,7 +1843,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'participant_register_date' => 'participant_register_date varchar(32)',
       'participant_registered_by_id' => 'participant_registered_by_id varchar(16)',
       'participant_is_test' => 'participant_is_test varchar(16)',
-      'componentpaymentfield_total_amount' => 'componentpaymentfield_total_amount text',
+      'componentpaymentfield_total_amount' => 'componentpaymentfield_total_amount varchar(32)',
       'componentpaymentfield_transaction_id' => 'componentpaymentfield_transaction_id varchar(255)',
       'transferred_to_contact_id' => 'transferred_to_contact_id varchar(16)',
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Part of wrapping up the cleanup on export to ensure all fields have declared metadata

Before
----------------------------------------
No metadata for component payment fields

After
----------------------------------------
Fields have metadata

Technical Details
----------------------------------------
Good test cover, changes in field type are ok

Comments
----------------------------------------

