### PR TITLE
Handling comma separated list of participant statuses in url

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -357,4 +357,11 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     return CRM_Activity_BAO_Query::getSearchFieldMetadata();
   }
 
+  /**
+   * Set the metadata for the form.
+   */
+  protected function setSearchMetadata() {
+    $this->addSearchFieldMetadata(['Activity' => $this->getEntityMetadata()]);
+  }
+
 }

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -304,7 +304,12 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       if (empty($_POST[$fieldName])) {
         $value = CRM_Utils_Request::retrieveValue($fieldName, $this->getValidationTypeForField($entity, $fieldName), NULL, NULL, 'GET');
         if ($value !== NULL) {
-          $defaults[$fieldName] = $value;
+          if ($fieldSpec['html']['type'] === 'Select') {
+            $defaults[$fieldName] = explode(',', $value);
+          }
+          else {
+            $defaults[$fieldName] = $value;
+          }
         }
         if ($fieldSpec['type'] === CRM_Utils_Type::T_DATE || ($fieldSpec['type'] === CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)) {
           $low = CRM_Utils_Request::retrieveValue($fieldName . '_low', 'Timestamp', NULL, NULL, 'GET');
@@ -393,7 +398,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       $title,
       CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name')
     );
-    $this->searchFieldMetadata['Contact']['sort_name'] = ['name' => 'sort_name', 'title' => $title, 'type' => CRM_Utils_Type::T_STRING];
+    $this->searchFieldMetadata['Contact']['sort_name'] = array_merge(CRM_Contact_DAO_Contact::fields()['sort_name'], ['name' => 'sort_name', 'title' => $title, 'type' => CRM_Utils_Type::T_STRING]);
   }
 
   /**

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -90,6 +90,9 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    * Processing needed for buildForm and later.
    *
    * @return void
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function preProcess() {
     $this->set('searchFormName', 'Search');
@@ -102,13 +105,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
 
     $this->_done = FALSE;
 
-    $this->loadStandardSearchOptionsFromUrl();
-    $this->loadFormValues();
-
-    if ($this->_force) {
-      $this->postProcess();
-      $this->set('force', 0);
-    }
+    parent::preProcess();
 
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, ['event_id']);
     $selector = new CRM_Event_Selector_Search($this->_queryParams,
@@ -374,6 +371,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    * @param
    *
    * @return void
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
     if ($this->_done) {
@@ -381,16 +379,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     }
 
     $this->_done = TRUE;
-    $formValues = [];
-
-    if (!empty($_POST)) {
-      $formValues = $this->controller->exportValues($this->_name);
-      CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, ['participant_status_id']);
-    }
-
-    if (empty($formValues)) {
-      $formValues = $this->controller->exportValues($this->_name);
-    }
+    $formValues = $this->getFormValues();
 
     $this->submit($formValues);
   }
@@ -464,13 +453,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
         $this->_single = TRUE;
       }
     }
-  }
-
-  /**
-   * @return null
-   */
-  public function getFormValues() {
-    return NULL;
   }
 
   /**

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -482,4 +482,13 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     return ts('Find Participants');
   }
 
+  /**
+   * Set the metadata for the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function setSearchMetadata() {
+    $this->addSearchFieldMetadata(['Participant' => CRM_Event_BAO_Query::getSearchFieldMetadata()]);
+  }
+
 }

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -293,4 +293,13 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
     return CRM_Grant_BAO_Query::getSearchFieldMetadata();
   }
 
+  /**
+   * Set the metadata for the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function setSearchMetadata() {
+    $this->addSearchFieldMetadata(['Grant' => $this->getEntityMetadata()]);
+  }
+
 }

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -74,6 +74,9 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
   /**
    * Processing needed for buildForm and later.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function preProcess() {
     $this->set('searchFormName', 'Search');
@@ -134,6 +137,9 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
@@ -358,6 +364,15 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
    */
   public function getTitle() {
     return ts('Find Memberships');
+  }
+
+  /**
+   * Set the metadata for the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function setSearchMetadata() {
+    $this->addSearchFieldMetadata(['Membership' => CRM_Member_BAO_Query::getSearchFieldMetadata()]);
   }
 
 }

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -86,23 +86,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     $this->_done = FALSE;
 
-    $this->loadStandardSearchOptionsFromUrl();
-
-    // get user submitted values
-    // get it from controller only if form has been submitted, else preProcess has set this
-    if (!empty($_POST)) {
-      $this->_formValues = $this->controller->exportValues($this->_name);
-    }
-    else {
-      $this->_formValues = $this->get('formValues');
-    }
-
-    if ($this->_force) {
-      $this->addSearchFieldMetadata(['Membership' => CRM_Member_BAO_Query::getSearchFieldMetadata()]);
-      $this->addFormFieldsFromMetadata();
-      $this->postProcess();
-      $this->set('force', 0);
-    }
+    parent::preProcess();
 
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
     $selector = new CRM_Member_Selector_Search($this->_queryParams,
@@ -241,7 +225,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
 
-    $this->set('formValues', $this->_formValues);
     $this->set('queryParams', $this->_queryParams);
 
     $buttonName = $this->controller->getButtonName();

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -391,4 +391,14 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     return ts('Find Pledges');
   }
 
+  /**
+   * Set the metadata for the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function setSearchMetadata() {
+    $this->addSearchFieldMetadata(['Pledge' => CRM_Pledge_BAO_Query::getSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['PledgePayment' => CRM_Pledge_BAO_Query::getPledgePaymentSearchFieldMetadata()]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds url support for participant_status_id = 1,2 in event search

Before
----------------------------------------
The above does not activate a filter

After
----------------------------------------
It does activate a filter

Technical Details
----------------------------------------
@seamuslee001 I think exploding when retrieving from the url is a  better method than wrangling in the BAO_Query or anywhere field-driven

Comments
----------------------------------------
Needs a rebase on sub-pr merge
