### PR TITLE
Ensure filtering on email via the api looks for an exact match

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -163,6 +163,8 @@ function _civicrm_api3_contact_create_spec(&$params) {
  *
  * @return array
  *   API Result Array
+ *
+ * @throws \API_Exception
  */
 function civicrm_api3_contact_get($params) {
   $options = [];
@@ -382,6 +384,11 @@ function _civicrm_api3_contact_get_spec(&$params) {
  *   Array of options (so we can modify the filter).
  */
 function _civicrm_api3_contact_get_supportanomalies(&$params, &$options) {
+  if (!empty($params['email']) && !is_array($params['email'])) {
+    // Fix this to be in array format so the query object does not add LIKE
+    // I think there is a better fix that I will do for master.
+    $params['email'] = ['=' => $params['email']];
+  }
   if (isset($params['showAll'])) {
     if (strtolower($params['showAll']) == "active") {
       $params['contact_is_deleted'] = 0;

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -367,6 +367,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Verify that attempt to create individual contact with only an email succeeds.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreateEmailIndividual() {
     $primaryEmail = 'man3@yahoo.com';
@@ -397,9 +399,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($primaryEmail, $email1['values'][$email1['id']]['email']);
 
     // Case 3: Check with email_id='primary email id'
-    $result = $this->callAPISuccess('contact', 'get', ['email_id' => $email1['id']]);
-    $this->assertEquals(1, $result['count']);
+    $result = $this->callAPISuccessGetSingle('contact', ['email_id' => $email1['id']]);
     $this->assertEquals($contact1['id'], $result['id']);
+
+    // Check no wildcard is appended
+    $this->callAPISuccessGetCount('Contact', ['email' => 'man3@yahoo.co'], 0);
 
     $this->callAPISuccess('contact', 'delete', $contact1);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a released regression whereby a wildcard was being added to api Contact.get requests with the email parameter

Before
----------------------------------------
```
  civicrm_api3('Contact', 'get', ['email' => 'bob@'];
```
Would return a contact with email 'bob@example.com'

After
----------------------------------------
Only exact matches returned

Technical Details
----------------------------------------
Wildcards are being added in the query object. We are most of the way now to converting them correctly at the form layer & deprecating that handling but is a little more conservative for the rc

Comments
----------------------------------------

