### PR TITLE
dev/core#1324 Adds missing join on the customtable of address customfields while exposed as profile

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1303,6 +1303,9 @@ class CRM_Contact_BAO_Query {
                   break;
 
                 default:
+                  if (isset($addressCustomFields[$elementName]['custom_field_id']) && !empty($addressCustomFields[$elementName]['custom_field_id'])) {
+                    $this->_tables[$tName] = "\nLEFT JOIN $tableName `$tName` ON `$tName`.id = $aName.id";
+                  }
                   if ($addWhere) {
                     $this->_whereTables["{$name}-address"] = $addressJoin;
                   }


### PR DESCRIPTION
Overview
----------------------------------------
This PR is adding a `LEFT JOIN` to the missing address customfields so that the query can function properly.
This is related to issue : https://lab.civicrm.org/dev/core/issues/1324

Before
----------------------------------------
A LEFT JOIN was missing from the table, resulting in a `DB Error: no such field` (field was included in the query but had no source to connect to)

After
----------------------------------------
Query executes properly

Technical Details
----------------------------------------
As this PR affects the CRM/Contact/BAO/Query.php , it's very important to be reviewed properly.

Comments
----------------------------------------
Please review it thoroughly.
