### PR TITLE
reporting-20: don't display soft credits by default when force=1

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -530,7 +530,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
       $this->noDisplayContributionOrSoftColumn = TRUE;
     }
 
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) == 'contributions_only') {
+    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params, 'contributions_only') == 'contributions_only') {
       $this->isContributionBaseMode = TRUE;
     }
     if ($this->isContributionBaseMode &&


### PR DESCRIPTION
https://lab.civicrm.org/dev/report/issues/20

Overview
----------------------------------------
When you load the Contribution Detail report with `force=1` it shows soft credits by default.  Without force=1, the default is to NOT show soft credits.  This sets the `force=1` default in line with the more common use case.

Before
----------------------------------------
`$params['contributions_or_soft_credits']` being undefined means "show soft credits".

After
----------------------------------------
`$params['contributions_or_soft_credits']` being undefined means "don't show soft credits".

Technical Details
----------------------------------------
The issue is that this piece of code assumes `contributions_or_soft_credits` is always defined, and the report defaults to `contributions_only`.  However, this param isn't defined when `force=1`.

Steps to replicate are on the ticket: https://lab.civicrm.org/dev/report/issues/20