### PR TITLE
Fix cachekey string

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1542,6 +1542,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     $cacheKeyString .= $export ? '_1' : '_0';
     $cacheKeyString .= $status ? '_1' : '_0';
     $cacheKeyString .= $search ? '_1' : '_0';
+    $cacheKeyString .= '_' . (bool) $checkPermissions;
     //CRM-14501 it turns out that the impact of permissioning here is sometimes inconsistent. The field that
     //calculates custom fields takes into account the logged in user & caches that for all users
     //as an interim fix we will cache the fields by contact


### PR DESCRIPTION
Overview
----------------------------------------
Fixes obscure bug where no custom fields returned when doing a Contact.get api call with check_permissions=0 where the user would not be able to retrieve them if check_permissions=1

Before
----------------------------------------
I hit a bug (in a unit test) where a user without permissions to access custom data would do a
check_permissions api call followed by a check_permissions = 0 call. In the second call
custom fields were not returned as the 'available' custom fields had been cached on the first call.

After
----------------------------------------
Fields reflect check_permissions flag

Technical Details
----------------------------------------
Just a misconstructed cachekeystring - although I would argue it's the wrong place to apply permissions but that's another day

Comments
----------------------------------------

