### PR TITLE
dev/core#560 Convert some more CRM_Core_Error::fatal to exception

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2251,7 +2251,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     }
 
     if (!in_array($id, $mailingIDs)) {
-      CRM_Core_Error::fatal(ts('You do not have permission to access this mailing report'));
+      throw new CRM_Core_Exception(ts('You do not have permission to access this mailing report'));
     }
   }
 
@@ -2473,7 +2473,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
    */
   public static function del($id) {
     if (empty($id)) {
-      CRM_Core_Error::fatal();
+      throw new CRM_Core_Exception(ts('No id passed to mailing del function'));
     }
 
     CRM_Utils_Hook::pre('delete', 'Mailing', $id, CRM_Core_DAO::$_nullArray);
@@ -2503,7 +2503,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
    */
   public static function delJob($id) {
     if (empty($id)) {
-      CRM_Core_Error::fatal();
+      throw new CRM_Core_Exception(ts('No id passed to mailing delJob function'));
     }
 
     \Civi::log('This function is deprecated, use CRM_Mailing_BAO_MailingJob::del instead', ['civi.tag' => 'deprecated']);

--- a/CRM/Mailing/BAO/MailingAB.php
+++ b/CRM/Mailing/BAO/MailingAB.php
@@ -117,7 +117,7 @@ class CRM_Mailing_BAO_MailingAB extends CRM_Mailing_DAO_MailingAB {
    */
   public static function del($id) {
     if (empty($id)) {
-      CRM_Core_Error::fatal();
+      throw new CRM_Core_Exception(ts('No id passed to MailingAB del function'));
     }
     CRM_Core_Transaction::create()->run(function () use ($id) {
       CRM_Utils_Hook::pre('delete', 'MailingAB', $id, CRM_Core_DAO::$_nullArray);

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -585,7 +585,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     static $smtpConnectionErrors = 0;
 
     if (!is_object($mailer) || empty($fields)) {
-      CRM_Core_Error::fatal();
+      throw new CRM_Core_Exception('Either mailer is not an object or we don\'t have recipients to send to in this group');
     }
 
     // get the return properties
@@ -989,7 +989,7 @@ AND    status IN ( 'Scheduled', 'Running', 'Paused' )
           $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Bulk Email');
         }
         if (!$activityTypeID) {
-          CRM_Core_Error::fatal();
+          throw new CRM_Core_Execption(ts('No relevant activity type found when recording Mailing Event delivered Activity'));
         }
       }
 

--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -137,7 +137,7 @@ SELECT     civicrm_email.id as email_id
     $dao = CRM_Core_DAO::executeQuery($query, $params);
 
     if (!$dao->fetch()) {
-      CRM_Core_Error::fatal('Please file an issue with the backtrace');
+      throw new CRM_Core_Exception('Please file an issue with the backtrace');
       return $success;
     }
 

--- a/CRM/Mailing/Form/Approve.php
+++ b/CRM/Mailing/Form/Approve.php
@@ -154,7 +154,7 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
     }
 
     if (!$ids['mailing_id']) {
-      CRM_Core_Error::fatal();
+      CRM_Core_Error::statusBounce(ts('No mailing id has been able to be determined'));
     }
 
     $params['approver_id'] = $this->_contactID;

--- a/CRM/Mailing/Form/Browse.php
+++ b/CRM/Mailing/Form/Browse.php
@@ -46,7 +46,7 @@ class CRM_Mailing_Form_Browse extends CRM_Core_Form {
 
     // check for action permissions.
     if (!CRM_Core_Permission::checkActionPermission('CiviMail', $this->_action)) {
-      CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
 
     $mailing = new CRM_Mailing_BAO_Mailing();

--- a/CRM/Mailing/Form/ForwardMailing.php
+++ b/CRM/Mailing/Form/ForwardMailing.php
@@ -48,7 +48,7 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
     if ($q == NULL) {
 
       // ERROR.
-      CRM_Core_Error::fatal(ts('Invalid form parameters.'));
+      throw new CRM_Core_Exception(ts('Invalid form parameters.'));
       CRM_Core_Error::statusBounce(ts('Invalid form parameters.'));
     }
     $mailing = &$q->getMailing();

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -44,13 +44,13 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
       !$queue_id ||
       !$hash
     ) {
-      CRM_Core_Error::fatal(ts("Missing input parameters"));
+      throw new CRM_Core_Exception(ts("Missing input parameters"));
     }
 
     // verify that the three numbers above match
     $q = CRM_Mailing_Event_BAO_Queue::verify($job_id, $queue_id, $hash);
     if (!$q) {
-      CRM_Core_Error::fatal(ts("There was an error in your request"));
+      throw new CRM_Core_Exception(ts("There was an error in your request"));
     }
 
     list($displayName, $email) = CRM_Mailing_Event_BAO_Queue::getContactInfo($queue_id);

--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -115,7 +115,7 @@ ORDER BY title";
         $rows[] = $row;
       }
       if (empty($rows)) {
-        CRM_Core_Error::fatal(ts('There are no public mailing list groups to display.'));
+        throw new CRM_Core_Exception(ts('There are no public mailing list groups to display.'));
       }
       $this->assign('rows', $rows);
       $this->addFormRule(['CRM_Mailing_Form_Subscribe', 'formRule']);

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -44,13 +44,13 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
       !$queue_id ||
       !$hash
     ) {
-      CRM_Core_Error::fatal(ts("Missing Parameters"));
+      throw new CRM_Core_Exception(ts('Missing Parameters'));
     }
 
     // verify that the three numbers above match
     $q = CRM_Mailing_Event_BAO_Queue::verify($job_id, $queue_id, $hash);
     if (!$q) {
-      CRM_Core_Error::fatal(ts("There was an error in your request"));
+      throw new CRM_Core_Exception(ts("There was an error in your request"));
     }
 
     list($displayName, $email) = CRM_Mailing_Event_BAO_Queue::getContactInfo($queue_id);

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -87,7 +87,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     if ($this->_sms) {
       // if this is an SMS page, check that the user has permission to browse SMS
       if (!CRM_Core_Permission::check('send SMS')) {
-        CRM_Core_Error::fatal(ts('You do not have permission to send SMS'));
+        CRM_Core_Error::statusBounce(ts('You do not have permission to send SMS'));
       }
     }
     else {
@@ -95,7 +95,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       // permission (specific permissions have been copied from
       // CRM/Mailing/xml/Menu/Mailing.xml)
       if (!CRM_Core_Permission::check([['access CiviMail', 'approve mailings', 'create mailings', 'schedule mailings']])) {
-        CRM_Core_Error::fatal(ts('You do not have permission to view this page.'));
+        CRM_Core_Error::statusBounce(ts('You do not have permission to view this page.'));
       }
     }
 
@@ -195,7 +195,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     }
     elseif ($this->_action & CRM_Core_Action::CLOSE) {
       if (!CRM_Core_Permission::checkActionPermission('CiviMail', CRM_Core_Action::CLOSE)) {
-        CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
       }
       CRM_Mailing_BAO_MailingJob::pause($this->_mailingId);
       CRM_Core_Session::setStatus(ts('The mailing has been paused. Active message deliveries may continue for a few minutes, but CiviMail will not begin delivery of any more batches.'), ts('Paused'), 'success');
@@ -203,7 +203,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     }
     elseif ($this->_action & CRM_Core_Action::REOPEN) {
       if (!CRM_Core_Permission::checkActionPermission('CiviMail', CRM_Core_Action::CLOSE)) {
-        CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
       }
       CRM_Mailing_BAO_MailingJob::resume($this->_mailingId);
       CRM_Core_Session::setStatus(ts('The mailing has been resumed.'), ts('Resumed'), 'success');
@@ -214,7 +214,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
 
         // check for action permissions.
         if (!CRM_Core_Permission::checkActionPermission('CiviMail', $this->_action)) {
-          CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+          CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
         }
 
         CRM_Mailing_BAO_Mailing::del($this->_mailingId);

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -50,13 +50,13 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
       !$queue_id ||
       !$hash
     ) {
-      CRM_Core_Error::fatal(ts("Missing input parameters"));
+      throw new CRM_Core_Exception(ts("Missing input parameters"));
     }
 
     // verify that the three numbers above match
     $q = CRM_Mailing_Event_BAO_Queue::verify($job_id, $queue_id, $hash);
     if (!$q) {
-      CRM_Core_Error::fatal(ts("There was an error in your request"));
+      throw new CRM_Core_Exception(ts("There was an error in your request"));
     }
 
     $cancel = CRM_Utils_Request::retrieve("_qf_{$this->_type}_cancel", 'String', CRM_Core_DAO::$_nullObject,

--- a/CRM/Mailing/Page/Confirm.php
+++ b/CRM/Mailing/Page/Confirm.php
@@ -47,7 +47,7 @@ class CRM_Mailing_Page_Confirm extends CRM_Core_Page {
       !$subscribe_id ||
       !$hash
     ) {
-      CRM_Core_Error::fatal(ts("Missing input parameters"));
+      throw new CRM_Core_Exception(ts("Missing input parameters"));
     }
 
     $result = CRM_Mailing_Event_BAO_Confirm::confirm($contact_id, $subscribe_id, $hash);

--- a/CRM/Mailing/Page/Event.php
+++ b/CRM/Mailing/Page/Event.php
@@ -78,7 +78,7 @@ class CRM_Mailing_Page_Event extends CRM_Core_Page {
     elseif ($context == 'angPage') {
       $angPage = CRM_Utils_Request::retrieve('angPage', 'String', $this);
       if (!preg_match(':^[a-zA-Z0-9\-_/]+$:', $angPage)) {
-        CRM_Core_Error::fatal('Malformed return URL');
+        throw new CRM_Core_Exception('Malformed return URL');
       }
       $backUrl = CRM_Utils_System::url('civicrm/a/#/' . $angPage);
       $backUrlTitle = ts('Back to Report');


### PR DESCRIPTION
Overview
----------------------------------------
This converts some more usages of CRM_Core_Error::fatal to relevant Exception throwing or statusBounce calling

Before
----------------------------------------
Deprecated CRM_Core_Error::fatal is used

After
----------------------------------------
Modern Error handling methods are used

ping @eileenmcnaughton @mattwire @totten 
