### PR TITLE
dev/core#561 Add in Upgrade routine to convert log_date smart group s…

### DIFF
--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -74,6 +74,8 @@ class CRM_Upgrade_Incremental_SmartGroups {
       'relationship_start_date' => 'relation_start',
       'relationship_end_date' => 'relation_end',
       'event' => 'event',
+      'created_date' => 'log',
+      'modified_date' => 'log',
     ];
 
     foreach ($fields as $field) {
@@ -252,6 +254,42 @@ class CRM_Upgrade_Incremental_SmartGroups {
     ])['values'];
     return $savedSearches;
 
+  }
+
+  public function renameLogFields() {
+    $addedDate = FALSE;
+    foreach ($this->getSearchesWithField('log_date') as $savedSearch) {
+      $formValues = $savedSearch['form_values'];
+      foreach ($formValues as $index => $formValue) {
+        if (isset($formValue[0]) && $formValue[0] === 'log_date') {
+          if ($formValue[2] == 1) {
+            $addedDate = TRUE;
+          }
+          else {
+            $addedDate = FALSE;
+          }
+        }
+        if (isset($formValue[0]) && ($formValue[0] === 'log_date_high' || $formValue[0] === 'log_date_low')) {
+          $isHigh = substr($index, -5, 5) === '_high';
+          if ($addedDate) {
+            $fieldName = 'created_date';
+          }
+          else {
+            $fieldName = 'modified_date';
+          }
+          if ($isHigh) {
+            $fieldName .= '_high';
+          }
+          else {
+            $fieldName .= '_low';
+          }
+          $formValues[$index][0] = $fieldName;
+        }
+      }
+      if ($formValues !== $savedSearch['form_values']) {
+        civicrm_api3('SavedSearch', 'create', ['id' => $savedSearch['id'], 'form_values' => $formValues]);
+      }
+    }
   }
 
 }

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -256,16 +256,17 @@ class CRM_Upgrade_Incremental_SmartGroups {
 
   }
 
+  /**
+   * Convert the log_date saved search date fields to their correct name
+   * default to switching to created_date as that is what the code did originally
+   */
   public function renameLogFields() {
-    $addedDate = FALSE;
+    $addedDate = TRUE;
     foreach ($this->getSearchesWithField('log_date') as $savedSearch) {
       $formValues = $savedSearch['form_values'];
       foreach ($formValues as $index => $formValue) {
         if (isset($formValue[0]) && $formValue[0] === 'log_date') {
-          if ($formValue[2] == 1) {
-            $addedDate = TRUE;
-          }
-          else {
+          if ($formValue[2] == 2) {
             $addedDate = FALSE;
           }
         }

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -123,6 +123,9 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
         ['old' => 'event_end_date_high', 'new' => 'event_high'],
       ],
     ]);
+    $this->addTask('Convert Log date searches to their final names either created date or modified date', 'updateSmartGroups', [
+      'renameLogFields' => [],
+    ]);
     $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
       'datepickerConversion' => [
         'birth_date',
@@ -134,6 +137,8 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
         'relationship_end_date',
         'event',
         'relation_active_period_date',
+        'created_date',
+        'modified_date',
       ],
     ]);
     $this->addTask('Clean up unused table "civicrm_persistent"', 'dropTableIfEmpty', 'civicrm_persistent');

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -259,6 +259,22 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
         ['log_date_low', '=', '20191001000000'],
       ],
     ]);
+    // On the original search form you didn't need to select the log_date radio
+    // If it wasn't selected it defaulted to created_date filtering.
+    $this->callAPISuccess('SavedSearch', 'create', [
+      'form_values' => [
+        ['log_date_low', '=', '20191001000000'],
+        ['log_date_high', '=', '20191031235959'],
+        'relative_dates' => [
+          'log' => 'this.month',
+        ],
+      ],
+    ]);
+    $this->callAPISuccess('SavedSearch', 'create', [
+      'form_values' => [
+        ['log_date_low', '=', '20191001000000'],
+      ],
+    ]);
     $smartGroupConversionObject = new CRM_Upgrade_Incremental_SmartGroups();
     $smartGroupConversionObject->renameLogFields();
     $smartGroupConversionObject->updateGroups([
@@ -288,6 +304,14 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
         0 => ['log_date', '=', 2],
         1 => ['modified_date_low', '=', '2019-10-01 00:00:00'],
         2 => ['modified_date_relative', '=', 0],
+      ],
+      5 => [
+        'relative_dates' => [],
+        2 => ['created_date_relative', '=', 'this.month'],
+      ],
+      6 => [
+        0 => ['created_date_low', '=', '2019-10-01 00:00:00'],
+        1 => ['created_date_relative', '=', 0],
       ],
     ];
   }


### PR DESCRIPTION
…earches to their new names

Overview
----------------------------------------
This adds in an upgrade process for converting from the 1 log_date search field to the 2 new search fields of created_date and modified_date as per #15693 

Before
----------------------------------------
1 Field in smart group searches

After
----------------------------------------
Correct Fields in smart group searches

ping @eileenmcnaughton 
