### PR TITLE
dev/core#561 Convert Case date fields on search forms from jcalendar …

### DIFF
--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -260,6 +260,11 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
    * @param CRM_Contact_BAO_Query $query
    */
   public static function whereClauseSingle(&$values, &$query) {
+    if ($query->buildDateRangeQuery($values)) {
+      // @todo - move this to Contact_Query in or near the call to
+      // $this->buildRelativeDateQuery($values);
+      return;
+    }
     list($name, $op, $value, $grouping, $wildcard) = $values;
     $val = $names = [];
     switch ($name) {
@@ -718,12 +723,6 @@ case_relation_type.id = case_relationship.relationship_type_id )";
     $form->addSearchFieldMetadata(['Case' => self::getSearchFieldMetadata()]);
     $form->addFormFieldsFromMetadata();
 
-    CRM_Core_Form_Date::buildDateRange($form, 'case_from', 1, '_start_date_low', '_start_date_high', ts('From'), FALSE);
-    CRM_Core_Form_Date::buildDateRange($form, 'case_to', 1, '_end_date_low', '_end_date_high', ts('From'), FALSE);
-    $form->addElement('hidden', 'case_from_start_date_range_error');
-    $form->addElement('hidden', 'case_to_end_date_range_error');
-    $form->addFormRule(['CRM_Case_BAO_Query', 'formRule'], $form);
-
     $form->assign('validCiviCase', TRUE);
 
     //give options when all cases are accessible.
@@ -750,28 +749,6 @@ case_relation_type.id = case_relationship.relationship_type_id )";
     self::addCustomFormFields($form, ['Case']);
 
     $form->setDefaults(['case_owner' => 1]);
-  }
-
-  /**
-   * Custom form rules.
-   *
-   * @param array $fields
-   * @param array $files
-   * @param CRM_Core_Form $form
-   *
-   * @return bool|array
-   */
-  public static function formRule($fields, $files, $form) {
-    $errors = [];
-
-    if ((empty($fields['case_from_start_date_low']) || empty($fields['case_from_start_date_high'])) && (empty($fields['case_to_end_date_low']) || empty($fields['case_to_end_date_high']))) {
-      return TRUE;
-    }
-
-    CRM_Utils_Rule::validDateRange($fields, 'case_from_start_date', $errors, ts('Case Start Date'));
-    CRM_Utils_Rule::validDateRange($fields, 'case_to_end_date', $errors, ts('Case End Date'));
-
-    return empty($errors) ? TRUE : $errors;
   }
 
 }

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -100,8 +100,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->loadFormValues();
 
     if ($this->_force) {
-      $this->postProcess();
-      $this->set('force', 0);
+      $this->handleForcedSearch();
     }
 
     $sortID = NULL;
@@ -213,7 +212,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->_done = TRUE;
     $this->setFormValues();
     $this->fixFormValues();
-
     if (isset($this->_ssID) && empty($_POST)) {
       // if we are editing / running a saved search and the form has not been posted
       $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
@@ -383,13 +381,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
         $this->_defaults['case_owner'] = $caseOwner;
       }
     }
-  }
-
-  /**
-   * @return null
-   */
-  public function getFormValues() {
-    return NULL;
   }
 
   /**

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1595,6 +1595,8 @@ class CRM_Contact_BAO_Query {
       'membership_join_date_relative',
       'membership_start_date_relative',
       'membership_end_date_relative',
+      'case_start_date_relative',
+      'case_end_date_relative',
     ];
     // Handle relative dates first
     foreach (array_keys($formValues) as $id) {

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -68,6 +68,8 @@ class CRM_Upgrade_Incremental_SmartGroups {
       'pledge_create_date' => 'pledge_create',
       'pledge_end_date' => 'pledge_end',
       'pledge_start_date' => 'pledge_start',
+      'case_start_date' => 'case_from',
+      'case_end_date' => 'case_to',
     ];
 
     foreach ($fields as $field) {

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -95,6 +95,22 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
     }
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add "Template" contribution status', 'templateStatus');
+    $this->addTask('Update smart groups to rename filters on case_from and case_to to case_start_date and case_end_date', 'updateSmartGroups', [
+      'renameField' => [
+        ['old' => 'case_from_relative', 'new' => 'case_start_date_relative'],
+        ['old' => 'case_from_start_date_high', 'new' => 'case_start_date_high'],
+        ['old' => 'case_from_start_date_low', 'new' => 'case_start_date_low'],
+        ['old' => 'case_to_relative', 'new' => 'case_end_date_relative'],
+        ['old' => 'case_to_end_date_high', 'new' => 'case_end_date_high'],
+        ['old' => 'case_to_end_date_low', 'new' => 'case_end_date_low'],
+      ],
+    ]);
+    $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
+      'datepickerConversion' => [
+        'case_start_date',
+        'case_end_date',
+      ],
+    ]);
   }
 
   public static function templateStatus(CRM_Queue_TaskContext $ctx) {

--- a/templates/CRM/Case/Form/Search/Common.tpl
+++ b/templates/CRM/Case/Form/Search/Common.tpl
@@ -38,16 +38,10 @@
   </tr>
 
   <tr>
-    <td>
-      <label>{ts}Case Start Date{/ts}</label>
-    </td>
-    {include file="CRM/Core/DateRange.tpl" fieldName="case_from" from='_start_date_low' to='_start_date_high'}
+    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="case_start_date"}
   </tr>
   <tr>
-    <td>
-      <label>{ts}Case End Date{/ts}</label>
-    </td>
-    {include file="CRM/Core/DateRange.tpl" fieldName="case_to" from='_end_date_low' to='_end_date_high'}
+    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="case_end_date"}
   </tr>
 
   <tr id='case_search_form'>


### PR DESCRIPTION
…to datepicker

Overview
----------------------------------------
This converts the case start and case end date search fields from using the jcalendar to using datepicker

Before
----------------------------------------
Jcalendar is used for these fields

After
----------------------------------------
datepicker is used

https://lab.civicrm.org/dev/core/issues/561

ping @eileenmcnaughton @monishdeb @colemanw 