### PR TITLE
dev/core#1281 fix e-notice on isLiveMode

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -180,7 +180,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     }
 
     $tee = NULL;
-    if ($isLiveMode && Civi::settings()->get('recordGeneratedLetters') === 'combined-attached') {
+    if (self::isLiveMode($form) && Civi::settings()->get('recordGeneratedLetters') === 'combined-attached') {
       if (count($activityIds) !== 1) {
         throw new CRM_Core_Exception("When recordGeneratedLetters=combined-attached, there should only be one activity.");
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a recent regression which appears to be an unintended change of functionality in 5.15
For replication - from ticket.

"Also in order to notice any missing functionality you'd have to have the setting at admin - system settings - misc - record generated letters set to "one combined activity plus one attachment", which isn't the default."

Before
----------------------------------------
Enotice seen , combined attachment code ignored

After
----------------------------------------
Prior behaviour restored

Technical Details
----------------------------------------
Looks like a regression from https://github.com/civicrm/civicrm-core/commit/752cee47213094c29b8e6ae5d0b20f0800520d80
which hit in 5.15 - seems good to merge to rc / about to cut to rc

Comments
----------------------------------------
@demeritcowboy thanks for spotting this - ideally we should get this one out
