### PR TITLE
[Test] Remove hard coded id reference

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -237,7 +237,7 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
       'fee_amount' => 0.00,
       'net_amount' => 300.00,
     ];
-    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][7];
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params);
     //make a payment one cent short
     $params = [
       'contribution_id' => $contribution['id'],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a test that, oddly, passes but fails when I try to add more stringent checkts https://github.com/civicrm/civicrm-core/pull/15706

Before
----------------------------------------
Reference to contribution is weirdly hard-coded

After
----------------------------------------
Accurately retrieves contribution['id']

Technical Details
----------------------------------------
Honestly - why isn't this failing already? We only need the contributionID so getting the top-level result is fine

Comments
----------------------------------------

