### PR TITLE
Fix default mode on Contact.merge api

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1195,7 +1195,7 @@ function _civicrm_api3_contact_merge_spec(&$params) {
   $params['mode'] = [
     'title' => ts('Dedupe mode'),
     'description' => ts("In 'safe' mode conflicts will result in no merge. In 'aggressive' mode the merge will still proceed (hook dependent)"),
-    'api.default' => ['safe', 'aggressive'],
+    'api.default' => 'safe',
     'options' => ['safe' => ts('Abort on unhandled conflict'), 'aggressive' => ts('Proceed on unhandled conflict. Note hooks may change handling here.')],
   ];
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the default mode for Contact.merge api back to 'safe' after it was changed in error

Before
----------------------------------------
default is ['safe', 'aggressive']

After
----------------------------------------
default is 'safe'

Technical Details
----------------------------------------
I believe this was a change I made in error & only the Contact.get_merge_conflicts api should
receive an array for 'mode'. The mode is part of a loop within that api

Comments
----------------------------------------
Looks like we should port to 5.18

@pfigel @seamuslee001  FYI