### PR TITLE
Implement drupal_get_user_timezone()

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -721,6 +721,14 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
+  public function getTimeZoneString() {
+    $timezone = drupal_get_user_timezone();
+    return $timezone;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function setUFLocale($civicrm_language) {
     $langcode = substr(str_replace('_', '', $civicrm_language), 0, 2);
     $languageManager = \Drupal::languageManager();


### PR DESCRIPTION
Before
----------------------------------------
Contributions made by anonymous user were recorded in CiviCRM using timezone set on server level. 

Drupal8.php is the only file in /var/www/drupal/vendor/civicrm/civicrm-core/CRM/Utils/System without a `public function getTimeZoneString()`

After
----------------------------------------
After implementing drupal_get_user_timezone() -> Contributions made by anonymous users are now recorded in the Default timezone configured within Drupal8:
/admin/config/regional/settings

For testing I added a drupal_set_message(print_r($timezone, TRUE)) in Drupal8.php -> it shows it's correctly finding America/Edmonton.

![image](https://user-images.githubusercontent.com/5340555/68548164-1aaa1f80-03a7-11ea-9088-b0e525a140e1.png)

![image](https://user-images.githubusercontent.com/5340555/68548162-12ea7b00-03a7-11ea-827b-b5f23067aa97.png)

![image](https://user-images.githubusercontent.com/5340555/68548169-24cc1e00-03a7-11ea-8764-fe25a045241b.png)

Technical Details
----------------------------------------
Similar to the D7 implementation - except simpler. Too simple actually - I could well be missing something though I did some more testing and this seems to work. 

Todo: more Testing -> done:
----------------------------------------
1) on /admin/config/regional/settings-> change default TimeZone in Drupal to Config to -> Europe/Amsterdam
2) Anonymous user is now recognized in that timezone (see drupal_set_message left bottom)
![image](https://user-images.githubusercontent.com/5340555/68548452-52669680-03aa-11ea-8446-2489497eb7d4.png)
3) And the Contribution in CiviCRM is correctly recorded in that site's default TimeZone - which is indeed +8h -> 
![image](https://user-images.githubusercontent.com/5340555/68548460-70cc9200-03aa-11ea-98af-4acd09d3f05c.png)
4) Note for all testing above -> php -i |grep timezone -> UTC
