### PR TITLE
dev/financial#94 fix eroneous payment creation when editing line items

### DIFF
--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -102,6 +102,10 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $this->assertEquals(55, $sum);
 
     CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $participants['id'], 'participant', $contribution['id'], $this->eventFeeBlock, $lineItem);
+    // Check that no payment records have been created.
+    // In https://lab.civicrm.org/dev/financial/issues/94 we had an issue where payments were created when none happend.
+    $payments = $this->callAPISuccess('Payment', 'get', [])['values'];
+    $this->assertCount(0, $payments);
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($participants['id'], 'participant');
     // Participants is updated to 0 but line remains.
     $this->assertEquals(0, $lineItem[1]['subTotal']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby specifically adding a line to an existing order results in a phony payment being created

Before
----------------------------------------
Set up per https://lab.civicrm.org/dev/financial/issues/94#note_26072 - the key feature is that there is a line item which is NOT initially selected and then IS selected when altering the fee selections.

An erroneous payment (row in civicrm_financial_trxn with is_payemnt = 1 is created

After
----------------------------------------
Payment not created. Note this is a change in the line items not payments so it should not be.

Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/financial/issues/94 an eroneous payment transaction is being created when an extra line is
added to an order. The code comments indicate that during the last refactoring the chunk of code
doing this was identified as highly suspect and on re-review of it I'm sure it should go
as we are altering the items purchases, not recording payment in this routine.
    
I think it dates back to an earlier concept of the flow where altering what was purchased implictly altered the payments towards that purchase

Comments
----------------------------------------

Assuming https://github.com/civicrm/civicrm-core/pull/15663 is merged first I will rebase

@kcristiano 

