### PR TITLE
Fix typo in parameter description for PaymentProcessor.pay

### DIFF
--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -155,7 +155,7 @@ function _civicrm_api3_payment_processor_pay_spec(&$params) {
   ];
   $params['amount'] = [
     'api.required' => TRUE,
-    'title' => ts('Amount to refund'),
+    'title' => ts('Amount to pay'),
     'type' => CRM_Utils_Type::T_MONEY,
   ];
 }


### PR DESCRIPTION
Overview
----------------------------------------
Typo in params

Before
----------------------------------------
"Amount to refund"

After
----------------------------------------
"Amount to pay"

Technical Details
----------------------------------------

Comments
----------------------------------------
@JoeMurray @eileenmcnaughton I'm trying to clear off a few "simple" fixes and backport them to the 5.19 RC so we've got a set of more useable APIs from 5.19 on.  These should all be "safe" changes.
