### PR TITLE
dev/translation#30 Move l10n resource dir under private files

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -178,7 +178,6 @@ class CRM_Core_Config_MagicMerge {
       // Option: `restrict` - auto-restrict remote access
       'configAndLogDir' => ['path', 'civicrm.log', ['mkdir', 'restrict']],
       'templateCompileDir' => ['path', 'civicrm.compile', ['mkdir', 'restrict']],
-      'l10nDir' => ['path', 'civicrm.l10n', ['mkdir', 'restrict']],
 
       // "setting-path" properties are settings with special filtering
       // to return normalized file paths.

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -178,6 +178,7 @@ class CRM_Core_Config_MagicMerge {
       // Option: `restrict` - auto-restrict remote access
       'configAndLogDir' => ['path', 'civicrm.log', ['mkdir', 'restrict']],
       'templateCompileDir' => ['path', 'civicrm.compile', ['mkdir', 'restrict']],
+      'l10nDir' => ['path', 'civicrm.l10n', ['mkdir', 'restrict']],
 
       // "setting-path" properties are settings with special filtering
       // to return normalized file paths.

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -282,11 +282,7 @@ class CRM_Core_I18n {
    * @return string
    */
   public static function getResourceDir() {
-    static $dir = NULL;
-    if ($dir === NULL) {
-      $dir = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'l10n' . DIRECTORY_SEPARATOR;
-    }
-    return $dir;
+    return \Civi::paths()->getPath('[civicrm.l10n]/.');
   }
 
   /**

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -78,6 +78,12 @@ class Paths {
           'path' => defined('CIVICRM_TEMPLATE_COMPILEDIR') ? CIVICRM_TEMPLATE_COMPILEDIR : \Civi::paths()->getPath('[civicrm.private]/templates_c'),
         ];
       })
+      ->register('civicrm.l10n', function () {
+        $dir = defined('CIVICRM_L10N_BASEDIR') ? CIVICRM_L10N_BASEDIR : \Civi::paths()->getPath('[civicrm.private]/l10n');
+        return [
+          'path' => is_dir($dir) ? $dir : \Civi::paths()->getPath('[civicrm.root]/l10n'),
+        ];
+      })
       ->register('wp.frontend.base', function () {
         return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
       })

--- a/xml/GenCode.php
+++ b/xml/GenCode.php
@@ -27,6 +27,7 @@ date_default_timezone_set('UTC');
 
 define('CIVICRM_UF', 'Drupal');
 define('CIVICRM_UF_BASEURL', '/');
+define('CIVICRM_L10N_BASEDIR', getenv('CIVICRM_L10N_BASEDIR') ? getenv('CIVICRM_L10N_BASEDIR') : __DIR__ . '/../l10n');
 
 require_once 'CRM/Core/ClassLoader.php';
 CRM_Core_ClassLoader::singleton()->register();


### PR DESCRIPTION
Overview
----------------------------------------
Allows the `l10n` directory to be outside of the main codebase, so installing files there doesn't change dirty the contents of a `vendor` directory. Later on, it could be possible to compile customized `*.mo` / `*.po` files to store in that directory.

Before
----------------------------------------
L10n files were always stored at the `[civicrm.root]/l10n`. When CiviCRM was installed via `composer`, installing `l10n` files would mean copying them into the `vendor` directory and making upgrades difficult.

After
----------------------------------------
L10n files can be stored under any of the following, in order of precedence:

* A custom location defined in `$civicrm_paths['civicrm.l10n']['path']`
* A custom location defined in `CIVICRM_L10N_BASEDIR` (for use with `xml/GenCode.php`)
* `[civicrm.private]/l10n` (often equivalent to `[civicrm.files]/l10n`; ex: `sites/default/files/civicrm/l10n`)
* `[civicrm.root]/l10n` (the traditional location)

Technical Details
----------------------------------------
Registers a new `[civicrm.l10n]` variable with \Civi\Paths and adds an `l10nDir` property to config via MagicMerge (probably unnecessary). Gets rid of function-scoped static caching in `I18n::getResourceDir()`. The `civicrm.l10n` factory function consults a `define()` before looking up `civicrm.private so that it can be used in GenCode.