### PR TITLE
Contribution url params - add contribution_page_id as a supported url parameter

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -341,7 +341,6 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       'activity_type_id',
       'status_id',
       'priority_id',
-      'contribution_page_id',
       'contribution_product_id',
       'payment_instrument_id',
       'group',

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -902,6 +902,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       'invoice_number',
       'receive_date',
       'contribution_cancel_date',
+      'contribution_page_id',
     ];
     $metadata = civicrm_api3('Contribution', 'getfields', [])['values'];
     return array_intersect_key($metadata, array_flip($fields));
@@ -941,12 +942,6 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::VIEW);
     $form->addSelect('financial_type_id',
       ['entity' => 'contribution', 'multiple' => 'multiple', 'context' => 'search', 'options' => $financialTypes]
-    );
-
-    $form->add('select', 'contribution_page_id',
-      ts('Contribution Page'),
-      CRM_Contribute_PseudoConstant::contributionPage(),
-      FALSE, ['class' => 'crm-select2', 'multiple' => 'multiple', 'placeholder' => ts('- any -')]
     );
 
     // use contribution_payment_instrument_id instead of payment_instrument_id

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -280,7 +280,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
         'contribution_soft_credit_type_id',
         'contribution_status_id',
         'contribution_trxn_id',
-        'contribution_page_id',
         'contribution_product_id',
         'invoice_id',
         'payment_instrument_id',
@@ -472,6 +471,12 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if (!empty($highReceiveDate)) {
       $this->_formValues['receive_date_high'] = date('Y-m-d H:i:s', strtotime($highReceiveDate));
       CRM_Core_Error::deprecatedFunctionWarning('pass receive_date_high not end');
+    }
+    //check for contribution page id.
+    $contribPageId = CRM_Utils_Request::retrieve('pid', 'Positive', $this);
+    if ($contribPageId) {
+      CRM_Core_Error::deprecatedFunctionWarning('pass contribution_page_id');
+      $this->_formValues['contribution_page_id'] = $contribPageId;
     }
   }
 

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -240,7 +240,7 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
       $yearNow = $yearDate + 10000;
 
       $urlString = 'civicrm/contribute/search';
-      $urlParams = 'reset=1&pid=%%id%%&force=1&test=0';
+      $urlParams = 'reset=1&contribution_page_id=%%id%%&force=1&test=0';
 
       self::$_contributionLinks = array(
         CRM_Core_Action::DETACH => array(


### PR DESCRIPTION
Overview
----------------------------------------
Makes it possible to put contribution_page_id=1 as a search param, deprecates the old variant

Before
----------------------------------------
contribution_page_id=1 does not work
<img width="391" alt="Screen Shot 2019-11-11 at 6 22 37 PM" src="https://user-images.githubusercontent.com/336308/68562839-42d17580-04b0-11ea-95ac-25c0a4f80dba.png">


After
----------------------------------------
contribution_page_id=1 does work

<img width="362" alt="Screen Shot 2019-11-11 at 6 23 37 PM" src="https://user-images.githubusercontent.com/336308/68562869-685e7f00-04b0-11ea-9ff7-2db25c78d7ee.png">


Technical Details
----------------------------------------
Part of a generalised standardisation

Comments
----------------------------------------
I'm not planning on doing more conversions on this page at the moment - I did this primarily in the context of auditing for https://github.com/civicrm/civicrm-user-guide/pull/420

@seamuslee001 this highlights a formatting issue ... oh - it's not select-2 by default - I don't like that!