### PR TITLE
financial#67 : Check number doesn't show up if payment method name - Check changed to Cheque

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -175,7 +175,7 @@
     <td>{$payment_instrument}{if $payment_processor_name} ({$payment_processor_name}){/if}</td>
   </tr>
 
-  {if $payment_instrument eq 'Check'|ts}
+  {if $check_number}
     <tr>
       <td class="label">{ts}Check Number{/ts}</td>
       <td>{$check_number}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

Edit the existing check payment method name to 'Check' to 'Cheque'
Do a contribution and enter a check number.
Then view the contribution page.

Result : Check number doesn't show up in Contribution view page

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/64610486-fbb20000-d3ec-11e9-8c11-532326e266bf.gif)


After
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/64610638-55b2c580-d3ed-11e9-8b61-956b603e33ae.gif)


Technical Details
----------------------------------------
Check number must be shown on its presence not on label text. 

ping @eileenmcnaughton @JoeMurray 
