### PR TITLE
Cleanup date handling on Payment.create

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -411,14 +411,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $config->defaultCurrency
     );
 
-    if (!empty($this->_params['trxn_date'])) {
-      $this->_params['receive_date'] = $this->_params['trxn_date'];
-    }
-
-    if (empty($this->_params['receive_date'])) {
-      $this->_params['receive_date'] = date('YmdHis');
-    }
-
     if (empty($this->_params['invoice_id'])) {
       $this->_params['invoiceID'] = md5(uniqid(rand(), TRUE));
     }
@@ -467,10 +459,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     if (!empty($result)) {
       $this->_params = array_merge($this->_params, $result);
-    }
-
-    if (empty($this->_params['receive_date'])) {
-      $this->_params['receive_date'] = $now;
     }
 
     $this->set('params', $this->_params);

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -59,7 +59,7 @@ class CRM_Financial_BAO_Payment {
     $isPaymentCompletesContribution = self::isPaymentCompletesContribution($params['contribution_id'], $params['total_amount']);
     $lineItems = self::getPayableLineItems($params);
 
-    $whiteList = ['check_number', 'payment_processor_id', 'fee_amount', 'total_amount', 'contribution_id', 'net_amount', 'card_type_id', 'pan_truncation', 'trxn_result_code', 'payment_instrument_id', 'trxn_id'];
+    $whiteList = ['check_number', 'payment_processor_id', 'fee_amount', 'total_amount', 'contribution_id', 'net_amount', 'card_type_id', 'pan_truncation', 'trxn_result_code', 'payment_instrument_id', 'trxn_id', 'trxn_date'];
     $paymentTrxnParams = array_intersect_key($params, array_fill_keys($whiteList, 1));
     $paymentTrxnParams['is_payment'] = 1;
     if (!empty($params['payment_processor'])) {
@@ -89,7 +89,6 @@ class CRM_Financial_BAO_Payment {
     if ($params['total_amount'] > 0) {
       $paymentTrxnParams['to_financial_account_id'] = CRM_Contribute_BAO_Contribution::getToFinancialAccount($contribution, $params);
       $paymentTrxnParams['from_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($contribution['financial_type_id'], 'Accounts Receivable Account is');
-      $paymentTrxnParams['trxn_date'] = CRM_Utils_Array::value('trxn_date', $params, CRM_Utils_Array::value('contribution_receive_date', $params, date('YmdHis')));
       $paymentTrxnParams['currency'] = $contribution['currency'];
       $paymentTrxnParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'status_id', 'Completed');
 

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -201,8 +201,10 @@ function _civicrm_api3_payment_create_spec(&$params) {
       'api.aliases' => ['payment_id'],
     ],
     'trxn_date' => [
-      'title' => ts('Cancel Date'),
+      'title' => ts('Payment Date'),
       'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
+      'api.default' => 'now',
+      'api.required' => TRUE,
     ],
     'is_send_contribution_notification' => [
       'title' => ts('Send out notifications based on contribution status change?'),
@@ -321,21 +323,25 @@ function _civicrm_api3_payment_create_spec(&$params) {
 function _civicrm_api3_payment_get_spec(&$params) {
   $params = [
     'contribution_id' => [
-      'title' => 'Contribution ID',
+      'title' => ts('Contribution ID'),
       'type' => CRM_Utils_Type::T_INT,
     ],
     'entity_table' => [
-      'title' => 'Entity Table',
+      'title' => ts('Entity Table'),
       'api.default' => 'civicrm_contribution',
     ],
     'entity_id' => [
-      'title' => 'Entity ID',
+      'title' => ts('Entity ID'),
       'type' => CRM_Utils_Type::T_INT,
       'api.aliases' => ['contribution_id'],
     ],
     'trxn_id' => [
-      'title' => 'Transaction ID',
+      'title' => ts('Transaction ID'),
       'type' => CRM_Utils_Type::T_STRING,
+    ],
+    'trxn_date' => [
+      'title' => ts('Payment Date'),
+      'type' => CRM_Utils_Type::T_TIMESTAMP,
     ],
   ];
 }

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -296,6 +296,9 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->submitPayment(70);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $this->_contributionId]);
     $this->assertEquals('Partially paid', $contribution['contribution_status']);
+    $this->assertEquals('2019-04-01 00:00:00', $contribution['receive_date']);
+    $payment = $this->callAPISuccessGetSingle('Payment', ['contribution_id' => $contribution['id']]);
+    $this->assertEquals('2017-04-11 13:05:11', $payment['trxn_date']);
 
     // pay additional amount
     $this->submitPayment(30);
@@ -430,8 +433,6 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'total_amount' => $amount,
       'currency' => 'USD',
       'financial_type_id' => 1,
-      'receive_date' => '04/21/2015',
-      'receive_date_time' => '11:27PM',
       'trxn_date' => '2017-04-11 13:05:11',
       'payment_processor_id' => 0,
       'is_email_receipt' => $isEmailReceipt,
@@ -493,6 +494,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $orderParams = array_merge($this->_params, [
       'contribution_status_id' => 'Pending',
       'is_pay_later' => 1,
+      'receive_date' => '2019-04-01',
     ]);
     $contribution = $this->callAPISuccess('Order', 'create', $orderParams);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contribution['id']]);


### PR DESCRIPTION
Overview
----------------------------------------
Fix a bug identified by @kcristiano whereby adding a payment with the
additional payment form changes the contribution receive_date.

Also, add a default to Payment.create of 'now' for the
trxn_date and require it to be set. Use that value later on.

Some string fixes

Before
----------------------------------------
Adding a payment on AdditionalPaymentForm changes Contribution.receive_date

After
----------------------------------------
Contribution.receive_date not altered

Technical Details
----------------------------------------
@kcristiano @magnolia61 

Comments
----------------------------------------

