### PR TITLE
[REF] remove  as a return Param of getHierContactDetails

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1770,7 +1770,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    */
   public static function getHierContactDetails($contactId, $fields) {
     $params = [['contact_id', '=', $contactId, 0, 0]];
-    $options = [];
 
     $returnProperties = self::makeHierReturnProperties($fields, $contactId);
 
@@ -1781,7 +1780,8 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     $returnProperties['household_name'] = 1;
     $returnProperties['contact_type'] = 1;
     $returnProperties['contact_sub_type'] = 1;
-    return list($query, $options) = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, $options);
+    list($query) = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties);
+    return $query;
   }
 
   /**
@@ -2116,7 +2116,7 @@ ORDER BY civicrm_email.is_primary DESC";
 
     // get the contact details (hier)
     if ($contactID) {
-      list($details, $options) = self::getHierContactDetails($contactID, $fields);
+      $details = self::getHierContactDetails($contactID, $fields);
 
       $contactDetails = $details[$contactID];
       $data['contact_type'] = CRM_Utils_Array::value('contact_type', $contactDetails);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2304,7 +2304,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
   ) {
     if (!$componentId) {
       //get the contact details
-      list($contactDetails, $options) = CRM_Contact_BAO_Contact::getHierContactDetails($contactId, $fields);
+      $contactDetails = CRM_Contact_BAO_Contact::getHierContactDetails($contactId, $fields);
       $details = CRM_Utils_Array::value($contactId, $contactDetails);
       $multipleFields = ['website' => 'url'];
 

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -1119,7 +1119,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
       $contactDetails = CRM_Contact_BAO_Contact::getHierContactDetails($this->_id,
         $greetingTypes
       );
-      $details = $contactDetails[0][$this->_id];
+      $details = $contactDetails[$this->_id];
     }
     if (!(!empty($details['addressee_id']) || !empty($details['email_greeting_id']) ||
       CRM_Utils_Array::value('postal_greeting_id', $details)


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup of unused variable

Before
----------------------------------------
$options returned but never used

After
----------------------------------------
$options not returned 


Technical Details
----------------------------------------
In trying to get to the bottom of BAO_CustomQuery I hit confusion about whether options should still exist.

This removes it from the return values of getHierContactDetails, making for a cleaner later PR when
we can check all calls to CRM_Contact_BAO_Query::apiQuery use the 'list' construct and only
use one param - at which point we can pull it out of apiQuery

Comments
----------------------------------------

