### PR TITLE
dev/core#1371 Fix e-notice caused by trying to pass in known  to the …

### DIFF
--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -245,6 +245,9 @@ function civicrm_api3_extension_download($params) {
     throw new API_Exception('Cannot resolve download url for extension. Try adding parameter "url"');
   }
 
+  if (!isset($info)) {
+    $info = NULL;
+  }
   foreach (CRM_Extension_System::singleton()->getDownloader()->checkRequirements($info) as $requirement) {
     return civicrm_api3_create_error($requirement['message']);
   }


### PR DESCRIPTION
…extension downloader when checking requirements

Overview
----------------------------------------
This fixes an e-noticed reported by @stesi561 when running cv ext:download

Before
----------------------------------------
E-notice

After
----------------------------------------
no e-notice

ping @eileenmcnaughton @mattwire 