### PR TITLE
dev/core/1266 widget header tab next state to pcp tab

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -412,6 +412,11 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
           $nextPage = 'thankyou';
           break;
 
+        case 'Widget':
+          $subPage = 'widget';
+          $nextPage = 'pcp';
+          break;
+
         default:
           $subPage = strtolower($className);
           $nextPage = strtolower($nextPage);


### PR DESCRIPTION
Overview
----------------------------------------
When configuring a contribution page through the GUI, clicking save and next typically moves a user to the next tab header. Only on the last tab the user will get a "Save & Done" button that brings them back to the "Manage Contribution Pages" screen.

Currently the "Save & Next" button on the second-to-last tab (Widgets) boots the user back to "Manage Contribution Pages" instead of moving them to the "Personal Campaigns" tab as expected.

Issue: https://lab.civicrm.org/dev/core/issues/1266

Before
----------------------------------------
Clicking "Save and Next" on the Widgets tab when configuring a contribution page brings user back to the "Manage Contribution Pages" screen instead of to the "Personal Campaigns" tab for that contribution page config.

After
----------------------------------------
Clicking "Save and Next" on the Widgets tab when configuring a contribution page brings user to the "Personal Campaigns" tab for that contribution page config.

Technical Details
----------------------------------------
This is a workaround with a precedent (I have added a case to a state override switch already in place). It would probably be better if the state machine brought back useful class names for the widget, pcp, etc pages even though the class structure is different than the other tabs, but that would involve much bigger changes like moving classes around than this issue warrants.
