### PR TITLE
[REF] Remove transaction as part of minor code cleanup

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1481,8 +1481,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
             $ppDAO->save();
           }
         }
-        // next create the transaction record
-        $transaction = new CRM_Core_Transaction();
 
         // CRM-11124
         if ($this->_params['discount_id']) {
@@ -1493,7 +1491,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
             CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($this->_params)
           );
         }
-        $transaction->commit();
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes some lines of code that probably do nothing but would not do something positive

Before
----------------------------------------
Disco squirrels

After
----------------------------------------
Lights are on, music is off

Technical Details
----------------------------------------
@mattwire proposed moving this in
https://github.com/civicrm/civicrm-core/pull/15446/commits/8f76cfacf156cfbd11e280b9a86926e0a5082c27

However, I believe removing it is the correct action. The usefullness of transactions is to maintain integrity
by rolling back the creation of a bunch of related entities together if one fails.

However in this case it's not rolling back the contribution or participant record or non discount line items so
if it worked (which I doubt) it would reduce rather than increase db integrity

Comments
----------------------------------------

