### PR TITLE
Minor a_b/b_a mixup on case type edit screen

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -488,9 +488,9 @@
     $scope.addRoleOnTheFly = function(roles, newType) {
       roles.push({name: newType.label_b_a, displaylabel: newType.label_a_b});
       // Assume that the case role should be A-B but add both directions as options.
-      $scope.relationshipTypeOptions.push({id: newType.label_a_b, text: newType.label_a_b});
+      $scope.relationshipTypeOptions.push({id: newType.label_a_b, text: newType.label_b_a});
       if (newType.label_a_b != newType.label_b_a) {
-        $scope.relationshipTypeOptions.push({id: newType.label_b_a, text: newType.label_b_a});
+        $scope.relationshipTypeOptions.push({id: newType.label_b_a, text: newType.label_a_b});
       }
     };
 

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -547,6 +547,114 @@ describe('crmCaseType', function() {
         );
       });
     });
+
+    describe('when adding a role on-the-fly', function() {
+      beforeEach(inject(function ($controller) {
+        ctrl = $controller('CaseTypeCtrl', {$scope: scope, apiCalls: apiCalls});
+      }));
+
+      it('updates the case roles for unidirectional', function() {
+        // first simulate the ajax popup to create a new relationship type
+        var newType = {
+          "id": "33",
+          "name_a_b": "Some New Type is",
+          "label_a_b": "Some New Type is",
+          "name_b_a": "Some New Type for",
+          "label_b_a": "Some New Type for",
+          "description": "Some New Type",
+          "contact_type_a": "Individual",
+          "contact_type_b": "Individual",
+          "is_reserved": "0",
+          "is_active": "1"
+        };
+        apiCalls.relTypes.values.push(newType);
+
+        // now let the real code do what it does with the new type
+        scope.addRoleOnTheFly(scope.caseType.definition.caseRoles, newType);
+
+        expect(scope.caseType.definition.caseRoles).toEqual(
+          [
+            {
+              name: 'Homeless Services Coordinator',
+              creator: '1',
+              manager: '1',
+              displaylabel: 'Homeless Services Coordinator is'
+            },
+            {
+              name: 'Some New Type for',
+              displaylabel: 'Some New Type is'
+            }
+          ]
+        );
+
+        expect(scope.relationshipTypeOptions.slice(-2)).toEqual(
+          [
+            {
+              id: 'Some New Type is',
+              text: 'Some New Type for'
+            },
+            {
+              id: 'Some New Type for',
+              text: 'Some New Type is'
+            }
+          ]
+        );
+      });
+
+      it('updates the case roles for bidirectional', function() {
+        // first simulate the ajax popup to create a new relationship type
+        var newType = {
+          "id": "34",
+          "name_a_b": "Friend of",
+          "label_a_b": "Friend of",
+          "name_b_a": "Friend of",
+          "label_b_a": "Friend of",
+          "description": "Friend",
+          "contact_type_a": "Individual",
+          "contact_type_b": "Individual",
+          "is_reserved": "0",
+          "is_active": "1"
+        };
+        apiCalls.relTypes.values.push(newType);
+
+        // now let the real code do what it does with the new type
+        scope.addRoleOnTheFly(scope.caseType.definition.caseRoles, newType);
+
+        expect(scope.caseType.definition.caseRoles).toEqual(
+          [
+            {
+              name: 'Homeless Services Coordinator',
+              creator: '1',
+              manager: '1',
+              displaylabel: 'Homeless Services Coordinator is'
+            },
+            {
+              name: 'Friend of',
+              displaylabel: 'Friend of'
+            }
+          ]
+        );
+
+        expect(scope.relationshipTypeOptions.slice(-1)).toEqual(
+          [
+            {
+              id: 'Friend of',
+              text: 'Friend of'
+            }
+          ]
+        );
+
+        // Check that it did NOT add two entries for this bidirectional type
+        expect(scope.relationshipTypeOptions.slice(-2,-1)).not.toEqual(
+          [
+            {
+              id: 'Friend of',
+              text: 'Friend of'
+            }
+          ]
+        );
+      });
+    });
   });
 
   describe('crmAddName', function () {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a minor a_b/b_a mixup that came up during [this testing](https://github.com/civicrm/civicrm-core/pull/15349#discussion_r328693910).

To reproduce:

1. Create/edit a case type.
2. On the roles tab in the dropdown to add a role start typing something that isn't in the list, like "Spacefleet Commander is".
3. It will suggest `(new)` beside your typing. Click it.
4. It will open a box to create a new relationship type on the fly. Fill it out.
5. When you save the new relationship type it will add the A to B direction to the table. So far everything is fine.
6. Now try to add the B to A direction to the table. It won't let you because while the table is correct, the dropdown has them mixed up and thinks you're trying to add the same thing that's already in the table.
7. Similarly try to add the A to B direction to the table again. It will make a duplicate, except it's not actually a duplicate it has added the opposite direction now. You can see this if you save and then re-edit the case type.

The affected code is only ever used in this scenario, before you close the case type edit screen, and only for the newly added relationship type. Before the patch the relationship type itself is fine, the rest of the dropdown is fine, and once you close and re-edit the case type the dropdown is also fine including the relationship type you just added earlier. So it's just this one thing in this one place in this one workflow.

Before
----------------------------------------
Confusing/can add wrong direction

After
----------------------------------------
Better

Technical Details
----------------------------------------

Comments
----------------------------------------
Also adds test which I couldn't add yet during https://github.com/civicrm/civicrm-core/pull/15378

@alifrumin @agh1