### PR TITLE
dev/core#1384 Fix Joomla! bootstrap to support windows directory separator

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -562,7 +562,9 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     if (!defined('_JEXEC') && $loadDefines) {
       define('_JEXEC', 1);
       define('DS', DIRECTORY_SEPARATOR);
-      define('JPATH_BASE', $joomlaBase . '/administrator');
+      // dev/core#1384 - Replace / by Ds to ensure correct value of JPATH_BASE in the
+      // Windows environment
+      define('JPATH_BASE', $joomlaBase . DS. 'administrator'); // to make sure we analyse correctly in the Windows environment
       require $joomlaBase . '/administrator/includes/defines.php';
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix Joomla! bootstrap to support windows directory separator

Before
----------------------------------------
 public function loadBootStrap($params = [], $loadUser = TRUE, $throwError = TRUE, $realPath = NULL, $loadDefines = TRUE) {
    $joomlaBase = self::getBasePath();

    // load BootStrap here if needed
    // We are a valid Joomla entry point.
    if (!defined('_JEXEC') && $loadDefines) {
      define('_JEXEC', 1);
      define('DS', DIRECTORY_SEPARATOR);
      define('JPATH_BASE', $joomlaBase . '/administrator');
      require $joomlaBase . '/administrator/includes/defines.php';
    }

After
----------------------------------------
public function loadBootStrap($params = [], $loadUser = TRUE, $throwError = TRUE, $realPath = NULL, $loadDefines = TRUE) {
    $joomlaBase = self::getBasePath();

    // load BootStrap here if needed
    // We are a valid Joomla entry point.
    if (!defined('_JEXEC') && $loadDefines) {
      define('_JEXEC', 1);
      define('DS', DIRECTORY_SEPARATOR);
      // dev/core#1384 - Replace / by Ds to ensure correct value of JPATH_BASE in the
      // Windows environment
      define('JPATH_BASE', $joomlaBase . DS. 'administrator'); // to make sure we analyse correctly in the Windows environment
      require $joomlaBase . '/administrator/includes/defines.php';
    }
Technical Details
----------------------------------------
Routines parsing JPATH_BASE assume the directory separator, so, without it, they miss virtual directories, e.g.
<Joomla base>\subdir/administrator translate to <joomla base> and the subdirectory gets forgotten,
Comments
----------------------------------------
_Anything else you would like the reviewer to note_
Unable to test this using the master branch, as some files come across corrupt.