### PR TITLE
Add help text to payment processor subject field

### DIFF
--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -88,7 +88,7 @@
 {/if}
 {if $form.subject}
         <tr class="crm-paymentProcessor-form-block-subject">
-            <td class="label">{$form.subject.label}</td><td>{$form.subject.html}</td>
+            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id=$ppTypeName|cat:'-live-subject' title=$form.subject.label}</td>
         </tr>
 {/if}
         <tr class="crm-paymentProcessor-form-block-url_site">
@@ -129,7 +129,7 @@
 {/if}
 {if $form.test_subject}
         <tr class="crm-paymentProcessor-form-block-test_subject">
-            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html}</td>
+            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id=$ppTypeName|cat:'-test-subject' title=$form.test_subject.label}</td>
         </tr>
 {/if}
         <tr class="crm-paymentProcessor-form-block-test_url_site">


### PR DESCRIPTION
Overview
----------------------------------------
Improves consistency by adding a help icon to the subject field on the  "Settings - Payment Processor" form (CiviCRM Admin bar -> Adminster -> System Settings -> Payment Processors add or edit a payment processor). 

NOTE: None of the processors that ship with core use a subject field, but the template for the field lives in core and other payment processors rely on it including:

+  [https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor](https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/blob/148d926919d37d0697712aa52ca58c69918d1002/Metadata/omnipay_PayboxSystem.mgd.php#L53) 
+ [https://github.com/aghstrategies/com.aghstrategies.tsys](https://github.com/aghstrategies/com.aghstrategies.tsys/blob/master/tsys.php#L163)

The labels for the subject field vary from payment processor to payment processor depending on how the 'subject_label' is defined in the metadata but the field template is the same.

Before
----------------------------------------
No blue help icon next to the subject field on the "Settings - Payment Processor" form. 

In this example (a site with  [https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor](https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/blob/148d926919d37d0697712aa52ca58c69918d1002/Metadata/omnipay_PayboxSystem.mgd.php#L53)  installed and the  Payment Processor Type "Omnipay - Paybox System" selected) the subject field has the label "Rang":
![rang](https://user-images.githubusercontent.com/11323624/67421606-d6ddaa80-f59e-11e9-8666-ce159599aafb.png)


After
----------------------------------------
With this change a blue help icon appears next to the subject field on the "Settings - Payment Processor" form. Payment processor developers can populate the help text with a `templates/CRM/Admin/Page/PaymentProcessor.extra.hlp` file like [this](https://github.com/aghstrategies/com.aghstrategies.tsys/blob/master/templates/CRM/Admin/Page/PaymentProcessor.extra.hlp)

Example: Site with TSYS processor set up where the Subject label is "Merchant Site ID" a blue help icon shows up next to it.
![merchantSite](https://user-images.githubusercontent.com/11323624/67422090-c0841e80-f59f-11e9-913e-43af8ddebd2a.png)

