### PR TITLE
Simplify logic for displaying card details for Event online registraion Confirm, Thankyou page

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -167,7 +167,7 @@
       </div>
     {/if}
 
-    {if $contributeMode eq 'direct' and ! $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+    {if $credit_card_type}
       {crmRegion name="event-confirm-billing-block"}
         <div class="crm-group credit_card-group">
           <div class="header-dark">

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -188,7 +188,7 @@
         </div>
     {/if}
 
-    {if $contributeMode eq 'direct' and $paidEvent and ! $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+    {if $credit_card_type}
       {crmRegion name="event-thankyou-billing-block"}
         <div class="crm-group credit_card-group">
           <div class="header-dark">


### PR DESCRIPTION
Overview
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/15532 but this time for the Confirm & Thank you pages

Before
----------------------------------------
Unnecessarily complex code logic

After
----------------------------------------
Straight forward logic

Technical Details
----------------------------------------
We don't collect card details unless we need them & if we do we should display them - we  don't need all the other complex logic here as it's duplicating the php layer's work.

Comments
----------------------------------------

