### PR TITLE
Remove legacy tpl param contributionTypeName

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -392,8 +392,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $tplParams['financialTypeId'] = $contributionTypeId;
         $tplParams['financialTypeName'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
           $contributionTypeId);
-        // Legacy support
-        $tplParams['contributionTypeName'] = $tplParams['financialTypeName'];
         $tplParams['contributionTypeId'] = $contributionTypeId;
       }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1418,8 +1418,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         //insert financial type name in receipt.
         $this->assign('financialTypeName', CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
           $contributionParams['financial_type_id']));
-        // legacy support
-        $this->assign('contributionTypeName', CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $contributionParams['financial_type_id']));
         $contributionParams['skipLineItem'] = 1;
         if ($this->_id) {
           $contributionParams['contribution_mode'] = 'participant';


### PR DESCRIPTION
Overview
----------------------------------------
Remove old legacy tpl param contributionTypeName

Before
----------------------------------------
Still 2 assigns

After
----------------------------------------
No assigns

Technical Details
----------------------------------------
I grepped for this & I think it is otherwise gone & has been for a while


Comments
----------------------------------------

