### PR TITLE
dev/core#1339 Dedupe screen check to carry across any data where the other contact has none by default.

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -225,13 +225,16 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
           // @todo consider enabling if it is an add & defaulting to true.
           $element[4] = array_merge((array) CRM_Utils_Array::value(4, $element, []), ['disabled' => TRUE]);
         }
-        $this->addElement($element[0],
+        $newCheckBox = $this->addElement($element[0],
           $element[1],
           array_key_exists('2', $element) ? $element[2] : NULL,
           array_key_exists('3', $element) ? $element[3] : NULL,
           array_key_exists('4', $element) ? $element[4] : NULL,
           array_key_exists('5', $element) ? $element[5] : NULL
         );
+        if (!empty($element['is_checked'])) {
+          $newCheckBox->setChecked(TRUE);
+        }
       }
 
       // add related table elements

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1109,12 +1109,13 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       // Display a checkbox to migrate, only if the values are different
       if ($value != $main[$field]) {
         $elements[] = [
-          'advcheckbox',
-          "move_$field",
-          NULL,
-          NULL,
-          NULL,
-          $value,
+          0 => 'advcheckbox',
+          1 => "move_$field",
+          2 => NULL,
+          3 => NULL,
+          4 => NULL,
+          5 => $value,
+          'is_checked' => (!isset($main[$field]) || $main[$field] === ''),
         ];
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
 This change in default means that if the contact to be deleted has data in a field and the contact to be kept does not the  checkbox loads as checked by default (so it's easier to keep too much data but harder to lose some.)

The user can override by unchecking - this is just what is set by default on screen load


Before
----------------------------------------
![not checked by default](https://lab.civicrm.org/dev/core/uploads/0d735a0240134575d32e9436b6844a7b/Screen_Shot_2019-10-24_at_4.06.23_PM.png)

After
----------------------------------------
![checked by default](https://lab.civicrm.org/dev/core/uploads/dec80d7f3cefd3d7c98cc9a8e1731419/Screen_Shot_2019-10-24_at_4.31.36_PM.png)

Technical Details
----------------------------------------
Change is superficial to the form presentation

I did some cleanup getting to where I could decide the code change. I can rebase out when merged https://github.com/civicrm/civicrm-core/pull/15594

Comments
----------------------------------------
    https://lab.civicrm.org/dev/core/issues/1339

