### PR TITLE
(dev/core#1065) Participant in Edit mode needs to be shown consistently

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -481,6 +481,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $this->assign('registered_by_display_name', CRM_Contact_BAO_Contact::displayName($registered_by_contact_id));
       }
     }
+    elseif ($this->_contactID) {
+      $defaults[$this->_id]['contact_id'] = $this->_contactID;
+    }
 
     //setting default register date
     if ($this->_action == CRM_Core_Action::ADD) {
@@ -641,11 +644,11 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       return;
     }
 
-    if ($this->_single && $this->_context == 'standalone') {
-      $this->addEntityRef('contact_id', ts('Contact'), [
-        'create' => TRUE,
-        'api' => ['extra' => ['email']],
-      ], TRUE);
+    if ($this->_single) {
+      $contactField = $this->addEntityRef('contact_id', ts('Participant'), ['create' => TRUE, 'api' => ['extra' => ['email']]], TRUE);
+      if ($this->_context != 'standalone') {
+        $contactField->freeze();
+      }
     }
 
     $eventFieldParams = [

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -227,17 +227,10 @@
         {else} {* If action is other than Delete *}
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
-          {if $single and $context neq 'standalone'}
-            <tr class="crm-participant-form-block-displayName">
-              <td class="label font-size12pt"><label>{ts}Participant{/ts}</label></td>
-              <td class="font-size12pt view-value">{$displayName}&nbsp;</td>
-            </tr>
-            {else}
-            <tr class="crm-participant-form-contact-id">
-              <td class="label">{$form.contact_id.label}</td>
-              <td>{$form.contact_id.html}</td>
-            </tr>
-          {/if}
+          <tr class="crm-participant-form-contact-id">
+            <td class="label">{$form.contact_id.label}</td>
+            <td>{$form.contact_id.html}</td>
+          </tr>
           {if $action EQ 2}
             {if $additionalParticipants} {* Display others registered by this participant *}
               <tr class="crm-participant-form-block-additionalParticipants">


### PR DESCRIPTION
Overview
----------------------------------------
Participant in Edit mode needs to be shown in consistency with Grant/Member screens. 

Before
----------------------------------------
Display name is hardcoded freeze value


After
----------------------------------------
Display name is clickable contact name.

<img width="691" alt="Screen Shot 2019-11-07 at 10 03 07 AM" src="https://user-images.githubusercontent.com/336308/68337661-d9670500-0145-11ea-9e47-166df479303a.png">

