### PR TITLE
dev/core#1347 - Fix php warning in advanced search when opening some accordions

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -302,7 +302,8 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     }
 
     self::setModeValues();
-    if (!array_key_exists($mode, self::$_modeValues)) {
+    // Note $mode might === FALSE because array_search above failed, e.g. for searchPane='location'
+    if (empty(self::$_modeValues[$mode])) {
       $mode = CRM_Contact_BAO_Query::MODE_CONTACTS;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1347
When opening some accordions on advanced search, the accordion might not have a mapping for $mode, so $mode ends up being false, which gives a warning when used in array_key_exists. The warning doesn't show on screen for some reason, even if you have messages to the screen enabled, but does show up in drupal watchdog.

Before
----------------------------------------
`Warning: array_key_exists(): The first argument should be either a string or an integer in CRM_Contact_Form_Search::getModeValue() (line 305 of .../CRM/Contact/Form/Search.php)`

After
----------------------------------------
""

Technical Details
----------------------------------------
I wasn't sure if the right fix is to add a mapping, but I'm not sure even what effect the code has anyway because even when there is a mapping e.g. for the activities section, at the point the warning is appearing it still doesn't actually change the mode, which is controlled by the mode field at the top of the form.

Comments
----------------------------------------

