### PR TITLE
(dev/core#1065) Contact missing in membership renewal form

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -263,6 +263,9 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     //CRM-16950
     $taxRate = $this->getTaxRateForFinancialType($this->allMembershipTypeDetails[$defaults['membership_type_id']]['financial_type_id']);
 
+    $contactField = $this->addEntityRef('contact_id', ts('Contact'), ['create' => TRUE, 'api' => ['extra' => ['email']]], TRUE);
+    $contactField->freeze();
+
     // auto renew options if enabled for the membership
     $options = CRM_Core_SelectValues::memberAutoRenew();
 

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -58,6 +58,10 @@
     </div>
     <div>{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout">
+      <tr class="crm-member-membershiprenew-form-block-contact-id">
+        <td class="label">{$form.contact_id.label}</td>
+        <td>{$form.contact_id.html}</td>
+      </tr>
       <tr class="crm-member-membershiprenew-form-block-org_name">
         <td class="label">{ts}Membership Organization and Type{/ts}</td>
         <td class="html-adjust">{$orgName}&nbsp;&nbsp;-&nbsp;&nbsp;{$memType}


### PR DESCRIPTION
Overview
----------------------------------------
Membership renewal screen needs to be shown in consistency with Grant/Member/Participant screens. Currently it is missing contact name.

Before
----------------------------------------
![renew_before](https://user-images.githubusercontent.com/3455173/68669261-1da43c00-0570-11ea-91f5-3bf15c67ca96.png)


After
----------------------------------------
![renew_after](https://user-images.githubusercontent.com/3455173/68669306-3b71a100-0570-11ea-8387-24364a6ab668.png)
