### PR TITLE
Secondarily order campaign dashboard by id

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -399,6 +399,7 @@ INNER JOIN civicrm_option_group grp ON ( campaign_type.option_group_id = grp.id 
       if ($orderOnCampaignTable) {
         $orderByClause = "ORDER BY campaign.{$sortParams['sort']} {$sortParams['sortOrder']}";
       }
+      $orderByClause .= ", campaign.id {$sortParams['sortOrder']}";
       $limitClause = "LIMIT {$sortParams['offset']}, {$sortParams['rowCount']}";
     }
 

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -399,7 +399,7 @@ INNER JOIN civicrm_option_group grp ON ( campaign_type.option_group_id = grp.id 
       if ($orderOnCampaignTable) {
         $orderByClause = "ORDER BY campaign.{$sortParams['sort']} {$sortParams['sortOrder']}";
       }
-      $orderByClause .= ", campaign.id {$sortParams['sortOrder']}";
+      $orderByClause = ( $orderByClause ) ?  $orderByClause . ", campaign.id {$sortParams['sortOrder']}" : $orderByClause;
       $limitClause = "LIMIT {$sortParams['offset']}, {$sortParams['rowCount']}";
     }
 

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -399,7 +399,7 @@ INNER JOIN civicrm_option_group grp ON ( campaign_type.option_group_id = grp.id 
       if ($orderOnCampaignTable) {
         $orderByClause = "ORDER BY campaign.{$sortParams['sort']} {$sortParams['sortOrder']}";
       }
-      $orderByClause = ( $orderByClause ) ?  $orderByClause . ", campaign.id {$sortParams['sortOrder']}" : $orderByClause;
+      $orderByClause = ($orderByClause) ? $orderByClause . ", campaign.id {$sortParams['sortOrder']}" : $orderByClause;
       $limitClause = "LIMIT {$sortParams['offset']}, {$sortParams['rowCount']}";
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
If multiple campaigns are added quickly, they are sorted on start date. However, they can get out of order, because start date rounds up to the nearest minute. This could confuse users and just looks funny. This patch adds a secondary order by on id for any campaign list query, taking the sort order from the params.

Before
----------------------------------------
The ordering is unclear because all start dates are the same.
![CampaignDashboard-Before](https://user-images.githubusercontent.com/4406809/65063539-75e20780-d94c-11e9-9778-65887655c555.png)


After
----------------------------------------
It sorts by id after start date.
![image](https://user-images.githubusercontent.com/4406809/65063584-8e522200-d94c-11e9-8f87-acfab71212f0.png)

Note that it still sorts correctly by start date if they vary.
![image](https://user-images.githubusercontent.com/4406809/65063802-f9035d80-d94c-11e9-9847-006b244c93d9.png)






Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
