### PR TITLE
dev/mail#17 Construct tracking URLs with an alternate method to avoid language prefix be appended to base URL

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1140,9 +1140,12 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     // push the tracking url on to the html email if necessary
     if ($this->open_tracking && $html) {
-      array_push($html, "\n" . '<img src="' . CRM_Utils_System::externUrl('extern/open', "q=$event_queue_id")
-        . '" width="1" height="1" alt="" border="0">'
+      $tracking_url = $config->userSystem->languageNegotiationURL(
+        $config->userFrameworkBaseURL . Civi::settings()->get('userFrameworkResourceURL') . "/extern/open.php?q=$event_queue_id",
+        FALSE,
+        TRUE
       );
+      array_push($html, "\n" . '<img src="' . $tracking_url . '" width="1" height="1" alt="" border="0">');
     }
 
     $message = new Mail_mime("\n");

--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -72,11 +72,15 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
       }
       $id = $tracker->id;
 
-      $redirect = CRM_Utils_System::externUrl('extern/url', "u=$id");
+      $redirect = $config->userSystem->languageNegotiationURL(
+        $config->userFrameworkBaseURL . Civi::settings()->get('userFrameworkResourceURL') . "/extern/url.php?u=$id",
+        FALSE,
+        TRUE
+      );
       $urlCache[$mailing_id . $url] = $redirect;
     }
 
-    $returnUrl = CRM_Utils_System::externUrl('extern/url', "u=$id&qid=$queue_id");
+    $returnUrl = "{$urlCache[$mailing_id . $url]}&qid={$queue_id}";
 
     if ($hrefExists) {
       $returnUrl = "href='{$returnUrl}' rel='nofollow'";


### PR DESCRIPTION
Overview
----------------------------------------
Originating from [dev/mail#17](https://lab.civicrm.org/dev/mail/issues/17), there are circumstances which cause tracking links in mailings be corrupted due to CiviCRM adding language prefixes into `\CRM_Core_Config::singleton()->userFrameworkResourceURL`. This happens when creating a mailing in a different language than the current UI language and causes the open e-mail tracking link within the image tag not be valid and thus nothing being tracked.

Before
----------------------------------------
Tracking URLs (extern/open.php and extern/url.php) are invalid under the described circumstances. A language prefix is appended to the base URL causing the tracking script file not be found.

After
----------------------------------------
The tracking URLs are valid under the described circumstances.

Technical Details
----------------------------------------
The underlying problem is somewhere in CiviCRM core code which constructs and caches this setting variable. In the meantime, this PR provides a workaround by doing the following:

- Do not use `\CRM_Core_Config::singleton()->userFrameworkResourceURL` since it may be broken
- Construct the URL using the relative representation of `userFrameworkResourceURL` with `\Civi::settings()->get()`
- Run the resulting URL through `\CRM_Core_Config::singleton()->userSystem->languageNegotiationURL()` with the `removeLanguagePart`parameter set to `TRUE`

Comments
----------------------------------------
This is a workaround until those endpoints for tracking links will be converted to something else using proper CMS routes, see [dev/cloud-native#16](https://lab.civicrm.org/dev/cloud-native/issues/16)
