### PR TITLE
Remove legacy Yahoo references from the Mapping/Geocoding settings/code.

### DIFF
--- a/CRM/Admin/Form/Setting/Mapping.php
+++ b/CRM/Admin/Form/Setting/Mapping.php
@@ -67,10 +67,6 @@ class CRM_Admin_Form_Setting_Mapping extends CRM_Admin_Form_Setting {
       $errors['_qf_default'] = ts('Mapping features require PHP version 5 or greater');
     }
 
-    if (!$fields['mapAPIKey'] && ($fields['mapProvider'] != '' && $fields['mapProvider'] == 'Yahoo')) {
-      $errors['mapAPIKey'] = "Map Provider key is a required field.";
-    }
-
     if ($fields['mapProvider'] == 'OpenStreetMaps' && $fields['geoProvider'] == '') {
       $errors['geoProvider'] = "Please select a Geocoding Provider - Open Street Maps does not provide geocoding.";
     }

--- a/settings/Map.setting.php
+++ b/settings/Map.setting.php
@@ -51,7 +51,7 @@ return [
     ],
     'default' => NULL,
     'title' => 'Geo Provider Key',
-    'description' => 'Enter the API key or Application ID associated with your geocoding provider (not required for Yahoo).',
+    'description' => 'Enter the API key or Application ID associated with your geocoding provider.',
   ],
   'geoProvider' => [
     'add' => '4.7',

--- a/templates/CRM/Admin/Form/Setting/Mapping.tpl
+++ b/templates/CRM/Admin/Form/Setting/Mapping.tpl
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="help">
-    {ts}CiviCRM includes plugins for several mapping and geocoding web services. When your users save a contact or event location address, a geocoding service will convert the address into geographical coordinates, which are required for mapping. Yahoo&rsquo;s geocoder will also automatically populate the postal code field. Mapping services allow your users to display addresses on a map.{/ts} {help id='map-intro-id'}
+    {ts}CiviCRM includes plugins for several mapping and geocoding web services. When your users save a contact or event location address, a geocoding service will convert the address into geographical coordinates, which are required for mapping. Mapping services allow your users to display addresses on a map.{/ts} {help id='map-intro-id'}
 </div>
 <div class="crm-block crm-form-block crm-map-form-block">
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
@@ -47,7 +47,7 @@
          <tr class="crm-map-form-block-geoAPIKey">
              <td>{$form.geoAPIKey.label}</td>
              <td>{$form.geoAPIKey.html|crmAddClass:huge}<br />
-             <span class="description">{ts}Enter the API key or Application ID associated with your geocoding provider (not required for Yahoo).{/ts}</span></td>
+             <span class="description">{ts}Enter the API key or Application ID associated with your geocoding provider.{/ts}</span></td>
          </tr>
     </table>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Admin/Page/ConfigTaskList.tpl
+++ b/templates/CRM/Admin/Page/ConfigTaskList.tpl
@@ -64,7 +64,7 @@
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/mapping" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Mapping and Geocoding{/ts}</a></td>
-        <td>{ts}Configure a mapping provider (e.g. Google or Yahoo) to display maps for contact addresses and event locations.{/ts}</td>
+        <td>{ts}Configure a mapping provider (e.g. OpenStreetMap or Google) to display maps for contact addresses and event locations.{/ts}</td>
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/search" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Search Settings{/ts}</a></td>


### PR DESCRIPTION
Overview
----------------------------------------
_Removes the references to the Yahoo mapping provider and geocoder from settings help test, from conditional logic and finally adds OSM to the Task Checklist to finalise the removal of the Yahoo remnants._

Before
----------------------------------------
_References remain to the removed Yahoo mapping and Geocoding services in the Civi interface._

After
----------------------------------------
_The references are removed._

Technical Details
----------------------------------------
_None_

Comments
----------------------------------------
_None_