### PR TITLE
CiviCase - Make static function `allActivityTypes()` static

### DIFF
--- a/CRM/Case/XMLProcessor.php
+++ b/CRM/Case/XMLProcessor.php
@@ -83,7 +83,7 @@ class CRM_Case_XMLProcessor {
    *
    * @return array
    */
-  public function &allActivityTypes($indexName = TRUE, $all = FALSE) {
+  public static function &allActivityTypes($indexName = TRUE, $all = FALSE) {
     if (self::$activityTypes === NULL) {
       self::$activityTypes = CRM_Case_PseudoConstant::caseActivityType($indexName, $all);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Wondering why this isn't static. It's coming up as an error for me.

Technical Details
----------------------------------------
Function only deals with static variables and is even called from CRM/Case/XMLProcessor/Report.php as static (except that line currently never executes but that's because of a separate problem I was in the middle of when this came up).