### PR TITLE
dev/core#1406 Ensure that we use the CRM_Member_DAO_Membership as dao…

### DIFF
--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -64,7 +64,7 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
   public function __construct() {
     $this->_columns = [
       'civicrm_membership' => [
-        'dao' => 'CRM_Member_DAO_MembershipType',
+        'dao' => 'CRM_Member_DAO_Membership',
         'grouping' => 'member-fields',
         'fields' => [
           'membership_type_id' => [


### PR DESCRIPTION
… for the civicrm_membership table

Overview
----------------------------------------
Fixes a problem with the Membership Summary report where you can't filter by membership since field

Before
----------------------------------------
DB Error generated when trying to filter the membership summary report

After
----------------------------------------
No DB error

ping @KarinG @eileenmcnaughton @demeritcowboy 