### PR TITLE
modified shared address note under contact dashboard

### DIFF
--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -114,7 +114,7 @@
             });
 
             if (!addressHTML) {
-              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please edit "+ "<a href='{crmURL p="civicrm/contact/add" q="reset=1&action=update&cid="}" + sharedContactId + "' target='_blank'> {ts}that contact{/ts} </a>" + "to add an address, or select a different contact.{/ts}"{literal};
+              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please click the following link to edit that contact to add an address, or select a different contact.{/ts}"{literal} + ' <a target="_blank" href="' + CRM.url('civicrm/contact/add', 'reset=1&action=update&cid=' + sharedContactId) + '">{/literal}{ts}Edit link{/ts}{literal}</a>';
             }
 
             $contentArea.html(addressHTML);

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -114,8 +114,7 @@
             });
 
             if (!addressHTML) {
-              var sharedContactLink =  "add?reset=1&action=update&cid=" + sharedContactId;
-              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please edit "+ "<a href='" + sharedContactLink + "' target='_blank'> that contact </a>" + "to add an address, or select a different contact.{/ts}"{literal};
+              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please edit "+ "<a href='{crmURL p="civicrm/contact/add" q="reset=1&action=update&cid="}" + sharedContactId + "' target='_blank'> {ts}that contact{/ts} </a>" + "to add an address, or select a different contact.{/ts}"{literal};
             }
 
             $contentArea.html(addressHTML);

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -114,7 +114,8 @@
             });
 
             if (!addressHTML) {
-              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please edit that contact to add an address, or select a different contact.{/ts}"{literal};
+              var sharedContactLink =  "add?reset=1&action=update&cid=" + sharedContactId;
+              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please edit "+ "<a href='" + sharedContactLink + "' target='_blank'> contact </a>" + "to add an address, or select a different contact.{/ts}"{literal};
             }
 
             $contentArea.html(addressHTML);
@@ -124,5 +125,3 @@
   });
 </script>
 {/literal}
-
-

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -115,7 +115,7 @@
 
             if (!addressHTML) {
               var sharedContactLink =  "add?reset=1&action=update&cid=" + sharedContactId;
-              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please edit "+ "<a href='" + sharedContactLink + "' target='_blank'> contact </a>" + "to add an address, or select a different contact.{/ts}"{literal};
+              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please edit "+ "<a href='" + sharedContactLink + "' target='_blank'> that contact </a>" + "to add an address, or select a different contact.{/ts}"{literal};
             }
 
             $contentArea.html(addressHTML);


### PR DESCRIPTION
Overview
----------------------------------------
While creating the share address for any contact , if we select contact who don't have address there is no way to jump on the selected contact and edit the address so that we can use that contact in for sharing the address.

Before
----------------------------------------
While creating a new contact and using  shared address feature if selected contact don't  have any address it will show the note like  `Selected contact does not have an address.....`  There is no such way to update selected contact address under Address tab.

<img width="707" alt="before_shared_address" src="https://user-images.githubusercontent.com/30790782/67857845-ccdb1f00-fb3d-11e9-82c1-b8cbb1610229.png">


After
----------------------------------------
Given patch gives us a link under shared address note itself to jump on selected contact to update contact address.

<img width="753" alt="after_shared_address" src="https://user-images.githubusercontent.com/30790782/67857861-d3699680-fb3d-11e9-91a4-1adbe20c7077.png">


Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1351
