### PR TITLE
Fix error when adding activities from Search Builder

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -437,6 +437,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         || $path == 'civicrm/contact/search/advanced'
         || $path == 'civicrm/contact/search/custom'
         || $path == 'civicrm/group/search'
+        || $path == 'civicrm/contact/search/builder'
       ) {
         $urlString = $path;
       }


### PR DESCRIPTION
Overview
----------------------------------------
When you use the "Add Activity" task from Search Builder, you get an error on submitting the activity.  Exact replication steps are on the issue: https://lab.civicrm.org/dev/core/issues/1323

Before
----------------------------------------
Yellow Screen of Death.

After
----------------------------------------
No error.

Technical Details
----------------------------------------
When you submit the activity, CiviCRM tries passing you back to the search screen you just came from.  However, it doesn't handle Search Builder.

Comments
----------------------------------------
I'm tagging this as `easy-review` because of the simplicity of the steps to replicate, the limited scope of the class being altered, and the obvious correctness of the fix :)
