### PR TITLE
dev/core#58 - Use CIVICRM_MAIL_SMARTY when sending schedule reminders

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -659,7 +659,7 @@ FROM civicrm_action_schedule cas
       'controller' => __CLASS__,
       'actionSchedule' => $schedule,
       'actionMapping' => $mapping,
-      'smarty' => TRUE,
+      'smarty' => (defined('CIVICRM_MAIL_SMARTY') ? (bool) CIVICRM_MAIL_SMARTY : FALSE),
     ]);
     $tp->addMessage('body_text', $schedule->body_text, 'text/plain');
     $tp->addMessage('body_html', $schedule->body_html, 'text/html');


### PR DESCRIPTION
Overview
----------------------------------------
This prevents smarty from being loaded by default when the system attempts to send schedule reminders and thus dying when a schedule reminder template contains CSS definitions that aren't enclosed in `{literal}` tags.
This can be confusing to users trying to send pretty email for membership or event reminders as the only symptom is that schedule reminders (and any subsequent scheduled job) stops working for days where these reminders would be sent.
See also [dev/core#58](https://lab.civicrm.org/dev/core/issues/58).

Before
----------------------------------------
When sending schedule reminders with CSS, Smarty crashes the cron job.

After
----------------------------------------
When sending schedule reminders, Smarty is not loaded unless `CIVICRM_MAIL_SMARTY` is truthy, and does not crash the cron job.

Technical Details
----------------------------------------
This causes the ActionSchedule class to honour `CIVICRM_MAIL_SMARTY`, which is not set by the default installation; this causes the default behaviour to change to schedule reminders not processing smarty.
I'm unsure what the use case is for processing Smarty in schedule reminders, however the most likely issue here is that reminders already working around this using `{literal}` tags will then have those appear in the CSS declarations; this is mitigated as they would not be rendered by any client that supports `<style>` tags correctly, as they would be interpreted as invalid rules and discarded – clients not supporting `<style>` correctly will likely render the entire stylesheet as text, making the appearance of `{literal}` and `{/literal}` a minor annoyance.

Agileware ref CIVICRM-1287
