### PR TITLE
Restrict inactive Dashlet query to Dashlets in the current domain

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -367,9 +367,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     // Get the array of IDs.
     $domainDashletIDs = [];
     if ($domainDashlets['is_error'] == 0) {
-      foreach ($domainDashlets['values'] as $domainDashlet) {
-        $domainDashletIDs[] = $domainDashlet['id'];
-      }
+      $domainDashletIDs = CRM_Utils_Array::collect('id', $domainDashlets['values']);
     }
 
     // Restrict query to Dashlets in this domain.

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -361,6 +361,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     $domainDashlets = civicrm_api3('Dashboard', 'get', [
       'return' => array('id'),
       'domain_id' => CRM_Core_Config::domainID(),
+      'options' => ['limit' => 0],
     ]);
 
     // Get the array of IDs.

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -373,15 +373,23 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     // Restrict query to Dashlets in this domain.
     $domainDashletClause = !empty($domainDashletIDs) ? "dashboard_id IN (" . implode(',', $domainDashletIDs) . ")" : '(1)';
 
-    // Disable inactive widgets.
-    $dashletClause = $dashletIDs ? "dashboard_id NOT IN  (" . implode(',', $dashletIDs) . ")" : '(1)';
+    // Target only those Dashlets which are inactive.
+    $dashletClause = $dashletIDs ? "dashboard_id NOT IN (" . implode(',', $dashletIDs) . ")" : '(1)';
+
+    // Build params.
+    $params = [
+      1 => [$contactID, 'Integer'],
+    ];
+
+    // Build query.
     $updateQuery = "UPDATE civicrm_dashboard_contact
                     SET is_active = 0
                     WHERE $domainDashletClause
                     AND $dashletClause
-                    AND contact_id = {$contactID}";
+                    AND contact_id = %1";
 
-    CRM_Core_DAO::executeQuery($updateQuery);
+    // Disable inactive widgets.
+    CRM_Core_DAO::executeQuery($updateQuery, $params);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Link to [the issue on Lab](https://lab.civicrm.org/dev/core/issues/1200). Ongoing fixes for the CiviCRM Dashboard when using multiple Domains.

Before
----------------------------------------
When a Contact has a Dashboard in more than one domain, adding a Dashlet to their Dashboard disables *all* unused Dashlets in all Domains. This resets their Dashboards on other Domains such that they show no active Dashlets at all.

After
----------------------------------------
When a Contact has a Dashboard in more than one domain, adding a Dashlet to their Dashboard will disable *only* unused Dashlets in the current Domain. This preserves the Dashlets on the Dashboards on other Domains.

Technical Details
----------------------------------------
Restricts the query that disables inactive Dashlets to those in the current Domain.