### PR TITLE
dev/core#1360: Fix Programatic Installation Of Multiple Extensions on v5.19

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -507,6 +507,8 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    */
   public function fixSchemaDifferencesForAll($rebuildTrigger = FALSE) {
     $diffs = [];
+    $this->resetTableColumnsCache();
+
     foreach ($this->tables as $table) {
       if (empty($this->logs[$table])) {
         $this->createLogTableFor($table);
@@ -523,6 +525,17 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
       // invoke the meta trigger creation call
       CRM_Core_DAO::triggerRebuild(NULL, TRUE);
     }
+  }
+
+  /**
+   * Resets columnSpecs.
+   *
+   * Resets columnSpecs static array in Civi's $statics to make sure we use the
+   * real state of the schema to perform sync operations between core and
+   * logging tables.
+   */
+  private function resetTableColumnsCache() {
+    unset(\Civi::$statics[__CLASS__]['columnSpecs']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
We have a drupal profile we use to install drupal sites with CiviCRM and some common extensions. When running the profile, CiviCRM is upgraded to v5.19. After that, the extensions are installed, however, the first extension installation causes a database exception to be thrown. It doesn't matter what extension is installed, every time, the installation of the first extension will fail.

Before
----------------------------------------
1. Upgrade `upgrade_5_19_alpha1()` creates a new `field on civicrm_status_pref` table. https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/php/FiveNineteen.php#L69-L74
1. At the end of the installation of the first extension, schema is synched by comparing the columns of every table in CiviCRM with its correspondig logging table, however, the columnStats cache in \\Civi:$statics has already been be initialized, with `civicrm_status_pref` table missing the new `is_active` column.
1. Schema is synched using cached values for columnStats. System erroneously detects `log_civicrm_status_pref` is missing the `is_active` column and tries to create it again, causing the exception to be thrown.

After
----------------------------------------
I've added a method that resets the columnStats cache when rebuilding the complete schema, in order to make sure we use the actual state of the schema when doing the sync.
