### PR TITLE
dev/core#826

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3376,7 +3376,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
             if ($value && empty($field['no_display'])) {
               $statistics['filters'][] = [
                 'title' => CRM_Utils_Array::value('title', $field),
-                'value' => $value,
+                'value' => CRM_Utils_String::htmlToText($value),
               ];
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------

Reports show `&nbsp;` in filters with child-groups

![image](https://user-images.githubusercontent.com/47253287/64799889-da384c00-d585-11e9-9660-5251a773e5f3.png)

Before
----------------------------------------
Reports show `&nbsp;` in filters with child-groups

After
----------------------------------------
Reports dont show `&nbsp;` in filters with child-groups

Technical Details
----------------------------------------
Implemented in CRM/Report/Form.php

Comments
----------------------------------------
link issue: https://lab.civicrm.org/dev/core/issues/826
