### PR TITLE
Extract the code to get the field name.

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -160,24 +160,14 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       $quoteValue = "\"$value\"";
     }
 
-    // These are legacy names.
-    // @todo enotices when these are hit so we can start to elimnate them.
-    $fieldAliases = [
-      'financial_type' => 'financial_type_id',
-      'contribution_page' => 'contribution_page_id',
-      'payment_instrument' => 'payment_instrument_id',
-      // or payment_instrument_id?
-      'contribution_payment_instrument' => 'contribution_payment_instrument_id',
-      'contribution_status' => 'contribution_status_id',
-    ];
+    $fieldAliases = self::getLegacySupportedFields();
 
-    $name = isset($fieldAliases[$name]) ? $fieldAliases[$name] : $name;
+    $fieldName = $name = self::getFieldName($values);
     $qillName = $name;
     if (in_array($name, $fieldAliases)) {
       $qillName = array_search($name, $fieldAliases);
     }
     $pseudoExtraParam = [];
-    $fieldName = str_replace(['_high', '_low'], '', $name);
     $fieldSpec = CRM_Utils_Array::value($fieldName, $fields, []);
     $tableName = CRM_Utils_Array::value('table_name', $fieldSpec, 'civicrm_contribution');
     $dataType = CRM_Utils_Type::typeToString(CRM_Utils_Array::value('type', $fieldSpec));

--- a/CRM/Core/BAO/Query.php
+++ b/CRM/Core/BAO/Query.php
@@ -59,6 +59,27 @@ class CRM_Core_BAO_Query {
   }
 
   /**
+   * Get legacy fields which we still maybe support.
+   *
+   * These are contribution specific but I think it's ok to have one list of legacy supported
+   * params in a central place.
+   *
+   * @return array
+   */
+  protected static function getLegacySupportedFields(): array {
+    // @todo enotices when these are hit so we can start to elimnate them.
+    $fieldAliases = [
+      'financial_type' => 'financial_type_id',
+      'contribution_page' => 'contribution_page_id',
+      'payment_instrument' => 'payment_instrument_id',
+      // or payment_instrument_id?
+      'contribution_payment_instrument' => 'contribution_payment_instrument_id',
+      'contribution_status' => 'contribution_status_id',
+    ];
+    return $fieldAliases;
+  }
+
+  /**
    * Getter for the qill object.
    *
    * @return string
@@ -79,5 +100,23 @@ class CRM_Core_BAO_Query {
    * @param $tables
    */
   public static function tableNames(&$tables) {}
+
+  /**
+   * Get the name of the field.
+   *
+   * @param array $values
+   *
+   * @return string
+   */
+  protected static function getFieldName($values) {
+    $name = $values[0];
+    $fieldAliases = self::getLegacySupportedFields();
+    if (isset($fieldAliases[$name])) {
+      CRM_Core_Error::deprecatedFunctionWarning('These parameters should be standardised before we get here');
+      return $fieldAliases[$name];
+    }
+
+    return str_replace(['_high', '_low'], '', $name);
+  }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Function extraction

Before
----------------------------------------
Less re-usable

After
----------------------------------------
More re-usable

Technical Details
----------------------------------------
Ideally we can share this across searches (@monishdeb is hitting some things in case search that are solved
in contribution search so trying to cleanup these bits  - this just pulls out one small piece.

Once this is passing tests (which could be affected by my new deprecations
I think the other fields - fieldspec & 'qillname' if still required can get the same treatment.
in the next step.

Getting the fieldSpec & adding the qill is what I specifically want to genericise.

Comments
----------------------------------------

