### PR TITLE
CRM-21740 - Relationships should be sorted by weight not sort name

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1175,7 +1175,9 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
                               civicrm_relationship.is_active as is_active,
                               civicrm_relationship.is_permission_a_b as is_permission_a_b,
                               civicrm_relationship.is_permission_b_a as is_permission_b_a,
-                              civicrm_relationship.case_id as case_id';
+                              civicrm_relationship.case_id as case_id,
+                              civicrm_relationship_type.weight as wt
+';
 
       if ($direction == 'a_b') {
         $select .= ', civicrm_relationship_type.label_a_b as label_a_b,
@@ -1315,7 +1317,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     $order = $limit = '';
     if (!$count) {
       if (empty($params['sort'])) {
-        $order = ' ORDER BY civicrm_relationship_type_id, sort_name ';
+        $order = ' ORDER BY wt ';
       }
       else {
         $order = " ORDER BY {$params['sort']} ";
@@ -1333,7 +1335,6 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
 
     // building the query string
     $queryString = $select1 . $from1 . $where1 . $select2 . $from2 . $where2;
-
     $relationship = new CRM_Contact_DAO_Relationship();
 
     $relationship->query($queryString . $order . $limit);

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1317,7 +1317,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     $order = $limit = '';
     if (!$count) {
       if (empty($params['sort'])) {
-        $order = ' ORDER BY wt ';
+        $order = ' ORDER BY wt , sort_name ';
       }
       else {
         $order = " ORDER BY {$params['sort']} ";

--- a/CRM/Contact/DAO/RelationshipType.php
+++ b/CRM/Contact/DAO/RelationshipType.php
@@ -106,6 +106,13 @@ class CRM_Contact_DAO_RelationshipType extends CRM_Core_DAO {
   public $is_reserved;
 
   /**
+   * Weight of the relationship type.
+   *
+   * @var int
+   */
+  public $weight;
+
+  /**
    * Is this relationship type currently active (i.e. can be used when creating or editing relationships)?
    *
    * @var bool
@@ -315,6 +322,18 @@ class CRM_Contact_DAO_RelationshipType extends CRM_Core_DAO {
           'html' => [
             'type' => 'CheckBox',
           ],
+        ],
+        'weight' => [
+          'name' => 'weight',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('Order'),
+          'description' => 'Weight of the relationship type.',
+          'required' => TRUE,
+          'default' => '1',
+          'table_name' => 'civicrm_relationship_type',
+          'entity' => 'RelationshipType',
+          'bao' => 'CRM_Contact_BAO_RelationshipType',
+          'localizable' => 0,
         ],
         'is_active' => [
           'name' => 'is_active',

--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -243,6 +243,9 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
     elseif ($key) {
       $object->orderBy($key . ' asc');
     }
+    elseif (property_exists($object, 'weight')) {
+      $object->orderBy('weight');
+    }
 
     $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements(FALSE, FALSE);
     // find all objects
@@ -279,6 +282,13 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
         }
       }
     }
+
+    // Add order changing widget to selector
+    $returnURL = CRM_Utils_System::url('civicrm/admin/reltype', "reset=1&action=browse");
+    CRM_Utils_Weight::addOrder($values, 'CRM_Contact_DAO_RelationshipType',
+      'id', $returnURL
+    );
+
     $this->assign('rows', $values);
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -103,7 +103,6 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
 
     $this->addTask('Add weight column to relationship type table', 'addColumn', 'civicrm_relationship_type',
       'weight', "INT NOT NULL COMMENT 'Relationship type weight'", TRUE, '5.20.alpha1');
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_relationship_type SET weight = id");
 
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add "Template" contribution status', 'templateStatus');

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -100,6 +100,11 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
     if (in_array('CiviCase', $config->enableComponents)) {
       $this->addTask('Change direction of autoassignees in case type xml', 'changeCaseTypeAutoassignee');
     }
+
+    $this->addTask('Add weight column to relationship type table', 'addColumn', 'civicrm_relationship_type',
+      'weight', "INT NOT NULL COMMENT 'Relationship type weight'", TRUE, '5.20.alpha1');
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_relationship_type SET weight = id");
+
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add "Template" contribution status', 'templateStatus');
     $this->addTask('Update smart groups to rename filters on case_from and case_to to case_start_date and case_end_date', 'updateSmartGroups', [

--- a/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
@@ -1,4 +1,3 @@
 {* file to handle db changes in 5.20.alpha1 during upgrade *}
 
 UPDATE civicrm_navigation SET url = "civicrm/api3" WHERE url = "civicrm/api" AND domain_id = {$domainID};
-

--- a/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
@@ -1,3 +1,7 @@
 {* file to handle db changes in 5.20.alpha1 during upgrade *}
 
 UPDATE civicrm_navigation SET url = "civicrm/api3" WHERE url = "civicrm/api" AND domain_id = {$domainID};
+
+-- CRM-21740
+ALTER TABLE  civicrm_relationship_type ADD weight INT NOT NULL;
+UPDATE civicrm_relationship_type SET weight = id;

--- a/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
@@ -2,6 +2,3 @@
 
 UPDATE civicrm_navigation SET url = "civicrm/api3" WHERE url = "civicrm/api" AND domain_id = {$domainID};
 
--- CRM-21740
-ALTER TABLE  civicrm_relationship_type ADD weight INT NOT NULL;
-UPDATE civicrm_relationship_type SET weight = id;

--- a/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.20.alpha1.mysql.tpl
@@ -1,3 +1,6 @@
 {* file to handle db changes in 5.20.alpha1 during upgrade *}
 
 UPDATE civicrm_navigation SET url = "civicrm/api3" WHERE url = "civicrm/api" AND domain_id = {$domainID};
+
+-- CRM-21740
+UPDATE civicrm_relationship_type SET weight = id;

--- a/templates/CRM/Admin/Page/RelationshipType.tpl
+++ b/templates/CRM/Admin/Page/RelationshipType.tpl
@@ -47,7 +47,6 @@
     {strip}
   {* handle enable/disable actions*}
   {include file="CRM/common/enableDisableApi.tpl"}
-    {include file="CRM/common/jsortable.tpl"}
         <table id="options" class="display">
         <thead>
         <tr>
@@ -55,6 +54,7 @@
           <th>{ts}Relationship B to A{/ts}</th>
           <th>{ts}Contact Type A{/ts}</th>
           <th>{ts}Contact Type B{/ts}</th>
+          <th>{ts}Order{/ts}</th>
           <th>{ts}Enabled?{/ts}</th>
           <th></th>
         </tr>
@@ -69,6 +69,7 @@
             <td class="crm-relationship-contact_type_b_display">
                 {if $row.contact_type_b_display} {$row.contact_type_b_display}
                 {if $row.contact_sub_type_b} - {$row.contact_sub_type_b}{/if} {else} {ts}All Contacts{/ts} {/if} </td>
+            <td class="nowrap crmf-weight">{$row.weight}</td>
             <td class="crm-relationship-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
@@ -30,7 +30,6 @@
   <table
     class="crm-contact-{$entityInClassFormat}-selector-{$context} crm-ajax-table"
     data-ajax="{crmURL p="civicrm/ajax/contactrelationships" q="context=$context&cid=$contactId"}"
-    data-order='[[0,"asc"],[1,"asc"]]'
     style="width: 100%;">
     <thead>
     <tr>

--- a/xml/schema/Contact/RelationshipType.xml
+++ b/xml/schema/Contact/RelationshipType.xml
@@ -150,6 +150,15 @@
     <add>1.1</add>
   </field>
   <field>
+    <name>weight</name>
+    <type>int</type>
+    <title>Order</title>
+    <required>true</required>
+    <default>1</default>
+    <comment>Weight of the relationship type.</comment>
+    <add>5.20</add>
+  </field>
+  <field>
     <name>is_active</name>
     <title>Relationship Type is Active</title>
     <type>boolean</type>


### PR DESCRIPTION
…rt name

Overview
----------------------------------------
Specification:
--------------------
Add column 'weight' in relationshipship type.
If there is no sort order, make sure the weight is respected when showing relationships in tab etc.

Before
----------------------------------------
Relationships are sorted based on relationship type id, sort name

After
----------------------------------------
Relationships are sorted based on assigned weight
![rel_type](https://user-images.githubusercontent.com/3455173/37702270-0643cf9e-2d18-11e8-8b78-6d7f757f6a06.png)
![after](https://user-images.githubusercontent.com/3455173/37702276-0acf2a4a-2d18-11e8-8d2d-176e3bb6aaa8.png)

