### PR TITLE
dev/financial#73 Update Order.create so that total_amount is not required.

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -80,12 +80,14 @@ function _civicrm_api3_order_get_spec(&$params) {
  * @param array $params
  *   Input parameters.
  *
- * @throws API_Exception
  * @return array
  *   Api result array
+ *
+ * @throws \CiviCRM_API3_Exception
+ * @throws API_Exception
  */
 function civicrm_api3_order_create($params) {
-
+  civicrm_api3_verify_one_mandatory($params, NULL, ['line_items', 'total_amount']);
   $entity = NULL;
   $entityIds = [];
   if (!empty($params['line_items']) && is_array($params['line_items'])) {
@@ -213,7 +215,6 @@ function _civicrm_api3_order_create_spec(&$params) {
   $params['total_amount'] = [
     'name' => 'total_amount',
     'title' => 'Total Amount',
-    'api.required' => TRUE,
   ];
   $params['financial_type_id'] = [
     'name' => 'financial_type_id',

--- a/api/v3/examples/Order/Cancel.ex.php
+++ b/api/v3/examples/Order/Cancel.ex.php
@@ -74,6 +74,7 @@ function order_cancel_expectedresult() {
         'creditnote_id' => '1',
         'tax_amount' => '',
         'revenue_recognition_date' => '',
+        'is_template' => 0,
         'contribution_type_id' => '1',
       ],
     ],

--- a/api/v3/examples/Order/Create.ex.php
+++ b/api/v3/examples/Order/Create.ex.php
@@ -9,7 +9,6 @@ function order_create_example() {
   $params = [
     'contact_id' => 8,
     'receive_date' => '2010-01-20',
-    'total_amount' => 200,
     'financial_type_id' => 'Event Fee',
     'contribution_status_id' => 1,
     'line_items' => [
@@ -106,6 +105,7 @@ function order_create_expectedresult() {
         'creditnote_id' => '',
         'tax_amount' => '',
         'revenue_recognition_date' => '',
+        'is_template' => '',
         'contribution_type_id' => '4',
       ],
     ],

--- a/api/v3/examples/Order/CreateOrderParticipant.ex.php
+++ b/api/v3/examples/Order/CreateOrderParticipant.ex.php
@@ -116,6 +116,7 @@ function order_create_expectedresult() {
         'creditnote_id' => '',
         'tax_amount' => '',
         'revenue_recognition_date' => '',
+        'is_template' => '',
         'contribution_type_id' => '1',
       ],
     ],

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -36,11 +36,12 @@ class api_v3_OrderTest extends CiviUnitTestCase {
 
   protected $_individualId;
   protected $_financialTypeId = 1;
-  protected $_apiversion;
   public $debug = 0;
 
   /**
    * Setup function.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function setUp() {
     parent::setUp();
@@ -51,6 +52,8 @@ class api_v3_OrderTest extends CiviUnitTestCase {
 
   /**
    * Clean up after each test.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
@@ -199,6 +202,8 @@ class api_v3_OrderTest extends CiviUnitTestCase {
 
   /**
    * Test create order api for membership
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testAddOrderForMembership() {
     $membershipType = $this->membershipTypeCreate();
@@ -207,7 +212,6 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     $p = [
       'contact_id' => $this->_individualId,
       'receive_date' => '2010-01-20',
-      'total_amount' => 200,
       'financial_type_id' => 'Event Fee',
       'contribution_status_id' => 1,
     ];
@@ -292,6 +296,8 @@ class api_v3_OrderTest extends CiviUnitTestCase {
 
   /**
    * Test create order api for participant
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testAddOrderForParticipant() {
     $event = $this->eventCreate();
@@ -530,8 +536,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
   }
 
   /**
-   * @expectedException CiviCRM_API3_Exception
-   * @expectedExceptionMessage Line item total doesn't match with total amount.
+   * Test an exception is thrown if line items do not add up to total_amount, no tax.
    */
   public function testCreateOrderIfTotalAmountDoesNotMatchLineItemsAmountsIfNoTaxSupplied() {
     $params = [
@@ -559,12 +564,11 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       ],
     ];
 
-    civicrm_api3('Order', 'create', $params);
+    $this->callAPIFailure('Order', 'create', $params, 'Line item total doesn\'t match with total amount');
   }
 
   /**
-   * @expectedException CiviCRM_API3_Exception
-   * @expectedExceptionMessage Line item total doesn't match with total amount.
+   * Test an exception is thrown if line items do not add up to total_amount, with tax.
    */
   public function testCreateOrderIfTotalAmountDoesNotMatchLineItemsAmountsIfTaxSupplied() {
     $params = [
@@ -594,7 +598,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       ],
     ];
 
-    civicrm_api3('Order', 'create', $params);
+    $this->callAPIFailure('Order', 'create', $params, 'Line item total doesn\'t match with total amount.');
   }
 
   public function testCreateOrderIfTotalAmountDoesMatchLineItemsAmountsAndTaxSupplied() {
@@ -625,7 +629,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       ],
     ];
 
-    $order = civicrm_api3('Order', 'create', $params);
+    $order = $this->callAPISuccess('Order', 'create', $params);
     $this->assertEquals(1, $order['count']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/financial/issues/73 total_amount should not be a required field for Order.create

Before
----------------------------------------
total_amount required

After
----------------------------------------
total_amount OR line_items required

Technical Details
----------------------------------------
As test shows it is otherwise created from the line items

Comments
----------------------------------------
@mecachisenros @artfulrobot @JoeMurray 
