### PR TITLE
Fix status check not rendering before 5.19 migrations

### DIFF
--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -104,11 +104,19 @@ abstract class CRM_Utils_Check_Component {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function isDisabled($method) {
-
-    $checks = $this->getChecksConfig();
-    if (!empty($checks[$method])) {
-      return (bool) empty($checks[$method]['is_active']);
+    try {
+      $checks = $this->getChecksConfig();
+      if (!empty($checks[$method])) {
+        return (bool) empty($checks[$method]['is_active']);
+      }
     }
+    catch (PEAR_Exception $e) {
+      // if we're hitting this, DB migration to 5.19 probably hasn't run yet, so
+      // is_active doesn't exist. Ignore this error so the status check (which
+      // might warn about missing migrations!) still renders.
+      // TODO: remove at some point after 5.19
+    }
+
     return FALSE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix an issue where the status check page does not render when migrations to 5.19 are pending.

Before
----------------------------------------
Status check page does not render on sites that haven't run the 5.19 migration because the `is_active` column doesn't exist yet.

After
----------------------------------------
Status check page renders.

Comments
----------------------------------------
The rationale for this change is to avoid scenarios where users forget to run upgrades because there's no status check warning. The `try`/`catch` can be removed at some point after 5.19 is released (will file a ticket after this is merged).
