### PR TITLE
dev/financial#68 Ensure that check number is correctly passed through…

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -525,7 +525,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           'payment_instrument' => 'payment_instrument_id',
           'contribution_source' => 'source',
           'contribution_note' => 'note',
-
+          'contribution_check_number' => 'check_number',
         ];
         foreach ($fieldTranslations as $formField => $baoField) {
           if (isset($value[$formField])) {

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -218,7 +218,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     $params = $this->getContributionData();
     $this->assertTrue($form->testProcessContribution($params));
     $result = $this->callAPISuccess('contribution', 'get', ['return' => 'total_amount']);
-    $this->assertEquals(2, $result['count']);
+    $this->assertEquals(3, $result['count']);
     foreach ($result['values'] as $contribution) {
       $this->assertEquals($this->callAPISuccess('line_item', 'getvalue', [
         'contribution_id' => $contribution['id'],
@@ -226,6 +226,11 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
 
       ]), $contribution['total_amount']);
     }
+    $checkResult = $this->callAPISuccess('Contribution', 'get', ['check_number' => ['IS NOT NULL' => 1]]);
+    $this->assertEquals(1, $checkResult['count']);
+    $entityFinancialTrxn = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['entity_table' => 'civicrm_contribution', 'entity_id' => $checkResult['id']]);
+    $financialTrxn = $this->callAPISuccess('FinancialTrxn', 'get', ['id' => $entityFinancialTrxn['values'][$entityFinancialTrxn['id']]['financial_trxn_id']]);
+    $this->assertEquals('1234', $financialTrxn['values'][$financialTrxn['id']]['check_number']);
   }
 
   /**
@@ -373,8 +378,17 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'check_number' => NULL,
           'contribution_status_id' => 1,
         ],
+        3 => [
+          'financial_type' => 1,
+          'total_amount' => $this->formatMoneyInput(1500.15),
+          'receive_date' => '2013-07-24',
+          'receive_date_time' => NULL,
+          'payment_instrument' => 4,
+          'contribution_check_number' => '1234',
+          'contribution_status_id' => 1,
+        ],
       ],
-      'actualBatchTotal' => $this->formatMoneyInput(3000.30),
+      'actualBatchTotal' => $this->formatMoneyInput(4500.45),
 
     ];
   }


### PR DESCRIPTION
… when processing a contribution or membership batch

Overview
----------------------------------------
This is an alternate to #15264 as it alters the post processing on the batch rather than altering field names as the field_name should be contribution_check_number now

Before
----------------------------------------
Check number is only recorded against the contribution not the payment as well when submitting a contribution or membership batch

After
----------------------------------------
Check number is recorded against the contribution and the payment

ping @monishdeb @eileenmcnaughton 