### PR TITLE
dev/core#1344 Simplify email template logic on displaying card inform…

### DIFF
--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3344,6 +3344,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test sending a mail via the API.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testSendMail() {
     $mut = new CiviMailUtils($this, TRUE);
@@ -3435,12 +3437,13 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Check credit card details in sent mail via API
    *
-   * @param $mut obj CiviMailUtils instance
+   * @param CiviMailUtils $mut
    * @param int $contributionID Contribution ID
    *
+   * @throws \CRM_Core_Exception
    */
   public function checkCreditCardDetails($mut, $contributionID) {
-    $contribution = $this->callAPISuccess('contribution', 'create', $this->_params);
+    $this->callAPISuccess('contribution', 'create', $this->_params);
     $this->callAPISuccess('contribution', 'sendconfirmation', [
       'id' => $contributionID,
       'receipt_from_email' => 'api@civicrm.org',

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -144,7 +144,7 @@
 {$email}
 {/if} {* End ! is_pay_later condition. *}
 {/if}
-{if $contributeMode eq 'direct' AND !$is_pay_later AND $amount GT 0}
+{if $credit_card_type}
 
 ===========================================================
 {ts}Credit Card Information{/ts}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -388,7 +388,7 @@
         </tr>
        {/if}
 
-       {if $contributeMode eq 'direct' and !$isAmountzero and !$is_pay_later and !$isOnWaitlist and !$isRequireApproval}
+       {if $credit_card_type}
         <tr>
          <th {$headerStyle}>
           {ts}Credit Card Information{/ts}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -204,7 +204,7 @@
 {$address}
 {/if}
 
-{if $contributeMode eq 'direct' and !$isAmountzero and !$is_pay_later and !$isOnWaitlist and !$isRequireApproval}
+{if $credit_card_type}
 ===========================================================
 {ts}Credit Card Information{/ts}
 

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -236,7 +236,7 @@
        </tr>
       {/if}
 
-      {if $contributeMode eq 'direct' and !$isAmountzero and !$is_pay_later}
+      {if $credit_card_type}
        <tr>
         <th {$headerStyle}>
          {ts}Credit Card Information{/ts}

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -89,7 +89,7 @@
 {$address}
 {/if}
 
-{if $contributeMode eq 'direct' and !$isAmountzero and !$is_pay_later}
+{if $credit_card_type}
 ===========================================================
 {ts}Credit Card Information{/ts}
 

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -420,7 +420,7 @@
       {/if}
      {/if}
 
-     {if $contributeMode eq 'direct' AND !$is_pay_later AND ($amount GT 0 OR $membership_amount GT 0)}
+     {if $credit_card_type}
       <tr>
        <th {$headerStyle}>
         {ts}Credit Card Information{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Same deal as https://github.com/civicrm/civicrm-core/pull/15646

Per https://lab.civicrm.org/dev/core/issues/1344 we currently use complex & fragile logic whereas we can simply display what we have gathered. Since email templates are already being upgraded this release it feels like a good opportunity to clean these up too.

Before
----------------------------------------
Complex fragile logic using deprecated parameters
```
{if $contributeMode eq 'direct' AND !$is_pay_later AND $amount GT 0}
   <tr>
       <th {$headerStyle}>
        {ts}Credit Card Information{/ts}
       </th>
      </tr>
      <tr>
       <td colspan="2" {$valueStyle}>
        {$credit_card_type}<br />
        {$credit_card_number}<br />
        {ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}<br />
       </td>
      </tr>
     {/if}
```

After
----------------------------------------
Simple logic

```

     {if $credit_card_type}
      <tr>
       <th {$headerStyle}>
        {ts}Credit Card Information{/ts}
       </th>
      </tr>
      <tr>
       <td colspan="2" {$valueStyle}>
        {$credit_card_type}<br />
        {$credit_card_number}<br />
        {ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}<br />
       </td>
      </tr>
     {/if}
```

Technical Details
----------------------------------------


Comments
----------------------------------------
