### PR TITLE
dev/core#371 Remove template refs to 'print for your records'

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -592,6 +592,9 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function on the contribution page.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testSubmitEmailReceipt() {
     $form = new CRM_Contribute_Form_Contribution();
@@ -606,7 +609,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     ], CRM_Core_Action::ADD);
     $this->callAPISuccessGetCount('Contribution', ['contact_id' => $this->_individualId], 1);
     $mut->checkMailLog([
-      '<p>Please print this receipt for your records.</p>',
+      'Contribution Information',
     ]);
     $mut->stop();
   }
@@ -631,7 +634,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     ], CRM_Core_Action::ADD);
     $this->callAPISuccessGetCount('Contribution', ['contact_id' => $this->_individualId], 1);
     $mut->checkMailLog([
-      '<p>Please print this receipt for your records.</p>',
+      'Thank you for your support',
       '<testloggedin@example.com>',
     ]);
     $mut->stop();

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -179,7 +179,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
     $this->assertTrue(is_array($msg), "Message returned as an array in line");
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('<p>Please print this confirmation for your records.</p>', $msg['html']);
     $this->assertContains('Membership Type: General', $msg['body']);
   }
 
@@ -219,7 +218,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
     $this->assertTrue(is_array($msg), "Message returned as an array in line" . __LINE__);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('<p>Please print this confirmation for your records.</p>', $msg['html']);
     $this->assertContains('Membership Type: General', $msg['body']);
   }
 
@@ -259,7 +257,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
     $this->assertTrue(is_array($msg), "Message returned as an array in line" . __LINE__);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('<p>Please print this confirmation for your records.</p>', $msg['html']);
     $this->assertContains('Thank you for your participation', $msg['body']);
   }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2847,7 +2847,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'is_email_receipt' => 1,
     ]);
     $mut->checkMailLog([
-      'Please print this receipt for your records.',
+      'Contribution Information',
     ]);
     $mut->stop();
   }
@@ -3342,7 +3342,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       '$ 100.00',
       'Contribution Information',
-      'Please print this confirmation for your records',
     ], [
       'Event',
     ]);
@@ -4102,7 +4101,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'From: CiviCRM LLC <api@civicrm.org>',
       'Contribution Information',
-      'Please print this confirmation for your records',
     ], [
       'Event',
     ]);
@@ -4123,7 +4121,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'From: ' . $domain['from_name'] . ' <' . $domain['from_email'] . '>',
       'Contribution Information',
-      'Please print this confirmation for your records',
     ], [
       'Event',
     ]);
@@ -4146,7 +4143,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'From: ' . $domain['from_name'] . ' <' . $domain['from_email'] . '>',
       'Contribution Information',
-      'Please print this confirmation for your records',
     ], [
       'Event',
     ]
@@ -4188,7 +4184,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'From: CiviCRM LLC <contributionpage@civicrm.org>',
       'Contribution Information',
-      'Please print this confirmation for your records',
     ], [
       'Event',
     ]);
@@ -4214,7 +4209,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'From: ' . $domain['name'] . ' <' . $domain['domain_email'] . '>',
       'Contribution Information',
-      'Please print this confirmation for your records',
     ], [
       'Event',
     ]);

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -28,8 +28,6 @@
      <p>{ts}Thank you for your support.{/ts}</p>
     {/if}
 
-    <p>{ts}Please print this receipt for your records.{/ts}</p>
-
    </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -2,8 +2,6 @@
 {$formValues.receipt_text}
 {else}{ts}Thank you for your support.{/ts}{/if}
 
-{ts}Please print this receipt for your records.{/ts}
-
 
 ===========================================================
 {ts}Contribution Information{/ts}

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -28,8 +28,6 @@
 
     {if $is_pay_later}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
-    {else}
-     <p>{ts}Please print this confirmation for your records.{/ts}</p>
     {/if}
 
    </td>

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -7,9 +7,6 @@
 ===========================================================
 {$pay_later_receipt}
 ===========================================================
-{else}
-
-{ts}Please print this receipt for your records.{/ts}
 {/if}
 
 {if $amount}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -39,8 +39,6 @@
      {/if}
     {elseif $is_pay_later}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
-    {else}
-     <p>{ts}Please print this confirmation for your records.{/ts}</p>
     {/if}
 
    </td>

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -32,9 +32,6 @@
 {$pay_later_receipt}
 ==========================================================={if $pricesetFieldsCount }===================={/if}
 
-{else}
-
-{ts}Please print this confirmation for your records.{/ts}
 {/if}
 
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -50,8 +50,6 @@
      {/if}
     {elseif $is_pay_later && !$isAmountzero && !$isAdditionalParticipant}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
-    {else}
-     <p>{ts}Please print this confirmation for your records.{/ts}</p>
     {/if}
 
    </td>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -38,9 +38,6 @@
 {$pay_later_receipt}
 ==========================================================={if $pricesetFieldsCount }===================={/if}
 
-{else}
-
-{ts}Please print this confirmation for your records.{/ts}
 {/if}
 
 

--- a/xml/templates/message_templates/event_registration_receipt_html.tpl
+++ b/xml/templates/message_templates/event_registration_receipt_html.tpl
@@ -24,7 +24,7 @@
       <p>{$pay_later_receipt}</p>
     {/if}
 
-    <p>Your order number is #{$transaction_id}. Please print this confirmation for your records.{if $line_items && !$is_refund} Information about the workshops will be sent separately to each participant.{/if}
+    <p>Your order number is #{$transaction_id}. {if $line_items && !$is_refund} Information about the workshops will be sent separately to each participant.{/if}
   Here's a summary of your transaction placed on {$transaction_date|date_format:"%D %I:%M %p %Z"}:</p>
 
 

--- a/xml/templates/message_templates/event_registration_receipt_text.tpl
+++ b/xml/templates/message_templates/event_registration_receipt_text.tpl
@@ -9,7 +9,7 @@ Dear {contact.display_name},
   {$pay_later_receipt}
 {/if}
 
-  Your order number is #{$transaction_id}. Please print this confirmation for your records.{if $line_items && !$is_refund} Information about the workshops will be sent separately to each participant.{/if}
+  Your order number is #{$transaction_id}. {if $line_items && !$is_refund} Information about the workshops will be sent separately to each participant.{/if}
  Here's a summary of your transaction placed on {$transaction_date|date_format:"%D %I:%M %p %Z"}:
 
 {if $billing_name}

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -28,9 +28,6 @@
     {else}
      <p>{ts}Thank you for your support.{/ts}</p>
     {/if}
-    {if ! $cancelled}
-     <p>{ts}Please print this receipt for your records.{/ts}</p>
-    {/if}
    </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -4,10 +4,6 @@
 {$formValues.receipt_text_renewal}
 {else}{ts}Thank you for your support.{/ts}{/if}
 
-{if ! $cancelled}{ts}Please print this receipt for your records.{/ts}
-
-
-{/if}
 {if !$lineItem}
 ===========================================================
 {ts}Membership Information{/ts}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -28,8 +28,6 @@
 
     {if $is_pay_later}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
-    {else}
-     <p>{ts}Please print this confirmation for your records.{/ts}</p>
     {/if}
 
    </td>

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -7,9 +7,6 @@
 ===========================================================
 {$pay_later_receipt}
 ===========================================================
-{else}
-
-{ts}Please print this receipt for your records.{/ts}
 {/if}
 
 {if $membership_assign && !$useForMember}


### PR DESCRIPTION
Overview
----------------------------------------
Removes remaining places where templates say to print for your records

Before
----------------------------------------
Some templates still have the message about printing for your records

After
----------------------------------------
Removed from remaining templates

Technical Details
----------------------------------------
This updates the default templates but does not upgrade. 
 https://github.com/civicrm/civicrm-core/pull/15466
is upgrading a bunch of templates so targetting the same release so that one will pick up the upgrade part

https://lab.civicrm.org/dev/user-interface/issues/6

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/371