### PR TITLE
dev/core#1293 Fix regression on  export filtering for postal address only

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -803,7 +803,7 @@ class CRM_Export_BAO_ExportProcessor {
             $addressWhere .= " OR civicrm_address.supplemental_address_1 <> ''";
           }
         }
-        $whereClauses['address'] = $addressWhere;
+        $whereClauses['address'] = '(' . $addressWhere . ')';
       }
     }
 

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1202,6 +1202,21 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'contact_type' => 'Individual',
     ], $reason));
 
+    // Create another contact not included in the exporrt set.
+    $this->callAPISuccess('contact', 'create', array_merge([
+      'first_name' => 'Janet',
+      'last_name' => 'Doe',
+      'contact_type' => 'Individual',
+      'api.address.create' => ['supplemental_address_1' => 'An address'],
+    ], $reason));
+
+    // Create another contact not included in the exporrt set.
+    $this->callAPISuccess('contact', 'create', array_merge([
+      'first_name' => 'Janice',
+      'last_name' => 'Doe',
+      'contact_type' => 'Individual',
+    ], $reason));
+
     //create address for contact A
     $this->callAPISuccess('address', 'create', [
       'contact_id' => $contactA['id'],


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/15429/files

The SQL "OR" expression in the filtering of street addresses was not properly wrapped.

Before
----------------------------------------
Wrong contacts are exported.

After
----------------------------------------
Correct contacts exported.

Credit for bug finding to @demeritcowboy for inclusion in point release notes