### PR TITLE
dev/core#183 Use Standard CRM_Utils_SQL_TempTable builder to create temporary tabl…

### DIFF
--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -502,17 +502,10 @@ INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
         $voterIdCount = count($voterIds);
 
         //create temporary table to store voter ids.
-        $tempTableName = CRM_Core_DAO::createTempTableName('civicrm_survey_respondent');
+        $tempTable = CRM_Utils_SQL_TempTable::build();
+        $tempTableName = $tempTable->getName();
         CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS {$tempTableName}");
-
-        $query = "
-     CREATE TEMPORARY TABLE {$tempTableName} (
-            id int unsigned NOT NULL AUTO_INCREMENT,
-            survey_contact_id int unsigned NOT NULL,
-  PRIMARY KEY ( id )
-);
-";
-        CRM_Core_DAO::executeQuery($query);
+        $tempTable->createWithColumns('id int unsigned NOT NULL AUTO_INCREMENT, survey_contact_id int unsigned NOT NULL, PRIMARY KEY ( id )')
 
         $batch = 100;
         $insertedCount = 0;

--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -505,7 +505,7 @@ INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
         $tempTable = CRM_Utils_SQL_TempTable::build();
         $tempTableName = $tempTable->getName();
         CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS {$tempTableName}");
-        $tempTable->createWithColumns('id int unsigned NOT NULL AUTO_INCREMENT, survey_contact_id int unsigned NOT NULL, PRIMARY KEY ( id )')
+        $tempTable->createWithColumns('id int unsigned NOT NULL AUTO_INCREMENT, survey_contact_id int unsigned NOT NULL, PRIMARY KEY ( id )');
 
         $batch = 100;
         $insertedCount = 0;

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -591,16 +591,9 @@ WHERE {$clause}
         $voterIdCount = count($this->_contactIds);
 
         //create temporary table to store voter ids.
-        $tempTableName = CRM_Core_DAO::createTempTableName('civicrm_survey_respondent');
-        CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS {$tempTableName}");
-        $query = "
-     CREATE TEMPORARY TABLE {$tempTableName} (
-            id int unsigned NOT NULL AUTO_INCREMENT,
-            survey_contact_id int unsigned NOT NULL,
-  PRIMARY KEY ( id )
-);
-";
-        CRM_Core_DAO::executeQuery($query);
+        $tempTableName = CRM_Utils_SQL_TempTable::build()
+          ->createWithColumns('id int unsigned NOT NULL AUTO_INCREMENT, survey_contact_id int unsigned NOT NULL, PRIMARY KEY ( id )')
+          ->getName();
         $batch = 100;
         $insertedCount = 0;
         do {

--- a/tests/phpunit/CRM/Campaign/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Campaign/BAO/QueryTest.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test APIv3 civicrm_contribute_* functions
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Contribution
+ * @group headless
+ */
+class CRM_Campaign_BAO_QueryTest extends CiviUnitTestCase {
+
+  public function testCampaignVoterClause() {
+    $loggedInContact = $this->createLoggedInUser();
+    $contact = $this->individualCreate();
+    $activityType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'survey');
+    $surveyParams = [
+      'title' => 'Test Survey',
+      'activity_type_id' => $activityType,
+      'created_id' => $loggedInContact,
+    ];
+    $survery = CRM_Campaign_BAO_Survey::create($surveyParams);
+    $voterClauseParams = [
+      'campaign_search_voter_for' => 'reserve',
+      'campaign_survey_id' => $survery->id,
+      'survey_interviewer_id' => $loggedInContact,
+    ];
+    CRM_Campaign_BAO_Query::voterClause($voterClauseParams);
+  }
+
+}


### PR DESCRIPTION
…e in Campaign and upgrade

Overview
----------------------------------------
This converts the creation of temporary tables in CRM/Campaign and CRM/Upgrade to be standardised through the CRM_Utils_SQL_TempTable interface

Before
----------------------------------------
Uses the deprecated `CRM_Core_DAO::createTempTableName` function to generate a temporary table name

After
----------------------------------------
Uses the standard CRM_Utils_SQL_TempTable functionality

ping @monishdeb @eileenmcnaughton @totten 
