### PR TITLE
dev/core#1355 Add contention handling for dedupe jobs

### DIFF
--- a/CRM/Core/Exception/ResourceConflictException.php
+++ b/CRM/Core/Exception/ResourceConflictException.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2019                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Exception thrown when contention over a resource causes process to abort.
+ *
+ * @param string $message
+ *   The human friendly error message.
+ * @param string $error_code
+ *   A computer friendly error code. By convention, no space (but underscore allowed).
+ *   ex: mandatory_missing, duplicate, invalid_format
+ * @param array $data
+ *   Extra params to return. eg an extra array of ids. It is not mandatory, but can help the computer using the api.
+ * Keep in mind the api consumer isn't to be trusted. eg. the database password is NOT a good extra data.
+ */
+class CRM_Core_Exception_ResourceConflictException extends \CRM_Core_Exception {
+
+}

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2062,6 +2062,9 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     }
     $migrationInfo = [];
     $conflicts = [];
+    // Try to lock the contacts before we load the data as we don't want it changing under us.
+    // https://lab.civicrm.org/dev/core/issues/1355
+    $locks = self::getLocksOnContacts([$mainId, $otherId]);
     if (!CRM_Dedupe_Merger::skipMerge($mainId, $otherId, $migrationInfo, $mode, $conflicts)) {
       CRM_Dedupe_Merger::moveAllBelongings($mainId, $otherId, $migrationInfo, $checkPermissions);
       $resultStats['merged'][] = [
@@ -2083,6 +2086,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     else {
       CRM_Core_BAO_PrevNextCache::deletePair($mainId, $otherId, $cacheKeyString);
     }
+    self::releaseLocks($locks);
     return $resultStats;
   }
 
@@ -2568,6 +2572,61 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       }
     }
     return $locationBlock;
+  }
+
+  /**
+   * Get a lock on the given contact.
+   *
+   * The lock is like a gentleman's agreement between php & mysql. It is reserved at the
+   * mysql level so it works across php processes but it doesn't actually lock the database.
+   *
+   * Instead php can check the lock to see if it has been acquired before taking an action.
+   *
+   * In this case we really don't want to attempt to dedupe contacts if another process is
+   * trying to act on the specific contact as it could result in messy deadlocks & possibly data corruption.
+   * In most databases this would be a rare event but if multiple dedupe processes are running
+   * at once (for example) or there is also an import process in play there is potential for them to crash.
+   * By throwing a specific error the calling process can catch it and determine it is worth trying again later without a lot of
+   * noise.
+   *
+   * As of writing no other processes DO grab contact locks but it would be reasonable to consider
+   * grabbing them doing contact edits in general as well as imports etc.
+   *
+   * @param array $contacts
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CRM_Core_Exception_ResourceConflictException
+   */
+  protected static function getLocksOnContacts($contacts):array {
+    $locks = [];
+    if (!CRM_Utils_SQL::supportsMultipleLocks()) {
+      return $locks;
+    }
+    foreach ($contacts as $contactID) {
+      $lock = Civi::lockManager()->acquire("data.core.contact.{$contactID}");
+      if ($lock->isAcquired()) {
+        $locks[] = $lock;
+      }
+      else {
+        self::releaseLocks($locks);
+        throw new CRM_Core_Exception_ResourceConflictException(ts('Contact is in Use'), 'contact_lock');
+      }
+    }
+    return $locks;
+  }
+
+  /**
+   * Release contact locks so another process can alter them if it wants.
+   *
+   * @param array $locks
+   */
+  protected static function releaseLocks(array $locks) {
+    foreach ($locks as $lock) {
+      /* @var Civi\Core\Lock\LockInterface $lock */
+      $lock->release();
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds code to the dedupe that causes it to abort early if another dedupe job is acting on one of the contacts involved.

Philosophically it's broader than that - ie although not implemented here another process could lock a contact for editing and the dedupe would abort rather than attempt to alter the given contact.

https://lab.civicrm.org/dev/core/issues/1355

Before
----------------------------------------
We see occasional conflicts when 2 dedupe jobs try to dedupe 2 conflicts at the same time.  It creates database deadlocks and noise on something where it feels like an Exception could be thrown and appropriately handled by the calling code. In addition it's possible for 2 jobs to 'successfully' dedupe the same contact at the same time. This looks like : Job 1 loads the contact, Job 2 loads the contact, Job 1 dedupes the contact, Job 2 dedupes the contact, based on data from before Job 1 deduped the contact. In some cases this means Job 2 makes incorrect changes because it is acting on out-of-date data.

After
----------------------------------------
Calling code would receive a clearly identifiable ResourceConflictException if another action is working on one of the contacts. At this stage this wouldn't result in 'pretty exception handling as that has to be done at the form / batch layer but it would be 'no worse' than a deadlock Exception and rather better than quiet data loss

Technical Details
----------------------------------------
In general I don't think a dedupe task wants to proceed if any other process is changing the given contact. For that reason I think it makes sense for the dedupe task to try to acquire generic 'contact' locks on the 2 contacts it is trying to dedupe before loading data about them. If any other task has demonstrated that it is acting on them (by acquiring one of both contact locks) the dedupe task can throw an exception & the form layer or batch job layer can handle that (as they already do handle exceptions).

The locks we are using are a bit flawed on old versions of mysql (5.7.5 was released in 2014 and per https://github.com/civicrm/civicrm-sysadmin-guide/issues/158 there is active discussion about not calling pre-5.7.5 'supported') but on the old version this would basically do nothing as the locks should be fake-acquired & fake-released

Comments
----------------------------------------

