### PR TITLE
Fix logic determining whether (masked) credit card details are displayed in event online receipts

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -209,6 +209,9 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     ], $entityFinancialTrxns[2], ['id', 'entity_id']);
     $mut->checkMailLog([
       'Event Information and Location', 'Registration Confirmation - Annual CiviCRM meet',
+      'Expires: January 2019',
+      'Visa',
+      '************1111',
       'This letter is a confirmation that your registration has been received and your status has been updated to <strong> Registered</strong>',
     ]);
     $mut->clearMessages();

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -410,7 +410,7 @@
         </tr>
        {/if}
 
-       {if $contributeMode eq 'direct' and !$isAmountzero and !$is_pay_later and !$isOnWaitlist and !$isRequireApproval}
+       {if $credit_card_type}
         <tr>
          <th {$headerStyle}>
           {ts}Credit Card Information{/ts}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -211,7 +211,7 @@ You were registered by: {$payer.name}
 {$address}
 {/if}
 
-{if $contributeMode eq 'direct' and !$isAmountzero and !$is_pay_later and !$isOnWaitlist and !$isRequireApproval}
+{if $credit_card_type}
 ==========================================================={if $pricesetFieldsCount }===================={/if}
 
 {ts}Credit Card Information{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Simplification & removal of reliance on deprecated parameters in Online Event receipt templates - no functional change

Before
----------------------------------------
Credit card details displayed if
$contributeMode eq 'direct' and !$isAmountzero and !$is_pay_later and !$isOnWaitlist and !$isRequireApproval

After
----------------------------------------
Simplified to card details shown if they have been collected from the submitter

Technical Details
----------------------------------------
Fix Event online receipts to display credit card info if available.

We currently have a very complex IF clause which includes some deprecated parameters.

However, we can simplify this to simply display the information if availble. We only collect
credit card information if we require it & hence the presence of it is an adequate indicator
as to whether to display it.

We could check for credit_card_number instead but actually there is precedent in another tpl
for checking credit_card_type & it's pretty neutral as both should be present or missing

Comments
----------------------------------------
