### PR TITLE
Fix Custom field date query builder to work with 'raw' high & low params

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -591,7 +591,6 @@ class CRM_Contact_BAO_Query {
       $this->_select = array_merge($this->_select, $this->_customQuery->_select);
       $this->_element = array_merge($this->_element, $this->_customQuery->_element);
       $this->_tables = array_merge($this->_tables, $this->_customQuery->_tables);
-      $this->_whereTables = array_merge($this->_whereTables, $this->_customQuery->_whereTables);
       $this->_options = $this->_customQuery->_options;
     }
     $isForcePrimaryOnly = !empty($apiEntity);
@@ -2077,12 +2076,12 @@ class CRM_Contact_BAO_Query {
     }
 
     if ($this->_customQuery) {
+      $this->_whereTables = array_merge($this->_whereTables, $this->_customQuery->_whereTables);
       // Added following if condition to avoid the wrong value display for 'my account' / any UF info.
       // Hope it wont affect the other part of civicrm.. if it does please remove it.
       if (!empty($this->_customQuery->_where)) {
         $this->_where = CRM_Utils_Array::crmArrayMerge($this->_where, $this->_customQuery->_where);
       }
-
       $this->_qill = CRM_Utils_Array::crmArrayMerge($this->_qill, $this->_customQuery->_qill);
     }
 
@@ -2154,7 +2153,8 @@ class CRM_Contact_BAO_Query {
         $realFieldName = str_replace(['_high', '_low'], '', $name);
         if (isset($this->_fields[$realFieldName])) {
           $field = $this->_fields[str_replace(['_high', '_low'], '', $realFieldName)];
-          $this->dateQueryBuilder($values, $field['table_name'], $realFieldName, $field['name'], $field['title']);
+          $columnName = $field['column_name'] ?? $field['name'];
+          $this->dateQueryBuilder($values, $field['table_name'], $realFieldName, $columnName, $field['title']);
         }
         return;
       }
@@ -5303,8 +5303,8 @@ civicrm_relationship.start_date > {$today}
       // Special handling for contact table as it has a known alias in advanced search.
       $tableName = 'contact_a';
     }
-    if ($name == "{$fieldName}_low" ||
-      $name == "{$fieldName}_high"
+    if ($name === "{$fieldName}_low" ||
+      $name === "{$fieldName}_high"
     ) {
       if (isset($this->_rangeCache[$fieldName]) || !$value) {
         return;

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5298,7 +5298,10 @@ civicrm_relationship.start_date > {$today}
   ) {
     // @todo - remove dateFormat - pretty sure it's never passed in...
     list($name, $op, $value, $grouping, $wildcard) = $values;
-
+    if ($name !== $fieldName && $name !== "{$fieldName}_low" && $name !== "{$fieldName}_high") {
+      CRM_Core_Error::deprecatedFunctionWarning('Date query builder called unexpectedly');
+      return;
+    }
     if ($tableName === 'civicrm_contact') {
       // Special handling for contact table as it has a known alias in advanced search.
       $tableName = 'contact_a';
@@ -5360,7 +5363,6 @@ civicrm_relationship.start_date > {$today}
         $secondDateFormat = CRM_Utils_Date::customFormat($secondDate);
       }
 
-      $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;
       if ($secondDate) {
         $highDBFieldName = $highDBFieldName ?? $dbFieldName;
         $this->_where[$grouping][] = "
@@ -5411,11 +5413,13 @@ civicrm_relationship.start_date > {$today}
         $this->_where[$grouping][] = self::buildClause("{$tableName}.{$dbFieldName}", $op);
       }
 
-      $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;
-
       $op = CRM_Utils_Array::value($op, CRM_Core_SelectValues::getSearchBuilderOperators(), $op);
       $this->_qill[$grouping][] = "$fieldTitle $op $format";
     }
+
+    // Ensure the tables are set, but don't whomp anything.
+    $this->_tables[$tableName] = $this->_tables[$tableName] ?? 1;
+    $this->_whereTables[$tableName] = $this->_whereTables[$tableName] ?? 1;
   }
 
   /**

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -396,7 +396,9 @@ SELECT f.id, f.label, f.data_type,
             break;
 
           case 'Date':
-            if (substr($name, -9, 9) !== '_relative') {
+            if (substr($name, -9, 9) !== '_relative'
+              && substr($name, -4, 4) !== '_low'
+              && substr($name, -5, 5) !== '_high') {
               // Relative dates are handled in the buildRelativeDateQuery function.
               $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'Date');
               list($qillOp, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $field['label'], $value, $op, [], CRM_Utils_Type::T_DATE);

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -578,7 +578,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
       $this->getCustomFieldName('select_date') => [
         'name' => $this->getCustomFieldName('select_date'),
         'type' => 4,
-        'title' => 'test_date',
+        'title' => 'Test Date',
         'headerPattern' => '//',
         'import' => 1,
         'custom_field_id' => $this->getCustomFieldID('select_date'),
@@ -590,7 +590,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => 'mm/dd/yy',
         'time_format' => '1',
         'id' => $this->getCustomFieldID('select_date'),
-        'label' => 'test_date',
+        'label' => 'Test Date',
         'groupTitle' => 'Custom Group',
         'default_value' => '20090711',
         'custom_group_id' => $customGroupID,

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -310,7 +310,7 @@ trait CRMTraits_Custom_CustomDataTrait {
   protected function createDateCustomField($params): array {
     $params = array_merge([
       'name' => 'test_date',
-      'label' => 'test_date',
+      'label' => 'Test Date',
       'html_type' => 'Select Date',
       'data_type' => 'Date',
       'default_value' => '20090711',


### PR DESCRIPTION
Overview
----------------------------------------
Preliminary query fixes to support the new datepicker format

Before
----------------------------------------
Many tech hurdles in switching datepicker over

After
----------------------------------------
They are melting away

Technical Details
----------------------------------------
Once we convert to datePicker we will be passing in parameters like custom_3_high, custom_3_low & custom_3_relative.

Currently we pass in custom_3_to & custom_3_from and custom_3_relative. This adds support for the new high & low
withoutt touching support for previously working or switching the field across (as yet). This paves the way for
the datepicker conversion. After a lot of brain pain I concluded the fundamental problem was the whereTables
from the CustomQuery were being merged in but actually then lost when where() is called.

Comments
----------------------------------------

