### PR TITLE
Allow regen.sh to work with either upper/lower case for CMS name to match elsewhere

### DIFF
--- a/bin/setup.lib.sh
+++ b/bin/setup.lib.sh
@@ -60,10 +60,10 @@ function has_commands() {
 ## usage: cms_eval '<php-code>'
 function cms_eval() {
   case "$GENCODE_CMS" in
-    Drupal*)
+    [Dd]rupal*)
       drush ev "$1"
       ;;
-    WordPress*)
+    [Ww]ordPress*)
       wp eval "$1"
       ;;
     *)


### PR DESCRIPTION
Overview
----------------------------------------
In bin/setup.conf.txt, it says to use lower case for GENCODE_CMS. This will work with setup.sh, but not regen.sh which is expecting e.g. "Drupal", because it calls a function in setup.lib.sh that expects that.

Before
----------------------------------------
regen.sh only works with GENCODE_CMS set to Proper Case.

After
----------------------------------------
regen.sh works with both Proper and lower case.

Technical Details
----------------------------------------
setup.sh worked already with either because CRM_Core_CodeGen_Main will accept either, but cms_eval() in setup.lib.sh only accepted Proper case.

Comments
----------------------------------------

