### PR TITLE
Test fixes - addresses more invalid setup data

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -37,6 +37,8 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
 
   /**
    * Check method create().
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreate() {
     $contactId = $this->individualCreate();

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -7,6 +7,8 @@ use Civi\Payment\Exception\PaymentProcessorException;
  * @group headless
  */
 class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
+  use CRMTraits_Financial_OrderTrait;
+
   protected $_contributionID;
   protected $_invoiceID = 'c2r9c15f7be20b4f3fef1f77e4c37424';
   protected $_financialTypeID = 1;
@@ -15,12 +17,16 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
   protected $_contributionPageID;
   protected $_paymentProcessorID;
 
+  /**
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function setUp() {
     parent::setUp();
     $this->_paymentProcessorID = $this->paymentProcessorAuthorizeNetCreate(['is_test' => 0]);
     $this->_contactID = $this->individualCreate();
     $contributionPage = $this->callAPISuccess('contribution_page', 'create', [
-      'title' => "Test Contribution Page",
+      'title' => 'Test Contribution Page',
       'financial_type_id' => $this->_financialTypeID,
       'currency' => 'USD',
       'payment_processor' => $this->_paymentProcessorID,
@@ -101,6 +107,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       $this->markTestSkipped('Error from A.net - cannot proceed');
     }
     $this->_contributionID = $contribution->id;
+    $this->ids['Contribution'][0] = $contribution->id;
     $this->_contributionRecurID = $contribution->contribution_recur_id;
     $recur_params = [
       'id' => $this->_contributionRecurID,
@@ -126,6 +133,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
 
   /**
    * Test IPN response updates contribution_recur & contribution for first & second contribution
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testIPNPaymentRecurSuccess() {
     $this->setupRecurringPaymentProcessorTransaction();
@@ -198,14 +207,15 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
    * Test IPN response updates contribution_recur & contribution for first & second contribution
    */
   public function testIPNPaymentMembershipRecurSuccess() {
-    $this->setupMembershipRecurringPaymentProcessorTransaction();
+    $this->createRepeatMembershipOrder();
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
     $IPN->main();
-    $contribution = $this->callAPISuccess('contribution', 'getsingle', ['id' => $this->_contributionID]);
+    $contribution = $this->callAPISuccess('contribution', 'getsingle', ['id' => $this->ids['Contribution'][0]]);
     $this->assertEquals(1, $contribution['contribution_status_id']);
     $this->assertEquals('6511143069', $contribution['trxn_id']);
+
     // source gets set by processor
-    $this->assertTrue(substr($contribution['contribution_source'], 0, 20) == "Online Contribution:");
+    $this->assertEquals('Online Contribution:', substr($contribution['contribution_source'], 0, 20));
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurSubsequentTransaction());
@@ -224,6 +234,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'contribution_id' => $contribution['values'][1]['id'],
       'entity_table' => 'civicrm_membership',
     ]);
+    $this->validateAllContributions();
+    $this->validateAllPayments();
   }
 
   /**
@@ -394,7 +406,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'x_state' => 'WA',
       'x_city' => 'Dallas',
       'x_address' => '41 My ST',
-      'x_invoice_num' => $this->_contributionID,
+      'x_invoice_num' => $this->ids['Contribution'][0],
       'x_cust_id' => $this->_contactID,
       'x_company' => 'nowhere@civicrm.org',
       'x_last_name' => 'Roberts',

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -1,0 +1,125 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2020                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Trait OrderTrait
+ *
+ * Trait for setting up orders for tests.
+ */
+trait CRMTraits_Financial_OrderTrait {
+
+  use \Civi\Test\Api3TestTrait;
+
+  /**
+   * Create a pending membership from a recurring order.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function createRepeatMembershipOrder() {
+    $this->createExtraneousContribution();
+    $this->ids['contact'][0] = $this->individualCreate();
+    $this->ids['membership_type'][0] = $this->membershipTypeCreate();
+
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge([
+      'contact_id' => $this->_contactID,
+      'amount' => 1000,
+      'sequential' => 1,
+      'installments' => 5,
+      'frequency_unit' => 'Month',
+      'frequency_interval' => 1,
+      'invoice_id' => $this->_invoiceID,
+      'contribution_status_id' => 2,
+      'payment_processor_id' => $this->_paymentProcessorID,
+      // processor provided ID - use contact ID as proxy.
+      'processor_id' => $this->_contactID,
+    ]));
+
+    $orderID = $this->callAPISuccess('Order', 'create', [
+      'total_amount' => '200',
+      'financial_type_id' => 'Donation',
+      'contribution_status_id' => 'Pending',
+      'contact_id' => $this->_contactID,
+      'contribution_page_id' => $this->_contributionPageID,
+      'payment_processor_id' => $this->_paymentProcessorID,
+      'is_test' => 0,
+      'receive_date' => '2019-07-25 07:34:23',
+      'skipCleanMoney' => TRUE,
+      'contribution_recur_id' => $contributionRecur['id'],
+      'line_items' => [
+        [
+          'params' => [
+            'contact_id' => $this->ids['contact'][0],
+            'membership_type_id' => $this->ids['membership_type'][0],
+            'contribution_recur_id' => $contributionRecur['id'],
+            'source' => 'Payment',
+          ],
+          'line_item' => [
+            [
+              'label' => 'General',
+              'qty' => 1,
+              'unit_price' => 200,
+              'line_total' => 200,
+              'financial_type_id' => 1,
+              'entity_table' => 'civicrm_membership',
+              'price_field_id' => $this->callAPISuccess('price_field', 'getvalue', [
+                'return' => 'id',
+                'label' => 'Membership Amount',
+                'options' => ['limit' => 1, 'sort' => 'id DESC'],
+              ]),
+              'price_field_value_id' => $this->callAPISuccess('price_field_value', 'getvalue', [
+                'return' => 'id',
+                'label' => 'General',
+                'options' => ['limit' => 1, 'sort' => 'id DESC'],
+              ]),
+            ],
+          ],
+        ],
+      ],
+    ])['id'];
+
+    $this->ids['ContributionRecur'][0] = $contributionRecur['id'];
+    $this->ids['Contribution'][0] = $orderID;
+  }
+
+  /**
+   * Create an extraneous contribution to throw off any 'number one bugs'.
+   *
+   * Ie this means our real data starts from 2 & we won't hit 'pretend passes'
+   * just because the number 1 is used for multiple entities.
+   */
+  protected function createExtraneousContribution() {
+    $this->contributionCreate([
+      'contact_id' => $this->_contactID,
+      'is_test' => 1,
+      'financial_type_id' => 1,
+      'invoice_id' => 'abcd',
+      'trxn_id' => 345,
+      'receive_date' => '2019-07-25 07:34:23',
+    ]);
+  }
+
+}

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -244,7 +244,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
         'is_override' => 1,
       ],
     ];
-    $order = $this->callAPIAndDocument('order', 'create', $p, __FUNCTION__, __FILE__);
+    $order = $this->callAPIAndDocument('Order', 'create', $p, __FUNCTION__, __FILE__);
     $params = [
       'contribution_id' => $order['id'],
     ];
@@ -258,7 +258,9 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       ],
     ];
     $this->checkPaymentResult($order, $expectedResult);
-    $this->callAPISuccessGetCount('MembershipPayment', $params, 1);
+    $membershipPayment = $this->callAPISuccessGetSingle('MembershipPayment', $params);
+
+    $membership = $this->callAPISuccessGetSingle('Membership', ['id' => $membershipPayment['id']]);
     $this->callAPISuccess('Contribution', 'Delete', [
       'id' => $order['id'],
     ]);


### PR DESCRIPTION
Overview
----------------------------------------
Addresses (for one test) an issue where we are creating invalid set up data for Authorize.net tests

Before
----------------------------------------
Tests butchering membership line item creations

After
----------------------------------------
Test (one so far) using new Order api based fn

Technical Details
----------------------------------------


Comments
----------------------------------------

