### PR TITLE
Remove CIVICRM_SUPPORT_MULTIPLE_LOCKS and make it always enabled if available

### DIFF
--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -124,16 +124,11 @@ class CRM_Utils_SQL {
    *
    * https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
    *
-   * As an interim measure we ALSO require CIVICRM_SUPPORT_MULTIPLE_LOCKS to be defined.
-   *
    * This is a conservative measure to introduce the change which we expect to deprecate later.
    *
    * @todo we only check mariadb & mysql right now but maybe can add percona.
    */
   public static function supportsMultipleLocks() {
-    if (!defined('CIVICRM_SUPPORT_MULTIPLE_LOCKS')) {
-      return FALSE;
-    }
     static $isSupportLocks = NULL;
     if (!isset($isSupportLocks)) {
       $version = self::getDatabaseVersion();

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -463,20 +463,6 @@ if (!defined('CIVICRM_PSR16_STRICT')) {
 define('CIVICRM_DEADLOCK_RETRIES', 3);
 
 /**
- * Enable support for multiple locks.
- *
- * This is a transitional setting. When enabled sites with mysql 5.7.5+ or equivalent
- * MariaDB can improve their DB conflict management.
- *
- * There is no known or expected downside or enabling this (and definite upside).
- * The setting only exists to allow sites to manage change in their environment
- * conservatively for the first 3 months.
- *
- * See https://github.com/civicrm/civicrm-core/pull/13854
- */
- // define('CIVICRM_SUPPORT_MULTIPLE_LOCKS', TRUE);
-
-/**
  * Configure MySQL to throw more errors when encountering unusual SQL expressions.
  *
  * If undefined, the value is determined automatically. For CiviCRM tarballs, it defaults


### PR DESCRIPTION
Overview
----------------------------------------
This is in use on all my production sites, @eileenmcnaughton uses it and I believe others do as well.  Adding the define was just to be really careful in case it could cause any issues - but it's been there a year now and time to go.

Before
----------------------------------------
You have to enable the `CIVICRM_SUPPORT_MULTIPLE_LOCKS` define to use multiple locks on modern versions of MySQL/MariaDB.

After
----------------------------------------
Multiple locks used by default - so less sites fall over when sending mailings.

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton @seamuslee001 per comments on #15588 