### PR TITLE
[REF] Consolidate getFormValues on contribution search

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -86,14 +86,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
 
     $this->loadStandardSearchOptionsFromUrl();
 
-    // get user submitted values
-    // get it from controller only if form has been submitted, else preProcess has set this
-    if (!empty($_POST)) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
-    else {
-      $this->_formValues = $this->get('formValues');
-    }
+    $this->_formValues = $this->getFormValues();
 
     //membership ID
     $memberShipId = CRM_Utils_Request::retrieve('memberId', 'Positive', $this);

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -129,7 +129,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    *
    * @return array|NULL
    *   reference to the array of default values
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function setDefaultValues() {
     $defaults = (array) $this->_formValues;
@@ -145,12 +145,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    * @throws \Exception
    */
   protected function setFormValues() {
-    if (!empty($_POST) && !$this->_force) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
-    elseif ($this->_force) {
-      $this->_formValues = $this->setDefaultValues();
-    }
+    $this->_formValues = $this->getFormValues();
     $this->convertTextStringsToUseLikeOperator();
   }
 
@@ -475,6 +470,25 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
         $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
       }
     }
+  }
+
+  /**
+   * Get the form values.
+   *
+   * @todo consolidate with loadFormValues()
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getFormValues() {
+    if (!empty($_POST) && !$this->_force) {
+      return $this->controller->exportValues($this->_name);
+    }
+    if ($this->_force) {
+      return $this->setDefaultValues();
+    }
+    return (array) $this->get('formValues');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code consolidation

Before
----------------------------------------
Less re-usable

After
----------------------------------------
More re-usable

Technical Details
----------------------------------------
This consolidates 2 places where formValues are determined on contribution search. In one place
force is handled in the other retrieving from the form is handled. It seems Ok to handle both in
one place & call that. This might help iron on some glitches Monish is hitting on #15370

We should probably add saved search retrieval in too

To confirm this works use this url
civicrm/contribute/search?reset=1&reset=1&sort_name=p&receive_date_high=20180101&force=1

- it should filter. If you add another criteria to the form afterwards the url criteria should
be present on the form from the url & the new one should also be respected. If you actively remove the url
criteria on the form it is ignored in the search

Comments
----------------------------------------
Cleanup towards helping on #15370

I've just noted this could be merged with loadFormValues - I think it's fine to merge this & then consider that since there are 2 things in it to make sense of - isModal & ssid
