### PR TITLE
Improve metadata support for table civicrm_mailing_job in search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2179,7 +2179,7 @@ class CRM_Contact_BAO_Query {
         $realFieldName = str_replace(['_high', '_low'], '', $name);
         if (isset($this->_fields[$realFieldName])) {
           $field = $this->_fields[str_replace(['_high', '_low'], '', $realFieldName)];
-          $this->dateQueryBuilder($values, $field['table_name'], $realFieldName, $realFieldName, $field['title']);
+          $this->dateQueryBuilder($values, $field['table_name'], $realFieldName, $field['name'], $field['title']);
         }
         return;
       }


### PR DESCRIPTION
Overview
----------------------------------------
This makes no change in itself but tidies up the Mailing BAO object to prepare for the datepicker change @seamuslee001  has been working on

Before
----------------------------------------
Less stdised - needs more funky handling

After
----------------------------------------
More standardised

Technical Details
----------------------------------------
This makes the civicrm_mailing_job_start_date field available as
metadata and cleans up the code specifying how
civicrm_mailing_job gets joined in.

It turns out the code design has a pretty sensible methodology for ensuring that required
tables are added but unaware of this the tables
got configured all over the place in the where clause
functions.

Comments
----------------------------------------

