### PR TITLE
dev/core#1272 - PHP 7.3 warning message on import contribution

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -896,7 +896,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
 
           // giving respect to pledge_payment flag.
           if (empty($params['pledge_payment'])) {
-            continue;
+            break;
           }
 
           // get total amount of from import fields


### PR DESCRIPTION
Overview
----------------------------------------
Fix warning on import contribution

Before
----------------------------------------
Get the below warning on Import Contribution screen after selecting the csv and moving on the "Match Fields" page.

> Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in require_once() (line 227 of /Users/jitendra/src/civicrm/CRM/Core/ClassLoader.php).

After
----------------------------------------
warning message is not shown.

Technical Details
----------------------------------------
https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1272