### PR TITLE
dev/core#1100 Add externUrl method and civicrm_alterExternUrl hook

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -55,6 +55,8 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
 
     $this->assign('cpageId', $this->_id);
 
+    $this->assign('widgetExternUrl', CRM_Utils_System::externUrl('extern/widget', "cpageId={$this->_id}&widgetId={$this->_widget->id}&format=3"));
+
     $config = CRM_Core_Config::singleton();
     $title = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',
       $this->_id,

--- a/CRM/Core/Payment/PaymentExpress.php
+++ b/CRM/Core/Payment/PaymentExpress.php
@@ -121,7 +121,7 @@ class CRM_Core_Payment_PaymentExpress extends CRM_Core_Payment {
       CRM_Core_Error::fatal(ts('Component is invalid'));
     }
 
-    $url = $config->userFrameworkResourceURL . "extern/pxIPN.php";
+    $url = CRM_Utils_System::externUrl('extern/pxIPN');
 
     if ($component == 'event') {
       $cancelURL = CRM_Utils_System::url('civicrm/event/register',

--- a/CRM/Cxn/BAO/Cxn.php
+++ b/CRM/Cxn/BAO/Cxn.php
@@ -45,22 +45,7 @@ class CRM_Cxn_BAO_Cxn extends CRM_Cxn_DAO_Cxn {
    * @return string
    */
   public static function getSiteCallbackUrl() {
-    $config = CRM_Core_Config::singleton();
-
-    if (preg_match('/^(http|https):/', $config->resourceBase)) {
-      $civiUrl = $config->resourceBase;
-    }
-    else {
-      $civiUrl = rtrim(CRM_Utils_System::baseURL(), '/') . '/' . ltrim($config->resourceBase, '/');
-    }
-
-    // In practice, this may not be necessary, but we want to prevent
-    // edge-cases that downgrade security-level below system policy.
-    if (Civi::settings()->get('enableSSL')) {
-      $civiUrl = preg_replace('/^http:/', 'https:', $civiUrl);
-    }
-
-    return rtrim($civiUrl, '/') . '/extern/cxn.php';
+    return CRM_Utils_System::externUrl('extern/cxn', NULL, NULL, TRUE, TRUE);
   }
 
   /**

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1163,8 +1163,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     // push the tracking url on to the html email if necessary
     if ($this->open_tracking && $html) {
-      array_push($html, "\n" . '<img src="' . $config->userFrameworkResourceURL .
-        "extern/open.php?q=$event_queue_id\" width='1' height='1' alt='' border='0'>"
+      array_push($html, "\n" . '<img src="' . CRM_Utils_System::externUrl('extern/open', "q=$event_queue_id")
+        . '" width="1" height="1" alt="" border="0">'
       );
     }
 

--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -93,7 +93,7 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
       $urlCache[$mailing_id . $url] = $redirect;
     }
 
-    $returnUrl = "{$urlCache[$mailing_id . $url]}&qid={$queue_id}";
+    $returnUrl = CRM_Utils_System::externUrl('extern/url', "u=$id&qid=$queue_id");
 
     if ($hrefExists) {
       $returnUrl = "href='{$returnUrl}' rel='nofollow'";

--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -73,7 +73,6 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
     else {
 
       $hrefExists = FALSE;
-      $config = CRM_Core_Config::singleton();
 
       $tracker = new CRM_Mailing_BAO_TrackableURL();
       if (preg_match('/^href/i', $url)) {
@@ -89,7 +88,7 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
       }
       $id = $tracker->id;
 
-      $redirect = $config->userFrameworkResourceURL . "extern/url.php?u=$id";
+      $redirect = CRM_Utils_System::externUrl('extern/url', "u=$id");
       $urlCache[$mailing_id . $url] = $redirect;
     }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -301,6 +301,41 @@ class CRM_Utils_System {
   }
 
   /**
+   * Generates an extern url.
+   *
+   * @param string $path
+   *   The extern path, such as "extern/url".
+   * @param string $query
+   *   A query string to append to the link.
+   * @param string $fragment
+   *   A fragment identifier (named anchor) to append to the link.
+   * @param bool $absolute
+   *   Whether to force the output to be an absolute link (beginning with a
+   *   URI-scheme such as 'http:').
+   * @param bool $isSSL
+   *   NULL to autodetect. TRUE to force to SSL.
+   */
+  public static function externUrl($path = NULL, $query = NULL, $fragment = NULL, $absolute = TRUE, $isSSL = NULL) {
+    $query = self::makeQueryString($query);
+
+    $url = Civi::paths()->getUrl("[civicrm.root]/{$path}.php", $absolute ? 'absolute' : 'relative', $isSSL)
+      . ($query ? "?$query" : "")
+      . ($fragment ? "#$fragment" : "");
+
+    $parsedUrl = CRM_Utils_Url::parseUrl($url);
+    $event = \Civi\Core\Event\GenericHookEvent::create([
+      'url' => &$parsedUrl,
+      'path' => $path,
+      'query' => $query,
+      'fragment' => $fragment,
+      'absolute' => $absolute,
+      'isSSL' => $isSSL,
+    ]);
+    Civi::service('dispatcher')->dispatch('hook_civicrm_alterExternUrl', $event);
+    return CRM_Utils_Url::unparseUrl($event->url);
+  }
+
+  /**
    * Path of the current page e.g. 'civicrm/contact/view'
    *
    * @return string|null

--- a/templates/CRM/Contribute/Page/Widget.tpl
+++ b/templates/CRM/Contribute/Page/Widget.tpl
@@ -211,4 +211,4 @@ function onReady( ) {
 }
 </script>
 {/literal}
-<script type="text/javascript" src="{$config->userFrameworkResourceURL}/extern/widget.php?cpageId={$cpageId}&widgetId={$widget_id}&format=3"></script>
+<script type="text/javascript" src="{$widgetExternUrl}"></script>

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -140,8 +140,8 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
   public function testAlterExternUrlHook($path, $expected) {
     Civi::service('dispatcher')->addListener('hook_civicrm_alterExternUrl', [$this, 'hook_civicrm_alterExternUrl']);
     $externUrl = CRM_Utils_System::externUrl($path, $expected['query']);
-    $this->assertContains($path, $externUrl);
-    $this->assertContains($expected['query'], $externUrl);
+    $this->assertContains('path/altered/by/hook', $externUrl, 'Hook failed to alter URL path');
+    $this->assertContains($expected['query'] . '&thisWas=alteredByHook', $externUrl, 'Hook failed to alter URL query');
   }
 
   /**
@@ -158,6 +158,8 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
     $this->assertTrue($event->hasField('fragment'));
     $this->assertTrue($event->hasField('absolute'));
     $this->assertTrue($event->hasField('isSSL'));
+    $event->url = $event->url->withPath('path/altered/by/hook');
+    $event->url = $event->url->withQuery($event->query . '&thisWas=alteredByHook');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Adds an `externUrl` method and `hook_civicrm_alterExternUrl` symfony event.

See [dev/core#1100](https://lab.civicrm.org/dev/core/issues/1100).

Before
----------------------------------------
There was no way to alter the extern scripts urls.

After
----------------------------------------
Extern scripts url can be altered.

Example:
``` php
function myextension_civicrm_alterExternUrl(\GuzzleHttp\Psr7\UriInterface $url, $path, $query, $fragment, $absolute, $isSSL) {
  // do something with url
}
```
Symfony hook example:
``` php
function myextension_civicrm_config(&$config) {
  Civi::dispatcher()->addListener(
    'hook_civicrm_alterExternUrl', 
    function(Civi\Core\Event\GenericHookEvent $event) {
      // do something with $event->url
    }
  );
}
```

Comments
----------------------------------------
Documentation for the hook is missing, will add soon.
