### PR TITLE
[REF] minor tidy ups on very nasty function

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1732,14 +1732,14 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         // contacts.
 
         // Get the Membership Type Details.
-        $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($membershipValues['membership_type_id']);
+        $membershipType = CRM_Member_BAO_MembershipType::getMembershipType($membershipValues['membership_type_id']);
         // Check if contact's relationship type exists in membership type
         $relTypeDirs = [];
         if (!empty($membershipType['relationship_type_id'])) {
-          $relTypeIds = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_type_id']);
+          $relTypeIds = (array) $membershipType['relationship_type_id'];
         }
         if (!empty($membershipType['relationship_direction'])) {
-          $relDirections = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_direction']);
+          $relDirections = (array) $membershipType['relationship_direction'];
         }
         foreach ($relTypeIds as $key => $value) {
           $relTypeDirs[] = $value . '_' . $relDirections[$key];

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1763,11 +1763,6 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
               $membershipValues['status_id'] = $deceasedStatusId;
               $membershipValues['skipStatusCal'] = TRUE;
             }
-            foreach (['join_date', 'start_date', 'end_date'] as $dateField) {
-              if (!empty($membershipValues[$dateField])) {
-                $membershipValues[$dateField] = CRM_Utils_Date::processDate($membershipValues[$dateField]);
-              }
-            }
 
             if ($action & CRM_Core_Action::UPDATE) {
               //if updated relationship is already related to contact don't delete existing inherited membership

--- a/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
@@ -243,6 +243,8 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
     $this->callAPISuccess('Membership', 'create', [
       'membership_type_id' => $membershipType['id'],
       'contact_id' => $organisationID,
+      'start_date' => '2019-08-19',
+      'join_date' => '2019-07-19',
     ]);
 
     $relationshipOne = $this->callAPISuccess('Relationship', 'create', [
@@ -256,7 +258,10 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
       'relationship_type_id' => $orgToPersonTypeId2,
     ]);
 
-    $this->callAPISuccessGetCount('Membership', ['contact_id' => $individualID], 1);
+    $inheritedMembership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $individualID]);
+    $this->assertEquals('2019-08-19', $inheritedMembership['start_date']);
+    $this->assertEquals('2019-07-19', $inheritedMembership['join_date']);
+
     $this->callAPISuccessGetCount('Membership', ['contact_id' => $organisationID], 1);
     // Disable the relationship & check the membership is not removed because the other relationship is still valid.
     $relationshipOne['is_active'] = 0;


### PR DESCRIPTION
Overview
----------------------------------------
Changes
- switches to using cached function rather than deprecated function to get MembershipTypeDetails (covered by existing tests)
- remove unnecessary date formatting

Before
----------------------------------------
Nasty

After
----------------------------------------
Still nasty if I'm honest

Technical Details
----------------------------------------
It used to be necessary to ISO format code before DAO->save. However, along the line wee fixed it lower
down & no longer need this smattered all over the code. Test proves it's OK (actually they noisily pointed out that the code had to stop unpacking the separated string as it was now getting that done for it :-)

Comments
----------------------------------------
