### PR TITLE
dev/financial#72 Make is_template=0 the default for api get requests.

### DIFF
--- a/tests/phpunit/api/v4/Action/EventTest.php
+++ b/tests/phpunit/api/v4/Action/EventTest.php
@@ -30,44 +30,24 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2019
- * $Id$
- *
  */
 
+use Civi\Api4\Event;
 
-namespace Civi\Api4\Service\Spec\Provider;
-
-use Civi\Api4\Service\Spec\RequestSpec;
-
-class GetActionDefaultsProvider implements Generic\SpecProviderInterface {
-
-  /**
-   * @inheritDoc
-   */
-  public function modifySpec(RequestSpec $spec) {
-    // Exclude deleted records from api Get by default
-    $isDeletedField = $spec->getFieldByName('is_deleted');
-    if ($isDeletedField) {
-      $isDeletedField->setDefaultValue('0');
-    }
-
-    // Exclude test records from api Get by default
-    $isTestField = $spec->getFieldByName('is_test');
-    if ($isTestField) {
-      $isTestField->setDefaultValue('0');
-    }
-
-    $isTemplateField = $spec->getFieldByName('is_template');
-    if ($isTemplateField) {
-      $isTemplateField->setDefaultValue('0');
-    }
-  }
+/**
+ * @group headless
+ */
+class EventTest extends \api\v4\UnitTestCase {
 
   /**
-   * @inheritDoc
+   * Test that the event api filters out templates by default.
+   *
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function applies($entity, $action) {
-    return $action === 'get';
+  public function testTemplateFilterByDefault() {
+    Event::create()->setValues(['template_title' => 'Big Event', 'is_template' => 1, 'start_date' => 'now', 'event_type_id' => 'Meeting'])->execute();
+    Event::create()->setValues(['title' => 'Bigger Event', 'start_date' => 'now', 'event_type_id' => 'Meeting'])->execute();
+    $this->assertEquals(1, Event::get()->selectRowCount()->execute()->count());
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds is_template=0 as a generic default on apiv4 get actions

Before
----------------------------------------
Civi\Api4\Event::get()->execute() will retrieve template as well as events

After
----------------------------------------
Templates excluded by default.

Technical Details
----------------------------------------
We are planning on adding is_template to the civicrm_contribution table - following the precedent from event.

By default it is NOT desirable to get template entities returned in a get request - this fixes that at the generic
apiv4 level and means that it will be a default filter when present

Comments
----------------------------------------

