### PR TITLE
[REF] Remove CRM_Exception in favour of CRM_Core_Exception

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1858,7 +1858,7 @@ SELECT contact_id
   /**
    * Drop all CiviCRM tables.
    *
-   * @throws \CRM_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function dropAllTables() {
 

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -40,34 +40,6 @@ require_once 'CRM/Core/Exception.php';
 require_once 'Log.php';
 
 /**
- * Class CRM_Exception
- */
-class CRM_Exception extends PEAR_Exception {
-
-  /**
-   * Redefine the exception so message isn't optional.
-   *
-   * Supported signatures:
-   *  - PEAR_Exception(string $message);
-   *  - PEAR_Exception(string $message, int $code);
-   *  - PEAR_Exception(string $message, Exception $cause);
-   *  - PEAR_Exception(string $message, Exception $cause, int $code);
-   *  - PEAR_Exception(string $message, PEAR_Error $cause);
-   *  - PEAR_Exception(string $message, PEAR_Error $cause, int $code);
-   *  - PEAR_Exception(string $message, array $causes);
-   *  - PEAR_Exception(string $message, array $causes, int $code);
-   *
-   * @param string $message exception message
-   * @param int $code
-   * @param Exception $previous
-   */
-  public function __construct($message = NULL, $code = 0, Exception $previous = NULL) {
-    parent::__construct($message, $code, $previous);
-  }
-
-}
-
-/**
  * Class CRM_Core_Error
  */
 class CRM_Core_Error extends PEAR_ErrorStack {

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -320,7 +320,7 @@ class CRM_Utils_File {
     if (FALSE === file_get_contents($fileName)) {
       // Our file cannot be found.
       // Using 'die' here breaks this on extension upgrade.
-      throw new CRM_Exception('Could not find the SQL file.');
+      throw new CRM_Core_Exception('Could not find the SQL file.');
     }
 
     self::runSqlQuery($dsn, file_get_contents($fileName), $prefix, $dieOnErrors);

--- a/tests/phpunit/api/v3/APITest.php
+++ b/tests/phpunit/api/v3/APITest.php
@@ -143,7 +143,7 @@ class api_v3_APITest extends CiviUnitTestCase {
     try {
       $result = civicrm_api3('contact', 'get', []);
     }
-    catch (CRM_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $this->fail("This should have been a success test");
     }
     $this->assertTrue(is_array($result));


### PR DESCRIPTION
Overview
----------------------------------------
This removes the CRM_Exception class and references to it in favour of CRM_Core_Exception which should be available no matter what due to the require_once in L38 of the CRM/Core/Error.php

Before
----------------------------------------
Odball exception code around

After
----------------------------------------
odball code gone

ping @eileenmcnaughton @colemanw @totten 