### PR TITLE
Fix typo in Manager.php

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -339,7 +339,7 @@ class CRM_Extension_Manager {
     // This munges order, but makes it comparable.
     sort($disableRequirements);
     if ($keys !== $disableRequirements) {
-      throw new CRM_Extension_Exception_DependencyException("Cannot disable extension due dependencies. Consider disabling all these: " . implode(',', $disableRequirements));
+      throw new CRM_Extension_Exception_DependencyException("Cannot disable extension due to dependencies. Consider disabling all these: " . implode(',', $disableRequirements));
     }
 
     foreach ($keys as $key) {


### PR DESCRIPTION
Overview
----------------------------------------
Typo

Before
----------------------------------------
Cannot disable extension due dependencies.

After
----------------------------------------
Cannot disable extension due to dependencies.
