### PR TITLE
dev/core#1302 fix regression on exported when merging addresses with specified fields

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -128,6 +128,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
     if ($processor->isMergeSameAddress()) {
       foreach (array_keys($processor->getAdditionalFieldsForSameAddressMerge()) as $field) {
+        if ($field === 'id') {
+          $field = 'civicrm_primary_id';
+        }
         $processor->setColumnAsCalculationOnly($field);
       }
     }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1045,6 +1045,17 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test merging same address when specifying fields.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
+   */
+  public function testMergeSameAddressSpecifyFields() {
+    $this->setUpContactSameAddressExportData();
+    $this->doExportTest(['mergeSameAddress' => TRUE, 'fields' => [['contact_type' => 'Individual', 'name' => 'master_id', 'location_type_id' => 1]]]);
+  }
+
+  /**
    * Test the merge same address option.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression whereby merging contacts with same address fails if fields are specified

Before
----------------------------------------
Do a contact search.
Select some results.
Choose Export from the Actions dropdown.
Choose Selected Fields.
Choose the option "Merge All Contacts with the Same Address".
Pick your selected fields.
Export.

= DB error

After
----------------------------------------
Above works

Technical Details
----------------------------------------


Comments
----------------------------------------

Code still contains misery