### PR TITLE
dev/core#183 Use CRM_Utils_SQL_TempTable for generating temp table na…

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -58,6 +58,9 @@ class Requirements {
    *   An array of check summaries. Each array contains the keys 'title', 'severity', and 'details'.
    */
   public function checkAll(array $config) {
+    if (!class_exists('\CRM_Utils_SQL_TempTable')) {
+      require_once dirname(__FILE__) . '/../../CRM/Utils/SQL/TempTable.php';
+    }
     return array_merge($this->checkSystem($config['file_paths']), $this->checkDatabase($config['db_config']));
   }
 
@@ -373,15 +376,15 @@ class Requirements {
       $results['details'] = "Could not select the database";
       return $results;
     }
-
-    $r = mysqli_query($conn, 'CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)');
+    $temporaryTableName = \CRM_Utils_SQL_TempTable::build()->setCategory('install')->getName();
+    $r = mysqli_query($conn, 'CREATE TEMPORARY TABLE ' . $temporaryTableName . ' (test text)');
     if (!$r) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = "Database does not support creation of temporary tables";
       return $results;
     }
 
-    mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+    mysqli_query($conn, 'DROP TEMPORARY TABLE ' . $temporaryTableName);
     return $results;
   }
 

--- a/install/index.php
+++ b/install/index.php
@@ -1127,12 +1127,13 @@ class InstallRequirements {
       return;
     }
 
-    $result = mysqli_query($conn, 'CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)');
+    $tempTableName = CRM_Utils_SQL_TempTable::build()->setCategory('install')->getName();
+    $result = mysqli_query($conn, 'CREATE TEMPORARY TABLE ' . $tempTableName . ' (test text)');
     if (!$result) {
       $testDetails[2] = ts('Could not create a temp table.');
       $this->error($testDetails);
     }
-    $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+    $result = mysqli_query($conn, 'DROP TEMPORARY TABLE ' . $tempTableName);
   }
 
   /**
@@ -1196,18 +1197,19 @@ class InstallRequirements {
       return;
     }
 
-    $result = mysqli_query($conn, 'CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)');
+    $tempTableName = CRM_Utils_SQL_TempTable::build()->setCategory('install')->getName();
+    $result = mysqli_query($conn, 'CREATE TEMPORARY TABLE ' . $tempTableName . ' (test text)');
     if (!$result) {
       $testDetails[2] = ts('Could not create a table in the database.');
       $this->error($testDetails);
       return;
     }
 
-    $result = mysqli_query($conn, 'LOCK TABLES civicrm_install_temp_table_test WRITE');
+    $result = mysqli_query($conn, 'LOCK TABLES ' . $tempTableName . ' WRITE');
     if (!$result) {
       $testDetails[2] = ts('Could not obtain a write lock for the database table.');
       $this->error($testDetails);
-      $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+      $result = mysqli_query($conn, 'DROP TEMPORARY TABLE ' . $tempTableName);
       return;
     }
 
@@ -1215,11 +1217,11 @@ class InstallRequirements {
     if (!$result) {
       $testDetails[2] = ts('Could not release the lock for the database table.');
       $this->error($testDetails);
-      $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+      $result = mysqli_query($conn, 'DROP TEMPORARY TABLE ' . $tempTableName);
       return;
     }
 
-    $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+    $result = mysqli_query($conn, 'DROP TEMPORARY TABLE ' . $tempTableName);
   }
 
   /**


### PR DESCRIPTION
…me for testing install requirements

Overview
----------------------------------------
This changes the test in requirements so that it uses CRM_Utils_SQL_TempTable functionality to create the name of the temporary table it tries to create

Before
----------------------------------------
Non standard way of generating table name

After
----------------------------------------
Uses standard ways of generating table name

ping @totten @monishdeb 