### PR TITLE
[NFC] Allow users on backdrop to trigger regen.sh

### DIFF
--- a/bin/setup.lib.sh
+++ b/bin/setup.lib.sh
@@ -60,7 +60,7 @@ function has_commands() {
 ## usage: cms_eval '<php-code>'
 function cms_eval() {
   case "$GENCODE_CMS" in
-    [Dd]rupal*)
+    [Dd]rupal*|[Bb]ackdrop)
       drush ev "$1"
       ;;
     [Ww]ordPress*)


### PR DESCRIPTION
Overview
----------------------------------------
This allows for users running a backdrop build from buildkit to trigger regen.sh

Before
----------------------------------------
backdrop users cannot run regen.sh

After
----------------------------------------
Backdrop users can run regen.sh

ping @totten @herbdool 