### PR TITLE
The loop doth process too much, methinks

### DIFF
--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -884,6 +884,10 @@ function _civicrm_api3_deprecated_activity_buildmailparams($result, $activityTyp
     if (isset($result["attachFile_$i"])) {
       $params["attachFile_$i"] = $result["attachFile_$i"];
     }
+    else {
+      // No point looping 100 times if there's only one attachment
+      break;
+    }
   }
 
   return $params;


### PR DESCRIPTION
Overview
----------------------------------------
The loop is too loopy. It doesn't need to be so loopy. See also the [recent commit](https://github.com/civicrm/civicrm-core/blob/8913e9151afd072b5f27e0367490b76657314289/CRM/Core/BAO/File.php#L629) which is the same loop in a different spot but correctly doesn't loop too much.

Before
----------------------------------------
Maximum loopiness, all day and all night.

After
----------------------------------------
The exact right amount of loopy.

Technical Details
----------------------------------------
Before commit 8913e915 it was hardcoded to 5 in this spot, so it was often too loopy but not too much. After that commit with the default new max setting it would loop 100 times every time.

Comments
----------------------------------------
Related to change made for https://lab.civicrm.org/dev/core/issues/1270
