### PR TITLE
PayPal: Add SOLUTIONTYPE parameter that triggers allowing to pay without having to create an account

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -257,6 +257,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['returnURL'] = $this->getReturnSuccessUrl($params['qfKey']);
     $args['cancelURL'] = $this->getCancelUrl($params['qfKey'], NULL);
     $args['version'] = '56.0';
+    $args['SOLUTIONTYPE'] = 'Sole';
 
     //LCD if recurring, collect additional data and set some values
     if (!empty($params['is_recur'])) {


### PR DESCRIPTION
Add SOLUTIONTYPE parameter that triggers allowing to pay without having to create a paypal account. 

Overview
----------------------------------------
Adds a single parameter to the checkout values.  Without this parameter, PayPal account creation is required to complete a transaction.  I can think of no reason why anyone would want to default to requiring account creation for a PayPal checkout unless they were actually a marketer at PayPal.


