### PR TITLE
[NFC] Remove unused variable not used since v4.4

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -104,12 +104,6 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $this->_caseType = $caseTypeName;
     $this->assign('caseDetails', $this->_caseDetails);
 
-    $reportUrl = CRM_Utils_System::url('civicrm/case/report',
-      "reset=1&cid={$this->_contactID}&caseid={$this->_caseID}&asn=",
-      FALSE, NULL, FALSE
-    );
-    $this->assign('reportUrl', $reportUrl);
-
     // add to recently viewed
 
     $url = CRM_Utils_System::url('civicrm/contact/view/case',


### PR DESCRIPTION
Overview
----------------------------------------
$reportUrl variable used to be used in templates/CRM/Case/Form/CaseView.tpl prior to v4.5 but got orphaned by putting similar urls directly in the template / js. Can't find anywhere this variable is currently used.
