### PR TITLE
dev/cloud-native#21 Don't cache the full path of extensions so they don't break with dynamic paths

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -304,7 +304,7 @@ class CRM_Extension_Mapper {
         try {
           $moduleExtensions[] = [
             'prefix' => $dao->file,
-            'filePath' => $this->keyToPath($dao->full_name),
+            'filePath' => $dao->full_name,
           ];
         }
         catch (CRM_Extension_Exception $e) {
@@ -323,6 +323,12 @@ class CRM_Extension_Mapper {
         $this->cache->set($this->cacheKey . '_moduleFiles', $moduleExtensions);
       }
     }
+
+    // Since we're not caching the full path we add it now.
+    array_walk($moduleExtensions, function(&$value, $key) {
+      $value['filePath'] = $this->keyToPath($value['filePath']);
+    });
+
     return $moduleExtensions;
   }
 

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -280,7 +280,7 @@ class CRM_Extension_Mapper {
       return [];
     }
 
-    $moduleExtensions = NULL;
+    static $moduleExtensions = NULL;
     if ($this->cache && !$fresh) {
       $moduleExtensions = $this->cache->get($this->cacheKey . '_moduleFiles');
     }

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -316,7 +316,9 @@ class CRM_Extension_Mapper {
     // Since we're not caching the full path we add it now.
     array_walk($moduleExtensions, function(&$value, $key) {
       try {
-        $value['filePath'] = $this->keyToPath($value['fullName']);
+        if (!$value['filePath']) {
+          $value['filePath'] = $this->keyToPath($value['fullName']);
+        }
       }
       catch (CRM_Extension_Exception $e) {
         // Putting a stub here provides more consistency

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -288,7 +288,7 @@ class CRM_Extension_Mapper {
     // 2. The ephemeral/thread-local tier (statics) stores names
     // WITH absolute paths.
     // Return static value instead of re-running query
-    if (isset(Civi::$statics[__CLASS__]['moduleExtensions'])) {
+    if (isset(Civi::$statics[__CLASS__]['moduleExtensions']) && !$fresh) {
       return Civi::$statics[__CLASS__]['moduleExtensions'];
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Addresses https://lab.civicrm.org/dev/cloud-native/issues/21

Technical Details
----------------------------------------
Nothing should be different in terms of the extensions loading. But this PR doesn't store the full path in the cache so it won't mess up systems that are using containers and backup containers that might have a different file path (and can switch at any time).

Testing is ongoing with Pantheon sites.
