### PR TITLE
Remove deprecatedCode

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5243,12 +5243,6 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
       // erm, yes because? but, hey, it's tested.
       return $lineItemDetails['line_total'];
     }
-    elseif (empty($lineItemDetails['line_total'])) {
-      // follow legacy code path
-      Civi::log()
-        ->warning('Deprecated bit of code, please log a ticket explaining how you got here!', ['civi.tag' => 'deprecated']);
-      return $params['total_amount'];
-    }
     else {
       return self::getMultiplier($params['contribution']->contribution_status_id, $context) * ((float) $lineItemDetails['line_total']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
This was deprecated in 2007 so it can go now

Before
----------------------------------------
Lines exist but would trigger a notice if ever hit on a dev site & this has been the case since 2007

After
----------------------------------------
Lines gone

Technical Details
----------------------------------------
<img width="848" alt="Screen Shot 2019-10-26 at 12 18 49 PM" src="https://user-images.githubusercontent.com/336308/67609785-10a2f100-f7eb-11e9-85a8-dc627f62cca9.png">


Comments
----------------------------------------

