### PR TITLE
dev/financial#2 Support payment processor title if configured on Contribution & Event Pages

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -35,7 +35,6 @@
  * form to process actions on the group aspect of Custom Data
  */
 class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_ContributionBase {
-  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * The id of the contact associated with this contribution.

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -335,15 +335,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->addElement('hidden', "email-{$this->_bltID}", 1);
       $this->add('text', 'total_amount', ts('Total Amount'), ['readonly' => TRUE], FALSE);
     }
-    $pps = [];
-    if (!empty($this->_paymentProcessors)) {
-      foreach ($this->_paymentProcessors as $key => $name) {
-        $pps[$key] = $name['name'];
-      }
-    }
-    if (!empty($this->_values['is_pay_later'])) {
-      $pps[0] = $this->_values['pay_later_text'];
-    }
+    $pps = $this->getProcessors();
 
     if (count($pps) > 1) {
       $this->addRadio('payment_processor_id', ts('Payment Method'), $pps,
@@ -356,7 +348,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->addElement('hidden', 'payment_processor_id', $key);
       if ($key === 0) {
         $this->assign('is_pay_later', $this->_values['is_pay_later']);
-        $this->assign('pay_later_text', $this->_values['pay_later_text']);
+        $this->assign('pay_later_text', $this->getPayLaterLabel());
       }
     }
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -344,6 +344,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           $this->_values['is_pay_later'] = FALSE;
         }
       }
+      if ($isPayLater) {
+        $this->setPayLaterLabel($this->_values['pay_later_text']);
+      }
 
       if ($isMonetary) {
         $this->_paymentProcessorIDs = array_filter(explode(

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -35,6 +35,7 @@
  * This class generates form components for processing a contribution.
  */
 class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
+  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * The id of the contribution page that we are processing.

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -308,6 +308,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $this->_values['event']['participant_role'] = $participant_role["{$this->_values['event']['default_role_id']}"];
       }
       $isPayLater = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_eventId, 'is_pay_later');
+      $this->setPayLaterLabel($isPayLater ? $this->_values['event']['pay_later_text'] : '');
       //check for various combinations for paylater, payment
       //process with paid event.
       if ($isMonetary && (!$isPayLater || !empty($this->_values['event']['payment_processor']))) {
@@ -315,7 +316,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
           $this->_values['event']
         ));
         $this->assignPaymentProcessor($isPayLater);
-
       }
       //init event fee.
       self::initEventFee($this, $this->_eventId);
@@ -503,7 +503,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $params['is_pay_later'] = CRM_Utils_Array::value('is_pay_later', $params, FALSE);
     $this->assign('is_pay_later', $params['is_pay_later']);
     if ($params['is_pay_later']) {
-      $this->assign('pay_later_text', $this->_values['event']['pay_later_text']);
+      $this->assign('pay_later_text', $this->getPayLaterLabel());
       $this->assign('pay_later_receipt', $this->_values['event']['pay_later_receipt']);
     }
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -34,6 +34,7 @@
  * This class generates form components for processing Event.
  */
 class CRM_Event_Form_Registration extends CRM_Core_Form {
+  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * How many locationBlocks should we display?

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -34,7 +34,6 @@
  * This class generates form components for processing Event.
  */
 class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
-  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * The values for the contribution db object.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -410,23 +410,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       self::buildAmount($this);
     }
 
-    $pps = [];
-    //@todo this could call the function on FrontEndPaymentTrait which also respects the payment processor
-    // title if configured. From my testing we don't need the 'if' around adding payment processor 0
-    // (below) - if someone else tests & confirms we can remove it, use the FrontEndPaymentTrait
-    // like the contribution page does & use the getPaymentLabel (provided we also set it)
-    // and we will get the title, if configured.
-    if (!empty($this->_paymentProcessors)) {
-      foreach ($this->_paymentProcessors as $key => $name) {
-        $pps[$key] = $name['name'];
-      }
-    }
-    // see @todo above
-    if (!empty($this->_values['event']['is_pay_later']) &&
-      ($this->_allowConfirmation || (!$this->_requireApproval && !$this->_allowWaitlist))
-    ) {
-      $pps[0] = $this->_values['event']['pay_later_text'];
-    }
+    $pps = $this->getProcessors();
     if ($this->getContactID() === 0 && !$this->_values['event']['is_multiple_registrations']) {
       //@todo we are blocking for multiple registrations because we haven't tested
       $this->addCIDZeroOptions();

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -411,21 +411,25 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
 
     $pps = [];
-    //@todo this processor adding fn is another one duplicated on contribute - a shared
-    // common class would make this sort of thing extractable
+    //@todo this could call the function on FrontEndPaymentTrait which also respects the payment processor
+    // title if configured. From my testing we don't need the 'if' around adding payment processor 0
+    // (below) - if someone else tests & confirms we can remove it, use the FrontEndPaymentTrait
+    // like the contribution page does & use the getPaymentLabel (provided we also set it)
+    // and we will get the title, if configured.
     if (!empty($this->_paymentProcessors)) {
       foreach ($this->_paymentProcessors as $key => $name) {
         $pps[$key] = $name['name'];
       }
     }
-    if ($this->getContactID() === 0 && !$this->_values['event']['is_multiple_registrations']) {
-      //@todo we are blocking for multiple registrations because we haven't tested
-      $this->addCIDZeroOptions();
-    }
+    // see @todo above
     if (!empty($this->_values['event']['is_pay_later']) &&
       ($this->_allowConfirmation || (!$this->_requireApproval && !$this->_allowWaitlist))
     ) {
       $pps[0] = $this->_values['event']['pay_later_text'];
+    }
+    if ($this->getContactID() === 0 && !$this->_values['event']['is_multiple_registrations']) {
+      //@todo we are blocking for multiple registrations because we haven't tested
+      $this->addCIDZeroOptions();
     }
 
     if ($this->_values['event']['is_monetary']) {

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -39,7 +39,6 @@
  *
  */
 class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
-  use CRM_Financial_Form_FrontEndPaymentFormTrait;
 
   /**
    * Set variables up before form is built.

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -37,6 +37,31 @@
 trait CRM_Financial_Form_FrontEndPaymentFormTrait {
 
   /**
+   * The label for the pay later pseudoprocessor option.
+   *
+   * @var string
+   */
+  protected $payLaterLabel;
+
+  /**
+   * @return string
+   */
+  public function getPayLaterLabel(): string {
+    if ($this->payLaterLabel) {
+      return $this->payLaterLabel;
+    }
+    return $this->get('payLaterLabel') ?? '';
+  }
+
+  /**
+   * @param string $payLaterLabel
+   */
+  public function setPayLaterLabel(string $payLaterLabel) {
+    $this->set('payLaterLabel', $payLaterLabel);
+    $this->payLaterLabel = $payLaterLabel;
+  }
+
+  /**
    * Alter line items for template.
    *
    * This is an early cut of what will ideally eventually be a hooklike call to the
@@ -77,6 +102,24 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     // @todo this should be a hook that invoicing code hooks into rather than a call to it.
     $this->alterLineItemsForTemplate($tplLineItems);
     $this->assign('lineItem', $tplLineItems);
+  }
+
+  /**
+   * Get the configured processors, including the pay later processor.
+   *
+   * @return array
+   */
+  protected function getProcessors(): array {
+    $pps = [];
+    if (!empty($this->_paymentProcessors)) {
+      foreach ($this->_paymentProcessors as $key => $processor) {
+        $pps[$key] = $processor['title'] ?? $processor['name'];
+      }
+    }
+    if ($this->getPayLaterLabel()) {
+      $pps[0] = $this->getPayLaterLabel();
+    }
+    return $pps;
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1315,6 +1315,9 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
 
   /**
    * Check payment processor is correctly assigned for a contribution page.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CRM_Contribute_Exception_InactiveContributionPageException
    */
   public function testContributionBasePreProcess() {
     //Create contribution page with only pay later enabled.
@@ -1324,6 +1327,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
       'currency' => 'NZD',
       'goal_amount' => 100,
       'is_pay_later' => 1,
+      'pay_later_text' => 'Send check',
       'is_monetary' => TRUE,
       'is_active' => TRUE,
       'is_email_receipt' => TRUE,

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -68,6 +68,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'currency' => 'NZD',
       'goal_amount' => $this->testAmount,
       'is_pay_later' => 1,
+      'pay_later_text' => 'Send check',
       'is_monetary' => TRUE,
       'is_email_receipt' => TRUE,
       'receipt_from_email' => 'yourconscience@donate.com',
@@ -1932,6 +1933,8 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
 
   /**
    * Test validating a contribution page submit.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testValidate() {
     $this->setUpContributionPage();


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/financial/issues/2 we agreed & added a 'title' field to the
civicrm_payment_processor table some time ago for exposure on front end forms.
    
We haven't actually done this, or made it UI configurable.
    
This fixes that for contribution pages &  events pages.
    
Once done we should add to the edit payment processor form


Before
----------------------------------------
The 'name' always shows

After
----------------------------------------
Where I have populated the 'title' field in the DB for a processor it shows instead on the ContributionPage form & Event form

<img width="627" alt="Screen Shot 2019-10-26 at 5 03 42 PM" src="https://user-images.githubusercontent.com/336308/67614069-971ef900-f812-11e9-9bb4-b38980cf4b63.png">

Technical Details
----------------------------------------
I moved the sharing of the frontend payment trait to the shared class for each flow & set up all the functions on that class to do for both event & contribution page.

Comments
----------------------------------------

