### PR TITLE
dev/core#1093: Fix Installation of Custom Fields with Option Values From XML

### DIFF
--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -358,13 +358,43 @@ AND        v.name = %1
     foreach ($xml->CustomFields as $customFieldsXML) {
       $total = count($customFieldsXML->CustomField);
       foreach ($customFieldsXML->CustomField as $customFieldXML) {
+        if (empty($customFieldXML->option_group_id) && isset($customFieldXML->option_group_name)) {
+          $customFieldXML->option_group_id = $this->getOptionGroupIDFromName((string) $customFieldXML->option_group_name, $idMap);
+        }
+
         $id = $idMap['custom_group'][(string ) $customFieldXML->custom_group_name];
         $fields_indexed_by_group_id[$id][] = $customFieldXML;
       }
     }
+
     foreach ($fields_indexed_by_group_id as $group_id => $fields) {
-      CRM_Core_BAO_CustomField::bulkSave(json_decode(json_encode($fields), TRUE), ['custom_group_id' => $group_id]);
+      \Civi\Api4\CustomField::save()
+        ->setDefaults(['custom_group_id' => $group_id])
+        ->setRecords(json_decode(json_encode($fields), TRUE))
+        ->execute();
     }
+  }
+
+  /**
+   * Get Option Group ID.
+   *
+   * Returns an option group's ID, given its name.
+   *
+   * @param $groupName
+   * @param $idMap
+   *
+   * @return int|null
+   */
+  private function getOptionGroupIDFromName($groupName, &$idMap) {
+    if (empty($groupName)) {
+      return NULL;
+    }
+
+    if (!isset($idMap['option_group'][$groupName])) {
+      $idMap['option_group'][$groupName] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $groupName, 'id', 'name');
+    }
+
+    return $idMap['option_group'][$groupName];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
we've run into an issue with bulk create of custom fields and direct debit extension. On previous versions of CiviCRM, when we defined option groups for a custom field on an xml file, we were able to use `option_group_name` to define the option group to be used for values of the custom field. 

Before
----------------------------------------
The old version of the method to import custom fields used to process these option group names and replace them by their corresponding ID. Check:

https://github.com/civicrm/civicrm-core/blob/5.5/CRM/Utils/Migrate/Import.php#L376-L380

This fails to happen when using bulkSave() to import custom fields.

After
----------------------------------------
Added logicthat maps option_group names to their ID's, and used API4 call to implement bulk save action to create the fields.
