### PR TITLE
dev/core#1344 Fix logic for displaying BillingName and Credit Card De…

### DIFF
--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3450,8 +3450,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'payment_processor_id' => $this->paymentProcessorID,
     ]);
     $mut->checkMailLog([
-      // credit card header
-      'Credit Card Information',
       // billing header
       'Billing Name and Address',
       // billing name

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -311,19 +311,7 @@
       </tr>
      {/if}
 
-     {if ! ($contributeMode eq 'notify' OR $contributeMode eq 'directIPN') and $is_monetary}
-      {if $is_pay_later && !$isBillingAddressRequiredForPayLater}
-       <tr>
-        <th {$headerStyle}>
-         {ts}Registered Email{/ts}
-        </th>
-       </tr>
-       <tr>
-        <td colspan="2" {$valueStyle}>
-         {$email}
-        </td>
-       </tr>
-      {elseif $amount GT 0}
+     {if $billingName}
        <tr>
         <th {$headerStyle}>
          {ts}Billing Name and Address{/ts}
@@ -336,10 +324,20 @@
          {$email}
         </td>
        </tr>
-      {/if}
+     {elseif $email}
+       <tr>
+        <th {$headerStyle}>
+         {ts}Registered Email{/ts}
+        </th>
+       </tr>
+       <tr>
+        <td colspan="2" {$valueStyle}>
+         {$email}
+        </td>
+       </tr>
      {/if}
 
-     {if $contributeMode eq 'direct' AND !$is_pay_later AND $amount GT 0}
+     {if $credit_card_type}
       <tr>
        <th {$headerStyle}>
         {ts}Credit Card Information{/ts}


### PR DESCRIPTION
…tails in email Receipts

Overview
----------------------------------------
This continues the patterns set by #15532 and #15646 

Before
----------------------------------------
Complex logic used to include BillingName and also credit card details

After
----------------------------------------
Less complex logic

ping @eileenmcnaughton @mattwire 