### PR TITLE
[NFC] dev/core#1046 - more accurate column heading

### DIFF
--- a/ang/crmCaseType/rolesTable.html
+++ b/ang/crmCaseType/rolesTable.html
@@ -5,7 +5,7 @@ Required vars: caseType
 <table>
   <thead>
 	  <tr>
-	    <th>{{ts('Name')}}</th>
+	    <th>{{ts('Display Label')}}</th>
 	    <th>{{ts('Assign to Creator')}}</th>
 	    <th>{{ts('Is Manager')}}</th>
 	    <th></th>


### PR DESCRIPTION
Overview
----------------------------------------
The smallest change I can make towards https://lab.civicrm.org/dev/core/issues/1046. This just makes the column heading more accurately reflect what's in the column. And possibly helps remove some confusion with the `<name>` tag in the xml which does NOT match what's in this column.