### PR TITLE
[WIP] Fix for core#1247 (export hooks don't work in 5.17)

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -115,6 +115,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     }
     $processor->setComponentTable($componentTable);
     $processor->setComponentClause($componentClause);
+    $processor->setIds($ids);
 
     list($query, $queryString) = $processor->runQuery($params, $order);
 

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -101,6 +101,13 @@ class CRM_Export_BAO_ExportProcessor {
   protected $contactGreetingFields = [];
 
   /**
+   * An array of contact IDs being exported.
+   *
+   * @var array
+   */
+  protected $ids = [];
+
+  /**
    * Get additional non-visible fields for address merge purposes.
    *
    * @return array
@@ -583,6 +590,20 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function setQueryOperator($queryOperator) {
     $this->queryOperator = $queryOperator;
+  }
+
+  /**
+   * @return array
+   */
+  public function getIds() {
+    return $this->ids;
+  }
+
+  /**
+   * @param array $ids
+   */
+  public function setIds($ids) {
+    $this->ids = $ids;
   }
 
   /**
@@ -2329,9 +2350,11 @@ WHERE  id IN ( $deleteIDString )
     $exportMode = $this->getExportMode();
     $sqlColumns = $this->getSQLColumns();
     $componentTable = $this->getComponentTable();
+    $ids = $this->getIds();
     CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode, $componentTable, $ids);
-    $this->setExportMode($exportMode);
-    $this->setComponentTable($componentTable);
+    if ($exportMode !== $this->getExportMode() || $componentTable !== $this->getComponentTable()) {
+      CRM_Core_Error::deprecatedFunctionWarning('altering the export mode and/or component table in the hook is no longer supported.');
+    }
     if ($exportTempTable !== $this->getTemporaryTable()) {
       CRM_Core_Error::deprecatedFunctionWarning('altering the export table in the hook is deprecated (in some flows the table itself will be)');
       $this->setTemporaryTable($exportTempTable);

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2326,7 +2326,12 @@ WHERE  id IN ( $deleteIDString )
     // call export hook
     $headerRows = $this->getHeaderRows();
     $exportTempTable = $this->getTemporaryTable();
+    $exportMode = $this->getExportMode();
+    $sqlColumns = $this->getSQLColumns();
+    $componentTable = $this->getComponentTable();
     CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode, $componentTable, $ids);
+    $this->setExportMode($exportMode);
+    $this->setComponentTable($componentTable);
     if ($exportTempTable !== $this->getTemporaryTable()) {
       CRM_Core_Error::deprecatedFunctionWarning('altering the export table in the hook is deprecated (in some flows the table itself will be)');
       $this->setTemporaryTable($exportTempTable);
@@ -2355,7 +2360,7 @@ LIMIT $offset, $limit
       while ($dao->fetch()) {
         $row = [];
 
-        foreach (array_keys($this->getSQLColumns()) as $column) {
+        foreach (array_keys($sqlColumns) as $column) {
           $row[$column] = $dao->$column;
         }
         $componentDetails[] = $row;


### PR DESCRIPTION
Overview
----------------------------------------
Export hooks no longer work.

Before
----------------------------------------
Export hooks don't work.

After
----------------------------------------
Export hooks kinda work.

Technical Details
----------------------------------------
#14913 moved the line that calls the hook to a place where the hook's arguments are mostly not defined.  This defines most of the arguments.

Comments
----------------------------------------
I need help with thoughts on how to finish this!
* `$ids` doesn't appear to be part of the export object.  We can probably determine which column has the IDs and query the temp table - is this the recommended approach here?  I've never used the `$ids` argument in an extension.
* I added these two lines to allow arguments passed by reference to update the object:
```php
    $this->setExportMode($exportMode);
    $this->setComponentTable($componentTable);
```
However, I'm thinking that we're almost at the point of export here, and these lines are likely useless.  If so, should we perhaps move them into the `if` statement below that deprecates altering them via hook?