### PR TITLE
Cleanup following smart group conversions and fix the old name of the…

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -391,6 +391,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
    *
    * @param array $queryParams
    * @param array $formValues
+   * @deprecated
    */
   public static function saveRelativeDates(&$queryParams, $formValues) {
     // This is required only until all fields are converted to datepicker fields as the new format is truer to the
@@ -398,11 +399,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     $relativeDates = ['relative_dates' => []];
     $specialDateFields = [
       'event_relative',
-      'participant_relative',
       'log_date_relative',
-      'birth_date_relative',
-      'deceased_date_relative',
-      'relation_date_relative',
       'relation_action_date_relative',
     ];
     foreach ($formValues as $id => $value) {

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -540,9 +540,6 @@ class CRM_Contact_Form_Search_Criteria {
     }
     CRM_Core_Form_Date::buildDateRange($form, 'relation_active_period_date', 1, '_low', '_high', ts('From:'), FALSE, FALSE);
 
-    // Add reltionship dates
-    CRM_Core_Form_Date::buildDateRange($form, 'relation_date', 1, '_low', '_high', ts('From:'), FALSE, FALSE);
-
     // add all the custom  searchable fields
     CRM_Core_BAO_Query::addCustomFormFields($form, ['Relationship']);
   }

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -71,8 +71,8 @@ class CRM_Upgrade_Incremental_SmartGroups {
       'case_start_date' => 'case_from',
       'case_end_date' => 'case_to',
       'mailing_job_start_date' => 'mailing_date',
-      'relationship_start_date' => 'relation_start_date',
-      'relationship_end_date' => 'relation_end_date',
+      'relationship_start_date' => 'relation_start',
+      'relationship_end_date' => 'relation_end',
     ];
 
     foreach ($fields as $field) {

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -183,7 +183,6 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     $formValues = [
       'operator' => 'AND',
       'event_relative' => 'this.month',
-      'participant_relative' => 'today',
       'participant_test' => 0,
       'title' => 'testsmart',
       'radio_ts' => 'ts_all',
@@ -197,7 +196,6 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
     $expectedResult = [
       'event' => 'this.month',
-      'participant' => 'today',
     ];
     $this->checkArrayEquals($result['relative_dates'], $expectedResult);
   }

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -157,6 +157,35 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test converting relationship fields
+   */
+  public function testSmartGroupRelationshipDateConversions() {
+    $this->callAPISuccess('SavedSearch', 'create', [
+      'form_values' => [
+        ['relationship_start_date_low', '=', '20191001000000'],
+        ['relationship_start_date_high', '=', '20191031235959'],
+        ['relationship_end_date_low', '=', '20191001000000'],
+        ['relationship_end_date_high', '=', '20191031235959'],
+        'relative_dates' => [
+          'relation_start' => 'this.month',
+          'relation_end' => 'this.month',
+        ],
+      ],
+    ]);
+    $smartGroupConversionObject = new CRM_Upgrade_Incremental_SmartGroups();
+    $smartGroupConversionObject->updateGroups([
+      'datepickerConversion' => [
+        'relationship_start_date',
+        'relationship_end_date',
+      ],
+    ]);
+    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
+    $this->assertEquals([], $savedSearch['form_values']['relative_dates']);
+    $this->assertEquals(['relationship_start_date_relative', '=', 'this.month'], $savedSearch['form_values'][4]);
+    $this->assertEquals(['relationship_end_date_relative', '=', 'this.month'], $savedSearch['form_values'][5]);
+  }
+
+  /**
    * Test conversion of on hold group.
    */
   public function testOnHoldConversion() {


### PR DESCRIPTION
… relationship date relative fields for conversion and add a unit test

Before
----------------------------------------
No unit test on the relationship conversion

After
----------------------------------------
Unit test

Technical Details
----------------------------------------
The unit test was mostly built off the smart group values found here https://github.com/civicrm/civicrm-core/pull/15637#issuecomment-547185181 with the field names already re-worked
