### PR TITLE
dev/core#1255 - fix display of email address on pay later contribution

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -576,21 +576,30 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->assign('onBehalfEmail', $this->_params['onbehalf_location']['email'][$locTypeId[0]]['email']);
     }
     $this->assignPaymentFields();
+    $this->assignEmailField();
 
+    // also assign the receipt_text
+    if (isset($this->_values['receipt_text'])) {
+      $this->assign('receipt_text', $this->_values['receipt_text']);
+    }
+  }
+
+  /**
+   * Assign email variable in the template.
+   */
+  public function assignEmailField() {
+    //If email exist in a profile, the default billing email field is not loaded on the page.
+    //Hence, assign the existing location type email by iterating through the params.
     if ($this->_emailExists && empty($this->_params["email-{$this->_bltID}"])) {
       foreach ($this->_params as $key => $val) {
         if (substr($key, 0, 6) == 'email-') {
           $this->assign('email', $this->_params[$key]);
+          break;
         }
       }
     }
     else {
       $this->assign('email', CRM_Utils_Array::value("email-{$this->_bltID}", $this->_params));
-    }
-
-    // also assign the receipt_text
-    if (isset($this->_values['receipt_text'])) {
-      $this->assign('receipt_text', $this->_values['receipt_text']);
     }
   }
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -577,9 +577,16 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
     $this->assignPaymentFields();
 
-    $this->assign('email',
-      $this->controller->exportValue('Main', "email-{$this->_bltID}")
-    );
+    if ($this->_emailExists && empty($this->_params["email-{$this->_bltID}"])) {
+      foreach ($this->_params as $key => $val) {
+        if (substr($key, 0, 6) == 'email-') {
+          $this->assign('email', $this->_params[$key]);
+        }
+      }
+    }
+    else {
+      $this->assign('email', CRM_Utils_Array::value("email-{$this->_bltID}", $this->_params));
+    }
 
     // also assign the receipt_text
     if (isset($this->_values['receipt_text'])) {

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
@@ -84,9 +84,11 @@ class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
     $pageContribution = $this->getPageContribution((($withPendingContribution) ? 2 : 1), $isTestContribution);
     $form = $this->getThankYouForm();
     $form->_lineItem = [];
+    $form->_bltID = 5;
 
     $form->_params['contributionID'] = $pageContribution['contribution_id'];
     $form->_params['invoiceID'] = $pageContribution['invoice_id'];
+    $form->_params['email-5'] = 'demo@example.com';
     $form->_params['payment_processor_id'] = $paymentProcessorID;
     if ($isTestContribution) {
       $form->_mode = 'test';


### PR DESCRIPTION
Overview
----------------------------------------
Fix for email address token on the confirmation message not working for a pay later contribution

Before
----------------------------------------
Email address is not displayed on the Thankyou screen. To replicate -

- Add a profile with an email(email-primary) field.
- Include this profile on a contribution page.
- Submit the page with pay later and notice the below confirmation message on the thankyou page-

![image](https://user-images.githubusercontent.com/5929648/64950144-62756480-d898-11e9-96df-b62a6608b903.png)

The second line ends with "has been sent to .". This should be displaying an email address of the user.

After
----------------------------------------
The confirmation message displays an email address correctly.

![image](https://user-images.githubusercontent.com/5929648/64950209-7ae57f00-d898-11e9-8a34-3b7aa8b933fe.png)


Comments
----------------------------------------
Gitlab link - https://lab.civicrm.org/dev/core/issues/1255