### PR TITLE
Move greeting handling up as it is not paymentValidation dependent

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -869,6 +869,16 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         ]);
       }
     }
+    foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
+      if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {
+        $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greeting . '_id', 'Customized');
+        if ($customizedValue == $greetingType && empty($fields[$greeting . '_custom'])) {
+          $errors[$greeting . '_custom'] = ts('Custom %1 is a required field if %1 is of type Customized.',
+            [1 => ucwords(str_replace('_', ' ', $greeting))]
+          );
+        }
+      }
+    }
 
     // @todo - can we remove the 'is_monetary' concept?
     if ($form->_values['event']['is_monetary']) {
@@ -895,16 +905,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       );
     }
 
-    foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
-      if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {
-        $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greeting . '_id', 'Customized');
-        if ($customizedValue == $greetingType && empty($fields[$greeting . '_custom'])) {
-          $errors[$greeting . '_custom'] = ts('Custom %1 is a required field if %1 is of type Customized.',
-            [1 => ucwords(str_replace('_', ' ', $greeting))]
-          );
-        }
-      }
-    }
     return empty($errors) ? TRUE : $errors;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Re-orders validation rules on the event registration form so that the validation for greetings is not after the early return

Before
----------------------------------------
Validation of greetings is at the end - for zero amount submissions it is never reached

After
----------------------------------------
Validation is before the early return statement

Technical Details
----------------------------------------
This is more logical & helps with other code fixes. However, I could be talked into just removing the validation. If feels like something that could be somewhat easily misconfigured & missing the custom value would be less bad than losing the form submission

Comments
----------------------------------------
