### PR TITLE
Add getQillValue fn to generalise qill string construct

### DIFF
--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -291,7 +291,7 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
         }
 
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_case.{$name}", $op, $value, "Integer");
-        $query->_qill[$grouping][] = self::getQillValue('CRM_Case_DAO_Case', $name, $value, $op, $label);
+        $query->_qill[$grouping][] = CRM_Contact_BAO_Query::getQillValue('CRM_Case_DAO_Case', $name, $value, $op, $label);
         $query->_tables['civicrm_case'] = $query->_whereTables['civicrm_case'] = 1;
         return;
 
@@ -332,7 +332,7 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
 
       case 'case_subject':
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_case.subject", $op, $value, 'String');
-        $query->_qill[$grouping][] = self::getQillValue('CRM_Case_DAO_Case', $name, $value, $op, 'Case Subject');
+        $query->_qill[$grouping][] = CRM_Contact_BAO_Query::getQillValue('CRM_Case_DAO_Case', $name, $value, $op, 'Case Subject');
         $query->_tables['civicrm_case'] = $query->_whereTables['civicrm_case'] = 1;
         $query->_tables['civicrm_case_contact'] = $query->_whereTables['civicrm_case_contact'] = 1;
         return;
@@ -586,25 +586,6 @@ case_relation_type.id = case_relationship.relationship_type_id )";
         break;
     }
     return $from;
-  }
-
-  /**
-   * Get the qill (search description for field) for the specified field.
-   *
-   * @todo this is private because it is the first step towards generalising rather than
-   * the final product IMHO.
-   *
-   * @param string $daoName
-   * @param string $name
-   * @param string $value
-   * @param string|array $op
-   * @param string $label
-   *
-   * @return string
-   */
-  private static function getQillValue($daoName, string $name, $value, $op, string $label) {
-    list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue($daoName, $name, $value, $op);
-    return ts('%1 %2 %3', [1 => $label, 2 => $op, 3 => $value]);
   }
 
   /**

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6248,6 +6248,22 @@ AND   displayRelType.is_active = 1
   }
 
   /**
+   * Get the qill (search description for field) for the specified field.
+   *
+   * @param string $daoName
+   * @param string $name
+   * @param string $value
+   * @param string|array $op
+   * @param string $label
+   *
+   * @return string
+   */
+  public static function getQillValue($daoName, string $name, $value, $op, string $label) {
+    list($op, $value) = self::buildQillForFieldValue($daoName, $name, $value, $op);
+    return ts('%1 %2 %3', [1 => $label, 2 => $op, 3 => $value]);
+  }
+
+  /**
    * Alter value to reflect wildcard settings.
    *
    * The form will have tried to guess whether this is a good field to wildcard but there is
@@ -6651,7 +6667,7 @@ AND   displayRelType.is_active = 1
         FROM (
       SELECT civicrm_contribution.total_amount, civicrm_contribution.currency
       $from
-      $where  AND civicrm_contribution.cancel_date IS NOT NULL 
+      $where  AND civicrm_contribution.cancel_date IS NOT NULL
       GROUP BY civicrm_contribution.id
     ) as conts
     GROUP BY currency";


### PR DESCRIPTION
Overview
----------------------------------------
I have moved fn getQillValue() introduced in https://github.com/civicrm/civicrm-core/pull/15616 in a base class CRM_Contact_BAO_Query. In order to generalize how qill string is built accross different search form.

Before
----------------------------------------
getQillValue() is private fn for case search form

After
----------------------------------------
getQillValue() can be called in any search form to build qill.


Comments
----------------------------------------
ping @eileenmcnaughton @seamuslee001 