### PR TITLE
Add transitional support to PaymentProcessor.pay

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -228,6 +228,15 @@ abstract class CRM_Core_Payment {
   protected $currency;
 
   /**
+   * Setter for currency.
+   *
+   * @param string $currency
+   */
+  public function setCurrency(string $currency) {
+    $this->currency = $currency;
+  }
+
+  /**
    * Payment processor generated string for the transaction ID.
    *
    * Note some gateways generate a reference for the order and one for the
@@ -246,6 +255,23 @@ abstract class CRM_Core_Payment {
    * @var float
    */
   protected $feeAmount;
+
+  /**
+   * Amount to be charged, formatted as decimal dotted e.g 10000.78 to represent 10 thousand
+   * dollars and 78 cents if using a dollar currency
+   *
+   * @var float
+   */
+  protected $amount;
+
+  /**
+   * Set amount to charge.
+   *
+   * @param float $amount
+   */
+  public function setAmount(float $amount) {
+    $this->amount = $amount;
+  }
 
   /**
    * Additional information returned by the payment processor regarding the payment outcome.
@@ -1445,7 +1471,7 @@ abstract class CRM_Core_Payment {
    *
    * @return string
    */
-  protected function getCurrency($params = []) {
+  public function getCurrency($params = []) {
     $params = array_merge($params, (array) $this->inputParams);
     return $this->currency ?? CRM_Utils_Array::value('currencyID', $params, CRM_Utils_Array::value('currency', $params));
   }
@@ -1658,6 +1684,20 @@ abstract class CRM_Core_Payment {
       throw new PaymentProcessorException(CRM_Core_Error::getMessages($result));
     }
     return $result;
+  }
+
+  /**
+   * @return array
+   */
+  public function getInputParams(): array {
+    return $this->inputParams;
+  }
+
+  /**
+   * @param array $inputParams
+   */
+  public function setInputParams(array $inputParams) {
+    $this->inputParams = $inputParams;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This addresses some issues identified by @artfulrobot in
https://artfulrobot.uk/blog/migrating-custom-civicrm-donation-form-support-sca-and-new-order-api
and ensures that PaymentProcessor.pay can provide a bridge between processors accepting 'whatever random parameter
they traditionally have received' and processors using getters to retrieve standardised parameters.

For example it means calling functions can just pass the 'approved' 'currency' parameter and not worry about
currencyID.

Ideally processors would use ->getCurrency() to retrieve the currency but at least for the next
six months they are likely to be looking for ['currencyID' so we ensure they get it

Before
----------------------------------------
Need to pass in 'currency_id' AND 'currencyID' to ensure all processors will get it. Ditto contributionRecurID vs conribution_recur_id

After
----------------------------------------
Calling code should just pass in the documented parameter.

Technical Details
----------------------------------------
From 5.20 payment processors should start to transition to using getters to retrieve 'sanctioned' variables. This should help the calling code to switch to better practice while they get there.

Comments
----------------------------------------
Not addressed from the blog

'email'                => $input_params['email'], // Without this it has to guess which to use
'paymentIntentID'      => $input_params['paymentIntentID'],
 payment_processor_id does not accept names - you need to look up the integer ID

The first one because we didn't touch any contact details yet (not for reason just because we didn't get there). Not sure what to make of paymentIntentID'

The issue with " payment_processor_id does not accept names " is the weirdness around live vs test. I think @mattwire did some code that 'pretends' test has a different name to live &  I'm tempted to support that rather than 'name might be one of test or live, use 'is_test' to determine which