### PR TITLE
dev/core#1126 - Don't freeze the end date if the membership is linked to a recurring payment

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -213,9 +213,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     // This string makes up part of the class names, differentiating them (not sure why) from the membership fields.
     $this->assign('formClass', 'membership');
     parent::preProcess();
-    if ($this->isUpdateToExistingRecurringMembership()) {
-      $this->entityFields['end_date']['is_freeze'] = TRUE;
-    }
+
     // get price set id.
     $this->_priceSetId = CRM_Utils_Array::value('priceSetId', $_GET);
     $this->set('priceSetId', $this->_priceSetId);

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -27,7 +27,7 @@
 {if $cancelAutoRenew}
   <div class="messages status no-popup">
     <div class="icon inform-icon"></div>
-    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type, End Date or Membership Status. <a href="%1">Click here</a> if you want to cancel the automatic renewal option.{/ts}</p>
+    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status. <a href="%1">Click here</a> if you want to cancel the automatic renewal option.{/ts}</p>
   </div>
 {/if}
 <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Currently the code freezes the end date in a membership record if it is linked to a recurring payment. This prevents users from editing this fields which can be an issue for them. I'm removing this code  so that CiviCRM core doesn't freeze this field by default.

See: https://lab.civicrm.org/dev/core/issues/1126

Before
----------------------------------------
If a membership is linked to a recurring contribution, users are unable to edit the end date.

![image](https://user-images.githubusercontent.com/13518928/67101708-09ac2b00-f1ba-11e9-937a-01ba0a00d451.png)


After
----------------------------------------
The user is able to edit the end date.

![image](https://user-images.githubusercontent.com/13518928/67101645-ec775c80-f1b9-11e9-9ef4-ac575d0acdc6.png)


Technical Details
----------------------------------------
N/A

Comments
----------------------------------------
I have split this change out of https://github.com/civicrm/civicrm-core/pull/15505
