### PR TITLE
dev/core#1126 - Don't freeze fields if the membership is linked to a recurring payment

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -213,9 +213,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     // This string makes up part of the class names, differentiating them (not sure why) from the membership fields.
     $this->assign('formClass', 'membership');
     parent::preProcess();
-    if ($this->isUpdateToExistingRecurringMembership()) {
-      $this->entityFields['end_date']['is_freeze'] = TRUE;
-    }
+
     // get price set id.
     $this->_priceSetId = CRM_Utils_Array::value('priceSetId', $_GET);
     $this->set('priceSetId', $this->_priceSetId);
@@ -580,9 +578,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     );
 
     $sel->setOptions([$selMemTypeOrg, $selOrgMemType]);
-    if ($isUpdateToExistingRecurringMembership) {
-      $sel->freeze();
-    }
 
     if ($this->_action & CRM_Core_Action::ADD) {
       $this->add('number', 'num_terms', ts('Number of Terms'), ['size' => 6]);
@@ -607,9 +602,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $statusOverride = $this->addElement('select', 'is_override', ts('Status Override?'),
         CRM_Member_StatusOverrideTypes::getSelectOptions()
       );
-      if ($statusOverride && $isUpdateToExistingRecurringMembership) {
-        $statusOverride->freeze();
-      }
 
       $this->add('datepicker', 'status_override_end_date', ts('Status Override End Date'), '', FALSE, ['minDate' => time(), 'time' => FALSE]);
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently the code freezes certain fields in a membership record if it is linked to a recurring payment. This prevents users from editing these fields which can be an issue for them. I'm removing this code so that CiviCRM core doesn't freeze fields by default.

If an individual payment processor requires this functionality it can implemented by the payment processor itself.

See: https://lab.civicrm.org/dev/core/issues/1126

Before
----------------------------------------
If a membership is linked to a recurring contribution, users are unable to edit the following fields:

- Membership organisation
- Membership type
- Membership end date
- Membership status

![1126 before](https://user-images.githubusercontent.com/13518928/66762246-8b8c1380-ee9d-11e9-9215-ac919d9905b4.png)

After
----------------------------------------
The user is no longer prevented from editing those fields.

![1126 after](https://user-images.githubusercontent.com/13518928/66762347-bd04df00-ee9d-11e9-9125-5053e3408893.png)

Technical Details
----------------------------------------
N/A

Comments
----------------------------------------
We may need to update the text in the [related template](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Member/Form/Membership.tpl#L30) file:

`    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type, End Date or Membership Status. <a href="%1">Click here</a> if you want to cancel the automatic renewal option.{/ts}</p>`
