### PR TITLE
core#1398: Option to open navigation item in new window (if present)

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -471,7 +471,7 @@
   }
 
   function attr(el, item) {
-    var ret = [], attr = _.cloneDeep(item.attr || {}), a = ['rel', 'accesskey'];
+    var ret = [], attr = _.cloneDeep(item.attr || {}), a = ['rel', 'accesskey', 'target'];
     if (el === 'a') {
       attr = _.pick(attr, a);
       attr.href = item.url || "#";


### PR DESCRIPTION
Overview
----------------------------------------
Currently, the ```target``` attribute of submenus are ignored whereas the menu item adds this property in the anchor links [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/Navigation.php#L443)

Before
----------------------------------------
The ```target``` attribute was ignored even if added using navigationMenu hook

After
----------------------------------------
The ```target``` atrribute is not ignored for (existing/new) sub-menu items 


Comments
----------------------------------------
ping @colemanw @lcdservices @eileenmcnaughton 