### PR TITLE
Api4 explorer: Fix variable leaking to global scope

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -658,7 +658,7 @@
 
         function makeWidget(field, op) {
           var $el = $(element),
-            inputType = field.input_type;
+            inputType = field.input_type,
             dataType = field.data_type;
           if (!op) {
             op = field.serialize || dataType === 'Array' ? 'IN' : '=';


### PR DESCRIPTION
Overview
----------------------------------------
Ensure a js var is declared locally instead of globally.

Before
----------------------------------------
Accidental global var

After
----------------------------------------
Local var

Technical Details
----------------------------------------
Sometimes you type a semicolon when you meant to type a comma.