### PR TITLE
(dev/event#15) Fix regression in handling of post profiles in email

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1143,6 +1143,10 @@ WHERE civicrm_event.is_active = 1
 
         // @todo - the goal is that all params available to the message template are explicitly defined here rather than
         // 'in a smattering of places'. Note that leakage can happen between mailings when not explicitly defined.
+        $customPostTitles = empty($profilePost[1]) ? NULL : [];
+        foreach ($postProfileID as $id) {
+          $customPostTitles[$id] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $postProfileID);
+        }
         $tplParams = array_merge($values, $participantParams, [
           'email' => $email,
           'confirm_email_text' => CRM_Utils_Array::value('confirm_email_text', $values['event']),
@@ -1152,7 +1156,7 @@ WHERE civicrm_event.is_active = 1
           'customPre' => $profilePre[0],
           'customPre_grouptitle' => empty($profilePre[1]) ? NULL : [CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $preProfileID)],
           'customPost' => $profilePost[0],
-          'customPost_grouptitle' => empty($profilePost[1]) ? NULL : [CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $postProfileID)],
+          'customPost_grouptitle' => $customPostTitles,
           'participantID' => $participantId,
           'conference_sessions' => $sessions,
           'credit_card_number' => CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $participantParams)),

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1145,7 +1145,7 @@ WHERE civicrm_event.is_active = 1
         // 'in a smattering of places'. Note that leakage can happen between mailings when not explicitly defined.
         $customPostTitles = empty($profilePost[1]) ? NULL : [];
         foreach ($postProfileID as $id) {
-          $customPostTitles[$id] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $postProfileID);
+          $customPostTitles[$id] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $id);
         }
         $tplParams = array_merge($values, $participantParams, [
           'email' => $email,

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1144,8 +1144,8 @@ WHERE civicrm_event.is_active = 1
         // @todo - the goal is that all params available to the message template are explicitly defined here rather than
         // 'in a smattering of places'. Note that leakage can happen between mailings when not explicitly defined.
         $customPostTitles = empty($profilePost[1]) ? NULL : [];
-        foreach ($postProfileID as $id) {
-          $customPostTitles[$id] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $id);
+        foreach ($postProfileID as $offset => $id) {
+          $customPostTitles[$offset] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $id);
         }
         $tplParams = array_merge($values, $participantParams, [
           'email' => $email,

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1143,9 +1143,14 @@ WHERE civicrm_event.is_active = 1
 
         // @todo - the goal is that all params available to the message template are explicitly defined here rather than
         // 'in a smattering of places'. Note that leakage can happen between mailings when not explicitly defined.
-        $customPostTitles = empty($profilePost[1]) ? NULL : [];
-        foreach ($postProfileID as $offset => $id) {
-          $customPostTitles[$offset] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $id);
+        if ($postProfileID) {
+          $customPostTitles = empty($profilePost[1]) ? NULL : [];
+          foreach ($postProfileID as $offset => $id) {
+            $customPostTitles[$offset] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $id);
+          }
+        }
+        else {
+          $customPostTitles = NULL;
         }
         $tplParams = array_merge($values, $participantParams, [
           'email' => $email,


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a regression from 5.17.0 when sending a confirmation email. If event uses any "post" profile forms, then the confirmation email includes subsections to summarize each post-profile. The subsection titles were miscomputed. This manifested as either a page crash or an inaccurate title.

See also: https://lab.civicrm.org/dev/event/issues/15

Before
----------------------------------------

<img width="1650" alt="Screen Shot 2019-10-03 at 7 44 02 AM" src="https://user-images.githubusercontent.com/1336047/66112301-7c19ea00-e5c2-11e9-88b5-3f666bd067a7.png">

After
----------------------------------------

<img width="730" alt="Screen Shot 2019-10-03 at 9 33 29 AM" src="https://user-images.githubusercontent.com/1336047/66112302-7c19ea00-e5c2-11e9-86a1-78bc443cab38.png">

Technical Details
----------------------------------------

The previous code took an array (`$postProfileID`) and casted it to an `int`. This produced an arbitrary int (`0` or `1`). The revised code handles the array as an array.