### PR TITLE
dev/core#183 Alter Import process to use standardised CRM_Utils_SQL_T…

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -53,10 +53,12 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
 
     //Test database user privilege to create table(Temporary) CRM-4725
     $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
+    $tempTable1 = CRM_Utils_SQL_TempTable::build()->getName();
+    $tempTable2 = CRM_Utils_SQL_TempTable::build()->getName();
     $daoTestPrivilege = new CRM_Core_DAO();
-    $daoTestPrivilege->query("CREATE TEMPORARY TABLE import_job_permission_one(test int) ENGINE=InnoDB");
-    $daoTestPrivilege->query("CREATE TEMPORARY TABLE import_job_permission_two(test int) ENGINE=InnoDB");
-    $daoTestPrivilege->query("DROP TEMPORARY TABLE IF EXISTS import_job_permission_one, import_job_permission_two");
+    $daoTestPrivilege->query("CREATE TEMPORARY TABLE {$tempTable1} (test int) ENGINE=InnoDB");
+    $daoTestPrivilege->query("CREATE TEMPORARY TABLE {$tempTable2} (test int) ENGINE=InnoDB");
+    $daoTestPrivilege->query("DROP TEMPORARY TABLE IF EXISTS {$tempTable1}, {$tempTable2}");
     unset($errorScope);
 
     if ($daoTestPrivilege->_lastError) {

--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -128,7 +128,7 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
 
     $importTableName = $this->get('importTableName');
     // do a basic sanity check here
-    if (strpos($importTableName, 'civicrm_import_job_') === 0) {
+    if (strpos($importTableName, 'civicrm_tmp') === 0 || strpos($importTableName, 'civicrm_import_job') === 0) {
       $query = "DROP TABLE IF EXISTS $importTableName";
       $db->query($query);
     }

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -79,7 +79,7 @@ class CRM_Contact_Import_ImportJob {
 
       // FIXME: we should regen this table's name if it exists rather than drop it
       if (!$tableName) {
-        $tableName = 'civicrm_import_job_' . md5(uniqid(rand(), TRUE));
+        $tableName = CRM_Utils_SQL_TempTable::build()->setCategory('importjob')->getName();
       }
       $db->query("DROP TABLE IF EXISTS $tableName");
       $db->query("CREATE TABLE $tableName ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci $createSql");
@@ -411,7 +411,7 @@ class CRM_Contact_Import_ImportJob {
     $database = $dao->database();
     $query = "SELECT   TABLE_NAME FROM INFORMATION_SCHEMA
                   WHERE    TABLE_SCHEMA = ? AND
-                           TABLE_NAME LIKE 'civicrm_import_job_%'
+                           ( TABLE_NAME LIKE 'civicrm_tmp_%_importjob%' OR TABLE_NAME LIKE 'civicrm_import_job_%')
                   ORDER BY TABLE_NAME";
     $result = CRM_Core_DAO::executeQuery($query, array($database));
     $incompleteImportTables = array();

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -200,7 +200,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
 
     // FIXME: we should regen this table's name if it exists rather than drop it
     if (!$table) {
-      $table = 'civicrm_import_job_' . md5(uniqid(rand(), TRUE));
+      $table = CRM_Utils_SQL_TempTable::build()->setCategory('importjob')->getName();
     }
 
     $db->query("DROP TABLE IF EXISTS $table");

--- a/tests/phpunit/CRM/Import/DataSource/CsvTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/CsvTest.php
@@ -38,7 +38,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
    * @dataProvider getCsvFiles
    */
   public function testToCsv($fileName) {
-    $dataSource = new CRM_Import_DataSource_Csv();
+    $dataSource = new CRM_Import_DataSource_CSV();
     $params = [
       'uploadFile' => [
         'name' => __DIR__ . '/' . $fileName,


### PR DESCRIPTION
…empTable for generating temporary tables

Overview
----------------------------------------
This alters the import process to use the standard CRM_Utils_SQL_TempTable functionality to generate table names as part of the import

Before
----------------------------------------
Non standard table names used

After
----------------------------------------
standard table names used

ping @totten @eileenmcnaughton @monishdeb 
