### PR TITLE
dev/financial#74 Create ParticipantPayment record for every participant when registering multiple participants for event

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2504,7 +2504,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         $componentDetails['event'] = $dao->event_id;
       }
       if ($dao->participant_id) {
-        $componentDetails['participant'] = $dao->participant_id;
+        $componentDetails['participant'][] = $dao->participant_id;
       }
       if ($dao->membership_id) {
         if (!isset($componentDetails['membership'])) {

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1399,14 +1399,12 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         }
 
         // Insert payment record for this participant
-        if (empty($contributionParams['id'])) {
-          foreach ($this->_contactIds as $num => $contactID) {
-            $participantPaymentParams = [
-              'participant_id' => $participants[$num]->id,
-              'contribution_id' => $contributions[$num]->id,
-            ];
-            civicrm_api3('ParticipantPayment', 'create', $participantPaymentParams);
-          }
+        foreach ($this->_contactIds as $num => $contactID) {
+          $participantPaymentParams = [
+            'participant_id' => $participants[$num]->id,
+            'contribution_id' => $contributions[$num]->id,
+          ];
+          civicrm_api3('ParticipantPayment', 'create', $participantPaymentParams);
         }
 
         // CRM-11124

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -715,24 +715,19 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       'Participant'
     );
 
-    $createPayment = (CRM_Utils_Array::value('amount', $this->_params, 0) != 0) ? TRUE : FALSE;
-
-    // force to create zero amount payment, CRM-5095
-    // we know the amout is zero since createPayment is false
-    if (!$createPayment &&
-      (isset($contribution) && $contribution->id) &&
-      $this->_priceSetId &&
-      $this->_lineItem
-    ) {
-      $createPayment = TRUE;
+    if ($contribution) {
+      $contributionID = $contribution->id;
+    }
+    elseif (CRM_Utils_Array::value('contributionID', $this->_params)) {
+      $contributionID = $this->_params['contributionID'];
     }
 
-    if ($createPayment && $this->_values['event']['is_monetary'] && !empty($this->_params['contributionID'])) {
-      $paymentParams = [
+    if (!empty($contributionID)) {
+      $participantPaymentParams = [
         'participant_id' => $participant->id,
-        'contribution_id' => $contribution->id,
+        'contribution_id' => $contributionID,
       ];
-      civicrm_api3('ParticipantPayment', 'create', $paymentParams);
+      civicrm_api3('ParticipantPayment', 'create', $participantPaymentParams);
     }
 
     $this->assign('action', $this->_action);

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -576,4 +576,85 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     list($contact_id, $participant_id) = $this->submitWithNote($event, $contact_id);
   }
 
+  /**
+   * Test for Multiple participant.
+   */
+  public function testMultipleParticipant() {
+    $params = ['is_monetary' => 1, 'financial_type_id' => 1];
+    $event = $this->eventCreate($params);
+    CRM_Event_Form_Registration_Confirm::testSubmit([
+      'id' => $event['id'],
+      'contributeMode' => 'direct',
+      'registerByID' => $this->createLoggedInUser(),
+      'totalAmount' => 440,
+      'event' => reset($event['values']),
+      'params' => [
+        [
+          'qfKey' => 'e6eb2903eae63d4c5c6cc70bfdda8741_2801',
+          'entryURL' => "http://dmaster.local/civicrm/event/register?reset=1&amp;id={$event['id']}",
+          'first_name' => 'Participant1',
+          'last_name' => 'LastName',
+          'email-Primary' => 'participant1@example.com',
+          'additional_participants' => 2,
+          'payment_processor_id' => 0,
+          'bypass_payment' => '',
+          'MAX_FILE_SIZE' => '33554432',
+          'is_primary' => 1,
+          'is_pay_later' => 1,
+          'campaign_id' => NULL,
+          'defaultRole' => 1,
+          'participant_role_id' => '1',
+          'currencyID' => 'USD',
+          'amount_level' => 'Tiny-tots (ages 5-8) - 1',
+          'amount' => '100.00',
+          'tax_amount' => 10,
+          'ip_address' => '127.0.0.1',
+          'invoiceID' => '57adc34957a29171948e8643ce906332',
+          'trxn_id' => '123456789',
+          'button' => '_qf_Register_upload',
+        ],
+        [
+          'qfKey' => 'e6eb2903eae63d4c5c6cc70bfdda8741_2801',
+          'entryURL' => "http://dmaster.local/civicrm/event/register?reset=1&amp;id={$event['id']}",
+          'first_name' => 'Participant2',
+          'last_name' => 'LastName',
+          'email-Primary' => 'participant2@example.com',
+          'campaign_id' => NULL,
+          'is_pay_later' => 1,
+          'participant_role_id' => '1',
+          'currencyID' => 'USD',
+          'amount_level' => 'Tiny-tots (ages 9-18) - 1',
+          'amount' => '200.00',
+          'tax_amount' => 20,
+        ],
+        [
+          'qfKey' => 'e6eb2903eae63d4c5c6cc70bfdda8741_2801',
+          'entryURL' => "http://dmaster.local/civicrm/event/register?reset=1&amp;id={$event['id']}",
+          'first_name' => 'Participant3',
+          'last_name' => 'LastName',
+          'email-Primary' => 'participant3@example.com',
+          'campaign_id' => NULL,
+          'is_pay_later' => 1,
+          'participant_role_id' => '1',
+          'currencyID' => 'USD',
+          'amount_level' => 'Tiny-tots (ages 5-8) - 1',
+          'amount' => '100.00',
+          'tax_amount' => 10,
+        ],
+      ],
+    ]);
+    $participants = $this->callAPISuccess('Participant', 'get', [])['values'];
+    $participantsPayment = $this->callAPISuccess('ParticipantPayment', 'get', [])['values'];
+
+    $ids_participant = array_column($participants, 'participant_id');
+
+    $ids_payment_participant = array_column($participantsPayment, 'participant_id');
+    if ($ids_participant == $ids_payment_participant) {
+      $this->assertTrue(TRUE);
+    }
+    else {
+      $this->assertFalse(TRUE);
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
We have `ParticipantPayment` and `MembershipPayment` records in CiviCRM which link a contribution to a participant / membership and show which contribution was used to "pay" for the participant/membership.  `ParticipantPayment` is not actually used very much, compared with `MembershipPayment` which is used for various UI forms when showing related memberships / contributions etc.
It was identified at the sprint in Barcelona that when registering multiple participants a `ParticipantPayment` record was only being created for the primary participant instead of for all participants.

Before
----------------------------------------
Only one participantPayment record created for multiple participant registration

After
----------------------------------------
One participantPayment record created for each participant in a multiple participant registration

Technical Details
----------------------------------------
The Order API creates one per participant. The MembershipPayment / ParticipantPayment records are not supposed to show who paid (that can be identified from the contribution) but is supposed to show that "this membership/participant" was paid for from this contribution.

Comments
----------------------------------------
@mecachisenros @eileenmcnaughton This is what we found at the sprint 
Thanks @sarvesh211999 for the unit test