### PR TITLE
Switch to explicitly using value from submitValues

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2441,7 +2441,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $membershipLineItems = [];
         foreach ($this->_values['fee'] as $key => $feeValues) {
           if ($feeValues['name'] == 'membership_amount') {
-            $fieldId = $this->_params['price_' . $key];
+            $fieldId = $this->_submitValues['price_' . $key];
             $membershipLineItems[$this->_priceSetId][$fieldId] = $this->_lineItem[$this->_priceSetId][$fieldId];
             unset($this->_lineItem[$this->_priceSetId][$fieldId]);
             break;


### PR DESCRIPTION
Overview
----------------------------------------
From #15252. `$this->_params` is not consistent across forms as to what it holds, sometimes it contains processed information, sometimes the submitted form values.  In this case from testing we've identified that this line is using the submitted values directly so we make that explicit in the code.

Before
----------------------------------------
Unclear which version of params being used from reading code.

After
----------------------------------------
Clear which version of params being used from reading code.

Technical Details
----------------------------------------
This came out of investigation into form params being passed and manipulated differently for contribution/event pages and being inconsistent.  It was identified that at this point in the code we are using the submitted value so changing it to be explicit means future refactoring is less likely to cause issues.

Comments
----------------------------------------
@eileenmcnaughton per our discussion.