### PR TITLE
Remove background opacity in menus; improving accessibility/readability

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -868,7 +868,7 @@ class CRM_Core_Resources {
       '$breakMin' => $params['breakpoint'] . 'px',
       '$breakMax' => ($params['breakpoint'] - 1) . 'px',
       '$menubarColor' => $menubarColor,
-      '$menuItemColor' => $params['menuItemColor'] ?? 'rgba(' . implode(', ', CRM_Utils_Color::getRgb($menubarColor)) . ", .9)",
+      '$menuItemColor' => $params['menuItemColor'] ?? $menubarColor,
       '$highlightColor' => $params['highlightColor'] ?? CRM_Utils_Color::getHighlight($menubarColor),
       '$textColor' => $params['textColor'] ?? CRM_Utils_Color::getContrast($menubarColor, '#333', '#ddd'),
     ];


### PR DESCRIPTION
Overview
----------------------------------------

Civi's menu is 90% opaque for some reason, presumably a stylistic decision. It makes it hard to read the menu items. This fixes that by making the menu opaque.

I found it hard to read and the idea of going opaque seemed to suit at least some others
https://chat.civicrm.org/civicrm/pl/cp98ne1isjbrtx41rgh936fejw

Before
----------------------------------------

![before-DT](https://user-images.githubusercontent.com/870343/68877606-41958800-06fe-11ea-8c9c-e026f05b1a1c.jpg)


After
----------------------------------------


![Screenshot from 2019-11-14 16-47-26-DT](https://user-images.githubusercontent.com/870343/68877832-9cc77a80-06fe-11ea-870a-d562e8a4ff65.jpg)

