### PR TITLE
Upgrader: handle missing obsolete extensions

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -648,7 +648,7 @@ SET    version = '$version'
     $disabled = [];
     $manager = CRM_Extension_System::singleton()->getManager();
     foreach ($compatInfo as $key => $ext) {
-      if (!empty($ext['obsolete']) && $manager->getStatus($key) == $manager::STATUS_INSTALLED) {
+      if (!empty($ext['obsolete']) && in_array($manager->getStatus($key), [$manager::STATUS_INSTALLED, $manager::STATUS_INSTALLED_MISSING])) {
         $disabled[$key] = sprintf("<li>%s</li>", ts('The extension %1 is now obsolete and has been disabled.', [1 => $key]));
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This improves the mechanism for auto-disabling obsolete extensions during the upgrade process to disable extensions even if they are missing.

Before
----------------------------------------
Obsolete extensions not disabled if missing.

After
----------------------------------------
Obsolete extensions disabled even if missing.

Comments
----------------------------------------
This came up while testing upgrade to 5.19 which includes Api v4. See https://github.com/civicrm/civicrm-core/pull/15309