### PR TITLE
dev/core#183 Convert creating of temp table in mailing test to use st…

### DIFF
--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -742,24 +742,19 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     CRM_Core_DAO::executeQuery($sql);
 
     foreach (['bounce', 'unsubscribe', 'opened'] as $type) {
-      $sql = "CREATE TEMPORARY TABLE mail_{$type}_temp
-(event_queue_id int, time_stamp datetime, delivered_id int)
-SELECT event_queue_id, time_stamp, id
- FROM civicrm_mailing_event_delivered
- WHERE id IN ($deliveredIds)
- ORDER BY RAND() LIMIT 0,20;";
-      CRM_Core_DAO::executeQuery($sql);
-
-      $sql = "DELETE FROM civicrm_mailing_event_delivered WHERE id IN (SELECT delivered_id FROM mail_{$type}_temp);";
-      CRM_Core_DAO::executeQuery($sql);
+      $temporaryTable = CRM_Utils_SQL_TempTable::build()->setCategory($type)->createWithQuery("SELECT event_queue_id, time_stamp, id as delivered_id
+        FROM civicrm_mailing_event_delivered
+        WHERE id IN ($deliveredIds)
+         ORDER BY RAND() LIMIT 0,20");
+      $temporaryTableName = $temporaryTable->getName();
 
       if ($type == 'unsubscribe') {
         $sql = "INSERT INTO civicrm_mailing_event_{$type} (event_queue_id, time_stamp, org_unsubscribe)
-SELECT event_queue_id, time_stamp, 1 FROM mail_{$type}_temp";
+SELECT event_queue_id, time_stamp, 1 FROM {$temporaryTableName}";
       }
       else {
         $sql = "INSERT INTO civicrm_mailing_event_{$type} (event_queue_id, time_stamp)
-SELECT event_queue_id, time_stamp FROM mail_{$type}_temp";
+SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
       }
       CRM_Core_DAO::executeQuery($sql);
     }
@@ -777,6 +772,7 @@ SELECT event_queue_id, time_stamp FROM mail_{$type}_temp";
       'clickthrough_rate' => '0%',
     ];
     $this->checkArrayEquals($expectedResult, $result['values'][$mail['id']]);
+    $temporaryTable->drop();
   }
 
   /**


### PR DESCRIPTION
…andardised CRM_Utils_SQL_TempTable interface

Overview
----------------------------------------
This changes the mailing test to use the CRM_Utils_SQL_TempTable interface to generate the temporary table

Before
----------------------------------------
Non standard method used

After
----------------------------------------
Standard method used