### PR TITLE
[NFC] Cleanup on exceptions

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -204,7 +204,8 @@ class CRM_Core_Resources {
    *   - string: Load translated strings. Use a specific domain.
    *
    * @return CRM_Core_Resources
-   * @throws \Exception
+   *
+   * @throws \CRM_Core_Exception
    */
   public function addScriptFile($ext, $file, $weight = self::DEFAULT_WEIGHT, $region = self::DEFAULT_REGION, $translate = TRUE) {
     if ($translate) {

--- a/CRM/Core/Resources/Strings.php
+++ b/CRM/Core/Resources/Strings.php
@@ -68,7 +68,7 @@ class CRM_Core_Resources_Strings {
    * @return array
    *   List of translatable strings.
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function get($bucket, $file, $format) {
     // array($file => array(...strings...))
@@ -97,7 +97,8 @@ class CRM_Core_Resources_Strings {
    *   Type of file (e.g. 'text/javascript', 'text/html').
    * @return array
    *   List of translatable strings.
-   * @throws Exception
+   *
+   * @throws CRM_Core_Exception
    */
   public function extract($file, $format) {
     switch ($format) {
@@ -109,7 +110,7 @@ class CRM_Core_Resources_Strings {
         return CRM_Utils_JS::parseStrings(file_get_contents($file));
 
       default:
-        throw new Exception("Cannot extract strings: Unrecognized file type.");
+        throw new CRM_Core_Exception('Cannot extract strings: Unrecognized file type.');
     }
   }
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -206,8 +206,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
   /**
    * Form preProcess function.
-   *
-   * @throws \Exception
    */
   public function preProcess() {
     // This string makes up part of the class names, differentiating them (not sure why) from the membership fields.
@@ -223,7 +221,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $contributionID = CRM_Member_BAO_Membership::getMembershipContributionId($this->_id);
       // check delete permission for contribution
       if ($this->_id && $contributionID && !CRM_Core_Permission::checkActionPermission('CiviContribute', $this->_action)) {
-        CRM_Core_Error::fatal(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
+        CRM_Core_Error::statusBounce(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
       }
     }
 
@@ -243,7 +241,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           foreach ($contactMemberships as $mem) {
             $mem['member_of_contact_id'] = CRM_Utils_Array::value($mem['membership_type_id'], $memberorgs);
             if (!empty($mem['membership_end_date'])) {
-              $mem['membership_end_date'] = CRM_Utils_Date::customformat($mem['membership_end_date']);
+              $mem['membership_end_date'] = CRM_Utils_Date::customFormat($mem['membership_end_date']);
             }
             $mem['membership_type'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType',
               $mem['membership_type_id'],

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -644,6 +644,9 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    *   punctuation used to refer to thousands.
    *
    * @dataProvider getThousandSeparators
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testSubmitPartialPayment($thousandSeparator) {
     $this->setCurrencySeparators($thousandSeparator);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a low level function to throw a CRM_Core_Exception & tidies up functions
above to specify that. Fixes casing on a function call, removes a fatal
for status bounce

Before
----------------------------------------
Less std

After
----------------------------------------
More std

Technical Details
----------------------------------------


Comments
----------------------------------------

