### PR TITLE
dev/core#1395 - Clear the asset builder cache when clearing cache

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1478,6 +1478,9 @@ class CRM_Utils_System {
     // reset ACL cache
     CRM_ACL_BAO_Cache::resetCache();
 
+    // clear asset builder folder
+    \Civi::service('asset_builder')->clear(FALSE);
+
     // reset various static arrays used here
     CRM_Contact_BAO_Contact::$_importableFields = CRM_Contact_BAO_Contact::$_exportableFields
       = CRM_Contribute_BAO_Contribution::$_importableFields

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -226,9 +226,11 @@ class AssetBuilder {
 
   /**
    * Clear out any cache files.
+   *
+   * @param bool $removeDir Should folder itself be removed too.
    */
-  public function clear() {
-    \CRM_Utils_File::cleanDir($this->getCachePath());
+  public function clear($removeDir = TRUE) {
+    \CRM_Utils_File::cleanDir($this->getCachePath(), $removeDir);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -250,4 +250,34 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
     $this->assertTrue(CRM_Utils_System::isNull($arr));
   }
 
+  /**
+   * Test that flushing cache clears the asset cache.
+   */
+  public function testFlushCacheClearsAssetCache() {
+    // We need to get the file path for the folder and there isn't a public
+    // method to get it, so create a file in the folder using public methods,
+    // then get the path from that, then flush the cache, then check if the
+    // folder is empty.
+    \Civi::dispatcher()->addListener('hook_civicrm_buildAsset', array($this, 'flushCacheClearsAssetCache_buildAsset'));
+    $fakeFile = \Civi::service("asset_builder")->getPath('fakeFile.json');
+
+    CRM_Utils_System::flushCache();
+
+    $fileList = scandir(dirname($fakeFile));
+    // count should be 2, just the standard . and ..
+    $this->assertCount(2, $fileList);
+  }
+
+  /**
+   * Implementation of a hook for civicrm_buildAsset() for testFlushCacheClearsAssetCache.
+   * Awkward wording of above sentence is because phpcs is bugging me about it.
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public function flushCacheClearsAssetCache_buildAsset(\Civi\Core\Event\GenericHookEvent $e) {
+    if ($e->asset === 'fakeFile.json') {
+      $e->mimeType = 'application/json';
+      $e->content = '{}';
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1395
When you clear civi cache e.g. via administer - system settings - cleanup caches, the "dyn" folder doesn't get cleared. It never seems to get cleared.

Technical Details
----------------------------------------
There's a function AssetBuilder::clear() available but doesn't seem to be used anywhere. This patch uses it during system flushCache. The addition of the $removeDir parameter isn't strictly necessary but avoids a seemingly out of place info message "Removed directory XXX" that pops up.

Comments
----------------------------------------
ping @tunbola 