### PR TITLE
dev/core#1321 [test] add unit test to demonstrate behaviour

### DIFF
--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -274,6 +274,22 @@ class api_v3_GroupTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test / demonstrate behaviour when attempting to filter by group_type.
+   *
+   * Per https://lab.civicrm.org/dev/core/issues/1321 the group_type filter is deceptive
+   * - it only filters on exact match not 'is one of'.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGroupWithGroupTypeFilter() {
+    $this->groupCreate(['group_type' => ['Access Control'], 'name' => 'access_list', 'title' => 'access list']);
+    $this->groupCreate(['group_type' => ['Mailing List'], 'name' => 'mailing_list', 'title' => 'mailing list']);
+    $this->groupCreate(['group_type' => ['Access Control', 'Mailing List'], 'name' => 'group', 'title' => 'group']);
+    $group = $this->callAPISuccessGetSingle('Group', ['return' => 'id,title,group_type', 'group_type' => 'Mailing List']);
+    $this->assertEquals('mailing list', $group['title']);
+  }
+
+  /**
    * @param int $version
    *
    * @dataProvider versionThreeAndFour


### PR DESCRIPTION
Overview
----------------------------------------
Adds a unit test to address issue logged in https://lab.civicrm.org/dev/core/issues/1321

Before
----------------------------------------
Not tested

After
----------------------------------------
Tested

Technical Details
----------------------------------------
The github issue states that the behaviour of this api has changed. On digging I'm pretty sure that is not the case. However, as the test demonstrates people could have been getting results calling 

`cv api Group.get return='id,title,group_type' group_type='Mailing List'` 

Where there are groups with group_type of ONLY 'Mailing List' but NOT where the group_type is 'Mailing List' AND 'Access Control' 

This is not much fun - but it's not a regression and neither do I think it should be fixed in apiv3

Comments
----------------------------------------
@artfulrobot
