### PR TITLE
Add in translation function around newly converted statusBounce messages

### DIFF
--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -405,7 +405,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
       $surveyId = key(CRM_Campaign_BAO_Survey::getSurveys(TRUE, TRUE));
     }
     if (!$surveyId) {
-      CRM_Core_Error::statusBounce('Could not find valid Survey Id.');
+      CRM_Core_Error::statusBounce(ts('Could not find valid Survey Id.'));
     }
     $this->_formValues['campaign_survey_id'] = $this->_formValues['campaign_survey_id'] = $surveyId;
 

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -97,7 +97,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     if (!$this->_caseId ||
       (!$this->_activityId && !$this->_activityTypeId)
     ) {
-      CRM_Core_Error::statusBounce('required params missing.');
+      CRM_Core_Error::statusBounce(ts('required params missing.'));
     }
 
     //check for case activity access.


### PR DESCRIPTION
Overview
----------------------------------------
This adds in ts function for some strings that weren't translated but now as they are status bounces should be. 

Before
----------------------------------------
Strings not translated

After
----------------------------------------
Strings translated

ping @yashodha @eileenmcnaughton i left this one https://github.com/civicrm/civicrm-core/pull/15770/files#diff-00a10e9176c4318681b5b18e5e9cc16cR268 alone as it seemed to be not to be tsed as per the comment in L267