### PR TITLE
Improve obsolete extension management

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -175,16 +175,21 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
 
       $row = self::createExtendedInfo($obj);
       $row['id'] = $obj->key;
+      $row['action'] = '';
 
       // assign actions
       $action = 0;
       switch ($row['status']) {
         case CRM_Extension_Manager::STATUS_UNINSTALLED:
-          $action += CRM_Core_Action::ADD;
+          if (!$manager->isIncompatible($row['id'])) {
+            $action += CRM_Core_Action::ADD;
+          }
           break;
 
         case CRM_Extension_Manager::STATUS_DISABLED:
-          $action += CRM_Core_Action::ENABLE;
+          if (!$manager->isIncompatible($row['id'])) {
+            $action += CRM_Core_Action::ENABLE;
+          }
           $action += CRM_Core_Action::DELETE;
           break;
 
@@ -201,18 +206,17 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       }
       // TODO if extbrowser is enabled and extbrowser has newer version than extcontainer,
       // then $action += CRM_Core_Action::UPDATE
-      $row['action'] = CRM_Core_Action::formLink(self::links(),
-        $action,
-        [
-          'id' => $row['id'],
-          'key' => $obj->key,
-        ],
-        ts('more'),
-        FALSE,
-        'extension.local.action',
-        'Extension',
-        $row['id']
-      );
+      if ($action) {
+        $row['action'] = CRM_Core_Action::formLink(self::links(),
+          $action,
+          ['id' => $row['id'], 'key' => $obj->key],
+          ts('more'),
+          FALSE,
+          'extension.local.action',
+          'Extension',
+          $row['id']
+        );
+      }
       // Key would be better to send, but it's not an integer.  Moreover, sending the
       // values to hook_civicrm_links means that you can still get at the key
 

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1454,6 +1454,7 @@ WHERE  id = %1
    */
   public static function &getExtensions() {
     if (!self::$extensions) {
+      $compat = CRM_Extension_System::getCompatibilityInfo();
       self::$extensions = [];
       $sql = '
         SELECT full_name, label
@@ -1462,6 +1463,9 @@ WHERE  id = %1
       ';
       $dao = CRM_Core_DAO::executeQuery($sql);
       while ($dao->fetch()) {
+        if (!empty($compat[$dao->full_name]['force-uninstall'])) {
+          continue;
+        }
         self::$extensions[$dao->full_name] = $dao->label;
       }
     }

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -465,6 +465,8 @@ class CRM_Extension_Manager {
    */
   public function getStatuses() {
     if (!is_array($this->statuses)) {
+      $compat = CRM_Extension_System::getCompatibilityInfo();
+
       $this->statuses = [];
 
       foreach ($this->fullContainer->getKeys() as $key) {
@@ -484,7 +486,10 @@ class CRM_Extension_Manager {
         catch (CRM_Extension_Exception $e) {
           $codeExists = FALSE;
         }
-        if ($dao->is_active) {
+        if (!empty($compat[$dao->full_name]['force-uninstall'])) {
+          $this->statuses[$dao->full_name] = self::STATUS_UNINSTALLED;
+        }
+        elseif ($dao->is_active) {
           $this->statuses[$dao->full_name] = $codeExists ? self::STATUS_INSTALLED : self::STATUS_INSTALLED_MISSING;
         }
         else {

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -215,11 +215,12 @@ class CRM_Extension_Manager {
   /**
    * Add records of the extension to the database -- and enable it
    *
-   * @param array $keys
-   *   List of extension keys.
+   * @param string|array $keys
+   *   One or more extension keys.
    * @throws CRM_Extension_Exception
    */
   public function install($keys) {
+    $keys = (array) $keys;
     $origStatuses = $this->getStatuses();
 
     // TODO: to mitigate the risk of crashing during installation, scan
@@ -322,11 +323,12 @@ class CRM_Extension_Manager {
   /**
    * Disable extension without removing record from db.
    *
-   * @param array $keys
-   *   List of extension keys.
+   * @param string|array $keys
+   *   One or more extension keys.
    * @throws CRM_Extension_Exception
    */
   public function disable($keys) {
+    $keys = (array) $keys;
     $origStatuses = $this->getStatuses();
 
     // TODO: to mitigate the risk of crashing during installation, scan
@@ -378,11 +380,12 @@ class CRM_Extension_Manager {
   /**
    * Remove all database references to an extension.
    *
-   * @param array $keys
-   *   List of extension keys.
+   * @param string|array $keys
+   *   One or more extension keys.
    * @throws CRM_Extension_Exception
    */
   public function uninstall($keys) {
+    $keys = (array) $keys;
     $origStatuses = $this->getStatuses();
 
     // TODO: to mitigate the risk of crashing during installation, scan

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -286,6 +286,8 @@ class CRM_Extension_Mapper {
     }
 
     if (!is_array($moduleExtensions)) {
+      $compat = CRM_Extension_System::getCompatibilityInfo();
+
       // Check canonical module list
       $moduleExtensions = [];
       $sql = '
@@ -296,6 +298,9 @@ class CRM_Extension_Mapper {
       ';
       $dao = CRM_Core_DAO::executeQuery($sql);
       while ($dao->fetch()) {
+        if (!empty($compat[$dao->full_name]['force-uninstall'])) {
+          continue;
+        }
         try {
           $moduleExtensions[] = [
             'prefix' => $dao->file,

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -264,7 +264,7 @@ class CRM_Extension_System {
    */
   public function getCache() {
     if ($this->cache === NULL) {
-      $cacheGroup = md5(serialize(['ext', $this->parameters]));
+      $cacheGroup = md5(serialize(['ext', $this->parameters, CRM_Utils_System::version()]));
       // Extension system starts before container. Manage our own cache.
       $this->cache = CRM_Utils_Cache::create([
         'name' => $cacheGroup,

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -362,6 +362,9 @@ class CRM_Extension_System {
       default:
         $extensionRow['statusLabel'] = '(' . $extensionRow['status'] . ')';
     }
+    if ($manager->isIncompatible($obj->key)) {
+      $extensionRow['statusLabel'] = ts('Obsolete') . ($extensionRow['statusLabel'] ? (' - ' . $extensionRow['statusLabel']) : '');
+    }
     return $extensionRow;
   }
 

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -673,6 +673,11 @@ SET    version = '$version'
             $messages[] = ts('The obsolete extension %1 could not be removed due to an error. It is recommended to remove this extension manually.', [1 => $key]);
           }
         }
+        if (!empty($obsolete['force-uninstall'])) {
+          CRM_Core_DAO::executeQuery('UPDATE civicrm_extension SET is_active = 0 WHERE full_name = %1', [
+            1 => [$key, 'String'],
+          ]);
+        }
       }
     }
     if ($messages) {

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -637,25 +637,47 @@ SET    version = '$version'
   }
 
   /**
-   * Disable any extensions not compatible with this new version.
+   * Disable/uninstall any extensions not compatible with this new version.
    *
    * @param \CRM_Queue_TaskContext $ctx
    * @param string $postUpgradeMessageFile
    * @return bool
    */
   public static function disableOldExtensions(CRM_Queue_TaskContext $ctx, $postUpgradeMessageFile) {
-    $compatInfo = CRM_Extension_System::getCompatibilityInfo();
-    $disabled = [];
+    $messages = [];
     $manager = CRM_Extension_System::singleton()->getManager();
-    foreach ($compatInfo as $key => $ext) {
-      if (!empty($ext['obsolete']) && in_array($manager->getStatus($key), [$manager::STATUS_INSTALLED, $manager::STATUS_INSTALLED_MISSING])) {
-        $disabled[$key] = sprintf("<li>%s</li>", ts('The extension %1 is now obsolete and has been disabled.', [1 => $key]));
+    foreach ($manager->getStatuses() as $key => $status) {
+      $obsolete = $manager->isIncompatible($key);
+      if ($obsolete) {
+        if (!empty($obsolete['disable']) && in_array($status, [$manager::STATUS_INSTALLED, $manager::STATUS_INSTALLED_MISSING])) {
+          try {
+            $manager->disable($key);
+            // Update the status for the sake of uninstall below.
+            $status = $status == $manager::STATUS_INSTALLED ? $manager::STATUS_DISABLED : $manager::STATUS_DISABLED_MISSING;
+            // This message is intentionally overwritten by uninstall below as it would be redundant
+            $messages[$key] = ts('The extension %1 is now obsolete and has been disabled.', [1 => $key]);
+          }
+          catch (CRM_Extension_Exception $e) {
+            $messages[] = ts('The obsolete extension %1 could not be removed due to an error. It is recommended to remove this extension manually.', [1 => $key]);
+          }
+        }
+        if (!empty($obsolete['uninstall']) && in_array($status, [$manager::STATUS_DISABLED, $manager::STATUS_DISABLED_MISSING])) {
+          try {
+            $manager->uninstall($key);
+            $messages[$key] = ts('The extension %1 is now obsolete and has been uninstalled.', [1 => $key]);
+            if ($status == $manager::STATUS_DISABLED) {
+              $messages[$key] .= ' ' . ts('You can remove it from your extensions directory.');
+            }
+          }
+          catch (CRM_Extension_Exception $e) {
+            $messages[] = ts('The obsolete extension %1 could not be removed due to an error. It is recommended to remove this extension manually.', [1 => $key]);
+          }
+        }
       }
     }
-    if ($disabled) {
-      $manager->disable(array_keys($disabled));
+    if ($messages) {
       file_put_contents($postUpgradeMessageFile,
-        '<br/><br/><ul>' . implode("\n", $disabled) . '</ul>',
+        '<br/><br/><ul><li>' . implode("</li>\n<li>", $messages) . '</li></ul>',
         FILE_APPEND
       );
     }

--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -1,8 +1,7 @@
 {
   "org.civicrm.api4": {
     "obsolete": "5.19",
-    "disable": true,
-    "uninstall": true
+    "force-uninstall": true
   },
   "uk.squiffle.kam": {
     "obsolete": "5.12",

--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -1,17 +1,27 @@
 {
   "org.civicrm.api4": {
-    "obsolete": "5.19"
+    "obsolete": "5.19",
+    "disable": true,
+    "uninstall": true
   },
   "uk.squiffle.kam": {
-    "obsolete": "5.12"
+    "obsolete": "5.12",
+    "disable": true,
+    "uninstall": true
   },
   "com.aghstrategies.slicknav": {
-    "obsolete": "5.12"
+    "obsolete": "5.12",
+    "disable": true,
+    "uninstall": true
   },
   "de.systopia.recentitems": {
-    "obsolete": "5.12"
+    "obsolete": "5.12",
+    "disable": true,
+    "uninstall": true
   },
   "com.ixiam.modules.quicksearch": {
-    "obsolete": "5.8"
+    "obsolete": "5.8",
+    "disable": true,
+    "uninstall": true
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
* Obsolete extensions are labeled as such on the extension page
* Obsolete extensions are not allowed to be installed or enabled
* Obsolete extensions are not just disabled but completely uninstalled during core upgrades

Before
----------------------------------------
Less thorough / verbose

After
----------------------------------------
Note that obsolete extensions are labeled on extension page and there is no button to install them. If you were to try installing it via `cv` you'd get an error.
![image](https://user-images.githubusercontent.com/2874912/65722529-6a908980-e07a-11e9-8719-92161e7b0354.png)
