### PR TITLE
dev/financial#79 minimal deprecation of Contribution.transact.

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -763,3 +763,13 @@ function _civicrm_api3_contribution_repeattransaction_spec(&$params) {
     'type' => CRM_Utils_Type::T_INT,
   ];
 }
+
+/**
+ * Declare deprecated functions.
+ *
+ * @return array
+ *   Array of deprecated actions
+ */
+function _civicrm_api3_contribution_deprecation() {
+  return ['transact' => 'Contribute.transact is ureliable & unsupported - see https://docs.civicrm.org/dev/en/latest/financial/OrderAPI/  for how to move on'];
+}


### PR DESCRIPTION
Overview
----------------------------------------
Mark  unsupported, flawed  Contribution.transact api as deprecated  in api explorer

Before
----------------------------------------
No messaging to tell people not to use this api

After
----------------------------------------
<img width="410" alt="Screen Shot 2019-10-21 at 4 38 56 PM" src="https://user-images.githubusercontent.com/336308/67175120-4e85cb00-f421-11e9-9fdd-e125d253178e.png">


Technical Details
----------------------------------------
It seems urgent that we so some deprecation of this api - this is the absolute minimum.

More would involve creating some noise when people use it but there
is a separate issue for that. This is just to get it out of being 'promoted'
by the api explorer


Comments
----------------------------------------
