### PR TITLE
dev/core#1399 Fixing 'DB Error: no such field' when doing export with…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1187,7 +1187,10 @@ class CRM_Contact_BAO_Query {
               $this->_select["{$tName}_id"] = "{$aName}.{$pf}_id as `{$tName}_id`";
             }
             else {
-              $this->_select["{$tName}_id"] = "`$tName`.id as `{$tName}_id`";
+              // custom table on address are special and treated after -- see https://lab.civicrm.org/dev/core/issues/1399
+              if (empty($field['custom_field_id']) || !array_key_exists($field['custom_field_id'], $addressCustomFieldIds)) {
+                $this->_select["{$tName}_id"] = "`$tName`.id as `{$tName}_id`";
+              }
             }
 
             $this->_element["{$tName}_id"] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
When doing export with a custom field on address, i get `DB Error: no such field`

Reproduction steps
----------------------------------------
1. Create a custom field on address
1. Search for contacts
1. Action `Export Contact`
1. Use `Select fields for export` and add the custom field on address
1. Click `Continue` -> `DB Error: no such field`

Current behaviour
----------------------------------------
`DB Error: no such field`

The field that doesn't exist is : 
```
`Home-value_validit_de_l_adresse_postale_41`.id as `Home-value_validit_de_l_adresse_postale_41_id`
```

See [dev/core#1399](https://lab.civicrm.org/dev/core/issues/1399) for more details