### PR TITLE
dev/core#1282 Takes care of customfields of type multiselect that were not being rendered

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2508,7 +2508,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                             $defaults[$fldName] = $value[substr($fieldName, 8)];
                             break;
                         }
-                      } 
+                      }
                       else {
                         $defaults[$fldName] = $value[substr($fieldName, 8)];
                       }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2479,7 +2479,39 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                     elseif (substr($fieldName, 0, 14) === 'address_custom' &&
                       CRM_Utils_Array::value(substr($fieldName, 8), $value)
                     ) {
-                      $defaults[$fldName] = $value[substr($fieldName, 8)];
+                      if (isset($fields[$name]['html_type'])) {
+                        switch ($fields[$name]['html_type']) {
+                          case 'Multi-Select State/Province':
+                          case 'Multi-Select Country':
+                          case 'Multi-Select':
+                            $v = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value[substr($fieldName, 8)]);
+                            foreach ($v as $item) {
+                              if ($item) {
+                                $defaults[$fldName][$item] = $item;
+                              }
+                            }
+                            break;
+
+                          case 'CheckBox':
+                            $v = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value[substr($fieldName, 8)]);
+                            foreach ($v as $item) {
+                              if ($item) {
+                                $defaults[$fldName][$item] = 1;
+                                // seems like we need this for QF style checkboxes in profile where its multiindexed
+                                // CRM-2969
+                                $defaults["{$fldName}[{$item}]"] = 1;
+                              }
+                            }
+                            break;
+
+                          default:
+                            $defaults[$fldName] = $value[substr($fieldName, 8)];
+                            break;
+                        }
+                      } 
+                      else {
+                        $defaults[$fldName] = $value[substr($fieldName, 8)];
+                      }
                     }
                   }
                 }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2445,6 +2445,13 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                     }
                   }
                 }
+                else {
+                  if (substr($fieldName, 0, 14) === 'address_custom' &&
+                    CRM_Utils_Array::value(substr($fieldName, 8), $value)
+                  ) {
+                    $defaults[$fldName] = self::reformatProfileDefaults($field, $value[substr($fieldName, 8)]);
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------
Customfields of type Multiselect attached to an Address do not render in profile page (appear empty). Related issue: https://lab.civicrm.org/dev/core/issues/1282

Before
----------------------------------------
MultiSelect customfield did not render values
![before-patchfix](https://user-images.githubusercontent.com/14973113/66033483-a6f33800-e507-11e9-8aad-00629acbf641.png)

After
----------------------------------------
MultiSelect customfield does render values
![after-patchfix](https://user-images.githubusercontent.com/14973113/66033495-ac508280-e507-11e9-98dd-bae62b42af2a.png)

Technical Details
----------------------------------------
Examines (using `switch`) the html-type of the field to render, as already being done a few lines before: https://lab.civicrm.org/dev/core/blob/master/CRM/Core/BAO/UFGroup.php#L2373-2400
If of type:
* Multi-Select
* Multi-Select State/Province
* Multi-Select Country
* Checkbox
default value assignment is following the logic of https://lab.civicrm.org/dev/core/blob/master/CRM/Core/BAO/UFGroup.php#L2373-2400

Comments
----------------------------------------
It seems that Checkbox works by itself. I could minimize the check only to the Multi-Select elements.
