### PR TITLE
Do no invoke Hooks via UF unless container has been built or it is a …

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -188,6 +188,11 @@ abstract class CRM_Utils_Hook {
       return $event->getReturnValues();
     }
     else {
+      // We need to ensure tht we will still run known bootstrap related hooks even if the container is not booted.
+      $prebootContainerHooks = $upgradeFriendlyHooks + ['civicrm_entityTypes', 'civicrm_config'];
+      if (!\Civi\Core\Container::isContainerBooted() && !in_array($fnSuffix, $prebootContainerHooks)) {
+        return;
+      }
       $count = is_array($names) ? count($names) : $names;
       return $this->invokeViaUF($count, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $fnSuffix);
     }


### PR DESCRIPTION
…hook designed to run without container being built

Overview
----------------------------------------
An issue raised in #15311 we found that hooks could be potentially invoked without the container being properly booted

Before
----------------------------------------
Hooks being run before container boots

After
----------------------------------------
Hooks don't run unless specified they can run without the container being booted