### PR TITLE
Fix Payment.create with a negative value to create the correct financial items

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -440,4 +440,10 @@ function _civicrm_api3_payment_sendconfirmation_spec(&$params) {
     'title' => ts('From email; an email string or the id of a valid email'),
     'type' => CRM_Utils_Type::T_STRING,
   ];
+  $params['is_send_contribution_notification'] = [
+    'title' => ts('Send any event or contribution confirmations triggered by this payment'),
+    'description' => ts('If this payment completes a contribution it may mean receipts will go out according to busines logic if thie is set to TRUE'),
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => 0,
+  ];
 }

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -161,6 +161,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -175,6 +176,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // pay additional amount
     $this->submitPayment(70);
     $this->checkResults([30, 70], 2);
+    $this->validateAllPayments();
   }
 
   /**
@@ -207,6 +209,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->assertEquals(CRM_Core_Session::singleton()->getLoggedInContactID(), $activities[0]['source_contact_id']);
     $this->assertEquals([$this->_individualId], $activities[0]['target_contact_id']);
     $this->assertEquals([], $activities[0]['assignee_contact_id']);
+    $this->validateAllPayments();
   }
 
   /**
@@ -251,6 +254,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -281,6 +285,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -303,6 +308,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // pay additional amount
     $this->submitPayment(30);
     $this->checkResults([30, 70], 2);
+    $this->validateAllPayments();
   }
 
   /**
@@ -320,6 +326,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $contributionMembership = $this->callAPISuccessGetSingle('Membership', ['id' => $membership['id']]);
     $membershipStatus = $this->callAPISuccessGetSingle('MembershipStatus', ['id' => $contributionMembership['status_id']]);
     $this->assertEquals('New', $membershipStatus['name']);
+    $this->validateAllPayments();
   }
 
   /**
@@ -385,6 +392,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
     $this->submitPayment(10);
     $this->checkResults([40, 20, 30, 10], 4);
+    $this->validateAllPayments();
   }
 
   /**
@@ -411,6 +419,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
     $this->submitPayment(10, 'live');
     $this->checkResults([50, 20, 20, 10], 4);
+    $this->validateAllPayments();
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3360,4 +3360,34 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     return $orderParams;
   }
 
+  /**
+   * @param $payments
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function validatePayments($payments) {
+    foreach ($payments as $payment) {
+      $items = $this->callAPISuccess('EntityFinancialTrxn', 'get', [
+        'financial_trxn_id' => $payment['id'],
+        'entity_table' => 'civicrm_financial_item',
+        'return' => ['amount'],
+      ])['values'];
+      $itemTotal = 0;
+      foreach ($items as $item) {
+        $itemTotal += $item['amount'];
+      }
+      $this->assertEquals($payment['total_amount'], $itemTotal);
+    }
+  }
+
+  /**
+   * Validate all created payments.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function validateAllPayments() {
+    $payments = $this->callAPISuccess('Payment', 'get', ['options' => ['limit' => 0]])['values'];
+    $this->validatePayments($payments);
+  }
+
 }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -38,12 +38,10 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   protected $_financialTypeId = 1;
 
-  protected $_apiversion;
-
-  public $debug = 0;
-
   /**
    * Setup function.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function setUp() {
     parent::setUp();
@@ -67,6 +65,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
   /**
    * Test Get Payment api.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetPayment() {
     $p = [
@@ -105,10 +105,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Retrieve Payment using trxn_id.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetPaymentWithTrxnID() {
     $this->_individualId2 = $this->individualCreate();
@@ -151,10 +154,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       ],
     ];
     $this->checkPaymentResult($payment, $expectedResult);
+    $this->validateAllPayments();
   }
 
   /**
    * Test email receipt for partial payment.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testPaymentEmailReceipt() {
     $mut = new CiviMailUtils($this);
@@ -196,6 +202,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -229,6 +236,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -237,6 +245,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    * @dataProvider getThousandSeparators
    *
    * @param string $thousandSeparator
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testRefundEmailReceipt($thousandSeparator) {
     $this->setCurrencySeparators($thousandSeparator);
@@ -282,6 +292,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $mut->clearMessages();
+    $this->validateAllPayments();
   }
 
   /**
@@ -295,6 +306,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'order_id' => $order['id'],
       'total_amount' => 50,
     ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -373,6 +385,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -461,9 +474,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $participantPayment = $this->callAPISuccess('ParticipantPayment', 'getsingle', $paymentParticipant);
     $participant = $this->callAPISuccess('participant', 'get', ['id' => $participantPayment['participant_id']]);
     $this->assertEquals($participant['values'][$participant['id']]['participant_status'], 'Registered');
-    $this->callAPISuccess('Contribution', 'Delete', [
-      'id' => $contribution['id'],
-    ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -502,10 +513,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Test delete payment api
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testDeletePayment() {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute'];
@@ -662,10 +676,13 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Test create payment api for paylater contribution
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreatePaymentPayLater() {
     $this->createLoggedInUser();
@@ -726,12 +743,14 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $contribution['id'],
     ]);
+    $this->validateAllPayments();
   }
 
   /**
    * Test create payment api for pay later contribution with partial payment.
    *
    * https://lab.civicrm.org/dev/financial/issues/69
+   * @throws \CRM_Core_Exception
    */
   public function testCreatePaymentIncompletePaymentPartialPayment() {
     $contributionParams = [
@@ -749,6 +768,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $payments = $this->callAPISuccess('Payment', 'get', ['contribution_id' => $contribution['id']])['values'];
     $this->assertCount(1, $payments);
+    $this->validateAllPayments();
   }
 
   /**
@@ -839,6 +859,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
     $this->callAPISuccess('OptionValue', 'get', ['name' => 'Completed', 'option_group_id' => 'contribution_status', 'api.OptionValue.create' => ['label' => 'Completed']]);
     $this->callAPISuccessGetCount('Activity', ['target_contact_id' => $this->_individualId, 'activity_type_id' => 'Payment'], 2);
+    $this->validateAllPayments();
   }
 
   /**
@@ -894,6 +915,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'loc_block_id' => $location['id'],
       'is_show_location' => TRUE,
     ]);
+    $this->validateAllPayments();
   }
 
   /**
@@ -922,6 +944,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     ]);
 
     $this->assertEquals($eft['values'][$eft['id']]['amount'], $amount);
+    $this->validateAllPayments();
   }
 
 }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -621,6 +621,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute', 'access CiviCRM', 'edit contributions'];
     $payment = $this->callAPIAndDocument('payment', 'create', $params, __FUNCTION__, __FILE__, 'Update Payment', 'UpdatePayment');
 
+    $this->validateAllPayments();
     // Check for proportional cancelled payment against lineitems.
     $minParams = [
       'entity_table' => 'civicrm_financial_item',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby refund payments are not resulting in entity_financial_trxn records being created. This is a regression but I don't know how recent - the tests that should have caught it did not as they were only checking that they were created correctly IF created. Due to complexity I am targetting 5.20 not 5.19


Before
----------------------------------------
Record a refund payment using api or Additional Payment form - no entity-financial items created with table = 'civicrm_financial_items'

After
----------------------------------------
Record a refund payment using api or Additional Payment form - proportional entity-financial items created

Technical Details
----------------------------------------
This PR contains the contents of a bunch of other PRs that would ideally be merged & resolved first but which are still hanging around in review  - I was going to wait to put this up but there is some urgency that it's merged for 5.20

The job of a refund in this function turns out to be exactly the same as the a payment. I originally thought the
from & to accounts would be reversed but in fact because we are recording a negative amount that is not the case.
We need the from-to accounts to be the same. The only difference turns out to be the status
of the financialTrxn (Completed vs Refunded it seems).

Without this change the refund code is calling the recordFinancialAccounts function but after stepping
through it I'm sure the only thing that function is doing for it is creating the
FinancialTrxn. It *should* be creating the EntityFinancialItem too but it is not
and the best place for that to be done is in the payment class not in a spaghetti function.

Note that after this we need some robust testing & probably a follow up
patch on the handling of tax items - which is unlikely to be correct since it wasn't in the past
AFAIK and is unchanged.....

However, this fixes an important bug & should be merged as soon as it is confirmed non-regressive
to allow the next one to be investigated

Comments
----------------------------------------
@joemurray @kcristiano this is the most important PR.

Please be very clear on steps to replicate for any problems you find as the last PR got stalled for a few months over lack of clarity over steps to replicate a possible issue (which I think turned out to be the bug in changing line items that we fixed)
