### PR TITLE
Toggle image inputs based on participant image selection

### DIFF
--- a/templates/CRM/Badge/Form/Layout.js
+++ b/templates/CRM/Badge/Form/Layout.js
@@ -24,6 +24,30 @@ CRM.$(function($) {
     );
   }
 
+  //toggle image inputs based on whether and where participant image is used
+  toggleImages();
+  $('#show_participant_image').change( function(){
+    toggleImages();
+  });
+  $('#alignment_participant_image').change( function(){
+    toggleImages();
+  } );
+
+  function toggleImages() {
+    var align = $('#alignment_participant_image').val();
+
+    $('.crm-badge-layout-form-block-image_1').show();
+    $('.crm-badge-layout-form-block-image_2').show();
+    if( $('#show_participant_image').is(':checked') ) {
+      if (align == "L") {
+        $('.crm-badge-layout-form-block-image_1').hide();
+      }
+      else if (align == "R") {
+        $('.crm-badge-layout-form-block-image_2').hide();
+      }
+    }
+  }
+
   $('input[id^="image_"]')
     .click(openKCFinder)
     .change(function() {

--- a/templates/CRM/Badge/Form/Layout.tpl
+++ b/templates/CRM/Badge/Form/Layout.tpl
@@ -46,46 +46,6 @@
         <td class="label">{$form.description.label}</td>
         <td>{$form.description.html}</td>
       </tr>
-      <tr class="crm-badge-layout-form-block-image_1">
-        <td class="label">{$form.image_1.label}</td>
-        <td>
-         <table>
-           <tr>
-            <td>{$form.image_1.html}
-               <a href="#" class="crm-hover-button clear-image" title="{ts}Clear{/ts}"><i class="crm-i fa-times"></i></a>
-             <br/>
-             <span class="description">{ts}Click above and select a file by double clicking on it.{/ts}</span>
-            </td>
-            <td>
-             {$form.width_image_1.html}<br/>{$form.width_image_1.label}
-            </td>
-           <td>
-              {$form.height_image_1.html}</br>{$form.height_image_1.label}
-            </td>
-           </tr>
-         </table>
-        </td>
-      </tr>
-      <tr class="crm-badge-layout-form-block-image_2">
-        <td class="label">{$form.image_2.label}</td>
-        <td>
-         <table>
-          <tr>
-           <td>{$form.image_2.html}
-              <a href="#" class="crm-hover-button clear-image" title="{ts}Clear{/ts}"><i class="crm-i fa-times"></i></a>
-            <br/>
-            <span class="description">{ts}Click above and select a file by double clicking on it.{/ts}</span>
-           </td>
-           <td>
-            {$form.width_image_2.html}<br/>{$form.width_image_2.label}
-           </td>
-           <td>
-            {$form.height_image_2.html}<br/>{$form.height_image_2.label}
-           </td>
-          </tr>
-         </table>
-        </td>
-      </tr>
       <tr class="crm-badge-layout-form-block-participant_image">
         <td class="label">{$form.show_participant_image.label}</td>
         <td>
@@ -108,6 +68,46 @@
          </table>
         </td>
       </tr>
+        <tr class="crm-badge-layout-form-block-image_1">
+            <td class="label">{$form.image_1.label}</td>
+            <td>
+                <table>
+                    <tr>
+                        <td>{$form.image_1.html}
+                            <a href="#" class="crm-hover-button clear-image" title="{ts}Clear{/ts}"><i class="crm-i fa-times"></i></a>
+                            <br/>
+                            <span class="description">{ts}Click above and select a file by double clicking on it.{/ts}</span>
+                        </td>
+                        <td>
+                            {$form.width_image_1.html}<br/>{$form.width_image_1.label}
+                        </td>
+                        <td>
+                            {$form.height_image_1.html}</br>{$form.height_image_1.label}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr class="crm-badge-layout-form-block-image_2">
+            <td class="label">{$form.image_2.label}</td>
+            <td>
+                <table>
+                    <tr>
+                        <td>{$form.image_2.html}
+                            <a href="#" class="crm-hover-button clear-image" title="{ts}Clear{/ts}"><i class="crm-i fa-times"></i></a>
+                            <br/>
+                            <span class="description">{ts}Click above and select a file by double clicking on it.{/ts}</span>
+                        </td>
+                        <td>
+                            {$form.width_image_2.html}<br/>{$form.width_image_2.label}
+                        </td>
+                        <td>
+                            {$form.height_image_2.html}<br/>{$form.height_image_2.label}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
       <tr class="crm-badge-layout-form-block-elements">
         <td class="label"><label>{ts}Elements{/ts}</label></td>
         <td>


### PR DESCRIPTION
Overview
----------------------------------------
I noticed that when editing name badge layouts, if a user selects use participant image, they can still add an image in the same position as the participant image. I also moved the "Use participant image?" checkbox above the image selectors.
Before
----------------------------------------
Participant image in use and image in the same position available to select.
![image](https://user-images.githubusercontent.com/4406809/65160339-8acda200-da03-11e9-9ce6-0f40bed7b232.png)


After
----------------------------------------
Participant image positioned above and is checked and image in the same position input hidden.
![image](https://user-images.githubusercontent.com/4406809/65163631-40e7ba80-da09-11e9-9469-27341beba889.png)







Technical Details
----------------------------------------
I added the jquery to the existing js file. I'm very open to feedback on the jQuery :).

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
