### PR TITLE
dev/drupal#89 - Drupal 8 - Contact Report does not load any values in…

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -109,11 +109,7 @@ class CRM_Report_Form_Instance {
     );
 
     // prepare user_roles to save as names not as ids
-    if (function_exists('user_roles')) {
-      $user_roles_array = user_roles();
-      foreach ($user_roles_array as $key => $value) {
-        $user_roles[$value] = $value;
-      }
+    if ($user_roles = CRM_Core_Config::singleton()->userSystem->getRoleNames()) {
       $grouprole = $form->addElement('advmultiselect',
         'grouprole',
         ts('ACL Group/Role'),

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -981,4 +981,13 @@ abstract class CRM_Utils_System_Base {
     session_start();
   }
 
+  /**
+   * Get role names
+   *
+   * @return array|null
+   */
+  public function getRoleNames() {
+    return NULL;
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -794,4 +794,13 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return $url;
   }
 
+  /**
+   * Get role names
+   *
+   * @return array|null
+   */
+  public function getRoleNames() {
+    return user_role_names();
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -681,4 +681,13 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     }
   }
 
+  /**
+   * Get role names
+   *
+   * @return array|null
+   */
+  public function getRoleNames() {
+    return array_combine(user_roles(), user_roles());
+  }
+
 }


### PR DESCRIPTION
… the ACL Group/Role field

Overview
----------------------------------------
Contact Report does not load any values in the ACL Group/Role field

Before
----------------------------------------
No roles are displayed in ACL Group/Role.

![image](https://user-images.githubusercontent.com/5929648/65123948-01719c00-da12-11e9-8734-7916c9077a6b.png)

After
----------------------------------------
Roles are listed correctly -

![image](https://user-images.githubusercontent.com/5929648/65124021-2403b500-da12-11e9-8f82-cb730449245a.png)


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/drupal/issues/89