### PR TITLE
dev/financial#100 Remove 'partially paid' as a contribution status option for 'record p…ayment'

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -538,7 +538,7 @@ LIMIT 1
    *   Array of contribution statuses in array('status id' => 'label') format
    */
   public static function getContributionStatuses($usedFor = 'contribution', $id = NULL) {
-    if ($usedFor == 'pledge') {
+    if ($usedFor === 'pledge') {
       $statusNames = CRM_Pledge_BAO_Pledge::buildOptions('status_id', 'validate');
     }
     else {
@@ -562,25 +562,29 @@ LIMIT 1
         'Pending refund',
       ]);
 
-      // Event registration and New Membership backoffice form support partially paid payment,
-      //  so exclude this status only for 'New Contribution' form
-      if ($usedFor == 'contribution') {
+      if ($usedFor === 'contribution') {
         $statusNamesToUnset = array_merge($statusNamesToUnset, [
           'In Progress',
           'Overdue',
           'Partially paid',
         ]);
       }
-      elseif ($usedFor == 'participant') {
+      elseif ($usedFor === 'participant') {
         $statusNamesToUnset = array_merge($statusNamesToUnset, [
           'Cancelled',
           'Failed',
-        ]);
-      }
-      elseif ($usedFor == 'membership') {
-        $statusNamesToUnset = array_merge($statusNamesToUnset, [
           'In Progress',
           'Overdue',
+          'Partially paid',
+        ]);
+      }
+      elseif ($usedFor === 'membership') {
+        $statusNamesToUnset = array_merge($statusNamesToUnset, [
+          'In Progress',
+          'Cancelled',
+          'Failed',
+          'Overdue',
+          'Partially paid',
         ]);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes the following statuses from the drop down to record payment for a membership 
- Partially Paid
- Cancelled
- Failed

And from an event registration
- Partially Paid
- Overdue
- In Progress.

(Cancelled & Failed are both still possible from New Contribution).

Rationale
1) consistency - we are offering different things in different places
2) meaningfulness - I'm basically sure the Overdue & In Progress were never intended to be shown. Originally Pledge statuses, Payment Payment statuses & contribution statuses shared the same option group & basically leaked all over the place. I wrongly though we were no longer adding those 2 statuses to new installs & hope to remove them from new installs as an agreed follow up (& perhaps we could remove or disable them on existing installs that have no contributions with those statuses)
3) Not creating bad data - creating contributions from the Membership form selecting 'Partially Paid' creates invalid data in terms of there being no financial_trxn, financial items etc- as revealed by the unit test when I added the validateAllPayments check to it.
4) confusion - are we creating a payment or a contribution - these statuses don't create the contribution but they add to it. As @mattwire pointed out on gitlab & as has come up many other times recently - ideally we would not be mixing our concepts ./ forms like this. This change doesn't solve that but it slightly improves it.



Before
----------------------------------------
Backoffice event
<img width="633" alt="Screen Shot 2019-11-09 at 12 46 25 AM" src="https://user-images.githubusercontent.com/336308/68474492-62875480-028a-11ea-9816-e8d1ce6ff467.png">

Backoffice membership
<img width="414" alt="Screen Shot 2019-11-09 at 12 48 04 AM" src="https://user-images.githubusercontent.com/336308/68474572-9e221e80-028a-11ea-8d97-181c179b86de.png">


After
----------------------------------------
<img width="708" alt="Screen Shot 2019-11-09 at 12 43 24 AM" src="https://user-images.githubusercontent.com/336308/68474426-41beff00-028a-11ea-9355-731a6a21810a.png">
<img width="671" alt="Screen Shot 2019-11-09 at 12 45 16 AM" src="https://user-images.githubusercontent.com/336308/68474427-42579580-028a-11ea-9fc0-2a440cd07fd4.png">


Technical Details
----------------------------------------
This came up because I tried adding a check to our unit tests to ensure they were creating valid payments & many are not. In some cases it's the tests but in this case the test is testing something that users can do too.

This is the test https://github.com/civicrm/civicrm-core/pull/15706

@JoeMurray @kcristiano @mattwire @magnolia61 @lcdservices @monishdeb @pradpnayak @agh1 @MegaphoneJon 

Comments
----------------------------------------
https://lab.civicrm.org/dev/financial/issues/100


Also Edit Contribution form has dubious statuses - I don't want to block this on resolving 'it all' but happy to agree some follow ups. My current goal is to work through the test fails in https://github.com/civicrm/civicrm-core/pull/15706 & identify where invalid data is being created.

<img width="414" alt="Screen Shot 2019-11-09 at 12 48 04 AM" src="https://user-images.githubusercontent.com/336308/68475415-efcba880-028c-11ea-9e92-e084917261ab.png">
