### PR TITLE
Generic Settings Pages: Make getSettingPageFilter() public so we can use it in hooks

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -126,9 +126,11 @@ trait CRM_Admin_Form_SettingTrait {
   }
 
   /**
+   * This is public so we can retrieve the filter name via hooks etc. and apply conditional logic (eg. loading javascript conditionals).
+   *
    * @return string
    */
-  protected function getSettingPageFilter() {
+  public function getSettingPageFilter() {
     if (!isset($this->_filter)) {
       // Get the last URL component without modifying the urlPath property.
       $urlPath = array_values($this->urlPath);


### PR DESCRIPTION
Overview
----------------------------------------
If you use the generic settings page and then want to load a custom resource (eg. javascript to conditionally hide fields) you can use the `buildForm` hook but can only match on `CRM_Admin_Form_Generic` which will match multiple forms.  To target an individual "page" we need to know the value of the filter.

Before
----------------------------------------
Not possible to get the filter value from the form.

After
----------------------------------------
Can retrieve the filter value from the form and use it to conditionally load resources.

Technical Details
----------------------------------------
The property _filter is available but private, it can be accessed via the protected method `getSettingPageFilter()`.  We need to check the filter value to work out which settings "page" we are loading.

Comments
----------------------------------------
@eileenmcnaughton This seems like a simple change, not sure if there is a better way to do this. But being able to match on a specific filter makes the generic settings pages much more useful because they can be individually customised via buildForm hooks.
