### PR TITLE
Ensure that using case_start_date_high and case_start_date_low etc in…

### DIFF
--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -392,4 +392,13 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     return ts('Find Cases');
   }
 
+  /**
+   * Set the metadata for the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function setSearchMetadata() {
+    $this->addSearchFieldMetadata(['Case' => CRM_Case_BAO_Query::getSearchFieldMetadata()]);
+  }
+
 }


### PR DESCRIPTION
… url variables works in force=1 mode

Overview
----------------------------------------
Date fields work as expected in force=1 mode on case search

Before
----------------------------------------
Passing date related variables in the URL will only cause the form to be filled out not to be included in the search query as well in force =1 

After
----------------------------------------
Included in the search query as well

ping @eileenmcnaughton @demeritcowboy @monishdeb 