### PR TITLE
dev/core#560 [REF] Throw exceptions for invalid type errors when aborting

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1550,7 +1550,7 @@ FROM   civicrm_domain
           $tr['%' . $key] = $item[0];
         }
         elseif ($abort) {
-          CRM_Core_Error::fatal("{$item[0]} is not of type {$item[1]}");
+          throw new CRM_Core_Exception("{$item[0]} is not of type {$item[1]}");
         }
       }
     }

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -376,7 +376,7 @@ class CRM_Utils_Type {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function validate($data, $type, $abort = TRUE, $name = 'One of parameters ', $isThrowException = FALSE) {
+  public static function validate($data, $type, $abort = TRUE, $name = 'One of parameters ', $isThrowException = TRUE) {
 
     $possibleTypes = [
       'Integer',

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -898,7 +898,7 @@ civicrm_relationship.is_active = 1 AND
     }
     catch (Exception $e) {
       $this->assertEquals(
-        "A fatal error was triggered: One of parameters  (value: foo@example.com) is not of the type Positive",
+        "One of parameters  (value: foo@example.com) is not of the type Positive",
         $e->getMessage()
       );
       $this->assertTrue(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Throw an exception if we are aborting for Type of param error

Before
----------------------------------------
Deprecated CRM_Core_Error::fatal triggered

After
----------------------------------------
Exception is triggered

https://lab.civicrm.org/dev/core/issues/560

ping @eileenmcnaughton 
