### PR TITLE
dev/financial#40 Fix for non-allocation of payment to fully reversed checkboxes option

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -102,7 +102,7 @@ class CRM_Financial_BAO_Payment {
     list($ftIds, $taxItems) = CRM_Contribute_BAO_Contribution::getLastFinancialItemIds($params['contribution_id']);
 
     foreach ($lineItems as $key => $value) {
-      if ($value['qty'] == 0 || $value['allocation'] === (float) 0) {
+      if ($value['allocation'] === (float) 0) {
         continue;
       }
       $eftParams = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue whereby
civicrm_entity_financial_trxn records for the civicrm_financial_item table are not created when
refunding against line items with a quantity of zero  - ie where there were selected checkboxes & they were reversed.



Before
----------------------------------------
1) create an event price set with at least 2 fields - one is checkboxes
2) Register a participant, selecting some of both (back office is fine)
3) edit the registration and de-select the checkboxes (leaving the quantity as 0)
4) add a refund payment against the contribution
-> no entity_financial_trxn records are created linking the financial_items to the refund payment. The refund payment is thus missing on the bookkeeping report


After
----------------------------------------
entity_financial_trxn records created

Technical Details
----------------------------------------
https://lab.civicrm.org/dev/financial/issues/98 

The reason this check was there relates to former logic - now we have a calculated allocation
we don't need this check.

I want to do a test but need to do a bit of work to get it set up & I think this should hit 5.20
as it relates to an issue identified by @kcristiano  in reviewing patches merged to that version

Comments
----------------------------------------
