### PR TITLE
dev/core#1377 Fix bug where search action doesn't work.

### DIFF
--- a/templates/CRM/Contact/Form/Search/ResultTasks.tpl
+++ b/templates/CRM/Contact/Form/Search/ResultTasks.tpl
@@ -83,12 +83,15 @@
         {$form.task.html}
      {/if}
      {if $action eq 512}
-       {$form._qf_Advanced_next_action.html}
+       {$form.$actionButtonName.html}
      {elseif $action eq 8192}
+       {* todo - just use action button name per above  - test *}
        {$form._qf_Builder_next_action.html}&nbsp;&nbsp;
      {elseif $action eq 16384}
+       {* todo - just use action button name per above - test *}
        {$form._qf_Custom_next_action.html}&nbsp;&nbsp;
      {else}
+       {* todo - just use action button name per above  - test *}
        {$form._qf_Basic_next_action.html}
      {/if}
      </td>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression where the search actions are not working on the contributionAggregate custom search


Before
----------------------------------------
Clicking on actions from Contribution Aggregate search doesn't work

After
----------------------------------------
Works again

Technical Details
----------------------------------------
The call to ```    $form->addFormFieldsFromMetadata();``` is setting the form action to 'advanced' - I tried just resetting it afterwards but for reasons I couldn't work out it was not enough. However,  when I went into the tpl this action was being used to determine the actionButtonName - which was separately assigned - so I switched to that in the relevant part

Comments
----------------------------------------
Since this is against the rc I only changed one part of thee IF & commented the others.