### PR TITLE
Fix E_NOTICE for is_required in address form

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -371,7 +371,7 @@ class CRM_Contact_Form_Edit_Address {
         }
 
         foreach ($csVal['fields'] as $cdId => $cdVal) {
-          if ($cdVal['is_required']) {
+          if (!empty($cdVal['is_required'])) {
             $elementName = $cdVal['element_name'];
             if (in_array($elementName, $form->_required)) {
               // store the omitted rule for a element, to be used later on


### PR DESCRIPTION
Overview
----------------------------------------
Fix an issue where `CRM_Contact_Form_Edit_Address` produces an `E_NOTICE`.

Before
----------------------------------------
Optional address custom fields cause an `E_NOTICE` in `CRM_Contact_Form_Edit_Address`.

After
----------------------------------------
No `E_NOTICE` are produced.