### PR TITLE
Get rid of jcalendar range in custom data

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6369,6 +6369,7 @@ AND   displayRelType.is_active = 1
    *
    * @return string
    *   list(string $orderByClause, string $additionalFromClause).
+   *
    * @throws \CRM_Core_Exception
    */
   protected function prepareOrderBy($sort, $sortOrder) {

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -417,47 +417,26 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
    * @param string $fieldName
    * @param string $op
    * @param array|string|int $value
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function decodeRelativeFields(&$formValues, $fieldName, $op, $value) {
     // check if its a custom date field, if yes then 'searchDate' format the value
-    $isCustomDateField = CRM_Contact_BAO_Query::isCustomDateField($fieldName);
-
-    // select date range as default
-    if ($isCustomDateField) {
-      if (array_key_exists('relative_dates', $formValues) && array_key_exists($fieldName, $formValues['relative_dates'])) {
-        $formValues[$fieldName . '_relative'] = $formValues['relative_dates'][$fieldName];
-      }
-      else {
-        $formValues[$fieldName . '_relative'] = 0;
-      }
+    if (CRM_Contact_BAO_Query::isCustomDateField($fieldName)) {
+      return;
     }
+
     switch ($op) {
       case 'BETWEEN':
-        if ($isCustomDateField) {
-          list($formValues[$fieldName . '_from'], $formValues[$fieldName . '_from_time']) = CRM_Utils_Date::setDateDefaults($value[0], 'searchDate');
-          list($formValues[$fieldName . '_to'], $formValues[$fieldName . '_to_time']) = CRM_Utils_Date::setDateDefaults($value[1], 'searchDate');
-        }
-        else {
-          list($formValues[$fieldName . '_from'], $formValues[$fieldName . '_to']) = $value;
-        }
+        list($formValues[$fieldName . '_from'], $formValues[$fieldName . '_to']) = $value;
         break;
 
       case '>=':
-        if ($isCustomDateField) {
-          list($formValues[$fieldName . '_from'], $formValues[$fieldName . '_from_time']) = CRM_Utils_Date::setDateDefaults($value, 'searchDate');
-        }
-        else {
-          $formValues[$fieldName . '_from'] = $value;
-        }
+        $formValues[$fieldName . '_from'] = $value;
         break;
 
       case '<=':
-        if ($isCustomDateField) {
-          list($formValues[$fieldName . '_to'], $formValues[$fieldName . '_to_time']) = CRM_Utils_Date::setDateDefaults($value, 'searchDate');
-        }
-        else {
-          $formValues[$fieldName . '_to'] = $value;
-        }
+        $formValues[$fieldName . '_to'] = $value;
         break;
     }
   }

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -605,6 +605,8 @@ class CRM_Contact_Form_Search_Criteria {
    * Generate the custom Data Fields based for those with is_searchable = 1.
    *
    * @param CRM_Contact_Form_Search $form
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function custom(&$form) {
     $form->add('hidden', 'hidden_custom', 1);
@@ -624,8 +626,8 @@ class CRM_Contact_Form_Search_Criteria {
       foreach ($group['fields'] as $field) {
         $fieldId = $field['id'];
         $elementName = 'custom_' . $fieldId;
-        if ($field['data_type'] == 'Date' && $field['is_search_range']) {
-          CRM_Core_Form_Date::buildDateRange($form, $elementName, 1, '_from', '_to', ts('From:'), FALSE);
+        if ($field['data_type'] === 'Date' && $field['is_search_range']) {
+          $form->addDatePickerRange($elementName, $field['label']);
         }
         else {
           CRM_Core_BAO_CustomField::addQuickFormElement($form, $elementName, $fieldId, FALSE, TRUE);

--- a/CRM/Core/BAO/Query.php
+++ b/CRM/Core/BAO/Query.php
@@ -47,8 +47,8 @@ class CRM_Core_BAO_Query {
         foreach ($group['fields'] as $field) {
           $fieldId = $field['id'];
           $elementName = 'custom_' . $fieldId;
-          if ($field['data_type'] == 'Date' && $field['is_search_range']) {
-            CRM_Core_Form_Date::buildDateRange($form, $elementName, 1, '_from', '_to', ts('From:'), FALSE);
+          if ($field['data_type'] === 'Date' && $field['is_search_range']) {
+            $form->addDatePickerRange($elementName, $field['label']);
           }
           else {
             CRM_Core_BAO_CustomField::addQuickFormElement($form, $elementName, $fieldId, FALSE, TRUE);

--- a/templates/CRM/Core/DatePickerRangeCustomField.tpl
+++ b/templates/CRM/Core/DatePickerRangeCustomField.tpl
@@ -29,20 +29,23 @@
 {assign var='to' value=$to|default:'_high'}
 
   {if !$hideRelativeLabel}
-    {$form.$relativeName.label}<br />
+    <td class="label">
+      {$form.$relativeName.label}
+    </td>
   {/if}
-  {$form.$relativeName.html}<br />
-  <span class="crm-absolute-date-range">
-    <span class="crm-absolute-date-from">
-      {assign var=fromName value=$fieldName|cat:$from}
-      {$form.$fromName.label}
-      {$form.$fromName.html}
+  <td>
+    {$form.$relativeName.html}<br />
+    <span class="crm-absolute-date-range">
+      <span class="crm-absolute-date-from">
+        {assign var=fromName value=$fieldName|cat:$from}
+        {$form.$fromName.label}
+        {$form.$fromName.html}
+      </span>
+      <span class="crm-absolute-date-to">
+        {assign var=toName   value=$fieldName|cat:$to}
+        {$form.$toName.label}
+        {$form.$toName.html}
+      </span>
     </span>
-    <span class="crm-absolute-date-to">
-      {assign var=toName   value=$fieldName|cat:$to}
-      {$form.$toName.label}
-      {$form.$toName.html}
-    </span>
-  </span>
+  </td>
   {include file="CRM/Core/DatePickerRangejs.tpl" relativeName=$relativeName}
-

--- a/templates/CRM/Core/DatePickerRangejs.tpl
+++ b/templates/CRM/Core/DatePickerRangejs.tpl
@@ -23,26 +23,18 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{*this is included inside a table row*}
-{assign var=relativeName   value=$fieldName|cat:"_relative"}
-{assign var='from' value=$from|default:'_low'}
-{assign var='to' value=$to|default:'_high'}
-
-  {if !$hideRelativeLabel}
-    {$form.$relativeName.label}<br />
-  {/if}
-  {$form.$relativeName.html}<br />
-  <span class="crm-absolute-date-range">
-    <span class="crm-absolute-date-from">
-      {assign var=fromName value=$fieldName|cat:$from}
-      {$form.$fromName.label}
-      {$form.$fromName.html}
-    </span>
-    <span class="crm-absolute-date-to">
-      {assign var=toName   value=$fieldName|cat:$to}
-      {$form.$toName.label}
-      {$form.$toName.html}
-    </span>
-  </span>
-  {include file="CRM/Core/DatePickerRangejs.tpl" relativeName=$relativeName}
-
+{literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      $("#{/literal}{$relativeName}{literal}").change(function() {
+        var n = cj(this).parent().parent();
+        if ($(this).val() == "0") {
+          $(".crm-absolute-date-range", n).show();
+        } else {
+          $(".crm-absolute-date-range", n).hide();
+          $(':text', n).val('');
+        }
+      }).change();
+    });
+  </script>
+{/literal}

--- a/templates/CRM/Custom/Form/Search.tpl
+++ b/templates/CRM/Custom/Form/Search.tpl
@@ -45,7 +45,7 @@
                     {$form.$element_name_from.html|crmAddClass:six}
                     &nbsp;&nbsp;{$form.$element_name_to.label}&nbsp;&nbsp;{$form.$element_name_to.html|crmAddClass:six}
                   {elseif $element.skip_calendar NEQ true }
-                    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName=$element_name}<td>
+                    {include file="CRM/Core/DatePickerRangeCustomField.tpl" fieldName=$element_name hideRelativeLabel=0}<td>
                   {/if}
             {else}
                 <td class="label">{$form.$element_name.label}</td><td>

--- a/templates/CRM/Custom/Form/Search.tpl
+++ b/templates/CRM/Custom/Form/Search.tpl
@@ -45,8 +45,7 @@
                     {$form.$element_name_from.html|crmAddClass:six}
                     &nbsp;&nbsp;{$form.$element_name_to.label}&nbsp;&nbsp;{$form.$element_name_to.html|crmAddClass:six}
                   {elseif $element.skip_calendar NEQ true }
-                    <td class="label"><label for='{$element_name}'>{$element.label}</label>
-                    {include file="CRM/Core/DateRange.tpl" fieldName=$element_name from='_from' to='_to'}</td><td>
+                    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName=$element_name}<td>
                   {/if}
             {else}
                 <td class="label">{$form.$element_name.label}</td><td>


### PR DESCRIPTION
Overview
----------------------------------------
This is the last jcalendar field in search so it has to go. My testing (& recollection) suggests a conversion routine is not required for saved searches using these. 

Before
----------------------------------------
Jcalendar
<img width="539" alt="Screen Shot 2019-11-02 at 11 35 53 AM" src="https://user-images.githubusercontent.com/336308/68060364-f32ed380-fd64-11e9-8ac7-f8723e67f541.png">


After
----------------------------------------
Datepicker rules KO

Technical Details
----------------------------------------
@seamuslee001  first attempt - the layout is a bit wonky in this first cut.

Comments
----------------------------------------

