### PR TITLE
Extract deprecated Contribution.transact API into it's own file

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -397,55 +397,6 @@ function _civicrm_api3_contribute_format_params($params, &$values) {
 }
 
 /**
- * Adjust Metadata for Transact action.
- *
- * The metadata is used for setting defaults, documentation & validation.
- *
- * @param array $params
- *   Array of parameters determined by getfields.
- */
-function _civicrm_api3_contribution_transact_spec(&$params) {
-  $fields = civicrm_api3('Contribution', 'getfields', ['action' => 'create']);
-  $params = array_merge($params, $fields['values']);
-  $params['receive_date']['api.default'] = 'now';
-}
-
-/**
- * Process a transaction and record it against the contact.
- *
- * @param array $params
- *   Input parameters.
- *
- * @return array
- *   contribution of created or updated record (or a civicrm error)
- */
-function civicrm_api3_contribution_transact($params) {
-  // Set some params specific to payment processing
-  // @todo - fix this function - none of the results checked by civicrm_error would ever be an array with
-  // 'is_error' set
-  // also trxn_id is not saved.
-  // but since there is no test it's not desirable to jump in & make the obvious changes.
-  $params['payment_processor_mode'] = empty($params['is_test']) ? 'live' : 'test';
-  $params['amount'] = $params['total_amount'];
-  if (!isset($params['net_amount'])) {
-    $params['net_amount'] = $params['amount'];
-  }
-  if (!isset($params['invoiceID']) && isset($params['invoice_id'])) {
-    $params['invoiceID'] = $params['invoice_id'];
-  }
-
-  // Some payment processors expect a unique invoice_id - generate one if not supplied
-  $params['invoice_id'] = CRM_Utils_Array::value('invoice_id', $params, md5(uniqid(rand(), TRUE)));
-
-  $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($params['payment_processor'], $params['payment_processor_mode']);
-  $paymentProcessor['object']->doPayment($params);
-
-  $params['payment_instrument_id'] = $paymentProcessor['object']->getPaymentInstrumentID();
-
-  return civicrm_api('Contribution', 'create', $params);
-}
-
-/**
  * Send a contribution confirmation (receipt or invoice).
  *
  * The appropriate online template will be used (the existence of related objects

--- a/api/v3/Contribution/Transact.php
+++ b/api/v3/Contribution/Transact.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CiviCRM_APIv3
+ */
+
+/**
+ * Adjust Metadata for Transact action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_contribution_transact_spec(&$params) {
+  $fields = civicrm_api3('Contribution', 'getfields', ['action' => 'create']);
+  $params = array_merge($params, $fields['values']);
+  $params['receive_date']['api.default'] = 'now';
+}
+
+/**
+ * Process a transaction and record it against the contact.
+ *
+ * @param array $params
+ *   Input parameters.
+ *
+ * @return array
+ *   contribution of created or updated record (or a civicrm error)
+ */
+function civicrm_api3_contribution_transact($params) {
+  // Set some params specific to payment processing
+  // @todo - fix this function - none of the results checked by civicrm_error would ever be an array with
+  // 'is_error' set
+  // also trxn_id is not saved.
+  // but since there is no test it's not desirable to jump in & make the obvious changes.
+  $params['payment_processor_mode'] = empty($params['is_test']) ? 'live' : 'test';
+  $params['amount'] = $params['total_amount'];
+  if (!isset($params['net_amount'])) {
+    $params['net_amount'] = $params['amount'];
+  }
+  if (!isset($params['invoiceID']) && isset($params['invoice_id'])) {
+    $params['invoiceID'] = $params['invoice_id'];
+  }
+
+  // Some payment processors expect a unique invoice_id - generate one if not supplied
+  $params['invoice_id'] = CRM_Utils_Array::value('invoice_id', $params, md5(uniqid(rand(), TRUE)));
+
+  $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($params['payment_processor'], $params['payment_processor_mode']);
+  $paymentProcessor['object']->doPayment($params);
+
+  $params['payment_instrument_id'] = $paymentProcessor['object']->getPaymentInstrumentID();
+
+  return civicrm_api('Contribution', 'create', $params);
+}


### PR DESCRIPTION
Overview
----------------------------------------
We have agreed that Contribution.transact should be deprecated and removed from CiviCRM core.  However, the recommended alternatives Order.create and PaymentProcessor.Pay are not quite ready and we don't know who is currently using Contribution.transact.
But Contribution.transact is currently doing *the wrong thing* and causes a big headache for payment processors because it does not pass a contribution ID, and it passes slightly odd/modified params.

However, it is currently impossible to override / modify the behaviour of this API without also overriding all the Contribution API calls (which would not be a good idea).

So this PR does a straight extraction of this API into it's own API which allows it to be overridden on a per-site basis if the site administrator wishes to do so.

Before
----------------------------------------
Not possible to replace / override Contribution.transact API without overriding all Contribution APIs.

After
----------------------------------------
We can override the (broken) Contribution.transact API if it is being used and avoid nasty workarounds in payment processors.

Technical Details
----------------------------------------
Split Contribution API functions into a separate file per CiviCRM core standards.

Comments
----------------------------------------
@eileenmcnaughton @JoeMurray @seamuslee001 @artfulrobot There has been a lot of discussion around this troublesome API.  We've all agreed to deprecate it but the alternatives are not quite ready.  As soon as we do we lock in the alternatives (ie. Order API etc).  This PR makes NO functional change in core but gives a bit more flexibility in our ability to override this API without applying core patches directly which is often not possible for a site admin (they can instead install a custom extension such as the paymentshared extension).

For these reasons I'm targetting 5.19 for this PR.  The recent rewrite of Stripe showed me just how messy it is to write payment processors for core and it's really really painful to be targetting 5.18 for this change, 5.19 for that change, 5.20 for the other change etc.  So I've thought about this hard and think this is the best solution - no actual change but allows the paymentshared extension to use a rolling "six month" deprecation window and ideally drop a load of overrides after six months.

