### PR TITLE
fix 'balance due' on Pledge Detail for non-US installs

### DIFF
--- a/CRM/Report/Form/Pledge/Detail.php
+++ b/CRM/Report/Form/Pledge/Detail.php
@@ -69,7 +69,7 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
    */
   public function __construct() {
     $this->_pledgeStatuses = CRM_Core_OptionGroup::values('pledge_status',
-      FALSE, FALSE, FALSE, NULL, 'label'
+      FALSE, FALSE, FALSE, NULL, 'name'
     );
 
     $this->_columns = [


### PR DESCRIPTION
Overview
----------------------------------------
Pledge Detail report crashes when "Balance Due" is selected and the label either of the pledge statuses "Completed" or "Cancelled" has been modified.

Before
----------------------------------------
Report crashes.

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
Someone pulled status IDs by label when they should have used name...
