### PR TITLE
Fix Participant Search in force mode to support query parameters in URL

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -916,6 +916,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     // can't by pass acls by passing search criteria in the url.
     $this->addSearchFieldMetadata(['Contribution' => CRM_Contribute_BAO_Query::getSearchFieldMetadata()]);
     $this->addSearchFieldMetadata(['ContributionRecur' => CRM_Contribute_BAO_ContributionRecur::getContributionRecurSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['Participant' => CRM_Event_BAO_Query::getSearchFieldMetadata()]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Before the participant search didn't work with force=1 urls

Before
----------------------------------------
URL parameters would fill out the search form but not be used in the query

After
----------------------------------------
URL parameters fill out both the search form and are used in the query

ping @demeritcowboy @eileenmcnaughton @monishdeb 

I was using this sort of url to test `civicrm/contact/search/advanced?reset=1&force=1&event_low=20190130000000&participant_register_date_high=20191130235959&sort_name=Cooper&participant_status_id=1,2&participant_role_id=1,2&participant_test=1` also `civicrm/event/search?reset=1&force=1&event_low=20190130000000&participant_register_date_high=20191130235959&sort_name=Cooper&participant_status_id=1,2&participant_role_id=1,2` 

On the 2nd one there is a e-notice due to the sort_name field which we probably want to try to address.  I also tried to replicate https://issues.civicrm.org/jira/browse/CRM-18322 but couldn't