### PR TITLE
dev/core#1270 - fix email processor dropping attachments

### DIFF
--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -879,10 +879,13 @@ function _civicrm_api3_deprecated_activity_buildmailparams($result, $activityTyp
   $params['activity_date_time'] = $result['date'];
   $params['details'] = $result['body'];
 
-  for ($i = 1; $i <= 5; $i++) {
-    if (isset($result["attachFile_$i"])) {
-      $params["attachFile_$i"] = $result["attachFile_$i"];
+  if (!empty($result['num_attachments'])) {
+    for ($i = 1; $i <= $result['num_attachments']; $i++) {
+      if (isset($result["attachFile_$i"])) {
+        $params["attachFile_$i"] = $result["attachFile_$i"];
+      }
     }
+    $params['num_attachments'] = $result['num_attachments'];
   }
 
   return $params;

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -252,7 +252,20 @@ class CRM_Utils_Mail_EmailProcessor {
           if (!empty($dao->activity_status)) {
             $params['status_id'] = $dao->activity_status;
           }
+
+          // Up the limit on attachments so it doesn't drop any when creating
+          // activity.
+          if (!empty($params['num_attachments'])) {
+            $old_limit = Civi::settings()->get('max_attachments');
+            Civi::settings()->set('max_attachments', max($old_limit, $params['num_attachments']));
+          }
+
           $result = civicrm_api('activity', 'create', $params);
+
+          // reset the attachments limit
+          if (!empty($params['num_attachments'])) {
+            Civi::settings()->set('max_attachments', $old_limit);
+          }
 
           if ($result['is_error']) {
             $matches = FALSE;

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -384,7 +384,8 @@ class CRM_Utils_Mail_Incoming {
     if (!empty($attachments)) {
       $date = date('YmdHis');
       $config = CRM_Core_Config::singleton();
-      for ($i = 0; $i < count($attachments); $i++) {
+      $params['num_attachments'] = count($attachments);
+      for ($i = 0; $i < $params['num_attachments']; $i++) {
         $attachNum = $i + 1;
         $fileName = basename($attachments[$i]['fullName']);
         $newName = CRM_Utils_File::makeFileName($fileName);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1270

The email processor will drop attachments if there's more in the incoming email than the limit set at system settings - misc. The setting is intended for activity creation in the UI, but shouldn't cause the email processor to drop attachments.

Before
----------------------------------------
Some attachments can be lost.

After
----------------------------------------
It files and keeps all the attachments.

Technical Details
----------------------------------------
In parseMailingObject() it knows the number of attachments. So return that back along with the other info and then in the email processor temporarily raise the limit to that number, and put it back after.

Comments
----------------------------------------
