### PR TITLE
Remove Print Icon

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -286,9 +286,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // we do not want to display recently viewed items, so turn off
     $this->assign('displayRecent', FALSE);
-    // Contribution page values are cleared from session, so can't use normal Printer Friendly view.
-    // Use Browser Print instead.
-    $this->assign('browserPrint', TRUE);
 
     // action
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -193,12 +193,6 @@ class CRM_Core_Invoke {
     $template->assign('formTpl', 'default');
 
     if ($item) {
-      // CRM-7656 - make sure we send a clean sanitized path to create printer friendly url
-      $printerFriendly = CRM_Utils_System::makeURL(
-          'snippet', FALSE, FALSE,
-          CRM_Utils_Array::value('path', $item)
-        ) . '2';
-      $template->assign('printerFriendly', $printerFriendly);
 
       if (!array_key_exists('page_callback', $item)) {
         CRM_Core_Error::debug('Bad item', $item);

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -394,9 +394,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     // we do not want to display recently viewed items on Registration pages
     $this->assign('displayRecent', FALSE);
-    // Registration page values are cleared from session, so can't use normal Printer Friendly view.
-    // Use Browser Print instead.
-    $this->assign('browserPrint', TRUE);
 
     $isShowLocation = CRM_Utils_Array::value('is_show_location', $this->_values['event']);
     $this->assign('isShowLocation', $isShowLocation);

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1812,16 +1812,6 @@ input.crm-form-entityref {
 
 /* Set/alter ICONS */
 
-#crm-container div#printer-friendly {
-  float: right;
-  position: relative;
-  margin: -2em 0.5em 0 0;
-}
-/* For Joomla, margin 0 works correctly */
-#crm-container table#crm-content div#printer-friendly {
-  margin: 0;
-}
-
 #crm-container .order-icon {
   height: 15px;
   width: 10px;

--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -40,22 +40,6 @@
   </div>
 {/if}
 
-{if isset($browserPrint) and $browserPrint}
-{* Javascript window.print link. Used for public pages where we can't do printer-friendly view. *}
-<div id="printer-friendly">
-<a href="#" onclick="window.print(); return false;" title="{ts}Print this page.{/ts}">
-  <i class="crm-i fa-print"></i>
-</a>
-</div>
-{else}
-{* Printer friendly link/icon. *}
-<div id="printer-friendly">
-<a href="{$printerFriendly}" target='_blank' title="{ts}Printer-friendly view of this page.{/ts}">
-  <i class="crm-i fa-print"></i>
-</a>
-</div>
-{/if}
-
 {if $pageTitle}
   <div class="crm-title">
     <h1 class="title">{if $isDeleted}<del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>

--- a/templates/CRM/common/joomla.tpl
+++ b/templates/CRM/common/joomla.tpl
@@ -49,14 +49,6 @@
     </div>
     {/if}
 
-{if $browserPrint}
-{* Javascript window.print link. Used for public pages where we can't do printer-friendly view. *}
-<div id="printer-friendly"><a href="#" onclick="window.print(); return false;" title="{ts}Print this page.{/ts}"><i class="crm-i fa-print"></i></a></div>
-{else}
-{* Printer friendly link/icon. *}
-<div id="printer-friendly"><a href="{$printerFriendly}" target='_blank' title="{ts}Printer-friendly view of this page.{/ts}"><i class="crm-i fa-print"></i></a></div>
-{/if}
-
 {if $pageTitle}
   <div class="crm-title">
     <h1 class="title">{if $isDeleted}<del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>


### PR DESCRIPTION
Overview
----------------------------------------
Removes the print icon from the upper left hand corner of all pages because printing the page nearly always looks better then printing by clicking the print icon.

Before
----------------------------------------
Printer icon in the upper left corner of all pages
![print Icon](https://user-images.githubusercontent.com/11323624/65156863-c8c7c780-d9fd-11e9-850a-47d526054d9e.png)


After
----------------------------------------
No printer icon
![no Print Icon](https://user-images.githubusercontent.com/11323624/65156883-d2e9c600-d9fd-11e9-819a-0e01c83dd4cc.png)
