### PR TITLE
Stop passing exportMode, componentTable and ids by reference in export hook

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2359,6 +2359,9 @@ WHERE  id IN ( $deleteIDString )
     if ($exportMode !== $this->getExportMode() || $componentTable !== $this->getComponentTable()) {
       CRM_Core_Error::deprecatedFunctionWarning('altering the export mode and/or component table in the hook is no longer supported.');
     }
+    if ($ids !== $this->getIds()) {
+      CRM_Core_Error::deprecatedFunctionWarning('altering the ids in the hook is no longer supported.');
+    }
     if ($exportTempTable !== $this->getTemporaryTable()) {
       CRM_Core_Error::deprecatedFunctionWarning('altering the export table in the hook is deprecated (in some flows the table itself will be)');
       $this->setTemporaryTable($exportTempTable);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1368,7 +1368,7 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function export(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode, $componentTable, $ids) {
+  public static function export(&$exportTempTable, &$headerRows, &$sqlColumns, $exportMode, $componentTable, $ids) {
     return self::singleton()->invoke(['exportTempTable', 'headerRows', 'sqlColumns', 'exportMode', 'componentTable', 'ids'],
       $exportTempTable, $headerRows, $sqlColumns,
       $exportMode, $componentTable, $ids,

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1368,7 +1368,7 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function export(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode, &$componentTable, &$ids) {
+  public static function export(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode, $componentTable, $ids) {
     return self::singleton()->invoke(['exportTempTable', 'headerRows', 'sqlColumns', 'exportMode', 'componentTable', 'ids'],
       $exportTempTable, $headerRows, $sqlColumns,
       $exportMode, $componentTable, $ids,


### PR DESCRIPTION
Overview
----------------------------------------
As per discussion on a recent export ticket it was discovered that its practically impossible to alter exportMode, ComponentTable and the ids array according to @MegaphoneJon https://github.com/civicrm/civicrm-core/pull/15266#issuecomment-530578734 and backed up by @scardinius https://github.com/civicrm/civicrm-core/pull/15266#issuecomment-530691330

ping @MegaphoneJon @eileenmcnaughton @scardinius 