### PR TITLE
Fix api Payment.create to support overpayments

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3424,6 +3424,13 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    */
   protected function validatePayments($payments) {
     foreach ($payments as $payment) {
+      $balance = CRM_Contribute_BAO_Contribution::getContributionBalance($payment['contribution_id']);
+      if ($balance < 0 && $balance + $payment['total_amount'] === 0.0) {
+        // This is an overpayment situation. there are no financial items to allocate the overpayment.
+        // This is a pretty rough way at guessing which payment is the overpayment - but
+        // for the test suite it should be enough.
+        continue;
+      }
       $items = $this->callAPISuccess('EntityFinancialTrxn', 'get', [
         'financial_trxn_id' => $payment['id'],
         'entity_table' => 'civicrm_financial_item',

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -688,6 +688,21 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that a contribution can be overpaid with the payment api.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreatePaymentOverPay() {
+    $contributionID = $this->contributionCreate(['contact_id' => $this->individualCreate()]);
+    $payment = $this->callAPISuccess('Payment', 'create', ['total_amount' => 5, 'order_id' => $contributionID]);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contributionID]);
+    $this->assertEquals('Completed', $contribution['contribution_status']);
+    $this->callAPISuccessGetCount('EntityFinancialTrxn', ['financial_trxn_id' => $payment['id'], 'entity_table' => 'civicrm_financial_item'], 0);
+    $this->validateAllPayments();
+    $this->validateAllContributions();
+  }
+
+  /**
    * Test create payment api for paylater contribution
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Fix api Payment.create to support overpayments

Before
----------------------------------------
Calling Payment.create api to add a payment to a fully paid order results in an error

After
----------------------------------------
Payment is created. Status remains at 'Completed' and no related entities are updated. No financial items are linked to the new payment

Technical Details
----------------------------------------
We've discussed this before - it's OK to add a payment to a fully paid contribution because ... life. Arguably we could make this more obvious in the UI when it happens but it's an edge case so let's not go there on a 'this might be useful'. Adding another 'should be calculated really' status would not be helpful but it would add complexity- Completed is fine.

When this happens there should be no financial items linked to the over payment

Comments
----------------------------------------
@lcdservices @JoeMurray @kcristiano @monishdeb @mattwire @magnolia61 
