### PR TITLE
Add noisy deprecation warning to Contribution.transact

### DIFF
--- a/api/v3/Contribution/Transact.php
+++ b/api/v3/Contribution/Transact.php
@@ -46,6 +46,8 @@ function _civicrm_api3_contribution_transact_spec(&$params) {
 /**
  * Process a transaction and record it against the contact.
  *
+ * @deprecated
+ *
  * @param array $params
  *   Input parameters.
  *
@@ -53,6 +55,7 @@ function _civicrm_api3_contribution_transact_spec(&$params) {
  *   contribution of created or updated record (or a civicrm error)
  */
 function civicrm_api3_contribution_transact($params) {
+  CRM_Core_Error::deprecatedFunctionWarning('The contibution.transact api is unsupported & known to have issues. Please see the section at the bottom of https://docs.civicrm.org/dev/en/latest/financial/OrderAPI/ for getting off it');
   // Set some params specific to payment processing
   // @todo - fix this function - none of the results checked by civicrm_error would ever be an array with
   // 'is_error' set


### PR DESCRIPTION
Overview
----------------------------------------
Add a deprecation notice when people use the broken Contribution.transact api.

The Order api has been the recommended api for several years & was adopted over a year ago by  by the wordpress integration - the bottom of this page contains instructions for getting off it https://docs.civicrm.org/dev/en/latest/financial/OrderAPI/

Currently it IS broken and while it's possible to install an extension to fix it we should strongly discourage people from using it.

Before
----------------------------------------
No warning that it is unsupported & broken

After
----------------------------------------
Warning

Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw since you merged the PR allowing people to override it please merge this
