### PR TITLE
Add in unit test for dev/mailing#56 and dev/mailing#57 and also fix i…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1839,9 +1839,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $report['mailing'] = [];
     foreach (array_keys(self::fields()) as $field) {
-      if ($field == 'mailing_modified_date') {
-        $field = 'modified_date';
-      }
+      $field = self::fields()[$field]['name'];
       $report['mailing'][$field] = $mailing->$field;
     }
 

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -177,6 +177,12 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     //Execute the job and it should send the mailing to the recipients now.
     $this->callAPISuccess('job', 'process_mailing', []);
     $this->_mut->assertRecipients($this->getRecipients(1, 2));
+    // Ensure that loading the report produces no errors.
+    $report = CRM_Mailing_BAO_Mailing::report($result['id']);
+    // dev/mailing#56 dev/mailing#57 Ensure that for completed mailings the jobs array is not empty.
+    $this->assertTrue(!empty($report['jobs']));
+    // Ensure that mailing name is correctly stored in the report.
+    $this->assertEquals('mailing name', $report['mailing']['name']);
   }
 
   /**


### PR DESCRIPTION
…ssue where by mailing_name has been namespaced also in 5.20

Overview
----------------------------------------
This adds a unit test to verify the fix for dev/mailing#56 and dev/mailing#57. It also handles another situation of the same problem which is that mailing_name has been namespaced in 5.20 https://github.com/civicrm/civicrm-core/commit/08d08c035157a7b78a3af0569128c2534b2c9f64 and when running the unit test locally without the changes in CRM/Mailing/BAO/Mailing a new notice was thrown

Before
----------------------------------------
No unit test and e-notice thrown when running mailing report about mailing_name

After
----------------------------------------
unit test and no e-notice

ping @eileenmcnaughton @monishdeb @demeritcowboy
