### PR TITLE
dev/core#1257 Make relationship description searchable

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2032,6 +2032,7 @@ class CRM_Contact_BAO_Query {
       case 'relation_active_period_date_low':
       case 'relation_target_name':
       case 'relation_status':
+      case 'relation_description':
       case 'relation_date_low':
       case 'relation_date_high':
         $this->relationship($values);
@@ -4160,6 +4161,7 @@ WHERE  $smartGroupClause
     // also get values array for relation_target_name
     // for relationship search we always do wildcard
     $relationType = $this->getWhereValues('relation_type_id', $grouping);
+    $description = $this->getWhereValues('relation_description', $grouping);
     $targetName = $this->getWhereValues('relation_target_name', $grouping);
     $relStatus = $this->getWhereValues('relation_status', $grouping);
     $targetGroup = $this->getWhereValues('relation_target_group', $grouping);
@@ -4274,6 +4276,13 @@ WHERE  $smartGroupClause
       else {
         $this->_qill[$grouping][] = implode(", ", $qillNames);
       }
+    }
+
+    // Description
+    if (!empty($description[2]) && trim($description[2])) {
+      $this->_qill[$grouping][] = ts('Relationship description - ' . $description[2]);
+      $description = CRM_Core_DAO::escapeString(trim($description[2]));
+      $where[$grouping][] = "civicrm_relationship.description LIKE '%{$description}%'";
     }
 
     // Note we do not currently set mySql to handle timezones, so doing this the old-fashioned way

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -487,12 +487,12 @@ class CRM_Contact_Form_Search_Criteria {
   }
 
   /**
-   * @param $form
+   * @param CRM_Core_Form_Search $form
    */
   public static function relationship(&$form) {
     $form->add('hidden', 'hidden_relationship', 1);
 
-    $allRelationshipType = [];
+    $form->add('text', 'relation_description', ts('Description'), ['class' => 'twenty']);
     $allRelationshipType = CRM_Contact_BAO_Relationship::getContactRelationshipType(NULL, NULL, NULL, NULL, TRUE);
     $form->add('select', 'relation_type_id', ts('Relationship Type'), ['' => ts('- select -')] + $allRelationshipType, FALSE, ['multiple' => TRUE, 'class' => 'crm-select2']);
     $form->addElement('text', 'relation_target_name', ts('Target Contact'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));

--- a/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
@@ -54,6 +54,12 @@
       </td>
     </tr>
     <tr>
+      <td colspan="2">
+        {$form.relation_description.label}<br />
+        {$form.relation_description.html}
+      </td>
+    </tr>
+    <tr>
       <td colspan="2"><label>{ts}Start Date{/ts}</label></td>
     </tr>
     <tr>


### PR DESCRIPTION
Overview
----------------------------------------
Exposes the relationship description field to advanced search.

Before
----------------------------------------
Relationship description not searchable.

After
----------------------------------------
Relationship description searchable.

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1257