### PR TITLE
Remove early return on joinTable

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -215,6 +215,11 @@ SELECT f.id, f.label, f.data_type,
 
     foreach (array_keys($this->_ids) as $id) {
       $field = $this->_fields[$id];
+
+      if ($this->_contactSearch && $field['search_table'] === 'contact_a') {
+        CRM_Contact_BAO_Query::$_openedPanes[ts('Custom Fields')] = TRUE;
+      }
+
       $name = $field['table_name'];
       $fieldName = 'custom_' . $field['id'];
       $this->_select["{$name}_id"] = "{$name}.id as {$name}_id";
@@ -240,9 +245,6 @@ SELECT f.id, f.label, f.data_type,
         }
         if ($joinTable != 'contact_a') {
           $this->_whereTables[$joinTableAlias] = $this->_tables[$joinTableAlias] = $joinClause;
-        }
-        elseif ($this->_contactSearch) {
-          CRM_Contact_BAO_Query::$_openedPanes[ts('Custom Fields')] = TRUE;
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes a confusing & pointless few lines of code

Before
----------------------------------------
Code serves to confuse

After
----------------------------------------
Poof

Technical Details
----------------------------------------
I looked up the reason for the early return here and it was that the UI for adding other tables
in was too complex. In other words the removed lines should never be true.

However, I don't think it's the place of the query object to enforce not attempting a query the
UI struggles with. Removing this will save a later person having to figure that out

Comments
----------------------------------------

