### PR TITLE
dev/core#1317 - Fix total_amount on repeattransaction when tax amount is involved.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2510,6 +2510,9 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       if (isset($contribution->contribution_page_id) && is_numeric($contribution->contribution_page_id)) {
         $contributionParams['contribution_page_id'] = $contribution->contribution_page_id;
       }
+      if (!empty($contribution->tax_amount)) {
+        $contributionParams['tax_amount'] = $contribution->tax_amount;
+      }
 
       $createContribution = civicrm_api3('Contribution', 'create', $contributionParams);
       $contribution->id = $createContribution['id'];

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4344,6 +4344,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'contribution_status_id' => 'Completed',
       'trxn_id' => uniqid(),
     ]);
+    $payments = $this->callAPISuccess('Contribution', 'get', ['sequential' => 1])['values'];
+    //Assert if first payment and repeated payment has the same contribution amount.
+    $this->assertEquals($payments[0]['total_amount'], $payments[1]['total_amount']);
     $this->callAPISuccessGetCount('Contribution', [], 2);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix total amount on repeattransaction when done for FT having tax.

Before
----------------------------------------
To replicate -

- Create an FT that includes a 10% GST on the main amount.
- Sign up an auto-renew Membership using this FT. So if membership amount is $10, the total amount paid by the user is $11.
- Now, when the next recur needs to be processed, if repeattransaction is called on this recur contribution, it recalculates the tax on the already taxed amount. So the second payment will be recorded with total amount = $12.1.
- Every repeattransaction api on this recur contribution will calculate incorrect total amount for the new payment. So, the next payment will have 12.1 + 10% followed by 12.1 + 10% + 10%. 

After
----------------------------------------
Fixed. Each repeattransaction will have the same amount as the original contribution.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1317