### PR TITLE
Improve item order inside Online Contributions section of configuration checklist; see lab issue dev/core#1278

### DIFF
--- a/templates/CRM/Admin/Page/ConfigTaskList.tpl
+++ b/templates/CRM/Admin/Page/ConfigTaskList.tpl
@@ -83,12 +83,12 @@
         <td colspan="2">{ts}Sending Emails (includes contribution receipts and event confirmations){/ts}</td>
     </tr>
     <tr class="even">
-        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/smtp" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Outbound Email{/ts}</a></td>
-        <td>{ts}Settings for outbound email - either SMTP server, port and authentication or Sendmail path and argument.{/ts}</td>
-    </tr>
-    <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/options/from_email_address" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}From Email Addresses{/ts}</a></td>
         <td>{ts}Define general email address(es) that can be used as the FROM address when sending email to contacts from within CiviCRM (e.g. info@example.org){/ts}</td>
+    </tr>
+    <tr class="even">
+        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/smtp" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Outbound Email{/ts}</a></td>
+        <td>{ts}Settings for outbound email - either SMTP server, port and authentication or Sendmail path and argument.{/ts}</td>
     </tr>
 
     <tr class="columnheader">


### PR DESCRIPTION
Overview
----------------------------------------
This changes the order of items inside the Sending Emails section of the configuration checklist. Overview in this issue: https://lab.civicrm.org/dev/core/issues/1278

Before
----------------------------------------
Order is

- Outbound Email
- From Email Addresses

After
----------------------------------------
Order is

- From Email Addresses
- Outbound Email

Technical Details
----------------------------------------
none

Comments
----------------------------------------
none
