### PR TITLE
Api3TestTrait - Only run api4 tests if api4 is present

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -22,7 +22,12 @@ trait Api3TestTrait {
    * @return array
    */
   public function versionThreeAndFour() {
-    return [[3], [4]];
+    $r = [[3]];
+    global $civicrm_root;
+    if (file_exists("$civicrm_root/Civi/Api4") || file_exists("$civicrm_root/ext/api4")) {
+      $r[] = [4];
+    }
+    return $r;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is meant to temporarily hush issues in `api_v3_AllTests` when running a mid-alpha codebase.

Before
----------------------------------------
* For dual-version tests within `api_v3_AllTests`, the tests always run on v3 and v4.

After
----------------------------------------
* For dual-version tests within `api_v3_AllTests`, the active tests depend on what code is present. It runs v4 mode if v4 is present.

Technical Details
----------------------------------------
This is meant to help bridge the interim while updating test systems and working on #15309. 

The test is framed in a way that should work in a minimal level of bootstrap (e.g. after classloader and `civicrm.settings.php` - but before API is brought online).