### PR TITLE
Cast result of getContributionBalance to float to match comment block.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4166,7 +4166,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $contributionTotal = CRM_Price_BAO_LineItem::getLineTotal($contributionId);
     }
 
-    return CRM_Utils_Money::subtractCurrencies(
+    return (float) CRM_Utils_Money::subtractCurrencies(
       $contributionTotal,
       CRM_Core_BAO_FinancialTrxn::getTotalPayments($contributionId, TRUE) ?: 0,
       CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency')


### PR DESCRIPTION
Overview
----------------------------------------
Fix CRM_Contribute_BAO_Contribution::getContributionBalance to always return a float per the comment block

Before
----------------------------------------
could be null

After
----------------------------------------
will be a float - 0 for null

Technical Details
----------------------------------------
Without this it is possible for it to return 'null' which is not useful / in keeping. I did a bit of an audit & did not find places where this would cause an === comparison to fail

Comments
----------------------------------------

