### PR TITLE
Fix for core#1247 - export hook doesn't work

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -115,6 +115,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     }
     $processor->setComponentTable($componentTable);
     $processor->setComponentClause($componentClause);
+    $processor->setIds($ids);
 
     list($query, $queryString) = $processor->runQuery($params, $order);
 

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -101,6 +101,13 @@ class CRM_Export_BAO_ExportProcessor {
   protected $contactGreetingFields = [];
 
   /**
+   * An array of primary IDs of the entity being exported.
+   *
+   * @var array
+   */
+  protected $ids = [];
+
+  /**
    * Get additional non-visible fields for address merge purposes.
    *
    * @return array
@@ -583,6 +590,20 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function setQueryOperator($queryOperator) {
     $this->queryOperator = $queryOperator;
+  }
+
+  /**
+   * @return array
+   */
+  public function getIds() {
+    return $this->ids;
+  }
+
+  /**
+   * @param array $ids
+   */
+  public function setIds($ids) {
+    $this->ids = $ids;
   }
 
   /**
@@ -2327,7 +2348,14 @@ WHERE  id IN ( $deleteIDString )
     // call export hook
     $headerRows = $this->getHeaderRows();
     $exportTempTable = $this->getTemporaryTable();
+    $exportMode = $this->getExportMode();
+    $sqlColumns = $this->getSQLColumns();
+    $componentTable = $this->getComponentTable();
+    $ids = $this->getIds();
     CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode, $componentTable, $ids);
+    if ($exportMode !== $this->getExportMode() || $componentTable !== $this->getComponentTable()) {
+      CRM_Core_Error::deprecatedFunctionWarning('altering the export mode and/or component table in the hook is no longer supported.');
+    }
     if ($exportTempTable !== $this->getTemporaryTable()) {
       CRM_Core_Error::deprecatedFunctionWarning('altering the export table in the hook is deprecated (in some flows the table itself will be)');
       $this->setTemporaryTable($exportTempTable);
@@ -2356,7 +2384,7 @@ LIMIT $offset, $limit
       while ($dao->fetch()) {
         $row = [];
 
-        foreach (array_keys($this->getSQLColumns()) as $column) {
+        foreach (array_keys($sqlColumns) as $column) {
           $row[$column] = $dao->$column;
         }
         $componentDetails[] = $row;


### PR DESCRIPTION
Overview
----------------------------------------
Export hooks no longer work.

Before
----------------------------------------
Export hooks don't work.

After
----------------------------------------
Export hooks work.

Technical Details
----------------------------------------
#14913 moved the line that calls the hook to a place where the hook's arguments are mostly not defined.  This defines the arguments.

Comments
----------------------------------------
We're deprecating passing some arguments by reference, because this hook is called too late in the process for the changed values to have any meaning.

The original PR against master is https://github.com/civicrm/civicrm-core/pull/15266, some good discussion there.