### PR TITLE
[NFC] fix test to correctly set up partially paid contribution

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -867,6 +867,9 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   /**
    * Test if membership is updated to New after contribution
    * is updated from Partially paid to Completed.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testSubmitUpdateMembershipFromPartiallyPaid() {
     $memStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'validate');
@@ -878,15 +881,14 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccessGetSingle('MembershipPayment', [
       'membership_id' => $membership['id'],
     ]);
-
-    //Update contribution to Partially paid.
-    $prevContribution = $this->callAPISuccess('Contribution', 'create', [
-      'id' => $contribution['contribution_id'],
-      'contribution_status_id' => 'Partially paid',
+    $prevContribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contribution['id']]);
+    $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $contribution['contribution_id'],
+      'payment_instrument_id' => 'Cash',
+      'total_amount' => 5,
     ]);
-    $prevContribution = $prevContribution['values'][1];
 
-    //Complete the contribution from offline form.
+    // Complete the contribution from offline form.
     $form = new CRM_Contribute_Form_Contribution();
     $submitParams = [
       'id' => $contribution['contribution_id'],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a test to not set up a partially paid payment in a way that does not create valid entries

Before
----------------------------------------
Passes contribution_status_id = 'Partially paid' - resulting in invalid financial data

After
----------------------------------------
Uses Payment.create

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
Towards deprecating this fault code path
https://github.com/civicrm/civicrm-core/pull/15855