### PR TITLE
Fixing a fatal error when installing extensions with Option Values defined in XML

### DIFF
--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -160,7 +160,7 @@ class CRM_Utils_Migrate_Import {
         $optionValue->option_group_id = $idMap['option_group'][(string ) $optionValueXML->option_group_name];
         if (empty($optionValue->option_group_id)) {
           //CRM-17410 check if option group already exist.
-          $optionValue->option_group_id = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $optionValueXML->option_group_name, 'id', 'name');
+          $optionValue->option_group_id = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', (string) $optionValueXML->option_group_name, 'id', 'name');
         }
         $this->copyData($optionValue, $optionValueXML, FALSE, 'label');
         if (!isset($optionValue->value)) {


### PR DESCRIPTION
If an Extension has an option value defined in an XML file and the
option value belongs to an option group that is already defined in Civi
But in the XML (e.g activity_type option group) then installing the
extension will result in a fatal error with the following message :

"A fatal error was triggered: One of parameters (value: ) is not of the type Integer"

The error happen because CiviCRM fails to find the option group in the
XML file so it look for it in the database, but the code that look for
it pass the option group name as a SimpleXML object (since SimpleXML
does not return scalar values and rather objects of Type SimpleXML) and
because of that the code won't be able to find the value which will
result in executing a query that expect an integer but rather a NULL
pass to it which result in the fatal error.

I fixed it by casting the option group name inside the SimpleXML object
to string.