### PR TITLE
Use Yes-No radio instead of checkbox on search form.

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -265,6 +265,7 @@ class CRM_Contact_Form_Search_Criteria {
       'contact_tags' => ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'template_grouping' => 'basic'],
       'birth_date' => ['name' => 'birth_date', 'template_grouping' => 'demographic'],
       'deceased_date' => ['name' => 'deceased_date', 'template_grouping' => 'demographic'],
+      'is_deceased' => ['is_deceased', 'template_grouping' => 'demographic'],
       'relationship_start_date' => ['name' => 'relationship_start_date', 'template_grouping' => 'relationship'],
       'relationship_end_date' => ['name' => 'relationship_end_date', 'template_grouping' => 'relationship'],
     ];
@@ -569,8 +570,6 @@ class CRM_Contact_Form_Search_Criteria {
     $form->add('number', 'age_high', ts('Max Age'), ['class' => 'four', 'min' => 0]);
     $form->addRule('age_high', ts('Please enter a positive integer'), 'positiveInteger');
     $form->add('datepicker', 'age_asof_date', ts('As of'), NULL, FALSE, ['time' => FALSE]);
-    // radio button for is_deceased
-    $form->addYesNo('is_deceased', ts('Deceased'), TRUE);
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1648,6 +1648,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         return $this->addRadio($name, $label, $options, $props, NULL, $required);
 
       case 'CheckBox':
+        if ($context === 'search') {
+          $this->addYesNo($name, $label, TRUE, FALSE, $props);
+          return;
+        }
         $text = isset($props['text']) ? $props['text'] : NULL;
         unset($props['text']);
         return $this->addElement('checkbox', $name, $label, $text, $props);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes addField to present Checkbox fields as YesNo in search context

Before
----------------------------------------
No UI change - change to add-by-metadata options

After
----------------------------------------


Technical Details
----------------------------------------
When a field has an html type of 'Checkbox' it means that when editing it we want a checkbox for
'yes' or 'no'. However in the search forms there is a 3rd option 'don't care'.

This change takes the context into account for those forms

Comments
----------------------------------------

