### PR TITLE
WIP Pass params through quickform object properly instead of re-exporting…

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -290,7 +290,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->_lineItem = $this->get('lineItem');
     $this->_ccid = $this->get('ccid');
 
-    $this->_params = $this->controller->exportValues('Main');
+    $this->_params = $this->get('params');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
     $this->_params['amount'] = $this->get('amount');
     if (isset($this->_params['amount'])) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2412,7 +2412,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $membershipLineItems = [];
         foreach ($this->_values['fee'] as $key => $feeValues) {
           if ($feeValues['name'] == 'membership_amount') {
-            $fieldId = $this->_params['price_' . $key];
+            $fieldId = $this->_submitValues['price_' . $key];
             $membershipLineItems[$this->_priceSetId][$fieldId] = $this->_lineItem[$this->_priceSetId][$fieldId];
             unset($this->_lineItem[$this->_priceSetId][$fieldId]);
             break;

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1242,6 +1242,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       ) {
         $this->handlePreApproval($this->_params);
       }
+      $this->set('params', $this->_params);
     }
   }
 

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -840,9 +840,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
       }
 
-      CRM_Price_BAO_PriceSet::processAmount($self->_values['fee'],
-        $fields, $lineItem
-      );
+      CRM_Price_BAO_PriceSet::processAmount($self->_values['fee'], $fields, $lineItem);
 
       $minAmt = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $fields['priceSetId'], 'min_amount');
       if ($fields['amount'] < 0) {


### PR DESCRIPTION
… (and losing everything that was previously done eg. via postProcess / hooks)

Overview
----------------------------------------
This was identified when manipulating the quickform _params array via the postProcessHook and finding that it behaved differently between the event registration and the contribution pages.  On event registration pages it correctly retains any modifications made by `$this->get('params'); $this->set('params', $modifiedParams);`  But on contribution pages it does not - because the postProcess function is not calling `$this->set()` and all the modifications to the $this->_params array are lost when they are re-exporting from the form in the `CRM_Contribution_Form_Confirm::preProcess()` function.

Before
----------------------------------------
Form params NOT passed through from Main->Confirm on contribution pages.  Form params passed through from Register->Confirm on event registration pages.

After
----------------------------------------
Form params passed through from Main->Confirm on contribution pages and passed through from Register->Confirm on event registration pages.

Technical Details
----------------------------------------


Comments
----------------------------------------
I'm surprised this has not been causing issues - but I imagine it's been worked around by running the same or similar functions multiple times to achieve the same result.

@eileenmcnaughton @colemanw I would appreciate some quick feedback on this if possible as it's currently a blocker for the stripe upgrade.
