### PR TITLE
dev/core#1316 Update 'Thank You' & other corrections

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -634,7 +634,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     ], CRM_Core_Action::ADD);
     $this->callAPISuccessGetCount('Contribution', ['contact_id' => $this->_individualId], 1);
     $mut->checkMailLog([
-      'Thank you for your support',
+      'Below you will find a receipt for this contribution.',
       '<testloggedin@example.com>',
     ]);
     $mut->stop();

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -257,7 +257,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
     $this->assertTrue(is_array($msg), "Message returned as an array in line" . __LINE__);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('Thank you for your participation', $msg['body']);
+    $this->assertContains('Thank you for your registration', $msg['body']);
   }
 
   /**
@@ -270,7 +270,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
     $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, FALSE);
     $mut->checkMailLog([
-      'Thank you for your participation',
+      'Thank you for your registration',
       'Annual CiviCRM meet',
       'Mr. Anthony Anderson II',
     ]);

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -80,7 +80,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     ]);
     $participant = $this->callAPISuccessGetSingle('Participant', []);
     $mut->checkMailLog([
-      'Dear Logged In,  Thank you for your participation.  This letter is a confirmation that your registration has been received and your status has been updated to Registered.',
+      'Dear Logged In,  Thank you for your registration.  This is a confirmation that your registration has been received and your status has been updated to Registered.',
     ]);
     $mut->stop();
     $mut->clearMessages();
@@ -212,7 +212,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'Expires: January 2019',
       'Visa',
       '************1111',
-      'This letter is a confirmation that your registration has been received and your status has been updated to <strong> Registered</strong>',
+      'This is a confirmation that your registration has been received and your status has been updated to <strong> Registered</strong>',
     ]);
     $mut->clearMessages();
   }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3097,7 +3097,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'Annual CiviCRM meet',
       'Event',
-      'This letter is a confirmation that your registration has been received and your status has been updated to Registered.',
+      'This is a confirmation that your registration has been received and your status has been updated to Registered.',
       'First Name: Logged In',
       'Public title',
       'public 2',

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -225,7 +225,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'Total Fees: $ 300.00',
       'This Payment Amount: $ 150.00',
       'Balance Owed: $ 0.00',
-      'Thank you for completing payment.',
+      'Thank you for completing this payment.',
     ]);
     $mut->stop();
     $mut->clearMessages();

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -25,9 +25,8 @@
     {if $formValues.receipt_text}
      <p>{$formValues.receipt_text|htmlize}</p>
     {else}
-     <p>{ts}Thank you for your support.{/ts}</p>
+     <p>{ts}Below you will find a receipt for this contribution.{/ts}</p>
     {/if}
-
    </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -2,8 +2,7 @@
 
 {if $formValues.receipt_text}
 {$formValues.receipt_text}
-{else}{ts}Thank you for your support.{/ts}{/if}
-
+{else}{ts}Below you will find a receipt for this contribution.{/ts}{/if}
 
 ===========================================================
 {ts}Contribution Information{/ts}

--- a/xml/templates/message_templates/contribution_recurring_notify_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_notify_html.tpl
@@ -94,7 +94,7 @@
       <tr>
        <td>
         <p>{ts}Your recurring contribution term has ended.{/ts}</p>
-        <p>{ts 1=$recur_installments}You have successfully completed %1 recurring contributions. Thank you for your support.{/ts}</p>
+        <p>{ts 1=$recur_installments}You have successfully completed %1 recurring contributions. Thank you.{/ts}</p>
        </td>
       </tr>
       <tr>

--- a/xml/templates/message_templates/contribution_recurring_notify_text.tpl
+++ b/xml/templates/message_templates/contribution_recurring_notify_text.tpl
@@ -49,7 +49,7 @@
 {ts}Your recurring contribution term has ended.{/ts}
 
 
-{ts 1=$recur_installments}You have successfully completed %1 recurring contributions. Thank you for your support.{/ts}
+{ts 1=$recur_installments}You have successfully completed %1 recurring contributions. Thank you.{/ts}
 
 
 ==================================================

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -31,9 +31,9 @@
      <p>{$event.confirm_email_text|htmlize}</p>
 
     {else}
-     <p>{ts}Thank you for your participation.{/ts}
-     {if $participant_status}{ts 1=$participant_status}This letter is a confirmation that your registration has been received and your status has been updated to <strong> %1</strong>.{/ts}
-     {else}{if $isOnWaitlist}{ts}This letter is a confirmation that your registration has been received and your status has been updated to <strong>waitlisted</strong>.{/ts}{else}{ts}This letter is a confirmation that your registration has been received and your status has been updated to <strong>registered<strong>.{/ts}{/if}{/if}</p>
+     <p>{ts}Thank you for your registration.{/ts}
+     {if $participant_status}{ts 1=$participant_status}This is a confirmation that your registration has been received and your status has been updated to <strong> %1</strong>.{/ts}
+     {else}{if $isOnWaitlist}{ts}This is a confirmation that your registration has been received and your status has been updated to <strong>waitlisted</strong>.{/ts}{else}{ts}This is a confirmation that your registration has been received and your status has been updated to <strong>registered<strong>.{/ts}{/if}{/if}</p>
 
     {/if}
 

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -3,9 +3,9 @@
 {$event.confirm_email_text}
 
 {else}
-  {ts}Thank you for your participation.{/ts}
-  {if $participant_status}{ts 1=$participant_status}This letter is a confirmation that your registration has been received and your status has been updated to %1.{/ts}
-  {else}{if $isOnWaitlist}{ts}This letter is a confirmation that your registration has been received and your status has been updated to waitlisted.{/ts}{else}{ts}This letter is a confirmation that your registration has been received and your status has been updated to registered.{/ts}{/if}
+  {ts}Thank you for your registration.{/ts}
+  {if $participant_status}{ts 1=$participant_status}This is a confirmation that your registration has been received and your status has been updated to %1.{/ts}
+  {else}{if $isOnWaitlist}{ts}This is a confirmation that your registration has been received and your status has been updated to waitlisted.{/ts}{else}{ts}This is a confirmation that your registration has been received and your status has been updated to registered.{/ts}{/if}
   {/if}
 {/if}
 

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -27,7 +27,7 @@
     {elseif $formValues.receipt_text_renewal}
      <p>{$formValues.receipt_text_renewal|htmlize}</p>
     {else}
-     <p>{ts}Thank you for your support.{/ts}</p>
+     <p>{ts}Thank you for this contribution.{/ts}</p>
     {/if}
    </td>
   </tr>

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -4,7 +4,7 @@
 {$formValues.receipt_text_signup}
 {elseif $formValues.receipt_text_renewal}
 {$formValues.receipt_text_renewal}
-{else}{ts}Thank you for your support.{/ts}{/if}
+{else}{ts}Thank you for this contribution.{/ts}{/if}
 
 {if !$lineItem}
 ===========================================================

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -22,6 +22,7 @@
   <tr>
    <td>
     {assign var="greeting" value="{contact.email_greeting}"}{if $greeting}<p>{$greeting},</p>{/if}
+    <p>{ts}This is an invitation to complete your registration that was initially waitlisted.{/ts}</p>
    </td>
   </tr>
   {if !$isAdditional and $participant.id}

--- a/xml/templates/message_templates/participant_confirm_text.tpl
+++ b/xml/templates/message_templates/participant_confirm_text.tpl
@@ -1,5 +1,7 @@
 {assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}
 
+{ts}This is an invitation to complete your registration that was initially waitlisted.{/ts}
+
 {if !$isAdditional and $participant.id}
 
 ===========================================================

--- a/xml/templates/message_templates/payment_or_refund_notification_html.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_html.tpl
@@ -94,7 +94,7 @@
       {if $paymentsComplete}
       <tr>
       <td colspan='2' {$valueStyle}>
-        {ts}Thank you for completing payment.{/ts}
+        {ts}Thank you for completing this payment.{/ts}
       </td>
      </tr>
       {/if}

--- a/xml/templates/message_templates/payment_or_refund_notification_text.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_text.tpl
@@ -31,7 +31,7 @@
 
 {if $paymentsComplete}
 
-{ts}Thank you for completing payment.{/ts}
+{ts}Thank you for completing this payment.{/ts}
 {/if}
 {/if}
 {if $receive_date}

--- a/xml/templates/message_templates/pledge_acknowledge_subject.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Thank you for your Pledge{/ts}
+{ts}Thank you for this pledge{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Some changes to the system workflow messages, since we are reworking them anyway this round.
Introduction in: https://lab.civicrm.org/dev/core/issues/1316

Before
----------------------------------------
Some text in the workflow messages were too specific in the workflow templates

**After**
----------------------------------------
1. The contribution receipt template had:
`'Thank you for your support',`
But the status can be anything, also pending (which does make the thanks a bit confusing)
Better and more neutral would be:
`'Below you will find a receipt for this contribution.',`
(It would even be better if the table would include the contribution status here)

2. Another example. The event online receipt had:
`Thank you for your participation.`
But the status can also be pending, and anyway chances are high this is all still before the event.
Better and more neutral would be:
`Thank you for your registration.`

3. Thirdly, the membership receipts had:
`Thank you for your support.`
But the membership could also just be something people pay for on a regular basis, without the notion of supporting the 'cause' of the organisation. There are many variations of the membership function. Better and more neutral here would be:
`Thank you for this contribution.`

4. Finally, the participant confirm template
I added {ts} to the 'click here to confirm text' in https://github.com/civicrm/civicrm-core/pull/15491
But the mail itself is lacking an introductory text. I would propose the following:
`This is a invitation to complete your registration that was initially waitlisted.`

Technical Details
----------------------------------------
The messages will be upgraded in 5.20alpha1 by https://github.com/civicrm/civicrm-core/pull/15491

Comments
----------------------------------------
Let's make this world a better place by more kindness :-)
