### PR TITLE
(dev/core#1065) Contribution in Edit mode needs to be shown consistently

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -368,6 +368,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if ($this->_id) {
       $this->_contactID = $defaults['contact_id'];
     }
+    elseif ($this->_contactID) {
+      $defaults['contact_id'] = $this->_contactID;
+    }
 
     // Set $newCredit variable in template to control whether link to credit card mode is included.
     $this->assign('newCredit', CRM_Core_Config::isEnabledBackOfficeCreditCardPayments());
@@ -621,11 +624,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('customDataSubType', $this->_contributionType);
     $this->assign('entityID', $this->_id);
 
-    if ($this->_context == 'standalone') {
-      $this->addEntityRef('contact_id', ts('Contact'), [
-        'create' => TRUE,
-        'api' => ['extra' => ['email']],
-      ], TRUE);
+    $contactField = $this->addEntityRef('contact_id', ts('Contributor'), ['create' => TRUE], TRUE);
+    if ($this->_context != 'standalone') {
+      $contactField->freeze();
     }
 
     $attributes = CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_Contribution');

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -74,14 +74,10 @@
   </div>
   {if $isOnline}{assign var=valueStyle value=" class='view-value'"}{else}{assign var=valueStyle value=""}{/if}
   <table class="form-layout-compressed">
-    {if $context neq 'standalone'}
-    <tr>
-      <td class="font-size12pt label"><strong><strong>{ts}Contributor{/ts}</strong></td><td class="font-size12pt"><strong>{$displayName}</strong></td>
-    </tr>
-    {else}
+    <tr class="crm-contribution-form-block-contact_id">
       <td class="label">{$form.contact_id.label}</td>
       <td>{$form.contact_id.html}</td>
-    {/if}
+    </tr>
     <tr class="crm-contribution-form-block-contribution_type_id crm-contribution-form-block-financial_type_id">
       <td class="label">{$form.financial_type_id.label}</td><td{$valueStyle}>{$form.financial_type_id.html}&nbsp;
       {if $is_test}


### PR DESCRIPTION
Overview
----------------------------------------
Contribution in Edit mode needs to be shown in consistency with Grant/Member/Participant screens. 

Before
----------------------------------------
Display name is hardcoded freeze value
![contri_before](https://user-images.githubusercontent.com/3455173/68364430-eab70e00-0153-11ea-8f4a-8d169eb01c18.png)


After
----------------------------------------
Display name is clickable contact name.

![contri_after](https://user-images.githubusercontent.com/3455173/68364435-eee32b80-0153-11ea-8125-5c1dce6a8d5a.png)
