### PR TITLE
Issue 1205: allow custom fields of type file for entities

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -433,8 +433,7 @@ class Container {
        FROM civicrm_custom_field fld
        INNER JOIN civicrm_custom_group grp ON fld.custom_group_id = grp.id
        WHERE fld.data_type = "File"
-      ',
-      ['civicrm_activity', 'civicrm_mailing', 'civicrm_contact', 'civicrm_grant']
+      '
     ));
 
     $kernel->setApiProviders([

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -100,6 +100,16 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
       ],
       'This comes from a file',
     ];
+    $cases[] = [
+      'CRM_Core_DAO_Domain',
+      [
+        'name' => self::getFilePrefix() . 'exampleFromContent.txt',
+        'mime_type' => 'text/plain',
+        'description' => 'My test description',
+        'content' => 'My test content',
+      ],
+      'My test content',
+    ];
 
     return $cases;
   }
@@ -153,17 +163,6 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
         'content' => 'My test content',
       ],
       "/Malformed name/",
-    ];
-    $cases[] = [
-      'CRM_Core_DAO_Domain',
-      [
-        'name' => self::getFilePrefix() . 'exampleFromContent.txt',
-        'mime_type' => 'text/plain',
-        'description' => 'My test description',
-        'content' => 'My test content',
-        'check_permissions' => 1,
-      ],
-      "/Unrecognized target entity/",
     ];
 
     return $cases;


### PR DESCRIPTION
Overview
----------------------------------------
The attachment API gives a permission denied on custom file fields on events (and other entities).
This PR removes the white list and removing the white list will check the Attachment API against core entities (even custom ones defined in extensions).

See: https://lab.civicrm.org/dev/core/issues/1205

Before
----------------------------------------
Attachment API on a file uploaded to a custom file field to an event would fail with permission denied.

After
----------------------------------------
Attachment API on a file uploaded to a custom file field to an event would succeed when the user also has access to the connected entity (in this case the event).

Technical Details
----------------------------------------
I have chosen to remove only the definition of the white list. I could have removed the white list but that got me into a corner where I had to redo the DynamicFKAuthorizationTest. 
