### PR TITLE
Use Exceptions for DB Queries within mergeGroupContact function incas…

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -603,6 +603,7 @@ SELECT    *
    * TODO: use the 3rd $sqls param to append sql statements rather than executing them here
    */
   public static function mergeGroupContact($mainContactId, $otherContactId) {
+    $errorScope = CRM_Core_TemporaryErrorScope::useException();
     $params = [
       1 => [$mainContactId, 'Integer'],
       2 => [$otherContactId, 'Integer'],
@@ -695,6 +696,7 @@ AND       group_id IN ( $groupIDString )
   WHERE  contact_id = %2
   ";
     CRM_Core_DAO::executeQuery($sql, $params);
+    $errorScope = NULL;
   }
 
   /**


### PR DESCRIPTION
…e of deadlocks on group_contact or group_contact_cache tables

Overview
----------------------------------------
This switches the error scope to be using an Exception rather than raising a CRM_Core_Error when trying to merge in the group contact memberships during a merger

Before
----------------------------------------
CRM_Core_Error::fatal raised if there is a db error

After
----------------------------------------
Exception raised if there is a DB error

ping @eileenmcnaughton @monishdeb