### PR TITLE
dev/core#1297 If start/end date is empty, results are empty

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -226,20 +226,29 @@ civicrm_contact AS contact_a {$this->_aclFrom}
       );
     }
 
-    foreach (CRM_Contact_BAO_Query::convertFormValues($dateParams) as $values) {
-      list($name, $op, $value) = $values;
-      if (strstr($name, '_low')) {
-        if (strlen($value) == 10) {
-          $value .= ' 00:00:00';
-        }
-        $clauses[] = "contrib.receive_date >= '{$value}'";
+    if ($dateParams['receive_date_relative']) {
+      list($relativeFrom, $relativeTo) = CRM_Utils_Date::getFromTo($dateParams['receive_date_relative'], $dateParams['receive_date_low'], $dateParams['receive_date_high']);
+    }
+    else {
+      if (strlen($dateParams['receive_date_low']) == 10) {
+        $relativeFrom = $dateParams['receive_date_low'] . ' 00:00:00';
       }
       else {
-        if (strlen($value) == 10) {
-          $value .= ' 23:59:59';
-        }
-        $clauses[] = "contrib.receive_date <= '{$value}'";
+        $relativeFrom = $dateParams['receive_date_low'];
       }
+      if (strlen($dateParams['receive_date_high']) == 10) {
+        $relativeTo = $dateParams['receive_date_high'] . ' 23:59:59';
+      }
+      else {
+        $relativeTo = $dateParams['receive_date_high'];
+      }
+    }
+
+    if ($relativeFrom) {
+      $clauses[] = "contrib.receive_date >= '{$relativeFrom}'";
+    }
+    if ($relativeTo) {
+      $clauses[] = "contrib.receive_date <= '{$relativeTo}'";
     }
 
     if ($includeContactIDs) {


### PR DESCRIPTION
Overview
----------------------------------------
If user has selected the 'Choose date range' date filtering option and he/she doesn't populate the end date field, the end date value becomes 0 and not a valid MySQL date, thus returning 0 results.
Related issue: https://lab.civicrm.org/dev/core/issues/1297

Before
----------------------------------------
No results are coming back

After
----------------------------------------
Results are coming back

Technical Details
----------------------------------------
If end date is empty, the clause produces `contrib.receive_date <= '0'`

Expected behaviour: `contrib.receive_date <= <current_date & time>`

Similarly, if start date is empty, we need to have valid date format.

Comments
----------------------------------------

