### PR TITLE
Change parent class on mailing_form

### DIFF
--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -128,6 +128,21 @@ class CRM_Mailing_BAO_Query {
   }
 
   /**
+   * Get the metadata for fields to be included on the mailing search form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   *
+   * @todo ideally this would be a trait included on the mailing search & advanced search
+   * rather than a static function.
+   */
+  public static function getSearchFieldMetadata() {
+    $fields = [];
+    $metadata = civicrm_api3('Mailing', 'getfields', [])['values'];
+    $metadata = array_merge($metadata, civicrm_api3('MailingJob', 'getfields', [])['values']);
+    return array_intersect_key($metadata, array_flip($fields));
+  }
+
+  /**
    * @param $query
    */
   public static function where(&$query) {
@@ -395,10 +410,14 @@ class CRM_Mailing_BAO_Query {
   /**
    * Add all the elements shared between Mailing search and advnaced search.
    *
+   * @param \CRM_Mailing_Form_Search $form
    *
-   * @param CRM_Core_Form $form
+   * @throws \CiviCRM_API3_Exception
    */
   public static function buildSearchForm(&$form) {
+    $form->addSearchFieldMetadata(['Mailing' => self::getSearchFieldMetadata()]);
+    $form->addFormFieldsFromMetadata();
+
     // mailing selectors
     $mailings = CRM_Mailing_BAO_Mailing::getMailingsList();
 

--- a/CRM/Mailing/Form/Search.php
+++ b/CRM/Mailing/Form/Search.php
@@ -30,7 +30,16 @@
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2019
  */
-class CRM_Mailing_Form_Search extends CRM_Core_Form {
+class CRM_Mailing_Form_Search extends CRM_Core_Form_Search {
+
+  /**
+   * Get the default entity being queried.
+   *
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'Mailing';
+  }
 
   public function preProcess() {
     parent::preProcess();


### PR DESCRIPTION
Overview
----------------------------------------
Just changes the parent class to be more like the other search forms. Also adds the call to getSearchFieldMetadata but  at this stage it's not using it to add fields

Before
----------------------------------------
Extends CRM_Core_Form

After
----------------------------------------
Extends CRM_Core_Form_Search

Technical Details
----------------------------------------
From https://github.com/civicrm/civicrm-core/pull/15369/files

Comments
----------------------------------------
I did some tests & it seemed to change nothing = good
