### PR TITLE
Add CRM_Utils_JS::encode function

### DIFF
--- a/CRM/Utils/JS.php
+++ b/CRM/Utils/JS.php
@@ -160,6 +160,26 @@ class CRM_Utils_JS {
   }
 
   /**
+   * Encodes a variable to js notation (not strict json).
+   *
+   * Like json_encode but the output is more suitable for an html attribute.
+   *
+   * @param $value
+   * @return string
+   */
+  public static function encode($value) {
+    if (is_array($value)) {
+      return self::writeObject($value, TRUE);
+    }
+    $result = json_encode($value, JSON_UNESCAPED_SLASHES);
+    // Prefer single quotes
+    if (is_string($value) && strpos($result, "'") === FALSE) {
+      return "'" . substr($result, 1, -1) . "'";
+    }
+    return $result;
+  }
+
+  /**
    * Gets the properties of a javascript object/array WITHOUT decoding them.
    *
    * Useful when the object might contain js functions, expressions, etc. which cannot be decoded.
@@ -258,7 +278,7 @@ class CRM_Utils_JS {
     $brackets = isset($obj[0]) && array_keys($obj) === range(0, count($obj) - 1) ? ['[', ']'] : ['{', '}'];
     foreach ($obj as $key => $val) {
       if ($encodeValues) {
-        $val = json_encode($val, JSON_UNESCAPED_SLASHES);
+        $val = self::encode($val);
       }
       if ($brackets[0] == '{') {
         // Enclose the key in quotes unless it is purely alphanumeric

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -237,6 +237,36 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
     $this->assertEquals($expectedOutput, CRM_Utils_JS::decode($input));
   }
 
+  public static function encodeExamples() {
+    return [
+      [
+        ['a' => 'Apple', 'b' => 'Banana', 'c' => [1, 2, 3]],
+        "{a: 'Apple', b: 'Banana', c: [1, 2, 3]}",
+      ],
+      [
+        ['a' => ['foo', 'bar'], 'b' => ["'a'" => ['foo/bar', 'bar(foo)'], 'b' => ['a' => ["fo'oo", 'bar'], 'b' => []]]],
+        "{a: ['foo', 'bar'], b: {\"'a'\": ['foo/bar', 'bar(foo)'], b: {a: [\"fo'oo\", 'bar'], b: {}}}}",
+      ],
+      [TRUE, 'true'],
+      [' ', "' '"],
+      [FALSE, 'false'],
+      [NULL, 'null'],
+      ['true', "'true'"],
+      ['0.5', "'0.5'"],
+      [0.5, '0.5'],
+      [[], "{}"],
+    ];
+  }
+
+  /**
+   * @param string $input
+   * @param string $expectedOutput
+   * @dataProvider encodeExamples
+   */
+  public function testEncode($input, $expectedOutput) {
+    $this->assertEquals($expectedOutput, CRM_Utils_JS::encode($input));
+  }
+
   /**
    * @return array
    */


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new utility function for encoding js strings.

Technical Details
----------------------------------------
The function gives output that looks more like handwritten js and less like the overly-quoted `json_encode`.