### PR TITLE
dev/core#1378 Scheduled reminders: do not email if do_not_email or on_hold

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2560,11 +2560,14 @@ WHERE      civicrm_openid.openid = %1";
    *
    * @param int $contactID
    *   Contact id.
+   * @param bool $polite
+   *   Whether to only pull an email if it's okay to send to it--that is, if it
+   *   is not on_hold and the contact is not do_not_email.
    *
    * @return string
    *   Email address if present else null
    */
-  public static function getPrimaryEmail($contactID) {
+  public static function getPrimaryEmail($contactID, $polite = FALSE) {
     // fetch the primary email
     $query = "
    SELECT civicrm_email.email as email
@@ -2572,6 +2575,11 @@ WHERE      civicrm_openid.openid = %1";
 LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
     WHERE civicrm_email.is_primary = 1
       AND civicrm_contact.id = %1";
+    if ($polite) {
+      $query .= '
+      AND civicrm_contact.do_not_email = 0
+      AND civicrm_email.on_hold = 0';
+    }
     $p = [1 => [$contactID, 'Integer']];
     $dao = CRM_Core_DAO::executeQuery($query, $p);
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -607,7 +607,7 @@ FROM civicrm_action_schedule cas
    *   List of error messages.
    */
   protected static function sendReminderEmail($tokenRow, $schedule, $toContactID) {
-    $toEmail = CRM_Contact_BAO_Contact::getPrimaryEmail($toContactID);
+    $toEmail = CRM_Contact_BAO_Contact::getPrimaryEmail($toContactID, TRUE);
     if (!$toEmail) {
       return ["email_missing" => "Couldn't find recipient's email address."];
     }

--- a/tests/phpunit/CRM/Activity/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Activity/ActionMappingTest.php
@@ -141,6 +141,13 @@ class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappin
       ],
     ];
 
+    // No recipients: Dave has `do_not_email` and Edith is dead.
+    $cs[] = [
+      '2015-02-01 00:00:00',
+      'addDaveMeeting addEdithMeeting scheduleForMeeting startOnTime useHelloFirstName recipientIsActivitySource',
+      [],
+    ];
+
     return $cs;
   }
 
@@ -166,6 +173,36 @@ class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappin
       'source_contact_id' => $this->contacts['bob']['id'],
       'activity_type_id' => 'Phone Call',
       'subject' => 'Subject for Bob',
+      'activity_date_time' => date('Y-m-d H:i:s', strtotime($this->targetDate)),
+      'status_id' => 2,
+      'assignee_contact_id' => [$this->contacts['carol']['id']],
+    ]);
+  }
+
+  /**
+   * Create an activity record for Dave with type "Meeting".  Dave has
+   * "do_not_email" set, so he should never receive an email reminder.
+   */
+  public function addDaveMeeting() {
+    $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => $this->contacts['dave']['id'],
+      'activity_type_id' => 'Meeting',
+      'subject' => 'Subject for Dave',
+      'activity_date_time' => date('Y-m-d H:i:s', strtotime($this->targetDate)),
+      'status_id' => 2,
+      'assignee_contact_id' => [$this->contacts['carol']['id']],
+    ]);
+  }
+
+  /**
+   * Create an activity record for Edith with type "Meeting". Edith is dead, so
+   * she should never receive an email reminder.
+   */
+  public function addEdithMeeting() {
+    $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => $this->contacts['edith']['id'],
+      'activity_type_id' => 'Meeting',
+      'subject' => 'Subject for Edith',
       'activity_date_time' => date('Y-m-d H:i:s', strtotime($this->targetDate)),
       'status_id' => 2,
       'assignee_contact_id' => [$this->contacts['carol']['id']],

--- a/tests/phpunit/CRM/Activity/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Activity/ActionMappingTest.php
@@ -149,6 +149,19 @@ class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappin
       [],
     ];
 
+    // Gretchen has one email on hold, but her primary email is not on hold.
+    $cs[] = [
+      '2015-02-01 00:00:00',
+      'addGretchenMeeting scheduleForMeeting startOnTime useHelloFirstName recipientIsActivitySource',
+      [
+        [
+          'time' => '2015-02-01 00:00:00',
+          'to' => ['gretchen@example.org'],
+          'subject' => '/Hello, Gretchen.*via subject/',
+        ],
+      ],
+    ];
+
     return $cs;
   }
 
@@ -219,6 +232,20 @@ class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappin
       'source_contact_id' => $this->contacts['francis']['id'],
       'activity_type_id' => 'Meeting',
       'subject' => 'Subject for Francis',
+      'activity_date_time' => date('Y-m-d H:i:s', strtotime($this->targetDate)),
+      'status_id' => 2,
+      'assignee_contact_id' => [$this->contacts['carol']['id']],
+    ]);
+  }
+
+  /**
+   * Create an activity record for Gretchen with type "Meeting".
+   */
+  public function addGretchenMeeting() {
+    $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => $this->contacts['gretchen']['id'],
+      'activity_type_id' => 'Meeting',
+      'subject' => 'Subject for Gretchen',
       'activity_date_time' => date('Y-m-d H:i:s', strtotime($this->targetDate)),
       'status_id' => 2,
       'assignee_contact_id' => [$this->contacts['carol']['id']],

--- a/tests/phpunit/CRM/Activity/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Activity/ActionMappingTest.php
@@ -141,10 +141,11 @@ class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappin
       ],
     ];
 
-    // No recipients: Dave has `do_not_email` and Edith is dead.
+    // No recipients: Dave has `do_not_email`, Edith is dead, and Francis' email
+    // is on hold.
     $cs[] = [
       '2015-02-01 00:00:00',
-      'addDaveMeeting addEdithMeeting scheduleForMeeting startOnTime useHelloFirstName recipientIsActivitySource',
+      'addDaveMeeting addEdithMeeting addFrancisMeeting scheduleForMeeting startOnTime useHelloFirstName recipientIsActivitySource',
       [],
     ];
 
@@ -203,6 +204,21 @@ class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappin
       'source_contact_id' => $this->contacts['edith']['id'],
       'activity_type_id' => 'Meeting',
       'subject' => 'Subject for Edith',
+      'activity_date_time' => date('Y-m-d H:i:s', strtotime($this->targetDate)),
+      'status_id' => 2,
+      'assignee_contact_id' => [$this->contacts['carol']['id']],
+    ]);
+  }
+
+  /**
+   * Create an activity record for Francis with type "Meeting". Francis' email
+   * is misspelled and has bounced, so he should never receive an email reminder.
+   */
+  public function addFrancisMeeting() {
+    $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => $this->contacts['francis']['id'],
+      'activity_type_id' => 'Meeting',
+      'subject' => 'Subject for Francis',
       'activity_date_time' => date('Y-m-d H:i:s', strtotime($this->targetDate)),
       'status_id' => 2,
       'assignee_contact_id' => [$this->contacts['carol']['id']],

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -241,6 +241,15 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
       'email' => 'edith@example.org',
       'is_deceased' => 1,
     ]);
+    $this->contacts['francis'] = $this->callAPISuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Francis',
+      'last_name' => 'Exemplar',
+      'api.Email.create' => [
+        'email' => 'frances@example.org',
+        'on_hold' => 1,
+      ],
+    ]);
   }
 
   /**

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -227,6 +227,20 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
       'last_name' => 'Exemplar',
       'email' => 'carol@example.org',
     ]);
+    $this->contacts['dave'] = $this->callAPISuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Dave',
+      'last_name' => 'Exemplar',
+      'email' => 'dave@example.org',
+      'do_not_email' => 1,
+    ]);
+    $this->contacts['edith'] = $this->callAPISuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Edith',
+      'last_name' => 'Exemplar',
+      'email' => 'edith@example.org',
+      'is_deceased' => 1,
+    ]);
   }
 
   /**

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -250,6 +250,16 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
         'on_hold' => 1,
       ],
     ]);
+    $this->contacts['gretchen'] = $this->callAPISuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Gretchen',
+      'last_name' => 'Exemplar',
+      'email' => 'gretchen@example.org',
+      'api.Email.create' => [
+        'email' => 'gratchen@example.org',
+        'on_hold' => 1,
+      ],
+    ]);
   }
 
   /**


### PR DESCRIPTION
*Note: this PR used to just be a test, but I figured out how to easily fix it*

Overview
----------------------------------------
This suppresses scheduled reminder emails for contacts that have "Do not email" or who have their primary email on hold.  This matches the behavior for SMS scheduled reminders

This also adds to the scheduled reminder tests a handful of cases to make sure that people with "Do not email", dead people, and people with their primary email address on hold are not emailed scheduled reminders.

See https://lab.civicrm.org/dev/core/issues/1378

Before
----------------------------------------
People with `do_not_email=1` nevertheless receive emailed scheduled reminders, as do people with emails where `on_hold=1`.

People with `is_deceased=1` do not receive scheduled reminders at all, nor do people with `do_not_sms=1` receive SMS scheduled reminders.

After
----------------------------------------
Emailed scheduled reminders are not sent if the contact has `do_not_email=1`, `is_deceased=1`, or the primary email with `on_hold=1`.  SMS scheduled reminders are not sent if the contact has `do_not_sms=1` or `is_deceased=1`.

Technical Details
----------------------------------------
Nothing that isn't otherwise obvious.  I also added a test case for "Gretchen" who has a primary email address that is not on hold and another email address that is on hold: she should and does receive reminders to her primary email.  I do not account for the reverse situation, where the primary address is on hold but some other address is not.  We can't/shouldn't try to read the contact's mind.

My edit follows the lead of the SMS code by skipping the contact at the level of finding the email address rather than excluding them from the overall list of recipients.  This means that if someone has an email on hold or has Do not email, they might still get the reminder if it's also sent as SMS.

Comments
----------------------------------------
This will also require a fix to the documentation to edit this: https://github.com/civicrm/civicrm-user-guide/blob/master/docs/email/scheduled-reminders.md#scheduled-reminders-and-privacy-options