### PR TITLE
Remove is_public flag from report paths

### DIFF
--- a/CRM/Report/xml/Menu/Report.xml
+++ b/CRM/Report/xml/Menu/Report.xml
@@ -14,7 +14,6 @@
      <title>CiviCRM Reports</title>
      <page_callback>CRM_Report_Page_InstanceList</page_callback>
      <access_callback>1</access_callback>
-     <is_public>true</is_public>
   </item>
   <item>
      <path>civicrm/report/template/list</path>
@@ -44,7 +43,6 @@
      <title>Report</title>
      <page_callback>CRM_Report_Page_Instance</page_callback>
      <access_callback>1</access_callback>
-     <is_public>true</is_public>
   </item>
   <item>
      <path>civicrm/admin/report/template/list</path>


### PR DESCRIPTION
Even though these paths are publicly accessible, they are not intended as 'public' paths

port of #15261 

ping @eileenmcnaughton 