### PR TITLE
REF Make the formatParamsForPaymentProcessor function more generic so it can be used more

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -283,7 +283,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $config = CRM_Core_Config::singleton();
     parent::preProcess();
 
     // lineItem isn't set until Register postProcess
@@ -305,7 +304,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->_params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($this->_params);
     }
 
-    $this->_params['currencyID'] = $config->defaultCurrency;
+    $this->_params['currencyID'] = CRM_Core_Config::singleton()->defaultCurrency;
 
     if (!empty($this->_membershipBlock)) {
       $this->_params['selectMembership'] = $this->get('selectMembership');

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -820,7 +820,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * Format the fields for the payment processor.
+   * Format the fields in $this->_params for the payment processor.
    *
    * In order to pass fields to the payment processor in a consistent way we add some renamed
    * parameters.
@@ -830,33 +830,48 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return array
    */
   protected function formatParamsForPaymentProcessor($fields) {
+    $this->_params = $this->prepareParamsForPaymentProcessor($this->_params);
+    $fields = array_merge($fields, ['first_name' => 1, 'middle_name' => 1, 'last_name' => 1]);
+    return $fields;
+  }
+
+  /**
+   * Format the fields in $params for the payment processor.
+   *
+   * In order to pass fields to the payment processor in a consistent way we add some renamed
+   * parameters.
+   *
+   * @param array $params Payment processor params
+   *
+   * @return array $params
+   */
+  protected function prepareParamsForPaymentProcessor($params) {
     // also add location name to the array
-    $this->_params["address_name-{$this->_bltID}"] = CRM_Utils_Array::value('billing_first_name', $this->_params) . ' ' . CRM_Utils_Array::value('billing_middle_name', $this->_params) . ' ' . CRM_Utils_Array::value('billing_last_name', $this->_params);
-    $this->_params["address_name-{$this->_bltID}"] = trim($this->_params["address_name-{$this->_bltID}"]);
+    $params["address_name-{$this->_bltID}"] = CRM_Utils_Array::value('billing_first_name', $params) . ' ' . CRM_Utils_Array::value('billing_middle_name', $params) . ' ' . CRM_Utils_Array::value('billing_last_name', $params);
+    $params["address_name-{$this->_bltID}"] = trim($params["address_name-{$this->_bltID}"]);
     // Add additional parameters that the payment processors are used to receiving.
-    if (!empty($this->_params["billing_state_province_id-{$this->_bltID}"])) {
-      $this->_params['state_province'] = $this->_params["state_province-{$this->_bltID}"] = $this->_params["billing_state_province-{$this->_bltID}"] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($this->_params["billing_state_province_id-{$this->_bltID}"]);
+    if (!empty($params["billing_state_province_id-{$this->_bltID}"])) {
+      $params['state_province'] = $params["state_province-{$this->_bltID}"] = $params["billing_state_province-{$this->_bltID}"] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($params["billing_state_province_id-{$this->_bltID}"]);
     }
-    if (!empty($this->_params["billing_country_id-{$this->_bltID}"])) {
-      $this->_params['country'] = $this->_params["country-{$this->_bltID}"] = $this->_params["billing_country-{$this->_bltID}"] = CRM_Core_PseudoConstant::countryIsoCode($this->_params["billing_country_id-{$this->_bltID}"]);
+    if (!empty($params["billing_country_id-{$this->_bltID}"])) {
+      $params['country'] = $params["country-{$this->_bltID}"] = $params["billing_country-{$this->_bltID}"] = CRM_Core_PseudoConstant::countryIsoCode($params["billing_country_id-{$this->_bltID}"]);
     }
 
-    list($hasAddressField, $addressParams) = CRM_Contribute_BAO_Contribution::getPaymentProcessorReadyAddressParams($this->_params, $this->_bltID);
+    list($hasAddressField, $addressParams) = CRM_Contribute_BAO_Contribution::getPaymentProcessorReadyAddressParams($params, $this->_bltID);
     if ($hasAddressField) {
-      $this->_params = array_merge($this->_params, $addressParams);
+      $params = array_merge($params, $addressParams);
     }
 
     // @fixme it would be really nice to have a comment here so I had a clue why we are setting $fields[$name] = 1
     // Also how does relate to similar code in CRM_Contact_BAO_Contact::addBillingNameFieldsIfOtherwiseNotSet()
     $nameFields = ['first_name', 'middle_name', 'last_name'];
     foreach ($nameFields as $name) {
-      $fields[$name] = 1;
-      if (array_key_exists("billing_$name", $this->_params)) {
-        $this->_params[$name] = $this->_params["billing_{$name}"];
-        $this->_params['preserveDBName'] = TRUE;
+      if (array_key_exists("billing_$name", $params)) {
+        $params[$name] = $params["billing_{$name}"];
+        $params['preserveDBName'] = TRUE;
       }
     }
-    return $fields;
+    return $params;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Currently this useful function that helps standardise parameters passed to the payment processor is limited in where it can be used because it hardcodes the params array as `$this->_params`.
Because it also returns a specific "fields" array which is used for the profileContact function I've created a new function with a different signature so we don't break backward compatibilty.

Before
----------------------------------------
Not possible to use formatParamsForPaymentProcessor in many places

After
----------------------------------------
Possible to use formatParamsForPaymentProcessor in many places

Technical Details
----------------------------------------


Comments
----------------------------------------
There are some other bits we could probably pull into this function such as the parsing of credit card expiry date.
