### PR TITLE
Don't pass \$input to completeOrder by reference - return values are never used

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4457,7 +4457,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder(&$input, &$ids, $objects, $transaction, $recur, $contribution, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, &$ids, $objects, $transaction, $recur, $contribution, $isPostPaymentCreate = FALSE) {
     $primaryContributionID = isset($contribution->id) ? $contribution->id : $objects['first_contribution']->id;
     // The previous details are used when calculating line items so keep it before any code that 'does something'
     if (!empty($contribution->id)) {


### PR DESCRIPTION
Overview
----------------------------------------
This is a preliminary for #15555. That "simple" change has exposed multiple areas where registration for multiple participants doesn't seem to be working correctly. In various place we are setting participant parameters on the `$input` array which is passed by reference but they are never used.  Eliminating this pass-by-reference means that we can remove some of those lines.

Before
----------------------------------------
`$input` params passed by reference but not used. Parameters being set that are not used.

After
----------------------------------------
`$input` params not passed by reference so it is easy to see which parameters do not need to be set.

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------
This "seems" like an unrelated change but will help move off this deprecated function by simplifying it and fix the issues around participantpayments identified in #15555