### PR TITLE
Fix Sybunt to select mark rows as selected

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -193,7 +193,7 @@ ORDER BY   donation_amount desc
 
     if ($justIDs) {
       $tempTable = CRM_Utils_SQL_TempTable::build()->createWithQuery($sql);
-      $sql = "SELECT contact_a.id as contact_id FROM {$tempTable->getName()} as contact_a";
+      $sql = "SELECT contact_a.id as contact_id FROM {$tempTable->getName()} c INNER JOIN civicrm_contact contact_a ON c.id = contact_a.id";
     }
     return $sql;
   }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1052,6 +1052,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
         $this->rebuildPreNextCache($start, $end, $sort, $cacheKey);
       }
       else {
+        CRM_Core_Error::deprecatedFunctionWarning('Custom searches should return sql capable of filling the prevnext cache.');
         // This will always show for CiviRules :-( as a) it orders by 'rule_label'
         // which is not available in the query & b) it uses contact not contact_a
         // as an alias.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a probably-not-that-recent bug where sybunt custom search does not permit contacts to be marked as selected

Before
----------------------------------------
Doing a Sybunt custom search & then selecting rows does not increment the 'selected' value

After
----------------------------------------
The selected value is incremented

Technical Details
----------------------------------------
With sort_name being retrievable the prevnext cache fails to fill. This is quietly caught - I also changed it to be more noisily caught

Comments
----------------------------------------
@seamuslee001 found while checking https://github.com/civicrm/civicrm-core/pull/15820 n& https://lab.civicrm.org/dev/core/issues/1377
