### PR TITLE
Remove is_public flag from report paths

### DIFF
--- a/CRM/Report/xml/Menu/Report.xml
+++ b/CRM/Report/xml/Menu/Report.xml
@@ -14,7 +14,6 @@
      <title>CiviCRM Reports</title>
      <page_callback>CRM_Report_Page_InstanceList</page_callback>
      <access_callback>1</access_callback>
-     <is_public>true</is_public>
   </item>
   <item>
      <path>civicrm/report/template/list</path>
@@ -44,7 +43,6 @@
      <title>Report</title>
      <page_callback>CRM_Report_Page_Instance</page_callback>
      <access_callback>1</access_callback>
-     <is_public>true</is_public>
   </item>
   <item>
      <path>civicrm/admin/report/template/list</path>


### PR DESCRIPTION
Even though these paths are publicly accessible (access callback is just TRUE), they are not intended as 'public' paths really. They still provide administrative functionality, and are not intended for end users of the site.

Having them with the is_public flag causes the report list and report pages to show up in the 'public' website theme, rather than the admin theme, which is a UI regression as identified by @jensschuppe in https://github.com/civicrm/civicrm-core/pull/14945#issuecomment-529858238

Pinging @eileenmcnaughton and @seamuslee001 as they were also involved in the review of the original PR.

If this is considered a regression then I can put it on another branch rather than master if needed.