### PR TITLE
dev/core/1259 update config checklist contribution section

### DIFF
--- a/CRM/Admin/Page/ConfigTaskList.php
+++ b/CRM/Admin/Page/ConfigTaskList.php
@@ -57,6 +57,17 @@ class CRM_Admin_Page_ConfigTaskList extends CRM_Core_Page {
 
     $this->assign('registerSite', htmlspecialchars('https://civicrm.org/register-your-site?src=iam&sid=' . CRM_Utils_System::getSiteID()));
 
+    //Provide ability to optionally display some component checklist items when components are on
+    $result = civicrm_api3('Setting', 'get', [
+      'sequential' => 1,
+      'return' => ["enable_components"],
+    ]);
+    $enabled = array();
+    foreach ($result['values'][0]['enable_components'] as $component) {
+      $enabled[$component] = 1;
+    }
+    $this->assign('enabledComponents', $enabled);
+
     return parent::run();
   }
 

--- a/templates/CRM/Admin/Page/ConfigTaskList.tpl
+++ b/templates/CRM/Admin/Page/ConfigTaskList.tpl
@@ -105,13 +105,15 @@
             {else}
                 <td class="tasklist"><a href="{$config->userFrameworkBaseURL}?q=admin/user/permissions&civicrmDestination=civicrm/admin/configtask">{ts}Permissions for Anonymous Users{/ts}</a></td>
             {/if}
-            <td>{ts}You will also need to change Drupal permissions so anonymous users can make contributions, register for events and / or use profiles to enter contact information.{/ts} {docURL page="Default Permissions and Roles" resource="wiki"}</td>
+            <td>{ts}You will also need to change Drupal permissions so anonymous users can make contributions, register for events and / or use profiles to enter contact information.{/ts} {docURL page="user/en/latest/initial-set-up/permissions-and-access-control" text="(learn more...)"}</td>
         </tr>
     {/if}
-    <tr class="even">
-        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/messageTemplates" q="selectedChild=workflow&reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}System Workflow Templates{/ts}</a></td>
-        <td>{ts}Review and modify the templates used for system-generated emails, including contribution receipts and event registration confirmations.{/ts}</td>
-    </tr>
+    {if $enabledComponents.CiviContribute eq 1}
+      <tr class="even">
+          <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/preferences/contribute" q="selectedChild=workflow&reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}CiviContribute Component Settings{/ts}</a></td>
+          <td>{ts}Review and modify the CiviContribute Component settings such as Taxes and Invoicing, Deferred Revenue, and Access Control by Financial Type{/ts}</td>
+      </tr>
+    {/if}
 </table>
 <br />
 


### PR DESCRIPTION
Overview
----------------------------------------
Updates to make the Online Contributions section of the Config Checklist more useful.

Overview in this issue: https://lab.civicrm.org/dev/core/issues/1259

Before
----------------------------------------
- Configuration Checklist omits CiviContribute Component Settings page which is important for a user to review before entering contribution data / taking contributions.
- Configuration Checklist includes a direct link to edit System Workflow Templates, which is perhaps not where a new user should be pointed to at this stage (system workflow templates are confusing to a new user and easily becomes destructive).
- The "learn more" link under the Drupal anonymous permissions entry leads to the old wiki

After
----------------------------------------
- Configuration Checklist checks if CiviContribute is enabled, and if so includes the CiviContribute Component Settings page as an item to check
- System workflow templates list item has been removed
- "learn more" link under Drupal anonymous permissions leads to its docs.civicrm.org article

![image](https://user-images.githubusercontent.com/12917373/65065792-f64a3d80-d937-11e9-94e2-a89f3f151b99.png)

Technical Details
----------------------------------------
Nothing noteworthy
