### PR TITLE
Add trxn_id as a parameter on Payment.get

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -47,6 +47,9 @@ function civicrm_api3_payment_get($params) {
     $limit = CRM_Utils_Array::value('limit', $params['options']);
   }
   $params['options']['limit'] = 0;
+  if (isset($params['trxn_id'])) {
+    $params['financial_trxn_id.trxn_id'] = $params['trxn_id'];
+  }
   $eft = civicrm_api3('EntityFinancialTrxn', 'get', $params);
   if (!empty($eft['values'])) {
     $eftIds = [];
@@ -209,6 +212,10 @@ function _civicrm_api3_payment_get_spec(&$params) {
       'title' => 'Entity ID',
       'type' => CRM_Utils_Type::T_INT,
       'api.aliases' => ['contribution_id'],
+    ],
+    'trxn_id' => [
+      'title' => 'Transaction ID',
+      'type' => CRM_Utils_Type::T_STRING,
     ],
   ];
 }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -108,6 +108,52 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Retrieve Payment using trxn_id.
+   */
+  public function testGetPaymentWithTrxnID() {
+    $this->_individualId2 = $this->individualCreate();
+    $params1 = [
+      'contact_id' => $this->_individualId,
+      'trxn_id' => 111111,
+      'total_amount' => 10,
+    ];
+    $contributionID1 = $this->contributionCreate($params1);
+
+    $params2 = [
+      'contact_id' => $this->_individualId2,
+      'trxn_id' => 222222,
+      'total_amount' => 20,
+    ];
+    $contributionID2 = $this->contributionCreate($params2);
+
+    $paymentParams = ['trxn_id' => 111111];
+    $payment = $this->callAPISuccess('payment', 'get', $paymentParams);
+    $expectedResult = [
+      $payment['id'] => [
+        'total_amount' => 10,
+        'trxn_id' => 111111,
+        'status_id' => 1,
+        'is_payment' => 1,
+        'contribution_id' => $contributionID1,
+      ],
+    ];
+    $this->checkPaymentResult($payment, $expectedResult);
+
+    $paymentParams = ['trxn_id' => 222222];
+    $payment = $this->callAPISuccess('payment', 'get', $paymentParams);
+    $expectedResult = [
+      $payment['id'] => [
+        'total_amount' => 20,
+        'trxn_id' => 222222,
+        'status_id' => 1,
+        'is_payment' => 1,
+        'contribution_id' => $contributionID2,
+      ],
+    ];
+    $this->checkPaymentResult($payment, $expectedResult);
+  }
+
+  /**
    * Test email receipt for partial payment.
    */
   public function testPaymentEmailReceipt() {


### PR DESCRIPTION
Overview
----------------------------------------
Alternative proposal to https://github.com/civicrm/civicrm-core/pull/15166

Before
----------------------------------------
trxn_id ignored

After
----------------------------------------
trxn_id filters payments

Technical Details
----------------------------------------
@mattwire I believe this is a simpler  version of your PR

Comments
----------------------------------------

