### PR TITLE
CRM_Utils_JS - Strip extra newlines when stripping comments

### DIFF
--- a/CRM/Utils/JS.php
+++ b/CRM/Utils/JS.php
@@ -123,7 +123,7 @@ class CRM_Utils_JS {
    * @return string
    */
   public static function stripComments($script) {
-    return preg_replace(":^\\s*//[^\n]+$:m", "", $script);
+    return preg_replace([":^\\s*//[^\n]+$:m", ':\n\n+:'], ["", "\n"], $script);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -168,8 +168,8 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
   public function stripCommentsExamples() {
     $cases = [];
     $cases[] = [
-      "a();\n//# sourceMappingURL=../foo/bar/baz.js\nb();",
-      "a();\n\nb();",
+      "a();\n//# sourceMappingURL=../foo/bar/baz.js\n\n\nb();",
+      "a();\nb();",
     ];
     $cases[] = [
       "// foo\na();",
@@ -181,11 +181,11 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
     ];
     $cases[] = [
       "/// foo\na();\n\t \t//bar\nb();\n// whiz",
-      "\na();\n\nb();\n",
+      "\na();\nb();\n",
     ];
     $cases[] = [
       "alert('//# sourceMappingURL=../foo/bar/baz.js');\n//zoop\na();",
-      "alert('//# sourceMappingURL=../foo/bar/baz.js');\n\na();",
+      "alert('//# sourceMappingURL=../foo/bar/baz.js');\na();",
     ];
     return $cases;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Makes output from CRM_Utils_JS::stripComments() smaller by eliminating duplicate newlines.

Before
----------------------------------------
After stripping a comment, an extra newline was left in the js.

After
----------------------------------------
Extra newlines removed.

Technical Details
----------------------------------------
This is going to make our javascript files **one byte smaller** per comment! Some very large files might even shave off upwards of **ten bytes!** This was completely worth my time.