### PR TITLE
REF Move ipAddress and CC expiry date to prepareParamsForPaymentProcessor

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -578,9 +578,7 @@ WHERE  contribution_id = {$id}
         $this->_params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($this->_params);
       }
       $this->assign('credit_card_exp_date', CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format($this->_params['credit_card_exp_date'])));
-      $this->assign('credit_card_number',
-        CRM_Utils_System::mungeCreditCard($this->_params['credit_card_number'])
-      );
+      $this->assign('credit_card_number', CRM_Utils_System::mungeCreditCard($this->_params['credit_card_number']));
       $this->assign('credit_card_type', CRM_Utils_Array::value('credit_card_type', $this->_params));
     }
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -862,8 +862,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $params = array_merge($params, $addressParams);
     }
 
-    // @fixme it would be really nice to have a comment here so I had a clue why we are setting $fields[$name] = 1
-    // Also how does relate to similar code in CRM_Contact_BAO_Contact::addBillingNameFieldsIfOtherwiseNotSet()
+    // How does this relate to similar code in CRM_Contact_BAO_Contact::addBillingNameFieldsIfOtherwiseNotSet()?
     $nameFields = ['first_name', 'middle_name', 'last_name'];
     foreach ($nameFields as $name) {
       if (array_key_exists("billing_$name", $params)) {
@@ -871,6 +870,16 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $params['preserveDBName'] = TRUE;
       }
     }
+
+    // For legacy reasons we set these creditcard expiry fields if present
+    if (isset($params['credit_card_exp_date'])) {
+      $params['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($params);
+      $params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($params);
+    }
+
+    // Assign IP address parameter
+    $params['ip_address'] = CRM_Utils_System::ipAddress();
+
     return $params;
   }
 

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -597,21 +597,12 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
    * @throws Exception
    */
   public function make_payment(&$params) {
-    $config = CRM_Core_Config::singleton();
-    if (isset($params["billing_state_province_id-{$this->_bltID}"]) && $params["billing_state_province_id-{$this->_bltID}"]) {
-      $params["billing_state_province-{$this->_bltID}"] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($params["billing_state_province_id-{$this->_bltID}"]);
-    }
-
-    if (isset($params["billing_country_id-{$this->_bltID}"]) && $params["billing_country_id-{$this->_bltID}"]) {
-      $params["billing_country-{$this->_bltID}"] = CRM_Core_PseudoConstant::countryIsoCode($params["billing_country_id-{$this->_bltID}"]);
-    }
-    $params['ip_address'] = CRM_Utils_System::ipAddress();
-    $params['currencyID'] = $config->defaultCurrency;
+    $params = $this->prepareParamsForPaymentProcessor($params);
+    $params['currencyID'] = CRM_Core_Config::singleton()->defaultCurrency;
 
     $payment = Civi\Payment\System::singleton()->getByProcessor($this->_paymentProcessor);
     CRM_Core_Payment_Form::mapParams($this->_bltID, $params, $params, TRUE);
-    $params['month'] = $params['credit_card_exp_date']['M'];
-    $params['year'] = $params['credit_card_exp_date']['Y'];
+
     try {
       $result = $payment->doPayment($params);
     }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -92,12 +92,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $registerParams = $this->_params[0];
       $registerParams = $this->prepareParamsForPaymentProcessor($registerParams);
 
-      if (isset($registerParams['credit_card_exp_date'])) {
-        $registerParams['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($registerParams);
-        $registerParams['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($registerParams);
-      }
       if ($this->_values['event']['is_monetary']) {
-        $registerParams['ip_address'] = CRM_Utils_System::ipAddress();
         $registerParams['currencyID'] = $this->_params[0]['currencyID'];
       }
       //assign back primary participant params.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -1107,12 +1107,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       // This code is duplicated multiple places and should be consolidated.
       $params = $this->prepareParamsForPaymentProcessor($params);
 
-      if (isset($params['credit_card_exp_date'])) {
-        $params['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($params);
-        $params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($params);
-      }
       if ($this->_values['event']['is_monetary']) {
-        $params['ip_address'] = CRM_Utils_System::ipAddress();
         $params['currencyID'] = $config->defaultCurrency;
         $params['invoiceID'] = $invoiceID;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Following on from #15281 this moves two more common parameters into the shared function.

Before
----------------------------------------
$params['ip_address'] set separately in multiple places.
$params['year'/'month'] set separately in multiple places.

After
----------------------------------------
Parameters moved to shared function.

Technical Details
----------------------------------------

Comments
----------------------------------------
@mlutfy This includes adding this function to the event cart which should help improve support for  payment processors there.  Could you give it a quick test?

