### PR TITLE
(dev/core#1065) Member in Edit mode needs to be shown consistently

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -337,6 +337,11 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         }
       }
     }
+    else {
+      if ($this->_contactID) {
+        $defaults['contact_id'] = $this->_contactID;
+      }
+    }
 
     //set Soft Credit Type to Gift by default
     $scTypes = CRM_Core_OptionGroup::values("soft_credit_type");
@@ -493,11 +498,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       return;
     }
 
-    if ($this->_context == 'standalone') {
-      $this->addEntityRef('contact_id', ts('Contact'), [
-        'create' => TRUE,
-        'api' => ['extra' => ['email']],
-      ], TRUE);
+    $contactField = $this->addEntityRef('contact_id', ts('Contact'), ['create' => TRUE, 'api' => ['extra' => ['email']]], TRUE);
+    if ($this->_context != 'standalone') {
+      $contactField->freeze();
     }
 
     $selOrgMemType[0][0] = $selMemTypeOrg[0] = ts('- select -');

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -83,14 +83,10 @@
     </div>
     {else}
       <table class="form-layout-compressed">
-        {if $context neq 'standalone'}
-          <tr>
-            <td class="font-size12pt label"><strong>{ts}Member{/ts}</strong></td><td class="font-size12pt"><strong>{$displayName}</strong></td>
-          </tr>
-        {else}
-          <td class="label">{$form.contact_id.label}</td>
-          <td>{$form.contact_id.html}</td>
-        {/if}
+        <tr class="crm-membership-form-contact-id">
+           <td class="label">{$form.contact_id.label}</td>
+           <td>{$form.contact_id.html}</td>
+        </tr>
         <tr class="crm-membership-form-block-membership_type_id">
           <td class="label">{$form.membership_type_id.label}</td>
           <td><span id='mem_type_id'>{$form.membership_type_id.html}</span>


### PR DESCRIPTION
Overview
----------------------------------------
Member in Edit mode needs to be shown in consistency with Grant screen. 

Before
----------------------------------------
Display name is hardcoded freeze value
<img width="656" alt="Screen Shot 2019-11-01 at 10 11 52 AM" src="https://user-images.githubusercontent.com/336308/67986648-60246980-fc90-11e9-85e4-ca8d3a6dcb5a.png">


After
----------------------------------------
Display name is clickable contact name.

<img width="638" alt="Screen Shot 2019-11-01 at 10 13 30 AM" src="https://user-images.githubusercontent.com/336308/67986637-5a2e8880-fc90-11e9-8354-18153ff2bc75.png">
