### PR TITLE
Jcalendar replacement for event date

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -398,7 +398,6 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     // form format and simply saves (e.g) custom_3_relative => "this.year"
     $relativeDates = ['relative_dates' => []];
     $specialDateFields = [
-      'event_relative',
       'log_date_relative',
       'relation_action_date_relative',
     ];

--- a/templates/CRM/Event/Form/Search/Common.tpl
+++ b/templates/CRM/Event/Form/Search/Common.tpl
@@ -33,8 +33,7 @@
   <td class="crm-event-form-block-event_type_id"> {$form.event_type_id.label}<br />{$form.event_type_id.html} </td>
 </tr>
 <tr>
-  {include file="CRM/Core/DateRange.tpl" fieldName="event" from='_start_date_low' to='_end_date_high' label="<label>Event Dates</label>"}
-</tr>
+    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="event" colspan="2"}</tr>
 <tr>
   {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="participant_register_date" colspan="2"}
 </tr>

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2120,6 +2120,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Ensure consistent return format for option group fields.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testPseudoFields() {
     $params = [
@@ -2156,6 +2158,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * These include value, array & birth_date_high, birth_date_low
    * && deceased.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testContactGetBirthDate() {
     $contact1 = $this->callAPISuccess('contact', 'create', array_merge($this->_params, ['birth_date' => 'first day of next month - 2 years']));


### PR DESCRIPTION
Overview
----------------------------------------
Remove jcalendar for event date in advanced search & event search

Before
----------------------------------------
Jcalendar

After
----------------------------------------
Datepicker

Technical Details
----------------------------------------
@seamuslee001 alternate approach to even_end_date  - the same would also be used for relationship active date. The advantage is we keep the submitted field 'intact' rather than wrangling it.

Comments
----------------------------------------
I didn't rename the field - but we could. 