### PR TITLE
Fix issues with retrieving supportsTestMode/supportsLiveMode for payment processors

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -372,19 +372,12 @@ WHERE  contribution_id = {$id}
     }
     $this->_processors = [];
     foreach ($this->_paymentProcessors as $id => $processor) {
-      // @todo review this. The inclusion of this IF was to address test processors being incorrectly loaded.
-      // However the function $this->getValidProcessors() is expected to only return the processors relevant
-      // to the mode (using the actual id - ie. the id of the test processor for the test processor).
-      // for some reason there was a need to filter here per commit history - but this indicates a problem
-      // somewhere else.
-      if ($processor['is_test'] == ($this->_mode == 'test')) {
-        $this->_processors[$id] = $processor['name'];
-        if (!empty($processor['description'])) {
-          $this->_processors[$id] .= ' : ' . $processor['description'];
-        }
-        if ($processor['is_recur']) {
-          $this->_recurPaymentProcessors[$id] = $this->_processors[$id];
-        }
+      $this->_processors[$id] = $processor['name'];
+      if (!empty($processor['description'])) {
+        $this->_processors[$id] .= ' : ' . $processor['description'];
+      }
+      if ($processor['is_recur']) {
+        $this->_recurPaymentProcessors[$id] = $this->_processors[$id];
       }
     }
     // CRM-21002: pass the default payment processor ID whose credit card type icons should be populated first

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -776,10 +776,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @throws \CRM_Core_Exception
    */
   protected function assignPaymentProcessor($isPayLaterEnabled) {
-    $this->_paymentProcessors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(
-      [ucfirst($this->_mode) . 'Mode'],
-      $this->_paymentProcessorIDs
-    );
+    $this->_paymentProcessors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors([ucfirst($this->_mode) . 'Mode'], $this->_paymentProcessorIDs);
     if ($isPayLaterEnabled) {
       $this->_paymentProcessors[0] = CRM_Financial_BAO_PaymentProcessor::getPayment(0);
     }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -354,7 +354,7 @@ abstract class CRM_Core_Payment {
    * @return bool
    */
   protected function supportsLiveMode() {
-    return TRUE;
+    return empty($this->_paymentProcessor['is_test']) ? TRUE : FALSE;
   }
 
   /**
@@ -363,7 +363,7 @@ abstract class CRM_Core_Payment {
    * @return bool
    */
   protected function supportsTestMode() {
-    return TRUE;
+    return empty($this->_paymentProcessor['is_test']) ? FALSE : TRUE;
   }
 
   /**

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -133,17 +133,6 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
-   * Are back office payments supported.
-   *
-   * E.g paypal standard won't permit you to enter a credit card associated with someone else's login.
-   *
-   * @return bool
-   */
-  protected function supportsLiveMode() {
-    return TRUE;
-  }
-
-  /**
    * Does this payment processor support refund?
    *
    * @return bool

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -161,6 +161,24 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
   }
 
   /**
+   * Are live payments supported - e.g dummy doesn't support this.
+   *
+   * @return bool
+   */
+  protected function supportsLiveMode() {
+    return TRUE;
+  }
+
+  /**
+   * Are test payments supported.
+   *
+   * @return bool
+   */
+  protected function supportsTestMode() {
+    return TRUE;
+  }
+
+  /**
    * Declare that more than one payment can be processed at once.
    *
    * @return bool

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -379,8 +379,8 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    *   available processors
    */
   public static function getPaymentProcessors($capabilities = [], $ids = FALSE) {
-    $testProcessors = in_array('TestMode', $capabilities) ? self::getAllPaymentProcessors('test') : [];
     if (is_array($ids)) {
+      $testProcessors = in_array('TestMode', $capabilities) ? self::getAllPaymentProcessors('test') : [];
       $processors = self::getAllPaymentProcessors('all', FALSE, FALSE);
       if (in_array('TestMode', $capabilities)) {
         $possibleLiveIDs = array_diff($ids, array_keys($testProcessors));

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
@@ -58,7 +58,6 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
     $liveProcessorID = $testProcessorID + 1;
 
     $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'TestMode']);
-    $this->markTestIncomplete('Not working yet :-(');
     $this->assertEquals([$testProcessorID, 0], array_keys($processors), 'Only the test processor and the manual processor should be returned');
 
     $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'TestMode'], [$liveProcessorID]);
@@ -72,7 +71,6 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
 
     $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'LiveMode'], [$liveProcessorID]);
     $this->assertEquals([$liveProcessorID], array_keys($processors), 'Only the Live processor should be returned');
-
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
`supportsLiveMode` should return live processors.
`supportsTestMode` should return test processors.
We should not be loading processors multiple times in `getPaymentProcessors()` - improves loading speed a little bit.
Running a backend payment form in test mode (ie URL param `mode=test`) selected the live processor instead of the test one.

Before
----------------------------------------
Open backend payment form in test mode (change mode=live to test) (eg. called via:
/civicrm/contact/view/contribution?reset=1&amp;action=add&amp;cid=202&amp;context=contribution&amp;mode=test).
Make sure you have multiple processors available.
Select a different processor which will load it's billingblock via AJAX. The live processor loads instead of the test one.

After
----------------------------------------
Resolve issues with loading processors in test/live mode.  Improve efficiency.

Technical Details
----------------------------------------

Comments
----------------------------------------

