### PR TITLE
Add in method to allow extensions to opt out of using temporary table…

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -33,6 +33,27 @@
 class CRM_Contact_BAO_Contact_Permission {
 
   /**
+   * @var bool
+   */
+  public static $useTempTable = TRUE;
+
+  /**
+   * Set whether to use a temporary table or not when building ACL Cache
+   * @param bool $useTemporaryTable
+   */
+  public static function setUseTemporaryTable($useTemporaryTable = TRUE) {
+    self::$useTempTable = $useTemporaryTable;
+  }
+
+  /**
+   * Get variable for determining if we should use Temporary Table or not
+   * @return bool
+   */
+  public static function getUseTemporaryTable() {
+    return self::$useTempTable;
+  }
+
+  /**
    * Check which of the given contact IDs the logged in user
    *   has permissions for the operation type according to:
    *    - general permissions (e.g. 'edit all contacts')
@@ -268,12 +289,18 @@ AND    $operationClause
     $sql = "SELECT DISTINCT $userID as user_id, contact_a.id as contact_id, '{$operation}' as operation
          $from
 WHERE    $permission";
-    $aclContactsTempTable = CRM_Utils_SQL_TempTable::build()->setCategory('aclccache')->setMemory();
-    $tempTable = $aclContactsTempTable->getName();
-    $aclContactsTempTable->createWithColumns('user_id int, contact_id int, operation varchar(255), UNIQUE UI_user_contact_operation (user_id,contact_id,operation)');
-    CRM_Core_DAO::executeQuery("INSERT INTO {$tempTable} (user_id, contact_id, operation) {$sql}");
-    CRM_Core_DAO::executeQuery("INSERT IGNORE INTO civicrm_acl_contact_cache (user_id, contact_id, operation) SELECT user_id, contact_id, operation FROM {$tempTable}");
-    $aclContactsTempTable->drop();
+    $useTempTable = self::getUseTemporaryTable();
+    if ($useTempTable) {
+      $aclContactsTempTable = CRM_Utils_SQL_TempTable::build()->setCategory('aclccache')->setMemory();
+      $tempTable = $aclContactsTempTable->getName();
+      $aclContactsTempTable->createWithColumns('user_id int, contact_id int, operation varchar(255), UNIQUE UI_user_contact_operation (user_id,contact_id,operation)');
+      CRM_Core_DAO::executeQuery("INSERT INTO {$tempTable} (user_id, contact_id, operation) {$sql}");
+      CRM_Core_DAO::executeQuery("INSERT IGNORE INTO civicrm_acl_contact_cache (user_id, contact_id, operation) SELECT user_id, contact_id, operation FROM {$tempTable}");
+      $aclContactsTempTable->drop();
+    }
+    else {
+      CRM_Core_DAO::executeQuery("INSERT IGNORE INTO civicrm_acl_contact_cache (user_id, contact_id, operation) {$sql}");
+    }
 
     // Add in a row for the logged in contact. Do not try to combine with the above query or an ugly OR will appear in
     // the permission clause.


### PR DESCRIPTION
… when building ACL Contact Cache

Overview
----------------------------------------
This adds in getter and setter functions and a static class variable to determine if temporary table should be used when building the ACL contact Cache

Before
----------------------------------------
Temporary Table always used

After
----------------------------------------
Temporary table used by default unless class variable set to not

Technical Details
----------------------------------------
in AUG we use the [Multisite extension](https://github.com/eileenmcnaughton/org.civicrm.multisite) and one of the permissions it adds is "View all Contacts in domain" which is separate from View All Contacts so the core code when say loading an mailing will trigger a cache build. In one of our domains we have > 400K contacts that users with the permission View all contacts in domain for that domain can see which means we can easily run into Temporary Table is full errors. This was after we had increased the tmp_table_size and max_heap_table_size variables. So this gives us a way of using either the multisite extension or some other extension telling it to not use a temporary table to build the ACL Contact Cache for these users

ping @eileenmcnaughton @mattwire @monishdeb 