### PR TITLE
Jcalendar conversion on relation_active_period_date

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -513,6 +513,16 @@ class CRM_Contact_BAO_Query {
       }
       $relationMetadata = CRM_Contact_BAO_Relationship::fields();
       $relationFields = array_intersect_key($relationMetadata, array_fill_keys(['relationship_start_date', 'relationship_end_date'], 1));
+      // No good option other than hard-coding metadata for this 'special' field in.
+      $relationFields['relation_active_period_date'] = [
+        'name' => 'relation_active_period_date',
+        'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
+        'title' => ts('Active Period'),
+        'table_name' => 'civicrm_relationship',
+        'where' => 'civicrm_relationship.start_date',
+        'where_end' => 'civicrm_relationship.end_date',
+        'html' => ['type' => 'SelectDate', 'formatType' => 'activityDateTime'],
+      ];
       $this->_fields = array_merge($relationFields, $this->_fields);
 
       $fields = CRM_Core_Component::getQueryFields(!$this->_skipPermission);
@@ -1608,6 +1618,7 @@ class CRM_Contact_BAO_Query {
       'mailing_job_start_date_relative',
       'birth_date_relative',
       'deceased_date_relative',
+      'relation_active_period_date_relative',
     ];
     // Handle relative dates first
     foreach (array_keys($formValues) as $id) {

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -399,7 +399,6 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     $relativeDates = ['relative_dates' => []];
     $specialDateFields = [
       'log_date_relative',
-      'relation_action_date_relative',
     ];
     foreach ($formValues as $id => $value) {
       if (in_array($id, $specialDateFields) && !empty($value)) {

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -268,7 +268,19 @@ class CRM_Contact_Form_Search_Criteria {
       'is_deceased' => ['is_deceased', 'template_grouping' => 'demographic'],
       'relationship_start_date' => ['name' => 'relationship_start_date', 'template_grouping' => 'relationship'],
       'relationship_end_date' => ['name' => 'relationship_end_date', 'template_grouping' => 'relationship'],
+       // PseudoRelationship date field.
+      'relation_active_period_date' => [
+        'name' => 'relation_active_period_date',
+        'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
+        'title' => ts('Active Period'),
+        'table_name' => 'civicrm_relationship',
+        'where' => 'civicrm_relationship.start_date',
+        'where_end' => 'civicrm_relationship.end_date',
+        'html' => ['type' => 'SelectDate', 'formatType' => 'activityDateTime'],
+        'template_grouping' => 'relationship',
+      ],
     ];
+
     $metadata = civicrm_api3('Relationship', 'getfields', [])['values'];
     $metadata = array_merge($metadata, civicrm_api3('Contact', 'getfields', [])['values']);
     foreach ($fields as $fieldName => $field) {
@@ -539,7 +551,6 @@ class CRM_Contact_Form_Search_Criteria {
         ['id' => 'relation_target_group', 'multiple' => 'multiple', 'class' => 'crm-select2']
       );
     }
-    CRM_Core_Form_Date::buildDateRange($form, 'relation_active_period_date', 1, '_low', '_high', ts('From:'), FALSE, FALSE);
 
     // add all the custom  searchable fields
     CRM_Core_BAO_Query::addCustomFormFields($form, ['Relationship']);

--- a/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
@@ -69,7 +69,7 @@
       <td colspan="2"><label>{ts}Active Period{/ts}</label> {help id="id-relationship-active-period" file="CRM/Contact/Form/Search/Advanced.hlp"}<br /></td>
     </tr>
     <tr>
-      {include file="CRM/Core/DateRange.tpl" fieldName="relation_active_period_date" from='_low' to='_high'}
+      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="relation_active_period_date" hideRelativeLabel=1}
     </tr>
     {if $relationshipGroupTree}
       <tr>

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -175,32 +175,6 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test if relative dates are stored correctly
-   * in civicrm_saved_search table.
-   */
-  public function testRelativeDateValues() {
-    $savedSearch = new CRM_Contact_BAO_SavedSearch();
-    $formValues = [
-      'operator' => 'AND',
-      'event_relative' => 'this.month',
-      'participant_test' => 0,
-      'title' => 'testsmart',
-      'radio_ts' => 'ts_all',
-    ];
-    $queryParams = [];
-    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
-    CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
-    $savedSearch->form_values = serialize($queryParams);
-    $savedSearch->save();
-
-    $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
-    $expectedResult = [
-      'event' => 'this.month',
-    ];
-    $this->checkArrayEquals($result['relative_dates'], $expectedResult);
-  }
-
-  /**
    * Test if change log relative dates are stored correctly
    * in civicrm_saved_search table.
    */


### PR DESCRIPTION
Overview
----------------------------------------
Remove jcalendar for relation_active_period_date in advanced search 

Before
----------------------------------------
Jcalendar

After
----------------------------------------
Datepicker

Technical Details
----------------------------------------
@seamuslee001 same as https://github.com/civicrm/civicrm-core/pull/15661 - currently excludes the conversion. I figure all the last fields are a conversion pain so doing all at once makes sense

Comments
----------------------------------------

For log_date I think we should expose created_date & modified_date separately - it's cleaner codewise & having seen a user work with it I think less confusing. 