### PR TITLE
dev/core#1279 - crmMailingRadioDateSpec.js always has a failure if west of GMT

### DIFF
--- a/tests/karma/unit/crmMailingRadioDateSpec.js
+++ b/tests/karma/unit/crmMailingRadioDateSpec.js
@@ -107,7 +107,10 @@ describe('crmMailingRadioDate', function() {
       var datenow = [year, month, day].join('-');
       var time = [hours, minutes, "00"].join(':');
       var currentDate = datenow + ' ' + time;
-      var ndate = new Date(datenow);
+      // Using datenow in the constructor here converts to local time. If not
+      // running on GMT (or east) then comparison to toDateString below fails.
+      // Also use month-1 because...javascript.
+      var ndate = new Date(year, month-1, day, 0, 0, 0);
       model.the_date = currentDate;
 
       $rootScope.$digest();


### PR DESCRIPTION
Overview
----------------------------------------
There's a line where it sets a date, but the way it does it it inadvertently converts to local time, so if west of GMT then when it compares using toDateString() later it is always the day before.
