### PR TITLE
[NFC] Rename local variable

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -354,9 +354,10 @@
 
       // go lookup and add client-perspective labels for $scope.caseType.definition.caseRoles
       _.each($scope.caseType.definition.caseRoles, function (set) {
-        _.each($scope.relationshipTypeOptions, function (relTypes) {
-          if (relTypes.text == set.name) {
-            set.displaylabel = relTypes.id;
+        _.each($scope.relationshipTypeOptions, function (relationshipTypeOption) {
+          if (relationshipTypeOption.text == set.name) {
+            // relationshipTypeOption.id here corresponds to one of the civicrm_relationship_type.label database fields, not civicrm_relationship_type.id
+            set.displaylabel = relationshipTypeOption.id;
           }
         });
       });


### PR DESCRIPTION
Overview
----------------------------------------
Every time I look at this block and see relTypes I need to spend a few minutes realizing it's not the same as apiCalls.relTypes, and in particular that relTypes.id here tracks back to apiCalls.relTypes.label.

Technical Details
----------------------------------------
Changes the name of a local variable in an anonymous function not used outside the block.

