### PR TITLE
Fetch Only Active Custom Group Extend Values

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2080,7 +2080,7 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
 
     if (!$flag) {
       $extendObjs = [];
-      CRM_Core_OptionValue::getValues(['name' => 'cg_extend_objects'], $extendObjs);
+      CRM_Core_OptionValue::getValues(['name' => 'cg_extend_objects'], $extendObjs, 'weight', TRUE);
 
       foreach ($extendObjs as $ovId => $ovValues) {
         if ($ovValues['description']) {


### PR DESCRIPTION
Overview
----------------------------------------
When adding Custom field support for an entity and a record is added as an option value to the `cg_extend_objects` option group, when the extension that added the entity is disabled and one tries to visit the Custom group page at `civicrm/admin/custom/group?action=add&reset=1` there is an error and the page is not accessible.

Before
----------------------------------------
The Custom Group page is in accessible when following the steps described in the overview.

After
----------------------------------------
Since the [description](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/CustomGroup.php#L2088) field holds the Class for returning the values for the Custom Group Object and the extension is disabled, this class is not found and this causes an error. 
`require_once(SAMPLE_CLASS.php): failed to open stream: No such file or directory in require_once() (line 2099 of ...../civicrm/CRM/Core/BAO/CustomGroup.php)`

Ideally, when the extension is disabled, the extension should set the `is_active` column for the option value to false so that the option value is not returned when fetched [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/CustomGroup.php#L2083): and this can be set back to active when the extension is enabled. However all the option values are fetched whether active / in-active. This PR fixes the issue so that only active option values are returned.

