### PR TITLE
We should give user feedback in case of a Payment Processor Exception

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -203,8 +203,15 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     }
 
     if (CRM_Utils_Array::value('send_cancel_request', $params) == 1) {
+      // Note the 'subscriptionId' here is the value stored in
+      // civicrm_contribution_recur.processor_id
       $cancelParams = ['subscriptionId' => $this->_subscriptionDetails->subscription_id];
-      $cancelSubscription = $this->_paymentProcessorObj->cancelSubscription($message, $cancelParams);
+      try {
+        $cancelSubscription = $this->_paymentProcessorObj->cancelSubscription($message, $cancelParams);
+      }
+      catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+        CRM_Core_Error::statusBounce($e->getMessage());
+      }
     }
 
     if (is_a($cancelSubscription, 'CRM_Core_Error')) {

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -14,6 +14,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+
 /**
  * This class generates form components generic to recurring contributions.
  *
@@ -208,7 +209,12 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     $params['subscriptionId'] = $this->_subscriptionDetails->subscription_id;
     $updateSubscription = TRUE;
     if ($this->_paymentProcessorObj->supports('changeSubscriptionAmount')) {
-      $updateSubscription = $this->_paymentProcessorObj->changeSubscriptionAmount($message, $params);
+      try {
+        $updateSubscription = $this->_paymentProcessorObj->changeSubscriptionAmount($message, $params);
+      }
+      catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+        CRM_Core_Error::statusBounce($e->getMessage());
+      }
     }
     if (is_a($updateSubscription, 'CRM_Core_Error')) {
       CRM_Core_Error::displaySessionError($updateSubscription);

--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -13,6 +13,8 @@
  * @author Marshal Newrock <marshal@idealso.com>
  */
 
+use Civi\Payment\Exception\PaymentProcessorException;
+
 /**
  * NOTE:
  * When looking up response codes in the Authorize.Net API, they
@@ -762,7 +764,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     // submit to authorize.net
     $submit = curl_init($this->_paymentProcessor['url_recur']);
     if (!$submit) {
-      return self::error(9002, 'Could not initiate connection to payment gateway');
+      throw new PaymentProcessorException('Could not initiate connection to payment gateway', 9002);
     }
 
     curl_setopt($submit, CURLOPT_RETURNTRANSFER, 1);
@@ -784,7 +786,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     $message = "{$responseFields['code']}: {$responseFields['text']}";
 
     if ($responseFields['resultCode'] == 'Error') {
-      return self::error($responseFields['code'], $responseFields['text']);
+      throw new PaymentProcessorException($responseFields['text'], $responseFields['code']);
     }
     return TRUE;
   }

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -697,7 +697,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @param string $message
    * @param array $params
    *
-   * @return array|bool|object
+   * @return bool
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function cancelSubscription(&$message = '', $params = []) {
@@ -711,7 +711,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
       $result = $this->invokeAPI($args);
       if (is_a($result, 'CRM_Core_Error')) {
-        return $result;
+        throw new PaymentProcessorException(CRM_Core_Error::getMessages($result, "\n"));
       }
       $message = "{$result['ack']}: profileid={$result['profileid']}";
       return TRUE;
@@ -805,7 +805,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @param string $message
    * @param array $params
    *
-   * @return array|bool|object
+   * @return bool
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function changeSubscriptionAmount(&$message = '', $params = []) {
@@ -822,7 +822,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       $result = $this->invokeAPI($args);
       CRM_Core_Error::debug_var('$result', $result);
       if (is_a($result, 'CRM_Core_Error')) {
-        return $result;
+        throw new PaymentProcessorException(CRM_Core_Error::getMessages($result, "\n"));
       }
       $message = "{$result['ack']}: profileid={$result['profileid']}";
       return TRUE;


### PR DESCRIPTION
Payment processors can throw exceptions when trying to do things like update or cancel a recurring payment. But the system expects them to return a CRM_Core_Error.

Before
----------------------------------------

no errors, modal edit forms  just hang if error.


After
----------------------------------------

user should get error

Technical Details
----------------------------------------

I added a catch block for this particular exception and wrapped it up in an CRM_Core_Error.

I've not been able to test this though, hence the WIP.