### PR TITLE
dev/financial#104 Use rounding and integers to compare monetary values…

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -134,18 +134,13 @@ class CRM_Utils_Money {
 
   /**
    * Tests if two currency values are equal, taking into account the currency's
-   * precision, so that if the difference between the two values is less than
-   * one more order of magnitude for the precision, then the values are
-   * considered as equal. So, if the currency has  precision of 2 decimal
-   * points, a difference of more than 0.001 will cause the values to be
-   * considered as different. Anything less than 0.001 will be considered as
-   * equal.
+   * precision, so that the two values are compared as integers after rounding.
    *
    * Eg.
    *
-   * 1.2312 == 1.2319 with a currency precision of 2 decimal points
-   * 1.2310 != 1.2320 with a currency precision of 2 decimal points
-   * 1.3000 != 1.2000 with a currency precision of 2 decimal points
+   * 1.231 == 1.232 with a currency precision of 2 decimal points
+   * 1.234 != 1.236 with a currency precision of 2 decimal points
+   * 1.300 != 1.200 with a currency precision of 2 decimal points
    *
    * @param $value1
    * @param $value2
@@ -154,14 +149,9 @@ class CRM_Utils_Money {
    * @return bool
    */
   public static function equals($value1, $value2, $currency) {
-    $precision = 1 / pow(10, self::getCurrencyPrecision($currency) + 1);
-    $difference = self::subtractCurrencies($value1, $value2, $currency);
+    $precision = pow(10, self::getCurrencyPrecision($currency));
 
-    if (abs($difference) > $precision) {
-      return FALSE;
-    }
-
-    return TRUE;
+    return (int) round($value1 * $precision) == (int) round($value2 * $precision);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -24,12 +24,12 @@ class CRM_Utils_MoneyTest extends CiviUnitTestCase {
   public function testEquals() {
     $testValue = 0.01;
 
-    for ($i = 0; $i <= 10; $i++) {
-      $equalValues = CRM_Utils_Money::equals($testValue, $testValue + ($i * 0.0001), 'USD');
-      $this->assertTrue($equalValues);
+    for ($i = 0; $i < 10; $i++) {
+      $equalValues = CRM_Utils_Money::equals($testValue, $testValue + ($i * 0.0005), 'USD');
+      $this->assertTrue($equalValues, 'Currency - USD' . $testValue . ' is equal to USD' . ($testValue + ($i * 0.0005)));
     }
 
-    $this->assertFalse(CRM_Utils_Money::equals($testValue, $testValue + 0.001000000001, 'USD'));
+    $this->assertFalse(CRM_Utils_Money::equals($testValue + 0.004, $testValue + 0.006, 'USD'), 'Currency - USD' . ($testValue + 0.004) . ' is different to USD' . ($testValue + 0.006));
   }
 
   /**


### PR DESCRIPTION
…with precision

Overview
----------------------------------------
Replace the questionable epsilon algorithm to compare two monetary amounts with rounded int casts
Ref [dev/financial#104](https://lab.civicrm.org/dev/financial/issues/104)

The existing implementation causes issues e.g. when an external application provides, as required, a pre-rounded post-tax amount to the Order.create API and pre-tax amounts to the embedded line items.

Before
----------------------------------------
Comparing two amounts using `CRM_Utils_Money::equals` would defer to `CRM_Utils_Money::subtractCurrencies` to get a delta between the amounts, and then make sure they were within 1/1000th of a currency unit (an "epsilon" check) to verify that the amounts are indeed the same.
There's not much makes sense about this; notably, the `subtractCurrencies` function doesn't actually do what it says it does (integer subtraction with currency precision), but just juggles floats about.

After
----------------------------------------
`CRM_Utils_Money::equals` multiplies and casts both values to a precision shifted integer, and compares if equal


Comments
----------------------------------------
Also [discussed on chat.civicrm.org](https://chat.civicrm.org/civicrm/pl/q3tuwo5sxjyp3r5wxw7cnaaqoy)

Agileware Ref CIVICRM-1368