### PR TITLE
Additional fixes to workflow templates

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -149,7 +149,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'From: site@something.com',
       'Dear Anthony,',
       'Payment Details',
-      'Total Fees: $ 100.00',
+      'Total Amount: $ 100.00',
       'This Payment Amount: $ 70.00',
       'Balance Owed: $ 0.00 ',
       'Billing Name and Address',
@@ -238,8 +238,8 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $mut->assertSubjects(['Payment Receipt - Mr. Anthony Anderson II']);
     $mut->checkMailLog([
       'Dear Anthony,',
-      'A payment has been received',
-      'Total Fees: $ 100.00',
+      'Below you will find a receipt for this payment.',
+      'Total Amount: $ 100.00',
       'This Payment Amount: $ 50.00',
       'Balance Owed: $ 20.00 ',
       'Paid By: Check',
@@ -268,8 +268,8 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->checkResults([100], 1);
 
     $mut->checkMailLog([
-      'A payment has been received',
-      'Total Fees: $ 100.00',
+      'Below you will find a receipt for this payment.',
+      'Total Amount: $ 100.00',
       'This Payment Amount: $ 100.00',
       'Balance Owed: $ 0.00 ',
       'Paid By: Credit Card',

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -183,7 +183,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'From: "FIXME" <info@EXAMPLE.ORG>',
       'Dear Anthony,',
-      'Total Fees: $ 300.00',
+      'Total Amount: $ 300.00',
       'This Payment Amount: $ 50.00',
       //150 was paid in the 1st payment.
       'Balance Owed: $ 100.00',
@@ -221,8 +221,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'From: "FIXME" <info@EXAMPLE.ORG>',
       'Dear Anthony,',
-      'A payment has been received.',
-      'Total Fees: $ 300.00',
+      'Below you will find a receipt for this payment.',
+      'Total Amount: $ 300.00',
       'This Payment Amount: $ 150.00',
       'Balance Owed: $ 0.00',
       'Thank you for completing this payment.',
@@ -273,12 +273,12 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'Dear Anthony,',
       'A refund has been issued based on changes in your registration selections.',
-      'Total Fees: $ 300' . $decimalSeparator . '00',
+      'Total Amount: $ 300' . $decimalSeparator . '00',
       'Refund Amount: $ -30' . $decimalSeparator . '00',
       'Event Information and Location',
       'Paid By: Check',
       'Transaction Date: November 13th, 2018 12:01 PM',
-      'You Paid: $ 170' . $decimalSeparator . '00',
+      'Totally Paid: $ 170' . $decimalSeparator . '00',
     ]);
     $mut->stop();
     $mut->clearMessages();

--- a/xml/templates/message_templates/case_activity_html.tpl
+++ b/xml/templates/message_templates/case_activity_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/contribution_dupalert_html.tpl
+++ b/xml/templates/message_templates/contribution_dupalert_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="500" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -33,7 +33,7 @@
    </td>
   </tr>
   </table>
-  <table width="500" style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
+  <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
 
      {if $amount}
 

--- a/xml/templates/message_templates/contribution_recurring_billing_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_billing_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -28,8 +28,8 @@
   <tr>
  </table>
 
-  <table width="500" style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
-<tr>
+  <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
+    <tr>
         <th {$headerStyle}>
          {ts}Billing Name and Address{/ts}
         </th>

--- a/xml/templates/message_templates/contribution_recurring_cancelled_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_cancelled_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/contribution_recurring_edit_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_edit_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/contribution_recurring_notify_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_notify_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -21,7 +21,7 @@
 
   <tr>
    <td>
-    <p>{contact.email_greeting}</p>
+    {assign var="greeting" value="{contact.email_greeting}"}{if $greeting}<p>{$greeting},</p>{/if}
 
     {if $event.confirm_email_text AND (not $isOnWaitlist AND not $isRequireApproval)}
      <p>{$event.confirm_email_text|htmlize}</p>

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -1,4 +1,4 @@
-{contact.email_greeting}
+{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}
 {if $event.confirm_email_text AND (not $isOnWaitlist AND not $isRequireApproval)}
 {$event.confirm_email_text}
 {/if}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -15,7 +15,7 @@
 
 
 <center>
- <table width="700" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -56,7 +56,7 @@
   </tr>
   <tr>
    <td>
-    <table width="700" style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
+    <table style="width:100%; max-width:700px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
      <tr>
       <th {$headerStyle}>
        {ts}Event Information and Location{/ts}
@@ -246,9 +246,9 @@
             {if $individual}
               <tr {$participantTotal}>
                 <td colspan=3>{ts}Participant Total{/ts}</td>
-                <td  colspan=2>{$individual.$priceset.totalAmtWithTax-$individual.$priceset.totalTaxAmt|crmMoney}</td>
-                <td  colspan=1>{$individual.$priceset.totalTaxAmt|crmMoney}</td>
-                <td  colspan=2>{$individual.$priceset.totalAmtWithTax|crmMoney}</td>
+                <td colspan=2>{$individual.$priceset.totalAmtWithTax-$individual.$priceset.totalTaxAmt|crmMoney}</td>
+                <td colspan=1>{$individual.$priceset.totalTaxAmt|crmMoney}</td>
+                <td colspan=2>{$individual.$priceset.totalAmtWithTax|crmMoney}</td>
               </tr>
             {/if}
            </table>
@@ -503,8 +503,6 @@
       </td>
      </tr>
     {/if}
-   </td>
-  </tr>
  </table>
 </center>
 

--- a/xml/templates/message_templates/event_registration_receipt_html.tpl
+++ b/xml/templates/message_templates/event_registration_receipt_html.tpl
@@ -67,7 +67,7 @@
     {$source}
 {/if}
     <p>&nbsp;</p>
-    <table width="600">
+    <table width="700">
       <thead>
     <tr>
 {if $line_items}

--- a/xml/templates/message_templates/friend_html.tpl
+++ b/xml/templates/message_templates/friend_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/membership_autorenew_billing_html.tpl
+++ b/xml/templates/message_templates/membership_autorenew_billing_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -28,8 +28,8 @@
   <tr>
  </table>
 
-  <table width="500" style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
-<tr>
+  <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
+   <tr>
         <th {$headerStyle}>
          {ts}Billing Name and Address{/ts}
         </th>

--- a/xml/templates/message_templates/membership_autorenew_cancelled_html.tpl
+++ b/xml/templates/message_templates/membership_autorenew_cancelled_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="500" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -27,7 +27,7 @@
    </td>
   </tr>
  </table>
- <table width="500" style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
+ <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
 
       <tr>
        <th {$headerStyle}>

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="500" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -33,7 +33,7 @@
    </td>
   </tr>
   </table>
-  <table width="500" style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
+  <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
 
      {if $membership_assign && !$useForMember}
       <tr>

--- a/xml/templates/message_templates/participant_cancelled_html.tpl
+++ b/xml/templates/message_templates/participant_cancelled_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -11,8 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
-
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
   <!-- END HEADER -->
@@ -34,14 +33,14 @@
    <tr>
     <td colspan="2" {$valueStyle}>
      {capture assign=confirmUrl}{crmURL p='civicrm/event/confirm' q="reset=1&participantId=`$participant.id`&cs=`$checksumValue`" a=true h=0 fe=1}{/capture}
-     <a href="{$confirmUrl}">{ts}Go to a web page where you can confirm your registration online{/ts}</a>
+     <a href="{$confirmUrl}">{ts}Click here to confirm and complete your registration{/ts}</a>
     </td>
    </tr>
   {/if}
   {if $event.allow_selfcancelxfer }
-  {ts}This event allows for self-cancel or transfer{/ts}
+  {ts}This event allows for{/ts}
   {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participantID`&{contact.checksum}" h=0 a=1 fe=1}{/capture}
-       <a href="{$selfService}">{ts}Self service cancel transfer{/ts}</a>
+       <a href="{$selfService}"> {ts}self service cancel or transfer{/ts}</a>
   {/if}
 
   <tr>

--- a/xml/templates/message_templates/participant_expired_html.tpl
+++ b/xml/templates/message_templates/participant_expired_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/participant_transferred_html.tpl
+++ b/xml/templates/message_templates/participant_transferred_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/payment_or_refund_notification_html.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_html.tpl
@@ -13,7 +13,7 @@
 {capture assign=emptyBlockValueStyle }style="padding: 10px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+ <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -22,20 +22,88 @@
   <!-- BEGIN CONTENT -->
   <tr>
     <td>
-      {if $emailGreeting}<tr><td>{$emailGreeting},</td></tr>{/if}
+      {assign var="greeting" value="{contact.email_greeting}"}{if $greeting}<p>{$greeting},</p>{/if}
       {if $isRefund}
-      <p>{ts}A refund has been issued based on changes in your registration selections.{/ts}</p>
+        <p>{ts}A refund has been issued based on changes in your registration selections.{/ts}</p>
       {else}
-      <p>{ts}A payment has been received.{/ts}</p>
+        <p>{ts}Below you will find a receipt for this payment.{/ts}</p>
+        {if $paymentsComplete}
+          <p>{ts}Thank you for completing this contribution.{/ts}</p>
+        {/if}
       {/if}
     </td>
   </tr>
   <tr>
    <td>
     <table style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse; width:100%;">
-  {if $isRefund}
+    {if $isRefund}
+      <tr>
+        <th {$headerStyle}>{ts}Refund Details{/ts}</th>
+      </tr>
+      <tr>
+        <td {$labelStyle}>
+        {ts}This Refund Amount{/ts}
+        </td>
+        <td {$valueStyle}>
+        {$refundAmount|crmMoney}
+        </td>
+      </tr>
+    {else}
+      <tr>
+        <th {$headerStyle}>{ts}Payment Details{/ts}</th>
+      </tr>
+      <tr>
+        <td {$labelStyle}>
+        {ts}This Payment Amount{/ts}
+        </td>
+        <td {$valueStyle}>
+        {$paymentAmount|crmMoney}
+        </td>
+      </tr>
+    {/if}
+    {if $receive_date}
+      <tr>
+        <td {$labelStyle}>
+        {ts}Transaction Date{/ts}
+        </td>
+        <td {$valueStyle}>
+        {$receive_date|crmDate}
+        </td>
+      </tr>
+    {/if}
+    {if $trxn_id}
+      <tr>
+        <td {$labelStyle}>
+        {ts}Transaction #{/ts}
+        </td>
+        <td {$valueStyle}>
+        {$trxn_id}
+        </td>
+      </tr>
+    {/if}
+    {if $paidBy}
+      <tr>
+        <td {$labelStyle}>
+        {ts}Paid By{/ts}
+        </td>
+        <td {$valueStyle}>
+        {$paidBy}
+        </td>
+      </tr>
+    {/if}
+    {if $checkNumber}
+      <tr>
+        <td {$labelStyle}>
+        {ts}Check Number{/ts}
+        </td>
+        <td {$valueStyle}>
+        {$checkNumber}
+        </td>
+      </tr>
+    {/if}
+
   <tr>
-    <th {$headerStyle}>{ts}Refund Details{/ts}</th>
+    <th {$headerStyle}>{ts}Contribution Details{/ts}</th>
   </tr>
   <tr>
     <td {$labelStyle}>
@@ -47,7 +115,7 @@
   </tr>
   <tr>
     <td {$labelStyle}>
-      {ts}You Paid{/ts}
+      {ts}Totally Paid{/ts}
     </td>
     <td {$valueStyle}>
       {$totalPaid|crmMoney}
@@ -55,91 +123,14 @@
   </tr>
   <tr>
     <td {$labelStyle}>
-      {ts}Refund Amount{/ts}
+      {ts}Balance Owed{/ts}
     </td>
     <td {$valueStyle}>
-      {$refundAmount|crmMoney}
-    <td>
+      {$amountOwed|crmMoney}
+    </td> {* This will be zero after final payment. *}
   </tr>
-  {else}
-    <tr>
-      <th {$headerStyle}>{ts}Payment Details{/ts}</th>
-    </tr>
-    <tr>
-      <td {$labelStyle}>
-        {ts}Total Amount{/ts}
-      </td>
-      <td {$valueStyle}>
-        {$totalAmount|crmMoney}
-      </td>
-      </tr>
-      <tr>
-      <td {$labelStyle}>
-        {ts}This Payment Amount{/ts}
-      </td>
-      <td {$valueStyle}>
-        {$paymentAmount|crmMoney}
-      </td>
-      </tr>
-     <tr>
-      <td {$labelStyle}>
-        {ts}Balance Owed{/ts}
-      </td>
-       <td {$valueStyle}>
-         {$amountOwed|crmMoney}
-      </td> {* This will be zero after final payment. *}
-     </tr>
-     <tr> <td {$emptyBlockStyle}></td>
-     <td {$emptyBlockValueStyle}></td></tr>
-      {if $paymentsComplete}
-      <tr>
-      <td colspan='2' {$valueStyle}>
-        {ts}Thank you for completing this payment.{/ts}
-      </td>
-     </tr>
-      {/if}
-  {/if}
-  {if $receive_date}
-    <tr>
-      <td {$labelStyle}>
-        {ts}Transaction Date{/ts}
-      </td>
-      <td {$valueStyle}>
-        {$receive_date|crmDate}
-      </td>
-    </tr>
-  {/if}
-  {if $trxn_id}
-    <tr>
-      <td {$labelStyle}>
-  {ts}Transaction #{/ts}
-      </td>
-      <td {$valueStyle}>
-        {$trxn_id}
-      </td>
-    </tr>
-  {/if}
-  {if $paidBy}
-    <tr>
-      <td {$labelStyle}>
-        {ts}Paid By{/ts}
-      </td>
-      <td {$valueStyle}>
-        {$paidBy}
-      </td>
-    </tr>
-  {/if}
-  {if $checkNumber}
-    <tr>
-      <td {$labelStyle}>
-        {ts}Check Number{/ts}
-      </td>
-      <td {$valueStyle}>
-        {$checkNumber}
-      </td>
-    </tr>
-  {/if}
   </table>
+
   </td>
   </tr>
     <tr>

--- a/xml/templates/message_templates/payment_or_refund_notification_text.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_text.tpl
@@ -4,7 +4,10 @@
 {if $isRefund}
 {ts}A refund has been issued based on changes in your registration selections.{/ts}
 {else}
-{ts}A payment has been received.{/ts}
+{ts}Below you will find a receipt for this payment.{/ts}
+{/if}
+{if $paymentsComplete}
+{ts}Thank you for completing this payment.{/ts}
 {/if}
 
 {if $isRefund}
@@ -13,10 +16,8 @@
 {ts}Refund Details{/ts}
 
 ===============================================================================
-{ts}Total Fees{/ts}: {$totalAmount|crmMoney}
-{ts}You Paid{/ts}: {$totalPaid|crmMoney}
+{ts}This Refund Amount{/ts}: {$refundAmount|crmMoney}
 ------------------------------------------------------------------------------------
-{ts}Refund Amount{/ts}: {$refundAmount|crmMoney}
 
 {else}
 ===============================================================================
@@ -24,16 +25,9 @@
 {ts}Payment Details{/ts}
 
 ===============================================================================
-{ts}Total Fees{/ts}: {$totalAmount|crmMoney}
 {ts}This Payment Amount{/ts}: {$paymentAmount|crmMoney}
 ------------------------------------------------------------------------------------
-{ts}Balance Owed{/ts}: {$amountOwed|crmMoney} {* This will be zero after final payment. *}
 
-{if $paymentsComplete}
-
-{ts}Thank you for completing this payment.{/ts}
-{/if}
-{/if}
 {if $receive_date}
 {ts}Transaction Date{/ts}: {$receive_date|crmDate}
 {/if}
@@ -46,6 +40,17 @@
 {if $checkNumber}
 {ts}Check Number{/ts}: {$checkNumber}
 {/if}
+
+===============================================================================
+
+{ts}Contribution Details{/ts}
+
+===============================================================================
+{ts}Total Amount{/ts}: {$totalAmount|crmMoney}
+{ts}Totally Paid{/ts}: {$totalPaid|crmMoney}
+{ts}Balance Owed{/ts}: {$amountOwed|crmMoney} {* This will be zero after final payment. *}
+
+
 {if $billingName || $address}
 
 ===============================================================================

--- a/xml/templates/message_templates/payment_or_refund_notification_text.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_text.tpl
@@ -27,7 +27,7 @@
 ===============================================================================
 {ts}This Payment Amount{/ts}: {$paymentAmount|crmMoney}
 ------------------------------------------------------------------------------------
-
+{/if}
 {if $receive_date}
 {ts}Transaction Date{/ts}: {$receive_date|crmDate}
 {/if}

--- a/xml/templates/message_templates/pcp_notify_html.tpl
+++ b/xml/templates/message_templates/pcp_notify_html.tpl
@@ -12,7 +12,7 @@
 {capture assign=pcpURL     }{crmURL p="civicrm/pcp/info" q="reset=1&id=`$pcpId`" h=0 a=1}{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/pcp_owner_notify_html.tpl
+++ b/xml/templates/message_templates/pcp_owner_notify_html.tpl
@@ -18,7 +18,7 @@
       {ts}The donor's name has been added to your honor roll unless they asked not to be included.{/ts}<br/>
     {/if}
   </p>
-  <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
     <tr><td>{ts}Received{/ts}:</td><td> {$receive_date|crmDate}</td></tr>
     <tr><td>{ts}Amount{/ts}:</td><td> {$total_amount|crmMoney:$currency}</td></tr>
     <tr><td>{ts}Name{/ts}:</td><td> {$donors_display_name}</td></tr>

--- a/xml/templates/message_templates/pcp_status_change_html.tpl
+++ b/xml/templates/message_templates/pcp_status_change_html.tpl
@@ -7,7 +7,7 @@
 <body>
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/pcp_supporter_notify_html.tpl
+++ b/xml/templates/message_templates/pcp_supporter_notify_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/pledge_acknowledge_html.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/pledge_reminder_html.tpl
+++ b/xml/templates/message_templates/pledge_reminder_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->

--- a/xml/templates/message_templates/test_preview_html.tpl
+++ b/xml/templates/message_templates/test_preview_html.tpl
@@ -1,5 +1,5 @@
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt_test" style="font-family: Arial, Verdana, sans-serif; text-align: left">
+ <table id="crm-event_receipt_test" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
   <tr>
    <td>
     <p>{ts}Test-drive Email / Receipt{/ts}</p>

--- a/xml/templates/message_templates/uf_notify_html.tpl
+++ b/xml/templates/message_templates/uf_notify_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <center>
- <table width="620" border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;">
+  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->


### PR DESCRIPTION
This is a reviewers cut of #15742

Overview
----------------------------------------
This PR contains some minor additions / missing improvements to the other pr's on the workflow messages upgrade in 5.20

Before
----------------------------------------
some minor improvements missing from the other PR's

After
----------------------------------------
some minor improvements included in 5.20

Technical Details
----------------------------------------
For responsive tables that look well on desktop as well as mobile view this is used in the container table:

`width:100%; max-width:700px;
`

Comments
----------------------------------------
1. missing greeting in event_offline template
2. changes to payment/refund template to better reflect amount paid & totals
3. changes to have the html tables have the same looks when viewed on a mobile

**OLD TEMPLATE Payment receipt**
![Screenshot from 2019-11-06 15-55-40](https://user-images.githubusercontent.com/2195908/68308962-04057f00-00ae-11ea-96a6-69cfc8960def.png)

**NEW TEMPLATE Payment receipt [completed]**
![Screenshot from 2019-11-06 13-12-15](https://user-images.githubusercontent.com/2195908/68309049-24cdd480-00ae-11ea-9459-4354407280f4.png)

**NEW TEMPLATE Refund notification**
![Screenshot from 2019-11-06 13-22-22](https://user-images.githubusercontent.com/2195908/68297987-97cc5080-0098-11ea-96d3-40f8412e4203.png)