### PR TITLE
Allow custom ts functions in extensions; defer custom ts calls until booted

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -768,7 +768,7 @@ class CRM_Core_I18n {
  *   the translated string
  */
 function ts($text, $params = []) {
-  static $areSettingsAvailable = FALSE;
+  static $bootstrapReady = FALSE;
   static $lastLocale = NULL;
   static $i18n = NULL;
   static $function = NULL;
@@ -778,13 +778,18 @@ function ts($text, $params = []) {
   }
 
   // When the settings become available, lookup customTranslateFunction.
-  if (!$areSettingsAvailable) {
-    $areSettingsAvailable = (bool) \Civi\Core\Container::getBootService('settings_manager');
-    if ($areSettingsAvailable) {
+  if (!$bootstrapReady) {
+    $bootstrapReady = (bool) \Civi\Core\Container::isContainerBooted();
+    if ($bootstrapReady) {
+      // just got ready: determine whether there is a working custom translation function
       $config = CRM_Core_Config::singleton();
       if (isset($config->customTranslateFunction) and function_exists($config->customTranslateFunction)) {
         $function = $config->customTranslateFunction;
       }
+    }
+    else {
+      // don't translate anything until bootstrap has progressed enough
+      return $text;
     }
   }
 

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -326,7 +326,7 @@ class CRM_Core_I18n {
    *   The params of the translation (if any).
    *   - domain: string|array a list of translation domains to search (in order)
    *   - context: string
-   *   - skip_translation: boolean (do only escape/replacement, skip the actual translation)
+   *   - skip_translation: flag (do only escape/replacement, skip the actual translation)
    *
    * @return string
    *   the translated string
@@ -379,7 +379,7 @@ class CRM_Core_I18n {
     $raw = !empty($params['raw']);
     unset($params['raw']);
 
-    if (empty($params['skip_translation'])) {
+    if (!isset($params['skip_translation'])) {
       if (!empty($domain)) {
         // It might be prettier to cast to an array, but this is high-traffic stuff.
         if (is_array($domain)) {
@@ -793,18 +793,6 @@ function ts($text, $params = []) {
     else {
       // don't _translate_ anything until bootstrap has progressed enough
       $params['skip_translation'] = 1;
-
-      // temporarily set locale to en_US to prevent spinning up gettext,
-      //   which would be a waste if we have custom translate function
-      global $tsLocale;
-      $current_locale = $tsLocale;
-      // fixme:: use variable?
-      $tsLocale = 'en_US';
-
-      // run translation purely for escape/param replacement/etc.
-      $text = CRM_Core_I18n::singleton()->crm_translate($text, $params);
-      $tsLocale = $current_locale;
-      return $text;
     }
   }
 

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -798,7 +798,8 @@ function ts($text, $params = []) {
       //   which would be a waste if we have custom translate function
       global $tsLocale;
       $current_locale = $tsLocale;
-      $tsLocale = 'en_US'; // fixme:: use variable?
+      // fixme:: use variable?
+      $tsLocale = 'en_US';
 
       // run translation purely for escape/param replacement/etc.
       $text = CRM_Core_I18n::singleton()->crm_translate($text, $params);


### PR DESCRIPTION
Overview
----------------------------------------
Custom ts functions didn't work when they are defined by extensions. The reason is that the ``I18n`` class starts looking for it when the extension files aren't ``require``d yet, and then gives up before they become available.

Before
----------------------------------------
If you set a custom ts function (``CRM_Core_Config::singleton()->customTranslateFunction``) that is defined in the ``module.php`` file in an extension, it wouldn't work.

After
----------------------------------------
It *does* work.

Technical Details
----------------------------------------
Changes discussed with @totten:
* consider the bootstrap process to be progressed enough to find the custom ts function after ``\Civi\Core\Container::isContainerBooted()`` instead of ``\Civi\Core\Container::getBootService('settings_manager')``
* don't translate any strings before the bootstrap process has reached that stage, in order to avoid double initialisation of the gettext system.
* renamed ``$areSettingsAvailable`` to ``$bootstrapReady`` for clarity.
* added ``skip_translation`` flag to ``ts()`` parameters
* ~~avoid spinning up gettext during bootstrap (in case there is a custom ts function)~~

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
