### PR TITLE
Renders customfields under campaign search in Campaign dashboard

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -476,6 +476,7 @@ INNER JOIN civicrm_option_group grp ON ( campaign_type.option_group_id = grp.id 
               $where[] = implode(' OR ', $or);
             }
             break;
+
           default:
             $where[] = "( {$customfields[$campaignCF]['table_name']}.{$customfields[$campaignCF]['column_name']} = '{$pdata}' )";
         }

--- a/CRM/Campaign/Form/Search/Campaign.php
+++ b/CRM/Campaign/Form/Search/Campaign.php
@@ -163,7 +163,6 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
    * @return array
    *
    */
-
   public static function preprocessCustomFields($entity) {
     if (!$entity) {
       return;
@@ -203,7 +202,6 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
    * @return none
    *
    */
-
   public static function renderCustomFieldsInForm($form, $entity) {
 
     if (!$entity) {
@@ -228,6 +226,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
               $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, ['class' => 'crm-select2', 'multiple' => TRUE, 'placeholder' => ts('- none -')]);
             }
             break;
+
           case 'Multi-Select':
             if ($customFieldData['option_group_id']) {
               // Get the option values from that optiongroup id
@@ -238,6 +237,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
               $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, $attributes);
             }
             break;
+
           case 'Select':
             if ($customFieldData['option_group_id']) {
               // Get the option values from that optiongroup id
@@ -248,6 +248,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
               $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, $attributes);
             }
             break;
+
           case 'CheckBox':
             if ($customFieldData['option_group_id']) {
               $options = CRM_Core_OptionGroup::valuesByID(
@@ -257,6 +258,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
               );
             }
             break;
+
           case 'Radio':
             if ($customFieldData['data_type'] == 'Boolean') {
               $options = ['' => '- any -', 0 => 'No', 1 => 'Yes'];
@@ -267,6 +269,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
             $attributes = ['placeholder' => ts('- none -')];
             $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, $attributes);
             break;
+
           default:
             $form->add($customFieldData['html_type'], $customFieldData['name'], $customFieldData['label']);
         }

--- a/CRM/Campaign/Form/Search/Campaign.php
+++ b/CRM/Campaign/Form/Search/Campaign.php
@@ -152,7 +152,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
     $this->assign('searchParams', json_encode($this->_searchParams));
   }
 
-  /*
+  /**
    * This function will enrich the customfield data with some more information
    * that is vital to us.
    *
@@ -181,7 +181,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
     return $customfields;
   }
 
-  /*
+  /**
    * This function will add customfields into a form (passed as parameter)
    * and will render only the searchable ones
    *

--- a/CRM/Campaign/Form/Search/Campaign.php
+++ b/CRM/Campaign/Form/Search/Campaign.php
@@ -81,6 +81,14 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
       return;
     }
 
+    $customfields = self::preprocessCustomFields('Campaign');
+    if (!empty($customfields)) {
+      // Assign a variable to the template to notify that we have some customfields
+      $this->assign('has_customfields', TRUE);
+      // Also add a variable so that we can analyse it later
+      $this->has_customfields = TRUE;
+    }
+
     $attributes = CRM_Core_DAO::getAttribute('CRM_Campaign_DAO_Campaign');
     $this->add('text', 'campaign_title', ts('Title'), $attributes['title']);
 
@@ -118,10 +126,22 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
       '1' => ts('No'),
     ]);
 
+    // Render the customfields into the form, if there are any
+    if ($this->has_customfields) {
+      self::renderCustomFieldsInForm($this, 'Campaign');
+    }
+
     //build the array of all search params.
     $this->_searchParams = [];
     foreach ($this->_elements as $element) {
-      $name = $element->_attributes['name'];
+      if (isset($element->_attributes['name'])) {
+        $name = $element->_attributes['name'];
+      }
+      elseif (isset($element->_name)) {
+        // For some reason, a specific form element is not returning its name
+        //in the attributes, therefore we need to take care of this
+        $name = $element->_name;
+      }
       $label = $element->_label;
       if ($name == 'qfKey') {
         continue;
@@ -130,6 +150,128 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
     }
     $this->set('searchParams', $this->_searchParams);
     $this->assign('searchParams', json_encode($this->_searchParams));
+  }
+
+  /*
+   * This function will enrich the customfield data with some more information
+   * that is vital to us.
+   *
+   * TODO: implement 'is_searchable' in the function CRM_Core_BAO_CustomField::getFields
+   *
+   * @param string $entity 'Campaign'
+   *
+   * @return array
+   *
+   */
+
+  public static function preprocessCustomFields($entity) {
+    if (!$entity) {
+      return;
+    }
+
+    $customfields = CRM_Core_BAO_CustomField::getFields($entity);
+    // We need to enrich the customfields array with some more information
+    foreach ($customfields as $customfieldkey => $dnc) {
+      if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $customfieldkey, 'is_searchable')) {
+        $customfields[$customfieldkey]['is_searchable'] = TRUE;
+      }
+      else {
+        $customfields[$customfieldkey]['is_searchable'] = FALSE;
+      }
+    }
+    return $customfields;
+  }
+
+  /*
+   * This function will add customfields into a form (passed as parameter)
+   * and will render only the searchable ones
+   *
+   * Currently works for the following html types:
+   *
+   *   * Multi-Select State/Province (though you cannot pickup the country yet)
+   *   * Multi-Select
+   *   * Select
+   *   * Checkbox
+   *   * Radio
+   *   * Text
+   *
+   * TODO: Dates, search ranges, multi-Select Country, Multi-Select State/Province based on Country
+   *
+   * @param obj $form
+   * @param string $entity 'Campaign'
+   *
+   * @return none
+   *
+   */
+
+  public static function renderCustomFieldsInForm($form, $entity) {
+
+    if (!$entity) {
+      return;
+    }
+    $customfields = self::preprocessCustomFields($entity);
+
+    if (!is_array($customfields)) {
+      return;
+    }
+
+    foreach ($customfields as $dnc => $customFieldData) {
+      // First check if customfield is searchable
+      if ($customFieldData['is_searchable']) {
+        $options = [];
+        switch ($customFieldData['html_type']) {
+          case 'Multi-Select State/Province':
+            // Is this a state province ?
+            if ($customFieldData['data_type'] == 'StateProvince') {
+              // Fetch the state province list
+              $options = CRM_Core_BAO_Address::buildOptions('state_province_id', NULL, NULL);
+              $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, ['class' => 'crm-select2', 'multiple' => TRUE, 'placeholder' => ts('- none -')]);
+            }
+            break;
+          case 'Multi-Select':
+            if ($customFieldData['option_group_id']) {
+              // Get the option values from that optiongroup id
+              $options = CRM_Core_OptionGroup::valuesByID(
+                  $customFieldData['option_group_id'], FALSE, FALSE, FALSE, 'label', TRUE
+              );
+              $attributes = ['class' => 'crm-select2', 'multiple' => TRUE, 'placeholder' => ts('- none -')];
+              $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, $attributes);
+            }
+            break;
+          case 'Select':
+            if ($customFieldData['option_group_id']) {
+              // Get the option values from that optiongroup id
+              $options = CRM_Core_OptionGroup::valuesByID(
+                  $customFieldData['option_group_id'], FALSE, FALSE, FALSE, 'label', TRUE
+              );
+              $attributes = ['class' => 'crm-select2', 'multiple' => FALSE, 'placeholder' => ts('- none -')];
+              $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, $attributes);
+            }
+            break;
+          case 'CheckBox':
+            if ($customFieldData['option_group_id']) {
+              $options = CRM_Core_OptionGroup::valuesByID(
+                  $customFieldData['option_group_id'], FALSE, FALSE, FALSE, 'label', TRUE
+              );
+              $form->addCheckBox($customFieldData['name'], $customFieldData['label'], array_flip($options), NULL, NULL, NULL, NULL, ['&nbsp;&nbsp;', '&nbsp;&nbsp;', '<br/>']
+              );
+            }
+            break;
+          case 'Radio':
+            if ($customFieldData['data_type'] == 'Boolean') {
+              $options = ['' => '- any -', 0 => 'No', 1 => 'Yes'];
+            }
+            else {
+              $options = CRM_Core_OptionGroup::values($customFieldData['name'], FALSE, FALSE, TRUE);
+            }
+            $attributes = ['placeholder' => ts('- none -')];
+            $form->addElement('select', $customFieldData['name'], $customFieldData['label'], $options, $attributes);
+            break;
+          default:
+            $form->add($customFieldData['html_type'], $customFieldData['name'], $customFieldData['label']);
+        }
+      }
+    }
   }
 
 }

--- a/templates/CRM/Campaign/Form/Search/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Search/Campaign.tpl
@@ -117,7 +117,18 @@
                 {$form.is_active.html}
               </td>
             </tr>
-
+            <tr style="width:200%;display:inline-block;">
+            {* Loop through all fields *}
+            {foreach from=$form item="field"}
+              {* If field name begins with 'custom_', then it's a customfield *}
+              {if $field.name|strpos:'custom_' === 0}
+                <td style="display:inline-block;width:25%;">
+                  {$field.label}<br />
+                  {$field.html}
+                </td>
+              {/if}
+            {/foreach}
+            </tr>
             <tr>
               <td colspan="2">
                 {if $context eq 'search'}


### PR DESCRIPTION
Overview
----------------------------------------
Customfields that are being attached to a campaign entity do not render on the search page of campaign dashboard, therefore, a user cannot use them to search for campaigns using those customfields.

Related issue: https://lab.civicrm.org/dev/core/issues/1354

Before
----------------------------------------
Customfields do not render on the search form of Campaign dashboard

After
----------------------------------------
Customfields render on the search form of Campaign dashboard and user can search with these.

Technical Details
----------------------------------------
During buildform of campaign dashboard, a new call is being made to a function that takes care of rendering customfields on the form itself by analysing the `html_type` & `datatype`.

Additionally, during the actual search, if field is a customfield, we `LEFT JOIN` the related table(s)

Comments
----------------------------------------
All comments are welcome!
