### PR TITLE
Allow to view (sent) mailing as a specific contact if the logged in contact has permission

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -129,8 +129,9 @@ WHERE contact_id IN ({$contact_id_list})
    * Check if the logged in user has permissions for the operation type.
    *
    * @param int $id
-   *   Contact id.
-   * @param int|string $type the type of operation (view|edit)
+   *   Contact id to check if logged contact has permission to view.
+   * @param int $type
+   *   The type of permission that the logged in contact must have (view|edit)
    *
    * @return bool
    *   true if the user has permission, false otherwise

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2915,7 +2915,7 @@ ORDER BY civicrm_mailing.name";
         CRM_Core_Action::VIEW => [
           'name' => ts('View'),
           'url' => 'civicrm/mailing/view',
-          'qs' => "reset=1&id=%%mkey%%",
+          'qs' => "reset=1&id=%%mkey%%&cid=%%cid%%",
           'title' => ts('View Mailing'),
           'class' => 'crm-popup',
         ],

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -105,7 +105,13 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       $this->_contactID = $contactID;
     }
     else {
-      $this->_contactID = CRM_Core_Session::getLoggedInContactID();
+      $urlContactID = CRM_Utils_Request::retrieve('cid', 'String');
+      if (!empty($urlContactID) && (CRM_Contact_BAO_Contact_Permission::allow($urlContactID, CRM_Core_Permission::VIEW))) {
+        $this->_contactID = $urlContactID;
+      }
+      else {
+        $this->_contactID = CRM_Core_Session::getLoggedInContactID();
+      }
     }
 
     // mailing key check


### PR DESCRIPTION
Overview
----------------------------------------
If the logged in contact has permission to view a contact, also allow them to view a mailing as that contact.  This is most useful on the contact summary mailings tab, as clicking "View" will now show the email with tokens parsed.

Before
----------------------------------------
Not possible to view a mailing as it would look to another user.

After
----------------------------------------
You can view a mailing as it would look to that user.

Technical Details
----------------------------------------
Allow a contact ID to be passed to the mailing viewer.  Add a permission check to prevent this becoming a security hole.

Comments
----------------------------------------
@BeccaTregenna as we talked about mosaico issues I think this is something you might be interested in testing?