### PR TITLE
dev/core#1298 Support custom data for emails in Block::create

### DIFF
--- a/api/v3/Email.php
+++ b/api/v3/Email.php
@@ -56,7 +56,6 @@ function _civicrm_api3_email_create_spec(&$params) {
   // TODO a 'clever' default should be introduced
   $params['is_primary']['api.default'] = 0;
   $params['email']['api.required'] = 1;
-  $params['contact_id']['api.required'] = 1;
   $defaultLocation = CRM_Core_BAO_LocationType::getDefault();
   if ($defaultLocation) {
     $params['location_type_id']['api.default'] = $defaultLocation->id;

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -734,6 +734,11 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     if (!$fields) {
       $fields = array_keys($originalValues);
     }
+    if (empty($mapperLocType)) {
+      foreach (array_keys($originalValues) as $key) {
+        $mapperLocType[] = in_array($key, ['email', 'phone']) ? 1 : NULL;
+      }
+    }
     $values = array_values($originalValues);
     $parser = new CRM_Contact_Import_Parser_Contact($fields, $mapperLocType);
     $parser->_contactType = 'Individual';


### PR DESCRIPTION
Overview
----------------------------------------
Adds support for adding custom data to emails in Block::create.

This does not expose it - although the goal of the larger issue is to expose it in the UI & add it to the Contact Summary email edit form - which calls this

Before
----------------------------------------
Block Create ignores email custom fields - even if cg_extends_objects custom value exists for email

After
----------------------------------------
Custom fields can be saved.

Technical Details
----------------------------------------
In order to do this I have switched Block::create to call the v3 email.create api instead of the BAO::create function.

Currently api v3 supports 'custom fields on any entity.' This is handled at the api layer so it doesn't work via the BAO.

It also turns out not to work (yet) on apiv4, or I haven't nailed the syntax. Either way it seems switching to apiv3 is an
appropriate change at this stage

I had to remove contact_id as a required field from Email api to do this as other tests deliberately did not set it and it is not required at the BAO level

Comments
----------------------------------------

