### PR TITLE
Fix unreleased regression on batch merge through the UI

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -713,7 +713,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       // explicitly set to NULL if not 1 or 0 as part of grandfathering out the mystical '2' value.
       $isSelected = NULL;
     }
-    $dupePairs = self::getDuplicatePairs($rgid, $gid, $reloadCacheIfEmpty, $batchLimit, $isSelected, ($mode == 'aggressive'), $criteria, $checkPermissions);
+    $dupePairs = self::getDuplicatePairs($rgid, $gid, $reloadCacheIfEmpty, $batchLimit, $isSelected, ($mode == 'aggressive'), $criteria, $checkPermissions, $searchLimit);
 
     $cacheParams = [
       'cache_key_string' => self::getMergeCacheKeyString($rgid, $gid, $criteria, $checkPermissions, $searchLimit),


### PR DESCRIPTION
Overview
----------------------------------------
FIxes an unreleased regression  whereby matches are skipped when doing a batch merge from the UI

Before
----------------------------------------
Batch merge via the UI appears to work but contacts are not merged

After
----------------------------------------
Sanity restored

Technical Details
----------------------------------------
We made searchLimit part of the cacheKey for found batches but in this place missed passing it in,
leading to it  not picking up the relevant cached entries & skipping them. Affects 5.18 rc & master

https://github.com/civicrm/civicrm-core/commit/997a03fe8fd367ec54b99aaf08012075fe8b8206

Comments
----------------------------------------

