### PR TITLE
dev/core#1264 - Fix notice error on contribution page

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4690,7 +4690,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // if we are still empty see if we can use anything from a contribution page.
     if (!empty($pageValues['receipt_from_email'])) {
       return [
-        $pageValues['receipt_from_name'],
+        CRM_Utils_Array::value('receipt_from_name', $pageValues),
         $pageValues['receipt_from_email'],
       ];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes e-notice display on the contribution page.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/5929648/65136191-c7f65c00-da24-11e9-8f17-00ae61f1bdf2.png)

Above error is displayed when the contribution page is missing a receipt name in settings. To replicate -

- Create a contribution page with empty `Receipt From Name` field in `Receipts` tab.
- Submit a payment using a dummy processor. The thankyou page displays the above notice error.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1264