### PR TITLE
[REF] remove another unnecessary pass-by-reference

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -72,18 +72,18 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function recur(&$input, &$ids, &$objects, $first) {
+  public function recur($input, $ids, $objects, $first) {
     if (!isset($input['txnType'])) {
       Civi::log()->debug('PayPalIPN: Could not find txn_type in input request');
       echo "Failure: Invalid parameters<p>";
       return;
     }
 
-    if ($input['txnType'] == 'subscr_payment' &&
-      $input['paymentStatus'] != 'Completed'
+    if ($input['txnType'] === 'subscr_payment' &&
+      $input['paymentStatus'] !== 'Completed'
     ) {
       Civi::log()->debug('PayPalIPN: Ignore all IPN payments that are not completed');
-      echo "Failure: Invalid parameters<p>";
+      echo 'Failure: Invalid parameters<p>';
       return;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup - do not unnecessarily pass variables by reference as it makes it hard to understand what is happening

Before
----------------------------------------
Input variables for PaypalIPN passed by reference

After
----------------------------------------
Input variables for PaypalIPN not passed by reference

Technical Details
----------------------------------------
The recur function is only called once. Immediately after it is called there is a return &
the calling function has not passed in any variables by reference - ergo we gain nothing but confusion by using pass-by-ref here

Comments
----------------------------------------

Also a couple of tidy ups on the following lines where strings should use strict comparisons & single quotes