### PR TITLE
[REF] Minor simplifcation on initSet

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -343,7 +343,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
       // get price info
       // CRM-5095
-      CRM_Price_BAO_PriceSet::initSet($this, $this->_id, 'civicrm_contribution_page');
+      $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id);
+      CRM_Price_BAO_PriceSet::initSet($this, 'civicrm_contribution_page', FALSE, $priceSetId);
 
       // this avoids getting E_NOTICE errors in php
       $setNullFields = [

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -621,10 +621,11 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     if ($discountId) {
       $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_Discount', $discountId, 'price_set_id');
-      $price = CRM_Price_BAO_PriceSet::initSet($form, $eventID, 'civicrm_event', $getAllPriceField, $priceSetId);
+      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $getAllPriceField, $priceSetId);
     }
     else {
-      $price = CRM_Price_BAO_PriceSet::initSet($form, $eventID, 'civicrm_event', $getAllPriceField);
+      $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $eventID);
+      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $getAllPriceField, $priceSetId);
     }
 
     if (property_exists($form, '_context') && ($form->_context == 'standalone'

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -555,19 +555,13 @@ WHERE  id = %1";
    * This function is not really a BAO function so the location is misleading.
    *
    * @param CRM_Core_Form $form
-   * @param int $id
    *   Form entity id.
    * @param string $entityTable
    * @param bool $validOnly
    * @param int $priceSetId
    *   Price Set ID
-   *
-   * @return bool|false|int|null
    */
-  public static function initSet(&$form, $id, $entityTable = 'civicrm_event', $validOnly = FALSE, $priceSetId = NULL) {
-    if (!$priceSetId) {
-      $priceSetId = self::getFor($entityTable, $id);
-    }
+  public static function initSet(&$form, $entityTable = 'civicrm_event', $validOnly = FALSE, $priceSetId = NULL) {
 
     //check if price set is is_config
     if (is_numeric($priceSetId)) {
@@ -650,10 +644,7 @@ WHERE  id = %1";
       }
       $form->set('priceSetId', $form->_priceSetId);
       $form->set('priceSet', $form->_priceSet);
-
-      return $priceSetId;
     }
-    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Instead of passing the information to calculate the priceSetID into this function it's more helpful
to calculate it first & pass it in - this determination makes more sense on the calling form

Before
----------------------------------------
InitSet requires the entity name & id & then does a one line call to get the price set id, if not passed in

After
----------------------------------------
Calling functions get the priceSet ID & don't pass in the id to retrieve it. Never-used-priceset id value no longer returned

Technical Details
----------------------------------------
This function is shared from 3 places but when it comes down to it it probably doesn't have enough shared code to justify it's existence - at least not in it's current form.

Comments
----------------------------------------

