### PR TITLE
Proper use of contribution and payment terminology

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -403,8 +403,8 @@ SELECT  id, html_type
 
       CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, FALSE, TRUE, self::getDefaultPaymentInstrumentId());
       if (!$form->_mode) {
-        $form->addElement('checkbox', 'record_contribution', ts('Record Payment?'), NULL,
-          ['onclick' => "return showHideByValue('record_contribution','','payment_information','table-row','radio',false);"]
+        $form->addElement('checkbox', 'record_contribution', ts('Record Contribution?'), NULL,
+          ['onclick' => "return showHideByValue('record_contribution','','contribution_information','table-row','radio',false);"]
         );
         // Check permissions for financial type first
         if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
@@ -438,7 +438,7 @@ SELECT  id, html_type
         }
 
         $form->add('select', 'contribution_status_id',
-          ts('Payment Status'), CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses('participant')
+          ts('Contribution Status'), CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses('participant')
         );
 
         $form->add('text', 'check_number', ts('Check Number'),

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -73,16 +73,16 @@
         <tr class="crm-event-eventfees-form-block-record_contribution">
             <td class="label">{$form.record_contribution.label}</td>
             <td>{$form.record_contribution.html}<br />
-                <span class="description">{ts}Check this box to enter payment information. You will also be able to generate a customized receipt.{/ts}</span>
+                <span class="description">{ts}Check this box to enter contribution information. You will also be able to generate a customized receipt.{/ts}</span>
             </td>
         </tr>
-        <tr id="payment_information" class="crm-event-eventfees-form-block-payment_information">
+        <tr id="contribution_information" class="crm-event-eventfees-form-block-payment_information">
            <td class ='html-adjust' colspan=2>
-           <fieldset><legend>{ts}Payment Information{/ts}</legend>
+           <fieldset><legend>{ts}Contribution Information{/ts}</legend>
              <table id="recordContribution" class="form-layout" style="width:auto;">
                 <tr class="crm-event-eventfees-form-block-financial_type_id">
                     <td class="label">{$form.financial_type_id.label}<span class="crm-marker"> *</span></td>
-                    <td>{$form.financial_type_id.html}<br /><span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
+                    <td>{$form.financial_type_id.html}<br /><span class="description">{ts}Select the appropriate financial type for this contribution.{/ts}</span></td>
                 </tr>
                 <tr class="crm-event-eventfees-form-block-total_amount"><td class="label">{$form.total_amount.label}</td><td>{$form.total_amount.html|crmMoney:$currency}</td></tr>
                 <tr>


### PR DESCRIPTION
**Overview**
----------------------------------------
There are a few places where the proper use of terminology surrounding contributions and payments could be very helpful for both administrators as well as end-users. 

Before
----------------------------------------
In some places the mixing of the terminology of contributions vs. payments can be confusing.
The context of this is that payments go towards a contribution.
![Screenshot from 2019-10-19 14-09-31](https://user-images.githubusercontent.com/2195908/67144774-e09f9f00-f27a-11e9-9ac4-9cab85a85d10.png)

After
----------------------------------------
More places where either the word 'contribution' of 'payment' is used 
![Screenshot from 2019-10-19 14-09-30](https://user-images.githubusercontent.com/2195908/67144770-daa9be00-f27a-11e9-997d-f9126ae5e56a.png)

Technical Details
----------------------------------------
Changes are made:
- in the edit event participation screen

Comments
----------------------------------------
NOTE to self (and probably to picked up in a different PR): In the record contribution screen I believe the receive date should (as per https://github.com/civicrm/civicrm-core/pull/14460)
ANOTHER NOTE: long term I think the 'receive date' should be renamed to something like 'contribution date' as "**received**" tends to suggest that something is received, whereas the contribution is becoming more of the administrative entity payments are made towards to.
FINAL NOTE: I also believe "payment method" is becoming less relevant for the contribution (it IS relevant for the payment) and will be likely to be removed at some point. 
