### PR TITLE
Eliminate silly parameter

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1660,7 +1660,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
 
       // CRM-15829 UPDATES
       // Since we want PENDING memberships as well, the $active flag needs to be set to false so that this will return all memberships and we can then filter the memberships based on the status IDs recieved above.
-      CRM_Member_BAO_Membership::getValues($memParams, $memberships, FALSE, TRUE);
+      CRM_Member_BAO_Membership::getValues($memParams, $memberships, FALSE);
       // CRM-15829 UPDATES
       // filter out the memberships returned by CRM_Member_BAO_Membership::getValues based on the status IDs fetched on line ~1462
       foreach ($memberships as $key => $membership) {
@@ -1672,17 +1672,15 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         if (!isset($membershipStatusRecordIds[$membershipStatusId])) {
           unset($memberships[$key]);
         }
+        //get ownerMembershipIds for related Membership
+        //this is to handle memberships being deleted and recreated
+        if (!empty($membership['owner_membership_id'])) {
+          $ownerMemIds[$cid] = $membership['owner_membership_id'];
+        }
       }
 
       if (empty($memberships)) {
         continue;
-      }
-
-      //get ownerMembershipIds for related Membership
-      //this is to handle memberships being deleted and recreated
-      if (!empty($memberships['owner_membership_ids'])) {
-        $ownerMemIds[$cid] = $memberships['owner_membership_ids'];
-        unset($memberships['owner_membership_ids']);
       }
 
       $values[$cid]['memberships'] = $memberships;

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -215,12 +215,11 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
    * @param bool $active
    *   Do you want only active memberships to.
    *                        be returned
-   * @param bool $relatedMemberships
    *
    * @return CRM_Member_BAO_Membership|null
    *   The found object or null
    */
-  public static function &getValues(&$params, &$values, $active = FALSE, $relatedMemberships = FALSE) {
+  public static function &getValues(&$params, &$values, $active = FALSE) {
     if (empty($params)) {
       return NULL;
     }
@@ -241,9 +240,6 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
       CRM_Core_DAO::storeValues($membership, $values[$membership->id]);
       $memberships[$membership->id] = $membership;
-      if ($relatedMemberships && !empty($membership->owner_membership_id)) {
-        $values['owner_membership_ids'][] = $membership->owner_membership_id;
-      }
     }
 
     return $memberships;


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes parameters do useful things. This one doesn't

Before
----------------------------------------
Code silliness

After
----------------------------------------
Code is more like a primary school kid

Technical Details
----------------------------------------
 is only ever passed into this function once. In that instance
it is then populated off owner_membership_id & then wrangled in the calling function
back to a separatte arry before being unset. The moves it back to the calling function &
simplifieds

Good test cover exists in testCreateMembership

Comments
----------------------------------------
