### PR TITLE
dev/core#1367 - Incorrect line items recorded with contribution repea…

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -932,7 +932,11 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
           // CRM-17718 allow for possibility of changed financial type ID having been set prior to calling this.
           $lineItem['financial_type_id'] = $financial_type_id;
         }
-        if ($lineItem['line_total'] != $total_amount) {
+        $taxAmountMatches = FALSE;
+        if ((!empty($lineItem['tax_amount']) && ($lineItem['line_total'] + $lineItem['tax_amount']) == $total_amount)) {
+          $taxAmountMatches = TRUE;
+        }
+        if ($lineItem['line_total'] != $total_amount && !$taxAmountMatches) {
           // We are dealing with a changed amount! Per CRM-16397 we can work out what to do with these
           // if there is only one line item, and the UI should prevent this situation for those with more than one.
           $lineItem['line_total'] = $total_amount;

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4380,6 +4380,14 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     //Assert if first payment and repeated payment has the same contribution amount.
     $this->assertEquals($payments[0]['total_amount'], $payments[1]['total_amount']);
     $this->callAPISuccessGetCount('Contribution', [], 2);
+
+    //Assert line item records.
+    $lineItems = $this->callAPISuccess('LineItem', 'get', ['sequential' => 1])['values'];
+    foreach ($lineItems as $lineItem) {
+      $this->assertEquals($lineItem['unit_price'], $this->_params['total_amount']);
+      $this->assertEquals($lineItem['line_total'], $this->_params['total_amount']);
+    }
+    $this->callAPISuccessGetCount('Contribution', [], 2);
   }
 
   public function testGetCurrencyOptions() {


### PR DESCRIPTION
…ttransaction api

Overview
----------------------------------------
Line item displays incorrect amount for recur contribution if tax amount is involved.

Before
----------------------------------------
To replicate -

- Create a Financial Type that adds 10% to the total amount.
- Create a priceset with a field of $10 amount using the above FT.
- Create a recur contribution record with this priceset.
- View the contribution and notice the line items are displayed correctly.

![image](https://user-images.githubusercontent.com/5929648/68207242-8fbad500-fff4-11e9-9c64-3b46f94e8d25.png)

- Call repeattransaction api on this record, eg

      cv api Contribution.repeattransaction contribution_status_id="Completed" contribution_recur_id=<your_recur_id> 

- A new contribution is created on the contact which displays a correct amount value.

- View this contribution record and notice that the line item calculation is incorrect.

![image](https://user-images.githubusercontent.com/5929648/68207275-9ba69700-fff4-11e9-80f7-278bcb5a3b99.png)

After
----------------------------------------
Correct amount is recorded.



Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1367

Added unit test.
