### PR TITLE
[REF] Remove usage of CRM_ACL_BAO_Cache::deleteEntry in favour of usi…

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -181,4 +181,13 @@ WHERE  modified_date IS NULL
     }
   }
 
+  /**
+   * Remove Entries from `civicrm_acl_contact_cache` for a specific ACLed user
+   * @param int $userID - contact_id of the ACLed user
+   *
+   */
+  public static function deleteContactCacheEntry($userID) {
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_acl_contact_cache WHERE user_id = %1", [1 => [$userID, 'Positive']]);
+  }
+
 }

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -287,9 +287,9 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     // If ACL applies to the current user, update cache before running the import.
     if (!CRM_Core_Permission::check('view all contacts')) {
-      $session = CRM_Core_Session::singleton();
-      $userID = $session->get('userID');
-      CRM_ACL_BAO_Cache::updateEntry($userID);
+      $userID = CRM_Core_Session::getLoggedInContactID();
+      CRM_ACL_BAO_Cache::deleteEntry($userID);
+      CRM_ACL_BAO_Cache::deleteContactCacheEntry($userID);
     }
 
     CRM_Utils_Address_USPS::disable($this->_disableUSPS);


### PR DESCRIPTION
…ng functions that just delete from the ACL caches

Overview
----------------------------------------
This removes the one and only usage of the function CRM_ACL_BAO_Cache::deleteEntry in favour of specific functions to delete rows relating to the logged in user from `CRM_ACL_Cache` and `CRM_ACL_Contact_Cache` 

Before
----------------------------------------
Function used to clear and build cache at the same time

After
----------------------------------------
Functions used only clear cache, caches will be built as needed

ping @mattwire @eileenmcnaughton