### PR TITLE
Order api updates to fix participant handling & deprecate creating 'completed

### DIFF
--- a/api/v3/examples/Order/Create.ex.php
+++ b/api/v3/examples/Order/Create.ex.php
@@ -7,10 +7,10 @@
  */
 function order_create_example() {
   $params = [
-    'contact_id' => 8,
+    'contact_id' => 3,
     'receive_date' => '2010-01-20',
     'financial_type_id' => 'Event Fee',
-    'contribution_status_id' => 1,
+    'contribution_status_id' => 'Pending',
     'line_items' => [
       '0' => [
         'line_item' => [
@@ -28,14 +28,13 @@ function order_create_example() {
           ],
         ],
         'params' => [
-          'contact_id' => 8,
+          'contact_id' => 3,
           'membership_type_id' => 2,
           'join_date' => '2006-01-21',
           'start_date' => '2006-01-21',
           'end_date' => '2006-12-21',
           'source' => 'Payment',
           'is_override' => 1,
-          'status_id' => 1,
         ],
       ],
     ],
@@ -76,7 +75,7 @@ function order_create_expectedresult() {
     'values' => [
       '1' => [
         'id' => '1',
-        'contact_id' => '8',
+        'contact_id' => '3',
         'financial_type_id' => '4',
         'contribution_page_id' => '',
         'payment_instrument_id' => '4',
@@ -98,7 +97,7 @@ function order_create_expectedresult() {
         'contribution_recur_id' => '',
         'is_test' => '',
         'is_pay_later' => '',
-        'contribution_status_id' => '1',
+        'contribution_status_id' => '2',
         'address_id' => '',
         'check_number' => '',
         'campaign_id' => '',

--- a/api/v3/examples/Order/CreateOrderParticipant.ex.php
+++ b/api/v3/examples/Order/CreateOrderParticipant.ex.php
@@ -11,9 +11,8 @@ function order_create_example() {
   $params = [
     'contact_id' => 11,
     'receive_date' => '2010-01-20',
-    'total_amount' => 300,
     'financial_type_id' => 1,
-    'contribution_status_id' => 1,
+    'contribution_status_id' => 'Pending',
     'line_items' => [
       '0' => [
         'line_item' => [
@@ -43,7 +42,6 @@ function order_create_example() {
         'params' => [
           'contact_id' => 11,
           'event_id' => 1,
-          'status_id' => 1,
           'role_id' => 1,
           'register_date' => '2007-07-21 00:00:00',
           'source' => 'Online Event Registration: API Testing',
@@ -109,7 +107,7 @@ function order_create_expectedresult() {
         'contribution_recur_id' => '',
         'is_test' => '',
         'is_pay_later' => '',
-        'contribution_status_id' => '1',
+        'contribution_status_id' => '2',
         'address_id' => '',
         'check_number' => '',
         'campaign_id' => '',

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1002,6 +1002,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
   /**
    * Test allowUpdateRevenueRecognitionDate.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testAllowUpdateRevenueRecognitionDate() {
     $contactId = $this->individualCreate();
@@ -1010,8 +1012,9 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'receive_date' => '2010-01-20',
       'total_amount' => 100,
       'financial_type_id' => 4,
+      'contribution_status_id' => 'Pending',
     ];
-    $order = $this->callAPISuccess('order', 'create', $params);
+    $order = $this->callAPISuccess('Order', 'create', $params);
     $allowUpdate = CRM_Contribute_BAO_Contribution::allowUpdateRevenueRecognitionDate($order['id']);
     $this->assertTrue($allowUpdate);
 
@@ -1021,7 +1024,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'receive_date' => '2010-01-20',
       'total_amount' => 300,
       'financial_type_id' => $this->getFinancialTypeId('Event Fee'),
-      'contribution_status_id' => 'Completed',
+      'contribution_status_id' => 'Pending',
     ];
     $priceFields = $this->createPriceSet('event', $event['id']);
     foreach ($priceFields['values'] as $key => $priceField) {
@@ -1048,7 +1051,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
         'source' => 'Online Event Registration: API Testing',
       ],
     ];
-    $order = $this->callAPISuccess('order', 'create', $params);
+    $order = $this->callAPISuccess('Order', 'create', $params);
     $allowUpdate = CRM_Contribute_BAO_Contribution::allowUpdateRevenueRecognitionDate($order['id']);
     $this->assertFalse($allowUpdate);
 
@@ -1057,7 +1060,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'receive_date' => '2010-01-20',
       'total_amount' => 200,
       'financial_type_id' => $this->getFinancialTypeId('Member Dues'),
-      'contribution_status_id' => 'Completed',
+      'contribution_status_id' => 'Pending',
     ];
     $membershipType = $this->membershipTypeCreate();
     $priceFields = $this->createPriceSet();
@@ -1089,7 +1092,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
         'status_id' => 1,
       ],
     ];
-    $order = $this->callAPISuccess('order', 'create', $params);
+    $order = $this->callAPISuccess('Order', 'create', $params);
     $allowUpdate = CRM_Contribute_BAO_Contribution::allowUpdateRevenueRecognitionDate($order['id']);
     $this->assertFalse($allowUpdate);
   }

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -97,6 +97,8 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
   /**
    * PR 13477 - Fix incorrect display of Line Items created via API
    * when printing invoice (for Participants).
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testInvoiceForLineItems() {
 
@@ -150,7 +152,7 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
         return $total;
       }),
       'financial_type_id' => $priceFieldValues['values'][0]['financial_type_id'],
-      'contribution_status_id' => 'Completed',
+      'contribution_status_id' => 'Pending',
       'currency' => 'USD',
       'line_items' => $lineItemParams,
     ];

--- a/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
@@ -42,7 +42,7 @@ trait CRMTraits_Financial_PriceSetTrait {
    *   Financial Types, if an override is intended.
    */
   protected function createContributionWithTwoLineItemsAgainstPriceSet($params, $lineItemFinancialTypes = []) {
-    $params = array_merge(['total_amount' => 300, 'financial_type_id' => 'Donation'], $params);
+    $params = array_merge(['total_amount' => 300, 'financial_type_id' => 'Donation', 'contribution_status_id' => 'Pending'], $params);
     $priceFields = $this->createPriceSet('contribution');
     foreach ($priceFields['values'] as $key => $priceField) {
       $financialTypeID = (!empty($lineItemFinancialTypes) ? array_shift($lineItemFinancialTypes) : $priceField['financial_type_id']);
@@ -58,7 +58,8 @@ trait CRMTraits_Financial_PriceSetTrait {
         'entity_table' => 'civicrm_contribution',
       ];
     }
-    $this->callAPISuccess('order', 'create', $params);
+    $order = $this->callAPISuccess('Order', 'create', $params);
+    $this->callAPISuccess('Payment', 'create', ['contribution_id' => $order['id'], 'total_amount' => $params['total_amount']]);
   }
 
 }

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -213,7 +213,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       'contact_id' => $this->_individualId,
       'receive_date' => '2010-01-20',
       'financial_type_id' => 'Event Fee',
-      'contribution_status_id' => 1,
+      'contribution_status_id' => 'Pending',
     ];
     $priceFields = $this->createPriceSet();
     foreach ($priceFields['values'] as $key => $priceField) {
@@ -240,7 +240,6 @@ class api_v3_OrderTest extends CiviUnitTestCase {
         'end_date' => '2006-12-21',
         'source' => 'Payment',
         'is_override' => 1,
-        'status_id' => 1,
       ],
     ];
     $order = $this->callAPIAndDocument('order', 'create', $p, __FUNCTION__, __FILE__);
@@ -252,7 +251,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       $order['id'] => [
         'total_amount' => 200,
         'contribution_id' => $order['id'],
-        'contribution_status' => 'Completed',
+        'contribution_status' => 'Pending Label**',
         'net_amount' => 200,
       ],
     ];
@@ -271,7 +270,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
         'end_date' => '2006-12-21',
         'source' => 'Payment',
         'is_override' => 1,
-        'status_id' => 1,
+        'status_id' => 'Pending',
       ],
     ];
     $p['total_amount'] = 300;
@@ -279,7 +278,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     $expectedResult = [
       $order['id'] => [
         'total_amount' => 300,
-        'contribution_status' => 'Completed',
+        'contribution_status' => 'Pending Label**',
         'net_amount' => 300,
       ],
     ];
@@ -305,9 +304,8 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     $p = [
       'contact_id' => $this->_individualId,
       'receive_date' => '2010-01-20',
-      'total_amount' => 300,
       'financial_type_id' => $this->_financialTypeId,
-      'contribution_status_id' => 1,
+      'contribution_status_id' => 'Pending',
     ];
     $priceFields = $this->createPriceSet();
     foreach ($priceFields['values'] as $key => $priceField) {
@@ -328,47 +326,47 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       'params' => [
         'contact_id' => $this->_individualId,
         'event_id' => $this->_eventId,
-        'status_id' => 1,
         'role_id' => 1,
         'register_date' => '2007-07-21 00:00:00',
         'source' => 'Online Event Registration: API Testing',
       ],
     ];
+
     $order = $this->callAPIAndDocument('order', 'create', $p, __FUNCTION__, __FILE__, 'Create order for participant', 'CreateOrderParticipant');
-    $params = [
-      'contribution_id' => $order['id'],
-    ];
+    $params = ['contribution_id' => $order['id']];
     $order = $this->callAPISuccess('order', 'get', $params);
     $expectedResult = [
       $order['id'] => [
         'total_amount' => 300,
         'contribution_id' => $order['id'],
-        'contribution_status' => 'Completed',
+        'contribution_status' => 'Pending Label**',
         'net_amount' => 300,
       ],
     ];
     $this->checkPaymentResult($order, $expectedResult);
-    $this->callAPISuccessGetCount('ParticipantPayment', $params, 1);
+    $paymentParticipant = $this->callAPISuccessGetSingle('ParticipantPayment', ['contribution_id' => $order['id']]);
+    $participant = $this->callAPISuccessGetSingle('Participant', ['participant_id' => $paymentParticipant['participant_id']]);
+    $this->assertEquals('Pending (incomplete transaction)', $participant['participant_status']);
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $order['id'],
     ]);
+
     $p['line_items'][] = [
       'line_item' => $lineItems,
       'params' => [
         'contact_id' => $this->individualCreate(),
         'event_id' => $this->_eventId,
-        'status_id' => 1,
         'role_id' => 1,
         'register_date' => '2007-07-21 00:00:00',
         'source' => 'Online Event Registration: API Testing',
       ],
     ];
-    $p['total_amount'] = 600;
+
     $order = $this->callAPISuccess('order', 'create', $p);
     $expectedResult = [
       $order['id'] => [
         'total_amount' => 600,
-        'contribution_status' => 'Completed',
+        'contribution_status' => 'Pending Label**',
         'net_amount' => 600,
       ],
     ];
@@ -544,7 +542,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       'receive_date' => '2018-01-01',
       'total_amount' => 50,
       'financial_type_id' => $this->_financialTypeId,
-      'contribution_status_id' => 1,
+      'contribution_status_id' => 'Pending',
       'line_items' => [
         0 => [
           'line_item' => [
@@ -576,7 +574,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       'receive_date' => '2018-01-01',
       'total_amount' => 50,
       'financial_type_id' => $this->_financialTypeId,
-      'contribution_status_id' => 1,
+      'contribution_status_id' => 'Pending',
       'tax_amount' => 15,
       'line_items' => [
         0 => [
@@ -607,7 +605,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       'receive_date' => '2018-01-01',
       'total_amount' => 50,
       'financial_type_id' => $this->_financialTypeId,
-      'contribution_status_id' => 1,
+      'contribution_status_id' => 'Pending',
       'tax_amount' => 15,
       'line_items' => [
         0 => [


### PR DESCRIPTION
Overview
----------------------------------------
Addresses 2 issues identified in the new Order Api does 

Per https://docs.civicrm.org/dev/en/latest/financial/OrderAPI/

1) we want to deprecate creating orders with a status other than 'Pending'
2) we don't want to have to require status is passed in for Participant.


Before
----------------------------------------
From the above docs 
<img width="729" alt="Screen Shot 2019-10-15 at 9 09 06 PM" src="https://user-images.githubusercontent.com/336308/66812793-0afa0f80-ef90-11e9-9f4f-1f518716fea9.png">

Statment in docs about status
<img width="723" alt="Screen Shot 2019-10-15 at 9 10 46 PM" src="https://user-images.githubusercontent.com/336308/66812927-48f73380-ef90-11e9-8643-5fd39da4daa6.png">



After
----------------------------------------
Status no longer required for creating participant, creating completed orders is deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------
@mecachisenros @JoeMurray @artfulrobot @mattwire @monishdeb   - this seems like a pretty small change to address a couple of issues you identified. If the tests pass I'll do a docs PR for it.
