### PR TITLE
Check requirements before upgrading extensions via the UI

### DIFF
--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -245,7 +245,7 @@ function civicrm_api3_extension_download($params) {
     throw new API_Exception('Cannot resolve download url for extension. Try adding parameter "url"');
   }
 
-  foreach (CRM_Extension_System::singleton()->getDownloader()->checkRequirements() as $requirement) {
+  foreach (CRM_Extension_System::singleton()->getDownloader()->checkRequirements($info) as $requirement) {
     return civicrm_api3_create_error($requirement['message']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
If an extension introduces a requirement on another extension but is ALREADY installed it will download and (attempt) to install the extension without checking those dependencies. This can result in CiviCRM crashing if there is a hard dependence.

This happens quite often for example when upgrading Stripe from 5.4.1 to 6.x which introduces the mjwshared extension as a requirement.

Before
----------------------------------------
CiviCRM can stop working if an extension is "upgraded" via the UI and it's (new) requirements are not met.

After
----------------------------------------
CiviCRM allows you to click "upgrade" but then bounces back with an error message if any dependencies are not already installed.

![image](https://user-images.githubusercontent.com/2052161/66400358-9e0bd600-e9e1-11e9-895d-ea80b8fe0437.png)


Technical Details
----------------------------------------
We modify a couple of checkrequirements functions to allow us to pass through the info retrieved via the http feed (ie. the new extension we want to install) instead of using the local (old) versions.

Comments
----------------------------------------
It is always nice to extend these things further but any attempt to automatically download / install would require far more work - contributions welcome but let's get this fix in first.

@totten @MikeyMJCO @aydun
