### PR TITLE
Fix test setup Function to use order api

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -196,6 +196,8 @@ class CRM_Financial_BAO_Payment {
    * @param array $params
    *
    * @return array
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function sendConfirmation($params) {
 

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -97,10 +97,12 @@ class api_v3_OrderTest extends CiviUnitTestCase {
 
   /**
    * Test Get Order api for participant contribution.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetOrderParticipant() {
     $this->addOrder(FALSE, 100);
-    list($items, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
 
     $params = [
       'contribution_id' => $contribution['id'],
@@ -108,7 +110,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
 
     $order = $this->callAPISuccess('Order', 'get', $params);
 
-    $this->assertEquals(2, count($order['values'][$contribution['id']]['line_items']));
+    $this->assertCount(2, $order['values'][$contribution['id']]['line_items']);
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -158,7 +158,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    */
   public function testPaymentEmailReceipt() {
     $mut = new CiviMailUtils($this);
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
     $event = $this->callAPISuccess('Event', 'get', []);
     $this->addLocationToEvent($event['id']);
     $params = [
@@ -206,7 +206,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   public function testPaymentEmailReceiptFullyPaid() {
     $mut = new CiviMailUtils($this);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviContribute', 'edit contributions', 'access CiviCRM'];
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
 
     $params = [
       'contribution_id' => $contribution['id'],
@@ -242,7 +242,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->setCurrencySeparators($thousandSeparator);
     $decimalSeparator = ($thousandSeparator === ',' ? '.' : ',');
     $mut = new CiviMailUtils($this);
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
     $this->callAPISuccess('payment', 'create', [
       'contribution_id' => $contribution['id'],
       'total_amount' => 50,
@@ -286,9 +286,11 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   /**
    * Test create payment api with no line item in params
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreatePaymentNoLineItems() {
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
 
     //Create partial payment
     $params = [
@@ -385,7 +387,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    * Test create payment api with line item in params
    */
   public function testCreatePaymentLineItems() {
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
     $lineItems = $this->callAPISuccess('LineItem', 'get', ['contribution_id' => $contribution['id']]);
 
     //Create partial payment by passing line item array is params
@@ -480,7 +482,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    */
   public function testCancelPayment() {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute'];
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
 
     $params = [
       'contribution_id' => $contribution['id'],
@@ -516,7 +518,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    */
   public function testDeletePayment() {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute'];
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
 
     $params = [
       'contribution_id' => $contribution['id'],
@@ -568,7 +570,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    */
   public function testUpdatePayment() {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute', 'edit contributions'];
-    list($lineItems, $contribution) = $this->createParticipantWithContribution();
+    $contribution = $this->createParticipantWithContribution();
 
     //Create partial payment by passing line item array is params
     $params = [


### PR DESCRIPTION
Overview
----------------------------------------
Test clean-up - user Order.create api to set up for tests

Before
----------------------------------------
Old methodology used

After
----------------------------------------
Preferred order api methodology used

Technical Details
----------------------------------------
After ongoing issues resolving https://github.com/civicrm/civicrm-core/pull/14763 I have concluded the underlying
issue on the failing tests is the test setup. Specifically the use of 'partial_amount_to_pay' does not
create the correct underlying entities - it 'sort of' creates a payment without linking it to
the financial items.

These parameters are part of our first attempt at partial payments. I am removing them from the test here but
will deprecate later from other places in the code

Comments
----------------------------------------

