### PR TITLE
financial#71 - allow emailing partially paid invoices

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -94,9 +94,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       parent::preProcess();
     }
 
-    // check that all the contribution ids have status Completed, Pending, Refunded.
+    // check that all the contribution ids have status Completed, Pending, Refunded, or Partially Paid.
     $this->_contributionStatusId = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-    $status = ['Completed', 'Pending', 'Refunded'];
+    $status = ['Completed', 'Pending', 'Refunded', 'Partially paid'];
     $statusId = [];
     foreach ($this->_contributionStatusId as $key => $value) {
       if (in_array($value, $status)) {
@@ -107,7 +107,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
     $query = "SELECT count(*) FROM civicrm_contribution WHERE contribution_status_id NOT IN ($Id) AND {$this->_componentClause}";
     $count = CRM_Core_DAO::singleValueQuery($query);
     if ($count != 0) {
-      CRM_Core_Error::statusBounce(ts('Please select only contributions with Completed, Pending, Refunded status.'));
+      CRM_Core_Error::statusBounce(ts('Please select only contributions with Completed, Pending, Refunded, or Partially Paid status.'));
     }
 
     // we have all the contribution ids, so now we get the contact ids


### PR DESCRIPTION
Overview
----------------------------------------
The "Email Invoice" functionality is hard-coded to not send partially paid invoices, even though the default invoice template supports them correctly.

Before
----------------------------------------
Can't email a partially paid invoice.  You get the error `Please select only contributions with Completed, Pending, Refunded status.`.

After
----------------------------------------
Partially paid invoices are emailed successfully.

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
**Steps to replicate:**
* You need to enable tax/invocing under CiviContribute Component Settings
* Create a pending contribution on the back end.
* Record a partial payment on the contribution.
* View the contribution and press "Email invoice".
