### PR TITLE
[NFC] Test cleanup -  switch to OrderApi in test setup, add throws, use sin…

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -85,6 +85,9 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Setup function.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function setUp() {
     parent::setUp();
@@ -119,19 +122,24 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Clean up after each test.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
-    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_mailing_spool ORDER BY id DESC');
+    $this->quickCleanup(['civicrm_mailing_spool']);
     parent::tearDown();
   }
 
   /**
    * Test the submit function that completes the partially paid Contribution using Credit Card.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testAddPaymentUsingCreditCardForPartialyPaidContribution() {
+  public function testAddPaymentUsingCreditCardForPartiallyPaidContribution() {
     $mut = new CiviMailUtils($this, TRUE);
-    $this->createContribution('Partially paid');
+    $this->createPartiallyPaidOrder();
 
     // pay additional amount by using Credit Card
     $this->submitPayment(70, 'live', TRUE);
@@ -157,9 +165,12 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the partially paid Contribution.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testAddPaymentForPartialyPaidContribution() {
-    $this->createContribution('Partially paid');
+  public function testAddPaymentForPartiallyPaidContribution() {
+    $this->createPartiallyPaidOrder();
 
     // pay additional amount
     $this->submitPayment(70);
@@ -168,9 +179,12 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the partially paid Contribution with multiple payments.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testMultiplePaymentForPartiallyPaidContribution() {
-    $this->createContribution('Partially paid');
+    $this->createPartiallyPaidOrder();
 
     // pay additional amount
     $this->submitPayment(50);
@@ -187,9 +201,9 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'sequential' => 1,
       'return' => ['target_contact_id', 'assignee_contact_id', 'subject'],
     ])['values'];
-    $this->assertEquals(2, count($activities));
-    $this->assertEquals('$ 50.00 - Offline Payment for Contribution', $activities[0]['subject']);
-    $this->assertEquals('$ 20.00 - Offline Payment for Contribution', $activities[1]['subject']);
+    $this->assertCount(3, $activities);
+    $this->assertEquals('$ 50.00 - Offline Payment for Contribution', $activities[1]['subject']);
+    $this->assertEquals('$ 20.00 - Offline Payment for Contribution', $activities[2]['subject']);
     $this->assertEquals(CRM_Core_Session::singleton()->getLoggedInContactID(), $activities[0]['source_contact_id']);
     $this->assertEquals([$this->_individualId], $activities[0]['target_contact_id']);
     $this->assertEquals([], $activities[0]['assignee_contact_id']);
@@ -199,10 +213,11 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
    * Test the submit function that completes the partially paid Contribution with multiple payments.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testMultiplePaymentForPartiallyPaidContributionWithOneCreditCardPayment() {
     $mut = new CiviMailUtils($this, TRUE);
-    $this->createContribution('Partially paid');
+    $this->createPartiallyPaidOrder();
     // In general when there is tpl leakage we try to fix. At the moment, however,
     // the tpl leakage on credit card related things is kind of 'by-design' - or
     // at least we haven't found a way to replace the way in with Payment.send_confirmation
@@ -242,10 +257,11 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
    * Test the submit function that completes the pending pay later Contribution using Credit Card.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testAddPaymentUsingCreditCardForPendingPayLaterContribution() {
     $mut = new CiviMailUtils($this, TRUE);
-    $this->createContribution('Pending');
+    $this->createPendingOrder();
 
     // pay additional amount by using Credit Card
     $this->submitPayment(100, 'live', TRUE);
@@ -269,9 +285,12 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the pending pay later Contribution.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testAddPaymentForPendingPayLaterContribution() {
-    $this->createContribution('Pending');
+    $this->createPendingOrder();
 
     // pay additional amount
     $this->submitPayment(70);
@@ -285,45 +304,55 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the Membership status after completing the pending pay later Contribution.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testMembershipStatusAfterCompletingPayLaterContribution() {
-    $this->createContribution('Pending');
+    $this->createPendingOrder();
     $membership = $this->createPendingMembershipAndRecordContribution($this->_contributionId);
     // pay additional amount
     $this->submitPayment(100);
-    $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $this->_contributionId]);
-    $contributionMembership = $this->callAPISuccessGetSingle('Membership', ['id' => $membership["id"]]);
-    $membershipStatus = $this->callAPISuccessGetSingle('MembershipStatus', ['id' => $contributionMembership["status_id"]]);
+    $this->callAPISuccessGetSingle('Contribution', ['id' => $this->_contributionId]);
+    $contributionMembership = $this->callAPISuccessGetSingle('Membership', ['id' => $membership['id']]);
+    $membershipStatus = $this->callAPISuccessGetSingle('MembershipStatus', ['id' => $contributionMembership['status_id']]);
     $this->assertEquals('New', $membershipStatus['name']);
   }
 
+  /**
+   * @param $contributionId
+   *
+   * @return array|int
+   *
+   * @throws \CRM_Core_Exception
+   */
   private function createPendingMembershipAndRecordContribution($contributionId) {
     $this->_individualId = $this->individualCreate();
     $membershipTypeAnnualFixed = $this->callAPISuccess('membership_type', 'create', [
       'domain_id' => 1,
-      'name' => "AnnualFixed",
+      'name' => 'AnnualFixed',
       'member_of_contact_id' => 1,
-      'duration_unit' => "year",
+      'duration_unit' => 'year',
       'duration_interval' => 1,
-      'period_type' => "fixed",
-      'fixed_period_start_day' => "101",
-      'fixed_period_rollover_day' => "1231",
+      'period_type' => 'fixed',
+      'fixed_period_start_day' => '101',
+      'fixed_period_rollover_day' => '1231',
       'relationship_type_id' => 20,
       'financial_type_id' => 2,
     ]);
     $membershipStatuses = CRM_Member_PseudoConstant::membershipStatus();
-    $pendingStatusId = array_search('Pending', $membershipStatuses);
+    $pendingStatusId = array_search('Pending', $membershipStatuses, TRUE);
     $membership = $this->callAPISuccess('Membership', 'create', [
       'contact_id' => $this->_individualId,
       'membership_type_id' => $membershipTypeAnnualFixed['id'],
     ]);
     // Updating Membership status to Pending
     $membership = $this->callAPISuccess('Membership', 'create', [
-      'id' => $membership["id"],
+      'id' => $membership['id'],
       'status_id' => $pendingStatusId,
     ]);
-    $membershipPayment = $this->callAPISuccess('MembershipPayment', 'create', [
-      'membership_id' => $membership["id"],
+    $this->callAPISuccess('MembershipPayment', 'create', [
+      'membership_id' => $membership['id'],
       'contribution_id' => $contributionId,
     ]);
     return $membership;
@@ -331,9 +360,12 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the pending pay later Contribution with multiple payments.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testMultiplePaymentForPendingPayLaterContribution() {
-    $this->createContribution('Pending');
+    $this->createPendingOrder();
 
     // pay additional amount
     $this->submitPayment(40);
@@ -354,9 +386,12 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the pending pay later Contribution with multiple payments.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testMultiplePaymentForPendingPayLaterContributionWithOneCreditCardPayment() {
-    $this->createContribution('Pending');
+    $this->createPendingOrder();
 
     // pay additional amount
     $this->submitPayment(50);
@@ -376,34 +411,6 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
   }
 
   /**
-   * Function to create pending pay later or partially paid conntribution.
-   *
-   * @param string $typeofContribution
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function createContribution($typeofContribution = 'Pending') {
-    if ($typeofContribution == 'Partially paid') {
-      $contributionParams = array_merge($this->_params, [
-        'partial_payment_total' => 100.00,
-        'partial_amount_to_pay' => 30,
-        'contribution_status_id' => 1,
-      ]);
-    }
-    elseif ($typeofContribution == 'Pending') {
-      $contributionParams = array_merge($this->_params, [
-        'contribution_status_id' => 2,
-        'is_pay_later' => 1,
-      ]);
-    }
-    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
-    $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contribution['id']]);
-    $this->assertNotEmpty($contribution);
-    $this->assertEquals($typeofContribution, CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution['contribution_status_id']));
-    $this->_contributionId = $contribution['id'];
-  }
-
-  /**
    * Function to submit payments for contribution.
    *
    * @param float $amount
@@ -411,6 +418,8 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
    * @param string $mode
    *  Mode of Payment
    * @param bool $isEmailReceipt
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function submitPayment($amount, $mode = NULL, $isEmailReceipt = FALSE) {
     $form = new CRM_Contribute_Form_AdditionalPayment();
@@ -430,7 +439,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     ];
     if ($mode) {
       $submitParams += [
-        'payment_instrument_id' => array_search('Credit Card', $this->paymentInstruments),
+        'payment_instrument_id' => array_search('Credit Card', $this->paymentInstruments, TRUE),
         'payment_processor_id' => $this->paymentProcessorID,
         'credit_card_exp_date' => ['M' => 5, 'Y' => 2025],
         'credit_card_number' => '411111111111111',
@@ -444,7 +453,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     }
     else {
       $submitParams += [
-        'payment_instrument_id' => array_search('Check', $this->paymentInstruments),
+        'payment_instrument_id' => array_search('Check', $this->paymentInstruments, TRUE),
         'check_number' => 'check-12345',
       ];
     }
@@ -460,6 +469,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
    * @param int $count
    *   Number payment for contribution
    *
+   * @throws \CRM_Core_Exception
    */
   public function checkResults($amounts, $count) {
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $this->_contributionId]);
@@ -467,11 +477,44 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->assertEquals('Completed', $contribution['contribution_status']);
 
     $this->callAPISuccessGetCount('EntityFinancialTrxn', [
-      'entity_table' => "civicrm_contribution",
+      'entity_table' => 'civicrm_contribution',
       'entity_id' => $this->_contributionId,
       'financial_trxn_id.is_payment' => 1,
       'financial_trxn_id.total_amount' => ['IN' => $amounts],
     ], $count);
+  }
+
+  /**
+   * Create a pending order.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function createPendingOrder() {
+    $orderParams = array_merge($this->_params, [
+      'contribution_status_id' => 'Pending',
+      'is_pay_later' => 1,
+    ]);
+    $contribution = $this->callAPISuccess('Order', 'create', $orderParams);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contribution['id']]);
+    $this->assertEquals('Pending', CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution['contribution_status_id']));
+    $this->_contributionId = $contribution['id'];
+  }
+
+  /**
+   * Create a partially paid order.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function createPartiallyPaidOrder() {
+    $orderParams = array_merge($this->_params, [
+      'total_amount' => 100.00,
+      'contribution_status_id' => 'Pending',
+      'api.Payment.create' => ['total_amount' => 30],
+    ]);
+    $contribution = $this->callAPISuccess('Order', 'create', $orderParams);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contribution['id']]);
+    $this->assertEquals('Partially paid', CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution['contribution_status_id']));
+    $this->_contributionId = $contribution['id'];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Test fix only - use preferred method for setup & various cleanup

Before
----------------------------------------
Contribution.create used to create Pending order in test set up

After
----------------------------------------
Order.create used.

Technical Details
----------------------------------------

Comments
----------------------------------------

