### PR TITLE
dev/core#1046 - Fix name vs label for case roles - alternate with case type edit screen code cleanup

### DIFF
--- a/CRM/Case/ManagedEntities.php
+++ b/CRM/Case/ManagedEntities.php
@@ -111,11 +111,11 @@ class CRM_Case_ManagedEntities {
     $result = [];
 
     if (!isset(Civi::$statics[__CLASS__]['reltypes'])) {
-      $relationshipInfo = CRM_Core_PseudoConstant::relationshipType('label', TRUE, NULL);
+      $relationshipInfo = CRM_Core_PseudoConstant::relationshipType('name', TRUE, NULL);
       foreach ($relationshipInfo as $id => $relTypeDetails) {
-        Civi::$statics[__CLASS__]['reltypes']["{$id}_a_b"] = $relTypeDetails['label_a_b'];
-        if ($relTypeDetails['label_a_b'] != $relTypeDetails['label_b_a']) {
-          Civi::$statics[__CLASS__]['reltypes']["{$id}_b_a"] = $relTypeDetails['label_b_a'];
+        Civi::$statics[__CLASS__]['reltypes']["{$id}_a_b"] = $relTypeDetails['name_a_b'];
+        if ($relTypeDetails['name_a_b'] != $relTypeDetails['name_b_a']) {
+          Civi::$statics[__CLASS__]['reltypes']["{$id}_b_a"] = $relTypeDetails['name_b_a'];
         }
       }
     }

--- a/CRM/Case/XMLProcessor.php
+++ b/CRM/Case/XMLProcessor.php
@@ -91,12 +91,10 @@ class CRM_Case_XMLProcessor {
   }
 
   /**
-   * Get all relationship type labels
-   *
-   * TODO: These should probably be names, but under legacy behavior this has
-   * been labels.
+   * Get all relationship type display labels (not machine names)
    *
    * @param bool $fromXML
+   *   TODO: This parameter is always FALSE now so no longer needed.
    *   Is this to be used for lookup of values from XML?
    *   Relationships are recorded in XML from the perspective of the non-client
    *   while relationships in the UI and everywhere else are from the
@@ -106,11 +104,24 @@ class CRM_Case_XMLProcessor {
    */
   public function &allRelationshipTypes($fromXML = FALSE) {
     if (!isset(Civi::$statics[__CLASS__]['reltypes'][$fromXML])) {
-      $relationshipInfo = CRM_Core_PseudoConstant::relationshipType('label', TRUE);
+      // Note this now includes disabled types too. The only place this
+      // function is being used is for comparison against a list, not
+      // displaying a dropdown list or something like that, so we need
+      // to include disabled.
+      $relationshipInfo = civicrm_api3('RelationshipType', 'get', [
+        'options' => ['limit' => 0],
+      ]);
 
       Civi::$statics[__CLASS__]['reltypes'][$fromXML] = [];
-      foreach ($relationshipInfo as $id => $info) {
+      foreach ($relationshipInfo['values'] as $id => $info) {
         Civi::$statics[__CLASS__]['reltypes'][$fromXML][$id . '_b_a'] = ($fromXML) ? $info['label_a_b'] : $info['label_b_a'];
+        /**
+         * Exclude if bidirectional
+         * (Why? I'm thinking this was for consistency with the dropdown
+         * in ang/crmCaseType.js where it would be needed to avoid seeing
+         * duplicates in the dropdown. Not sure if needed here but keeping
+         * as-is.)
+         */
         if ($info['label_b_a'] !== $info['label_a_b']) {
           Civi::$statics[__CLASS__]['reltypes'][$fromXML][$id . '_a_b'] = ($fromXML) ? $info['label_b_a'] : $info['label_a_b'];
         }

--- a/CRM/Utils/Check/Component/Case.php
+++ b/CRM/Utils/Check/Component/Case.php
@@ -162,4 +162,239 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
     return $messages;
   }
 
+  /**
+   * Check that the relationship types aren't going to cause problems.
+   *
+   * @return array<CRM_Utils_Check_Message>
+   *   An empty array, or a list of warnings
+   */
+  public function checkRelationshipTypeProblems() {
+    $messages = [];
+
+    /**
+     * There's no use-case to have two different relationship types
+     * with the same machine name, and it will cause problems because the
+     * system might match up the wrong type when comparing to xml.
+     * A single bi-directional one CAN and probably does have the same
+     * name_a_b and name_b_a and that's ok.
+     */
+
+    $dao = CRM_Core_DAO::executeQuery("SELECT rt1.*, rt2.id AS id2, rt2.name_a_b AS nameab2, rt2.name_b_a AS nameba2 FROM civicrm_relationship_type rt1 INNER JOIN civicrm_relationship_type rt2 ON (rt1.name_a_b = rt2.name_a_b OR rt1.name_a_b = rt2.name_b_a) WHERE rt1.id <> rt2.id");
+    while ($dao->fetch()) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . $dao->id . "dupe1",
+        ts("Relationship type <em>%1</em> has the same internal machine name as another type.
+          <table>
+            <tr><th>ID</th><th>name_a_b</th><th>name_b_a</th></tr>
+            <tr><td>%2</td><td>%3</td><td>%4</td></tr>
+            <tr><td>%5</td><td>%6</td><td>%7</td></tr>
+          </table>", [
+            1 => htmlspecialchars($dao->label_a_b),
+            2 => $dao->id,
+            3 => htmlspecialchars($dao->name_a_b),
+            4 => htmlspecialchars($dao->name_b_a),
+            5 => $dao->id2,
+            6 => htmlspecialchars($dao->nameab2),
+            7 => htmlspecialchars($dao->nameba2),
+          ]) .
+          '<br /><a href="' . CRM_Utils_System::docURL2('user/case-management/what-you-need-to-know#relationship-type-internal-name-duplicates', TRUE) . '">' .
+          ts('Read more about this warning') .
+          '</a>',
+        ts('Relationship Type Internal Name Duplicates'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-exchange'
+      );
+    }
+
+    // Ditto for labels
+    $dao = CRM_Core_DAO::executeQuery("SELECT rt1.*, rt2.id AS id2, rt2.label_a_b AS labelab2, rt2.label_b_a AS labelba2 FROM civicrm_relationship_type rt1 INNER JOIN civicrm_relationship_type rt2 ON (rt1.label_a_b = rt2.label_a_b OR rt1.label_a_b = rt2.label_b_a) WHERE rt1.id <> rt2.id");
+    while ($dao->fetch()) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . $dao->id . "dupe2",
+        ts("Relationship type <em>%1</em> has the same display label as another type.
+          <table>
+            <tr><th>ID</th><th>label_a_b</th><th>label_b_a</th></tr>
+            <tr><td>%2</td><td>%3</td><td>%4</td></tr>
+            <tr><td>%5</td><td>%6</td><td>%7</td></tr>
+          </table>", [
+            1 => htmlspecialchars($dao->label_a_b),
+            2 => $dao->id,
+            3 => htmlspecialchars($dao->label_a_b),
+            4 => htmlspecialchars($dao->label_b_a),
+            5 => $dao->id2,
+            6 => htmlspecialchars($dao->labelab2),
+            7 => htmlspecialchars($dao->labelba2),
+          ]) .
+          '<br /><a href="' . CRM_Utils_System::docURL2('user/case-management/what-you-need-to-know#relationship-type-display-label-duplicates', TRUE) . '">' .
+          ts('Read more about this warning') .
+          '</a>',
+        ts('Relationship Type Display Label Duplicates'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-exchange'
+      );
+    }
+
+    /**
+     * If the name of one type matches the label of another type, there may
+     * also be problems. This can happen if for example you initially set
+     * it up and then keep changing your mind adding and deleting and renaming
+     * a couple times in a certain order.
+     */
+    $dao = CRM_Core_DAO::executeQuery("SELECT rt1.*, rt2.id AS id2, rt2.name_a_b AS nameab2, rt2.name_b_a AS nameba2, rt2.label_a_b AS labelab2, rt2.label_b_a AS labelba2 FROM civicrm_relationship_type rt1 INNER JOIN civicrm_relationship_type rt2 ON (rt1.name_a_b = rt2.label_a_b OR rt1.name_b_a = rt2.label_a_b OR rt1.name_a_b = rt2.label_b_a OR rt1.name_b_a = rt2.label_b_a) WHERE rt1.id <> rt2.id");
+    // No point displaying the same matching id twice, which can happen with
+    // the query.
+    $ids = [];
+    while ($dao->fetch()) {
+      if (isset($ids[$dao->id2])) {
+        continue;
+      }
+      $ids[$dao->id] = $dao->id;
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . $dao->id . "dupe3",
+        ts("Relationship type <em>%1</em> has an internal machine name that is the same as the display label as another type.
+          <table>
+            <tr><th>ID</th><th>name_a_b</th><th>name_b_a</th><th>label_a_b</th><th>label_b_a</th></tr>
+            <tr><td>%2</td><td>%3</td><td>%4</td><td>%5</td><td>%6</td></tr>
+            <tr><td>%7</td><td>%8</td><td>%9</td><td>%10</td><td>%11</td></tr>
+          </table>", [
+            1 => htmlspecialchars($dao->label_a_b),
+            2 => $dao->id,
+            3 => htmlspecialchars($dao->name_a_b),
+            4 => htmlspecialchars($dao->name_b_a),
+            5 => htmlspecialchars($dao->label_a_b),
+            6 => htmlspecialchars($dao->label_b_a),
+            7 => $dao->id2,
+            8 => htmlspecialchars($dao->nameab2),
+            9 => htmlspecialchars($dao->nameab2),
+            10 => htmlspecialchars($dao->labelab2),
+            11 => htmlspecialchars($dao->labelba2),
+          ]) .
+          '<br /><a href="' . CRM_Utils_System::docURL2('user/case-management/what-you-need-to-know#relationship-type-cross-duplication', TRUE) . '">' .
+          ts('Read more about this warning') .
+          '</a>',
+        ts('Relationship Type Cross-Duplication'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-exchange'
+      );
+    }
+
+    /**
+     * Check that ones that appear to be unidirectional don't have the same
+     * machine name for both a_b and b_a. This can happen for example if you
+     * forget to fill in the b_a label when creating, then go back and edit.
+     */
+    $dao = CRM_Core_DAO::executeQuery("SELECT rt1.* FROM civicrm_relationship_type rt1 WHERE rt1.name_a_b = rt1.name_b_a AND rt1.label_a_b <> rt1.label_b_a");
+    while ($dao->fetch()) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . $dao->id . "ambiguousname",
+        ts("Relationship type <em>%1</em> appears to be unidirectional, but has the same internal machine name for both sides.
+          <table>
+            <tr><th>ID</th><th>name_a_b</th><th>name_b_a</th><th>label_a_b</th><th>label_b_a</th></tr>
+            <tr><td>%2</td><td>%3</td><td>%4</td><td>%5</td><td>%6</td></tr>
+          </table>", [
+            1 => htmlspecialchars($dao->label_a_b),
+            2 => $dao->id,
+            3 => htmlspecialchars($dao->name_a_b),
+            4 => htmlspecialchars($dao->name_b_a),
+            5 => htmlspecialchars($dao->label_a_b),
+            6 => htmlspecialchars($dao->label_b_a),
+          ]) .
+          '<br /><a href="' . CRM_Utils_System::docURL2('user/case-management/what-you-need-to-know#relationship-type-ambiguity', TRUE) . '">' .
+          ts('Read more about this warning') .
+          '</a>',
+        ts('Relationship Type Ambiguity'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-exchange'
+      );
+    }
+
+    /**
+     * Check that ones that appear to be unidirectional don't have the same
+     * label for both a_b and b_a. This can happen for example if you
+     * created it as unidirectional, then edited it later trying to make it
+     * bidirectional.
+     */
+    $dao = CRM_Core_DAO::executeQuery("SELECT rt1.* FROM civicrm_relationship_type rt1 WHERE rt1.label_a_b = rt1.label_b_a AND rt1.name_a_b <> rt1.name_b_a");
+    while ($dao->fetch()) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . $dao->id . "ambiguouslabel",
+        ts("Relationship type <em>%1</em> appears to be unidirectional internally, but has the same display label for both sides. Possibly you created it initially as unidirectional and then made it bidirectional later.
+          <table>
+            <tr><th>ID</th><th>name_a_b</th><th>name_b_a</th><th>label_a_b</th><th>label_b_a</th></tr>
+            <tr><td>%2</td><td>%3</td><td>%4</td><td>%5</td><td>%6</td></tr>
+          </table>", [
+            1 => htmlspecialchars($dao->label_a_b),
+            2 => $dao->id,
+            3 => htmlspecialchars($dao->name_a_b),
+            4 => htmlspecialchars($dao->name_b_a),
+            5 => htmlspecialchars($dao->label_a_b),
+            6 => htmlspecialchars($dao->label_b_a),
+          ]) .
+          '<br /><a href="' . CRM_Utils_System::docURL2('user/case-management/what-you-need-to-know#relationship-type-ambiguity', TRUE) . '">' .
+          ts('Read more about this warning') .
+          '</a>',
+        ts('Relationship Type Ambiguity'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-exchange'
+      );
+    }
+
+    /**
+     * Check for missing roles listed in the xml but not defined as
+     * relationship types.
+     */
+
+    // Don't use database since might be in xml files.
+    $caseTypes = civicrm_api3('CaseType', 'get', [
+      'options' => ['limit' => 0],
+    ])['values'];
+    // Don't use pseudoconstant since want all and also name and label.
+    $relationshipTypes = civicrm_api3('RelationshipType', 'get', [
+      'options' => ['limit' => 0],
+    ])['values'];
+    $allConfigured = array_column($relationshipTypes, 'id', 'name_a_b')
+      + array_column($relationshipTypes, 'id', 'name_b_a')
+      + array_column($relationshipTypes, 'id', 'label_a_b')
+      + array_column($relationshipTypes, 'id', 'label_b_a');
+    $missing = [];
+    foreach ($caseTypes as $caseType) {
+      foreach ($caseType['definition']['caseRoles'] as $role) {
+        if (!isset($allConfigured[$role['name']])) {
+          $missing[$role['name']] = $role['name'];
+        }
+      }
+    }
+    if (!empty($missing)) {
+      $tableRows = [];
+      foreach ($relationshipTypes as $relationshipType) {
+        $tableRows[] = ts('<tr><td>%1</td><td>%2</td><td>%3</td><td>%4</td><td>%5</td></tr>', [
+          1 => $relationshipType['id'],
+          2 => htmlspecialchars($relationshipType['name_a_b']),
+          3 => htmlspecialchars($relationshipType['name_b_a']),
+          4 => htmlspecialchars($relationshipType['label_a_b']),
+          5 => htmlspecialchars($relationshipType['label_b_a']),
+        ]);
+      }
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . "missingroles",
+        ts("<p>The following roles listed in your case type definitions do not match any relationship type defined in the system: <em>%1</em>.</p>"
+          . "<p>This might be because of a mismatch if you are using external xml files to manage case types. If using xml files, then use either the name_a_b or name_b_a value from the following table. (Out of the box you would use name_b_a, which lists them on the case from the client perspective.) If you are not using xml files, you can edit your case types at Administer - CiviCase - Case Types.</p>"
+          . "<table>
+            <tr><th>ID</th><th>name_a_b</th><th>name_b_a</th><th>label_a_b</th><th>label_b_a</th></tr>"
+          . implode("\n", $tableRows)
+          . "</table>", [
+            1 => htmlspecialchars(implode(', ', $missing)),
+          ]) .
+          '<br /><a href="' . CRM_Utils_System::docURL2('user/case-management/what-you-need-to-know#missing-roles', TRUE) . '">' .
+          ts('Read more about this warning') .
+          '</a>',
+        ts('Missing Roles'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-exclamation'
+      );
+    }
+
+    return $messages;
+  }
+
 }

--- a/ang/crmCaseType/rolesTable.html
+++ b/ang/crmCaseType/rolesTable.html
@@ -12,7 +12,7 @@ Required vars: caseType
 	  </tr>
   </thead>
   <tbody>
-	  <tr ng-repeat="relType in caseType.definition.caseRoles | orderBy:'name'" ng-class-even="'crm-entity even-row even'" ng-class-odd="'crm-entity odd-row odd'">
+	  <tr ng-repeat="relType in caseType.definition.caseRoles | orderBy:'displayLabel'" ng-class-even="'crm-entity even-row even'" ng-class-odd="'crm-entity odd-row odd'">
       <!-- display label (client-perspective) -->
 	    <td>{{relType.displayLabel}}</td>
 	    <td><input type="checkbox" ng-model="relType.creator" ng-true-value="'1'" ng-false-value="'0'"></td>

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -76,7 +76,7 @@ Required vars: activitySet
           ui-jq="select2"
           ui-options="{dropdownAutoWidth: true}"
           ng-model="activity.default_assignee_relationship"
-          ng-options="option.value as option.label for option in defaultRelationshipTypeOptions"
+          ng-options="option.id as option.text for option in relationshipTypeOptions"
           required
         ></select>
       </p>

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -224,32 +224,6 @@ describe('crmCaseType', function() {
             }
           ]
         },
-        // Where is this used in the tests?
-        // It seems to be in the format for the activity assignee.
-        relTypesForm: {
-          values: [
-            {
-                "key": "14_b_a",
-                "value": "Benefits Specialist"
-            },
-            {
-                "key": "14_a_b",
-                "value": "Benefits Specialist is"
-            },
-            {
-                "key": "9_b_a",
-                "value": "Case Coordinator"
-            },
-            {
-                "key": "9_a_b",
-                "value": "Case Coordinator is"
-            },
-            {
-                "key": "2_b_a",
-                "value": "Spouse of"
-            }
-          ]
-        },
         caseType: {
           "id": "1",
           "name": "housing_support",
@@ -373,24 +347,58 @@ describe('crmCaseType', function() {
       expect(scope.defaultAssigneeTypeValues).toEqual(defaultAssigneeTypeValues);
     });
 
-    it('should store the default assignee relationship type options', function() {
-      var defaultRelationshipTypeOptions = _.transform(apiCalls.relTypes.values, function(result, relType) {
-        var isBidirectionalRelationship = relType.label_a_b === relType.label_b_a;
-
-        result.push({
-          label: relType.label_b_a,
-          value: relType.id + '_a_b'
-        });
-
-        if (!isBidirectionalRelationship) {
-          result.push({
-            label: relType.label_a_b,
-            value: relType.id + '_b_a'
-          });
+    it('should compute the relationship type options', function() {
+      var expectedRelationshipTypeOptions = [
+        {
+          "id": "14_a_b",
+          "text": "Benefits Specialist",
+          "xmlName": "Benefits Specialist is"
+        },
+        {
+          "id": "14_b_a",
+          "text": "Benefits Specialist is",
+          "xmlName": "Benefits Specialist"
+        },
+        {
+          "id": "9_a_b",
+          "text": "Case Coordinator",
+          "xmlName": "Case Coordinator is"
+        },
+        {
+          "id": "9_b_a",
+          "text": "Case Coordinator is",
+          "xmlName": "Case Coordinator"
+        },
+        {
+          "id": "10_a_b",
+          "text": "Homeless Services Coordinator",
+          "xmlName": "Homeless Services Coordinator is"
+        },
+        {
+          "id": "10_b_a",
+          "text": "Homeless Services Coordinator is",
+          "xmlName": "Homeless Services Coordinator"
+        },
+        // Bidirectional, so should only have the one direction in the list
+        {
+          "id": "2_a_b",
+          "text": "Spouse of",
+          "xmlName": "Spouse of"
+        },
+        // include one where name is different from label
+        {
+          "id": "27_a_b",
+          "text": "Guardian Angel for",
+          "xmlName": "GA123ab",
+        },
+        {
+          "id": "27_b_a",
+          "text": "Guardian Angel is",
+          "xmlName": "GA123ba",
         }
-      }, []);
+      ];
 
-      expect(scope.defaultRelationshipTypeOptions).toEqual(defaultRelationshipTypeOptions);
+      expect(scope.relationshipTypeOptions).toEqual(expectedRelationshipTypeOptions);
     });
 
     it('addActivitySet should add an activitySet to the case type', function() {
@@ -492,10 +500,13 @@ describe('crmCaseType', function() {
         // dropdown. It doesn't test that clicking picks the right value to
         // add, just that if it did then the function that gets called does
         // the right thing with it.
-        // Note the value returned by the dropdown is "backwards", e.g.
+        // Note the value returned by the dropdown is "backwards" to match
+        // historically what has been stored in the xml as name, e.g.
         // for the client perspective direction the dropdown returns the other
-        // direction, which is also what's stored in the xml.
-        scope.addRole(scope.caseType.definition.caseRoles, 'Case Coordinator');
+        // direction.
+        // So 9_b_a is "Case Coordinator", which means that they actually
+        // selected "Case Coordinator is".
+        scope.addRole(scope.caseType.definition.caseRoles, '9_b_a');
 
         expect(scope.caseType.definition.caseRoles).toEqual(
           [
@@ -513,9 +524,27 @@ describe('crmCaseType', function() {
         );
       });
 
+      it('updates case roles when name and label are different', function() {
+        scope.addRole(scope.caseType.definition.caseRoles, '27_b_a');
+        expect(scope.caseType.definition.caseRoles).toEqual(
+          [
+            {
+              name: 'Homeless Services Coordinator',
+              creator: '1',
+              manager: '1',
+              displayLabel: 'Homeless Services Coordinator is'
+            },
+            {
+              name: 'GA123ba',
+              displayLabel: 'Guardian Angel is'
+            }
+          ]
+        );
+      });
+
       it('updates case roles if choose non-client-perspective direction', function() {
         // again, the dropdown returns the opposite direction
-        scope.addRole(scope.caseType.definition.caseRoles, 'Homeless Services Coordinator is');
+        scope.addRole(scope.caseType.definition.caseRoles, '10_a_b');
         expect(scope.caseType.definition.caseRoles).toEqual(
           [
             {
@@ -532,9 +561,8 @@ describe('crmCaseType', function() {
         );
       });
 
-      it("doesn't add the same role twice", function() {
-        // This is in the mock casetype to start, so check if can add twice.
-        scope.addRole(scope.caseType.definition.caseRoles, 'Homeless Services Coordinator');
+      it('updates case roles non-client-perspective direction name/label different', function() {
+        scope.addRole(scope.caseType.definition.caseRoles, '27_a_b');
         expect(scope.caseType.definition.caseRoles).toEqual(
           [
             {
@@ -542,6 +570,44 @@ describe('crmCaseType', function() {
               creator: '1',
               manager: '1',
               displayLabel: 'Homeless Services Coordinator is'
+            },
+            {
+              name: 'GA123ab',
+              displayLabel: 'Guardian Angel for'
+            }
+          ]
+        );
+      });
+
+      it("doesn't add the same role twice", function() {
+        // This is in the mock casetype to start, so check if can add twice.
+        scope.addRole(scope.caseType.definition.caseRoles, '10_b_a');
+        expect(scope.caseType.definition.caseRoles).toEqual(
+          [
+            {
+              name: 'Homeless Services Coordinator',
+              creator: '1',
+              manager: '1',
+              displayLabel: 'Homeless Services Coordinator is'
+            }
+          ]
+        );
+
+        // Try with name and label different. We already tested one time in
+        // another test so just go straight to twice.
+        scope.addRole(scope.caseType.definition.caseRoles, '27_b_a');
+        scope.addRole(scope.caseType.definition.caseRoles, '27_b_a');
+        expect(scope.caseType.definition.caseRoles).toEqual(
+          [
+            {
+              name: 'Homeless Services Coordinator',
+              creator: '1',
+              manager: '1',
+              displayLabel: 'Homeless Services Coordinator is'
+            },
+            {
+              name: 'GA123ba',
+              displayLabel: 'Guardian Angel is'
             }
           ]
         );
@@ -567,7 +633,6 @@ describe('crmCaseType', function() {
           "is_reserved": "0",
           "is_active": "1"
         };
-        apiCalls.relTypes.values.push(newType);
 
         // now let the real code do what it does with the new type
         scope.addRoleOnTheFly(scope.caseType.definition.caseRoles, newType);
@@ -590,11 +655,13 @@ describe('crmCaseType', function() {
         expect(scope.relationshipTypeOptions.slice(-2)).toEqual(
           [
             {
-              id: 'Some New Type is',
+              xmlName: 'Some New Type is',
+              id: '33_a_b',
               text: 'Some New Type for'
             },
             {
-              id: 'Some New Type for',
+              xmlName: 'Some New Type for',
+              id: '33_b_a',
               text: 'Some New Type is'
             }
           ]
@@ -615,7 +682,6 @@ describe('crmCaseType', function() {
           "is_reserved": "0",
           "is_active": "1"
         };
-        apiCalls.relTypes.values.push(newType);
 
         // now let the real code do what it does with the new type
         scope.addRoleOnTheFly(scope.caseType.definition.caseRoles, newType);
@@ -638,7 +704,8 @@ describe('crmCaseType', function() {
         expect(scope.relationshipTypeOptions.slice(-1)).toEqual(
           [
             {
-              id: 'Friend of',
+              xmlName: 'Friend of',
+              id: '34_a_b',
               text: 'Friend of'
             }
           ]
@@ -648,7 +715,8 @@ describe('crmCaseType', function() {
         expect(scope.relationshipTypeOptions.slice(-2,-1)).not.toEqual(
           [
             {
-              id: 'Friend of',
+              xmlName: 'Friend of',
+              id: '34_b_a',
               text: 'Friend of'
             }
           ]

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -512,4 +512,66 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     $this->assertNotEmpty($bounceMessage);
   }
 
+  /**
+   * Test changing the label for the case manager role and then creating
+   * a case.
+   * At the time this test was written this test would fail, demonstrating
+   * one problem with name vs label.
+   */
+  public function testCreateCaseWithChangedManagerLabel() {
+    // We could just assume the relationship that gets created has
+    // relationship_type_id = 1, but let's create a case, see what the
+    // id is, then do our actual test.
+    $loggedInUser = $this->createLoggedInUser();
+    $client_id = $this->individualCreate();
+    $caseObj = $this->createCase($client_id, $loggedInUser);
+    $case_id = $caseObj->id;
+
+    // Going to assume the stock case type has what it currently has at the
+    // time of writing, which is the autocreated case manager relationship for
+    // the logged in user.
+    $getParams = [
+      'contact_id_b' => $loggedInUser,
+      'case_id' => $case_id,
+    ];
+    $result = $this->callAPISuccess('Relationship', 'get', $getParams);
+    // as noted above assume this is the only one
+    $relationship_type_id = $result['values'][$result['id']]['relationship_type_id'];
+
+    // Save the old labels first so we can put back at end of test.
+    $oldParams = [
+      'id' => $relationship_type_id,
+    ];
+    $oldValues = $this->callAPISuccess('RelationshipType', 'get', $oldParams);
+    // Now change the label of the relationship type.
+    $changeParams = [
+      'id' => $relationship_type_id,
+      'label_a_b' => 'Best ' . $oldValues['values'][$relationship_type_id]['label_a_b'],
+      'label_b_a' => 'Best ' . $oldValues['values'][$relationship_type_id]['label_b_a'],
+    ];
+    $this->callAPISuccess('RelationshipType', 'create', $changeParams);
+
+    // Now try creating another case.
+    $caseObj2 = $this->createCase($client_id, $loggedInUser);
+    $case_id2 = $caseObj2->id;
+
+    $checkParams = [
+      'contact_id_b' => $loggedInUser,
+      'case_id' => $case_id2,
+    ];
+    $result = $this->callAPISuccess('Relationship', 'get', $checkParams);
+    // Main thing is the above createCase call doesn't fail, but let's check
+    // the relationship type id is what we expect too while we're here.
+    // See note above about assuming this is the only relationship autocreated.
+    $this->assertEquals($relationship_type_id, $result['values'][$result['id']]['relationship_type_id']);
+
+    // Now put relationship type back to the way it was.
+    $changeParams = [
+      'id' => $relationship_type_id,
+      'label_a_b' => $oldValues['values'][$relationship_type_id]['label_a_b'],
+      'label_b_a' => $oldValues['values'][$relationship_type_id]['label_b_a'],
+    ];
+    $this->callAPISuccess('RelationshipType', 'create', $changeParams);
+  }
+
 }

--- a/tests/phpunit/CRM/Case/XMLProcessorTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessorTest.php
@@ -1,0 +1,51 @@
+<?php
+require_once 'CiviTest/CiviCaseTestCase.php';
+
+/**
+ * Class CRM_Case_XMLProcessorTest
+ * @group headless
+ */
+class CRM_Case_XMLProcessorTest extends CiviCaseTestCase {
+
+  public function setUp() {
+    parent::setUp();
+
+    $this->processor = new CRM_Case_XMLProcessor();
+  }
+
+  /**
+   * Test that allRelationshipTypes() doesn't have name and label mixed up
+   * and that is has the right directions.
+   */
+  public function testAllRelationshipTypes() {
+
+    // Add a relationship type to test against.
+    $params = [
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Individual',
+      'name_a_b' => 'fpt123a',
+      'label_a_b' => 'Food poison tester is',
+      'name_b_a' => 'fpt123b',
+      'label_b_a' => 'Food poison tester for',
+      'description' => 'Food poison tester',
+    ];
+    $result = $this->callAPISuccess('relationship_type', 'create', $params);
+    $relationshipTypeID = $result['id'];
+
+    // All we can test against is label, so just check A and B are right (or
+    // wrong, depending on your point of view). Let's not use the words right
+    // and wrong let's just call it one way and the other way.
+    $relationshipTypes = $this->processor->allRelationshipTypes(FALSE);
+    $this->assertEquals('Food poison tester is', $relationshipTypes["{$relationshipTypeID}_a_b"]);
+    $this->assertEquals('Food poison tester for', $relationshipTypes["{$relationshipTypeID}_b_a"]);
+
+    // For true, B and A are the other way around here.
+    $relationshipTypes = $this->processor->allRelationshipTypes(TRUE);
+    $this->assertEquals('Food poison tester is', $relationshipTypes["{$relationshipTypeID}_b_a"]);
+    $this->assertEquals('Food poison tester for', $relationshipTypes["{$relationshipTypeID}_a_b"]);
+
+    // cleanup
+    $this->callAPISuccess('relationship_type', 'delete', ['id' => $relationshipTypeID]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Alternate to https://github.com/civicrm/civicrm-core/pull/15349 that is the same server-side but includes some code cleanup in ang/crmCaseType.js.

**See technical details below.**

Overview blurb copied from other PR:

There is a longstanding issue where name and label got mixed at some point for case roles which then comes up in multiple scenarios. This fixes at least the following:

* Fresh out of the box, changing the default language and then enabling civicase causes fatal errors with `drush cc civicrm`, enabling extensions, and creating a new case. [dev/core#329](https://lab.civicrm.org/dev/core/issues/329)
* Also fresh out of the box, enabling civicase and changing the label of a relationship type causes various problems, including a fatal error if it's the case manager role. This is another way to cause the above fatal errors since it's the same root cause. [dev/core#774](https://lab.civicrm.org/dev/core/issues/774) and [dev/core#856](https://lab.civicrm.org/dev/core/issues/856)
* People using xml files need to update their xml files if they change the label of a relationship type (defeating the purpose of `name`).

I can break this PR down into some smaller chunks but I wanted to put up the whole thing because in order to try it out you need the whole thing. The meat of it is the 3 files under CRM/Case and ang/crmCaseType.js, which I don't think I can break up too much because a change in one place throws everything else off.

It also adds some system status checks to warn about edge cases, e.g. if you have somehow ended up with a label that matches another type's machine name, or roles you have in your xml file that don't exist as relationship types. There is a WIP addition to the user guide [here](https://github.com/civicrm/civicrm-user-guide/compare/master...demeritcowboy:case-role-status-checks-help) that goes along with this. I'm not sure it belongs in the user guide but that's where the other case setup/admin docs are.

Before
----------------------------------------
Case roles broken if you change a label.

After
----------------------------------------
Better

Technical Details
----------------------------------------
The only differences between this PR and https://github.com/civicrm/civicrm-core/pull/15349 are:

* This includes code cleanup in ang/crmCaseType.js as referenced in that PR and further described at https://lab.civicrm.org/dev/core/issues/1046#note_24073 and the comment after it. And then related variable name changes in rolesTable.html and timelineTable.html.

* It does update an existing test (the one now called `it('should compute the relationship type options')`) because the object it tested no longer exists on its own, so instead it now does a similar test on the combined object (relationshipTypeOptions).

* Some more tests.

* Merged with PRs #15377, #15378, #15385, #15412.

* The .php files are all unchanged from the other PR. The above only touches the case type edit screen.

Comments
----------------------------------------
Have broken out two minor changes from this as #15485 and #15486.