### PR TITLE
dev/translation#32 Contribution ThankYou: Fix translation of recurring units

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -558,6 +558,11 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         if ($v == "amount" && $this->_params[$v] === 0) {
           $this->_params[$v] = CRM_Utils_Money::format($this->_params[$v], NULL, NULL, TRUE);
         }
+        if ($v == 'frequency_unit' || $v == 'pledge_frequency_unit') {
+          // This is an incorrect, but required use of 'ts', because of upstream confusion
+          // exposing machine-names as end-user strings.
+          $this->_params[$v] = ts($this->_params[$v]);
+        }
         $this->assign($v, $this->_params[$v]);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/translation/issues/32

To reproduce:

* Configure CiviCRM to non-English (ex: French)
* Setup a recurring contribution page
* Contribute a recurring amount (ex: 5$ every month)

Result:

> Cette contribution périodique sera automatiquement prélevée chaque month.

(i.e. the frequency unit is not translated)

From the string:

> This recurring contribution will be automatically processed every %1.

_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------

> Cette contribution périodique sera automatiquement prélevée chaque month.

After
----------------------------------------

> Cette contribution périodique sera automatiquement prélevée chaque mois.

Technical Details
----------------------------------------

It unfortunately requires an incorrect usage of 'ts' because we are exposing machine names as end-user text.