### PR TITLE
Adding  pre and post regions around the intro text on to contribution page

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -67,7 +67,9 @@
   {/if}
 
   <div id="intro_text" class="crm-public-form-item crm-section intro_text-section">
+    {crmRegion name="contribution-main-intro-pre"}{/crmRegion}
     {$intro_text}
+    {crmRegion name="contribution-main-intro-post"}{/crmRegion}
   </div>
   {include file="CRM/common/cidzero.tpl"}
   {if $islifetime or $ispricelifetime }


### PR DESCRIPTION
Overview
----------------------------------------
Regions are a mechanism for extensions to alter core templates. This PR adds the option to put text before and after the introduction text on a contribution page.

An example of a hook that uses these regions is:

````
function patchrequest_civicrm_buildForm($formName, &$form) {
  if($formName=='CRM_Contribute_Form_Contribution_Main'){
    CRM_Core_Region::instance('contribution-main-intro-pre')->add([
      'markup' => '<b>Some remark <i>before</i> the helptext</b>',
    ]);
    CRM_Core_Region::instance('contribution-main-intro-post')->add([
      'markup' => '<b>Some comments <i>after</i> the helptext</b>',
    ]);
  }
}
````

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/14834891/69336744-85890f80-0c5f-11ea-924b-cef9bae09431.png)
After
----------------------------------------
Now the text added by the hook is shown.
![after](https://user-images.githubusercontent.com/14834891/69336852-c08b4300-0c5f-11ea-9f29-230b45caf0fa.png)

Technical Details
----------------------------------------
The PR has not much technical impact. It only adds a possibility.

Comments
----------------------------------------
The other regions in the contribution page are documented at https://docs.civicrm.org/dev/en/latest/framework/region/#contributon-page 
