### PR TITLE
Remove nbsp from UserDashboard Event section

### DIFF
--- a/templates/CRM/Event/Page/UserDashboard.tpl
+++ b/templates/CRM/Event/Page/UserDashboard.tpl
@@ -50,9 +50,8 @@
         {/strip}
     {else}
         <div class="messages status no-popup">
-           <div class="icon inform-icon"></div>&nbsp;
-                 {ts}You are not registered for any current or upcoming Events.{/ts}
-
+           <div class="icon inform-icon"></div>
+           {ts}You are not registered for any current or upcoming Events.{/ts}
         </div>
     {/if}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

On the Contact Dashboard, under the event section, there is a space (nbsp) that should not be there. Other sections do not have it, so the text does not align correctly.

To reproduce:

- Login to the demo site: https://dmaster.demo.civicrm.org
- Go here: https://dmaster.demo.civicrm.org/civicrm/user?reset=1&id=203&cid=203

Before
----------------------------------------

See how under "Vos évènements" is not aligned correctly:

![Capture d’écran de 2019-11-18 15-59-34](https://user-images.githubusercontent.com/254741/69093494-8aaa4c80-0a1c-11ea-8a59-5d9db58e0805.png)

It's more visible because I am hiding the "info" icons. On the demo site, it is less visible, but we can still see it:

![Capture d’écran de 2019-11-18 16-03-00](https://user-images.githubusercontent.com/254741/69093713-ff7d8680-0a1c-11ea-90f3-002b814ec33d.png)

After
----------------------------------------

![Capture d’écran de 2019-11-18 16-00-44](https://user-images.githubusercontent.com/254741/69093517-985fd200-0a1c-11ea-9a2b-a3b101b67250.png)

Technical Details
----------------------------------------

There was an `&nbsp;` in the template. It seems to have been there since the dawn of time (SVN import). Other templates do not have it. 