### PR TITLE
Update all payment tests to ensure entity financial items created

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -161,6 +161,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -175,6 +176,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // pay additional amount
     $this->submitPayment(70);
     $this->checkResults([30, 70], 2);
+    $this->validateAllPayments();
   }
 
   /**
@@ -207,6 +209,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->assertEquals(CRM_Core_Session::singleton()->getLoggedInContactID(), $activities[0]['source_contact_id']);
     $this->assertEquals([$this->_individualId], $activities[0]['target_contact_id']);
     $this->assertEquals([], $activities[0]['assignee_contact_id']);
+    $this->validateAllPayments();
   }
 
   /**
@@ -251,6 +254,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -281,6 +285,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -303,6 +308,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // pay additional amount
     $this->submitPayment(30);
     $this->checkResults([30, 70], 2);
+    $this->validateAllPayments();
   }
 
   /**
@@ -320,6 +326,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $contributionMembership = $this->callAPISuccessGetSingle('Membership', ['id' => $membership['id']]);
     $membershipStatus = $this->callAPISuccessGetSingle('MembershipStatus', ['id' => $contributionMembership['status_id']]);
     $this->assertEquals('New', $membershipStatus['name']);
+    $this->validateAllPayments();
   }
 
   /**
@@ -385,6 +392,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
     $this->submitPayment(10);
     $this->checkResults([40, 20, 30, 10], 4);
+    $this->validateAllPayments();
   }
 
   /**
@@ -411,6 +419,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
     $this->submitPayment(10, 'live');
     $this->checkResults([50, 20, 20, 10], 4);
+    $this->validateAllPayments();
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3360,4 +3360,34 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     return $orderParams;
   }
 
+  /**
+   * @param $payments
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function validatePayments($payments) {
+    foreach ($payments as $payment) {
+      $items = $this->callAPISuccess('EntityFinancialTrxn', 'get', [
+        'financial_trxn_id' => $payment['id'],
+        'entity_table' => 'civicrm_financial_item',
+        'return' => ['amount'],
+      ])['values'];
+      $itemTotal = 0;
+      foreach ($items as $item) {
+        $itemTotal += $item['amount'];
+      }
+      $this->assertEquals($payment['total_amount'], $itemTotal);
+    }
+  }
+
+  /**
+   * Validate all created payments.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function validateAllPayments() {
+    $payments = $this->callAPISuccess('Payment', 'get', ['options' => ['limit' => 0]])['values'];
+    $this->validatePayments($payments);
+  }
+
 }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -38,12 +38,10 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   protected $_financialTypeId = 1;
 
-  protected $_apiversion;
-
-  public $debug = 0;
-
   /**
    * Setup function.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function setUp() {
     parent::setUp();
@@ -67,6 +65,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   /**
    * Test Get Payment api.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetPayment() {
     $p = [
@@ -105,10 +105,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Retrieve Payment using trxn_id.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetPaymentWithTrxnID() {
     $this->_individualId2 = $this->individualCreate();
@@ -151,10 +154,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       ],
     ];
     $this->checkPaymentResult($payment, $expectedResult);
+    $this->validateAllPayments();
   }
 
   /**
    * Test email receipt for partial payment.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testPaymentEmailReceipt() {
     $mut = new CiviMailUtils($this);
@@ -196,6 +202,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -229,6 +236,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -237,6 +245,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    * @dataProvider getThousandSeparators
    *
    * @param string $thousandSeparator
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testRefundEmailReceipt($thousandSeparator) {
     $this->setCurrencySeparators($thousandSeparator);
@@ -282,6 +292,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -295,6 +306,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'order_id' => $order['id'],
       'total_amount' => 50,
     ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -373,6 +385,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -461,9 +474,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $participantPayment = $this->callAPISuccess('ParticipantPayment', 'getsingle', $paymentParticipant);
     $participant = $this->callAPISuccess('participant', 'get', ['id' => $participantPayment['participant_id']]);
     $this->assertEquals($participant['values'][$participant['id']]['participant_status'], 'Registered');
-    $this->callAPISuccess('Contribution', 'Delete', [
-      'id' => $contribution['id'],
-    ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -502,10 +513,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Test delete payment api
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testDeletePayment() {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute'];
@@ -662,10 +676,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Test create payment api for paylater contribution
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreatePaymentPayLater() {
     $this->createLoggedInUser();
@@ -726,12 +743,14 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Test create payment api for pay later contribution with partial payment.
    *
    * https://lab.civicrm.org/dev/financial/issues/69
+   * @throws \CRM_Core_Exception
    */
   public function testCreatePaymentIncompletePaymentPartialPayment() {
     $contributionParams = [
@@ -749,10 +768,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $payments = $this->callAPISuccess('Payment', 'get', ['contribution_id' => $contribution['id']])['values'];
     $this->assertCount(1, $payments);
+    $this->validateAllPayments();
   }
 
   /**
    * Test create payment api for pay later contribution with partial payment.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreatePaymentPayLaterPartialPayment() {
     $this->createLoggedInUser();
@@ -837,12 +859,15 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $this->callAPISuccess('OptionValue', 'get', ['name' => 'Completed', 'option_group_id' => 'contribution_status', 'api.OptionValue.create' => ['label' => 'Completed']]);
     $this->callAPISuccessGetCount('Activity', ['target_contact_id' => $this->_individualId, 'activity_type_id' => 'Payment'], 2);
+    $this->validateAllPayments();
   }
 
   /**
    * Add a location to our event.
    *
    * @param int $eventID
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function addLocationToEvent($eventID) {
     $addressParams = [
@@ -860,6 +885,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'loc_block_id' => $location['id'],
       'is_show_location' => TRUE,
     ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -888,6 +914,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
 
     $this->assertEquals($eft['values'][$eft['id']]['amount'], $amount);
+    $this->validateAllPayments();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Updates tests to catch the failure to create entity_financial_items - our existing tests were not catching that

Expected to fail as bug exists

Before
----------------------------------------
Not tested

After
----------------------------------------
Tested

Technical Details
----------------------------------------
Although we had tests for this it turns out they were only checking that they were correct IF created. This
ensures they also exist & is a sanity check to run at the end of tests. The two failing tests are
really failing :-(

Comments
----------------------------------------
