### PR TITLE
dev/core#1293 Still output csv file on export, even if no rows are in it

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2376,6 +2376,7 @@ WHERE  id IN ( $deleteIDString )
 
     $query = "SELECT * FROM $exportTempTable";
 
+    $this->instantiateTempTable($headerRows);
     while (1) {
       $limitQuery = $query . "
 LIMIT $offset, $limit
@@ -2395,16 +2396,38 @@ LIMIT $offset, $limit
         }
         $componentDetails[] = $row;
       }
-      CRM_Core_Report_Excel::writeCSVFile($this->getExportFileName(),
-        $headerRows,
-        $componentDetails,
-        NULL,
-        $writeHeader
-      );
+      $this->writeRows($headerRows, $componentDetails);
 
-      $writeHeader = FALSE;
       $offset += $limit;
     }
+  }
+
+  /**
+   * Set up the temp table.
+   *
+   * @param array $headerRows
+   */
+  protected function instantiateTempTable(array $headerRows) {
+    CRM_Utils_System::download(CRM_Utils_String::munge($this->getExportFileName()),
+      'text/x-csv',
+      CRM_Core_DAO::$_nullObject,
+      'csv',
+      FALSE
+    );
+    CRM_Core_Report_Excel::makeCSVTable($headerRows, [], NULL, TRUE, TRUE);
+  }
+
+  /**
+   * @param array $headerRows
+   * @param array $componentDetails
+   */
+  protected function writeRows(array $headerRows, array $componentDetails) {
+    CRM_Core_Report_Excel::writeCSVFile($this->getExportFileName(),
+      $headerRows,
+      $componentDetails,
+      NULL,
+      FALSE
+    );
   }
 
 }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1179,6 +1179,31 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test exporting when no rows are retrieved.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
+   */
+  public function testExportNoRows() {
+    $contactA = $this->callAPISuccess('contact', 'create', [
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+      'contact_type' => 'Individual',
+    ]);
+    $this->doExportTest([
+      'selectAll' => TRUE,
+      'ids' => [$contactA['id']],
+      'exportParams' => [
+        'postal_mailing_export' => [
+          'postal_mailing_export' => TRUE,
+        ],
+        'mergeSameAddress' => TRUE,
+      ],
+    ]);
+    $this->assertEquals('Contact ID', $this->csv->getHeader()[0]);
+  }
+
+  /**
    * Test that deceased and do not mail contacts are removed from contacts before
    *
    * @dataProvider getReasonsNotToMail


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where output is confusing when there are no rows

Before
----------------------------------------

1. Do a contact search.
2. Select contacts so that none of them have a street address, the Do Not Mail choice, or deceased. E.g. pick a couple contacts where all they have is name and/or email.
3. Choose export from the dropdown.
4. Choose selected fields.
5. Check the box that says Exclude contacts with "do not mail" privacy, no street address, or who are deceased.
6. On the next page choose a field like Do Not Mail.
7. When you export you just get a blank screen and there's no errors anywhere. It's because there is no actual error, it's just that there are now zero contacts to export, but it also doesn't give you a zero-length file to download.

After
----------------------------------------

Step 7 works.
