### PR TITLE
(dev/core#1285) Support for importing "campaign_id" (& other fields where it could be an ID, name or label)

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -148,6 +148,12 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $values['contribution_status_id'] = 'just say no';
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::ERROR);
     $this->callAPISuccessGetCount('Contribution', ['contact_id' => $contactID], 2);
+
+    // Per https://lab.civicrm.org/dev/core/issues/1285 it's a bit arguable but Ok we can support id...
+    $values['contribution_status_id'] = 3;
+    $this->runImport($values, CRM_Import_Parser::DUPLICATE_UPDATE, NULL);
+    $this->callAPISuccessGetCount('Contribution', ['contact_id' => $contactID, 'contribution_status_id' => 3], 1);
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a change / regression where the id stopped working as a valid option when importing campaigns for contributions

Before
----------------------------------------
Only name or label work

After
----------------------------------------
id, name & label work (in that order)

Technical Details
----------------------------------------
After digging into https://lab.civicrm.org/dev/core/issues/1285 it feels a little arguable what we should support but issues in
gitlab indicate there is at least some demand for id & label so it now will
- accept id if input matches an id
- accept name if input matches a name
- accept label if input matches a label.

This means for payment instrument it would accept '1', 'Check' or 'Cheque' (in that order if name were renamed).

This should apply to a few fields - payment instrument, constribution status & per the issue campaign
(on contribution). There are 'some' on membership too I think

Comments
----------------------------------------

