### PR TITLE
allow distinction to be made whether relationships are shown for user…

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2148,7 +2148,9 @@ AND cc.sort_name LIKE '%$name%'";
 
     $columnHeaders = self::getColumnHeaders();
     $selector = NULL;
-    CRM_Utils_Hook::searchColumns('relationship.rows', $columnHeaders, $contactRelationships, $selector);
+
+    $contextName = (CRM_Utils_Array::value('context', $params) == 'user') ? 'relationship.rows.user' : 'relationship.rows';
+    CRM_Utils_Hook::searchColumns($contextName, $columnHeaders, $contactRelationships, $selector);
 
     $relationshipsDT = [];
     $relationshipsDT['data'] = $contactRelationships;


### PR DESCRIPTION
… dashboard or relationship tab for hook usage

Overview
----------------------------------------
allow distinction to be made whether relationships are shown for user dashboard or relationship tab for hook usage

Comments
----------------------------------------
We could also add another parameter in the hook to indicate context but that would involve making changes to a commonly used hook signature.
