### PR TITLE
CiviMail - Only display "Headers and Footers" if there are headers and footers

### DIFF
--- a/ang/crmMailing.js
+++ b/ang/crmMailing.js
@@ -47,6 +47,9 @@
           selectedMail: function($route, crmMailingMgr) {
             return crmMailingMgr.get($route.current.params.id);
           },
+          mailingFields: function(crmMetadata) {
+            return crmMetadata.getFields('Mailing');
+          },
           attachments: function($route, CrmAttachments) {
             var attachments = new CrmAttachments(function () {
               return {entity_table: 'civicrm_mailing', entity_id: $route.current.params.id};

--- a/ang/crmMailing/EditMailingCtrl.js
+++ b/ang/crmMailing/EditMailingCtrl.js
@@ -1,12 +1,13 @@
 (function(angular, $, _) {
 
-  angular.module('crmMailing').controller('EditMailingCtrl', function EditMailingCtrl($scope, selectedMail, $location, crmMailingMgr, crmStatus, attachments, crmMailingPreviewMgr, crmBlocker, CrmAutosaveCtrl, $timeout, crmUiHelp) {
+  angular.module('crmMailing').controller('EditMailingCtrl', function EditMailingCtrl($scope, selectedMail, $location, crmMailingMgr, crmStatus, attachments, crmMailingPreviewMgr, crmBlocker, CrmAutosaveCtrl, $timeout, crmUiHelp, mailingFields) {
     var APPROVAL_STATUSES = {'Approved': 1, 'Rejected': 2, 'None': 3};
 
     $scope.mailing = selectedMail;
     $scope.attachments = attachments;
     $scope.crmMailingConst = CRM.crmMailing;
     $scope.checkPerm = CRM.checkPerm;
+    $scope.mailingFields = mailingFields;
 
     var ts = $scope.ts = CRM.ts(null);
     $scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});

--- a/ang/crmMailing/EditMailingCtrl/2step.html
+++ b/ang/crmMailing/EditMailingCtrl/2step.html
@@ -17,7 +17,7 @@
           <div crm-ui-tab id="tab-attachment" crm-title="ts('Attachments')">
             <div crm-attachments="attachments"></div>
           </div>
-          <div crm-ui-tab id="tab-header" crm-title="ts('Header and Footer')">
+          <div crm-ui-tab id="tab-header" crm-title="ts('Header and Footer')" ng-if="mailingFields.header_id.options.length > 0 || mailingFields.footer_id.options.length > 0">
             <div crm-mailing-block-header-footer crm-mailing="mailing"></div>
           </div>
           <div crm-ui-tab id="tab-pub" crm-title="ts('Publication')">

--- a/ang/crmMailing/EditMailingCtrl/workflow.html
+++ b/ang/crmMailing/EditMailingCtrl/workflow.html
@@ -13,7 +13,7 @@
           <div crm-mailing-body-text crm-mailing="mailing"></div>
         </div>
         <span ng-model="placeholder" crm-ui-validate="mailing.body_html || mailing.body_text"></span>
-        <div crm-ui-accordion="{title: ts('Header and Footer'), collapsed: true}">
+        <div crm-ui-accordion="{title: ts('Header and Footer'), collapsed: true}" ng-if="mailingFields.header_id.options.length > 0 || mailingFields.footer_id.options.length > 0">
           <div crm-mailing-block-header-footer crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Attachments'), collapsed: true}">

--- a/ang/crmMailingAB.js
+++ b/ang/crmMailingAB.js
@@ -32,6 +32,9 @@
         templateUrl: '~/crmMailingAB/EditCtrl/main.html',
         controller: 'CrmMailingABEditCtrl',
         resolve: {
+          mailingFields: function(crmMetadata) {
+            return crmMetadata.getFields('Mailing');
+          },
           abtest: function($route, CrmMailingAB) {
             var abtest = new CrmMailingAB($route.current.params.id == 'new' ? null : $route.current.params.id);
             return abtest.load();

--- a/ang/crmMailingAB/EditCtrl.js
+++ b/ang/crmMailingAB/EditCtrl.js
@@ -1,6 +1,6 @@
 (function(angular, $, _) {
 
-  angular.module('crmMailingAB').controller('CrmMailingABEditCtrl', function($scope, abtest, crmMailingABCriteria, crmMailingMgr, crmMailingPreviewMgr, crmStatus, $q, $location, crmBlocker, $interval, $timeout, CrmAutosaveCtrl, dialogService) {
+  angular.module('crmMailingAB').controller('CrmMailingABEditCtrl', function($scope, abtest, crmMailingABCriteria, crmMailingMgr, crmMailingPreviewMgr, crmStatus, $q, $location, crmBlocker, $interval, $timeout, CrmAutosaveCtrl, dialogService, mailingFields) {
     $scope.abtest = abtest;
     var ts = $scope.ts = CRM.ts(null);
     var block = $scope.block = crmBlocker();
@@ -9,6 +9,7 @@
     $scope.crmMailingABCriteria = crmMailingABCriteria;
     $scope.crmMailingConst = CRM.crmMailing;
     $scope.checkPerm = CRM.checkPerm;
+    $scope.mailingFields = mailingFields;
 
     $scope.isSubmitted = function isSubmitted() {
       return _.size(abtest.mailings.a.jobs) > 0 || _.size(abtest.mailings.b.jobs) > 0;

--- a/ang/crmMailingAB/EditCtrl/edit.html
+++ b/ang/crmMailingAB/EditCtrl/edit.html
@@ -63,7 +63,7 @@
             <div crm-attachments="abtest.attachments.a"></div>
           </div>
           -->
-          <div crm-ui-tab id="tab-header" crm-title="ts('Header and Footer')">
+          <div crm-ui-tab id="tab-header" crm-title="ts('Header and Footer')" ng-if="mailingFields.header_id.options.length > 0 || mailingFields.footer_id.options.length > 0">
             <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.a"></div>
           </div>
           <div crm-ui-tab id="tab-pub" crm-title="ts('Publication')">
@@ -101,7 +101,7 @@
           <div crm-ui-tab id="tab-attachmentA" crm-title="ts('Attachments')">
             <div crm-attachments="abtest.attachments.a"></div>
           </div>
-          <div crm-ui-tab id="tab-headerA" crm-title="ts('Header and Footer')">
+          <div crm-ui-tab id="tab-headerA" crm-title="ts('Header and Footer')" ng-if="mailingFields.header_id.options.length > 0 || mailingFields.footer_id.options.length > 0">
             <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.a"></div>
           </div>
           <div crm-ui-tab id="tab-pubA" crm-title="ts('Publication')">
@@ -136,7 +136,7 @@
           <div crm-ui-tab id="tab-attachmentB" crm-title="ts('Attachments')">
             <div crm-attachments="abtest.attachments.b"></div>
           </div>
-          <div crm-ui-tab id="tab-headerB" crm-title="ts('Header and Footer')">
+          <div crm-ui-tab id="tab-headerB" crm-title="ts('Header and Footer')" ng-if="mailingFields.header_id.options.length > 0 || mailingFields.footer_id.options.length > 0">
             <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.b"></div>
           </div>
           <div crm-ui-tab id="tab-pubB" crm-title="ts('Publication')">


### PR DESCRIPTION
Overview
----------------------------------------

Anecdotally, traditional CiviMail users follow several different tactics for managing templates, such as:

1. Define 1 (or more) `Message Template`(s); each template includes a complete layout. Don't use headers or footers for layout.
2. Define 1 (or more) `Header`(s) and  `Footer`(s) with partial layouts. Don't use  `Message Template`s for layout.
3. Define a universal `Header`/`Footer` with partial layouts - and then use `Message Template`s for different content.

The importance of the "Header" and "Footer" fields vary - if you use approach (1), the headers/footers are distractions and could be completely removed from the system. For (2), they're central part of composition process. For (3), the values should be set but rarely consulted or changed. The current layout represents a compromise (making the fields always-available but not in-your-face).

This change is an optimization for scenario (1) - if you don't use headers/footers, then you should disable them, and the UI will become cleaner.

Additionally, once you have the technique of hiding the field completely, then you can consider moving the fields to a more prominent spot to improve usability for folks in scenario (2). I'm on the fence about some details, so I've left that as a matter for a different PR.

Depends: #15325
Origin: https://lab.civicrm.org/dev/core/issues/1258

Before
----------------------------------------

The "Headers and Footers" tab is *always* displayed.

<img width="1031" alt="Screen Shot 2019-09-18 at 1 51 22 PM" src="https://user-images.githubusercontent.com/1336047/65173476-dccef180-da1c-11e9-8609-3751229259ef.png">

After
----------------------------------------

The "Headers and Footers" tab is only displayed if there are some headers or footers to choose from. If there aren't any, then the section is omitted.

<img width="1026" alt="Screen Shot 2019-09-18 at 1 51 39 PM" src="https://user-images.githubusercontent.com/1336047/65173477-dccef180-da1c-11e9-9098-be3915c85243.png">

Comments
----------------------------------------

There are some other changes that may be good follow-ups:

* Provide some doc/help to encourage in scenario (1)
* Provide a better layout and doc/help for folks in scenario (2)