### PR TITLE
reporting#21 - don't multiple contribution details when a 1-to-many r…

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -413,17 +413,21 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
     $totalAmount = $average = $fees = $net = [];
     $count = 0;
     $select = "
-        SELECT COUNT({$this->_aliases['civicrm_contribution']}.total_amount ) as count,
-               SUM( {$this->_aliases['civicrm_contribution']}.total_amount ) as amount,
-               ROUND(AVG({$this->_aliases['civicrm_contribution']}.total_amount), 2) as avg,
-               {$this->_aliases['civicrm_contribution']}.currency as currency,
-               SUM( {$this->_aliases['civicrm_contribution']}.fee_amount ) as fees,
-               SUM( {$this->_aliases['civicrm_contribution']}.net_amount ) as net
+        SELECT COUNT(civicrm_contribution_total_amount ) as count,
+               SUM( civicrm_contribution_total_amount ) as amount,
+               ROUND(AVG(civicrm_contribution_total_amount), 2) as avg,
+               stats.currency as currency,
+               SUM( stats.fee_amount ) as fees,
+               SUM( stats.net_amount ) as net
         ";
 
-    $group = "\nGROUP BY {$this->_aliases['civicrm_contribution']}.currency";
-    $sql = "{$select} {$this->_from} {$this->_where} {$group}";
+    $group = "\nGROUP BY civicrm_contribution_currency";
+    $from = " FROM {$this->temporaryTables['civireport_contribution_detail_temp3']['name']} "
+    . "JOIN civicrm_contribution stats ON {$this->temporaryTables['civireport_contribution_detail_temp3']['name']}.civicrm_contribution_contribution_id = stats.id ";
+    $sql = "{$select} {$from} {$group} ";
+    CRM_Core_DAO::disableFullGroupByMode();
     $dao = CRM_Core_DAO::executeQuery($sql);
+    CRM_Core_DAO::reenableFullGroupByMode();
     $this->addToDeveloperTab($sql);
 
     while ($dao->fetch()) {


### PR DESCRIPTION
…elationship exists

Overview
----------------------------------------
In core#655 (PR #13906) someone solved the problem whereby in some cases the total amount of a contribution on the Contribution Details report was multiplied.  This applies a similar fix to the statistics section, which was unfixed.

Before
----------------------------------------
The amount/count in statistics is off if you have soft credits, or display a multi-record custom field, or display a field in the financial items table (e.g. credit card type).

After
----------------------------------------
The amount/count is accurate.

Technical Details
----------------------------------------
Contribution Details generates many temp tables, and instead of running statistics on the original SQL query, we run it against a temp table, which is corrected for one-to-many relationships already.  We do a join to `civicrm_contribution` again just to ensure that we have all the fields statistics expects (e.g. `currency`, `fee_amount` and `net_amount`).

Comments
----------------------------------------
I tried writing a test, but struggled for a long time because I couldn't get `ReportInstance.getStatistics` to work when I tried displaying a custom field.

Steps to replicate
----------------------------------------
* Create a new custom field group that can record multiple records.
* On any contact with at least one contribution, fill in at least two records in the new custom field group.
* Run Contribution Details report such that the contributions on this contact are displayed.

Note that the number of rows is less than the "number of contributions" listed.  Contributions with two multi-record custom fields are counted, twice, with three multi-record custom fields it's counted 3 times, etc.