### PR TITLE
Order the getContactIDsFromComponent query results 

### DIFF
--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -44,11 +44,20 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
    * @inheritDoc
    */
   public function setContactIDs() {
-    $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_entityIds,
+    $this->_contactIds = CRM_Core_Form_Task::getContactIDsFromComponent($this->_entityIds,
       'civicrm_case_contact', 'case_id'
     );
   }
 
+  // order by case id 
+  public function orderBy() {
+    $order_array = 'ORDER BY ';
+    foreach ($this->_entityIds as $item) {
+       $order_array .= case_id . ' = ' . $item . ' DESC,';
+     }
+    return $order_array = trim($order_array, ',');
+  }
+  
   /**
    * Get the query mode (eg. CRM_Core_BAO_Query::MODE_CASE)
    *

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1737,13 +1737,11 @@ FROM   civicrm_domain
     }
 
     $IDs = implode(',', $componentIDs);
-    
     $order_array = 'ORDER BY ';
     foreach ($componentIDs as $item) {
-      $order_array .= $idField. ' = ' . $item . ' DESC,';
+      $order_array .= $idField . ' = ' . $item . ' DESC,';
     }
     $order_array = trim($order_array, ',');
-    
     $query = "
 SELECT contact_id
   FROM $tableName

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1737,10 +1737,17 @@ FROM   civicrm_domain
     }
 
     $IDs = implode(',', $componentIDs);
+    
+    $order_array = 'ORDER BY ';
+    foreach ($componentIDs as $item) {
+      $order_array .= $idField. ' = ' . $item . ' DESC,';
+    }
+    $order_array = trim($order_array, ',');
+    
     $query = "
 SELECT contact_id
   FROM $tableName
- WHERE $idField IN ( $IDs )
+ WHERE $idField IN ( $IDs ) $order_array
 ";
 
     $dao = CRM_Core_DAO::executeQuery($query);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1720,42 +1720,6 @@ FROM   civicrm_domain
   }
 
   /**
-   * Given the component id, compute the contact id
-   * since its used for things like send email
-   *
-   * @param $componentIDs
-   * @param string $tableName
-   * @param string $idField
-   *
-   * @return array
-   */
-  public static function getContactIDsFromComponent($componentIDs, $tableName, $idField = 'id') {
-    $contactIDs = array();
-
-    if (empty($componentIDs)) {
-      return $contactIDs;
-    }
-
-    $IDs = implode(',', $componentIDs);
-    $order_array = 'ORDER BY ';
-    foreach ($componentIDs as $item) {
-      $order_array .= $idField . ' = ' . $item . ' DESC,';
-    }
-    $order_array = trim($order_array, ',');
-    $query = "
-SELECT contact_id
-  FROM $tableName
- WHERE $idField IN ( $IDs ) $order_array
-";
-
-    $dao = CRM_Core_DAO::executeQuery($query);
-    while ($dao->fetch()) {
-      $contactIDs[] = $dao->contact_id;
-    }
-    return $contactIDs;
-  }
-
-  /**
    * Fetch object based on array of properties.
    *
    * @param string $daoName

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -177,11 +177,46 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
    * For example, for cases we need to override this function as the table name is civicrm_case_contact
    */
   public function setContactIDs() {
-    $this->_contactIds = &CRM_Core_DAO::getContactIDsFromComponent($this->_entityIds,
+    $this->_contactIds = &getContactIDsFromComponent($this->_entityIds,
       $this::$tableName
     );
   }
+  
+  public function orderBy() {
+    return NULL;
+  }
+  /**
+   * Given the component id, compute the contact id
+   * since its used for things like send email
+   *
+   * @param $componentIDs
+   * @param string $tableName
+   * @param string $idField
+   *
+   * @return array
+   */
+  public function getContactIDsFromComponent($componentIDs, $tableName, $idField = 'id') {
+    $contactIDs = array();
 
+    if (empty($componentIDs)) {
+      return $contactIDs;
+    }
+
+    $IDs = implode(',', $componentIDs);
+    $order_array = $this->orderBy();
+    $query = "
+  SELECT contact_id
+  FROM $tableName
+  WHERE $idField IN ( $IDs ) $order_array
+  ";
+
+    $dao = CRM_Core_DAO::executeQuery($query);
+    while ($dao->fetch()) {
+      $contactIDs[] = $dao->contact_id;
+    }
+    return $contactIDs;
+  }
+  
   /**
    * Simple shell that derived classes can call to add buttons to
    * the form with a customized title for the main Submit


### PR DESCRIPTION
Print Merge document from case search doesn't file on correct contact.

Overview
----------------------------------------
With Record generated letters set to "Multiple activities (one per contact)" when you print/merge documents directly on a case, they don't file on the correct contact. Full issue here: https://lab.civicrm.org/dev/core/issues/893

Before
----------------------------------------
When selecting the following cases/contacts in this order (custom sort order on the results page)
- Case Number 103, Contact 560 (Linda)
- Case Number 112, Contact 579 (Victor)
- Case Number 116, Contact 622 (Henry)

Activities are filed in this order
- 560 (Linda) - filed correctly on case 103
- 622 (Henry) - filed INCORRECTLY on case 112 (that case belongs to Victor)
- 579 (Victor) - filed INCORRECTLY on case 116 (that case belongs to Henry)

Rather than the list of contact IDs respecting the sort order, they are in case order.

After
----------------------------------------
When selecting the following cases/contacts in this order (custom sort order on the results page)
- Case Number 103, Contact 560
- Case Number 112, Contact 579
- Case Number 116, Contact 622

Activities are filed in this order
- 560 - filed correctly on case 103
- 579 - filed correctly on case 112
- 622 - filed correctly on case 116

Comments
----------------------------------------
I did run contact level searches and pdf filing and that was not affected/ran as expected. But I'm not sure if there are other places I should test for 'fallout'.

