### PR TITLE
Implement PaymentProcessor and PaymentProcessorType APIv4 Entities

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.23.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.23.alpha1.mysql.tpl
@@ -1,1 +1,11 @@
 {* file to handle db changes in 5.23.alpha1 during upgrade *}
+UPDATE civicrm_payment_processor SET is_default = 0 WHERE is_default IS NULL;
+UPDATE civicrm_payment_processor SET is_active = 1 WHERE is_active IS NULL;
+UPDATE civicrm_payment_processor SET is_test = 0 WHERE is_test IS NULL;
+UPDATE civicrm_payment_processor_type SET is_active = 1 WHERE is_active IS NULL;
+UPDATE civicrm_payment_processor_type SET is_default = 0 WHERE is_default IS NULL;
+ALTER TABLE civicrm_payment_processor ALTER COLUMN is_default SET DEFAULT 0;
+ALTER TABLE civicrm_payment_processor ALTER COLUMN is_active SET DEFAULT 1;
+ALTER TABLE civicrm_payment_processor ALTER COLUMN is_test SET DEFAULT 0;
+ALTER TABLE civicrm_payment_processor_type ALTER COLUMN is_active SET DEFAULT 1;
+ALTER TABLE civicrm_payment_processor_type ALTER COLUMN is_default SET DEFAULT 0;

--- a/Civi/Api4/PaymentProcessor.php
+++ b/Civi/Api4/PaymentProcessor.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4;
+
+/**
+ * Payment Processor entity.
+ *
+ * @package Civi\Api4
+ */
+class PaymentProcessor extends Generic\DAOEntity {
+
+}

--- a/Civi/Api4/PaymentProcessorType.php
+++ b/Civi/Api4/PaymentProcessorType.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4;
+
+/**
+ * Payment Processor Type entity.
+ *
+ * @package Civi\Api4
+ */
+class PaymentProcessorType extends Generic\DAOEntity {
+
+}

--- a/Civi/Api4/Service/Spec/Provider/PaymentProcessorCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/PaymentProcessorCreationSpecProvider.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class PaymentProcessorCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * This runs for both create and get actions
+   *
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('domain_id')->setRequired(FALSE)->setDefaultValue('current_domain');
+    // Billing mode is copied across from the payment processor type field in the BAO::create function.
+    $spec->getFieldByName('billing_mode')->setRequired(FALSE);
+
+    $financial_account_id = new FieldSpec('financial_account_id', 'PaymentProcessor', 'Integer');
+    $financial_account_id
+      ->setTitle('Financial Account ID')
+      ->setDescription('The financial account that this payment processor is linked to')
+      ->setRequired(FALSE)
+      ->setDefaultValue(\CRM_Financial_BAO_PaymentProcessor::getDefaultFinancialAccountID())
+      ->setFkEntity('FinancialAccount');
+    $spec->addFieldSpec($financial_account_id);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'PaymentProcessor' && in_array($action, ['create']);
+  }
+
+}

--- a/Civi/Api4/Service/Spec/Provider/PaymentProcessorTypeCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/PaymentProcessorTypeCreationSpecProvider.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2019
+ * $Id$
+ *
+ */
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class PaymentProcessorTypeCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * This runs for both create and get actions
+   *
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('payment_instrument_id')->setRequired(FALSE)->setDefaultValue(1);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'PaymentProcessorType' && in_array($action, ['create']);
+  }
+
+}

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -48,17 +48,21 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
 
   /**
    * Check create with no name specified.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorCreateWithoutName() {
+  public function testPaymentProcessorCreateWithoutName($version) {
+    $this->_apiversion = $version;
     $this->callAPIFailure('payment_processor', 'create', ['is_active' => 1]);
   }
 
   /**
    * Create payment processor.
+   * @dataProvider versionThreeAndFour
    *
    * @throws \CRM_Core_Exception
    */
-  public function testPaymentProcessorCreate() {
+  public function testPaymentProcessorCreate($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     $result = $this->callAPIAndDocument('payment_processor', 'create', $params, __FUNCTION__, __FILE__);
     $this->callAPISuccessGetSingle('EntityFinancialAccount', ['entity_table' => 'civicrm_payment_processor', 'entity_id' => $result['id']]);
@@ -77,10 +81,12 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
 
   /**
    * Update payment processor.
+   * @dataProvider versionThreeAndFour
    *
    * @throws \CRM_Core_Exception
    */
-  public function testPaymentProcessorUpdate() {
+  public function testPaymentProcessorUpdate($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     $params['payment_instrument_id'] = 1;
     $result = $this->callAPISuccess('payment_processor', 'create', $params);
@@ -108,6 +114,14 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
       'payment_instrument_id' => 1,
       'is_active' => 1,
     ];
+    if ($version === 4) {
+      // In APIv3 If a field is default NULL it is not returned.
+      foreach ($result['values'][$result['id']] as $field => $value) {
+        if (is_null($value)) {
+          unset($result['values'][$result['id']][$field]);
+        }
+      }
+    }
     $this->checkArrayEquals($expectedResult, $result['values'][$result['id']]);
   }
 
@@ -123,10 +137,12 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
 
   /**
    * Check payment processor delete.
+   * @dataProvider versionThreeAndFour
    *
    * @throws \CRM_Core_Exception
    */
-  public function testPaymentProcessorDelete() {
+  public function testPaymentProcessorDelete($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('payment_processor', 'create', $this->_params);
     $params = [
       'id' => $result['id'],
@@ -137,10 +153,12 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
 
   /**
    * Check with valid params array.
+   * @dataProvider versionThreeAndFour
    *
    * @throws \CRM_Core_Exception
    */
-  public function testPaymentProcessorsGet() {
+  public function testPaymentProcessorsGet($version) {
+    $this->_apiversion = $version;
     $params = $this->_params;
     $params['user_name'] = 'test@test.com';
     $this->callAPISuccess('payment_processor', 'create', $params);

--- a/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
@@ -16,13 +16,11 @@
  */
 class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
   protected $_ppTypeID;
-  protected $_apiversion;
 
   public function setUp() {
 
     parent::setUp();
     $this->useTransaction(TRUE);
-    $this->_apiversion = 3;
   }
 
   //  function tearDown() {
@@ -37,21 +35,23 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with no name.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeCreateWithoutName() {
+  public function testPaymentProcessorTypeCreateWithoutName($version) {
+    $this->_apiversion = $version;
     $payProcParams = [
       'is_active' => 1,
     ];
     $result = $this->callAPIFailure('payment_processor_type', 'create', $payProcParams);
-    $this->assertEquals($result['error_message'],
-      'Mandatory key(s) missing from params array: name, title, class_name, billing_mode'
-    );
+    $this->assertContains('name, title, class_name, billing_mode', $result['error_message']);
   }
 
   /**
    * Create payment processor type.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeCreate() {
+  public function testPaymentProcessorTypeCreate($version) {
+    $this->_apiversion = $version;
     $params = [
       'sequential' => 1,
       'name' => 'API_Test_PP',
@@ -84,16 +84,20 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with empty array.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeDeleteEmpty() {
+  public function testPaymentProcessorTypeDeleteEmpty($version) {
+    $this->_apiversion = $version;
     $params = [];
     $result = $this->callAPIFailure('payment_processor_type', 'delete', $params);
   }
 
   /**
    * Check if required fields are not passed.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeDeleteWithoutRequired() {
+  public function testPaymentProcessorTypeDeleteWithoutRequired($version) {
+    $this->_apiversion = $version;
     $params = [
       'name' => 'API_Test_PP',
       'title' => 'API Test Payment Processor',
@@ -101,20 +105,24 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
     ];
 
     $result = $this->callAPIFailure('payment_processor_type', 'delete', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: id');
+    $this->assertEquals(($version === 4 ? 'Parameter "where" is required.' : 'Mandatory key(s) missing from params array: id'), $result['error_message']);
   }
 
   /**
    * Check with incorrect required fields.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeDeleteWithIncorrectData() {
+  public function testPaymentProcessorTypeDeleteWithIncorrectData($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIFailure('payment_processor_type', 'delete', ['id' => 'abcd']);
   }
 
   /**
    * Check payment processor type delete.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeDelete() {
+  public function testPaymentProcessorTypeDelete($version) {
+    $this->_apiversion = $version;
     $payProcType = $this->paymentProcessorTypeCreate();
     $params = [
       'id' => $payProcType,
@@ -127,17 +135,21 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with empty array.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeUpdateEmpty() {
+  public function testPaymentProcessorTypeUpdateEmpty($version) {
+    $this->_apiversion = $version;
     $params = [];
     $result = $this->callAPIFailure('payment_processor_type', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: name, title, class_name, billing_mode');
+    $this->assertContains('name, title, class_name, billing_mode', $result['error_message']);
   }
 
   /**
    * Check with all parameters.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypeUpdate() {
+  public function testPaymentProcessorTypeUpdate($version) {
+    $this->_apiversion = $version;
     // create sample payment processor type.
     $this->_ppTypeID = $this->paymentProcessorTypeCreate(NULL);
 
@@ -161,8 +173,10 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with empty array.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypesGetEmptyParams() {
+  public function testPaymentProcessorTypesGetEmptyParams($version) {
+    $this->_apiversion = $version;
     $results = $this->callAPISuccess('payment_processor_type', 'get', []);
     $baselineCount = $results['count'];
 
@@ -192,8 +206,10 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
 
   /**
    * Check with valid params array.
+   * @dataProvider versionThreeAndFour
    */
-  public function testPaymentProcessorTypesGet() {
+  public function testPaymentProcessorTypesGet($version) {
+    $this->_apiversion = $version;
     $firstRelTypeParams = [
       'name' => 'API_Test_PP_11',
       'title' => 'API Test Payment Processor 11',


### PR DESCRIPTION
Overview
----------------------------------------
Adds PaymentProcesor and PaymentProcessorType entities to APIv4

Before
----------------------------------------
Entities don't exist in APIv4

After
----------------------------------------
Entities exist in APIv4

Technical Details
----------------------------------------
There are some changes to the DAO to set some defaults and also make it clearer some fields are required. This was done after consulting the create specs in the APIv3 versions of these Entities

ping @eileenmcnaughton @mattwire @colemanw 