### PR TITLE
Add github stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Stale issue message'
+          stale-pr-message: 'Stale pull request message'
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          days-before-stale: 60
+          days-before-close: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'Stale issue message'
-          stale-pr-message: 'Stale pull request message'
+          stale-pr-message: 'This PR has been marked as stale due to no activity for 60 days. We are still experimenting with the new workflow feature but please close the issue yourself & track it through gitlab if you are not actively engaged with it anymore so we can prioritise our reviewer resources. Stale PRs will be autoclosed after 60 days .... we think ... but we are still experimenting & testing this at the moment. See https://github.com/civicrm/civicrm-core/pull/15573 for latest...'
           stale-issue-label: 'no-issue-activity'
           stale-pr-label: 'no-pr-activity'
           days-before-stale: 60


### PR DESCRIPTION
Overview
----------------------------------------
Github has introduced the concept of workflows whereby it can identify PRs which are stale or inactive and tag them - this has the potential to solve one of our biggest product maintenance - time wastage. 

Anyone who wants something merged needs reviewer / merger time to help them. We are very short of reviewer/merger time and I would say as much as half of the time we do have is wasted trying to deal with PRs that the submitter is not committed enough to to reach completion. By having stale PRs age-out of the queue automatically but allowing people to re-create them if they actually care we will be able to better target review time on PRs that actually are a good use of time & both submitter & reviewer time will be better respected.

Anecdotally it is probably as common for me to spend 2 hours reviewing a PR only to get no response from the submitter - the chance of that goes up on older PRs. The key is 
1) for it to be clearly automated
2) for the message to be appropriate & to invite people to take the right next steps

You can see the actions intro at 
https://github.com/civicrm/civicrm-core/actions/new

<img width="761" alt="Screen Shot 2019-10-22 at 4 41 34 PM" src="https://user-images.githubusercontent.com/336308/67257972-f1eee280-f4ea-11e9-80c1-42b38a5462d6.png">


Git ref https://github.com/actions/stale
I think this relates - https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/

Before
----------------------------------------
Stale issues sit around & suck resources

After
----------------------------------------
People have to in one way or another heartbeat the PRs every 2 months

Technical Details
----------------------------------------
I tried this out on buildkit when github 'advertised it' - https://github.com/civicrm/civicrm-buildkit/pulls?q=is%3Apr+is%3Aclosed+label%3Ano-pr-activity - I received a notification that the PRs had been tagged 'no-pr-activity' by email which triggered me to look & realise that I didn't think they were worth keeping open & close them. I don't *think* the closing 

Comments
----------------------------------------

I do think we need to figure out how to hone the various messages. This is the default + I updated days-before-close to be 60 like days before stale - which would give us lots to to tweak & experiment
