### PR TITLE
forgot tpl file

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.17.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.17.1.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.17.1 during upgrade *}


### PR DESCRIPTION
Overview
----------------------------------------
I forgot to add the tpl file for 5.17.1 when adding the first upgrade task for it in https://github.com/civicrm/civicrm-core/pull/15239. See also comments at https://github.com/civicrm/civicrm-core/pull/15246.