### PR TITLE
dev/core#1283 fix inability to export more than 255 chars

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -596,6 +596,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       ) {
         continue;
       }
+      if (!empty($values['text_length'])) {
+        $values['maxlength'] = (int) $values['text_length'];
+      }
 
       /* generate the key for the fields array */
 

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -514,7 +514,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'import' => 1,
         'custom_field_id' => $this->getCustomFieldID('text'),
         'options_per_line' => NULL,
-        'text_length' => NULL,
+        'text_length' => 300,
         'data_type' => 'String',
         'html_type' => 'Text',
         'is_search_range' => '0',
@@ -537,6 +537,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'where' => 'civicrm_value_custom_group_' . $customGroupID . '.enter_text_here_' . $this->getCustomFieldID('text'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
+        'maxlength' => 300,
       ],
       $this->getCustomFieldName('select_string') => [
         'name' => $this->getCustomFieldName('select_string'),

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -682,9 +682,14 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->setUpContactExportData();
     $this->entity = 'Contact';
     $this->createCustomGroupWithFieldsOfAllTypes();
+    $longString = 'Blah';
+    for ($i = 0; $i < 70; $i++) {
+      $longString .= 'Blah';
+    }
+
     $this->callAPISuccess('Contact', 'create', [
       'id' => $this->contactIDs[1],
-      $this->getCustomFieldName('text') => 'BlahdeBlah',
+      $this->getCustomFieldName('text') => $longString,
       $this->getCustomFieldName('country') => 'LA',
       'api.Address.create' => ['location_type_id' => 'Billing', 'city' => 'Waipu'],
     ]);
@@ -699,7 +704,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'ids' => [$this->contactIDs[1]],
     ]);
     $row = $this->csv->fetchOne();
-    $this->assertEquals('BlahdeBlah', $row['Enter text here']);
+    $this->assertEquals($longString, $row['Enter text here']);
     $this->assertEquals('Waipu', $row['Billing-City']);
     $this->assertEquals("Lao People's Democratic Republic", $row['Country']);
   }

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -195,6 +195,7 @@ trait CRMTraits_Custom_CustomDataTrait {
       'is_required' => 1,
       'sequential' => 1,
       'is_searchable' => 1,
+      'text_length' => 300,
     ], $params);
 
     return $this->callAPISuccess('CustomField', 'create', $params)['values'][0];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where custom fields longer than 255 chars are not completely exported

Before
----------------------------------------
FIeld truncates or crashes

After
----------------------------------------
Field exports

Technical Details
----------------------------------------


Comments
----------------------------------------

