### PR TITLE
[NFC] dev/core#1352 - Add comments why there's two custom blocks on new case form

### DIFF
--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -61,6 +61,7 @@
 {/if}
 
 {* custom data group *}
+{* This shows ACTIVITY custom fields, as opposed to CASE custom fields, so is not a duplicate of the other custom data block below. *}
 {if $groupTree}
     <tr>
        <td colspan="2">{include file="CRM/Custom/Form/CustomData.tpl"}</td>
@@ -97,6 +98,7 @@
     </tr>
 {/if}
 
+{* This shows CASE custom fields, as opposed to ACTIVITY custom fields, so is not a duplicate of the other custom data block above. *}
 <tr class="crm-case-form-block-custom_data">
     <td colspan="2">
       {include file="CRM/common/customDataBlock.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Adds comments to new case template so someone doesn't get confused like I did.

I'll rant elsewhere about case custom fields, but because new case is the open case activity, it's possible to have custom field blocks that come from both case and activity. So this adds comments explaining it's not a duplicate.
