### PR TITLE
core#1346: Tagsets should display vertically in activity/new case forms

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -184,7 +184,9 @@
   {/if}
 
   {if $tagsetInfo.activity}
-  <tr class="crm-activity-form-block-tag_set">{include file="CRM/common/Tagset.tpl" tagsetType='activity' tableLayout=true}</tr>
+    <tr class="crm-activity-form-block-tag_set">
+      {include file="CRM/common/Tagset.tpl" tagsetType='activity' tableLayout=true}
+    </tr>
   {/if}
 
   {if $action neq 4 OR $viewCustomData}

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -119,7 +119,9 @@
     </td>
 </tr>
 
-<tr class="crm-case-form-block-tag_set"><td colspan="2">{include file="CRM/common/Tagset.tpl" tagsetType='case'}</td></tr>
+<tr class="crm-case-form-block-tag_set">
+    {include file="CRM/common/Tagset.tpl" tagsetType='case' tableLayout=true}
+</tr>
 
 </table>
 {/if}

--- a/templates/CRM/common/Tagset.tpl
+++ b/templates/CRM/common/Tagset.tpl
@@ -26,28 +26,38 @@
 {if empty($tagsetType)}
   {assign var="tagsetType" value="contact"}
 {/if}
-{foreach from=$tagsetInfo.$tagsetType item=tagset}
-  {assign var="elemName" value=$tagset.tagsetElementName}
-  {if empty($tagsetElementName) or $tagsetElementName eq $elemName}
-    {assign var="parID" value=$tagset.parentID}
-    {assign var="skipEntityAction" value=$tagset.skipEntityAction}
-    {if $tableLayout}
-      <td class="label">
-        {$form.$elemName.$parID.label}
-      </td>
-      <td class="{$tagsetType}-tagset {$tagsetType}-tagset-{$tagset.parentID}-section">
-          {$form.$elemName.$parID.html}
-      </td>
-    {else}
-      <div class="crm-section tag-section {$tagsetType}-tagset {$tagsetType}-tagset-{$tagset.parentID}-section">
-        <div class="crm-clearfix">
-          {$form.$elemName.$parID.label}
-          {$form.$elemName.$parID.html}
-        </div>
-      </div>
-    {/if}
-  {/if}
-{/foreach}
+{if $tableLayout}
+  <td colspan="2" class="crm-content-block">
+    <table>
+{/if}
+    {foreach from=$tagsetInfo.$tagsetType item=tagset}
+      {assign var="elemName" value=$tagset.tagsetElementName}
+      {if empty($tagsetElementName) or $tagsetElementName eq $elemName}
+        {assign var="parID" value=$tagset.parentID}
+        {assign var="skipEntityAction" value=$tagset.skipEntityAction}
+        {if $tableLayout}
+          <tr>
+            <td class="label">
+              {$form.$elemName.$parID.label}
+            </td>
+            <td class="{$tagsetType}-tagset {$tagsetType}-tagset-{$tagset.parentID}-section">
+              {$form.$elemName.$parID.html}
+            </td>
+          </tr>
+        {else}
+          <div class="crm-section tag-section {$tagsetType}-tagset {$tagsetType}-tagset-{$tagset.parentID}-section">
+            <div class="crm-clearfix">
+              {$form.$elemName.$parID.label}
+              {$form.$elemName.$parID.html}
+            </div>
+          </div>
+        {/if}
+      {/if}
+    {/foreach}
+{if $tableLayout}
+    </table>
+  </td>
+{/if}
 
 {if !$skipEntityAction and empty($form.frozen)}
   <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
Currently when there are more than one tagsets configured for activity and/or case, on the new activity or case form the tagset are listed horizontally. Please check the before/after screenshots for the style fixes:

Before
----------------------------------------
**New Activity form:**
<img width="1314" alt="Screen Shot 2019-10-29 at 7 00 23 PM" src="https://user-images.githubusercontent.com/3735621/67772146-95a63880-fa7f-11e9-9d73-7cb32ad3070b.png">

**New Case form:**
<img width="643" alt="Screen Shot 2019-10-29 at 7 09 35 PM" src="https://user-images.githubusercontent.com/3735621/67772228-b79fbb00-fa7f-11e9-9c4b-3b8de18c32ea.png">


After
----------------------------------------
**New Activity form:**
<img width="452" alt="Screen Shot 2019-10-29 at 7 10 35 PM" src="https://user-images.githubusercontent.com/3735621/67772293-d605b680-fa7f-11e9-8fab-06cd73e80e5c.png">

**New Case form:**
<img width="430" alt="Screen Shot 2019-10-29 at 7 11 11 PM" src="https://user-images.githubusercontent.com/3735621/67772359-f2095800-fa7f-11e9-9dca-bcb951fd552c.png">



Comments
----------------------------------------
ping @lcdservices @colemanw @eileenmcnaughton 