### PR TITLE
dev/core#1335 - Prevent php warning when saving case type

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -219,7 +219,12 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
    */
   protected static function encodeXmlString($str) {
     // PHP 5.4: return htmlspecialchars($str, ENT_XML1, 'UTF-8')
-    return htmlspecialchars($str);
+    if (is_scalar($str)) {
+      return htmlspecialchars($str);
+    }
+    else {
+      return NULL;
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
@@ -115,10 +115,64 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
       'xml' => file_get_contents(__DIR__ . '/xml/forkable-1.xml'),
     ];
 
+    $fixtures['empty-node-text'] = [
+      'json' => json_encode([
+        'activityTypes' => [
+          ['name' => 'First act'],
+          ['name' => 'Second act'],
+        ],
+        'activitySets' => [
+          [
+            'name' => 'set1',
+            'label' => 'Label 1',
+            'timeline' => 1,
+            'activityTypes' => [
+              ['name' => 'Open Case', 'status' => 'Completed'],
+            ],
+          ],
+          [
+            'name' => 'set2',
+            'label' => 'Label 2',
+            'timeline' => 1,
+            'activityTypes' => [
+              [
+                'name' => 'First act',
+                'status' => 'Scheduled',
+                'reference_activity' => 'Open Case',
+                'reference_offset' => 1,
+                'reference_select' => 'newest',
+                'default_assignee_type' => '2',
+                'default_assignee_relationship' => '2_b_a',
+                'default_assignee_contact' => [],
+              ],
+            ],
+          ],
+        ],
+        'timelineActivityTypes' => [
+          ['name' => 'Open Case', 'status' => 'Completed'],
+          [
+            'name' => 'First act',
+            'status' => 'Scheduled',
+            'reference_activity' => 'Open Case',
+            'reference_offset' => '1',
+            'reference_select' => 'newest',
+            'default_assignee_type' => '2',
+            'default_assignee_relationship' => '2_b_a',
+            'default_assignee_contact' => [],
+          ],
+        ],
+        'caseRoles' => [
+          ['name' => 'First role', 'creator' => 1, 'manager' => 1],
+        ],
+      ]),
+      'xml' => file_get_contents(__DIR__ . '/xml/empty-node-text.xml'),
+    ];
+
     $cases = [];
     foreach ([
       'empty-defn',
       'empty-lists',
+      'empty-node-text',
       'one-item-in-each',
       'two-items-in-each',
       'forkable-0',

--- a/tests/phpunit/CRM/Case/BAO/xml/empty-node-text.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/empty-node-text.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<CaseType>
+  <name>Housing Support</name>
+  <ActivityTypes>
+    <ActivityType>
+      <name>First act</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Second act</name>
+    </ActivityType>
+  </ActivityTypes>
+  <ActivitySets>
+    <ActivitySet>
+      <name>set1</name>
+      <label>Label 1</label>
+      <timeline>true</timeline>
+      <ActivityTypes>
+        <ActivityType>
+          <name>Open Case</name>
+          <status>Completed</status>
+        </ActivityType>
+      </ActivityTypes>
+    </ActivitySet>
+    <ActivitySet>
+      <name>set2</name>
+      <label>Label 2</label>
+      <timeline>true</timeline>
+      <ActivityTypes>
+        <ActivityType>
+          <name>First act</name>
+          <status>Scheduled</status>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>1</reference_offset>
+          <reference_select>newest</reference_select>
+          <default_assignee_type>2</default_assignee_type>
+          <default_assignee_relationship>2_b_a</default_assignee_relationship>
+          <default_assignee_contact></default_assignee_contact>
+        </ActivityType>
+      </ActivityTypes>
+    </ActivitySet>
+  </ActivitySets>
+  <CaseRoles>
+    <RelationshipType>
+      <name>First role</name>
+      <creator>1</creator>
+      <manager>1</manager>
+    </RelationshipType>
+  </CaseRoles>
+</CaseType>


### PR DESCRIPTION
Overview
----------------------------------------
htmlspecialchars is being passed an array sometimes. It also prevents unit tests from running if they do something like retrieve a case type via api and then try to save it again even without changing anything.
https://lab.civicrm.org/dev/core/issues/1335

Before
----------------------------------------
As described in the lab ticket there's warnings in drupal watchdog. Also the attached added test gives 3 fails:

CRM_Case_BAO_CaseTypeTest::testConvertDefinitionToXml
CRM_Case_BAO_CaseTypeTest::testRoundtrip_XmlToJsonToXml
CRM_Case_BAO_CaseTypeTest::testRoundtrip_JsonToXmlToJson

htmlspecialchars() expects parameter 1 to be string, array given
.../CRM/Case/BAO/CaseType.php:222
.../CRM/Case/BAO/CaseType.php:154

After
----------------------------------------
Better

Technical Details
----------------------------------------

Comments
----------------------------------------

