### PR TITLE
(NFC) Remove windows-specific debugging code from 11 years ago

### DIFF
--- a/CRM/Case/Audit/Audit.php
+++ b/CRM/Case/Audit/Audit.php
@@ -220,12 +220,6 @@ class CRM_Case_Audit_Audit {
    * @return mixed
    */
   public static function run($xmlString, $clientID, $caseID, $printReport = FALSE) {
-    /*
-    $fh = fopen('C:/temp/audit2.xml', 'w');
-    fwrite($fh, $xmlString);
-    fclose($fh);
-     */
-
     $audit = new CRM_Case_Audit_Audit($xmlString, 'audit.conf.xml');
     $activities = $audit->getActivities($printReport);
 


### PR DESCRIPTION
Overview
----------------------------------------
Doesn't really need any explanation. In fact it's best not to think about it.
