### PR TITLE
Fix for core#1247 (export hooks don't work in 5.17+) 

### DIFF
--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -321,7 +321,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       foreach ($fields as $fieldName => $field) {
         if (!empty($this->_formValues[$fieldName]) && empty($field['options']) && empty($field['pseudoconstant'])) {
           if (in_array($field['type'], [CRM_Utils_Type::T_STRING, CRM_Utils_Type::T_TEXT])) {
-            $this->_formValues[$fieldName] = ['LIKE' => CRM_Contact_BAO_Query::getWildCardedValue(TRUE, 'LIKE', $this->_formValues[$fieldName])];
+            $this->_formValues[$fieldName] = ['LIKE' => CRM_Contact_BAO_Query::getWildCardedValue(TRUE, 'LIKE', trim($this->_formValues[$fieldName]))];
           }
         }
       }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -115,6 +115,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     }
     $processor->setComponentTable($componentTable);
     $processor->setComponentClause($componentClause);
+    $processor->setIds($ids);
 
     list($query, $queryString) = $processor->runQuery($params, $order);
 

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -101,6 +101,13 @@ class CRM_Export_BAO_ExportProcessor {
   protected $contactGreetingFields = [];
 
   /**
+   * An array of primary IDs of the entity being exported.
+   *
+   * @var array
+   */
+  protected $ids = [];
+
+  /**
    * Get additional non-visible fields for address merge purposes.
    *
    * @return array
@@ -583,6 +590,20 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function setQueryOperator($queryOperator) {
     $this->queryOperator = $queryOperator;
+  }
+
+  /**
+   * @return array
+   */
+  public function getIds() {
+    return $this->ids;
+  }
+
+  /**
+   * @param array $ids
+   */
+  public function setIds($ids) {
+    $this->ids = $ids;
   }
 
   /**
@@ -2327,7 +2348,14 @@ WHERE  id IN ( $deleteIDString )
     // call export hook
     $headerRows = $this->getHeaderRows();
     $exportTempTable = $this->getTemporaryTable();
+    $exportMode = $this->getExportMode();
+    $sqlColumns = $this->getSQLColumns();
+    $componentTable = $this->getComponentTable();
+    $ids = $this->getIds();
     CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode, $componentTable, $ids);
+    if ($exportMode !== $this->getExportMode() || $componentTable !== $this->getComponentTable()) {
+      CRM_Core_Error::deprecatedFunctionWarning('altering the export mode and/or component table in the hook is no longer supported.');
+    }
     if ($exportTempTable !== $this->getTemporaryTable()) {
       CRM_Core_Error::deprecatedFunctionWarning('altering the export table in the hook is deprecated (in some flows the table itself will be)');
       $this->setTemporaryTable($exportTempTable);
@@ -2356,7 +2384,7 @@ LIMIT $offset, $limit
       while ($dao->fetch()) {
         $row = [];
 
-        foreach (array_keys($this->getSQLColumns()) as $column) {
+        foreach (array_keys($sqlColumns) as $column) {
           $row[$column] = $dao->$column;
         }
         $componentDetails[] = $row;

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -163,6 +163,8 @@ function _civicrm_api3_contact_create_spec(&$params) {
  *
  * @return array
  *   API Result Array
+ *
+ * @throws \API_Exception
  */
 function civicrm_api3_contact_get($params) {
   $options = [];
@@ -382,6 +384,11 @@ function _civicrm_api3_contact_get_spec(&$params) {
  *   Array of options (so we can modify the filter).
  */
 function _civicrm_api3_contact_get_supportanomalies(&$params, &$options) {
+  if (!empty($params['email']) && !is_array($params['email'])) {
+    // Fix this to be in array format so the query object does not add LIKE
+    // I think there is a better fix that I will do for master.
+    $params['email'] = ['=' => $params['email']];
+  }
   if (isset($params['showAll'])) {
     if (strtolower($params['showAll']) == "active") {
       $params['contact_is_deleted'] = 0;

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -367,6 +367,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Verify that attempt to create individual contact with only an email succeeds.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreateEmailIndividual() {
     $primaryEmail = 'man3@yahoo.com';
@@ -397,9 +399,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($primaryEmail, $email1['values'][$email1['id']]['email']);
 
     // Case 3: Check with email_id='primary email id'
-    $result = $this->callAPISuccess('contact', 'get', ['email_id' => $email1['id']]);
-    $this->assertEquals(1, $result['count']);
+    $result = $this->callAPISuccessGetSingle('contact', ['email_id' => $email1['id']]);
     $this->assertEquals($contact1['id'], $result['id']);
+
+    // Check no wildcard is appended
+    $this->callAPISuccessGetCount('Contact', ['email' => 'man3@yahoo.co'], 0);
 
     $this->callAPISuccess('contact', 'delete', $contact1);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Export hooks no longer work.

Before
----------------------------------------
Export hooks don't work.

After
----------------------------------------
Export hooks work.

Technical Details
----------------------------------------
#14913 moved the line that calls the hook to a place where the hook's arguments are mostly not defined.  This defines the arguments.

Comments
----------------------------------------
We're deprecating passing some arguments by reference, because this hook is called too late in the process for the changed values to have any meaning.

The original PR against master is https://github.com/civicrm/civicrm-core/pull/15266, some good discussion there.