### PR TITLE
[NFC] Reword event docs to clarify priority vs weight

### DIFF
--- a/Civi/API/Events.php
+++ b/Civi/API/Events.php
@@ -33,8 +33,7 @@ namespace Civi\API;
  * event is dispatched.
  *
  * Event subscribers which are concerned about the order of execution should assign
- * a weight to their subscription (such as W_EARLY, W_MIDDLE, or W_LATE).
- * W_LATE).
+ * a priority to their subscription (such as W_EARLY, W_MIDDLE, or W_LATE).
  */
 class Events {
 
@@ -78,17 +77,17 @@ class Events {
   const EXCEPTION = 'civi.api.exception';
 
   /**
-   * Weight - Early
+   * Priority - Higher numbers execute earlier
    */
   const W_EARLY = 100;
 
   /**
-   * Weight - Middle
+   * Priority - Middle
    */
   const W_MIDDLE = 0;
 
   /**
-   * Weight - Late
+   * Priority - Lower numbers execute later
    */
   const W_LATE = -100;
 


### PR DESCRIPTION
Overview
----------------------------------------
In CiviCRM we have the concept of "weight", e.g. custom fields and option values have a "weight" which determines the order in which they are displayed. With weights, lower numbers always come before higher numbers (in sql terms we `ORDER BY weight ASC`).

Symfony events have a concept of "priority" also using numbers, but the order is reversed from weight, where events with a *higher* priority execute first (in sql terms event listeners `ORDER BY priority DESC`).

So I think it was a mistake to conflate the two in `Civi\Api\Events` and refer to "priority" as "weight". It's led to a lot of confusion (at least with me) about which listeners actually come first. I've reworded the docs here. Renaming the constants would break things though so I left them alone.