### PR TITLE
Core/dev#692 : Support search arguments to Case Search form

### DIFF
--- a/CRM/Case/DAO/Case.php
+++ b/CRM/Case/DAO/Case.php
@@ -140,6 +140,9 @@ class CRM_Case_DAO_Case extends CRM_Core_DAO {
           'entity' => 'Case',
           'bao' => 'CRM_Case_BAO_Case',
           'localizable' => 0,
+          'html' => [
+            'type' => 'Text',
+          ],
         ],
         'case_type_id' => [
           'name' => 'case_type_id',
@@ -265,6 +268,9 @@ class CRM_Case_DAO_Case extends CRM_Core_DAO {
           'entity' => 'Case',
           'bao' => 'CRM_Case_BAO_Case',
           'localizable' => 0,
+          'html' => [
+            'type' => 'CheckBox',
+          ],
         ],
         'case_created_date' => [
           'name' => 'created_date',

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -64,6 +64,13 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
   protected $_prefix = 'case_';
 
   /**
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'Case';
+  }
+
+  /**
    * Processing needed for buildForm and later.
    */
   public function preProcess() {
@@ -204,7 +211,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     }
 
     $this->_done = TRUE;
-    $this->_formValues = $this->controller->exportValues($this->_name);
+    $this->setFormValues();
     $this->fixFormValues();
 
     if (isset($this->_ssID) && empty($_POST)) {
@@ -312,19 +319,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     }
 
     return TRUE;
-  }
-
-  /**
-   * Set the default form values.
-   *
-   *
-   * @return array
-   *   the default array reference
-   */
-  public function setDefaultValues() {
-    $defaults = [];
-    $defaults = $this->_formValues;
-    return $defaults;
   }
 
   public function fixFormValues() {

--- a/xml/schema/Case/Case.xml
+++ b/xml/schema/Case/Case.xml
@@ -14,6 +14,9 @@
     <import>true</import>
     <title>Case ID</title>
     <comment>Unique Case ID</comment>
+    <html>
+      <type>Text</type>
+    </html>
     <add>1.8</add>
   </field>
   <primaryKey>
@@ -186,6 +189,9 @@
     <default>0</default>
     <import>true</import>
     <title>Case Deleted</title>
+    <html>
+      <type>CheckBox</type>
+    </html>
     <add>2.2</add>
   </field>
   <index>


### PR DESCRIPTION
Overview
----------------------------------------
This PR extends the fix and make all possible mailing search filters to be used as a url arguments on forced search using 'Find Mailing' or 'Advance Search'


Before
----------------------------------------
Search arguments didn't work
<img width="899" alt="Screen Shot 2019-10-01 at 6 23 16 PM" src="https://user-images.githubusercontent.com/3735621/65964656-09eabd80-e47b-11e9-9812-a36fe53a9a74.png">


After
----------------------------------------
Search arguments works:
<img width="928" alt="Screen Shot 2019-10-01 at 6 40 21 PM" src="https://user-images.githubusercontent.com/3735621/65964626-fccdce80-e47a-11e9-81e5-b860d74850ad.png">

