### PR TITLE
dev/core#1333 Fix incorrect balance amount on fully paid payment

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4053,13 +4053,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $financialTypeId = $contribution['financial_type_id'];
     $feeFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($financialTypeId, 'Expense Account is');
 
-    if ($paymentBalance == 0 && $info['payLater']) {
-      // @todo - review - this looks very unlikely to be correct.
-      // the balance should be correct based on payment transactions not
-      // assumptions.
-      $paymentBalance = $total;
-    }
-
     $info['total'] = $total;
     $info['paid'] = $total - $paymentBalance;
     $info['balance'] = $paymentBalance;

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -239,6 +239,7 @@ class CRM_Financial_BAO_Payment {
    *   - event = [.... full event details......]
    *   - contribution = ['id' => x],
    *   - payment = [payment info + payment summary info]
+   * @throws \CiviCRM_API3_Exception
    */
   protected static function loadRelatedEntities($id) {
     $entities = [];

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -197,6 +197,8 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the partially paid Contribution with multiple payments.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testMultiplePaymentForPartiallyPaidContributionWithOneCreditCardPayment() {
     $mut = new CiviMailUtils($this, TRUE);
@@ -238,13 +240,31 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the pending pay later Contribution using Credit Card.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testAddPaymentUsingCreditCardForPendingPayLaterContribution() {
+    $mut = new CiviMailUtils($this, TRUE);
     $this->createContribution('Pending');
 
     // pay additional amount by using Credit Card
-    $this->submitPayment(100, 'live');
+    $this->submitPayment(100, 'live', TRUE);
     $this->checkResults([100], 1);
+
+    $mut->checkMailLog([
+      'A payment has been received',
+      'Total Fees: $ 100.00',
+      'This Payment Amount: $ 100.00',
+      'Balance Owed: $ 0.00 ',
+      'Paid By: Credit Card',
+      '***********1111',
+      'Billing Name and Address',
+      'Vancouver, AE 1321312',
+      'Expires: May 2025',
+
+    ]);
+    $mut->stop();
+    $mut->clearMessages();
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/1333 the payment notification email shows the wrong amount for the Balance Due.

Interestingly it show the proper Balance Due when doing partial payments

Before
----------------------------------------
```
Total Amount : 100
This Payment Amount : 60
Balance Due: 40
```

But at the final payment to full fill the contribution it shows the same as the full amount

```
Total Amount : 100
This Payment Amount : 100
Balance Due: 100
```

After
----------------------------------------
Balance dues is zero in second scenario.

Technical Details
----------------------------------------
The code was previously marked as highly dubious

Comments
----------------------------------------

