### PR TITLE
IconPicker widget improvements

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2867,6 +2867,10 @@ tbody.scrollContent tr.alternateRow {
   color: #3e3e3e;
 }
 
+.crm-container a.crm-icon-picker-button .ui-button-icon {
+  margin: 5px 0 5px 5px;
+}
+
 .crm-container a.crm-icon-picker-button .ui-button-text {
   color: #9f9f9f;
 }

--- a/js/jquery/jquery.crmIconPicker.js
+++ b/js/jquery/jquery.crmIconPicker.js
@@ -71,7 +71,7 @@
           $.each(icons, function(i, icon) {
             if (!term.length || icon.replace(/-/g, '').indexOf(term) > -1) {
               var item = $('<a href="#" title="' + icon + '"/>').button({
-                icons: {primary: icon}
+                icons: {primary: icon + ' ' + $style.val()}
               });
               $place.append(item);
             }
@@ -81,20 +81,34 @@
         function displayDialog() {
           dialog.append('<style type="text/css">' +
             '#crmIconPicker {font-size: 20px;}' +
-            '#crmIconPicker .icon-search input {font-family: FontAwesome; padding-left: .5em; margin-bottom: 1em;}' +
+            '#crmIconPicker .icon-ctrls input {font-family: FontAwesome; padding-left: .5em; margin-bottom: 1em;}' +
+            '#crmIconPicker .icon-ctrls > * {display: inline-block; vertical-align: top; margin-right: 1em;}' +
+            '#crmIconPicker .icon-ctrls > button {float: right; margin-right: 0;}' +
             '#crmIconPicker a.ui-button {width: 1em; height: 1em; color: #222;}' +
             '#crmIconPicker a.ui-button .ui-icon {margin-top: -0.5em; width: auto; height: auto;}' +
             '</style>' +
-            '<div class="icon-search"><input class="crm-form-text" name="search" placeholder="&#xf002"/></div>' +
+            '<div class="icon-ctrls crm-clearfix">' +
+            '<input class="crm-form-text" name="search" placeholder="&#xf002"/>' +
+            '<select class="crm-form-select"></select>' +
+            '<button type="button" class="cancel" title=""><i class="crm-i fa-ban"></i> ' + ts('No icon') + '</button>' +
+            '</div>' +
             '<div class="icons"></div>'
           );
+          var $styleSelect = $('.icon-ctrls select', dialog);
+          CRM.utils.setOptions($styleSelect, options, ts('Normal'));
+          $styleSelect.val($style.val());
+          $styleSelect.change(function() {
+            $style.val($styleSelect.val());
+            displayIcons();
+          });
+          $('.icon-ctrls button', dialog).click(pickIcon);
           displayIcons();
           dialog.unblock();
         }
 
         function pickIcon(e) {
           var newIcon = $(this).attr('title'),
-            style = $style.val();
+            style = newIcon ? $style.val() : '';
           $input.val(newIcon + (style ? ' ' + style : '')).change();
           dialog.dialog('close');
           e.preventDefault();
@@ -103,7 +117,7 @@
         dialog = $('<div id="crmIconPicker"/>').dialog({
           title: $input.attr('title'),
           width: '80%',
-          height: 400,
+          height: '90%',
           modal: true
         }).block()
           .on('click', 'a', pickIcon)


### PR DESCRIPTION
Overview
----------------------------------------
Fixes some style issues with the icon picker widget and adds some controls to the dialog.

Before
----------------------------------------
Icon inside form widget was misaligned:
![image](https://user-images.githubusercontent.com/2874912/68416368-61f39e80-0162-11ea-8b8f-602411074459.png)

Controls for rotating & clearing the icon were in the widget but not in the dialog:
![image](https://user-images.githubusercontent.com/2874912/68416461-88193e80-0162-11ea-956d-fe04af274482.png)

After
----------------------------------------
Fixed alignment:
![image](https://user-images.githubusercontent.com/2874912/68415987-91ee7200-0161-11ea-803d-190e1e79215b.png)

Controls are still part of the widget but are now also at the top of the dialog:
![image](https://user-images.githubusercontent.com/2874912/68416303-3e305880-0162-11ea-9307-bb0fc7b332b0.png)

Comments
----------------------------------------
I added the controls to the dialog because there are several UIs that now use a more compact widget and there isn't room for the controls there. For example the icon picker in the ContactLayout editor is just an icon with a dashed box around it, so the only place to stick those controls is in the dialog.
![image](https://user-images.githubusercontent.com/2874912/68417167-e397fc00-0163-11ea-8206-996113dff405.png)
