### PR TITLE
Test  calling CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -175,6 +175,15 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Getter for the id.
+   *
+   * @return int
+   */
+  public function getID() {
+    return (int) $this->_paymentProcessor['id'];
+  }
+
+  /**
    * Set payment Instrument id.
    *
    * By default we actually ignore the form value. The manual processor takes it more seriously.

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
@@ -74,6 +74,7 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
     $liveProcessorID = $testProcessorID + 1;
 
     $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'TestMode']);
+    $this->markTestIncomplete('Not working yet :-(');
     $this->assertEquals([$testProcessorID, 0], array_keys($processors), 'Only the test processor and the manual processor should be returned');
 
     $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'TestMode'], [$liveProcessorID]);

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
@@ -63,4 +63,31 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
     $this->assertEquals($cards, $expectedCards, 'Verify correct credit card types are returned');
   }
 
+  /**
+   * Test the processor retrieval function.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testGetProcessors() {
+    $testProcessor = $this->dummyProcessorCreate();
+    $testProcessorID = $testProcessor->getID();
+    $liveProcessorID = $testProcessorID + 1;
+
+    $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'TestMode']);
+    $this->assertEquals([$testProcessorID, 0], array_keys($processors), 'Only the test processor and the manual processor should be returned');
+
+    $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'TestMode'], [$liveProcessorID]);
+    $this->assertEquals([$testProcessorID], array_keys($processors), 'Only the test processor should be returned');
+
+    $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'TestMode'], [$testProcessorID]);
+    $this->assertEquals([$testProcessorID], array_keys($processors), 'Only the test processor should be returned');
+
+    $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'LiveMode']);
+    $this->assertEquals([$liveProcessorID, 0], array_keys($processors), 'Only the Live processor and the manual processor should be returned');
+
+    $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['BackOffice', 'LiveMode'], [$liveProcessorID]);
+    $this->assertEquals([$liveProcessorID], array_keys($processors), 'Only the Live processor should be returned');
+
+  }
+
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -806,9 +806,15 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @return \CRM_Core_Payment_Dummy
    *   Instance of Dummy Payment Processor
+   *
+   * @throws \CiviCRM_API3_Exception
    */
-  public function dummyProcessorCreate($processorParams = array()) {
+  public function dummyProcessorCreate($processorParams = []) {
     $paymentProcessorID = $this->processorCreate($processorParams);
+    // For the tests we don't need a live processor, but as core ALWAYS creates a processor in live mode and one in test mode we do need to create both
+    //   Otherwise we are testing a scenario that only exists in tests (and some tests fail because the live processor has not been defined).
+    $processorParams['is_test'] = FALSE;
+    $this->processorCreate($processorParams);
     return System::singleton()->getById($paymentProcessorID);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add test to ensure calling with Test capability only returns testMode processors

Test was written as part of review for https://github.com/civicrm/civicrm-core/pull/15330 but in fact it doesn't pass before or after that is applied :-(

Before
----------------------------------------
No tests

After
----------------------------------------
Tests

Technical Details
----------------------------------------
I believe the function should be updated so the tests pass

Comments
----------------------------------------

