### PR TITLE
Fix bug in SQL queue that can cause tasks to be run twice in a multiprocess environment

### DIFF
--- a/CRM/Queue/Queue/Sql.php
+++ b/CRM/Queue/Queue/Sql.php
@@ -126,13 +126,19 @@ class CRM_Queue_Queue_Sql extends CRM_Queue_Queue {
    *   With key 'data' that matches the inputted data.
    */
   public function claimItem($lease_time = 3600) {
+
+    $result = NULL;
+    $dao = CRM_Core_DAO::executeQuery('LOCK TABLES civicrm_queue_item WRITE;');
     $sql = "
-      SELECT id, queue_name, submit_time, release_time, data
-      FROM civicrm_queue_item
-      WHERE queue_name = %1
-      ORDER BY weight ASC, id ASC
-      LIMIT 1
-    ";
+        SELECT first_in_queue.* FROM (
+          SELECT id, queue_name, submit_time, release_time, data
+          FROM civicrm_queue_item
+          WHERE queue_name = %1
+          ORDER BY weight ASC, id ASC
+          LIMIT 1
+        ) first_in_queue
+        WHERE release_time IS NULL OR release_time < NOW()
+      ";
     $params = [
       1 => [$this->getName(), 'String'],
     ];
@@ -144,19 +150,22 @@ class CRM_Queue_Queue_Sql extends CRM_Queue_Queue {
 
     if ($dao->fetch()) {
       $nowEpoch = CRM_Utils_Time::getTimeRaw();
-      if ($dao->release_time === NULL || strtotime($dao->release_time) < $nowEpoch) {
-        CRM_Core_DAO::executeQuery("UPDATE civicrm_queue_item SET release_time = %1 WHERE id = %2", [
-          '1' => [date('YmdHis', $nowEpoch + $lease_time), 'String'],
-          '2' => [$dao->id, 'Integer'],
-        ]);
-        // work-around: inconsistent date-formatting causes unintentional breakage
-        #        $dao->submit_time = date('YmdHis', strtotime($dao->submit_time));
-        #        $dao->release_time = date('YmdHis', $nowEpoch + $lease_time);
-        #        $dao->save();
-        $dao->data = unserialize($dao->data);
-        return $dao;
-      }
+      CRM_Core_DAO::executeQuery("UPDATE civicrm_queue_item SET release_time = %1 WHERE id = %2", [
+        '1' => [date('YmdHis', $nowEpoch + $lease_time), 'String'],
+        '2' => [$dao->id, 'Integer'],
+      ]);
+      // (Comment by artfulrobot Sep 2019: Not sure what the below comment means, should be removed/clarified?)
+      // work-around: inconsistent date-formatting causes unintentional breakage
+      #        $dao->submit_time = date('YmdHis', strtotime($dao->submit_time));
+      #        $dao->release_time = date('YmdHis', $nowEpoch + $lease_time);
+      #        $dao->save();
+      $dao->data = unserialize($dao->data);
+      $result = $dao;
     }
+
+    $dao = CRM_Core_DAO::executeQuery('UNLOCK TABLES;');
+
+    return $result;
   }
 
   /**

--- a/CRM/Queue/Queue/Sql.php
+++ b/CRM/Queue/Queue/Sql.php
@@ -137,10 +137,11 @@ class CRM_Queue_Queue_Sql extends CRM_Queue_Queue {
           ORDER BY weight ASC, id ASC
           LIMIT 1
         ) first_in_queue
-        WHERE release_time IS NULL OR release_time < NOW()
+        WHERE release_time IS NULL OR release_time < %2
       ";
     $params = [
       1 => [$this->getName(), 'String'],
+      2 => [CRM_Utils_Time::getTime(), 'Timestamp'],
     ];
     $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, 'CRM_Queue_DAO_QueueItem');
     if (is_a($dao, 'DB_Error')) {


### PR DESCRIPTION
…

Overview
----------------------------------------

The SQL queue is supposed to ensure that each task on the queue is run once and only once, and in order.


Before
----------------------------------------

There was the possiblity that some tasks would be run more than once, if multiple queue runners were on the go at the same time.


After
----------------------------------------

Only one task is run at once, regardless how many simultaneous queue runners there may be.


Technical Details
----------------------------------------

In a multiprocess situation (e.g. if 2+ crons run at once, or other special setups) the existing implementation of SQL queue could result in tasks being run twice (or even more).

This is explored with the following extension which lets you set up multiple queue processor processes in parallel to attack a queue and then checks whether the jobs all ran once etc. 

https://github.com/artfulrobot/queuetest

This MR is the result of a successful patch to the SQL queue (in the extension above this is called Sql2 so that it could be compared with the original).

This MR does not change how queues are handled; jobs must still run one after the other. It just protects the queue from problems in a multiprocess situation.
