### PR TITLE
Remove extraneous full stop, line

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -100,6 +100,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    */
   public function testPaidSubmit($thousandSeparator) {
     $this->setCurrencySeparators($thousandSeparator);
+    $mut = new CiviMailUtils($this);
     $paymentProcessorID = $this->processorCreate();
     /* @var \CRM_Core_Payment_Dummy $processor */
     $processor = Civi\Payment\System::singleton()->getById($paymentProcessorID);
@@ -136,15 +137,12 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
           'billing_state_province_id-5' => '1061',
           'billing_postal_code-5' => '7',
           'billing_country_id-5' => '1228',
-          'scriptFee' => '',
-          'scriptArray' => '',
           'priceSetId' => '6',
           'price_7' => [
             13 => 1,
           ],
           'payment_processor_id' => $paymentProcessorID,
           'bypass_payment' => '',
-          'MAX_FILE_SIZE' => '33554432',
           'is_primary' => 1,
           'is_pay_later' => 0,
           'campaign_id' => NULL,
@@ -209,6 +207,11 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'financial_trxn_id' => $financialTrxn['id'] + 1,
       'amount' => '1.67',
     ], $entityFinancialTrxns[2], ['id', 'entity_id']);
+    $mut->checkMailLog([
+      'Event Information and Location', 'Registration Confirmation - Annual CiviCRM meet',
+      'This letter is a confirmation that your registration has been received and your status has been updated to <strong> Registered</strong>',
+    ]);
+    $mut->clearMessages();
   }
 
   /**

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -33,7 +33,7 @@
     {else}
      <p>{ts}Thank you for your participation.{/ts}
      {if $participant_status}{ts 1=$participant_status}This letter is a confirmation that your registration has been received and your status has been updated to <strong> %1</strong>.{/ts}
-     {else}{if $isOnWaitlist}{ts}This letter is a confirmation that your registration has been received and your status has been updated to <strong>waitlisted</strong>.{/ts}{else}{ts}This letter is a confirmation that your registration has been received and your status has been updated to <strong>registered<strong>.{/ts}{/if}{/if}.</p>
+     {else}{if $isOnWaitlist}{ts}This letter is a confirmation that your registration has been received and your status has been updated to <strong>waitlisted</strong>.{/ts}{else}{ts}This letter is a confirmation that your registration has been received and your status has been updated to <strong>registered<strong>.{/ts}{/if}{/if}</p>
 
     {/if}
 

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -6,8 +6,7 @@
   {ts}Thank you for your participation.{/ts}
   {if $participant_status}{ts 1=$participant_status}This letter is a confirmation that your registration has been received and your status has been updated to %1.{/ts}
   {else}{if $isOnWaitlist}{ts}This letter is a confirmation that your registration has been received and your status has been updated to waitlisted.{/ts}{else}{ts}This letter is a confirmation that your registration has been received and your status has been updated to registered.{/ts}{/if}
-  {/if}.
-
+  {/if}
 {/if}
 
 {if $isOnWaitlist}


### PR DESCRIPTION
Overview
----------------------------------------
Removes a full stop that doesn't belong in the default online event receipt

Before
----------------------------------------
Dear p,  Thank you for your participation.  This letter is a confirmation that your registration has been received and your status has been updated to Registered.  .



After
----------------------------------------
Dear p,  Thank you for your participation.  This letter is a confirmation that your registration has been received and your status has been updated to Registered.

Technical Details
----------------------------------------
We already have template updates in this release so we can just update the default template here.

Comments
----------------------------------------
