### PR TITLE
Civi\Core\Container - Fix warning about Symfony 3=>4 and boot services

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -214,7 +214,7 @@ class Container {
       throw new \RuntimeException("Cannot initialize container. Boot services are undefined.");
     }
     foreach (\Civi::$statics[__CLASS__]['boot'] as $bootService => $def) {
-      $container->setDefinition($bootService, new Definition())->setSynthetic(TRUE);
+      $container->setDefinition($bootService, new Definition())->setSynthetic(TRUE)->setPublic(TRUE);
     }
 
     // Expose legacy singletons as services in the container.


### PR DESCRIPTION
Overview
----------------------------------------

"Boot services" are initialized during bootstrap (before the container starts) -- and then passed into the container via `$container->set()`.

Symfony 3.4 changes the default handling of `set()` - it now emits warnings unless the services were previously flagged as public.

https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default

Before
------

```
[bknix-min:~/bknix/build/d8re] drush php
Psy Shell v0.9.9 (PHP 7.0.32 — cli) by Justin Hileman
>>> \Drupal::service('civicrm')->initialize();
PHP Deprecated:  The "runtime" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0. in /Users/totten/bknix/build/d8re/vendor/symfony/dependency-injection/Container.php on line 190
PHP Deprecated:  The "paths" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0. in /Users/totten/bknix/build/d8re/vendor/symfony/dependency-injection/Container.php on line 190
PHP Deprecated:  The "userSystem" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0. in /Users/totten/bknix/build/d8re/vendor/symfony/dependency-injection/Container.php on line 190
PHP Deprecated:  The "userPermissionClass" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0. in /Users/totten/bknix/build/d8re/vendor/symfony/dependency-injection/Container.php on line 190
PHP Deprecated:  The "cache.settings" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0. in /Users/totten/bknix/build/d8re/vendor/symfony/dependency-injection/Container.php on line 190
PHP Deprecated:  The "settings_manager" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0. in /Users/totten/bknix/build/d8re/vendor/symfony/dependency-injection/Container.php on line 190
PHP Deprecated:  The "lockManager" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0. in /Users/totten/bknix/build/d8re/vendor/symfony/dependency-injection/Container.php on line 190
```

After
-----

The warnings don't appear.

Comments
--------

The `Definition` class includes two methods, `setPublic()` and `setPrivate()`, which appear to do the same thing (but as opposites). `setPublic()` exists in Symfony 2.8+, but `setPrivate()` was added in Symfony 3.x, so we use `setPublic()` for broader compatibility.

