### PR TITLE
Simplify billingName logic on xml/templates/message_templates/members…

### DIFF
--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -392,33 +392,31 @@
       {/foreach}
      {/if}
 
-     {if ! ($contributeMode eq 'notify' OR $contributeMode eq 'directIPN') and $is_monetary}
-      {if $is_pay_later}
+     {if $billingName}
        <tr>
-        <th {$headerStyle}>
-         {ts}Registered Email{/ts}
-        </th>
-       </tr>
-       <tr>
+         <th {$headerStyle}>
+           {ts}Billing Name and Address{/ts}
+         </th>
+      </tr>
+      <tr>
         <td colspan="2" {$valueStyle}>
-         {$email}
+          {$billingName}<br />
+          {$address|nl2br}<br />
+          {$email}
         </td>
-       </tr>
-      {elseif $amount GT 0 OR $membership_amount GT 0}
-       <tr>
+      </tr>
+    {elseif $email}}
+      <tr>
         <th {$headerStyle}>
-         {ts}Billing Name and Address{/ts}
+          {ts}Registered Email{/ts}
         </th>
-       </tr>
-       <tr>
+      </tr>
+      <tr>
         <td colspan="2" {$valueStyle}>
-         {$billingName}<br />
-         {$address|nl2br}<br />
-         {$email}
+          {$email}
         </td>
-       </tr>
-      {/if}
-     {/if}
+      </tr>
+    {/if}
 
      {if $credit_card_type}
       <tr>


### PR DESCRIPTION
Overview
----------------------------------------
This continues the patterns set by #15532 and #15646 

Before
----------------------------------------
Complex logic used to include BillingName and also credit card details

After
----------------------------------------
Less complex logic

@seamuslee001 per my comments on https://github.com/civicrm/civicrm-core/pull/15651 I think we need to reverse the IF order for this one as the $email is present in both cases so putting it in the elseif works I think