### PR TITLE
dev/core#1366 - Make case activity audit print report work again

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -177,13 +177,6 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
       $map[$aType['id']] = $aType;
     }
 
-    // get all core activities
-    $coreActivityTypes = CRM_Case_PseudoConstant::caseActivityType(FALSE, TRUE);
-
-    foreach ($coreActivityTypes as $aType) {
-      $map[$aType['id']] = $aType;
-    }
-
     $activityTypeIDs = implode(',', array_keys($map));
     $query = "
 SELECT a.*, c.id as caseID
@@ -776,7 +769,7 @@ LIMIT  1
       $activityTypes = $form->getActivityTypes($xml, $activitySetName);
     }
     else {
-      $activityTypes = CRM_Case_XMLProcessor::allActivityTypes();
+      $activityTypes = CRM_Case_XMLProcessor::allActivityTypes(FALSE, TRUE);
     }
 
     if (!$activityTypes) {

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -103,7 +103,7 @@
     <div>
       <p>
         {if $hasAccessToAllCases}
-          <a class="crm-hover-button action-item no-popup" href="{crmURL p='civicrm/case/report/print' q="all=1&redact=0&cid=$contactID&caseID=$caseId&asn=standard_timeline"}"><i class="crm-i fa-print"></i> {ts}Print Report{/ts}</a>
+          <a class="crm-hover-button action-item no-popup" href="{crmURL p='civicrm/case/report/print' q="all=1&redact=0&cid=$contactID&caseID=$caseId&asn="}"><i class="crm-i fa-print"></i> {ts}Print Report{/ts}</a>
         {/if}
 
         {if !empty($exportDoc)}


### PR DESCRIPTION
Overview
----------------------------------------
There is a print report link on manage case and an activity audit report dropdown on manage case. Internally the print report is implemented via the activity audit report which predates the print report. When the print report button was implemented it got implemented in a way that broke the intent of the audit report, likely because there was no real documentation for the audit report other than some hidden wiki project planning notes (my fault), combined with the fact that originally in civicase you couldn't include non-case activity types like Meeting on a case, so when that became possible there was a "flaw" in the audit report output which likely caused further confusion about what it was supposed to do.

What it's supposed to do is present you with a choice of activity set (timeline) to run against, and then use that choice when generating the output. It's currently overriding the selected choice and including all the activities on the case, so is really no different at the moment from the print report (which itself is actually giving the correct output even though the implementation isn't quite right).

There's more but that's all this PR addresses. See comments below for proposed next steps.

Before
----------------------------------------
Audit report including activities it's not supposed to.

After
----------------------------------------
Audit report includes only activities in the chosen activity set.

Technical Details
----------------------------------------
The unit test is in PR https://github.com/civicrm/civicrm-core/pull/15877 and what it's currently failing on against the current master is that when you choose to run an audit report on standard_timeline it's incorrectly including a Meeting activity that isn't in the standard timeline.

Note that

`CRM_Case_XMLProcessor::allActivityTypes($indexName = TRUE, $all = FALSE)`

is just an alias for

`CRM_Case_PseudoConstant::caseActivityType($indexName = TRUE, $all = FALSE)`

and so are the same function, with the same parameters. So the deleted block in Report.php that calls the PseudoConstant does the exact same thing as the change in line 779 that calls the other function, but in a different place, i.e. it now does it only when there is no Activity Set chosen, instead of always doing it regardless of what you chose.

Then the change in the .tpl doesn't change the output of the print report from current but makes it do the proper thing by not specifying an activity set. The earlier introduction of specifying "standard_timeline" to mean "everything" I assume was caused by the confusion mentioned in Overview.

So to test this, you need a case type with at least one timeline, and the activity types defined in the case type need to include at least one type that isn't in the timeline. So for example take a stock case type and add "Meeting" as an available activity type on the activity types tab. Then create a case and add a Meeting activity to the case.

Then if you click Print Report, it will include all the activities on the case including Meeting. If you click on Activity Audit and choose standard timeline, then click the audit's own print report button on the resulting screen, it will only include the activities in the standard timeline, i.e. not Meeting.

Comments
----------------------------------------
For future steps: The on-screen *interactive* version of the audit report that you get before getting the print button for the audit report has been broken since 2015 when the supporting javascript file was deleted and so nothing on that screen works. Since then obviously nobody is using it, the next two proposed steps are to bypass that screen and go straight to the audit print report when you choose to do an activity audit, and then at some future time remove all the code related to the on-screen javascripty page.
