### PR TITLE
Change test to use preferred methods, fix revealed money bug

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -349,6 +349,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->processCreditCard();
     }
 
+    // @todo we should clean $ on the form & pass in skipCleanMoney
     $trxnsData = $this->_params;
     if ($this->_paymentType == 'refund') {
       $trxnsData['total_amount'] = -$trxnsData['total_amount'];

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -137,6 +137,13 @@ function civicrm_api3_payment_cancel($params) {
  * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_payment_create($params) {
+  if (empty($params['skipCleanMoney'])) {
+    foreach (['total_amount', 'net_amount', 'fee_amount'] as $field) {
+      if (isset($params[$field])) {
+        $params[$field] = CRM_Utils_Rule::cleanMoney($params[$field]);
+      }
+    }
+  }
   // Check if it is an update
   if (!empty($params['id'])) {
     $amount = $params['total_amount'];

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1168,6 +1168,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
   /**
    * Test recording of amount with comma separator.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCommaSeparatorAmount() {
     $contactId = $this->individualCreate();
@@ -1176,16 +1178,15 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'contact_id' => $contactId,
       'currency' => 'USD',
       'financial_type_id' => 1,
-      'contribution_status_id' => 8,
+      'contribution_status_id' => 'Pending',
       'payment_instrument_id' => 1,
       'receive_date' => '20080522000000',
       'receipt_date' => '20080522000000',
-      'total_amount' => '20000.00',
-      'partial_payment_total' => '20,000.00',
-      'partial_amount_to_pay' => '8,000.00',
+      'total_amount' => '20,000.00',
+      'api.Payment.create' => ['total_amount' => '8,000.00'],
     ];
 
-    $contribution = $this->callAPISuccess('Contribution', 'create', $params);
+    $contribution = $this->callAPISuccess('Order', 'create', $params);
     $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');
     $financialTrxn = $this->callAPISuccessGetSingle(
       'FinancialTrxn',
@@ -1194,7 +1195,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
         'return' => ['total_amount'],
       ]
     );
-    $this->assertEquals($financialTrxn['total_amount'], 8000, 'Invalid Tax amount.');
+    $this->assertEquals($financialTrxn['total_amount'], 8000, 'Invalid amount.');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Switches to preferred function calls, fixes revealed money cleaning bug

Before
----------------------------------------
Calling Payment.create with total_amount => '2,000.00' fails

After
----------------------------------------
Calling Payment.create with total_amount => '2,000.00' works in the same way as Contribution.create

Technical Details
----------------------------------------
In switching this test over I found that Payment.create does not handle cleaning money - which it should to bring it
into line with Contribution.create api

Comments
----------------------------------------

