### PR TITLE
[REF] Replace deprecated function call with a more readable alternative

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3786,10 +3786,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             $itemParams['amount'] = self::getMultiplier($params['contribution']->contribution_status_id, $context) * $taxAmount;
             $itemParams['description'] = $taxTerm;
             if ($lineItemDetails['financial_type_id']) {
-              $itemParams['financial_account_id'] = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount(
-                $lineItemDetails['financial_type_id'],
-                'Sales Tax Account is'
-              );
+              $itemParams['financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getSalesTaxFinancialAccount($lineItemDetails['financial_type_id']);
             }
             CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnIds);
           }

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -271,6 +271,19 @@ WHERE cft.id = %1
   }
 
   /**
+   * Get the sales tax financial account id for the financial type id.
+   *
+   * This is a helper wrapper to make the function name more readable.
+   *
+   * @param int $financialAccountID
+   *
+   * @return int
+   */
+  public static function getSalesTaxFinancialAccount($financialAccountID) {
+    return self::getFinancialAccountForFinancialTypeByRelationship($financialAccountID, 'Sales Tax Account is');
+  }
+
+  /**
    * Get Financial Account type relations.
    *
    * @param $flip bool

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -154,6 +154,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
     }
     if ($self->_action & CRM_Core_Action::UPDATE) {
       if (!(isset($values['is_tax']))) {
+        // @todo replace with call to CRM_Financial_BAO_FinancialAccount getSalesTaxFinancialAccount
         $relationshipId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Sales Tax Account is' "));
         $params = [
           'financial_account_id' => $self->_id,

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -244,6 +244,7 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
       ];
       $defaults = [];
       if ($self->_action == CRM_Core_Action::ADD) {
+        // @todo replace with call to CRM_Financial_BAO_FinancialAccount getSalesTaxFinancialAccount
         $relationshipId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Sales Tax Account is' "));
         $isTax = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialAccount', $values['financial_account_id'], 'is_tax');
         if ($values['account_relationship'] == $relationshipId) {


### PR DESCRIPTION
Overview
----------------------------------------
This adds a wrapper to getting financial accounts with the type & uses it rather than the non-deprecated function

Before
----------------------------------------
Deprecated function called

After
----------------------------------------
More readable function called

Technical Details
----------------------------------------
@monishdeb I'd like to advocate for functions like this for getting the financial accounts. They are a pretty thin wrapper on getFinancialAccountForFinancialTypeByRelationship but I feel it's more readable & less error prone (no need to get 'Sales Account Is' exactly right, instead use IDE autocomplete)


Comments
----------------------------------------

