### PR TITLE
dev/core#861 Ensure that when processing mailings that no emails are …

### DIFF
--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -73,10 +73,26 @@ WHERE  mailing_id = %1
       $limitString = "LIMIT $offset, $limit";
     }
 
+    $isSMSmode = CRM_Core_DAO::getFieldValue('CRM_Mailing_BAO_Mailing', $mailingID, 'sms_provider_id', 'id');
+    $additionalJoin = '';
+    if (!$isSMSmode) {
+      // mailing_recipients added when mailing is submitted in UI by user.
+      // if any email is marked on_hold =1 or contact is deceased after mailing is submitted
+      // then it should be get skipped while preparing event_queue
+      // event_queue list is prepared when mailing job gets started.
+      $additionalJoin = " INNER JOIN civicrm_email e ON (r.email_id = e.id AND e.on_hold = 0 AND e.is_primary = 1)
+                          INNER JOIN civicrm_contact c on (c.id = r.contact_id AND c.is_deceased <> 1 AND c.do_not_email = 0 AND c.is_opt_out = 0)
+";
+    }
+    else {
+      $additionalJoin = "INNER JOIN civicrm_contact c on (c.id = r.contact_id AND c.is_deceased <> 1 AND c.do_not_sms = 0 AND c.is_opt_out = 0)";
+    }
+
     $sql = "
-SELECT contact_id, email_id, phone_id
-FROM   civicrm_mailing_recipients
-WHERE  mailing_id = %1
+SELECT r.contact_id, r.email_id, r.phone_id
+FROM   civicrm_mailing_recipients r
+{$additionalJoin}
+WHERE  r.mailing_id = %1
        $limitString
 ";
     $params = [1 => [$mailingID, 'Integer']];


### PR DESCRIPTION
…sent to deceased contacts or those with emails now on hold

Overview
----------------------------------------
This resurects #14020 from Yash by adding a test and also expanding the checks so that for SMSes we also exclude deceased contacts

Before
----------------------------------------
Newly deceased contacts may get mailed if mailing scheudled before contact is marked as deceased

After
----------------------------------------
No deceased contacts emailed or smsed

ping @eileenmcnaughton 