### PR TITLE
Switch creation of ParticipantPayment to use API

### DIFF
--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -82,11 +82,11 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     $participant->save();
 
     if (!empty($params['contributionID'])) {
-      $payment_params = [
+      $participantPaymentParams = [
         'participant_id' => $participant->id,
         'contribution_id' => $params['contributionID'],
       ];
-      CRM_Event_BAO_ParticipantPayment::create($payment_params);
+      civicrm_api3('ParticipantPayment', 'create', $participantPaymentParams);
     }
 
     $transaction->commit();

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1316,13 +1316,14 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $participants[0]->id,
         'Participant'
       );
-      //add participant payment
-      $paymentParticipant = [
+
+      // Add participant payment
+      $participantPaymentParams = [
         'participant_id' => $participants[0]->id,
         'contribution_id' => $contribution->id,
       ];
+      civicrm_api3('ParticipantPayment', 'create', $participantPaymentParams);
 
-      CRM_Event_BAO_ParticipantPayment::create($paymentParticipant);
       $this->_contactIds[] = $this->_contactId;
     }
     else {
@@ -1472,13 +1473,14 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           }
         }
 
-        //insert payment record for this participation
+        // Insert payment record for this participant
         if (empty($ids['contribution'])) {
           foreach ($this->_contactIds as $num => $contactID) {
-            $ppDAO = new CRM_Event_DAO_ParticipantPayment();
-            $ppDAO->participant_id = $participants[$num]->id;
-            $ppDAO->contribution_id = $contributions[$num]->id;
-            $ppDAO->save();
+            $participantPaymentParams = [
+              'participant_id' => $participants[$num]->id,
+              'contribution_id' => $contributions[$num]->id,
+            ];
+            civicrm_api3('ParticipantPayment', 'create', $participantPaymentParams);
           }
         }
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -695,6 +695,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    *
    * @param int $contactID
    * @param \CRM_Contribute_BAO_Contribution $contribution
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function confirmPostProcess($contactID = NULL, $contribution = NULL) {
     // add/update contact information
@@ -742,11 +744,11 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
 
     if ($createPayment && $this->_values['event']['is_monetary'] && !empty($this->_params['contributionID'])) {
-      $paymentParams = array(
+      $paymentParams = [
         'participant_id' => $participant->id,
         'contribution_id' => $contribution->id,
-      );
-      $paymentPartcipant = CRM_Event_BAO_ParticipantPayment::create($paymentParams);
+      ];
+      civicrm_api3('ParticipantPayment', 'create', $paymentParams);
     }
 
     $this->assign('action', $this->_action);
@@ -790,6 +792,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @param int $contactID
    *
    * @return \CRM_Event_BAO_Participant
+   * @throws \CiviCRM_API3_Exception
    */
   public static function addParticipant(&$form, $contactID) {
     if (empty($form->_params)) {


### PR DESCRIPTION
Overview
----------------------------------------
Switch creation of ParticipantPayment  to use API

Before
----------------------------------------
ParticipantPayment create calls  don't use the api

After
----------------------------------------
ParticipantPayment create calls  use the api

Technical Details
----------------------------------------
Reviewer's commit of patch from https://github.com/civicrm/civicrm-core/pull/15446 - MOP

Comments
----------------------------------------

