### PR TITLE
Filter out is_template contributions by default

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -374,6 +374,7 @@ function _civicrm_api3_contribution_get_spec(&$params) {
   $params['payment_instrument_id']['api.aliases'] = ['contribution_payment_instrument', 'payment_instrument'];
   $params['contact_id'] = CRM_Utils_Array::value('contribution_contact_id', $params);
   $params['contact_id']['api.aliases'] = ['contribution_contact_id'];
+  $params['is_template']['api.default'] = 0;
   unset($params['contribution_contact_id']);
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Filter template contributions by default on apiv3

It is now possible (but not yet in use) to have template contributions & they should not be visible in the UI by default (we'll start using them once that is solid. This filters from api3 contribution.get

Before
----------------------------------------
Not filtered

After
----------------------------------------
Filtered

Technical Details
----------------------------------------


Comments
----------------------------------------
@aydun @artfulrobot
