### PR TITLE
Check email when creating a user in drupal 8

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -153,27 +153,27 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
       // This checks for both username uniqueness and validity.
       $violations = iterator_to_array($user->validate());
       // We only care about violations on the username field; discard the rest.
-      $violations = array_filter($violations, function ($v) {
+      $violations = array_values(array_filter($violations, function ($v) {
         return $v->getPropertyPath() == 'name';
-      });
+      }));
       if (count($violations) > 0) {
         $errors['cms_name'] = (string) $violations[0]->getMessage();
       }
     }
 
     // And if we are given an email address, let's check to see if it already exists.
-    if (!empty($params[$emailName])) {
-      $mail = $params[$emailName];
+    if (!empty($params[$emailName]) || !empty($params['mail'])) {
+      $key = (!empty($params[$emailName])) ? $emailName : 'mail';
 
       $user = entity_create('user');
-      $user->setEmail($mail);
+      $user->setEmail($params[$key]);
 
       // This checks for both email uniqueness.
       $violations = iterator_to_array($user->validate());
       // We only care about violations on the email field; discard the rest.
-      $violations = array_filter($violations, function ($v) {
+      $violations = array_values(array_filter($violations, function ($v) {
         return $v->getPropertyPath() == 'mail';
-      });
+      }));
       if (count($violations) > 0) {
         $errors[$emailName] = (string) $violations[0]->getMessage();
       }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -162,8 +162,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     }
 
     // And if we are given an email address, let's check to see if it already exists.
-    if (!empty($params[$emailName]) || !empty($params['mail'])) {
-      $key = (!empty($params[$emailName])) ? $emailName : 'mail';
+    if (!empty($params['mail'])) {
+      $mail = $params['mail'];
 
       $user = entity_create('user');
       $user->setEmail($params[$key]);

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -166,7 +166,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
       $mail = $params['mail'];
 
       $user = entity_create('user');
-      $user->setEmail($params[$key]);
+      $user->setEmail($mail);
 
       // This checks for both email uniqueness.
       $violations = iterator_to_array($user->validate());


### PR DESCRIPTION
When visiting a contribution page as an anonymous user & it is possible to create a new Drupal 8 user, there is currently no correct validation on email address within the profile form.

So when using an email address of an existing Drupal 8 user in the profile form and you continue on the confirmation page you will be redirected to the home page instead of for example the online payment page.

I noticed that in the function "checkUserNameEmailExists" the variable "$emailName" does not match the key in the "$params" array.

Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
