### PR TITLE
(dev/core#1093) Fix regression during extension activation

### DIFF
--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -369,6 +369,7 @@ AND        v.name = %1
 
     foreach ($fields_indexed_by_group_id as $group_id => $fields) {
       \Civi\Api4\CustomField::save()
+        ->setCheckPermissions(FALSE)
         ->setDefaults(['custom_group_id' => $group_id])
         ->setRecords(json_decode(json_encode($fields), TRUE))
         ->execute();


### PR DESCRIPTION
Overview
--------

This fixes a recent/unreleased regression from #15726 in which the D7 demo build fails.

Before
------

When running `civibuild reinstall ...` on a `drupal-demo` site, it fails at this step:

```
+++ drush -y cvapi extension.install key=org.civicrm.volunteer debug=1
Authorization failed                                                                                                                                                   [error]
Array
(
    [error_code] => unauthorized
    [entity] => Extension
    [action] => install
    [trace] => #0 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(166): Civi\API\Kernel->authorize(Object(Civi\Api4\Provider\ActionObjectProvider), Object(Civi\Api4\Generic\DAOSaveAction))
1 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Api4/Generic/AbstractAction.php(235): Civi\API\Kernel->runRequest(Object(Civi\Api4\Generic\DAOSaveAction))
2 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Utils/Migrate/Import.php(374): Civi\Api4\Generic\AbstractAction->execute()
3 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Utils/Migrate/Import.php(82): CRM_Utils_Migrate_Import->customFields(Object(SimpleXMLElement), Array)
4 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/tools/extensions/civivolunteer/CRM/Volunteer/Upgrader.php(836): CRM_Utils_Migrate_Import->runXmlElement(Object(SimpleXMLElement))
5 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/tools/extensions/civivolunteer/CRM/Volunteer/Upgrader.php(48): CRM_Volunteer_Upgrader->executeCustomDataTemplateFile('volunteer-custo...')
6 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/tools/extensions/civivolunteer/CRM/Volunteer/Upgrader/Base.php(306): CRM_Volunteer_Upgrader->install()
7 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/tools/extensions/civivolunteer/volunteer.civix.php(131): CRM_Volunteer_Upgrader_Base->onInstall()
8 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/tools/extensions/civivolunteer/volunteer.php(204): _volunteer_civix_civicrm_install()
9 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Extension/Manager/Module.php(76): volunteer_civicrm_install()
10 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Extension/Manager/Module.php(48): CRM_Extension_Manager_Module->callHook(Object(CRM_Extension_Info), 'install')
11 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Extension/Manager.php(264): CRM_Extension_Manager_Module->onPreInstall(Object(CRM_Extension_Info))
12 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/api/v3/Extension.php(58): CRM_Extension_Manager->install(Array)
13 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Provider/MagicFunctionProvider.php(101): civicrm_api3_extension_install(Array)
14 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(168): Civi\API\Provider\MagicFunctionProvider->invoke(Array)
15 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(99): Civi\API\Kernel->runRequest(Array)
16 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/api/api.php(23): Civi\API\Kernel->runSafe('extension', 'install', Array, NULL)
17 /Users/myuser/bknix/build/dmaster/web/sites/all/modules/civicrm/drupal/drush/civicrm.drush.inc(1557): civicrm_api('extension', 'install', Array)
18 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/includes/command.inc(422): drush_civicrm_api('extension.insta...', 'key=org.civicrm...', 'debug=1')
19 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/includes/command.inc(231): _drush_invoke_hooks(Array, Array)
20 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/includes/command.inc(199): drush_command('extension.insta...', 'key=org.civicrm...', 'debug=1')
21 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)
22 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/includes/preflight.inc(66): Drush\Boot\BaseBoot->bootstrap_and_dispatch()
23 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/includes/startup.inc(465): drush_main()
24 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/includes/startup.inc(369): drush_run_main(false, '/', 'Phar detected. ...')
25 phar:///Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar/drush(114): drush_startup(Array)
26 /Users/myuser/bknix/civicrm-buildkit/extern/drush8.phar(10): require('phar:///Users/t...')
27 {main}
    [is_error] => 1
    [error_message] => Authorization failed
)
```

This is not particularly anomalous. Most CLI-based sysadmin work is done without setting a specific CMS user, and `CRM_Utils_Migrate_Import` is part of the standard template for extension code.

After
-----

It works again.
