### PR TITLE
Fix loading of profile fields on additional participant form

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -178,8 +178,14 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       CRM_Event_Form_Registration_Register::buildAmount($this);
     }
 
+    //Add pre and post profiles on the form.
+    foreach (['pre', 'post'] as $keys) {
+      if (isset($this->_values['additional_custom_' . $keys . '_id'])) {
+        $this->buildCustom($this->_values['additional_custom_' . $keys . '_id'], 'additionalCustom' . ucfirst($keys));
+      }
+    }
+
     //add buttons
-    $js = NULL;
     if ($this->isLastParticipant(TRUE) && empty($this->_values['event']['is_monetary'])) {
       $this->submitOnce = TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Profile fields missing from the Additional participant page.

Before
----------------------------------------
No fields are loaded on the additional participant form. If `Continue` button is pressed, it returns an error as displayed below -

![image](https://user-images.githubusercontent.com/5929648/68024517-515da700-fcd0-11e9-9044-7fe4efa238c4.png)

After
----------------------------------------
Profile is loaded correctly.

![image](https://user-images.githubusercontent.com/5929648/68024550-6a665800-fcd0-11e9-8775-46d4c722a509.png)

Technical Details
----------------------------------------
Kept the required bits from #15515 

Comments
----------------------------------------
5.19 rc is unaffected by this problem. ping @eileenmcnaughton @colemanw 