### PR TITLE
Trim form values when adding LIKE operator

### DIFF
--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -321,7 +321,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       foreach ($fields as $fieldName => $field) {
         if (!empty($this->_formValues[$fieldName]) && empty($field['options']) && empty($field['pseudoconstant'])) {
           if (in_array($field['type'], [CRM_Utils_Type::T_STRING, CRM_Utils_Type::T_TEXT])) {
-            $this->_formValues[$fieldName] = ['LIKE' => CRM_Contact_BAO_Query::getWildCardedValue(TRUE, 'LIKE', $this->_formValues[$fieldName])];
+            $this->_formValues[$fieldName] = ['LIKE' => CRM_Contact_BAO_Query::getWildCardedValue(TRUE, 'LIKE', trim($this->_formValues[$fieldName]))];
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fix a 5.17 regression whereby the email string is no longer being trimmed when searching

Before
----------------------------------------
'info@example.org' works

After
----------------------------------------
'info@example.org ' doesn't work

Technical Details
----------------------------------------
The form layer seems like the right place to trim & it  makes sense to be generic when adding 'LIKE'

Comments
----------------------------------------
