### PR TITLE
dev/core#1390 - Search builder error on Membership source field

### DIFF
--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -151,6 +151,8 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
       return;
     }
     list($name, $op, $value, $grouping) = $values;
+    $fields = self::getFields();
+
     switch ($name) {
       case 'member_join_date_low':
       case 'member_join_date_high':
@@ -206,12 +208,8 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
 
       case 'member_source':
       case 'membership_source':
-        $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
-        $value = $strtolower(CRM_Core_DAO::escapeString(trim($value)));
-
-        $query->_where[$grouping][] = "civicrm_membership.source $op '{$value}'";
-        $query->_qill[$grouping][] = ts('Source %2 %1', [1 => $value, 2 => $op]);
-        $query->_tables['civicrm_membership'] = $query->_whereTables['civicrm_membership'] = 1;
+        $fieldSpec = $fields['membership_source'] ?? [];
+        $query->handleWhereFromMetadata($fieldSpec, $name, $value, $op);
         return;
 
       // CRM-17011 These 2 variants appear in some smart groups saved at some time prior to 4.6.6.

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -53,6 +53,12 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
       'auto_renew' => 1,
     ], $rows[0]);
     $this->assertCount(1, $rows);
+
+    //Verify if NULL search on source returns the row correctly.
+    $params = [['membership_source', 'IS NOT NULL', '', 1, 0]];
+    $selector = new CRM_Member_Selector_Search($params);
+    $rows = $selector->getRows(CRM_Core_Permission::VIEW, 0, 25, NULL);
+    $this->assertCount(1, $rows);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Search builder error on Membership source field

Before
----------------------------------------
- Click on Search -> Search Builder.
- Select Membership => Source => IS NULL and Submit the form.
- Got an error "DB error: syntax error".

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1390

Added unit test.