### PR TITLE
dev/core#1241 : Custom field value for a new Event based on an Event Template are not checked causing false validation message and Event not to save

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -66,9 +66,9 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
       $this->set('type', 'Event');
       $this->set('subType', CRM_Utils_Array::value('event_type_id', $_POST));
       $this->assign('customDataSubType', CRM_Utils_Array::value('event_type_id', $_POST));
-      $this->set('entityId', $this->_id);
+      $this->set('entityId', $entityID);
 
-      CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_eventType, 1, 'Event', $this->_id);
+      CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_eventType, 1, 'Event', $entityID);
       CRM_Custom_Form_CustomData::buildQuickForm($this);
       CRM_Custom_Form_CustomData::setDefaultValues($this);
     }


### PR DESCRIPTION

Overview
----------------------------------------
Steps to reproduce:

1. Create a custom field, assign to Events and set to be a required field
2. Create a new Event
3. Select an Event Template for the Event
4. Set a value for the custom field
5. Save the Event
6. Validation message appears for custom field, even though a value has been set
7. Event does not save
8. If no Event Template is selected then field validation is correct and the Event will save

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/64771332-6a699780-d56c-11e9-8b74-3c24806b6552.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/64771153-2080b180-d56c-11e9-99bd-74d56574270b.gif)


ping @mlutfy @jusfreeman 