### PR TITLE
dev/mailing#56 dev/mailing#57 Ensure that we don't pass in any namesp…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2028,6 +2028,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $report['event_totals']['optout'] += $row['optout'];
 
       foreach (array_keys(CRM_Mailing_BAO_MailingJob::fields()) as $field) {
+        // Get the field name from the MailingJob fields as that will not have any prefixing.
+        // dev/mailing#56
+        $field = CRM_Mailing_BAO_MailingJob::fields()[$field]['name'];
         $row[$field] = $mailing->$field;
       }
 


### PR DESCRIPTION
…aced fields when building the row array for mailing reports

Overview
----------------------------------------
Following the datepicker conversion for some mailing smart groups, some mailing job fields started to be name spaced which then lead to e-notices of undefined property as per [dev/mailing#57](https://lab.civicrm.org/dev/mail/issues/57) and mailing reports showing incorrect information [dev/mailing#56](https://lab.civicrm.org/dev/mail/issues/56)

This resolves it by using the name key for the fields as that will be the non unique / non name spaced version

Before
----------------------------------------
unique field name used causing e-notices

After
----------------------------------------
non unique field name used

ping @eileenmcnaughton @totten @demeritcowboy 
