### PR TITLE
dev/core#1291 rollback to search Pending by key

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1554,7 +1554,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
         // @todo Move this into CRM_Member_BAO_Membership::processMembership
         if (!empty($membershipContribution)) {
-          $pending = ($membershipContribution->contribution_status_id == array_search('Pending', CRM_Contribute_PseudoConstant::contributionStatus())) ? TRUE : FALSE;
+          $pendingStatus = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
+          $pending = ($membershipContribution->contribution_status_id == $pendingStatus) ? TRUE : FALSE;
         }
         else {
           $pending = $this->getIsPending();


### PR DESCRIPTION
Overview
----------------------------------------
Regression introduced by https://github.com/civicrm/civicrm-core/pull/15124 that could lead to membership getting twice the period of the membership (as if they were renewed once) for translated sites where the contribution status "Pending" as been translated.

Before
----------------------------------------
Using the contribution page:

- 1 year membership gets 2 years
- pending membership gets one year

After
----------------------------------------
The part of the code that caused the regression has been rolled back.

Technical Details
----------------------------------------
We use the key (name) of the option value instead of the label.

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1291
