### PR TITLE
[REF] Update doc blocks and abort early when going to build ACL conta…

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -109,7 +109,8 @@ SELECT acl_id
   }
 
   /**
-   * @param int $id
+   * Delete entries from the civicrm_acl_cache for a specific contact.
+   * @param int $id contact_id
    */
   public static function deleteEntry($id) {
     if (self::$_cache &&
@@ -127,7 +128,8 @@ WHERE contact_id = %1
   }
 
   /**
-   * @param int $id
+   * Update civicrm_acl_contact_cache and civicrm_acl_cache for a specific user
+   * @param int $id contact_id for the user that ACLs apply to.
    */
   public static function updateEntry($id) {
     // rebuilds civicrm_acl_cache

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -189,7 +189,7 @@ WHERE contact_a.id = %1 AND $permission
   /**
    * Fill the acl contact cache for this contact id if empty.
    *
-   * @param int $userID
+   * @param int $userID contact id matching the ACLed user that we are filling the cache for
    * @param int|string $type the type of operation (view|edit)
    * @param bool $force
    *   Should we force a recompute.
@@ -204,6 +204,12 @@ WHERE contact_a.id = %1 AND $permission
         CRM_Core_Permission::VIEW => [],
         CRM_Core_Permission::EDIT => [],
       ];
+    }
+    // We may find ourselves here if a function has called CRM_ACL_BAO_Cache::updateEntry function. That function doesn't appropriately
+    // Check for view all contacts permission or similar which we don't need to cache.
+    if (CRM_Core_Permission::check('edit all contacts') || $type == CRM_ACL_API::VIEW && CRM_Core_Permission::check('view all contacts')) {
+      Civi::$statics[__CLASS__]['processed'][$type][$userID] = 1;
+      return;
     }
 
     if ($type == CRM_Core_Permission::VIEW) {


### PR DESCRIPTION
…ct Cache if user has edit all contacts or view all contacts permission

Overview
----------------------------------------
Updates doc blocks but also adds an early return in the `CRM_Contact_BAO_Contact_Permission::cache` function in case someone has called the `CRM_ACL_BAO_Cache::updateEntry` function without checking if user has edit all contacts or view all contacts permission

ping @eileenmcnaughton @mattwire 