### PR TITLE
dev/core#1262 - Fix case status order in case type settings page

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -57,7 +57,10 @@
             reqs.caseStatuses = ['OptionValue', 'get', {
               option_group_id: 'case_status',
               sequential: 1,
-              options: {limit: 0}
+              options: {
+                sort: 'weight',
+                limit: 0
+              }
             }];
             reqs.actTypes = ['OptionValue', 'get', {
               option_group_id: 'activity_type',


### PR DESCRIPTION
Overview
----------------------------------------
In the case type settings/config page, where we have a tab for 'Case status' that lists all case statuses from which we can select the ones we want for that case type.
This list of case statuses are not ordered by their weight which would the correct way to list these.

Before
----------------------------------------
I have added a screenshot of the page when adding a new case type. In this the case status 'first' has the lowest weight and so I expect to see it on the top of the list.
![screenshot-localhost-2019 09 18-11_02_06](https://user-images.githubusercontent.com/36624620/65128118-76df6b80-da16-11e9-8410-3f4d78971d4b.png)

After
----------------------------------------
Now the case statuses are sorted by their weight.
![screenshot-localhost-2019 09 18-13_22_24](https://user-images.githubusercontent.com/36624620/65128612-68458400-da17-11e9-862c-e02205c03ff0.png)

Technical Details
----------------------------------------
In crmCaseType.js, where case statues are obtained (reqs.caseStatuses), I have added 'sort: 'weight'' to the options array.
