### PR TITLE
Remove unhelpful alert from contribution search

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -482,12 +482,6 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         //all other elements are handle in this case
         $fldName = substr($name, 13);
         if (!isset($fields[$fldName])) {
-          // CRM-12597
-          CRM_Core_Session::setStatus(ts(
-              'We did not recognize the search field: %1. Please check and fix your contribution related smart groups.',
-              [1 => $fldName]
-            )
-          );
           return;
         }
         $whereTable = $fields[$fldName];
@@ -495,7 +489,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
           $value = trim($value);
         }
 
-        $dataType = "String";
+        $dataType = 'String';
         if (!empty($whereTable['type'])) {
           $dataType = CRM_Utils_Type::typeToString($whereTable['type']);
         }


### PR DESCRIPTION
Overview
----------------------------------------
Removes an alert that gives the false impression there is a problem

Before
----------------------------------------

Search succeeds but message - per url this is searching on contribution_recur_start_date

<img width="1039" alt="Screen Shot 2019-11-09 at 2 08 43 PM" src="https://user-images.githubusercontent.com/336308/68520298-54bde780-02fb-11ea-9d42-0190aaec4bed.png">



After
----------------------------------------
Message gone

Technical Details
----------------------------------------
Increasingly fields where searching can be done by metadata in the main search are being done that way so this error isn't helping

Comments
----------------------------------------

@seamuslee001 I'm not sure how recent but this will be a recent regression as we converted to datepicker