### PR TITLE
Add parameters to PaymentProcessor doRefund

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1286,9 +1286,12 @@ abstract class CRM_Core_Payment {
    *
    * @param array $params
    *
+   * @return array
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function doRefund(&$params) {}
+  public function doRefund($params) {
+    return [];
+  }
 
   /**
    * Query payment processor for details about a transaction.

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1290,7 +1290,19 @@ abstract class CRM_Core_Payment {
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function doRefund($params) {
-    return [];
+    // Mandatory Params:
+    // trxn_id: The transaction ID that the payment processor uses to identify the payment to refund.
+    // amount: The amount to refund (eg. 12.05). This should always be specified in "dot" notation with no currency symbol.
+    return [
+      // refund_status_id would normally return the contribution_status_id Completed or Failed
+      'refund_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      // The refund trxn_id may be different from the trxn_id of the original payment.
+      // If it is the same then trxn_id should be copied to refund_trxn_id
+      'refund_trxn_id' => NULL,
+      // Array of params returned by the payment processor. The contents of this will vary by processor and should not be relied on.
+      // However, they can be very useful for logging or providing specific feedback.
+      'processor_result' => [],
+    ];
   }
 
   /**

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -168,7 +168,7 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
    * @param array $params
    *   Assoc array of input parameters for this transaction.
    */
-  public function doRefund(&$params) {}
+  public function doRefund($params) {}
 
   /**
    * Generate error object.

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -167,13 +167,16 @@ function _civicrm_api3_payment_processor_pay_spec(&$params) {
  *
  * @return array
  *   API result array.
- * @throws CiviCRM_API3_Exception
+ * @throws \API_Exception
+ * @throws \CiviCRM_API3_Exception
+ * @throws \Civi\Payment\Exception\PaymentProcessorException
  */
 function civicrm_api3_payment_processor_refund($params) {
+  /** @var \CRM_Core_Payment $processor */
   $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
   $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', array('id' => $params['payment_processor_id'])));
   if (!$processor->supportsRefund()) {
-    throw API_Exception('Payment Processor does not support refund');
+    throw new API_Exception('Payment Processor does not support refund');
   }
   $result = $processor->doRefund($params);
   return civicrm_api3_create_success(array($result), $params);
@@ -187,7 +190,7 @@ function civicrm_api3_payment_processor_refund($params) {
  */
 function _civicrm_api3_payment_processor_refund_spec(&$params) {
   $params['payment_processor_id'] = [
-    'api.required' => 1,
+    'api.required' => TRUE,
     'title' => ts('Payment processor'),
     'type' => CRM_Utils_Type::T_INT,
   ];


### PR DESCRIPTION
Overview
----------------------------------------
**Builds on #15478**

This adds a prototype set of return values for the doRefund function.  It will probably need to evolve further but this works for Stripe and mirrors what we must return from doPayment.  The code comments explain in detail what is expected.

Before
----------------------------------------
No parameters specified for doRefund.

After
----------------------------------------
Refund parameters that are sufficient to implement doRefund in Stripe specified.

Technical Details
----------------------------------------
This may need to evolve further but this seems like the minimum required set of parameters.  And we should ensure that we define them / return params before we start using it!

Comments
----------------------------------------
