### PR TITLE
Add Payment PropertyBag for payment processor method arguments

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1237,6 +1237,23 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Processors may need to inspect, validate, cast and copy data that is
+   * specific to this Payment Processor from the input array to custom fields
+   * on the PropertyBag.
+   *
+   * @param Civi\Payment\PropertyBag $propertyBag
+   * @param array $params
+   * @param string $component
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function extractCustomPropertiesForDoPayment(PropertyBag $propertyBag, array $params, $component = 'contribute') {
+    // example
+    // (validation and casting goes first)
+    // $propertyBag->setCustomProperty('myprocessor_customPropertyName', $value);
+  }
+
+  /**
    * Process payment - this function wraps around both doTransferCheckout and doDirectPayment.
    * Any processor that still implements the deprecated doTransferCheckout() or doDirectPayment() should be updated to use doPayment().
    *

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -48,7 +48,9 @@ class CRM_Core_Payment_Form {
 
     $processor['object']->setBillingProfile($billing_profile_id);
     $processor['object']->setBackOffice($isBackOffice);
-    $processor['object']->setPaymentInstrumentID($paymentInstrumentID);
+    if (isset($paymentInstrumentID)) {
+      $processor['object']->setPaymentInstrumentID($paymentInstrumentID);
+    }
     $paymentTypeName = self::getPaymentTypeName($processor);
     $form->assign('paymentTypeName', $paymentTypeName);
     $form->assign('paymentTypeLabel', self::getPaymentLabel($processor['object']));

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -1,0 +1,642 @@
+<?php
+namespace Civi\Payment;
+
+use InvalidArgumentException;
+use Civi;
+use CRM_Core_PseudoConstant;
+
+/**
+ * @class
+ *
+ * This class provides getters and setters for arguments needed by CRM_Core_Payment methods.
+ *
+ * The setters know how to validate each setting that they are responsible for.
+ *
+ * Different methods need different settings and the concept is that by passing
+ * in a property bag we can encapsulate the params needed for a particular
+ * method call, rather than setting arguments for different methods on the main
+ * CRM_Core_Payment object.
+ *
+ * This class is also supposed to help with transition away from array key naming nightmares.
+ *
+ */
+class PropertyBag implements \ArrayAccess {
+  protected $props = ['default' => []];
+
+  protected static $propMap = [
+    'contactID'              => TRUE,
+    'contact_id'             => 'contactID',
+    'contributionID'         => TRUE,
+    'contribution_id'        => 'contributionID',
+    'contributionRecurID'    => TRUE,
+    'contribution_recur_id'  => 'contributionRecurID',
+    'currency'               => TRUE,
+    'currencyID'             => 'currency',
+    'description'            => TRUE,
+    'feeAmount'              => TRUE,
+    'fee_amount'             => 'feeAmount',
+    'invoiceID'              => TRUE,
+    'invoice_id'             => 'invoiceID',
+    'isBackOffice'           => TRUE,
+    'is_back_office'         => 'isBackOffice',
+    'isRecur'                => TRUE,
+    'is_recur'               => 'isRecur',
+    'paymentToken'           => TRUE,
+    'payment_token'          => 'paymentToken',
+    'recurFrequencyInterval' => TRUE,
+    'frequency_interval' => 'recurFrequencyInterval',
+    'recurFrequencyUnit'     => TRUE,
+    'frequency_unit' => 'recurFrequencyUnit',
+    'transactionID'          => TRUE,
+    'transaction_id'         => 'transactionID',
+    'trxnResultCode'         => TRUE,
+  ];
+
+  /**
+   * @var string Just for unit testing.
+   */
+  public $lastWarning;
+
+  /**
+   * Implements ArrayAccess::offsetExists
+   *
+   * @param mixed $offset
+   * @return bool TRUE if we have that value (on our default store)
+   */
+  public function offsetExists ($offset): bool {
+    $prop = $this->handleLegacyPropNames($offset);
+    return isset($this->props['default'][$prop]);
+  }
+
+  /**
+   * Implements ArrayAccess::offsetGet
+   *
+   * @param mixed $offset
+   * @return mixed
+   */
+  public function offsetGet ($offset) {
+    $prop = $this->handleLegacyPropNames($offset);
+    return $this->get($prop, 'default');
+  }
+
+  /**
+   * Implements ArrayAccess::offsetSet
+   *
+   * @param mixed $offset
+   * @param mixed $value
+   */
+  public function offsetSet($offset, $value) {
+    try {
+      $prop = $this->handleLegacyPropNames($offset);
+    }
+    catch (InvalidArgumentException $e) {
+      // We need to make a lot of noise here, we're being asked to merge in
+      // something we can't validate because we don't know what this property is.
+      // This is fine if it's something particular to a payment processor
+      // (which should be using setCustomProperty) however it could also lead to
+      // things like 'my_weirly_named_contact_id'.
+      $this->legacyWarning($e->getMessage() . " We have merged this in for now as a custom property. Please rewrite your code to use PropertyBag->setCustomProperty if it is a genuinely custom property, or a standardised setter like PropertyBag->setContactID for standard properties");
+      $this->setCustomProperty($offset, $value, 'default');
+      return;
+    }
+
+    // Coerce legacy values that were in use but shouldn't be in our new way of doing things.
+    if ($prop === 'feeAmount' && $value === '') {
+      // At least the following classes pass in ZLS for feeAmount.
+      // CRM_Core_Payment_AuthorizeNetTest::testCreateSingleNowDated
+      // CRM_Core_Payment_AuthorizeNetTest::testCreateSinglePostDated
+      $value = 0;
+    }
+
+    // These lines are here (and not in try block) because the catch must only
+    // catch the case when the prop is custom.
+    $setter = 'set' . ucfirst($prop);
+    $this->$setter($value, 'default');
+  }
+
+  /**
+   * Implements ArrayAccess::offsetUnset
+   *
+   * @param mixed $offset
+   */
+  public function offsetUnset ($offset) {
+    $prop = $this->handleLegacyPropNames($offset);
+    unset($this->props['default'][$prop]);
+  }
+
+  /**
+   * @param string $message
+   */
+  protected function legacyWarning($message) {
+    $message = "Deprecated code: $message";
+    $this->lastWarning = $message;
+    Civi::log()->warning($message);
+  }
+
+  /**
+   * @param string $prop
+   * @return string canonical name.
+   * @throws \InvalidArgumentException if prop name not known.
+   */
+  protected function handleLegacyPropNames($prop) {
+    $newName = static::$propMap[$prop] ?? NULL;
+    if ($newName === TRUE) {
+      // Good, modern name.
+      return $prop;
+    }
+    if ($newName === NULL) {
+      throw new \InvalidArgumentException("Unknown property '$prop'.");
+    }
+    // Remaining case is legacy name that's been translated.
+    $this->legacyWarning("We have translated '$prop' to '$newName' for you, but please update your code to use the propper setters and getters.");
+    return $newName;
+  }
+
+  /**
+   * Internal getter.
+   *
+   * @param mixed $prop Valid property name
+   * @param string $label e.g. 'default'
+   */
+  protected function get($prop, $label) {
+    if (isset($this->props['default'][$prop])) {
+      return $this->props[$label][$prop];
+    }
+    throw new \BadMethodCallException("Property '$prop' has not been set.");
+  }
+
+  /**
+   * Internal setter.
+   *
+   * @param mixed $prop Valid property name
+   * @param string $label e.g. 'default'
+   * @param mixed $value
+   *
+   * @return PropertyBag $this object so you can chain set setters.
+   */
+  protected function set($prop, $label = 'default', $value) {
+    $this->props[$label][$prop] = $value;
+    return $this;
+  }
+
+  /**
+   * DRY code.
+   */
+  protected function coercePseudoConstantStringToInt(string $baoName, string $field, $input) {
+    if (is_numeric($input)) {
+      // We've been given a numeric ID.
+      $_ = (int) $input;
+    }
+    elseif (is_string($input)) {
+      // We've been given a named instrument.
+      $_ = (int) CRM_Core_PseudoConstant::getKey($baoName, $field, $input);
+    }
+    else {
+      throw new InvalidArgumentException("Expected an integer ID or a String name for $field.");
+    }
+    if (!($_ > 0)) {
+      throw new InvalidArgumentException("Expected an integer greater than 0 for $field.");
+    }
+    return $_;
+  }
+
+  /**
+   */
+  public function has($prop, $label = 'default') {
+    // We do NOT translate legacy prop names since only new code should be
+    // using this method, and new code should be using canonical names.
+    // $prop = $this->handleLegacyPropNames($prop);
+    return isset($this->props[$label][$prop]);
+  }
+
+  /**
+   * This is used to merge values from an array.
+   * It's a transitional function and should not be used!
+   *
+   * @param array $data
+   */
+  public function mergeLegacyInputParams($data) {
+    $this->legacyWarning("We have merged input params into the property bag for now but please rewrite code to not use this.");
+    foreach ($data as $key => $value) {
+      if ($value !== NULL) {
+        $this->offsetSet($key, $value);
+      }
+    }
+  }
+
+  /**
+   * Throw an exception if any of the props is unset.
+   *
+   * @param array $props Array of proper property names (no legacy aliases allowed).
+   *
+   * @return PropertyBag
+   */
+  public function require(array $props) {
+    $missing = [];
+    foreach ($props as $prop) {
+      if (!isset($this->props['default'][$prop])) {
+        $missing[] = $prop;
+      }
+    }
+    if ($missing) {
+      throw new \InvalidArgumentException("Required properties missing: " . implode(', ', $missing));
+    }
+    return $this;
+  }
+
+  // Public getters, setters.
+
+  /**
+   * Get the monetary amount.
+   */
+  public function getAmount($label = 'default') {
+    return $this->get('amount', $label);
+  }
+
+  /**
+   * Get the monetary amount.
+   */
+  public function setAmount($value, $label = 'default') {
+    if (!is_numeric($value)) {
+      throw new \InvalidArgumentException("setAmount requires a numeric amount value");
+    }
+
+    return $this->set('amount', CRM_Utils_Money::format($value, NULL, NULL, TRUE), $label);
+  }
+
+  /**
+   * @return int
+   */
+  public function getContactID($label = 'default'): int {
+    return $this->get('contactID', $label);
+  }
+
+  /**
+   * @param int $contactID
+   * @param string $label
+   */
+  public function setContactID($contactID, $label = 'default') {
+    // We don't use this because it counts zero as positive: CRM_Utils_Type::validate($contactID, 'Positive');
+    if (!($contactID > 0)) {
+      throw new InvalidArgumentException("ContactID must be a positive integer");
+    }
+
+    return $this->set('contactID', $label, (int) $contactID);
+  }
+
+  /**
+   * Getter for contributionID.
+   *
+   * @return int|null
+   * @param string $label
+   */
+  public function getContributionID($label = 'default') {
+    return $this->get('contributionID', $label);
+  }
+
+  /**
+   * @param int $contributionID
+   * @param string $label e.g. 'default'
+   */
+  public function setContributionID($contributionID, $label = 'default') {
+    // We don't use this because it counts zero as positive: CRM_Utils_Type::validate($contactID, 'Positive');
+    if (!($contributionID > 0)) {
+      throw new InvalidArgumentException("ContributionID must be a positive integer");
+    }
+
+    return $this->set('contributionID', $label, (int) $contributionID);
+  }
+
+  /**
+   * Getter for contributionRecurID.
+   *
+   * @return int|null
+   * @param string $label
+   */
+  public function getContributionRecurID($label = 'default') {
+    return $this->get('contributionRecurID', $label);
+  }
+
+  /**
+   * @param int $contributionRecurID
+   * @param string $label e.g. 'default'
+   */
+  public function setContributionRecurID($contributionRecurID, $label = 'default') {
+    // We don't use this because it counts zero as positive: CRM_Utils_Type::validate($contactID, 'Positive');
+    if (!($contributionRecurID > 0)) {
+      throw new InvalidArgumentException("ContributionRecurID must be a positive integer");
+    }
+
+    return $this->set('contributionRecurID', $label, (int) $contributionRecurID);
+  }
+
+  /**
+   * Three character currency code.
+   *
+   * https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+   *
+   * @param string $label e.g. 'default'
+   */
+  public function getCurrency($label = 'default') {
+    return $this->get('currency', $label);
+  }
+
+  /**
+   * Three character currency code.
+   *
+   * @param string $value
+   * @param string $label e.g. 'default'
+   */
+  public function setCurrency($value, $label = 'default') {
+    if (!preg_match('/^[A-Z]{3}$/', $value)) {
+      throw new \InvalidArgumentException("Attemted to setCurrency with a value that was not an ISO 3166-1 alpha 3 currency code");
+    }
+    return $this->set('currency', $label, $value);
+  }
+
+  /**
+   *
+   * @param string $label
+   *
+   * @return string
+   */
+  public function getDescription($label = 'default') {
+    return $this->get('description', $label);
+  }
+
+  /**
+   * @param string $description
+   * @param string $label e.g. 'default'
+   */
+  public function setDescription($description, $label = 'default') {
+    // @todo this logic was copied from a commit that then got deleted. Is it good?
+    $uninformativeStrings = [
+      ts('Online Event Registration: '),
+      ts('Online Contribution: '),
+    ];
+    $cleanedDescription = str_replace($uninformativeStrings, '', $description);
+    return $this->set('description', $label, $cleanedDescription);
+  }
+
+  /**
+   * Amount of money charged in fees by the payment processor.
+   *
+   * This is notified by (some) payment processers.
+   *
+   * @param string $label
+   *
+   * @return float
+   */
+  public function getFeeAmount($label = 'default') {
+    return $this->get('feeAmount', $label);
+  }
+
+  /**
+   * @param string $feeAmount
+   * @param string $label e.g. 'default'
+   */
+  public function setFeeAmount($feeAmount, $label = 'default') {
+    if (!is_numeric($feeAmount)) {
+      throw new \InvalidArgumentException("feeAmount must be a number.");
+    }
+    return $this->set('feeAmount', $label, (float) $feeAmount);
+  }
+
+  /**
+   * Getter for invoiceID.
+   *
+   * @param string $label
+   *
+   * @return string|null
+   */
+  public function getInvoiceID($label = 'default') {
+    return $this->get('invoiceID', $label);
+  }
+
+  /**
+   * @param string $invoiceID
+   * @param string $label e.g. 'default'
+   */
+  public function setInvoiceID($invoiceID, $label = 'default') {
+    return $this->set('invoiceID', $label, $invoiceID);
+  }
+
+  /**
+   * Getter for isBackOffice.
+   *
+   * @param string $label
+   *
+   * @return bool|null
+   */
+  public function getIsBackOffice($label = 'default'):bool {
+    // @todo should this return FALSE instead of exception to keep current situation?
+    return $this->get('isBackOffice', $label);
+  }
+
+  /**
+   * @param bool $isBackOffice
+   * @param string $label e.g. 'default'
+   */
+  public function setIsBackOffice($isBackOffice, $label = 'default') {
+    if (is_null($isBackOffice)) {
+      throw new \InvalidArgumentException("isBackOffice must be a bool, received NULL.");
+    }
+    return $this->set('isBackOffice', $label, (bool) $isBackOffice);
+  }
+
+  /**
+   * Getter for isRecur.
+   *
+   * @param string $label
+   *
+   * @return bool|null
+   */
+  public function getIsRecur($label = 'default'):bool {
+    return $this->get('isRecur', $label);
+  }
+
+  /**
+   * @param bool $isRecur
+   * @param string $label e.g. 'default'
+   */
+  public function setIsRecur($isRecur, $label = 'default') {
+    if (is_null($isRecur)) {
+      throw new \InvalidArgumentException("isRecur must be a bool, received NULL.");
+    }
+    return $this->set('isRecur', $label, (bool) $isRecur);
+  }
+
+  /**
+   * Getter for payment processor generated string for charging.
+   *
+   * A payment token could be a single use token (e.g generated by
+   * a client side script) or a token that permits recurring or on demand charging.
+   *
+   * The key thing is it is passed to the processor in lieu of card details to
+   * initiate a payment.
+   *
+   * Generally if a processor is going to pass in a payment token generated through
+   * javascript it would add 'payment_token' to the array it returns in it's
+   * implementation of getPaymentFormFields. This will add a hidden 'payment_token' field to
+   * the form. A good example is client side encryption where credit card details are replaced by
+   * an encrypted token using a gateway provided javascript script. In this case the javascript will
+   * remove the credit card details from the form before submitting and populate the payment_token field.
+   *
+   * A more complex example is used by paypal checkout where the payment token is generated
+   * via a pre-approval process. In that case the doPreApproval function is called on the processor
+   * class to get information to then interact with paypal via js, finally getting a payment token.
+   * (at this stage the pre-approve api is not in core but that is likely to change - we just need
+   * to think about the permissions since we don't want to expose to anonymous user without thinking
+   * through any risk of credit-card testing using it.
+   *
+   * If the token is not totally transient it would be saved to civicrm_payment_token.token.
+   *
+   * @param string $label
+   *
+   * @return string|null
+   */
+  public function getPaymentToken($label = 'default') {
+    return $this->get('paymentToken', $label);
+  }
+
+  /**
+   * @param string $paymentToken
+   * @param string $label e.g. 'default'
+   */
+  public function setPaymentToken($paymentToken, $label = 'default') {
+    return $this->set('paymentToken', $label, $paymentToken);
+  }
+
+  /**
+   * Combined with recurFrequencyUnit this gives how often billing will take place.
+   *
+   * e.g every if this is 1 and recurFrequencyUnit is 'month' then it is every 1 month.
+   * @return int|null
+   */
+  public function getRecurFrequencyInterval($label = 'default') {
+    return $this->get('recurFrequencyInterval', $label);
+  }
+
+  /**
+   * @param int $recurFrequencyInterval
+   * @param string $label e.g. 'default'
+   */
+  public function setRecurFrequencyInterval($recurFrequencyInterval, $label = 'default') {
+    if (!($recurFrequencyInterval > 0)) {
+      throw new InvalidArgumentException("recurFrequencyInterval must be a positive integer");
+    }
+
+    return $this->set('recurFrequencyInterval', $label, (int) $recurFrequencyInterval);
+  }
+
+  /**
+   * Getter for recurFrequencyUnit.
+   * Combined with recurFrequencyInterval this gives how often billing will take place.
+   *
+   * e.g every if this is 'month' and recurFrequencyInterval is 1 then it is every 1 month.
+   *
+   *
+   * @param string $label
+   *
+   * @return string month|day|year
+   */
+  public function getRecurFrequencyUnit($label = 'default') {
+    return $this->get('recurFrequencyUnit', $label);
+  }
+
+  /**
+   * @param string $recurFrequencyUnit month|day|week|year
+   * @param string $label e.g. 'default'
+   */
+  public function setRecurFrequencyUnit($recurFrequencyUnit, $label = 'default') {
+    if (!preg_match('/^day|week|month|year$/', $recurFrequencyUnit)) {
+      throw new \InvalidArgumentException("recurFrequencyUnit must be day|week|month|year");
+    }
+    return $this->set('recurFrequencyUnit', $label, $recurFrequencyUnit);
+  }
+
+  /**
+   * Getter for payment processor generated string for the transaction ID.
+   *
+   * Note some gateways generate a reference for the order and one for the
+   * payment. This is for the payment reference and is saved to
+   * civicrm_financial_trxn.trxn_id.
+   *
+   * @param string $label
+   *
+   * @return string|null
+   */
+  public function getTransactionID($label = 'default') {
+    return $this->get('transactionID', $label);
+  }
+
+  /**
+   * @param string $transactionID
+   * @param string $label e.g. 'default'
+   */
+  public function setTransactionID($transactionID, $label = 'default') {
+    return $this->set('transactionID', $label, $transactionID);
+  }
+
+  /**
+   * Getter for trxnResultCode.
+   *
+   * Additional information returned by the payment processor regarding the
+   * payment outcome.
+   *
+   * This would normally be saved in civicrm_financial_trxn.trxn_result_code.
+   *
+   *
+   * @param string $label
+   *
+   * @return string|null
+   */
+  public function getTrxnResultCode($label = 'default') {
+    return $this->get('trxnResultCode', $label);
+  }
+
+  /**
+   * @param string $trxnResultCode
+   * @param string $label e.g. 'default'
+   */
+  public function setTrxnResultCode($trxnResultCode, $label = 'default') {
+    return $this->set('trxnResultCode', $label, $trxnResultCode);
+  }
+
+  // Custom Properties.
+
+  /**
+   * Sometimes we may need to pass in things that are specific to the Payment
+   * Processor.
+   *
+   * @param string $prop
+   * @param string $label e.g. 'default' or 'old' or 'new'
+   * @return mixed
+   *
+   * @throws InvalidArgumentException if trying to use this against a non-custom property.
+   */
+  public function getCustomProperty($prop, $label = 'default') {
+    if (isset(static::$propMap[$prop])) {
+      throw new \InvalidArgumentException("Attempted to get '$prop' via getCustomProperty - must use using its getter.");
+    }
+    return $this->props[$label][$prop] ?? NULL;
+  }
+
+  /**
+   * We have to leave validation to the processor, but we can still give them a
+   * way to store their data on this PropertyBag
+   *
+   * @param string $prop
+   * @param mixed $value
+   * @param string $label e.g. 'default' or 'old' or 'new'
+   *
+   * @throws InvalidArgumentException if trying to use this against a non-custom property.
+   */
+  public function setCustomProperty($prop, $value, $label = 'default') {
+    if (isset(static::$propMap[$prop])) {
+      throw new \InvalidArgumentException("Attempted to set '$prop' via setCustomProperty - must use using its setter.");
+    }
+    $this->props[$label][$prop] = $value;
+  }
+
+}

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1010,7 +1010,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
       'total_amount' => 40,
       'currency' => 'USD',
       'financial_type_id' => 1,
-      'payment_instrument_id' => array_search('Credit card', $this->paymentInstruments),
+      'payment_instrument_id' => array_search('Credit Card', $this->paymentInstruments),
       'payment_processor_id' => $this->paymentProcessorID,
       'credit_card_exp_date' => ['M' => 5, 'Y' => 2025],
       'credit_card_number' => '411111111111111',

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -1,0 +1,210 @@
+<?php
+namespace Civi\Payment;
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->apply();
+  }
+
+  protected function setUp() {
+    parent::setUp();
+    // $this->useTransaction(TRUE);
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Test we can set a contact ID.
+   */
+  public function testSetContactID() {
+    // Do things proper.
+    $propertyBag = new PropertyBag();
+    $propertyBag->setContactID(123);
+    $this->assertEquals(123, $propertyBag->getContactID());
+
+    // Same but this time set contact ID with string.
+    // (php should throw its own warnings about this because of the signature)
+    $propertyBag = new PropertyBag();
+    $propertyBag->setContactID('123');
+    $this->assertInternalType('int', $propertyBag->getContactID());
+    $this->assertEquals(123, $propertyBag->getContactID());
+
+    // Test we can have different labels
+    $propertyBag = new PropertyBag();
+    $propertyBag->setContactID(123);
+    $propertyBag->setContactID(456, 'new');
+    $this->assertEquals(123, $propertyBag->getContactID());
+    $this->assertEquals(456, $propertyBag->getContactID('new'));
+  }
+
+  /**
+   * Test we cannot set an invalid contact ID.
+   *
+   * @expectedException \InvalidArgumentException
+   */
+  public function testSetContactIDFailsIfInvalid() {
+    $propertyBag = new PropertyBag();
+    $propertyBag->setContactID(0);
+  }
+
+  /**
+   * Test we can set a contact ID the wrong way
+   */
+  public function testSetContactIDLegacyWay() {
+    $propertyBag = new PropertyBag();
+    $propertyBag['contactID'] = 123;
+    $this->assertEquals(123, $propertyBag->getContactID());
+    $this->assertEquals(123, $propertyBag['contactID']);
+    // There should not be any warnings yet.
+    $this->assertEquals("", $propertyBag->lastWarning);
+
+    // Now access via legacy name - should work but generate warning.
+    $this->assertEquals(123, $propertyBag['contact_id']);
+    $this->assertEquals("Deprecated code: We have translated 'contact_id' to 'contactID' for you, but please update your code to use the propper setters and getters.", $propertyBag->lastWarning);
+
+    // Repeat but this time set the property using a legacy name, fetch by new name.
+    $propertyBag = new PropertyBag();
+    $propertyBag['contact_id'] = 123;
+    $this->assertEquals("Deprecated code: We have translated 'contact_id' to 'contactID' for you, but please update your code to use the propper setters and getters.", $propertyBag->lastWarning);
+    $this->assertEquals(123, $propertyBag->getContactID());
+    $this->assertEquals(123, $propertyBag['contactID']);
+    $this->assertEquals(123, $propertyBag['contact_id']);
+  }
+
+  /**
+   */
+  public function testMergeInputs() {
+    $propertyBag = new PropertyBag();
+    $propertyBag->mergeLegacyInputParams([
+      'contactID' => 123,
+      'contributionRecurID' => 456,
+    ]);
+    $this->assertEquals("Deprecated code: We have merged input params into the property bag for now but please rewrite code to not use this.", $propertyBag->lastWarning);
+    $this->assertEquals(123, $propertyBag->getContactID());
+    $this->assertEquals(456, $propertyBag->getContributionRecurID());
+  }
+
+  /**
+   * Test we can set and access custom props.
+   */
+  public function testSetCustomProp() {
+    $propertyBag = new PropertyBag();
+    $propertyBag->setCustomProperty('customThingForMyProcessor', 'fidget');
+    $this->assertEquals('fidget', $propertyBag->getCustomProperty('customThingForMyProcessor'));
+    $this->assertEquals('', $propertyBag->lastWarning);
+
+    // Test we can do this with array, although we should get a warning.
+    $propertyBag = new PropertyBag();
+    $propertyBag['customThingForMyProcessor'] = 'fidget';
+    $this->assertEquals('fidget', $propertyBag->getCustomProperty('customThingForMyProcessor'));
+    $this->assertEquals("Deprecated code: Unknown property 'customThingForMyProcessor'. We have merged this in for now as a custom property. Please rewrite your code to use PropertyBag->setCustomProperty if it is a genuinely custom property, or a standardised setter like PropertyBag->setContactID for standard properties", $propertyBag->lastWarning);
+  }
+
+  /**
+   * Test we can't set a custom prop that we know about.
+   *
+   * @expectedException \InvalidArgumentException
+   * @expectedExceptionMessage Attempted to set 'contactID' via setCustomProperty - must use using its setter.
+   */
+  public function testSetCustomPropFails() {
+    $propertyBag = new PropertyBag();
+    $propertyBag->setCustomProperty('contactID', 123);
+  }
+
+  /**
+   *
+   * @dataProvider otherParamsDataProvider
+   */
+  public function testOtherParams($prop, $legacy_names, $valid_values, $invalid_values) {
+    $setter = 'set' . ucfirst($prop);
+    $getter = 'get' . ucfirst($prop);
+
+    // Using the setter and getter, check we can pass stuff in and get expected out.
+    foreach ($valid_values as $_) {
+      list($given, $expect) = $_;
+      $propertyBag = new PropertyBag();
+      $propertyBag->$setter($given);
+      $this->assertEquals($expect, $propertyBag->$getter());
+    }
+    // Using the setter and getter, check we get an error for invalid data.
+    foreach ($invalid_values as $given) {
+      try {
+        $propertyBag = new PropertyBag();
+        $propertyBag->$setter($given);
+      }
+      catch (\InvalidArgumentException $e) {
+        // counts this assertion.
+        $this->assertTrue(TRUE);
+        continue;
+      }
+      $this->fail("Expected an error trying to set $prop to " . json_encode($given) . " but did not get one.");
+    }
+
+    // Check array access for the proper property name and any aliases.
+    foreach (array_merge([$prop], $legacy_names) as $name) {
+      // Check array access
+      foreach ($valid_values as $_) {
+        list($given, $expect) = $_;
+        $propertyBag = new PropertyBag();
+        $propertyBag[$name] = $given;
+        $this->assertEquals($expect, $propertyBag->$getter(), "Failed to set $prop via array access on $name");
+        // Nb. I don't feel the need to repeat all the checks above for every alias.
+        // We only really need to test that the array access works for each alias.
+        break;
+      }
+    }
+  }
+
+  /**
+   * Test the require method works.
+   */
+  public function testRequire() {
+    $propertyBag = new PropertyBag();
+    $propertyBag->setContactID(123);
+    $propertyBag->setDescription('foo');
+    // This one should not error.
+    $propertyBag->require(['contactID', 'description']);
+    try {
+      $propertyBag->require(['contactID', 'description', 'contributionID', 'somethingthatdoesntexist']);
+    }
+    catch (\InvalidArgumentException $e) {
+      $this->assertEquals('Required properties missing: contributionID, somethingthatdoesntexist', $e->getMessage());
+    }
+  }
+
+  /**
+   *
+   * Data provider for testOtherParams
+   *
+   */
+  public function otherParamsDataProvider() {
+    $valid_bools = [['0' , FALSE], ['', FALSE], [0, FALSE], [FALSE, FALSE], [TRUE, TRUE], [1, TRUE], ['1', TRUE]];
+    $valid_strings = [['foo' , 'foo'], ['', '']];
+    $valid_ints = [[123, 123], ['123', 123]];
+    $invalid_ints = [-1, 0, NULL, ''];
+    return [
+      ['contributionID', ['contribution_id'], $valid_ints, $invalid_ints],
+      ['contributionRecurID', ['contribution_recur_id'], $valid_ints, $invalid_ints],
+      ['description', [], [['foo' , 'foo'], ['', '']], []],
+      ['feeAmount', ['fee_amount'], [[1.23, 1.23], ['4.56', 4.56]], [NULL]],
+      ['invoiceID', ['invoice_id'], $valid_strings, []],
+      ['isBackOffice', ['is_back_office'], $valid_bools, [NULL]],
+      ['isRecur', ['is_recur'], $valid_bools, [NULL]],
+      ['paymentToken', [], $valid_strings, []],
+      ['recurFrequencyInterval', ['frequency_interval'], $valid_ints, $invalid_ints],
+      ['recurFrequencyUnit', [], [['month', 'month'], ['day', 'day'], ['year', 'year']], ['', NULL, 0]],
+      ['transactionID', ['transaction_id'], $valid_strings, []],
+      ['trxnResultCode', [], $valid_strings, []],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Summary

Below is a long thread that nobody should have to suffer, and also see https://lab.civicrm.org/dev/financial/issues/82 but I've edited this description as a PR summary/overview.

- This PR adds a new class, `Civi\Payment\PropertyBag` which will eventually replace the wild `$params` array that gets thrown at payment processors, with a standardised, at least minimally validated and type cast object. It has a test class, too, and is designed for backwards compatibility with older processor code that expect arrays as inputs.

- **This PR only actually uses this class in one very minimal way at present** (to validate currencies), and as such it should not cause any grief or changes to UI/UX or APIs, but it paves the way for a bigger PR to follow.

- The rest of the PR is comment updates.

I am [working on documentation](https://github.com/civicrm/civicrm-dev-docs/pull/735), but that can't really come out until the PropertyBag is properly used in core, but here's a static copy of that draft documentation to give you an idea of what the problem is and why we solved it this way. **again, note that the stuff below can't happen until more changes are made in core, which are out of scope for this PR**.

## Introducing `PropertyBag` objects

Currently as of 5.19 `$params` is a sprawling array with who-knows-what keys. From 5.xx, a better way is to pass in a `Civi\Payment\PropertyBag` object instead.

This object has getters and setters that enforce standardised property names and a certain level of validation and type casting. For example, the property `contactID` (note capitalisation) has `getContactID()` and `setContactID()`.

For backwards compatibility, this class implements `ArrayAccess` which means if old code does `$propertyBag['contact_id'] = '123'` or `$propertyBag['contactID'] = 123` it will translate this to the new `contactID` property and use that setter which will ensure that accesing the property returns the integer value *123*. When this happens deprecation messages are emitted to the log file. New code should not use array access.

### Checking for existence of a property

Calling a getter for a property that has not been set will throw a `BadMethodCall` exception.

Code can require certain properties by calling
`$propertyBag->require(['contactID', 'contributionID'])` which will throw an `InvalidArgumentException` if any property is missing. These calls should go at the top of your methods so that it's clear to a developer.

You can check whether a property has been set using `$propertyBag->has('contactID')` which will return `TRUE` or `FALSE`.

### Multiple values, e.g. changing amounts

All the getters and setters take an optional extra parameter called `$label`. This can be used to store two (or more) different versions of a property, e.g. 'old' and 'new'

```php
<?php
use Civi\Payment\PropertyBag;
//...
$propertyBag = new PropertyBag();
$propertyBag->setAmount(1.23, 'old');
$propertyBag->setAmount(2.46, 'new');
//...
$propertyBag->getAmount('old'); // 1.23
$propertyBag->getAmount('new'); // 2.46
$propertyBag->getAmount(); // throws BadMethodCall
```

This means the value is still validated and type-cast as an amount (in this example).


### Custom payment processor-specific data

Sometimes a payment processor will requrie custom data. e.g. Stripe may use a `paymentMethodID` and a `paymentIntentID` on its `doPayment()` method.

Property names should be prefixed, e.g. `stripe_paymentMethodID` and set using `PropertyBag->setCustomProperty($prop, $value, $label = 'default')`.

The payment class is responsible for validating such data; anything is allowed by `setCustomProperty`, including `NULL`.

Where support for custom properties is needed for a method, e.g. `doPayment()`, you should implement a method as follows:

```php
<?php
use Civi\Payment\PropertyBag;
use Civi\Payment\Exception\PaymentProcessorException;

class CRM_Core_Payment_MyExtension extends CRM_Core_Payment {
...
  /**
   * Copy our custom properties from the form data.
   *
   * @param PropertyBag
   * @param Array form values
   * @param String $component as for doPayment()
   */
  public function extractCustomPropertiesForDoPayment(PropertyBag $propertyBag, Array $input, $component = 'contribute') {

    // We require a paymentIntentID
    if (empty($input['paymentIntentID'])) {
      throw new PaymentProcessorException("paymentIntentID missing");
    }
    // (possible validation of the value goes here since it could be malicious)
    $propertyBag->setCustomProperty( 'stripe_paymentIntentID', $input['paymentIntentID']);

    // We might need a paymentMethodID but sometimes not.
    if (!empty($input['paymentMethodID'])) {
      $propertyBag->setCustomProperty( 'stripe_paymentMethodID', $input['paymentMethodID']);
    }
  }
  ...
}
```

