### PR TITLE
Removing 'Array' from user dashboard contributions

### DIFF
--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -46,7 +46,7 @@
                 {foreach from=$contribute_rows item=row}
                     <tr id='rowid{$row.contribution_id}'
                         class="{cycle values="odd-row,even-row"}{if $row.cancel_date} disabled{/if}">
-                        <td>{$row.total_amount|crmMoney:$row.currency} {if $row.amount_level } - {$row.amount_level} {/if}
+                        <td>{$row.total_amount|crmMoney:$row.currency} {if $row.amount_level && !is_array($row.amount_level)} - {$row.amount_level} {/if}
                             {if $row.contribution_recur_id}
                                 <br/>
                                 {ts}(Recurring Contribution){/ts}


### PR DESCRIPTION
Overview
----------------------------------------
On the user dashboard, `Your Contribution(s)` section, the total amount sometimes display the word `Array` :

![Screenshot_2019-09-30 Dashboard](https://user-images.githubusercontent.com/372004/65914770-02a2b180-e3a0-11e9-8222-507f575e89a5.png)

Before
----------------------------------------
The word `Array` is displayed on the user dashboard.

After
----------------------------------------
The word `Array` is removed from the user dashboard.

Technical Details
----------------------------------------
When looking in the code and database, it seems that the field `civicrm_contribution.amount_level` contains more often than not a list of value even if it's only one item.

It seems to be the case for events for example but not always for donation.
Not sure how this works exactly.

```sql
SELECT distinct(replace(amount_level, UNHEX(01), '|'))
FROM civicrm_contribution 
ORDER BY ID DESC
LIMIT 5;
```
```
+--------------------------------------------------+
| (replace(amount_level, UNHEX(01), '|'))          |
+--------------------------------------------------+
| Donate                                           |
| |Full Rate - 1|                                  |
| |Barrier Free Rate - 1|                          |
| |Full Rate - 1|Gathering Contribution - 20|      |
| |Barrier Free Rate - 1| (multiple participants)| |
+--------------------------------------------------+
5 rows in set (0.03 sec)
```

It doesn't seems very useful to display the information in the user dashboard, so i propose to simply hide the information when it's an array.

Comments
----------------------------------------
Probably an old bug but somehow hadn't noticed before.
I can reproduce the problem on 5.14 and latest 5.18 as well.

Not sure if the amount_level is really useful here but to keep it from any regression, i have kept the display as it is if it's not an array.

