### PR TITLE
[REF] Convert CRM_Core_Error::fatal to CRM_Core_Error::statusBounce i…

### DIFF
--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -71,7 +71,7 @@ class CRM_Extension_Downloader {
 
     if (empty($errors) && !CRM_Utils_HttpClient::singleton()->isRedirectSupported()) {
       CRM_Core_Session::setStatus(ts('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.'));
-      CRM_Core_Error::debug_log_message('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.');
+      Civi::log()->debug('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.');
     }
 
     if ($extensionInfo) {
@@ -105,7 +105,7 @@ class CRM_Extension_Downloader {
     $destDir = $this->containerDir . DIRECTORY_SEPARATOR . $key;
 
     if (!$downloadUrl) {
-      CRM_Core_Error::fatal(ts('Cannot install this extension - downloadUrl is not set!'));
+      throw new CRM_Extension_Exception(ts('Cannot install this extension - downloadUrl is not set!'));
     }
 
     if (!$this->fetch($downloadUrl, $filename)) {
@@ -196,6 +196,7 @@ class CRM_Extension_Downloader {
    * @param $extractedZipPath
    *
    * @return bool
+   * @throws CRM_Core_Exception
    */
   public function validateFiles($key, $extractedZipPath) {
     $filename = $extractedZipPath . DIRECTORY_SEPARATOR . CRM_Extension_Info::FILENAME;
@@ -213,7 +214,7 @@ class CRM_Extension_Downloader {
     }
 
     if ($newInfo->key != $key) {
-      CRM_Core_Error::fatal(ts('Cannot install - there are differences between extdir XML file and archive XML file!'));
+      throw new CRM_Core_Exception(ts('Cannot install - there are differences between extdir XML file and archive XML file!'));
     }
 
     return TRUE;

--- a/CRM/Extension/Manager/Payment.php
+++ b/CRM/Extension/Manager/Payment.php
@@ -34,17 +34,18 @@ class CRM_Extension_Manager_Payment extends CRM_Extension_Manager_Base {
    * @inheritDoc
    *
    * @param CRM_Extension_Info $info
+   * @throws CRM_Core_Exception
    */
   public function onPreInstall(CRM_Extension_Info $info) {
     $paymentProcessorTypes = $this->_getAllPaymentProcessorTypes('class_name');
 
     if (array_key_exists($info->key, $paymentProcessorTypes)) {
-      CRM_Core_Error::fatal(ts('This payment processor type is already installed.'));
+      throw new CRM_Core_Exception(ts('This payment processor type is already installed.'));
     }
 
     $ppByName = $this->_getAllPaymentProcessorTypes('name');
     if (array_key_exists($info->name, $ppByName)) {
-      CRM_Core_Error::fatal(ts('This payment processor type already exists.'));
+      throw new CRM_Core_Exception(ts('This payment processor type already exists.'));
     }
 
     $dao = new CRM_Financial_DAO_PaymentProcessorType();
@@ -82,7 +83,7 @@ class CRM_Extension_Manager_Payment extends CRM_Extension_Manager_Base {
         break;
 
       default:
-        CRM_Core_Error::fatal(ts('Billing mode in info file has wrong value.'));
+        throw new CRM_Core_Exception(ts('Billing mode in info file has wrong value.'));
     }
 
     $dao->is_recur = trim($info->typeInfo['isRecur']);

--- a/CRM/Extension/Manager/Report.php
+++ b/CRM/Extension/Manager/Report.php
@@ -32,12 +32,12 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
   /**
    * @param CRM_Extension_Info $info
    *
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   public function onPreInstall(CRM_Extension_Info $info) {
     $customReports = $this->getCustomReportsByName();
     if (array_key_exists($info->key, $customReports)) {
-      CRM_Core_Error::fatal(ts('This report is already registered.'));
+      throw new CRM_Core_Exception(ts('This report is already registered.'));
     }
 
     if ($info->typeInfo['component'] === 'Contact') {
@@ -48,7 +48,7 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
       $compId = $comp->componentID;
     }
     if (empty($compId)) {
-      CRM_Core_Error::fatal(ts('Component for which you are trying to install the extension (%1) is currently disabled.', [1 => $info->typeInfo['component']]));
+      throw new CRM_Core_Exception(ts('Component for which you are trying to install the extension (%1) is currently disabled.', [1 => $info->typeInfo['component']]));
     }
     $weight = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_OptionValue',
       ['option_group_id' => $this->groupId]
@@ -74,11 +74,6 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
    * @return bool
    */
   public function onPreUninstall(CRM_Extension_Info $info) {
-
-    //        if( !array_key_exists( $info->key, $this->customReports ) ) {
-    //            CRM_Core_Error::fatal( 'This report is not registered.' );
-    //        }
-
     $customReports = $this->getCustomReportsByName();
     $cr = $this->getCustomReportsById();
     $id = $cr[$customReports[$info->key]];

--- a/CRM/Extension/Manager/Search.php
+++ b/CRM/Extension/Manager/Search.php
@@ -33,12 +33,12 @@ class CRM_Extension_Manager_Search extends CRM_Extension_Manager_Base {
    * @param CRM_Extension_Info $info
    *
    * @return bool
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   public function onPreInstall(CRM_Extension_Info $info) {
     $customSearchesByName = $this->getCustomSearchesByName();
     if (array_key_exists($info->key, $customSearchesByName)) {
-      CRM_Core_Error::fatal(ts('This custom search is already registered.'));
+      throw new CRM_Core_Exception(ts('This custom search is already registered.'));
     }
 
     $weight = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_OptionValue',


### PR DESCRIPTION
…n Extension folder

Overview
----------------------------------------
This converts from deprecated function `CRM_Core_Error::fatal` to using `CRM_Core_Error::statusBounce`

Before
----------------------------------------
Deprecated function used in the Extensions subsystem

After
----------------------------------------
Non depreacted function used

ping @yashodha @eileenmcnaughton 