### PR TITLE
dev/mem#17 - Deleting memberships does not delete its related line item

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -641,6 +641,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       CRM_Activity_BAO_Activity::deleteActivity($params);
     }
     self::deleteMembershipPayment($membershipId, $preserveContrib);
+    CRM_Price_BAO_LineItem::deleteLineItems($membershipId, 'civicrm_membership');
 
     $results = $membership->delete();
     $transaction->commit();
@@ -2227,7 +2228,7 @@ WHERE      civicrm_membership.is_test = 0
       self::processOverriddenUntilDateMembership($dao1);
     }
 
-    $query = $baseQuery . " AND (civicrm_membership.is_override = 0 OR civicrm_membership.is_override IS NULL) 
+    $query = $baseQuery . " AND (civicrm_membership.is_override = 0 OR civicrm_membership.is_override IS NULL)
      AND civicrm_membership.status_id NOT IN (%1, %2, %3, %4)
      AND civicrm_membership.owner_membership_id IS NULL ";
     $params = [

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -291,6 +291,9 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $this->assertDBNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for deleted membership.'
     );
+    $this->assertDBNull('CRM_Price_BAO_LineItem', $membershipId, 'id',
+      'entity_id', 'Database check for deleted line item.'
+    );
     $this->contactDelete($contactId);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Deleting membership does not delete its related line item.

Before
----------------------------------------
To replicate -

- Create a membership.
- A new row is inserted in `civicrm_line_item`.
- Delete the membership from civicrm.
- The line item row remains as it is and is never removed from the database.

After
----------------------------------------
Line Item is deleted after related membership deletion. 

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/membership/issues/17