### PR TITLE
dev/core#1348 - activity search no longer working

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -345,13 +345,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
-   * @return null
-   */
-  public function getFormValues() {
-    return NULL;
-  }
-
-  /**
    * Return a descriptive name for the page, used in wizard header
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1348
A change in the base class form value handling in 5.19 makes the activity search form not work anymore. It just always returns all results.

Before
----------------------------------------
Any activity search always returns all results.

After
----------------------------------------
Form field values get picked up.

Technical Details
----------------------------------------
CRM_Core_Form_Search::setFormValues() was changed to call $this->getFormValues(), but activity search already has such a function that just returns null. It doesn't seem to be used though, and removing it seems to work and looking at the related 5.18.4 code it's mostly the same.

Comments
----------------------------------------
5.19 backport PR coming
