### PR TITLE
Add $params type declaration to global API functions.

### DIFF
--- a/api/api.php
+++ b/api/api.php
@@ -19,7 +19,7 @@
  *
  * @return array|int
  */
-function civicrm_api($entity, $action, $params, $extra = NULL) {
+function civicrm_api($entity, $action, array $params, $extra = NULL) {
   return \Civi::service('civi_api_kernel')->runSafe($entity, $action, $params, $extra);
 }
 
@@ -37,7 +37,7 @@ function civicrm_api($entity, $action, $params, $extra = NULL) {
  * @throws \API_Exception
  * @throws \Civi\API\Exception\NotImplementedException
  */
-function civicrm_api4($entity, $action, $params = [], $index = NULL) {
+function civicrm_api4($entity, $action, array $params = [], $index = NULL) {
   $apiCall = \Civi\Api4\Utils\ActionUtil::getAction($entity, $action);
   foreach ($params as $name => $param) {
     $setter = 'set' . ucfirst($name);
@@ -81,7 +81,7 @@ function civicrm_api4($entity, $action, $params = [], $index = NULL) {
  *
  * @return array
  */
-function civicrm_api3($entity, $action, $params = []) {
+function civicrm_api3($entity, $action, array $params = []) {
   $params['version'] = 3;
   $result = \Civi::service('civi_api_kernel')->runSafe($entity, $action, $params);
   if (is_array($result) && !empty($result['is_error'])) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1752,9 +1752,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   public function testDeleteParamsNotArrayContribution() {
+    $this->expectException(TypeError::class);
     $params = 'contribution_id= 1';
     $contribution = $this->callAPIFailure('contribution', 'delete', $params);
-    $this->assertEquals($contribution['error_message'], 'Input variable `params` is not an array');
   }
 
   public function testDeleteWrongParamContribution() {

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -32,16 +32,6 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with no array.
-   */
-  public function testCustomFieldCreateNoArray() {
-    $fieldParams = NULL;
-
-    $customField = $this->callAPIFailure('custom_field', 'create', $fieldParams);
-    $this->assertEquals($customField['error_message'], 'Input variable `params` is not an array');
-  }
-
-  /**
    * Check with no label.
    */
   public function testCustomFieldCreateWithoutLabel() {
@@ -405,15 +395,6 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
   }
 
   ///////////////// civicrm_custom_field_delete methods
-
-  /**
-   * Check with no array.
-   */
-  public function testCustomFieldDeleteNoArray() {
-    $params = NULL;
-    $customField = $this->callAPIFailure('custom_field', 'delete', $params);
-    $this->assertEquals($customField['error_message'], 'Input variable `params` is not an array');
-  }
 
   /**
    * Check without Field ID.

--- a/tests/phpunit/api/v3/CustomGroupTest.php
+++ b/tests/phpunit/api/v3/CustomGroupTest.php
@@ -200,15 +200,6 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with not array.
-   */
-  public function testCustomGroupCreateNotArray() {
-    $params = NULL;
-    $customGroup = $this->callAPIFailure('custom_group', 'create', $params);
-    $this->assertEquals($customGroup['error_message'], 'Input variable `params` is not an array');
-  }
-
-  /**
    * Check without title.
    */
   public function testCustomGroupCreateNoTitle() {
@@ -334,15 +325,6 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
   public function testCustomGroupDeleteWithoutGroupID() {
     $customGroup = $this->callAPIFailure('custom_group', 'delete', []);
     $this->assertEquals($customGroup['error_message'], 'Mandatory key(s) missing from params array: id');
-  }
-
-  /**
-   * Check with no array.
-   */
-  public function testCustomGroupDeleteNoArray() {
-    $params = NULL;
-    $customGroup = $this->callAPIFailure('custom_group', 'delete', $params);
-    $this->assertEquals($customGroup['error_message'], 'Input variable `params` is not an array');
   }
 
   /**

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -757,17 +757,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test civicrm_event_search with wrong params type.
-   * @param int $version
-   * @dataProvider versionThreeAndFour
-   */
-  public function testSearchWrongParamsType($version) {
-    $this->_apiversion = $version;
-    $params = 'a string';
-    $result = $this->callAPIFailure('event', 'get', $params);
-  }
-
-  /**
    * Test civicrm_event_search with empty params.
    * @param int $version
    * @dataProvider versionThreeAndFour

--- a/tests/phpunit/api/v3/GroupOrganizationTest.php
+++ b/tests/phpunit/api/v3/GroupOrganizationTest.php
@@ -84,17 +84,6 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test civicrm_group_organization_get with wrong params.
-   *
-   * @dataProvider versionThreeAndFour
-   */
-  public function testGroupOrganizationGetWithWrongParams() {
-    $params = 'groupOrg';
-    $result = $this->callAPIFailure('group_organization', 'get', $params);
-    $this->assertEquals($result['error_message'], 'Input variable `params` is not an array');
-  }
-
-  /**
    * Test civicrm_group_organization_get invalid keys.
    *
    * @dataProvider versionThreeAndFour
@@ -150,17 +139,6 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with invalid params.
-   *
-   * @dataProvider versionThreeAndFour
-   */
-  public function testGroupOrganizationCreateParamsNotArray() {
-    $params = 'group_org';
-    $result = $this->callAPIFailure('group_organization', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Input variable `params` is not an array');
-  }
-
-  /**
    * Check with invalid params keys.
    *
    * @dataProvider versionThreeAndFour
@@ -174,17 +152,6 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
   }
 
   ///////////////// civicrm_group_organization_remove methods
-
-  /**
-   * Test civicrm_group_organization_remove with params not an array.
-   *
-   * @dataProvider versionThreeAndFour
-   */
-  public function testGroupOrganizationDeleteParamsNotArray() {
-    $params = 'delete';
-    $result = $this->callAPIFailure('group_organization', 'delete', $params);
-    $this->assertEquals($result['error_message'], 'Input variable `params` is not an array');
-  }
 
   /**
    * Test civicrm_group_organization_remove with empty params.

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -189,7 +189,8 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     ]);
     $this->callAPISuccess('mailing', 'create', $this->_params);
     $this->_mut->assertRecipients([]);
-    $this->callAPIFailure('job', 'process_mailing', "Failure in api call for job process_mailing:  Job has not been executed as it is a non-production environment.");
+    $result = $this->callAPIFailure('job', 'process_mailing', []);
+    $this->assertEquals($result['error_message'], "Job has not been executed as it is a Staging (non-production) environment.");
 
     // Test with runInNonProductionEnvironment param.
     $this->callAPISuccess('job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);

--- a/tests/phpunit/api/v3/MailingContactTest.php
+++ b/tests/phpunit/api/v3/MailingContactTest.php
@@ -41,20 +41,6 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
-  /**
-   * Test that the api responds correctly to null params.
-   *
-   * Do not copy and paste.
-   *
-   * Tests like this that test the wrapper belong in the SyntaxConformance class
-   * (which already has a 'not array test)
-   * I have left this here in case 'null' isn't covered in that class
-   * but don't copy it only any other classes
-   */
-  public function testMailingNullParams() {
-    $this->callAPIFailure('MailingContact', 'get', NULL);
-  }
-
   public function testMailingContactGetFields() {
     $result = $this->callAPISuccess('MailingContact', 'getfields', [
       'action' => 'get',

--- a/tests/phpunit/api/v3/MembershipPaymentTest.php
+++ b/tests/phpunit/api/v3/MembershipPaymentTest.php
@@ -92,14 +92,6 @@ class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
   ///////////////// civicrm_membershipPayment_get methods
 
   /**
-   * Test civicrm_membershipPayment_get with wrong params type.
-   */
-  public function testGetWrongParamsType() {
-    $params = 'eeee';
-    $GetWrongParamsType = $this->callAPIFailure('membership_payment', 'get', $params, 'Input variable `params` is not an array');
-  }
-
-  /**
    * Test civicrm_membershipPayment_get - success expected.
    */
   public function testGet() {

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -101,14 +101,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test civicrm_membership_delete() with invalid Membership Id.
-   */
-  public function testMembershipDeleteWithInvalidMembershipId() {
-    $membershipId = 'membership';
-    $this->callAPIFailure('membership', 'delete', $membershipId);
-  }
-
-  /**
    * Test membership deletion and with the preserve contribution param.
    */
   public function testMembershipDeletePreserveContribution() {

--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -61,14 +61,6 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test civicrm_participant_payment_create with wrong params type.
-   */
-  public function testPaymentCreateWrongParamsType() {
-    $params = 'a string';
-    $this->callAPIFailure('participant_payment', 'create', $params);
-  }
-
-  /**
    * Test civicrm_participant_payment_create with empty params.
    */
   public function testPaymentCreateEmptyParams() {
@@ -129,15 +121,6 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
   }
 
   ///////////////// civicrm_participant_payment_create methods
-
-  /**
-   * Test civicrm_participant payment create with wrong params type.
-   */
-  public function testPaymentUpdateWrongParamsType() {
-    $params = 'a string';
-    $result = $this->callAPIFailure('participant_payment', 'create', $params);
-    $this->assertEquals('Input variable `params` is not an array', $result['error_message']);
-  }
 
   /**
    * Check with empty array.
@@ -266,14 +249,6 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
       'id' => $this->_participantPaymentID,
     ];
     $this->callAPISuccess('participant_payment', 'delete', $params);
-  }
-
-  /**
-   * Test civicrm_participant_payment_delete with wrong params type.
-   */
-  public function testPaymentDeleteWrongParamsType() {
-    $params = 'a string';
-    $this->callAPIFailure('participant_payment', 'delete', $params);
   }
 
   /**

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -646,15 +646,6 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
   ///////////////// civicrm_participant_update methods
 
   /**
-   * Test civicrm_participant_update with wrong params type.
-   */
-  public function testUpdateWrongParamsType() {
-    $params = 'a string';
-    $result = $this->callAPIFailure('participant', 'create', $params);
-    $this->assertEquals('Input variable `params` is not an array', $result['error_message']);
-  }
-
-  /**
    * Check with empty array.
    */
   public function testUpdateEmptyParams() {
@@ -719,14 +710,6 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
   }
 
   ///////////////// civicrm_participant_delete methods
-
-  /**
-   * Test civicrm_participant_delete with wrong params type.
-   */
-  public function testDeleteWrongParamsType() {
-    $params = 'a string';
-    $result = $this->callAPIFailure('participant', 'delete', $params);
-  }
 
   /**
    * Test civicrm_participant_delete with empty params.

--- a/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
@@ -91,13 +91,6 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with No array.
-   */
-  public function testPaymentProcessorTypeDeleteParamsNotArray() {
-    $result = $this->callAPIFailure('payment_processor_type', 'delete', 'string');
-  }
-
-  /**
    * Check if required fields are not passed.
    */
   public function testPaymentProcessorTypeDeleteWithoutRequired() {
@@ -139,14 +132,6 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
     $params = [];
     $result = $this->callAPIFailure('payment_processor_type', 'create', $params);
     $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: name, title, class_name, billing_mode');
-  }
-
-  /**
-   * Check with No array.
-   */
-  public function testPaymentProcessorTypeUpdateParamsNotArray() {
-    $result = $this->callAPIFailure('payment_processor_type', 'create', 'string');
-    $this->assertEquals($result['error_message'], 'Input variable `params` is not an array');
   }
 
   /**

--- a/tests/phpunit/api/v3/RelationshipTypeTest.php
+++ b/tests/phpunit/api/v3/RelationshipTypeTest.php
@@ -250,17 +250,6 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with params Not Array.
-   * @param int $version
-   * @dataProvider versionThreeAndFour
-   */
-  public function testRelationshipTypesGetParamsNotArray($version) {
-    $this->_apiversion = $version;
-
-    $results = $this->callAPIFailure('relationship_type', 'get', 'string');
-  }
-
-  /**
    * Check with valid params array.
    * @param int $version
    * @dataProvider versionThreeAndFour

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -811,21 +811,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
   /**
    * @dataProvider entities_get
-   * @param $Entity
-   */
-  public function testEmptyParam_getString($Entity) {
-
-    if (in_array($Entity, $this->toBeImplemented['get'])) {
-      // $this->markTestIncomplete("civicrm_api3_{$Entity}_get to be implemented");
-      return;
-    }
-    $result = $this->callAPIFailure($Entity, 'Get', 'string');
-    $this->assertEquals(2000, $result['error_code']);
-    $this->assertEquals('Input variable `params` is not an array', $result['error_message']);
-  }
-
-  /**
-   * @dataProvider entities_get
    * @Xdepends testEmptyParam_get // no need to test the simple if the empty doesn't work/is skipped. doesn't seem to work
    * @param $Entity
    */
@@ -1318,15 +1303,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   }
 
   /**
-   * @dataProvider entities
-   */
-  public function testCreateWrongTypeParamTag_create() {
-    $result = civicrm_api("Tag", 'Create', 'this is not a string');
-    $this->assertEquals(1, $result['is_error']);
-    $this->assertEquals("Input variable `params` is not an array", $result['error_message']);
-  }
-
-  /**
    * @dataProvider entities_updatesingle
    *
    * limitations include the problem with avoiding loops when creating test objects -
@@ -1589,15 +1565,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
    */
   public function testInvalidID_delete($Entity) {
     $result = $this->callAPIFailure($Entity, 'Delete', ['id' => 999999]);
-  }
-
-  /**
-   * @dataProvider entities
-   */
-  public function testDeleteWrongTypeParamTag_delete() {
-    $result = civicrm_api("Tag", 'Delete', 'this is not a string');
-    $this->assertEquals(1, $result['is_error']);
-    $this->assertEquals("Input variable `params` is not an array", $result['error_message']);
   }
 
   /**

--- a/tests/phpunit/api/v3/UFJoinTest.php
+++ b/tests/phpunit/api/v3/UFJoinTest.php
@@ -85,17 +85,6 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
    * @param int $version
    * @dataProvider versionThreeAndFour
    */
-  public function testUFJoinEditWrongParamsType($version) {
-    $this->_apiversion = $version;
-    $params = 'a string';
-    $result = $this->callAPIFailure('uf_join', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Input variable `params` is not an array');
-  }
-
-  /**
-   * @param int $version
-   * @dataProvider versionThreeAndFour
-   */
   public function testUFJoinEditWithoutUFGroupId($version) {
     $this->_apiversion = $version;
     $params = [

--- a/tests/phpunit/api/v3/UFMatchTest.php
+++ b/tests/phpunit/api/v3/UFMatchTest.php
@@ -76,16 +76,6 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
   }
 
   /**
-   * @param int $version
-   * @dataProvider versionThreeAndFour
-   */
-  public function testGetUFMatchIDWrongParam($version) {
-    $this->_apiversion = $version;
-    $params = 'a string';
-    $result = $this->callAPIFailure('uf_match', 'get', $params);
-  }
-
-  /**
    * Fetch uf id by contact id.
    * @param int $version
    * @dataProvider versionThreeAndFour
@@ -97,16 +87,6 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
     ];
     $result = $this->callAPIAndDocument('uf_match', 'get', $params, __FUNCTION__, __FILE__);
     $this->assertEquals($result['values'][$result['id']]['uf_id'], 42);
-  }
-
-  /**
-   * @param int $version
-   * @dataProvider versionThreeAndFour
-   */
-  public function testGetUFIDWrongParam($version) {
-    $this->_apiversion = $version;
-    $params = 'a string';
-    $result = $this->callAPIFailure('uf_match', 'get', $params);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Why not add a type declaration for API $params?

Before
----------------------------------------
There is no type declaration for API $params; if you pass in scalar you get Warning: Cannot use a scalar value as an array and then Uncaught exception: CiviCRM_API3_Exception: Input variable `params` is not an array 

After
----------------------------------------
Declare type so IDE can use it, and PHP throws earlier.