### PR TITLE
Fix CRM_Contribute_BAO_ContributionTest to no longer use unreliable legacy set up method

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4841,12 +4841,16 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   }
 
   /**
-   * Function to add payments for contribution
-   * for Partially Paid status
+   * Function to add payments for contribution for Partially Paid status
+   *
+   * @deprecated this is known to be flawed and possibly buggy.
+   *
+   * Replace with Order.create->Payment.create flow.
    *
    * @param array $contributions
    * @param string $contributionStatusId
    *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function addPayments($contributions, $contributionStatusId = NULL) {
     // get financial trxn which is a payment

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -98,6 +98,8 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
    * Clean up after each test.
    */
   public function tearDown() {
+    $this->validateAllPayments();
+    $this->validateAllContributions();
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(
       [

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1042,6 +1042,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param array $params
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function eventCreatePaid($params) {
     $event = $this->eventCreate($params);


### PR DESCRIPTION
Overview
----------------------------------------
Improvement to test class to not use (buggy & deprecated) partial_amount_to_pay params & use Order.create + Payment,create

Before
----------------------------------------
Bad method called to set up for test - contribution created with status  = 'Partially Paid' & no financial trxns

After
----------------------------------------
Better (not quite preferred since we are still using Contrribution not Order) method used. Since the test is still fixing legacy-flow functions we then have to hack out some of the correctly created data to replicate things being done badly.

Technical Details
----------------------------------------

The whole partial_amount_to_pay params thing works badly & was actually the cause of other fixes stalling for 6 months.

This is part of an effort to deprecate & eliminate it

Comments
----------------------------------------
