### PR TITLE
Fix ambiguous column in search with ORDER BY

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6477,7 +6477,10 @@ AND   displayRelType.is_active = 1
           // Pretty sure this validation ALSO happens in the order clause & this can't be reached but...
           // this might give some early warning.
           CRM_Utils_Type::validate($fieldIDsInOrder, 'CommaSeparatedIntegers');
-          $order = str_replace("$field", "field({$fieldSpec['name']},$fieldIDsInOrder)", $order);
+          // use where if it's set to fully qualify ambiguous column names
+          // i.e. civicrm_contribution.contribution_status_id instead of contribution_status_id
+          $pseudoColumnName = $fieldSpec['where'] ?? $fieldSpec['name'];
+          $order = str_replace("$field", "field($pseudoColumnName,$fieldIDsInOrder)", $order);
         }
         //CRM-12565 add "`" around $field if it is a pseudo constant
         // This appears to be for 'special' fields like locations with appended numbers or hyphens .. maybe.


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where columns whose names are not unique in a search query cause a DB error when they're used as a sort column. The issue can be observed in the contribution search when sorting by contribution status.

Before
----------------------------------------
Contribution search fails with a DB error when sorting results by contribution status.

After
----------------------------------------
Contribution search can be sorted by contribution status.

Technical Details
----------------------------------------
The issue is resolved by using the where field of the field spec, which holds the fully-qualified name of the column.

Comments
----------------------------------------
I initially thought about fixing this by adding a special case for `contribution_status_id` somewhere, but then figured this would fix the general case. The downside is that it changes something quite central in `CRM_Contact_BAO_Query`, so I'm having a hard time deciding on the trade-off.