### PR TITLE
Related / Inherited Memberships: Custom fields not filled with data

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1407,8 +1407,10 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
       unset($params['reminder_date']);
       // unset the custom value ids
       if (is_array(CRM_Utils_Array::value('custom', $params))) {
-        foreach ($params['custom'] as $k => $v) {
-          unset($params['custom'][$k]['id']);
+        foreach ($params['custom'] as $k => $values) {
+          foreach ($values as $i => $value) {
+            unset($params['custom'][$k][$i]['id']);
+          }
         }
       }
       if (!isset($params['membership_type_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
In CiviCRM, a membership can be for a group of contacts that are connected by relationships. For example a household, or cooperation. One of them has a master membership. The membership of the others is derived from the master membership. Any change in the master membership must be copied to the other memberships. Unfortunately, this does not for custom fields. This issue is described on https://lab.civicrm.org/dev/core/issues/1365

Before
----------------------------------------
On updating the custom fields of the master membership are changed in the update, the others are left behind.

After
----------------------------------------
The custom fields of every membership follow the master, as expected.

Technical Details
----------------------------------------
In the code, there is an effort to do all the custom fields. Part of the strategy was to unset the technical keys of the custom field. But the custom field was stored in an array instead of a single value. So that is corrected.