### PR TITLE
dev/core#1294 Remove getFormValues function

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -758,13 +758,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
-   * @return array
-   */
-  public function &getFormValues() {
-    return $this->_formValues;
-  }
-
-  /**
    * Common post processing.
    */
   public function postProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an unreleased regression where values entered are ignored

Before
----------------------------------------
Input ignored

After
----------------------------------------
Normality resumes

Technical Details
----------------------------------------
A recent extraction on the parent function created a getFormValues but it's not being called on adv search because this is overriding. I couldn't see anywhere that this was being used in it's current form

Comments
----------------------------------------
@pfigel 
