### PR TITLE
dev/drupal#52 Override getUrlPath() for Drupal8

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -37,6 +37,7 @@
  * @method static array synchronizeUsers() Create CRM contacts for all existing CMS users.
  * @method static appendCoreResources(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_coreResourceList.
  * @method static alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_getAssetUrl.
+ * @method static string|NULL getUrlPath() Path of the current page e.g. 'civicrm/contact/view'
  */
 class CRM_Utils_System {
 
@@ -319,24 +320,6 @@ class CRM_Utils_System {
     ]);
     Civi::service('dispatcher')->dispatch('hook_civicrm_alterExternUrl', $event);
     return urldecode(CRM_Utils_Url::unparseUrl($event->url));
-  }
-
-  /**
-   * Path of the current page e.g. 'civicrm/contact/view'
-   *
-   * @return string|null
-   */
-  public static function getUrlPath() {
-    $config = CRM_Core_Config::singleton();
-
-    if (method_exists($config->userSystem, 'getUrlPath')) {
-      return $config->userSystem->getUrlPath();
-    }
-
-    if (isset($_GET[$config->userFrameworkURLVar])) {
-      return $_GET[$config->userFrameworkURLVar];
-    }
-    return NULL;
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -327,8 +327,14 @@ class CRM_Utils_System {
    * @return string|null
    */
   public static function getUrlPath() {
-    if (isset($_GET[CRM_Core_Config::singleton()->userFrameworkURLVar])) {
-      return $_GET[CRM_Core_Config::singleton()->userFrameworkURLVar];
+    $config = CRM_Core_Config::singleton();
+
+    if (method_exists($config->userSystem, 'getUrlPath')) {
+      return $config->userSystem->getUrlPath();
+    }
+
+    if (isset($_GET[$config->userFrameworkURLVar])) {
+      return $_GET[$config->userFrameworkURLVar];
     }
     return NULL;
   }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -291,6 +291,19 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Path of the current page e.g. 'civicrm/contact/view'
+   *
+   * @return string|null
+   */
+  public function getUrlPath() {
+    $config = CRM_Core_Config::singleton();
+    if (isset($_GET[$config->userFrameworkURLVar])) {
+      return $_GET[$config->userFrameworkURLVar];
+    }
+    return NULL;
+  }
+
+  /**
    * Get the absolute path to the site's base url.
    *
    * @return bool|mixed|string

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -803,7 +803,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return user_role_names();
   }
 
-  /*
+  /**
    * @inheritDoc
    */
   public function getUrlPath() {

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -803,4 +803,29 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return user_role_names();
   }
 
+  /*
+   * @inheritDoc
+   */
+  public function getUrlPath() {
+    if (!class_exists('Drupal') || !\Drupal::hasContainer()) {
+      return NULL;
+    }
+
+    $path = \Drupal::service('path.current')->getPath();
+
+    // Remove '/' prefix for compatibility with CiviCRM d7-style assumptions
+    // Ex: '/civicrm/contribute' becomes 'civicrm/contribute'
+    if ($path) {
+      $path = substr($path, 1);
+
+      // Remove the language prefix, if present
+      // The URL returned by Drupal randomly includes the language prefix, sometimes not.
+      if (preg_match('/^\w\w\//', $path)) {
+        $path = substr($path, 3);
+      }
+    }
+
+    return $path;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Aims to deprecate the use of the "q" variable in Drupal8. The "q" variable is deprecated, so accessing it throws notices/warnings.

More details: https://lab.civicrm.org/dev/drupal/issues/52

This is a companion PR for #15265

Full disclosure: I have been running a variant of this patch in production for a long time, but I have not tested this specific patch.
