### PR TITLE
Restrict case roles by group

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -167,7 +167,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       foreach ($definition['caseRoles'] as $values) {
         $xmlFile .= "<RelationshipType>\n";
         foreach ($values as $key => $value) {
-          $xmlFile .= "<{$key}>" . (is_array($value) ? implode(',', array_map(['\CRM_Case_BAO_CaseType', 'encodeXmlString'], $value)) : self::encodeXmlString($value)) . "</{$key}>\n";
+          $xmlFile .= "<{$key}>" . ($key == 'groups' ? implode(',', array_map(['\CRM_Case_BAO_CaseType', 'encodeXmlString'], (array) $value)) : self::encodeXmlString($value)) . "</{$key}>\n";
         }
         $xmlFile .= "</RelationshipType>\n";
       }
@@ -180,7 +180,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
 
     if (!empty($definition['activityAsgmtGrps'])) {
       $xmlFile .= "<ActivityAsgmtGrps>\n";
-      foreach ($definition['activityAsgmtGrps'] as $value) {
+      foreach ((array) $definition['activityAsgmtGrps'] as $value) {
         $xmlFile .= "<Group>$value</Group>\n";
       }
       $xmlFile .= "</ActivityAsgmtGrps>\n";

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -234,6 +234,12 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
 
     if (isset($xml->ActivityAsgmtGrps)) {
       $definition['activityAsgmtGrps'] = (array) $xml->ActivityAsgmtGrps->Group;
+      // Backwards compat - convert group ids to group names if ids are supplied
+      if (array_filter($definition['activityAsgmtGrps'], ['\CRM_Utils_Rule', 'integer']) === $definition['activityAsgmtGrps']) {
+        foreach ($definition['activityAsgmtGrps'] as $idx => $group) {
+          $definition['activityAsgmtGrps'][$idx] = CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_Group', $group);
+        }
+      }
     }
 
     // set activity types

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -167,7 +167,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       foreach ($definition['caseRoles'] as $values) {
         $xmlFile .= "<RelationshipType>\n";
         foreach ($values as $key => $value) {
-          $xmlFile .= "<{$key}>" . self::encodeXmlString($value) . "</{$key}>\n";
+          $xmlFile .= "<{$key}>" . (is_array($value) ? implode(',', array_map(['\CRM_Case_BAO_CaseType', 'encodeXmlString'], $value)) : self::encodeXmlString($value)) . "</{$key}>\n";
         }
         $xmlFile .= "</RelationshipType>\n";
       }
@@ -284,7 +284,11 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     if (isset($xml->CaseRoles)) {
       $definition['caseRoles'] = [];
       foreach ($xml->CaseRoles->RelationshipType as $caseRoleXml) {
-        $definition['caseRoles'][] = json_decode(json_encode($caseRoleXml), TRUE);
+        $caseRole = json_decode(json_encode($caseRoleXml), TRUE);
+        if (!empty($caseRole['groups'])) {
+          $caseRole['groups'] = explode(',', $caseRole['groups']);
+        }
+        $definition['caseRoles'][] = $caseRole;
       }
     }
 

--- a/ang/crmCaseType/caseTypeDetails.html
+++ b/ang/crmCaseType/caseTypeDetails.html
@@ -48,7 +48,7 @@ The original form used table layout; don't know if we have an alternative, CSS-b
           <input
             name="activityAsgmtGrps"
             crm-ui-id="caseTypeDetailForm.activityAsgmtGrps"
-            crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, placeholder: ts('Select Group')}}"
+            crm-entityref="{entity: 'Group', api: {id_field: 'name', params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, placeholder: ts('Select Group')}}"
             ng-model="caseType.definition.activityAsgmtGrps"
           />
         </div>

--- a/ang/crmCaseType/rolesTable.html
+++ b/ang/crmCaseType/rolesTable.html
@@ -8,6 +8,7 @@ Required vars: caseType
 	    <th>{{ts('Display Label')}}</th>
 	    <th>{{ts('Assign to Creator')}}</th>
 	    <th>{{ts('Is Manager')}}</th>
+	    <th>{{ts('Restrict to Groups')}}</th>
 	    <th></th>
 	  </tr>
   </thead>
@@ -17,6 +18,10 @@ Required vars: caseType
 	    <td>{{relType.displayLabel}}</td>
 	    <td><input type="checkbox" ng-model="relType.creator" ng-true-value="'1'" ng-false-value="'0'"></td>
 	    <td><input type="radio" ng-model="relType.manager" value="1" ng-change="onManagerChange(relType)"></td>
+	    <td><input ng-list class="big"
+				crm-entityref="{entity: 'Group', api: {id_field: 'name', params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, placeholder: ts('Select Group')}}"
+				ng-model="relType.groups"
+			/></td>
 	    <td>
 	      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.caseRoles,relType)" title="{{ts('Remove')}}"></a>
 	    </td>

--- a/templates/CRM/Case/Form/CaseView.js
+++ b/templates/CRM/Case/Form/CaseView.js
@@ -73,29 +73,12 @@
             var val = $(this).val();
             $contactField.val('').change().prop('disabled', !val);
             if (val) {
-              var
-                pieces = val.split('_'),
-                rType = pieces[0],
-                target = pieces[2], // b or a
-                contact_type = CRM.vars.relationshipTypes[rType]['contact_type_' + target],
-                contact_sub_type = CRM.vars.relationshipTypes[rType]['contact_sub_type_' + target],
-                api = {params: {}};
-              if (contact_type) {
-                api.params.contact_type = contact_type;
-              }
-              if (contact_sub_type) {
-                api.params.contact_sub_type = contact_sub_type;
-              }
-              $contactField
-                .data('api-params', api)
-                .data('user-filter', {})
-                .attr('placeholder', CRM.vars.relationshipTypes[rType]['placeholder_' + target])
-                .change();
+              prepareRelationshipField(val, $contactField);
             }
           })
           .val('')
           .change();
-        $contactField.val('').crmEntityRef({create: true, api: {params: {contact_type: 'Individual'}}});
+        $contactField.val('').crmEntityRef();
       },
       post: function(data) {
         var contactID = $('[name=add_role_contact_id]', this).val(),
@@ -114,11 +97,7 @@
     },
     '#editCaseRoleDialog': {
       pre: function(data) {
-        var params = {create: true};
-        if (data.contact_type) {
-          params.api = {params: {contact_type: data.contact_type}};
-        }
-        $('[name=edit_role_contact_id]', this).val('').crmEntityRef(params);
+        prepareRelationshipField(data.rel_type, $('[name=edit_role_contact_id]', this));
       },
       post: function(data) {
         data.rel_contact = $('[name=edit_role_contact_id]', this).val();
@@ -163,6 +142,31 @@
     }
   },
     detached = {};
+
+  function prepareRelationshipField(relType, $contactField) {
+    var
+      pieces = relType.split('_'),
+      rType = pieces[0],
+      target = pieces[2], // b or a
+      relationshipType = CRM.vars.relationshipTypes[rType],
+      api = {params: {}};
+    if (relationshipType['contact_type_' + target]) {
+      api.params.contact_type = relationshipType['contact_type_' + target];
+    }
+    if (relationshipType['contact_sub_type_' + target]) {
+      api.params.contact_sub_type = relationshipType['contact_sub_type_' + target];
+    }
+    if (relationshipType['group_' + target]) {
+      api.params.group = {IN: relationshipType['group_' + target]};
+    }
+    $contactField
+      .data('create-links', !relationshipType['group_' + target])
+      .data('api-params', api)
+      .data('user-filter', {})
+      .attr('placeholder', relationshipType['placeholder_' + target])
+      .change()
+      .crmEntityRef();
+  }
 
   function detachMiniForms() {
     detached = {};

--- a/tests/phpunit/api/v3/CaseTypeTest.php
+++ b/tests/phpunit/api/v3/CaseTypeTest.php
@@ -241,4 +241,31 @@ class api_v3_CaseTypeTest extends CiviCaseTestCase {
     $this->assertEquals($template['definition']['statuses'], array_values($result['values']));
   }
 
+  public function testDefinitionGroups() {
+    $gid1 = $this->groupCreate(['name' => 'testDefinitionGroups1', 'title' => 'testDefinitionGroups1']);
+    $gid2 = $this->groupCreate(['name' => 'testDefinitionGroups2', 'title' => 'testDefinitionGroups2']);
+    $def = $this->fixtures['Application_with_Definition'];
+    $def['definition']['caseRoles'][] = [
+      'name' => 'Second role',
+      'groups' => ['testDefinitionGroups1', 'testDefinitionGroups2'],
+    ];
+    $def['definition']['caseRoles'][] = [
+      'name' => 'Third role',
+      'groups' => 'testDefinitionGroups2',
+    ];
+    $def['definition']['activityAsgmtGrps'] = $gid1;
+    $createCaseType = $this->callAPISuccess('CaseType', 'create', $def);
+    $caseType = $this->callAPISuccess('CaseType', 'getsingle', ['id' => $createCaseType['id']]);
+
+    // Assert the group id got converted to array with name not id
+    $this->assertEquals(['testDefinitionGroups1'], $caseType['definition']['activityAsgmtGrps']);
+
+    // Assert multiple groups are stored
+    $this->assertEquals(['testDefinitionGroups1', 'testDefinitionGroups2'], $caseType['definition']['caseRoles'][1]['groups']);
+
+    // Assert single group got converted to array
+    $this->assertEquals(['testDefinitionGroups2'], $caseType['definition']['caseRoles'][2]['groups']);
+
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allows an admin to limit selection of contacts to certain groups when adding case roles.

Before
----------------------------------------
Any contact can be selected for a case role.

After
----------------------------------------
Each case role selector can be limited to one or more group.
![image](https://user-images.githubusercontent.com/2874912/67305745-d8867000-f4c3-11e9-8dc4-e4eed40409d0.png)

Doing so will affect the contact selectors for add/edit role on the case summary screen. Those selectors will also have the "New Contact" buttons disabled.

Technical Details
----------------------------------------
Stores group by name in order to be xml-friendly. This also changes the `activityAsgmtGrps` setting to store group name instead of id (although it will still work with previously stored ids for backward-compat).
