### PR TITLE
Fix 5.18 regression on membership handling

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -588,7 +588,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     }
 
     // @todo Move this into CRM_Member_BAO_Membership::processMembership
-    $pending = ($this->_params['contribution_status_id'] == array_search('Pending', CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'label'))) ? TRUE : FALSE;
+    $pending = ($this->_params['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'));
     list($membership) = CRM_Member_BAO_Membership::processMembership(
       $this->_contactID, $this->_params['membership_type_id'][1], $isTestMembership,
       $renewalDate, NULL, $customFieldsFormatted, $numRenewTerms, $this->_membershipId,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a 5.18 regression where sites with labels for contribution status 'Pending' that are NOT 'Pending' would result in the end date being inappropriately extended when back office renewal form is submitted with a pending payment

This was picked up in  test with https://github.com/civicrm/civicrm-core/pull/15399
& originates from
https://github.com/civicrm/civicrm-core/commit/5b9d3ce80f1a64b39bdd63160ad0a1b960f2faed


Before
----------------------------------------
Test fail indicates label rather than name is checked for determining pending status

After
----------------------------------------
Name checked

Technical Details
----------------------------------------

Comments
----------------------------------------
