### PR TITLE
Remove a redundant call to formatParamsForPaymentProcessor in AdditionalPayment form

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -399,8 +399,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->assign('displayName', $this->userDisplayName);
     }
 
-    $this->formatParamsForPaymentProcessor($this->_params);
-
     $this->_params['amount'] = $this->_params['total_amount'];
     // @todo - stop setting amount level in this function & call the CRM_Price_BAO_PriceSet::getAmountLevel
     // function to get correct amount level consistently. Remove setting of the amount level in


### PR DESCRIPTION
Overview
----------------------------------------
This is called via `processBillingAddress()` slightly earlier in the `submit()` function.  `formatParamsForPaymentProcessor` calls `prepareParamsForPaymentProcessor` with $this->_values as a parameter so we're repeating the same thing with no changes to the input data.

Before
----------------------------------------
`formatParamsForPaymentProcessor` called twice during submit.

After
----------------------------------------
`formatParamsForPaymentProcessor` called once during submit.

Technical Details
----------------------------------------

Comments
----------------------------------------
I've traced this through the code and it seems quite straightforward that it only needs to be called once.
