### PR TITLE
Add YesNo field type to support boolean fields of entities

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1677,6 +1677,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $props['size'] = isset($props['size']) ? $props['size'] : 60;
         return $this->add('password', $name, $label, $props, $required);
 
+      case 'YesNo':
+        $allowClear = (bool) (!empty($props['allowClear']));
+        return $this->addYesNo($name, $label, $allowClear, $required, $props);
+
       // Check datatypes of fields
       // case 'Int':
       //case 'Float':

--- a/CRM/Mailing/DAO/Mailing.php
+++ b/CRM/Mailing/DAO/Mailing.php
@@ -865,7 +865,7 @@ class CRM_Mailing_DAO_Mailing extends CRM_Core_DAO {
           'bao' => 'CRM_Mailing_BAO_Mailing',
           'localizable' => 0,
           'html' => [
-            'type' => 'CheckBox',
+            'type' => 'YesNo',
           ],
         ],
         'visibility' => [

--- a/xml/schema/Mailing/Mailing.xml
+++ b/xml/schema/Mailing/Mailing.xml
@@ -384,7 +384,7 @@
     <default>0</default>
     <comment>Is this mailing archived?</comment>
     <html>
-      <type>CheckBox</type>
+      <type>YesNo</type>
     </html>
     <add>2.2</add>
   </field>


### PR DESCRIPTION
Overview
----------------------------------------
This PR extends the addField() capability to add YesNo special radio field for boolean attributes. Like in this PR I have cited an example of civicrm_mailing.is_archived field.

Before
----------------------------------------
$this->addYesNo('is_archived', ts('Mailing is Archived'), TRUE);

After
----------------------------------------
$this->addField('is_archived', NULL, FALSE, FALSE, ['entity' => 'Mailing']);


Comments
----------------------------------------
ping @eileenmcnaughton @seamuslee001 