### PR TITLE
Regression fix on Paypal Std with memberships not being finalised correctly.

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -336,7 +336,8 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
 
     Civi::log()->debug('PayPalIPN: Received (ContactID: ' . $ids['contact'] . '; trxn_id: ' . $input['trxn_id'] . ').');
 
-    if ($this->retrieve('membershipID', 'Integer', FALSE)) {
+    // Debugging related to possible missing membership linkage
+    if ($contributionRecurID && $this->retrieve('membershipID', 'Integer', FALSE)) {
       $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionRecurID);
       $membershipPayment = civicrm_api3('MembershipPayment', 'get', [
         'contribution_id' => $templateContribution['id'],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression per comment by @mattwire  here Per https://github.com/civicrm/civicrm-core/pull/15053#issuecomment-542770130

Before
----------------------------------------
Paypal std IPNs not updating memberships correctly

After
----------------------------------------
Normal behaviour

Technical Details
----------------------------------------
Just adds a precautionary if

Comments
----------------------------------------

