### PR TITLE
[WIP] dev/core#600 Add locale to word replacements table, remove civicrm_domain sync

### DIFF
--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -138,48 +138,6 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement {
   }
 
   /**
-   * Get all word-replacements in the form of an array.
-   *
-   * @param int $id
-   *   Domain ID.
-   *
-   * @return array
-   * @see civicrm_domain.locale_custom_strings
-   */
-  public static function getAllAsConfigArray($id) {
-    $query = "
-SELECT find_word,replace_word,is_active,match_type
-FROM   civicrm_word_replacement
-WHERE  domain_id = %1
-";
-    $params = [1 => [$id, 'Integer']];
-
-    $dao = CRM_Core_DAO::executeQuery($query, $params);
-
-    $overrides = [];
-
-    while ($dao->fetch()) {
-      if ($dao->is_active == 1) {
-        $overrides['enabled'][$dao->match_type][$dao->find_word] = $dao->replace_word;
-      }
-      else {
-        $overrides['disabled'][$dao->match_type][$dao->find_word] = $dao->replace_word;
-      }
-    }
-    $config = CRM_Core_Config::singleton();
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-
-    // So. Weird. Some bizarre/probably-broken multi-lingual thing where
-    // data isn't really stored in civicrm_word_replacements. Probably
-    // shouldn't exist.
-    $stringOverride = self::_getLocaleCustomStrings($id);
-    $stringOverride[$config->lcMessages] = $overrides;
-
-    return $stringOverride;
-  }
-
-  /**
    * Rebuild.
    *
    * @param bool $clearCaches
@@ -188,7 +146,6 @@ WHERE  domain_id = %1
    */
   public static function rebuild($clearCaches = TRUE) {
     $id = CRM_Core_Config::domainID();
-    self::_setLocaleCustomStrings($id, self::getAllAsConfigArray($id));
 
     // Partially mitigate the inefficiency introduced in CRM-13187 by doing this conditionally
     if ($clearCaches) {
@@ -202,86 +159,11 @@ WHERE  domain_id = %1
   }
 
   /**
-   * Get word replacements for the api.
-   *
-   * Get all the word-replacements stored in config-arrays for the
-   * configured language, and convert them to params for the
-   * WordReplacement.create API.
-   *
-   * Note: This function is duplicated in CRM_Core_BAO_WordReplacement and
-   * CRM_Upgrade_Incremental_php_FourFour to ensure that the incremental upgrade
-   * step behaves consistently even as the BAO evolves in future versions.
-   * However, if there's a bug in here prior to 4.4.0, we should apply the
-   * bug-fix in both places.
-   *
-   * @param bool $rebuildEach
-   *   Whether to perform rebuild after each individual API call.
-   *
-   * @return array
-   *   Each item is $params for WordReplacement.create
-   * @see CRM_Core_BAO_WordReplacement::convertConfigArraysToAPIParams
-   */
-  public static function getConfigArraysAsAPIParams($rebuildEach) {
-    $settingsResult = civicrm_api3('Setting', 'get', [
-      'return' => 'lcMessages',
-    ]);
-    $returnValues = CRM_Utils_Array::first($settingsResult['values']);
-    $lang = $returnValues['lcMessages'];
-
-    $wordReplacementCreateParams = [];
-    // get all domains
-    $result = civicrm_api3('domain', 'get', [
-      'return' => ['locale_custom_strings'],
-    ]);
-    if (!empty($result["values"])) {
-      foreach ($result["values"] as $value) {
-        $params = [];
-        $params["domain_id"] = $value["id"];
-        $params["options"] = ['wp-rebuild' => $rebuildEach];
-        // Unserialize word match string.
-        $localeCustomArray = unserialize($value["locale_custom_strings"]);
-        if (!empty($localeCustomArray)) {
-          $wordMatchArray = [];
-          // Only return the replacement strings of the current language,
-          // otherwise some replacements will be duplicated, which will
-          // lead to undesired results, like CRM-19683.
-          $localCustomData = $localeCustomArray[$lang];
-          // Traverse status array "enabled" "disabled"
-          foreach ($localCustomData as $status => $matchTypes) {
-            $params["is_active"] = ($status == "enabled") ? TRUE : FALSE;
-            // Traverse Match Type array "wildcardMatch" "exactMatch"
-            foreach ($matchTypes as $matchType => $words) {
-              $params["match_type"] = $matchType;
-              foreach ($words as $word => $replace) {
-                $params["find_word"] = $word;
-                $params["replace_word"] = $replace;
-                $wordReplacementCreateParams[] = $params;
-              }
-            }
-          }
-        }
-      }
-    }
-    return $wordReplacementCreateParams;
-  }
-
-  /**
    * Rebuild word replacements.
    *
-   * Get all the word-replacements stored in config-arrays
-   * and write them out as records in civicrm_word_replacement.
-   *
-   * Note: This function is duplicated in CRM_Core_BAO_WordReplacement and
-   * CRM_Upgrade_Incremental_php_FourFour to ensure that the incremental upgrade
-   * step behaves consistently even as the BAO evolves in future versions.
-   * However, if there's a bug in here prior to 4.4.0, we should apply the
-   * bug-fix in both places.
+   * @deprecated
    */
   public static function rebuildWordReplacementTable() {
-    civicrm_api3('word_replacement', 'replace', [
-      'options' => ['match' => ['domain_id', 'find_word']],
-      'values' => self::getConfigArraysAsAPIParams(FALSE),
-    ]);
     CRM_Core_BAO_WordReplacement::rebuild();
   }
 
@@ -299,55 +181,20 @@ WHERE  domain_id = %1
       $domainId = CRM_Core_Config::domainID();
     }
 
-    return CRM_Utils_Array::value($locale, self::_getLocaleCustomStrings($domainId));
-  }
-
-  /**
-   * Get custom locale strings.
-   *
-   * @param int $domainId
-   *
-   * @return array|mixed
-   */
-  private static function _getLocaleCustomStrings($domainId) {
     // TODO: Would it be worthwhile using memcache here?
-    $domain = CRM_Core_DAO::executeQuery('SELECT locale_custom_strings FROM civicrm_domain WHERE id = %1', [
+    $overrides = [];
+
+    $dao = CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_word_replacement WHERE domain_id = %1 AND language = %2 ORDER BY id ASC', [
       1 => [$domainId, 'Integer'],
+      2 => [$locale, 'String'],
     ]);
-    while ($domain->fetch()) {
-      return empty($domain->locale_custom_strings) ? [] : unserialize($domain->locale_custom_strings);
-    }
-  }
 
-  /**
-   * Set locale strings.
-   *
-   * @param string $locale
-   * @param array $values
-   * @param int $domainId
-   */
-  public static function setLocaleCustomStrings($locale, $values, $domainId = NULL) {
-    if ($domainId === NULL) {
-      $domainId = CRM_Core_Config::domainID();
+    while ($dao->fetch()) {
+      $status = $dao->is_active ? 'enabled' : 'disabled';
+      $overrides[$status][$dao->match_type][$dao->find_word] = $dao->replace_word;
     }
 
-    $lcs = self::_getLocaleCustomStrings($domainId);
-    $lcs[$locale] = $values;
-
-    self::_setLocaleCustomStrings($domainId, $lcs);
-  }
-
-  /**
-   * Set locale strings.
-   *
-   * @param int $domainId
-   * @param string $lcs
-   */
-  private static function _setLocaleCustomStrings($domainId, $lcs) {
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_domain SET locale_custom_strings = %1 WHERE id = %2", [
-      1 => [serialize($lcs), 'String'],
-      2 => [$domainId, 'Integer'],
-    ]);
+    return $overrides;
   }
 
 }

--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -121,6 +121,9 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         'content',
         // CiviCampaign Goal Details
         'goal_general',
+        // Word Replacements
+        'find_word',
+        'replace_word',
       ];
       $custom = CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_custom_field WHERE html_type = "RichTextEditor"');
       while ($custom->fetch()) {

--- a/xml/schema/Core/WordReplacement.xml
+++ b/xml/schema/Core/WordReplacement.xml
@@ -48,6 +48,7 @@
     <name>UI_domain_find</name>
     <fieldName>domain_id</fieldName>
     <fieldName>find_word</fieldName>
+    <fieldName>language</fieldName>
     <unique>true</unique>
     <add>4.4</add>
   </index>
@@ -76,6 +77,18 @@
     </pseudoconstant>
     <comment>FK to Domain ID. This is for Domain specific word replacement</comment>
     <add>1.1</add>
+  </field>
+  <field>
+    <name>language</name>
+    <title>Word Replacement Language</title>
+    <type>varchar</type>
+    <length>5</length>
+    <pseudoconstant>
+      <optionGroupName>languages</optionGroupName>
+      <keyColumn>name</keyColumn>
+    </pseudoconstant>
+    <comment>Word Replacement Language</comment>
+    <add>5.21</add>
   </field>
   <foreignKey>
     <name>domain_id</name>


### PR DESCRIPTION
Overview
----------------------------------------

Issue: https://lab.civicrm.org/dev/core/issues/600

Word Replacements have two major bugs:

* They get lost when we enter HTML in the from/replacement values, because the code serializes the strings (before duplicating them).
* They don't work very well in multi-lingual. They kind of do, but not really, or not always the way you think they will.

Before
----------------------------------------

Word Replacements are easily lost and confusing.

After
----------------------------------------

They are not lost and less confusing.

Technical Details
----------------------------------------

Removes a lot of legacy code.

Todo
----------------------------------------

* Upgrader code