### PR TITLE
Cleanup PaymentProcessor.doRefund API

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1286,9 +1286,12 @@ abstract class CRM_Core_Payment {
    *
    * @param array $params
    *
+   * @return array
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function doRefund(&$params) {}
+  public function doRefund($params) {
+    return [];
+  }
 
   /**
    * Query payment processor for details about a transaction.

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -168,7 +168,7 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
    * @param array $params
    *   Assoc array of input parameters for this transaction.
    */
-  public function doRefund(&$params) {}
+  public function doRefund($params) {}
 
   /**
    * Generate error object.

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -167,13 +167,16 @@ function _civicrm_api3_payment_processor_pay_spec(&$params) {
  *
  * @return array
  *   API result array.
- * @throws CiviCRM_API3_Exception
+ * @throws \API_Exception
+ * @throws \CiviCRM_API3_Exception
+ * @throws \Civi\Payment\Exception\PaymentProcessorException
  */
 function civicrm_api3_payment_processor_refund($params) {
+  /** @var \CRM_Core_Payment $processor */
   $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
   $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', array('id' => $params['payment_processor_id'])));
   if (!$processor->supportsRefund()) {
-    throw API_Exception('Payment Processor does not support refund');
+    throw new API_Exception('Payment Processor does not support refund');
   }
   $result = $processor->doRefund($params);
   return civicrm_api3_create_success(array($result), $params);
@@ -187,7 +190,7 @@ function civicrm_api3_payment_processor_refund($params) {
  */
 function _civicrm_api3_payment_processor_refund_spec(&$params) {
   $params['payment_processor_id'] = [
-    'api.required' => 1,
+    'api.required' => TRUE,
     'title' => ts('Payment processor'),
     'type' => CRM_Utils_Type::T_INT,
   ];


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup docs, return values and exceptions. Also change from deprecated pass by reference on params to just returning a $params array.

Before
----------------------------------------
Less correct

After
----------------------------------------
More correct

Technical Details
----------------------------------------

Comments
----------------------------------------
