### PR TITLE
Remove unused  parameter recur from CompleteOrder signature

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4442,7 +4442,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @param array $ids
    * @param array $objects
    * @param CRM_Core_Transaction $transaction
-   * @param int $recur
    * @param CRM_Contribute_BAO_Contribution $contribution
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
@@ -4453,7 +4452,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder($input, &$ids, $objects, $transaction, $recur, $contribution, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, &$ids, $objects, $transaction, $contribution, $isPostPaymentCreate = FALSE) {
     $primaryContributionID = isset($contribution->id) ? $contribution->id : $objects['first_contribution']->id;
     // The previous details are used when calculating line items so keep it before any code that 'does something'
     if (!empty($contribution->id)) {

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -134,14 +134,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
 
     $now = date('YmdHis');
 
-    // fix dates that already exist
-    $dates = ['create_date', 'start_date', 'end_date', 'cancel_date', 'modified_date'];
-    foreach ($dates as $name) {
-      if ($recur->$name) {
-        $recur->$name = CRM_Utils_Date::isoToMysql($recur->$name);
-      }
-    }
-
     //load new contribution object if required.
     if (!$first) {
       // create a contribution and then get it processed

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -473,15 +473,14 @@ class CRM_Core_Payment_BaseIPN {
    * @param array $ids
    * @param array $objects
    * @param CRM_Core_Transaction $transaction
-   * @param bool $recur
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function completeTransaction(&$input, &$ids, &$objects, &$transaction, $recur = FALSE) {
+  public function completeTransaction(&$input, &$ids, &$objects, &$transaction) {
     $contribution = &$objects['contribution'];
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction, $recur, $contribution);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction, $contribution);
   }
 
   /**

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -656,6 +656,8 @@ function civicrm_api3_contribution_repeattransaction($params) {
  * @param CRM_Contribute_BAO_Contribution $firstContribution
  *
  * @return mixed
+ * @throws \CRM_Core_Exception
+ * @throws \CiviCRM_API3_Exception
  */
 function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstContribution = NULL) {
   $objects = $contribution->_relatedObjects;
@@ -690,7 +692,7 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
   $input['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $params);
   $transaction = new CRM_Core_Transaction();
   return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction,
-    !empty($contribution->contribution_recur_id), $contribution, CRM_Utils_Array::value('is_post_payment_create', $params));
+     $contribution, CRM_Utils_Array::value('is_post_payment_create', $params));
 }
 
 /**

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -205,6 +205,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
 
   /**
    * Test IPN response updates contribution_recur & contribution for first & second contribution
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testIPNPaymentMembershipRecurSuccess() {
     $this->createRepeatMembershipOrder();


### PR DESCRIPTION
Overview
----------------------------------------
Minor tidy up affecting Authorize.net IPN - remove an unused parameter, stop doing date wrangling we haven't needed in years

Before
----------------------------------------
Less readable

After
----------------------------------------
More readable

Technical Details
----------------------------------------
We've been pretty clear this should always be called via the api so  I'm not worried about
calling functions outside core being affected.

I've discovered that A.net is creating borked transactions so trying to break this down & fix

Also the removed date wrangling is from when the DAO could not save dates in the same format it retrieved from the DB with - we fixed that a while back

Comments
----------------------------------------

