### PR TITLE
Enforce isSkipLineItem for membership payment entity in Order.create

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -138,6 +138,9 @@ function civicrm_api3_order_create($params) {
       if ($entity == 'pledge') {
         $paymentParams += $entityParams;
       }
+      elseif ($entity == 'membership') {
+        $paymentParams['isSkipLineItem'] = TRUE;
+      }
       $payments = civicrm_api3($entity . '_payment', 'create', $paymentParams);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Enforce `isSkipLineItem` for membership payment entity in the `Order.create` API to prevent error on line item update. The line items are already _correctly_ created by the time the membership payment is created so there's no need to update. 

Before
----------------------------------------
Creating an Order with two or more memberships (and using a Price field with a membership type set) will trigger an error when creating the `MembershipPayment` entity.
```
DB Error: already exists

UPDATE civicrm_line_item li
LEFT JOIN civicrm_price_field_value pv ON pv.id = li.price_field_value_id
SET entity_table = 'civicrm_membership', entity_id = 898
WHERE pv.membership_type_id = 3
AND contribution_id = 1493 [nativecode=1062 ** Duplicate entry 'civicrm_membership-898-1493-196-114' for key 'UI_line_item_value']
```

After
----------------------------------------
No errors, contribution is processed correctly.

Technical Details
----------------------------------------


Comments
----------------------------------------
I believe `isSkipLineItem` was introduced fairly recently, but I could not find a reference to an issue/conversation.
