### PR TITLE
composer.{json,lock} - Make the "tplaner/when" exception for old PHP reproducible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
     "katzien/php-mime-type": "2.1.0",
     "civicrm/composer-downloads-plugin": "^2.0",
     "league/csv": "^9.2",
-    "tplaner/when": "dev-master#c1ec099f421bff354cc5c929f83b94031423fc80"
+    "tplaner/when": "dev-master#c1ec099f421bff354cc5c929f83b94031423fc80",
+    "xkerman/restricted-unserialize": "~1.1"
   },
   "require-dev": {
     "cache/integration-tests": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "katzien/php-mime-type": "2.1.0",
     "civicrm/composer-downloads-plugin": "^2.0",
     "league/csv": "^9.2",
-    "tplaner/when": "dev-master#c1ec099f421bff354cc5c929f83b94031423fc80",
+    "tplaner/when": "~3.0.0",
     "xkerman/restricted-unserialize": "~1.1"
   },
   "require-dev": {
@@ -88,6 +88,25 @@
       "bash tools/scripts/composer/pear-mail-fix.sh",
       "bash tools/scripts/composer/phpword-jquery.sh"
     ]
+  },
+  "repositories": {
+    "tplaner-when-1ec099f421bff354cc5c929f83b94031423fc80": {
+      "type": "package",
+      "package": {
+        "version": "3.0.0+php53",
+        "dist": {"url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip", "type": "zip"},
+        "name": "tplaner/when",
+        "type": "library",
+        "description": "Date/Calendar recursion library.",
+        "keywords": ["recurrence", "date", "time", "DateTime"],
+        "homepage": "https://github.com/tplaner/When",
+        "license": "MIT",
+        "authors": [{"name": "Tom Planer", "email": "tplaner@gmail.com"}],
+        "require": {"php": ">=5.3.0"},
+        "require-dev": {"phpunit/phpunit": "~4.0"},
+        "autoload": {"psr-4": {"When\\": "src/"}}
+      }
+    }
   },
   "extra": {
     "downloads": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec0b6779b9262fd5c0b41d3eb4d5f109",
+    "content-hash": "fc2b275e88919949aad21babc71c1706",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -2230,23 +2230,16 @@
         },
         {
             "name": "tplaner/when",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tplaner/When.git",
-                "reference": "c1ec099f421bff354cc5c929f83b94031423fc80"
-            },
+            "version": "3.0.0+php53",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tplaner/When/zipball/c1ec099f421bff354cc5c929f83b94031423fc80",
-                "reference": "c1ec099f421bff354cc5c929f83b94031423fc80",
-                "shasum": ""
+                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip"
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0"
+                "phpunit/phpunit": "~4.0"
             },
             "type": "library",
             "autoload": {
@@ -2254,7 +2247,6 @@
                     "When\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -2267,13 +2259,11 @@
             "description": "Date/Calendar recursion library.",
             "homepage": "https://github.com/tplaner/When",
             "keywords": [
+                "DateTime",
                 "date",
-                "datetime",
                 "recurrence",
-                "repeat",
                 "time"
-            ],
-            "time": "2019-01-11T21:59:13+00:00"
+            ]
         },
         {
             "name": "xkerman/restricted-unserialize",
@@ -2616,7 +2606,7 @@
                 {
                     "name": "Tobias Nyholm",
                     "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
+                    "homepage": "https://github.com/Nyholm"
                 },
                 {
                     "name": "Nicolas Grekas",
@@ -2806,7 +2796,6 @@
     "stability-flags": {
         "zetacomponents/mail": 20,
         "pear/validate_finance_creditcard": 20,
-        "tplaner/when": 20,
         "cache/integration-tests": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ac00e2168797fa522d7a6f036a5e296",
+    "content-hash": "ec0b6779b9262fd5c0b41d3eb4d5f109",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -2274,6 +2274,57 @@
                 "time"
             ],
             "time": "2019-01-11T21:59:13+00:00"
+        },
+        {
+            "name": "xkerman/restricted-unserialize",
+            "version": "1.1.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/xKerman/restricted-unserialize.git",
+                "reference": "4c6cadbb176c04d3e19b9bb8b40df12998460489"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/xKerman/restricted-unserialize/zipball/4c6cadbb176c04d3e19b9bb8b40df12998460489",
+                "reference": "4c6cadbb176c04d3e19b9bb8b40df12998460489",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^1.4|^3.0|^4.2",
+                "phpmd/phpmd": "^2.6",
+                "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.4|^8.2",
+                "sebastian/phpcpd": "^2.0|^3.0|^4.1",
+                "squizlabs/php_codesniffer": "^2.9|^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/function.php"
+                ],
+                "psr-4": {
+                    "xKerman\\Restricted\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "xKerman",
+                    "email": "xKhorasan@gmail.com"
+                }
+            ],
+            "description": "provide PHP Object Injection safe unserialize function",
+            "keywords": [
+                "PHP Object Injection",
+                "deserialize",
+                "unserialize"
+            ],
+            "time": "2019-08-11T00:04:39+00:00"
         },
         {
             "name": "zendframework/zend-escaper",


### PR DESCRIPTION
Overview
--------

The library `tplaner/when` has an inaccurate dependency on `php71` and requires special work to deploy on `php70`.

Before
------

The `composer.lock` file was manually edited to make it runnable on `php70`.
However, if you `rm composer.lock && composer install`, then it fails.

After
-----

The `composer.json` and `composer.lock` are more repeatable.  If you run
`rm composer.lock && composer install`, then it works.

Comments
--------

This adds a fairly ugly section.  However, the good news is that it should
be more transparent - which should make it easier to understand/remove
later.

As a general rule, we don't want to have `civicrm-core.git` depend on
packages/versions that aren't published.  This is a somewhat unusual
edge-case - this package/version is published via `packagist.org`.  If you
run without this on php71+, then you still get a valid/equivalent package.
All that we've done is to enable running on `php70` (when `civicrm-core` is
a root project).

To head off MC's, I based this on top of another #15730 which also touches `composer.lock`.