### PR TITLE
Fix cancel payment action to reverse financial items related to cancelled payment

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -97,9 +97,11 @@ function civicrm_api3_payment_delete($params) {
  * @param array $params
  *   Input parameters.
  *
- * @throws API_Exception
  * @return array
  *   Api result array
+ *
+ * @throws \CiviCRM_API3_Exception
+ * @throws API_Exception
  */
 function civicrm_api3_payment_cancel($params) {
   $eftParams = [
@@ -112,6 +114,7 @@ function civicrm_api3_payment_cancel($params) {
     'total_amount' => -$entity['amount'],
     'contribution_id' => $entity['entity_id'],
     'trxn_date' => CRM_Utils_Array::value('trxn_date', $params, 'now'),
+    'cancelled_payment_id' => $params['id'],
   ];
 
   foreach (['trxn_id', 'payment_instrument_id'] as $permittedParam) {

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -620,10 +620,11 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'financial_trxn_id' => $payment['id'] - 1,
     ];
 
-    $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $minParams);
+    $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $minParams)['values'];
+    $this->assertCount(2, $eft);
     $amounts = [-33.33, -16.67];
 
-    foreach ($eft['values'] as $value) {
+    foreach ($eft as $value) {
       $this->assertEquals($value['amount'], array_pop($amounts));
     }
 
@@ -632,9 +633,9 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'entity_table' => 'civicrm_financial_item',
       'financial_trxn_id' => $payment['id'],
     ];
-    $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params);
+    $eft = $this->callAPISuccess('EntityFinancialTrxn', 'get', $params)['values'];
     $amounts = [66.67, 33.33];
-    foreach ($eft['values'] as $value) {
+    foreach ($eft as $value) {
       $this->assertEquals($value['amount'], array_pop($amounts));
     }
     $items = $this->callAPISuccess('FinancialItem', 'get', [])['values'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where the financial_entity_trxn entries associated with a cancelled payment were not being reversed as they should have been and the test was not picking it up due to a flaw in the test.

When a payment is cancelled the code will create a second negative payment financial_trxn that reverses the first payment. Associated with this should also be rows in civicrm_entity_financial_trxn that reverse the rows in that table associated with the first payment

Before
----------------------------------------
Reversal rows not created for the reversal payment - ie. reverse a payment with

```
civicrm_api3('Payment', 'cancel', ['id' => xx])
```
where xx is the id in the civicrm_financial_trxn table for the given payment. No new entries will be created in civicrm_financial_trxn


After
----------------------------------------
Reversal rows create - ie one negative row against the new payment transaction in civicrm_entity_financial_trxn for each row against the old one

Technical Details
----------------------------------------

The unit test to test & ensure this was failing to pick up that the records were not being created because it iterated
through the created rows & checked they were right but there was no check to ensure the rows were created :-(

This still leaves a gap I think for refunds not tied to a specific payment but that can be a later step

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
