### PR TITLE
Replace log_date with created_date & modified_date in advanced search

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -387,35 +387,6 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
   }
 
   /**
-   * Store relative dates in separate array format
-   *
-   * @param array $queryParams
-   * @param array $formValues
-   * @deprecated
-   */
-  public static function saveRelativeDates(&$queryParams, $formValues) {
-    // This is required only until all fields are converted to datepicker fields as the new format is truer to the
-    // form format and simply saves (e.g) custom_3_relative => "this.year"
-    $relativeDates = ['relative_dates' => []];
-    $specialDateFields = [
-      'log_date_relative',
-    ];
-    foreach ($formValues as $id => $value) {
-      if (in_array($id, $specialDateFields) && !empty($value)) {
-        $entityName = strstr($id, '_date', TRUE);
-        if (empty($entityName)) {
-          $entityName = strstr($id, '_relative', TRUE);
-        }
-        $relativeDates['relative_dates'][$entityName] = $value;
-      }
-    }
-    // merge with original queryParams if relative date value(s) found
-    if (count($relativeDates['relative_dates'])) {
-      $queryParams = array_merge($queryParams, $relativeDates);
-    }
-  }
-
-  /**
    * Store search variables in $queryParams which were skipped while processing query params,
    * precisely at CRM_Contact_BAO_Query::fixWhereValues(...). But these variable are required in
    * building smart group criteria otherwise it will cause issues like CRM-18585,CRM-19571

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -263,6 +263,8 @@ class CRM_Contact_Form_Search_Criteria {
       'sort_name' => ['title' => ts('Complete OR Partial Name'), 'template_grouping' => 'basic'],
       'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
       'contact_tags' => ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'template_grouping' => 'basic'],
+      'created_date' => ['name' => 'created_date', 'template_grouping' => 'changeLog'],
+      'modified_date' => ['name' => 'modified_date', 'template_grouping' => 'changeLog'],
       'birth_date' => ['name' => 'birth_date', 'template_grouping' => 'demographic'],
       'deceased_date' => ['name' => 'deceased_date', 'template_grouping' => 'demographic'],
       'is_deceased' => ['is_deceased', 'template_grouping' => 'demographic'],
@@ -503,17 +505,15 @@ class CRM_Contact_Form_Search_Criteria {
 
   /**
    * @param CRM_Core_Form $form
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function changeLog(&$form) {
     $form->add('hidden', 'hidden_changeLog', 1);
-
+    $form->addSearchFieldMetadata(['Contact' => self::getFilteredSearchFieldMetadata('changeLog')]);
+    $form->addFormFieldsFromMetadata();
     // block for change log
     $form->addElement('text', 'changed_by', ts('Modified By'), NULL);
-
-    $dates = [1 => ts('Added'), 2 => ts('Modified')];
-    $form->addRadio('log_date', NULL, $dates, ['allowClear' => TRUE]);
-
-    CRM_Core_Form_Date::buildDateRange($form, 'log_date', 1, '_low', '_high', ts('From:'), FALSE, FALSE);
   }
 
   /**

--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -191,7 +191,6 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     // Ideally per CRM-17075 we will use entity reference fields heavily in the form layer & convert to the
     // sql operator syntax at the query layer.
     if (!$isSearchBuilder) {
-      CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
       CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
       $savedSearch->form_values = serialize($queryParams);
     }

--- a/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
@@ -26,16 +26,14 @@
 <div id="changelog" class="form-item">
   <table class="form-layout">
     <tr>
+      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="created_date"}
       <td>
         <span class="modifiedBy"><label>{ts}Modified By{/ts}</label></span></br>
-        {$form.changed_by.html}
+        {$form.changed_by.html}<br><span class="description">{ts}Note this field just filters on who made a change no matter when that change happened, It doesn't have any link to the modified date field below{/ts}</span>
       </td>
-      <td>
-        {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="created_date"}
-      </td>
-      <td>
-        {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="modified_date"}
-      </td>
+    </tr>
+    <tr>
+      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="modified_date"}
     </tr>
   </table>
 </div>

--- a/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
@@ -26,49 +26,16 @@
 <div id="changelog" class="form-item">
   <table class="form-layout">
     <tr>
-      <td colspan="2">
-        {$form.log_date.html}
-      </td>
-    </tr>
-    <tr>
-      <td width="30%">
-        <span class="modifiedBy"><label>{ts}Modified By{/ts}</label></span>
-        <span class="hiddenElement addedBy"><label>{ts}Added By{/ts}</label></span>
-      </td>
       <td>
-        <span class="modifiedBy"><label>{ts}Modified Between{/ts}</label></span>
-        <span class="hiddenElement addedBy"><label>{ts}Added Between{/ts}</label></span>
-      </td>
-    </tr>
-    <tr>
-      <td>
+        <span class="modifiedBy"><label>{ts}Modified By{/ts}</label></span></br>
         {$form.changed_by.html}
       </td>
-      {include file="CRM/Core/DateRange.tpl" fieldName="log_date" from='_low' to='_high'}
+      <td>
+        {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="created_date"}
+      </td>
+      <td>
+        {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="modified_date"}
+      </td>
     </tr>
   </table>
 </div>
-
-{literal}
-  <script type="text/javascript">
-    CRM.$(function($) {
-      function updateChangeLogLabels() {
-        var changeType = $('input[name=log_date]:checked').val();
-        if (changeType == 2) {
-          $('.addedBy').hide();
-          $('.modifiedBy').show();
-        }
-        else {
-          if (changeType == 1) {
-            $('.addedBy').show();
-            $('.modifiedBy').hide();
-          }
-        }
-      }
-      $('[name=log_date]:input').change(updateChangeLogLabels);
-      updateChangeLogLabels();
-    });
-
-
-  </script>
-{/literal}

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -1028,46 +1028,6 @@ civicrm_relationship.is_active = 1 AND
   }
 
   /**
-   * When we have a relative date in search criteria, check that convertFormValues() sets _low & _high date fields and returns other criteria.
-   * CRM-21816 fix relative dates in search bug
-   */
-  public function testConvertFormValuesCRM21816() {
-    $fv = [
-      // next 60 days
-      "member_end_date_relative" => "starting_2.month",
-      "member_end_date_low" => "20180101000000",
-      "member_end_date_high" => "20180331235959",
-      "membership_is_current_member" => "1",
-      "member_is_primary" => "1",
-    ];
-    // $fv is modified by convertFormValues()
-    $fv_orig = $fv;
-    $params = CRM_Contact_BAO_Query::convertFormValues($fv);
-
-    // restructure for easier testing
-    $modparams = [];
-    foreach ($params as $p) {
-      $modparams[$p[0]] = $p;
-    }
-
-    // Check member_end_date_low is in params
-    $this->assertTrue(is_array($modparams['member_end_date_low']));
-    // ... fv and params should match
-    $this->assertEquals($modparams['member_end_date_low'][2], $fv['member_end_date_low']);
-    // ... fv & fv_orig should be different
-    $this->assertNotEquals($fv['member_end_date_low'], $fv_orig['member_end_date_low']);
-
-    // same for member_end_date_high
-    $this->assertTrue(is_array($modparams['member_end_date_high']));
-    $this->assertEquals($modparams['member_end_date_high'][2], $fv['member_end_date_high']);
-    $this->assertNotEquals($fv['member_end_date_high'], $fv_orig['member_end_date_high']);
-
-    // Check other fv values are in params
-    $this->assertEquals($modparams['membership_is_current_member'][2], $fv_orig['membership_is_current_member']);
-    $this->assertEquals($modparams['member_is_primary'][2], $fv_orig['member_is_primary']);
-  }
-
-  /**
    * Create contributions to test summary calculations.
    *
    * financial type     | cancel_date        |total_amount| source    | line_item_financial_types  |number_line_items| line_amounts
@@ -1078,6 +1038,8 @@ civicrm_relationship.is_active = 1 AND
    * Donation           |NULL                | 300.00     |SSF         | Donation,Donation         | 2                | 200.00,100.00
    * Donation           |2019-02-13 00:00:00 | 50.00      |SSF         | Donation                  | 1                | 50.00
    * Member Dues        |2019-02-13 00:00:00 | 50.00      |SSF         | Member Dues               | 1                | 50.00
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function createContributionsForSummaryQueryTests() {
     $contactID = $this->individualCreate();

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -98,53 +98,6 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test if dates ranges are stored correctly
-   * in civicrm_saved_search table and are
-   * extracted properly.
-   */
-  public function testDateRange() {
-    $savedSearch = new CRM_Contact_BAO_SavedSearch();
-    $formValues = [
-      'hidden_basic' => 1,
-      'group_search_selected' => 'group',
-      'component_mode' => 1,
-      'operator' => 'AND',
-      'privacy_operator' => 'OR',
-      'privacy_toggle' => 1,
-      'participant_register_date_low' => '01/01/2009',
-      'participant_register_date_high' => '01/01/2018',
-      'radio_ts' => 'ts_all',
-      'title' => 'bah bah bah',
-    ];
-
-    $queryParams = [
-      0 => [
-        0 => 'participant_register_date_low',
-        1 => '=',
-        2 => '01/01/2009',
-        3 => 0,
-        4 => 0,
-      ],
-      1 => [
-        0 => 'participant_register_date_high',
-        1 => '=',
-        2 => '01/01/2018',
-        3 => 0,
-        4 => 0,
-      ],
-    ];
-
-    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
-    CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
-    $savedSearch->form_values = serialize($queryParams);
-    $savedSearch->save();
-
-    $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
-    $this->assertEquals('01/01/2009', $result['participant_register_date_low']);
-    $this->assertEquals('01/01/2018', $result['participant_register_date_high']);
-  }
-
-  /**
    * Test if skipped elements are correctly
    * stored and retrieved as formvalues.
    */
@@ -172,81 +125,6 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
       'uf_group_id' => 1,
     ];
     $this->checkArrayEquals($result, $expectedResult);
-  }
-
-  /**
-   * Test if change log relative dates are stored correctly
-   * in civicrm_saved_search table.
-   */
-  public function testRelativeDateChangeLog() {
-    $savedSearch = new CRM_Contact_BAO_SavedSearch();
-    $formValues = [
-      'operator' => 'AND',
-      'log_date_relative' => 'this.month',
-      'radio_ts' => 'ts_all',
-    ];
-    $queryParams = [];
-    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
-    CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
-    $savedSearch->form_values = serialize($queryParams);
-    $savedSearch->save();
-
-    $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
-    $expectedResult = [
-      'log' => 'this.month',
-    ];
-    $this->checkArrayEquals($result['relative_dates'], $expectedResult);
-  }
-
-  /**
-   * Test relative dates
-   *
-   * This is a slightly odd test because it was originally created to test that we DO create a
-   * special 'relative_dates' key but the new favoured format is not to do that and to
-   * save (eg) custom_1_relative = this.day.
-   *
-   * It still presumably provides useful 'this does not fatal or give enotice' coverage.
-   */
-  public function testCustomFieldRelativeDates() {
-    // Create a custom field.
-    $customGroup = $this->customGroupCreate(['extends' => 'Individual', 'title' => 'relative_date_test_group']);
-    $params = [
-      'custom_group_id' => $customGroup['id'],
-      'name' => 'test_datefield',
-      'label' => 'Date Field for Testing',
-      'html_type' => 'Select Date',
-      'data_type' => 'Date',
-      'default_value' => NULL,
-      'weight' => 4,
-      'is_required' => 1,
-      'is_searchable' => 1,
-      'date_format' => 'mm/dd/yy',
-      'is_active' => 1,
-    ];
-    $customField = $this->callAPIAndDocument('custom_field', 'create', $params, __FUNCTION__, __FILE__);
-    $id = $customField['id'];
-
-    $queryParams = [
-      0 => [
-        0 => "custom_${id}_low",
-        1 => '=',
-        2 => '20170425000000',
-      ],
-      1 => [
-        0 => "custom_${id}_high",
-        1 => '=',
-        2 => '20170501235959',
-      ],
-    ];
-    $formValues = [
-      "custom_${id}_relative" => 'ending.week',
-    ];
-    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
-    // Since custom_13 doesn't have the word 'date' in it, the key is
-    // set to 0, rather than the field name.
-    $this->assertArrayNotHasKey('relative_dates', $queryParams, 'Relative date in custom field smart group creation failed.');
-    $dropCustomValueTables = TRUE;
-    $this->quickCleanup(['civicrm_saved_search'], $dropCustomValueTables);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is almost the last step in getting rid of an awful lot of technical debt & hard to maintain code around jcalendar & datepicker.

It does change the UI a bit - the code to create the current UI is pretty tough going and from seeing users try to work with it I don't think all that code is making it more usable. OTOH we can remove a maintainability blocker by switching over


Before
----------------------------------------
<img width="813" alt="Screen Shot 2019-11-01 at 7 20 14 PM" src="https://user-images.githubusercontent.com/336308/68006203-a69fb580-fcdc-11e9-9bd8-62dc0ed3913c.png">


After
----------------------------------------
<img width="807" alt="Screen Shot 2019-11-01 at 7 18 05 PM" src="https://user-images.githubusercontent.com/336308/68006178-87088d00-fcdc-11e9-9abe-da87b734122f.png">



Technical Details
----------------------------------------
@seamuslee001 I'm keen for you to take a look & see what you think
1)  I've still got a problem to solve with display on the 'choose range' - I recall we had this before but I can't spot why
<img width="799" alt="Screen Shot 2019-11-01 at 7 25 49 PM" src="https://user-images.githubusercontent.com/336308/68006451-760c4b80-fcdd-11e9-835e-138eb13bd0d9.png">


2) my read on what the code does without this change is it filters by contact.created_date or contact.modified_date AND it joins onto the modified contact (if entered) but the implication that it means 'this contact created it in this date range' is wrong and the current UI is misleading

Comments
----------------------------------------
Conversion not included as yet
