### PR TITLE
dev/financial#69 Fix misrecording of payments against non pay_later Pending contribution.

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -342,20 +342,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     if ($this->_component == 'event') {
       $participantId = $this->_id;
     }
-    $contributionStatuses = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution',
-      'contribution_status_id',
-      ['labelColumn' => 'name']
-    );
-    $contributionStatusID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'contribution_status_id');
-    if ($contributionStatuses[$contributionStatusID] == 'Pending') {
-      civicrm_api3('Contribution', 'create',
-        [
-          'id' => $this->_contributionId,
-          'contribution_status_id' => array_search('Partially paid', $contributionStatuses),
-          'is_pay_later' => 0,
-        ]
-      );
-    }
 
     if ($this->_mode) {
       // process credit card

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -171,12 +171,7 @@ class CRM_Financial_BAO_Payment {
       }
     }
     elseif ($contributionStatus === 'Pending') {
-      civicrm_api3('Contribution', 'create',
-        [
-          'id' => $contribution['id'],
-          'contribution_status_id' => 'Partially paid',
-        ]
-      );
+      self::updateContributionStatus($contribution['id'], 'Partially Paid');
     }
     CRM_Contribute_BAO_Contribution::recordPaymentActivity($params['contribution_id'], CRM_Utils_Array::value('participant_id', $params), $params['total_amount'], $trxn->currency, $trxn->trxn_date);
     return $trxn;
@@ -532,6 +527,26 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     $outstandingBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($contributionID);
     $cmp = bccomp($paymentAmount, $outstandingBalance, 5);
     return ($cmp == 0 || $cmp == 1);
+  }
+
+  /**
+   * Update the status of the contribution.
+   *
+   * We pass the is_post_payment_create as we have already created the line items
+   *
+   * @param int $contributionID
+   * @param string $status
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function updateContributionStatus(int $contributionID, string $status) {
+    civicrm_api3('Contribution', 'create',
+      [
+        'id' => $contributionID,
+        'is_post_payment_create' => TRUE,
+        'contribution_status_id' => $status,
+      ]
+    );
   }
 
 }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -716,7 +716,28 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   /**
    * Test create payment api for pay later contribution with partial payment.
    *
-   * @throws \Exception
+   * https://lab.civicrm.org/dev/financial/issues/69
+   */
+  public function testCreatePaymentIncompletePaymentPartialPayment() {
+    $contributionParams = [
+      'total_amount' => 100,
+      'currency' => 'USD',
+      'contact_id' => $this->_individualId,
+      'financial_type_id' => 1,
+      'contribution_status_id' => 2,
+    ];
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $contribution['id'],
+      'total_amount' => 50,
+      'payment_instrument_id' => 'Cash',
+    ]);
+    $payments = $this->callAPISuccess('Payment', 'get', ['contribution_id' => $contribution['id']])['values'];
+    $this->assertCount(1, $payments);
+  }
+
+  /**
+   * Test create payment api for pay later contribution with partial payment.
    */
   public function testCreatePaymentPayLaterPartialPayment() {
     $this->createLoggedInUser();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bugs when payments are added against a non-pay later contribution. There were 2 different bugs
1) bug in form layer when the payment is fully paid
2) bug in BAO layer for partial payments.

This fixes both. It may be a regression, hence 5.19

Before
----------------------------------------
I replicated

1) Create pending contribution by api 
CRM.api3('Contribution', 'create', {'contact_id' : 203, 'financial_type_id' : '1', 'contribution_status_id' : 2, total_amount: 60})

![Screen_Shot_2019-10-14_at_5.50.52_PM](https://lab.civicrm.org/dev/financial/uploads/7b4526844b8fbfb455ad60fc9cefec88/Screen_Shot_2019-10-14_at_5.50.52_PM.png)

2) Add payment - in fact I think it depends a bit on which payment instrument you use - I used cash in the end

![Screen_Shot_2019-10-14_at_5.51.25_PM](https://lab.civicrm.org/dev/financial/uploads/3c346a73f132c325faaa553618cbe101/Screen_Shot_2019-10-14_at_5.51.25_PM.png)

3) ![Screen_Shot_2019-10-14_at_6.02.01_PM](https://lab.civicrm.org/dev/financial/uploads/20217c8ed68716733cb8842c8bbcae95/Screen_Shot_2019-10-14_at_6.02.01_PM.png)

After
----------------------------------------
Only one payment recorded in both full payment & partial payment mode

Technical Details
----------------------------------------
1) The lines removed from AdditionalPayment are updating the status & are no longer required in the form layer. They caused one bug

2) When the payment api calls Contribution.create to update the status it needs to pass  'is_post_payment_create' => TRUE, which is a parameter solely for the Payment.create bao to indicate all financial transactions have been actioned. Long term it would not be needed as all payment adds would go via payment.create & handling in Contribution.create will go

Comments
----------------------------------------
@monishdeb @MegaphoneJon @JoeMurray possible payment regression.

It was logged a month ago so not a 5.18 regression - am OK to port to 5.18 or just target 5.19