### PR TITLE
Add test for participant receipts, super minor consistency fix.

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1172,6 +1172,7 @@ WHERE civicrm_event.is_active = 1
           'customPost' => $profilePost[0],
           'customPost_grouptitle' => $customPostTitles,
           'participantID' => $participantId,
+          'contactID' => $contactID,
           'conference_sessions' => $sessions,
           'credit_card_number' => CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $participantParams)),
           'credit_card_exp_date' => CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format(CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -915,7 +915,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $this->_values['params']['isRequireApproval'] = $this->_requireApproval;
 
         //send mail to primary as well as additional participants.
-        $this->assign('contactID', $contactId);
         CRM_Event_BAO_Event::sendMail($contactId, $this->_values, $participantID, $isTest);
       }
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2731,17 +2731,18 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    * Replace the template with a test-oriented template designed to show all the variables.
    *
    * @param string $templateName
+   * @param string $type
    */
-  protected function swapMessageTemplateForTestTemplate($templateName = 'contribution_online_receipt') {
-    $testTemplate = file_get_contents(__DIR__ . '/../../templates/message_templates/' . $templateName . '_html.tpl');
+  protected function swapMessageTemplateForTestTemplate($templateName = 'contribution_online_receipt', $type = 'html') {
+    $testTemplate = file_get_contents(__DIR__ . '/../../templates/message_templates/' . $templateName . '_' . $type . '.tpl');
     CRM_Core_DAO::executeQuery(
       "UPDATE civicrm_option_group og
       LEFT JOIN civicrm_option_value ov ON ov.option_group_id = og.id
       LEFT JOIN civicrm_msg_template m ON m.workflow_id = ov.id
-      SET m.msg_html = '{$testTemplate}'
-      WHERE og.name = 'msg_tpl_workflow_contribution'
+      SET m.msg_{$type} = %1
+      WHERE og.name LIKE 'msg_tpl_workflow_%'
       AND ov.name = '{$templateName}'
-      AND m.is_default = 1"
+      AND m.is_default = 1", [1 => [$testTemplate, 'String']]
     );
   }
 
@@ -2749,14 +2750,15 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    * Reinstate the default template.
    *
    * @param string $templateName
+   * @param string $type
    */
-  protected function revertTemplateToReservedTemplate($templateName = 'contribution_online_receipt') {
+  protected function revertTemplateToReservedTemplate($templateName = 'contribution_online_receipt', $type = 'html') {
     CRM_Core_DAO::executeQuery(
       "UPDATE civicrm_option_group og
       LEFT JOIN civicrm_option_value ov ON ov.option_group_id = og.id
       LEFT JOIN civicrm_msg_template m ON m.workflow_id = ov.id
       LEFT JOIN civicrm_msg_template m2 ON m2.workflow_id = ov.id AND m2.is_reserved = 1
-      SET m.msg_html = m2.msg_html
+      SET m.msg_{$type} = m2.msg_{$type}
       WHERE og.name = 'msg_tpl_workflow_contribution'
       AND ov.name = '{$templateName}'
       AND m.is_default = 1"

--- a/tests/templates/message_templates/event_online_receipt_text.tpl
+++ b/tests/templates/message_templates/event_online_receipt_text.tpl
@@ -1,0 +1,73 @@
+{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}
+
+contactID:::{$contactID}
+event.confirm_email_text:::{$event.confirm_email_text}
+isOnWaitlist:::{$isOnWaitlist}
+isRequireApproval:::{$isRequireApproval}
+participant_status:::{$participant_status}
+pricesetFieldsCount:::{$pricesetFieldsCount}
+isPrimary:::{$isPrimary}
+conference_sessions:::{$conference_sessions}
+is_pay_later:::{$is_pay_later}
+isAmountzero:::{$isAmountzero}
+isAdditionalParticipant:::{$isAdditionalParticipant}
+pay_later_receipt:::{$pay_later_receipt}
+event.event_title:::{$event.event_title}
+event.event_start_date:::{$event.event_start_date|date_format:"%A"}
+event.event_end_date:::{$event.event_end_date|date_format:"%Y%m%d"}
+event.is_monetary:::{$event.is_monetary}
+event.fee_label:::{$event.fee_label}
+conference_sessions:::{$conference_sessions}
+event.participant_role::{$event.participant_role}
+defaultRole:::{$defaultRole}
+isShowLocation:::{$isShowLocation}
+location.address.1.display:::{$location.address.1.display}
+location.phone.1.phone:::{$location.phone.1.phone}
+location.phone.1.phone_type_display:::{$location.phone.1.phone_type_display}
+location.phone.1.phone_ext:::{$location.phone.1.phone_ext}
+location.email.1.email:::{$location.email.1.email}
+event.is_public:::{$event.is_public}
+payer.name:::{$payer.name}
+lineitem:::{if $lineItem}
+ {foreach from=$lineItem item=value key=priceset}
+  {foreach from=$value item=line}
+     line.html_type:::{$line.html_type}
+     line.label:::{$line.label}
+     line.field_title:::{$line.field_title}
+     line.description:::{$line.description}
+     line.qty:::{$line.qty}
+     line.unit_price:::{$line.unit_price}
+     line.tax_rate:::{$line.tax_rate}
+     line.tax_amount:::{$line.tax_amount}
+     line.line_total:::{$line.line_total}
+  {/foreach}
+ {/foreach}
+{/if}
+
+part:::{foreach from=$part item=value key=key}
+{$key}{$value}
+{/foreach}
+
+dataArray:::{$dataArray}
+
+totalTaxAmount:::{$totalTaxAmount}
+amounts:::{$amounts}
+register_date:::{$register_date|crmDate}
+receive_date:::{$receive_date|crmDate}
+financialTypeName:::{$financialTypeName}
+trxn_id:::{$trxn_id}
+paidBy:::{$paidBy}
+checkNumber:::{$checkNumber}
+billingName:::{$billingName}
+credit_card_type:::{$credit_card_type}
+credit_card_number:::{$credit_card_number}
+address:::{$address}
+credit_card_exp_date:::{$credit_card_exp_date}
+{foreach from=$customPre item=customValue key=customName}
+  customPre: customName:::$customName
+  customPre: customValue:::$customValue
+{/foreach}
+{foreach from=$customPost item=customValue key=customName}
+  customPost: customName:::$customName
+  customPost: customValue:::$customValue
+{/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
This is mostly adding testing for participant receipts. The one change to core code is to move the assignment
of contactID to the template from a specific path into the shared code. This parameter is not required by
the templates but it is somewhat common for sites to want to have it assigned to templates for
customisation which is presumably why it's there. Since it is there in one path we should either remove or
have it in all & for a field like contactID all makes sense. Tests lock in that var


Before
----------------------------------------
Less tests

After
----------------------------------------
More tests

Technical Details
----------------------------------------


Comments
----------------------------------------
I'm mostly trying to build up the test suite here so we can have another go at moving events to create pending + create payment.

I think we should remove $contributeMode from the tpl next

@mattwire @kcristiano 
