### PR TITLE
[REF] Rename balanceTrxnParams variable to paymentTrxnParams 

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -60,27 +60,27 @@ class CRM_Financial_BAO_Payment {
     $isPaymentCompletesContribution = self::isPaymentCompletesContribution($params['contribution_id'], $params['total_amount']);
 
     if ($params['total_amount'] > 0) {
-      $balanceTrxnParams['to_financial_account_id'] = CRM_Contribute_BAO_Contribution::getToFinancialAccount($contribution, $params);
-      $balanceTrxnParams['from_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($contribution['financial_type_id'], 'Accounts Receivable Account is');
-      $balanceTrxnParams['total_amount'] = $params['total_amount'];
-      $balanceTrxnParams['contribution_id'] = $params['contribution_id'];
-      $balanceTrxnParams['trxn_date'] = CRM_Utils_Array::value('trxn_date', $params, CRM_Utils_Array::value('contribution_receive_date', $params, date('YmdHis')));
-      $balanceTrxnParams['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
-      $balanceTrxnParams['net_amount'] = CRM_Utils_Array::value('total_amount', $params);
-      $balanceTrxnParams['currency'] = $contribution['currency'];
-      $balanceTrxnParams['trxn_id'] = CRM_Utils_Array::value('contribution_trxn_id', $params, NULL);
-      $balanceTrxnParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'status_id', 'Completed');
-      $balanceTrxnParams['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $params, $contribution['payment_instrument_id']);
-      $balanceTrxnParams['check_number'] = CRM_Utils_Array::value('check_number', $params);
-      $balanceTrxnParams['is_payment'] = 1;
+      $paymentTrxnParams['to_financial_account_id'] = CRM_Contribute_BAO_Contribution::getToFinancialAccount($contribution, $params);
+      $paymentTrxnParams['from_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($contribution['financial_type_id'], 'Accounts Receivable Account is');
+      $paymentTrxnParams['total_amount'] = $params['total_amount'];
+      $paymentTrxnParams['contribution_id'] = $params['contribution_id'];
+      $paymentTrxnParams['trxn_date'] = CRM_Utils_Array::value('trxn_date', $params, CRM_Utils_Array::value('contribution_receive_date', $params, date('YmdHis')));
+      $paymentTrxnParams['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
+      $paymentTrxnParams['net_amount'] = CRM_Utils_Array::value('total_amount', $params);
+      $paymentTrxnParams['currency'] = $contribution['currency'];
+      $paymentTrxnParams['trxn_id'] = CRM_Utils_Array::value('contribution_trxn_id', $params, NULL);
+      $paymentTrxnParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'status_id', 'Completed');
+      $paymentTrxnParams['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $params, $contribution['payment_instrument_id']);
+      $paymentTrxnParams['check_number'] = CRM_Utils_Array::value('check_number', $params);
+      $paymentTrxnParams['is_payment'] = 1;
 
       if (!empty($params['payment_processor'])) {
         // I can't find evidence this is passed in - I was gonna just remove it but decided to deprecate  as I see getToFinancialAccount
         // also anticipates it.
         CRM_Core_Error::deprecatedFunctionWarning('passing payment_processor is deprecated - use payment_processor_id');
-        $balanceTrxnParams['payment_processor_id'] = $params['payment_processor'];
+        $paymentTrxnParams['payment_processor_id'] = $params['payment_processor'];
       }
-      $trxn = CRM_Core_BAO_FinancialTrxn::create($balanceTrxnParams);
+      $trxn = CRM_Core_BAO_FinancialTrxn::create($paymentTrxnParams);
 
       // @todo - this is just weird & historical & inconsistent - why 2 tracks?
       if (!empty($params['line_item']) && !empty($trxn)) {


### PR DESCRIPTION
Overview
----------------------------------------
Rename a variable to be  less misleading

Before
----------------------------------------
Variable called $balanceTrxnParams

After
----------------------------------------
Variable called $paymentTrxnParams

Technical Details
----------------------------------------
This array needs some fixes but I wanted to rename the parameter first as balanceTrxnParams is misleading.

The parameters are for the financial_trxn entry corresponding to the payment

Comments
----------------------------------------
