### PR TITLE
Fix CSS for public select2 elements regardless of parent theme box-si…

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3663,7 +3663,7 @@ span.crm-status-icon {
   box-sizing: content-box;
 }
 .crm-container.crm-public .select2-container .select2-choice {
-  padding: 0 5px 0 8px;
+  padding: 5px 5px 5px 8px;
 }
 .crm-container.crm-public .select2-container-multi .select2-choices {
   padding: 4px;

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3659,9 +3659,11 @@ span.crm-status-icon {
 .crm-container.crm-public .select2-results {
   font-size: 14px;
 }
+.crm-container.crm-public .select2-container * {
+  box-sizing: content-box;
+}
 .crm-container.crm-public .select2-container .select2-choice {
-  padding: 5px 5px 5px 8px;
-  height: 35px;
+  padding: 0 5px 0 8px;
 }
 .crm-container.crm-public .select2-container-multi .select2-choices {
   padding: 4px;


### PR DESCRIPTION
This is a followup PR from https://github.com/civicrm/civicrm-core/pull/15403 which fixed the problem for some themes, but introduced a problem for others.

This PR I believe fixes things for both cases.

Tested: Drupal 7, various themes (the CSS that matters is whether the theme places a default box-sizing or not) on Firefox, Chromium, and a WebKit browser (usually a reasonable test for Safari).

Pinging @mattwire @seamuslee001 @smaen123 @eileenmcnaughton who were involved in original PR.