### PR TITLE
core#1364 : 'Merge All Contacts with the Same Address' doesn't consider Household replace individuals that share same address.

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -190,6 +190,10 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         $processor->mergeSameAddress();
       }
 
+      if (!empty($exportParams['suppress_csv_for_testing'])) {
+        return [$processor->getTemporaryTable(), $sqlColumns];
+      }
+
       $processor->writeCSVFromTable();
 
       // delete the export temp table and component table

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -973,6 +973,7 @@ class CRM_Export_BAO_ExportProcessor {
     $phoneTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
     $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
 
+    $row = [];
     $householdMergeRelationshipType = $this->getHouseholdMergeTypeForRow($iterationDAO->contact_id);
     if ($householdMergeRelationshipType) {
       return $this->getRelatedHousehold($iterationDAO->contact_id, $outputColumns);
@@ -1984,7 +1985,6 @@ class CRM_Export_BAO_ExportProcessor {
    * Merge contacts with the same address.
    */
   public function mergeSameAddress() {
-
     $tableName = $this->getTemporaryTable();
     // check if any records are present based on if they have used shared address feature,
     // and not based on if city / state .. matches.
@@ -2002,8 +2002,9 @@ SELECT    r1.id                 as copy_id,
           r2.addressee          as master_addressee,
           r2.addressee_id       as master_addressee_id
 FROM      $tableName r1
-INNER JOIN civicrm_address adr ON r1.master_id   = adr.id
-INNER JOIN $tableName      r2  ON adr.contact_id = r2.civicrm_primary_id
+INNER JOIN civicrm_address adr1 ON r1.civicrm_primary_id   = adr1.contact_id AND r1.master_id IS NOT NULL
+INNER JOIN civicrm_address adr2 ON adr2.id = adr1.master_id
+INNER JOIN $tableName      r2  ON adr2.contact_id = r2.civicrm_primary_id
 ORDER BY  r1.id";
     $this->buildMasterCopyArray($sql, TRUE);
 

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -434,7 +434,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       TRUE,
       FALSE,
       array(
-        'exportOption' => 1,
         'suppress_csv_for_testing' => TRUE,
       )
     );

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -421,34 +421,23 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     ]);
     $contactIDs = array_merge($this->contactIDs, [$householdID]);
     $params = ['contact_id' => $contactIDs];
-    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
-      FALSE,
-      $contactIDs,
-      CRM_Contact_BAO_Query::convertFormValues($params),
-      NULL,
-      NULL,
-      NULL,
-      CRM_Export_Form_Select::CONTACT_EXPORT,
-      NULL,
-      NULL,
-      TRUE,
-      FALSE,
-      array(
-        'suppress_csv_for_testing' => TRUE,
-      )
-    );
-    $exportedRows = CRM_Utils_SQL_Select::from($tableName)->execute()->fetchAll();
-    $this->assertEquals(1, count($exportedRows));
+
+    $this->doExportTest([
+      'selectAll' => FALSE,
+      'ids' => $contactIDs,
+      'mergeSameAddress' => TRUE,
+    ]);
+    $this->assertEquals(1, $this->csv->count());
+
+    $exportedRows = $this->csv->fetchOne();
+
     $expectedValues = [
-      'civicrm_primary_id' => $householdID,
-      'contact_type' => 'Household',
+      'Contact ID' => $householdID,
+      'Contact Type' => 'Household',
     ];
     foreach ($expectedValues as $columnName => $expectedValue) {
-      $this->assertEquals($expectedValue, $exportedRows[0][$columnName]);
+      $this->assertEquals($expectedValue, $exportedRows[$columnName]);
     }
-    // delete the export temp table and component table
-    $sql = "DROP TABLE IF EXISTS {$tableName}";
-    CRM_Core_DAO::executeQuery($sql);
   }
 
   /**

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -405,6 +405,54 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test to ensure that 'Merge All Contacts with the Same Address' works on export.
+   */
+  public function testMergeSameAddressOnExport() {
+    // Here's how this test case works - 3 contacts are created A, B and C where A and B are individual contacts that share same address via master_id.
+    //  C is a household contact whose member is contact A. These 3 contacts are selected for export with 'Merge All Contacts with the Same Address' = TRUE
+    //  And at the end export table contain only 1 contact i.e. is C as A and B got merged into 1 as they share same address but then A is Household member of C.
+    //  So C take preference over A and thus C is exported as result.
+    $addressID = $this->setUpContactExportData();
+    $householdID = $this->householdCreate();
+    $this->callAPISuccess('relationship', 'create', [
+      'contact_id_a' => $this->contactIDs[0],
+      'contact_id_b' => $householdID,
+      'relationship_type_id' => CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', 'Household Member of', 'id', 'name_a_b'),
+    ]);
+    $contactIDs = array_merge($this->contactIDs, [$householdID]);
+    $params = ['contact_id' => $contactIDs];
+    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
+      FALSE,
+      $contactIDs,
+      CRM_Contact_BAO_Query::convertFormValues($params),
+      NULL,
+      NULL,
+      NULL,
+      CRM_Export_Form_Select::CONTACT_EXPORT,
+      NULL,
+      NULL,
+      TRUE,
+      FALSE,
+      array(
+        'exportOption' => 1,
+        'suppress_csv_for_testing' => TRUE,
+      )
+    );
+    $exportedRows = CRM_Utils_SQL_Select::from($tableName)->execute()->fetchAll();
+    $this->assertEquals(1, count($exportedRows));
+    $expectedValues = [
+      'civicrm_primary_id' => $householdID,
+      'contact_type' => 'Household',
+    ];
+    foreach ($expectedValues as $columnName => $expectedValue) {
+      $this->assertEquals($expectedValue, $exportedRows[0][$columnName]);
+    }
+    // delete the export temp table and component table
+    $sql = "DROP TABLE IF EXISTS {$tableName}";
+    CRM_Core_DAO::executeQuery($sql);
+  }
+
+  /**
    * Set up some data for us to do testing on.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. 5 contacts A,B,C, D, E where A, B and C individuals share same address.
2. D is a household but shares same address as of ABC.
3. E is a household which has a different address but Household head of A and B
4. On exporting these 5 contacts and choosing merge same address:


Before
----------------------------------------
3 records i.e. combined record of (A,B,C) , D and E (Incorrect)

After
----------------------------------------
2 records i.e. D and E. Because D has a same address as of A,B and C so it would replace these 3. E is a household though but has different address so it should not be merged

Technical Details
----------------------------------------
This PR solves an [old issue](https://issues.civicrm.org/jira/browse/CRM-21858) which was not fixed and previously the old PR https://github.com/civicrm/civicrm-core/pull/11901 was dropped because the export code itself needs improvements. So I have made the changes on top of refactored code which utilizes ExportProcessor to do the essential job to merge and export contacts on basis of address or household. 


Comments
----------------------------------------
ping @lcdservices @eileenmcnaughton 