### PR TITLE
[NFC] Test fix - incorrect records created due to test set up using PartiallyPaid when no payment is made

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -231,7 +231,7 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
       'currency' => 'USD',
       'financial_type_id' => 1,
-      'contribution_status_id' => 8,
+      'contribution_status_id' => 'Pending',
       'payment_instrument_id' => 4,
       'total_amount' => 300.00,
       'fee_amount' => 0.00,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a test to use an better setup method

Before
----------------------------------------
Test creates 'partially paid' contribution with no payments

After
----------------------------------------
Test creates pending contribution with no payments

Technical Details
----------------------------------------
Part of an effort to fix tests to create valid financial entries

Comments
----------------------------------------

