### PR TITLE
Remove call to updateRecurMembership which is handled by Membership::create BAO

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1575,8 +1575,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
 
         if (!empty($membershipContribution)) {
-          // update recurring id for membership record
-          CRM_Member_BAO_Membership::updateRecurMembership($membership, $membershipContribution);
           // Next line is probably redundant. Checks prevent it happening twice.
           $membershipPaymentParams = [
             'membership_id' => $membership->id,

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1117,12 +1117,14 @@ AND civicrm_membership.is_test = %2";
   }
 
   /**
+   * @deprecated This is not used anywhere and should be removed soon!
    * Function for updating a membership record's contribution_recur_id.
    *
    * @param CRM_Member_DAO_Membership $membership
    * @param \CRM_Contribute_BAO_Contribution|\CRM_Contribute_DAO_Contribution $contribution
    */
   public static function updateRecurMembership(CRM_Member_DAO_Membership $membership, CRM_Contribute_BAO_Contribution $contribution) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use the API instead');
 
     if (empty($contribution->contribution_recur_id)) {
       return;
@@ -1844,6 +1846,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
     $membershipTypeDetails = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($membershipTypeID);
     $dates = [];
     $ids = [];
+
     // CRM-7297 - allow membership type to be be changed during renewal so long as the parent org of new membershipType
     // is the same as the parent org of an existing membership of the contact
     $currentMembership = CRM_Member_BAO_Membership::getContactMembership($contactID, $membershipTypeID,

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -935,6 +935,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->assertEquals($membership['contact_id'], $contribution['contact_id']);
     $this->assertEquals($expectedMembershipStatus, $membership['status_id']);
     $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $contribution['contribution_recur_id']]);
+    $this->assertEquals($contribution['contribution_recur_id'], $membership['contribution_recur_id']);
 
     $this->callAPISuccess('line_item', 'getsingle', ['contribution_id' => $contribution['id'], 'entity_id' => $membership['id']]);
     //renew it with processor setting completed - should extend membership


### PR DESCRIPTION
Overview
----------------------------------------
Updating the contribution recur ID is already handled in `CRM_Member_BAO_Membership::processMembership`

Before
----------------------------------------
We call a specific function `updateRecurMembership` which is only used here to update the recur ID which was already updated in the call to `CRM_Member_BAO_Membership::processMembership`

After
----------------------------------------
We don't call a specific function for something that is already done..

Technical Details
----------------------------------------
If you look in `CRM_Member_BAO_Membership::processMembership` you can see that `contribution_recur_id` is always set and passed to the BAO create if available where it will get written to the database.  `CRM_Member_BAO_Membership::processMembership` takes the recur ID as a parameter.
In the code there is a possibility that the recur ID is set on the contribution but not the form - I don't know if this could happen in reality but we add an IF to processMembership to ensure that nothing is changed.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
