### PR TITLE
(NFC) api_v3_ExtensionTest - Fix when executing on build with 25+ extensions

### DIFF
--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -70,7 +70,7 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
    * CRM-20532
    */
   public function testExtensionGet() {
-    $result = $this->callAPISuccess('extension', 'get', []);
+    $result = $this->callAPISuccess('extension', 'get', ['options' => ['limit' => 0]]);
     $testExtensionResult = $this->callAPISuccess('extension', 'get', ['key' => 'test.extension.manager.paymenttest']);
     $this->assertNotNull($result['values'][$testExtensionResult['id']]['typeInfo']);
     $this->assertTrue($result['count'] >= 6);
@@ -80,8 +80,8 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
    * Filtering by status=installed or status=uninstalled should produce different results.
    */
   public function testExtensionGetByStatus() {
-    $installed = $this->callAPISuccess('extension', 'get', ['status' => 'installed']);
-    $uninstalled = $this->callAPISuccess('extension', 'get', ['status' => 'uninstalled']);
+    $installed = $this->callAPISuccess('extension', 'get', ['status' => 'installed', 'options' => ['limit' => 0]]);
+    $uninstalled = $this->callAPISuccess('extension', 'get', ['status' => 'uninstalled', 'options' => ['limit' => 0]]);
 
     // If the filter works, then results should be strictly independent.
     $this->assertEquals(
@@ -92,7 +92,7 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
       )
     );
 
-    $all = $this->callAPISuccess('extension', 'get', []);
+    $all = $this->callAPISuccess('extension', 'get', ['options' => ['limit' => 0]]);
     $this->assertEquals($all['count'], $installed['count'] + $uninstalled['count']);
   }
 


### PR DESCRIPTION
Overview
--------

This fixes a small issue with running the test locally.

Before
------

If the system has code for 25+ extensions (whether enabled or not), `api_v3_ExtensionTest` fails.

After
-----

The number of extensions doesn't matter.

Comment
----------

Marked as NFC because it only affects a unit-test and doesn't change the semantics of the test.