### PR TITLE
Fix test to be more valid

### DIFF
--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -675,6 +675,9 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * Test submit with a membership block in place.
    *
    * We are expecting a separate payment for the membership vs the contribution.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testSubmitMembershipBlockIsSeparatePaymentPaymentProcessorNow() {
     $mut = new CiviMailUtils($this, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
I've added a check to run after tests & before tearDown to ensure that all payments have the
right entity_financial_trxn records.

This required fixing one test to be valid. It's not possible to create a contribution using the
back office for with status set to Partially Paid (it's not an option in the drop down, so
the test should create as Pending & then add a payment to get to partially paid

Before
----------------------------------------
Payment validity not checked in this class

After
----------------------------------------
Checked

Technical Details
----------------------------------------
I want to add this test to a bunch of classes that deal with payments - but there are some test setup issues to resolve

Comments
----------------------------------------
