### PR TITLE
dev/core#1320 Include displayname in subjects to prevent grouping in email clients

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -136,7 +136,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // pay additional amount by using Credit Card
     $this->submitPayment(70, 'live', TRUE);
     $this->checkResults([30, 70], 2);
-    $mut->assertSubjects(['Payment Receipt -']);
+    $mut->assertSubjects(['Payment Receipt - Mr. Anthony Anderson II']);
     $mut->checkMailLog([
       'From: site@something.com',
       'Dear Anthony,',
@@ -220,7 +220,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // pay additional amount by using credit card
     $this->submitPayment(20, 'live');
     $this->checkResults([30, 50, 20], 3);
-    $mut->assertSubjects(['Payment Receipt -']);
+    $mut->assertSubjects(['Payment Receipt - Mr. Anthony Anderson II']);
     $mut->checkMailLog([
       'Dear Anthony,',
       'A payment has been received',

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -179,7 +179,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
 
     $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id']]);
-    $mut->assertSubjects(['Payment Receipt - Annual CiviCRM meet']);
+    $mut->assertSubjects(['Payment Receipt - Annual CiviCRM meet - Mr. Anthony Anderson II']);
     $mut->checkMailLog([
       'From: "FIXME" <info@EXAMPLE.ORG>',
       'Dear Anthony,',
@@ -217,7 +217,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     // Here we set the email to an  invalid email & use check_permissions, domain email should be used.
     $email = $this->callAPISuccess('Email', 'create', ['contact_id' => 1, 'email' => 'bob@example.com']);
     $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id'], 'from' => $email['id'], 'check_permissions' => 1]);
-    $mut->assertSubjects(['Payment Receipt - Annual CiviCRM meet', 'Registration Confirmation - Annual CiviCRM meet']);
+    $mut->assertSubjects(['Payment Receipt - Annual CiviCRM meet - Mr. Anthony Anderson II', 'Registration Confirmation - Annual CiviCRM meet - Mr. Anthony Anderson II']);
     $mut->checkMailLog([
       'From: "FIXME" <info@EXAMPLE.ORG>',
       'Dear Anthony,',
@@ -269,7 +269,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     }
 
     $this->callAPISuccess('Payment', 'sendconfirmation', ['id' => $payment['id']]);
-    $mut->assertSubjects(['Refund Notification - Annual CiviCRM meet']);
+    $mut->assertSubjects(['Refund Notification - Annual CiviCRM meet - Mr. Anthony Anderson II']);
     $mut->checkMailLog([
       'Dear Anthony,',
       'A refund has been issued based on changes in your registration selections.',

--- a/xml/templates/message_templates/contribution_dupalert_subject.tpl
+++ b/xml/templates/message_templates/contribution_dupalert_subject.tpl
@@ -1,1 +1,1 @@
-{ts}CiviContribute Alert: Possible Duplicate Contact Record{/ts}
+{ts}CiviContribute Alert: Possible Duplicate Contact Record{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/contribution_invoice_receipt_subject.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_subject.tpl
@@ -9,3 +9,4 @@
 {else}
   {ts}Invoice{/ts}
 {/if}
+ - {contact.display_name}

--- a/xml/templates/message_templates/contribution_offline_receipt_subject.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Contribution Receipt{/ts}
+{ts}Contribution Receipt{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/contribution_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if $is_pay_later}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title}
+{if $is_pay_later}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title} - {contact.display_name}

--- a/xml/templates/message_templates/contribution_recurring_billing_subject.tpl
+++ b/xml/templates/message_templates/contribution_recurring_billing_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Recurring Contribution Billing Updates{/ts}
+{ts}Recurring Contribution Billing Updates{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/contribution_recurring_cancelled_subject.tpl
+++ b/xml/templates/message_templates/contribution_recurring_cancelled_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Recurring Contribution Cancellation Notification{/ts}
+{ts}Recurring Contribution Cancellation Notification{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/contribution_recurring_edit_subject.tpl
+++ b/xml/templates/message_templates/contribution_recurring_edit_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Recurring Contribution Update Notification{/ts}
+{ts}Recurring Contribution Update Notification{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/contribution_recurring_notify_subject.tpl
+++ b/xml/templates/message_templates/contribution_recurring_notify_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Recurring Contribution Notification{/ts}
+{ts}Recurring Contribution Notification{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/event_offline_receipt_subject.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Event Confirmation{/ts} - {$event.title}
+{ts}Event Confirmation{/ts} - {$event.title} - {contact.display_name}

--- a/xml/templates/message_templates/event_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/event_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if $isOnWaitlist}{ts}Wait List Confirmation{/ts}{elseif $isRequireApproval}{ts}Registration Request Confirmation{/ts}{else}{ts}Registration Confirmation{/ts}{/if} - {$event.event_title}
+{if $isOnWaitlist}{ts}Wait List Confirmation{/ts}{elseif $isRequireApproval}{ts}Registration Request Confirmation{/ts}{else}{ts}Registration Confirmation{/ts}{/if} - {$event.event_title} - {contact.display_name}

--- a/xml/templates/message_templates/event_registration_receipt_subject.tpl
+++ b/xml/templates/message_templates/event_registration_receipt_subject.tpl
@@ -1,1 +1,1 @@
-Receipt for {if $events_in_cart} Event Registration{/if}
+Receipt for {if $events_in_cart} Event Registration{/if} - {contact.display_name}

--- a/xml/templates/message_templates/membership_autorenew_billing_subject.tpl
+++ b/xml/templates/message_templates/membership_autorenew_billing_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Membership Autorenewal Billing Updates{/ts}
+{ts}Membership Autorenewal Billing Updates{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/membership_autorenew_cancelled_subject.tpl
+++ b/xml/templates/message_templates/membership_autorenew_cancelled_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Autorenew Membership Cancellation Notification{/ts}
+{ts}Autorenew Membership Cancellation Notification{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/membership_offline_receipt_subject.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_subject.tpl
@@ -2,4 +2,4 @@
 {ts}Membership Confirmation and Receipt{/ts}
 {elseif $receiptType EQ 'membership renewal'}
 {ts}Membership Renewal Confirmation and Receipt{/ts}
-{/if}
+{/if} - {contact.display_name}

--- a/xml/templates/message_templates/membership_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if $is_pay_later}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title}
+{if $is_pay_later}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title} - {contact.display_name}

--- a/xml/templates/message_templates/participant_cancelled_subject.tpl
+++ b/xml/templates/message_templates/participant_cancelled_subject.tpl
@@ -1,1 +1,1 @@
-{ts 1=$event.event_title}Event Registration Cancelled for %1{/ts}
+{ts 1=$event.event_title}Event Registration Cancelled for %1{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/participant_confirm_subject.tpl
+++ b/xml/templates/message_templates/participant_confirm_subject.tpl
@@ -1,1 +1,1 @@
-{ts 1=$event.event_title}Confirm your registration for %1{/ts}
+{ts 1=$event.event_title}Confirm your registration for %1{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/participant_expired_subject.tpl
+++ b/xml/templates/message_templates/participant_expired_subject.tpl
@@ -1,1 +1,1 @@
-{ts 1=$event.event_title}Event registration has expired for %1{/ts}
+{ts 1=$event.event_title}Event registration has expired for %1{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/participant_transferred_subject.tpl
+++ b/xml/templates/message_templates/participant_transferred_subject.tpl
@@ -1,1 +1,1 @@
-{ts 1=$event.event_title}Event Registration Transferred for %1{/ts}
+{ts 1=$event.event_title}Event Registration Transferred for %1{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/payment_or_refund_notification_subject.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_subject.tpl
@@ -1,1 +1,1 @@
-{if $isRefund}{ts}Refund Notification{/ts}{else}{ts}Payment Receipt{/ts}{/if} - {if $component eq 'event'}{$event.title}{/if}
+{if $isRefund}{ts}Refund Notification{/ts}{else}{ts}Payment Receipt{/ts}{/if}{if $component eq 'event'} - {$event.title}{/if} - {contact.display_name}

--- a/xml/templates/message_templates/pcp_notify_subject.tpl
+++ b/xml/templates/message_templates/pcp_notify_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Personal Campaign Page Notification{/ts}
+{ts}Personal Campaign Page Notification{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/pcp_owner_notify_subject.tpl
+++ b/xml/templates/message_templates/pcp_owner_notify_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Someone has just donated to your personal campaign page{/ts}
+{ts}Someone has just donated to your personal campaign page{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/pcp_status_change_subject.tpl
+++ b/xml/templates/message_templates/pcp_status_change_subject.tpl
@@ -1,1 +1,1 @@
-{ts 1=$contribPageTitle}Your Personal Campaign Page for %1{/ts}
+{ts 1=$contribPageTitle}Your Personal Campaign Page for %1{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/pcp_supporter_notify_subject.tpl
+++ b/xml/templates/message_templates/pcp_supporter_notify_subject.tpl
@@ -1,1 +1,1 @@
-{ts 1=$contribPageTitle}Your Personal Campaign Page for %1{/ts}
+{ts 1=$contribPageTitle}Your Personal Campaign Page for %1{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/petition_confirmation_needed_subject.tpl
+++ b/xml/templates/message_templates/petition_confirmation_needed_subject.tpl
@@ -1,1 +1,1 @@
-Confirmation of signature needed for {$petition.title}
+Confirmation of signature needed for {$petition.title} - {contact.display_name}

--- a/xml/templates/message_templates/petition_sign_subject.tpl
+++ b/xml/templates/message_templates/petition_sign_subject.tpl
@@ -1,1 +1,1 @@
-Thank you for signing {$petition.title}
+Thank you for signing {$petition.title} - {contact.display_name}

--- a/xml/templates/message_templates/pledge_acknowledge_subject.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Thank you for this pledge{/ts}
+{ts}Thank you for your Pledge{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/pledge_reminder_subject.tpl
+++ b/xml/templates/message_templates/pledge_reminder_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Pledge Payment Reminder{/ts}
+{ts}Pledge Payment Reminder{/ts} - {contact.display_name}

--- a/xml/templates/message_templates/uf_notify_subject.tpl
+++ b/xml/templates/message_templates/uf_notify_subject.tpl
@@ -1,1 +1,1 @@
-{$grouptitle} {ts 1=$displayName}Submitted by %1{/ts}
+{$grouptitle} {ts 1=$displayName}Submitted by %1{/ts} - {contact.display_name}


### PR DESCRIPTION
Overview
----------------------------------------
Many email providers group emails with the same subject which leads to time-consuming processes for many organisations, and many additional unnecessary clicks.

Before
----------------------------------------
No system workflow template subjects include the display name

After
----------------------------------------
Some system workflow template subjects include the display name
Also it makes the email more personal as it is clear who it is addressed to.
This is proven to be beneficial for open-rates of transactional mails.

Technical Details
----------------------------------------
The messages will be upgraded in 5.20alpha1 by #15491

Comments
----------------------------------------
Let's make civiworld a better place by these small changes ;-)