### PR TITLE
[WIP] By Default throw Execptions

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -97,7 +97,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * If modeException == true, errors are raised as exception instead of returning civicrm_errors
    * @var bool
    */
-  public static $modeException = NULL;
+  public static $modeException = TRUE;
 
   /**
    * Singleton function used to manage this object.

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -97,7 +97,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * If modeException == true, errors are raised as exception instead of returning civicrm_errors
    * @var bool
    */
-  public static $modeException = TRUE;
+  public static $modeException = NULL;
 
   /**
    * Singleton function used to manage this object.
@@ -125,6 +125,11 @@ class CRM_Core_Error extends PEAR_ErrorStack {
 
     $log = CRM_Core_Config::getLog();
     $this->setLogger($log);
+
+    // Throw Exceptions in non production environments
+    if (CRM_Core_Config::environment() !== 'production') {
+      self::$modeException = TRUE;
+    }
 
     // PEAR<=1.9.0 does not declare "static" properly.
     if (!is_callable(['PEAR', '__callStatic'])) {

--- a/CRM/Queue/ErrorPolicy.php
+++ b/CRM/Queue/ErrorPolicy.php
@@ -71,15 +71,12 @@ class CRM_Queue_ErrorPolicy {
       ini_set($key, 0);
     }
     set_error_handler([$this, 'onError'], $this->level);
-    // FIXME make this temporary/reversible
-    $this->errorScope = CRM_Core_TemporaryErrorScope::useException();
   }
 
   /**
    * Disable the error policy.
    */
   public function deactivate() {
-    $this->errorScope = NULL;
     restore_error_handler();
     foreach ([
       'display_errors',

--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -167,9 +167,7 @@ class CRM_Queue_Runner {
       // setting -- it should be more of a contextual/stack-based setting.
       // This should be appropriate because queue-runners are not used with
       // basic web pages -- they're used with CLI/REST/AJAX.
-      $errorScope = CRM_Core_TemporaryErrorScope::useException();
       $taskResult = $this->runNext();
-      $errorScope = NULL;
     }
 
     if ($taskResult['numberOfItems'] == 0) {

--- a/CRM/Utils/SQL/Delete.php
+++ b/CRM/Utils/SQL/Delete.php
@@ -257,7 +257,6 @@ class CRM_Utils_SQL_Delete extends CRM_Utils_SQL_BaseParamQuery {
     // Don't pass through $abort, $trapException. Just use straight-up exceptions.
     $abort = TRUE;
     $trapException = FALSE;
-    $errorScope = CRM_Core_TemporaryErrorScope::useException();
 
     // Don't pass through freeDAO. You can do it yourself.
     $freeDAO = FALSE;

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -160,7 +160,6 @@ class Kernel {
    */
   public function runRequest($apiRequest) {
     $this->boot($apiRequest);
-    $errorScope = \CRM_Core_TemporaryErrorScope::useException();
 
     list($apiProvider, $apiRequest) = $this->resolve($apiRequest);
     $this->authorize($apiProvider, $apiRequest);

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -23,11 +23,6 @@ else {
    */
   class CiviTestListener extends \PHPUnit\Framework\BaseTestListener {
     /**
-     * @var \CRM_Core_TemporaryErrorScope
-     */
-    private $errorScope;
-
-    /**
      * @var array
      *  Ex: $cache['Some_Test_Class']['civicrm_foobar'] = 'hook_civicrm_foobar';
      *  Array(string $testClass => Array(string $hookName => string $methodName)).
@@ -52,7 +47,6 @@ else {
     public function startTest(\PHPUnit\Framework\Test $test) {
       if ($this->isCiviTest($test)) {
         error_reporting(E_ALL);
-        $this->errorScope = \CRM_Core_TemporaryErrorScope::useException();
       }
 
       if ($test instanceof HeadlessInterface) {

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -15,10 +15,6 @@ namespace Civi\Test\Legacy;
  * @see HookInterface
  */
 class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
-  /**
-   * @var \CRM_Core_TemporaryErrorScope
-   */
-  private $errorScope;
 
   /**
    * @var array
@@ -45,7 +41,6 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
   public function startTest(\PHPUnit_Framework_Test $test) {
     if ($this->isCiviTest($test)) {
       error_reporting(E_ALL);
-      $this->errorScope = \CRM_Core_TemporaryErrorScope::useException();
     }
 
     if ($test instanceof \Civi\Test\HeadlessInterface) {

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -330,14 +330,12 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     CRM_Core_BAO_CustomField::moveField($fields['countryB']['id'], $groupB['id']);
 
     // Group[A] no longer has fields[countryB]
-    $errorScope = CRM_Core_TemporaryErrorScope::useException();
     try {
       $this->assertDBQuery(1, "SELECT {$fields['countryB']['column_name']} FROM " . $groupA['table_name']);
       $this->fail('Expected exception when querying column on wrong table');
     }
-    catch (PEAR_Exception$e) {
+    catch (PEAR_Exception $e) {
     }
-    $errorScope = NULL;
 
     // Alice: Group[B] has fields[countryB], but fields[countryC] did not exist before
     $this->assertDBQuery(1,

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
@@ -66,7 +66,6 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
       'custom_' . $fieldID => $badDate,
     ];
 
-    CRM_Core_TemporaryErrorScope::useException();
     $message = NULL;
     try {
       CRM_Core_BAO_CustomValueTable::setValues($params);
@@ -165,7 +164,6 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
       'custom_' . $fieldID => $badYesNo,
     ];
 
-    CRM_Core_TemporaryErrorScope::useException();
     $message = NULL;
     try {
       CRM_Core_BAO_CustomValueTable::setValues($params);

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -164,7 +164,6 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * @param $expectSql
    */
   public function testComposeQuery($inputSql, $inputParams, $expectSql) {
-    $scope = CRM_Core_TemporaryErrorScope::useException();
     try {
       $actualSql = CRM_Core_DAO::composeQuery($inputSql, $inputParams);
     }

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -244,7 +244,6 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
       'email' => 'hood@example.com',
       'street_address' => 'Ambachtstraat 23',
     ];
-    CRM_Core_TemporaryErrorScope::useException();
     $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($fields, 'Individual', 'General', [], TRUE, NULL, ['event_id' => 1]);
 
     // Check with default Individual-General rule

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -311,7 +311,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->_apiversion = 3;
 
     // REVERT
-    $this->errorScope = CRM_Core_TemporaryErrorScope::useException();
     //  Use a temporary file for STDIN
     $GLOBALS['stdin'] = tmpfile();
     if ($GLOBALS['stdin'] === FALSE) {


### PR DESCRIPTION
Overview
----------------------------------------
This PR switches the default behaviour of CRM_Core_Error:: to be to throw Exceptions rather than the Fatal as previous 

Before
----------------------------------------
Old Fatal Error Screen by default

After
----------------------------------------
by default we throw exceptions

ping @eileenmcnaughton @totten 