### PR TITLE
reporting#19 - Performance improvements on report display/export

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -264,7 +264,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     if (!$this->id) {
       return FALSE;
     }
-    $cacheKey = "CRM_Core_BAO_CustomField_getOptions_{$this->id}";
+    $cacheKey = "CRM_Core_BAO_CustomField_getOptions_{$this->id}_$context";
     $cache = CRM_Utils_Cache::singleton();
     $options = $cache->get($cacheKey);
     if (!isset($options)) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2441,7 +2441,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       // Run the alter display functions
       foreach ($rows as $index => & $row) {
         foreach ($row as $selectedField => $value) {
-          if (array_key_exists($selectedField, $alterFunctions)) {
+          if (array_key_exists($selectedField, $alterFunctions) && isset($value)) {
             $rows[$index][$selectedField] = $this->{$alterFunctions[$selectedField]}($value, $row, $selectedField, $alterMap[$selectedField], $alterSpecs[$selectedField]);
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
When CiviCRM displays a report on screen, it only alters the display of the first 50 rows.  However, when exporting, it must alter the display of all the rows.  This means that performance issues in altering the display aren't always apparent until you export.  This patch fixes two performance issues with altering the display

Before
----------------------------------------
My sample report exported in 29 seconds.

After
----------------------------------------
My sample report exported in 17 seconds.

Technical Details
----------------------------------------
There are two patches here:
* In `CRM_Report_Form()`, we check that a field has a value before calling the relevant alter function.  I can't see that any core functions alter on `NULL`, and the hook is called later, so you can still alter on `NULL`.  This accounts for about 1 second of speedup.
* In `CRM_Core_BAO_CustomField()` is the more significant speedup.  `CRM_Core_BAO_CustomField::DisplayValue` called `$this->getOptions()` once per custom field, once per row.  So 3000 contacts with 5 custom fields is 15,000 calls.  By caching the results of `getOptions()` we achieve a significant speedup.

Comments
----------------------------------------
I was going to write a test against `CRM_Core_BAO_CustomField::displayValue()` but I found that it already has excellent coverage.
