### PR TITLE
dev/core#183 Remove references to and noisly deprecated CRM_Core_DAO::createTempTableName

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4184,7 +4184,9 @@ WHERE  $smartGroupClause
     $relationshipTempTable = NULL;
     if (self::$_relType == 'reciprocal') {
       $where = [];
-      self::$_relationshipTempTable = $relationshipTempTable = CRM_Core_DAO::createTempTableName('civicrm_rel');
+      self::$_relationshipTempTable = $relationshipTempTable = CRM_Utils_SQL_TempTable::build()
+        ->createWithColumns("`contact_id` int(10) unsigned NOT NULL DEFAULT '0', `contact_id_alt` int(10) unsigned NOT NULL DEFAULT '0', relationship_id int unsigned, KEY `contact_id` (`contact_id`), KEY `contact_id_alt` (`contact_id_alt`)")
+        ->getName();
       if ($nameClause) {
         $where[$grouping][] = " sort_name $nameClause ";
       }
@@ -4307,13 +4309,7 @@ civicrm_relationship.start_date > {$today}
         $whereClause = str_replace('contact_b', 'c', $whereClause);
       }
       $sql = "
-        CREATE TEMPORARY TABLE {$relationshipTempTable}
-          (
-            `contact_id` int(10) unsigned NOT NULL DEFAULT '0',
-            `contact_id_alt` int(10) unsigned NOT NULL DEFAULT '0',
-            KEY `contact_id` (`contact_id`),
-            KEY `contact_id_alt` (`contact_id_alt`)
-          )
+        INSERT INTO {$relationshipTempTable} (contact_id, contact_id_alt, relationship_id)
           (SELECT contact_id_b as contact_id, contact_id_a as contact_id_alt, civicrm_relationship.id
             FROM civicrm_relationship
             INNER JOIN  civicrm_contact c ON civicrm_relationship.contact_id_a = c.id

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2112,6 +2112,7 @@ SELECT contact_id
    * @see CRM_Utils_SQL_TempTable
    */
   public static function createTempTableName($prefix = 'civicrm', $addRandomString = TRUE, $string = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use CRM_Utils_SQL_TempTable interface to create temporary tables');
     $tableName = $prefix . "_temp";
 
     if ($addRandomString) {

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -708,7 +708,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
       ],
     ];
     $sql = CRM_Contact_BAO_Query::getQuery($params);
-    $this->assertContains('INNER JOIN civicrm_rel_temp_', $sql, "Query appears to use temporary table of compiled relationships?", TRUE);
+    $this->assertContains('INNER JOIN civicrm_tmp_e', $sql, "Query appears to use temporary table of compiled relationships?", TRUE);
   }
 
   public function testRelationshipPermissionClause() {

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -296,21 +296,14 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $this->assertEquals(1, CRM_Core_DAO::isDBMyISAM());
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_my_isam');
 
-    // A temp table should not raise flag (static naming).
-    $tempName = CRM_Core_DAO::createTempTableName('civicrm', FALSE);
-    $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
-    CRM_Core_DAO::executeQuery("CREATE TABLE $tempName (`id` int(10) unsigned NOT NULL) ENGINE = MyISAM");
-    // Ignore temp tables
-    $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
-    CRM_Core_DAO::executeQuery("DROP TABLE $tempName");
-
+    // A temp table should not raise flag.
+    $tempTableName = CRM_Utils_SQL_TempTable::build()->setCategory('myisam')->getName();
     // A temp table should not raise flag (randomized naming).
-    $tempName = CRM_Core_DAO::createTempTableName('civicrm', TRUE);
     $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
-    CRM_Core_DAO::executeQuery("CREATE TABLE $tempName (`id` int(10) unsigned NOT NULL) ENGINE = MyISAM");
+    CRM_Core_DAO::executeQuery("CREATE TABLE $tempTableName (`id` int(10) unsigned NOT NULL) ENGINE = MyISAM");
     // Ignore temp tables
     $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
-    CRM_Core_DAO::executeQuery("DROP TABLE $tempName");
+    CRM_Core_DAO::executeQuery("DROP TABLE $tempTableName");
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This removes the last references to `CRM_Core_DAO::createTempTableName` and also adds in some noisy deprecation

Before
----------------------------------------
Deprecated function used and not noisley deprecated

After
----------------------------------------
Deprecated function not used and noisely deprecated

This includes #15792 

ping @eileenmcnaughton @totten @monishdeb 