### PR TITLE
Fix contribution cancel_date not being loaded

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -756,7 +756,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       // @todo return this & fix query to do pseudoconstant thing.
       'contribution_status' => 1,
       'currency' => 1,
-      'cancel_date' => 1,
+      'contribution_cancel_date' => 1,
       'contribution_recur_id' => 1,
     ];
     if (self::isSiteHasProducts()) {

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -66,7 +66,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
     'thankyou_date',
     'contribution_status_id',
     'contribution_status',
-    'cancel_date',
+    'contribution_cancel_date',
     'product_name',
     'is_test',
     'contribution_recur_id',

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -51,7 +51,7 @@
 
     {counter start=0 skip=1 print=false}
     {foreach from=$rows item=row}
-      <tr id="rowid{$row.contribution_id}" class="{cycle values="odd-row,even-row"} {if $row.cancel_date} cancelled{/if} crm-contribution_{$row.contribution_id}">
+      <tr id="rowid{$row.contribution_id}" class="{cycle values="odd-row,even-row"} {if $row.contribution_cancel_date} cancelled{/if} crm-contribution_{$row.contribution_id}">
         {if !$single }
           {if $context eq 'Search' }
             {assign var=cbName value=$row.checkbox}
@@ -72,11 +72,11 @@
         {if !$columnName}{* if field_name has not been set skip, this helps with not changing anything not specifically edited *}
         {elseif $columnName === 'total_amount'}{* rendered above as soft credit columns = confusing *}
         {elseif $column.type === 'actions'}{* rendered below as soft credit column handling = not fixed *}
-        {elseif $columnName == 'contribution-status'}
+        {elseif $columnName == 'contribution_status'}
           <td class="crm-contribution-status">
             {$row.contribution_status}<br/>
-            {if $row.cancel_date}
-              {$row.cancel_date|crmDate}
+            {if $row.contribution_cancel_date}
+              {$row.contribution_cancel_date|crmDate}
             {/if}
           </td>
         {else}

--- a/templates/CRM/Contribute/Form/Task/Print.tpl
+++ b/templates/CRM/Contribute/Form/Task/Print.tpl
@@ -53,8 +53,8 @@
         <td class="crm-contribution-thankyou_date">{$row.thankyou_date|truncate:10:''|crmDate}</td>
         <td class="crm-contribution-status crm-contribution-status_{$row.contribution_status_id}">
             {$row.contribution_status_id}<br />
-            {if $row.cancel_date}
-                {$row.cancel_date|truncate:10:''|crmDate}
+            {if $row.contribution_cancel_date}
+                {$row.contribution_cancel_date|truncate:10:''|crmDate}
             {/if}
         </td>
         <td class="crm-contribution-product_name">{$row.product_name}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where the contribution cancel date is not loaded in the contribution search, causing cancelled contributions not to be greyed out and the cancel date not to be shown.

Before
----------------------------------------
Cancelled contributions are not greyed out and don't show the cancel date:

![image](https://user-images.githubusercontent.com/277794/68861804-8b757280-06ec-11ea-9557-9606f37a3545.png)

After
----------------------------------------
Cancelled contributions are greyed out and show the cancel date:

![image](https://user-images.githubusercontent.com/277794/68861875-af38b880-06ec-11ea-8f3c-11a221c57167.png)