### PR TITLE
Make sure labels match the actual date input format

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -731,21 +731,21 @@ class CRM_Core_SelectValues {
    */
   public static function getDatePluginInputFormats() {
     return [
-      "mm/dd/yy" => ts('mm/dd/yyyy (12/31/2009)'),
-      "dd/mm/yy" => ts('dd/mm/yyyy (31/12/2009)'),
-      "yy-mm-dd" => ts('yyyy-mm-dd (2009-12-31)'),
-      "dd-mm-yy" => ts('dd-mm-yyyy (31-12-2009)'),
-      'dd.mm.yy' => ts('dd.mm.yyyy (31.12.2009)'),
-      "M d, yy" => ts('M d, yyyy (Dec 31, 2009)'),
-      'd M yy' => ts('d M yyyy (31 Dec 2009)'),
-      "MM d, yy" => ts('MM d, yyyy (December 31, 2009)'),
-      'd MM yy' => ts('d MM yyyy (31 December 2009)'),
-      "DD, d MM yy" => ts('DD, d MM yyyy (Thursday, 31 December 2009)'),
-      "mm/dd" => ts('mm/dd (12/31)'),
-      "dd-mm" => ts('dd-mm (31-12)'),
-      "yy-mm" => ts('yyyy-mm (2009-12)'),
-      'M yy' => ts('M yyyy (Dec 2009)'),
-      "yy" => ts('yyyy (2009)'),
+      'mm/dd/yy' => ts('mm/dd/yy (12/31/2009)'),
+      'dd/mm/yy' => ts('dd/mm/yy (31/12/2009)'),
+      'yy-mm-dd' => ts('yy-mm-dd (2009-12-31)'),
+      'dd-mm-yy' => ts('dd-mm-yy (31-12-2009)'),
+      'dd.mm.yy' => ts('dd.mm.yy (31.12.2009)'),
+      'M d, yy' => ts('M d, yy (Dec 31, 2009)'),
+      'd M yy' => ts('d M yy (31 Dec 2009)'),
+      'MM d, yy' => ts('MM d, yy (December 31, 2009)'),
+      'd MM yy' => ts('d MM yy (31 December 2009)'),
+      'DD, d MM yy' => ts('DD, d MM yy (Thursday, 31 December 2009)'),
+      'mm/dd' => ts('mm/dd (12/31)'),
+      'dd-mm' => ts('dd-mm (31-12)'),
+      'yy-mm' => ts('yy-mm (2009-12)'),
+      'M yy' => ts('M yy (Dec 2009)'),
+      'yy' => ts('yy (2009)'),
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The labels of the date input format dropdown (under /civicrm/admin/setting/date) don't match the actual value of the formats.

This might confuse people trying to set format using, for example, the API, as they might think that `yyyy` is the right way to display the full year.

Before
----------------------------------------

The labels of the date input format dropdown don't match the actual value of the formats. Specifically, the labels shows `yyyy` as the format used to display the full year:

![2019-10-18-104324_6000x3840_scrot](https://user-images.githubusercontent.com/388373/67100039-60ebd480-f195-11e9-8ba1-d0b833790be7.png)

Here's the markup for the field, showing the difference between the option values and their labels:

![2019-10-18-104554_1044x443_scrot](https://user-images.githubusercontent.com/388373/67100096-706b1d80-f195-11e9-92b3-bb7e1dc2f385.png)


After
----------------------------------------

The labels match the actual formats and display `yy` as the format used to display the full year.

Here is how it looks like after the update:

![2019-10-18-104500_6000x3840_scrot](https://user-images.githubusercontent.com/388373/67100191-9d1f3500-f195-11e9-99d1-7bee5cb0e1d8.png)

And here is the markup after the update, showing that only the options labels have been updated:

![2019-10-18-104522_1050x439_scrot](https://user-images.githubusercontent.com/388373/67100232-ad371480-f195-11e9-8912-b0fb7d87e30c.png)

