### PR TITLE
[REF] Further deconstruction of updateFinancialAccounts

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3691,7 +3691,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $params['prevContribution']->contribution_status_id != $params['contribution']->contribution_status_id
         ) {
           //Update Financial Records
-          self::updateFinancialAccounts($params, 'changedStatus');
+          $callUpdateFinancialAccounts = self::updateFinancialAccountsOnContributionStatusChange($params);
+          if ($callUpdateFinancialAccounts) {
+            self::updateFinancialAccounts($params, 'changedStatus');
+          }
           $updated = TRUE;
         }
 
@@ -3807,14 +3810,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $trxnID = NULL;
     $inputParams = $params;
     $isARefund = self::isContributionUpdateARefund($params['prevContribution']->contribution_status_id, $params['contribution']->contribution_status_id);
-
-    if ($context == 'changedStatus') {
-      $continue = self::updateFinancialAccountsOnContributionStatusChange($params);
-      // @todo - it may be that this is always false & the parent function is just a confusing wrapper for the child fn.
-      if (!$continue) {
-        return;
-      }
-    }
 
     if ($context == 'changedAmount' || $context == 'changeFinancialType') {
       // @todo we should stop passing $params by reference - splitting this out would be a step towards that.


### PR DESCRIPTION
Overview
----------------------------------------
Further incremental code cleanup step in updateFinancialAccounts

Before
----------------------------------------
non-generic code in generic function

After
----------------------------------------
non generic code in  the bit of function it relates to

Technical Details
----------------------------------------
updateFinancialAccounts is only called from one place with the context of 'changedStatus'. When called this
way the function updateFinancialAccountsOnContributionStatusChange is called & that 'tells'
the calling function whether to call the rest of this function.

Since this handling is specific to one place from which the function is called we can move that logic
back to the place that calls it & further simplify the updateFinancialAccounts function
which has been a bit of a haven of chaos

Comments
----------------------------------------
