### PR TITLE
[REF] Remove early return on joinTable

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -148,7 +148,7 @@ class CRM_Core_BAO_CustomQuery {
    * @param array $locationSpecificFields
    */
   public function __construct($ids, $contactSearch = FALSE, $locationSpecificFields = []) {
-    $this->_ids = &$ids;
+    $this->_ids = $ids;
     $this->_locationSpecificCustomFields = $locationSpecificFields;
 
     $this->_select = [];
@@ -222,10 +222,6 @@ SELECT f.id, f.label, f.data_type,
       $this->_select[$fieldName] = "{$field['table_name']}.{$field['column_name']} as $fieldName";
       $this->_element[$fieldName] = 1;
       $joinTable = $field['search_table'];
-      // CRM-14265
-      if ($joinTable == 'civicrm_group' || empty($joinTable)) {
-        return;
-      }
 
       $this->joinCustomTableForField($field);
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup - removes 2 unnecessary things
1) use of reference on $ids
2) a check that doesn't make sense here

Before
----------------------------------------
Code more confusing

After
----------------------------------------
Code less confusing

Technical Details
----------------------------------------
I looked up the reason for the early return here and it was that the UI for adding other tables
in was too complex. In other words the removed lines should never be true.

However, I don't think it's the place of the query object to enforce not attempting a query the
UI struggles with. Removing this will save a later person having to figure that out.

Re $ids  - it's never used again so does not need to be a reference

Comments
----------------------------------------
_
