### PR TITLE
Support chaining Payment.create from Order api

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -147,6 +147,8 @@ trait Api3TestTrait {
    *   better or worse )
    *
    * @return array|int
+   *
+   * @throws \CRM_Core_Exception
    */
   public function callAPISuccess($entity, $action, $params = [], $checkAgainst = NULL) {
     $params = array_merge([

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -161,6 +161,9 @@ function _civicrm_api3_payment_create_spec(&$params) {
       'api.required' => 1,
       'title' => ts('Contribution ID'),
       'type' => CRM_Utils_Type::T_INT,
+      // We accept order_id as an alias so that we can chain like
+      // civicrm_api3('Order', 'create', ['blah' => 'blah', 'contribution_status_id' => 'Pending', 'api.Payment.create => ['total_amount' => 5]]
+      'api.aliases' => ['order_id'],
     ],
     'total_amount' => [
       'api.required' => 1,

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -631,4 +631,17 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     $this->assertEquals(1, $order['count']);
   }
 
+  /**
+   * Test that a contribution can be added in pending mode with a chained payment.
+   *
+   * We have just deprecated creating an order with a status other than pending. It makes
+   * sense to support adding a payment straight away by chaining.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreateWithChainedPayment() {
+    $contributionID = $this->callAPISuccess('Order', 'create', ['contact_id' => $this->_individualId, 'total_amount' => 5, 'financial_type_id' => 2, 'contribution_status_id' => 'Pending', 'api.Payment.create' => ['total_amount' => 5]])['id'];
+    $this->assertEquals('Completed', $this->callAPISuccessGetValue('Contribution', ['id' => $contributionID, 'return' => 'contribution_status']));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Now that we have deprecated creating an order without passing the status of 'Pending' I'm having to switch over some tested code. I quickly realised that supporting chaining would be really helpful here.

This PR creates the tests and code to make this work
```
civicrm_api3('Order', 'create', [
   'contact_id' => 4 
   'total_amount' => 5,
   'financial_type_id' => 2, 
   'contribution_status_id' => 'Pending',
   'api.Payment.create' => ['total_amount' => 5]]
);
```

Before
----------------------------------------
Above call fails

After
----------------------------------------
Above call passes & is tested 

Technical Details
----------------------------------------
@JoeMurray @mattwire @artfulrobot @aydun 

Comments
----------------------------------------
Note the impact of the deprecation is to show notices - this causes tested code to start failing if it hits the deprecation - this is a good thing.


@seamuslee001 I'll fix the extended reports tests once this is merged