### PR TITLE
dev/core#561 Convert mailing date search field to using datepicker

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1597,6 +1597,7 @@ class CRM_Contact_BAO_Query {
       'membership_end_date_relative',
       'case_start_date_relative',
       'case_end_date_relative',
+      'mailing_job_start_date_relative',
     ];
     // Handle relative dates first
     foreach (array_keys($formValues) as $id) {

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -402,7 +402,6 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
       'log_date_relative',
       'birth_date_relative',
       'deceased_date_relative',
-      'mailing_date_relative',
       'relation_date_relative',
       'relation_start_date_relative',
       'relation_end_date_relative',

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -652,6 +652,9 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'mailing_unsubscribe',
           'mailing_date_low',
           'mailing_date_high',
+          'mailing_job_start_date_low',
+          'mailing_job_start_date_high',
+          'mailing_job_start_date_relative',
         ] as $mailingFilter) {
           $type = 'String';
           if ($mailingFilter == 'mailing_id' &&

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -183,9 +183,9 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
     foreach ($this->getSearchFieldMetadata() as $entity => $fields) {
       foreach ($fields as $fieldName => $fieldSpec) {
         $fieldType = $fieldSpec['type'] ?? '';
-        if ($fieldType === CRM_Utils_Type::T_DATE || $fieldType === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)) {
+        if ($fieldType === CRM_Utils_Type::T_DATE || $fieldType === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME) || $fieldType === CRM_Utils_Type::T_TIMESTAMP) {
           $title = empty($fieldSpec['unique_title']) ? $fieldSpec['title'] : $fieldSpec['unique_title'];
-          $this->addDatePickerRange($fieldName, $title, ($fieldType === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)));
+          $this->addDatePickerRange($fieldName, $title, ($fieldType === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME) || $fieldType === CRM_Utils_Type::T_TIMESTAMP));
         }
         else {
           // Not quite sure about moving to a mix of keying by entity vs permitting entity to

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -136,7 +136,7 @@ class CRM_Mailing_BAO_Query {
    * rather than a static function.
    */
   public static function getSearchFieldMetadata() {
-    $fields = [];
+    $fields = ['mailing_job_start_date'];
     $metadata = civicrm_api3('Mailing', 'getfields', [])['values'];
     $metadata = array_merge($metadata, civicrm_api3('MailingJob', 'getfields', [])['values']);
     return array_intersect_key($metadata, array_flip($fields));
@@ -427,10 +427,6 @@ class CRM_Mailing_BAO_Query {
       );
     }
 
-    CRM_Core_Form_Date::buildDateRange($form, 'mailing_date', 1, '_low', '_high', ts('From'), FALSE);
-    $form->addElement('hidden', 'mailing_date_range_error');
-    $form->addFormRule(['CRM_Mailing_BAO_Query', 'formRule'], $form);
-
     $mailingJobStatuses = [
       '' => ts('- select -'),
       'Complete' => 'Complete',
@@ -515,27 +511,6 @@ class CRM_Mailing_BAO_Query {
     $query->_tables['civicrm_mailing_event_queue'] = $query->_whereTables['civicrm_mailing_event_queue'] = 1;
     $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;
     $query->_tables[$tableName] = $query->_whereTables[$tableName] = 1;
-  }
-
-  /**
-   * Check if the values in the date range are in correct chronological order.
-   *
-   * @param array $fields
-   * @param array $files
-   * @param CRM_Core_Form $form
-   *
-   * @return bool|array
-   */
-  public static function formRule($fields, $files, $form) {
-    $errors = [];
-
-    if (empty($fields['mailing_date_high']) || empty($fields['mailing_date_low'])) {
-      return TRUE;
-    }
-
-    CRM_Utils_Rule::validDateRange($fields, 'mailing_date', $errors, ts('Mailing Date'));
-
-    return empty($errors) ? TRUE : $errors;
   }
 
 }

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -70,6 +70,7 @@ class CRM_Upgrade_Incremental_SmartGroups {
       'pledge_start_date' => 'pledge_start',
       'case_start_date' => 'case_from',
       'case_end_date' => 'case_to',
+      'mailing_job_start_date' => 'mailing_date',
     ];
 
     foreach ($fields as $field) {

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -103,12 +103,16 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
         ['old' => 'case_to_relative', 'new' => 'case_end_date_relative'],
         ['old' => 'case_to_end_date_high', 'new' => 'case_end_date_high'],
         ['old' => 'case_to_end_date_low', 'new' => 'case_end_date_low'],
+        ['old' => 'mailing_date_relative', 'new' => 'mailing_job_start_date_relative'],
+        ['old' => 'mailing_date_high', 'new' => 'mailing_job_start_date_high'],
+        ['old' => 'mailing_date_low', 'new' => 'mailing_job_start_date_low'],
       ],
     ]);
     $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
       'datepickerConversion' => [
         'case_start_date',
         'case_end_date',
+        'mailing_job_start_date',
       ],
     ]);
   }

--- a/templates/CRM/Mailing/Form/Search/Common.tpl
+++ b/templates/CRM/Mailing/Form/Search/Common.tpl
@@ -12,7 +12,7 @@
 </tr>
 <tr><td><label>{ts}Mailing Date{/ts}</label></td></tr>
 <tr>
-{include file="CRM/Core/DateRange.tpl" fieldName="mailing_date" from='_low' to='_high'}
+{include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="mailing_job_start_date"}
 </tr>
 <tr>
   <td>


### PR DESCRIPTION
Overview
----------------------------------------
This converts the mailing_date field on the Mailing subsection of advanced search to using date picker rather than jcalender 

Before
----------------------------------------
Jcalender is used

After
----------------------------------------
Date picker is used

ping @monishdeb @eileenmcnaughton 

Note that this isn't fully complete the one thing that doesn't seem to be working at this point is that the where clause doesn't seem to be getting run correctly but am not sure why


https://lab.civicrm.org/dev/core/issues/561