### PR TITLE
dev/core#1291 Use name instead of label to check contribution status

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1554,7 +1554,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
         // @todo Move this into CRM_Member_BAO_Membership::processMembership
         if (!empty($membershipContribution)) {
-          $pending = ($membershipContribution->contribution_status_id == array_search('Pending', CRM_Contribute_PseudoConstant::contributionStatus())) ? TRUE : FALSE;
+          $pending = ($membershipContribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')) ? TRUE : FALSE;
         }
         else {
           $pending = $this->getIsPending();


### PR DESCRIPTION
Overview
----------------------------------------
This will fail if the label is changed (eg. different language).  Now it won't.

https://lab.civicrm.org/dev/core/issues/1291

Before
----------------------------------------
Check label

After
----------------------------------------
Check name

Technical Details
----------------------------------------
Need to check name not label.

Comments
----------------------------------------
@mlutfy This is similar to other translation fixes you've done - can you check?
