### PR TITLE
dev/core#1322 Fix regression whereby Additional Payment Form not setting from when sending email confirmations

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -67,8 +67,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
   protected $fromEmailId = NULL;
 
-  protected $_fromEmails = NULL;
-
   protected $_view = NULL;
 
   public $_action = NULL;
@@ -94,18 +92,14 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       CRM_Utils_System::setTitle($title);
       return;
     }
-    $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
-
     $entityType = 'contribution';
     if ($this->_component == 'event') {
       $entityType = 'participant';
       $this->_contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $this->_id, 'contribution_id', 'participant_id');
       $eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'event_id', 'id');
-      $this->_fromEmails = CRM_Event_BAO_Event::getFromEmailIds($eventId);
     }
     else {
       $this->_contributionId = $this->_id;
-      $this->_fromEmails['from_email_id'] = CRM_Core_BAO_Email::getFromEmail();
     }
 
     $paymentInfo = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($this->_id, $entityType);
@@ -222,7 +216,11 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     //add receipt for offline contribution
     $this->addElement('checkbox', 'is_email_receipt', ts('Send Receipt?'));
 
-    $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails['from_email_id']);
+    if ($this->_component === 'event') {
+      $eventID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'event_id', 'id');
+    }
+
+    $this->add('select', 'from_email_address', ts('Receipt From'), CRM_Financial_BAO_Payment::getValidFromEmailsForPayment($eventID));
 
     $this->add('textarea', 'receipt_text', ts('Confirmation Message'));
 
@@ -330,8 +328,10 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
   /**
    * Process Payments.
+   *
    * @param array $submittedValues
    *
+   * @throws \CiviCRM_API3_Exception
    */
   public function submit($submittedValues) {
     $this->_params = $submittedValues;
@@ -375,7 +375,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $statusMsg = ts('The payment record has been processed.');
     // send email
     if (!empty($paymentID) && !empty($this->_params['is_email_receipt'])) {
-      $sendResult = civicrm_api3('Payment', 'sendconfirmation', ['id' => $paymentID])['values'][$paymentID];
+      $sendResult = civicrm_api3('Payment', 'sendconfirmation', ['id' => $paymentID, 'from' => $submittedValues['from_email_address']])['values'][$paymentID];
       if ($sendResult['is_sent']) {
         $statusMsg .= ' ' . ts('A receipt has been emailed to the contributor.');
       }

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -385,7 +385,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     ];
     $params = array_merge($defaults, $params);
 
-    // Core#644 - handle contact ID passed as "From".
+    // Core#644 - handle Email ID passed as "From".
     if (isset($params['from'])) {
       $params['from'] = CRM_Utils_Mail::formatFromAddress($params['from']);
     }

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -196,7 +196,33 @@ class CRM_Financial_BAO_Payment {
       'toEmail' => $entities['contact']['email'],
       'tplParams' => self::getConfirmationTemplateParameters($entities),
     ];
+    if (!empty($params['from']) && !empty($params['check_permissions'])) {
+      // Filter from against permitted emails.
+      $validEmails = self::getValidFromEmailsForPayment($entities['event']['id'] ?? NULL);
+      if (!isset($validEmails[$params['from']])) {
+        // Ignore unpermitted parameter.
+        unset($params['from']);
+      }
+    }
+    $sendTemplateParams['from'] = $params['from'] ?? key(CRM_Core_BAO_Email::domainEmails());
     return CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+  }
+
+  /**
+   * Get valid from emails for payment.
+   *
+   * @param int $eventID
+   *
+   * @return array
+   */
+  public static function getValidFromEmailsForPayment($eventID = NULL) {
+    if ($eventID) {
+      $emails = CRM_Event_BAO_Event::getFromEmailIds($eventID);
+    }
+    else {
+      $emails['from_email_id'] = CRM_Core_BAO_Email::getFromEmail();
+    }
+    return $emails['from_email_id'];
   }
 
   /**

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -273,12 +273,9 @@ function _civicrm_api3_payment_cancel_spec(&$params) {
  */
 function civicrm_api3_payment_sendconfirmation($params) {
   $allowedParams = [
-    'receipt_from_email',
-    'receipt_from_name',
-    'cc_receipt',
-    'bcc_receipt',
-    'receipt_text',
+    'from',
     'id',
+    'check_permissions',
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
   // use either the contribution or membership receipt, based on whether it’s a membership-related contrib or not
@@ -306,5 +303,9 @@ function _civicrm_api3_payment_sendconfirmation_spec(&$params) {
     'api.required' => 1,
     'title' => ts('Payment ID'),
     'type' => CRM_Utils_Type::T_INT,
+  ];
+  $params['from_email_address'] = [
+    'title' => ts('From email; an email string or the id of a valid email'),
+    'type' => CRM_Utils_Type::T_STRING,
   ];
 }

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -138,6 +138,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->checkResults([30, 70], 2);
     $mut->assertSubjects(['Payment Receipt -']);
     $mut->checkMailLog([
+      'From: site@something.com',
       'Dear Anthony,',
       'Payment Details',
       'Total Fees: $ 100.00',


### PR DESCRIPTION
Overview
----------------------------------------
Fix for regression on from addresses on Additional Payment emails

This ensures that the from email is passed through & the default email is used if none is specified. 

Before
----------------------------------------
If no email is passed through from the form (currently the case), no email is used

After
----------------------------------------
Domain default is the default

Technical Details
----------------------------------------
This wound up slightly more complex than I expected as I realised we didn't want the api to be callable with 'any' from address - unless called with check_permissions => FALSE so I had to move stuff around to add validation in the api-called function

Comments
----------------------------------------

