### PR TITLE
dev/financial#72 Modify getTemplateContribution() to use is_template field

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -433,12 +433,23 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       'return' => "is_test",
       'id' => $id,
     ]);
+    // First look for new-style template contribution with is_template=1
     $templateContributions = \Civi\Api4\Contribution::get()
       ->addWhere('contribution_recur_id', '=', $id)
+      ->addWhere('is_template', '=', 1)
       ->addWhere('is_test', '=', $is_test)
       ->addOrderBy('id', 'DESC')
       ->setLimit(1)
       ->execute();
+    if (!$templateContributions->count()) {
+      // Fall back to old style template contributions
+      $templateContributions = \Civi\Api4\Contribution::get()
+        ->addWhere('contribution_recur_id', '=', $id)
+        ->addWhere('is_test', '=', $is_test)
+        ->addOrderBy('id', 'DESC')
+        ->setLimit(1)
+        ->execute();
+    }
     if ($templateContributions->count()) {
       $templateContribution = $templateContributions->first();
       $result = array_merge($templateContribution, $overrides);

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -428,14 +428,15 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @throws \CiviCRM_API3_Exception
    */
   public static function getTemplateContribution($id, $overrides = []) {
-    $templateContribution = civicrm_api3('Contribution', 'get', [
-      'contribution_recur_id' => $id,
-      'options' => ['limit' => 1, 'sort' => ['id DESC']],
-      'sequential' => 1,
-      'contribution_test' => '',
-    ]);
-    if ($templateContribution['count']) {
-      $result = array_merge($templateContribution['values'][0], $overrides);
+    $templateContributions = \Civi\Api4\Contribution::get()
+      ->addWhere('contribution_recur_id', '=', $id)
+      ->addWhere('is_test', 'IN', [0, 1])
+      ->addOrderBy('id', 'DESC')
+      ->setLimit(1)
+      ->execute();
+    if ($templateContributions->count()) {
+      $templateContribution = $templateContributions->first();
+      $result = array_merge($templateContribution, $overrides);
       $result['line_item'] = CRM_Contribute_BAO_ContributionRecur::calculateRecurLineItems($id, $result['total_amount'], $result['financial_type_id']);
       return $result;
     }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -428,9 +428,14 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @throws \CiviCRM_API3_Exception
    */
   public static function getTemplateContribution($id, $overrides = []) {
+    // use api3 because api4 doesn't handle ContributionRecur yet...
+    $is_test = civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => "is_test",
+      'id' => $id,
+    ]);
     $templateContributions = \Civi\Api4\Contribution::get()
       ->addWhere('contribution_recur_id', '=', $id)
-      ->addWhere('is_test', 'IN', [0, 1])
+      ->addWhere('is_test', '=', $is_test)
       ->addOrderBy('id', 'DESC')
       ->setLimit(1)
       ->execute();

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -200,4 +200,38 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $this->assertEquals($firstContrib['id'], $fetchedTemplate['id']);
   }
 
+  /**
+   * Test that is_template contribution is used where available
+   *
+   */
+  public function testGetTemplateContributionNewTemplate() {
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
+    // Create the template
+    $templateContrib = $this->callAPISuccess('Contribution', 'create', [
+      'contribution_recur_id' => $contributionRecur['id'],
+      'total_amount' => '3.00',
+      'financial_type_id' => 1,
+      'payment_instrument_id' => 1,
+      'currency' => 'USD',
+      'contact_id' => $this->individualCreate(),
+      'contribution_status_id' => 1,
+      'receive_date' => 'yesterday',
+      'is_template' => 1,
+    ]);
+    // Create another normal contrib
+    $this->callAPISuccess('Contribution', 'create', [
+      'contribution_recur_id' => $contributionRecur['id'],
+      'total_amount' => '3.00',
+      'financial_type_id' => 1,
+      'payment_instrument_id' => 1,
+      'currency' => 'USD',
+      'contact_id' => $this->individualCreate(),
+      'contribution_status_id' => 1,
+      'receive_date' => 'yesterday',
+    ]);
+    $fetchedTemplate = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionRecur['id']);
+    // Fetched template should be the is_template, not the latest contrib
+    $this->assertEquals($fetchedTemplate['id'], $templateContrib['id']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Further part of dev/financial#72 - modify getTemplateContribution to prefer Contribution's with is_template

Before
----------------------------------------
getTemplateContribution() ignores is_template field

After
----------------------------------------
getTemplateContribution() prefers is_template field, falls back to old method.

