### PR TITLE
dev/drupal#52 Partial fix for Deprecated q variable

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -673,9 +673,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    * @return bool
    */
   public function isFrontEndPage() {
-    // Get the menu items.
-    $args = explode('?', $_GET['q']);
-    $path = $args[0];
+    $path = CRM_Utils_System::getUrlPath();
 
     // Get the menu for above URL.
     $item = CRM_Core_Menu::get($path);


### PR DESCRIPTION
Overview
----------------------------------------

In Drupal8, the 'q' variable is deprecated. This caused various warnings since the recent introduction of `isFrontEndPage` (68e3bc34581).

Example: https://www.drupal.org/project/webform_civicrm/issues/3080284

Before
----------------------------------------

Annoying PHP notices.

After
----------------------------------------

No more notices.

Comments
----------------------------------------

This is only a partial fix to hush the notices.  To fully support scenarios that have traditionally relied on `q`, we still need to create a patch for `getUrlPath` as described in https://lab.civicrm.org/dev/drupal/issues/52

This is a resubmission of https://github.com/civicrm/civicrm-core/pull/15265 to the RC branch.