### PR TITLE
Fix fatal error when sorting by status in activity search

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2129,6 +2129,7 @@ AND cl.modified_id  = c.id
         'activity_status' => [
           'title' => ts('Activity Status'),
           'name' => 'activity_status',
+          'where' => 'civicrm_activity.status_id',
           'type' => CRM_Utils_Type::T_STRING,
           'searchByLabel' => TRUE,
         ],

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6470,7 +6470,7 @@ AND   displayRelType.is_active = 1
           if (empty($fieldSpec['bao'])) {
             continue;
           }
-          $sortedOptions = $fieldSpec['bao']::buildOptions($fieldSpec['name'], NULL, [
+          $sortedOptions = $fieldSpec['bao']::buildOptions($fieldSpec['field_name'] ?? $fieldSpec['name'], NULL, [
             'orderColumn' => CRM_Utils_Array::value('labelColumn', $pseudoConstantMetadata, 'label'),
           ]);
           $fieldIDsInOrder = implode(',', array_keys($sortedOptions));

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6477,7 +6477,10 @@ AND   displayRelType.is_active = 1
           // Pretty sure this validation ALSO happens in the order clause & this can't be reached but...
           // this might give some early warning.
           CRM_Utils_Type::validate($fieldIDsInOrder, 'CommaSeparatedIntegers');
-          $order = str_replace("$field", "field({$fieldSpec['name']},$fieldIDsInOrder)", $order);
+          // use where if it's set to fully qualify ambiguous column names
+          // i.e. civicrm_contribution.contribution_status_id instead of contribution_status_id
+          $pseudoColumnName = $fieldSpec['where'] ?? $fieldSpec['name'];
+          $order = str_replace("$field", "field($pseudoColumnName,$fieldIDsInOrder)", $order);
         }
         //CRM-12565 add "`" around $field if it is a pseudo constant
         // This appears to be for 'special' fields like locations with appended numbers or hyphens .. maybe.


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where sorting activity search results by activity status fails with a fatal error because the pseudoconstants are not loaded with the correct field name.

Before
----------------------------------------
Sorting activity search results by activity status results in a fatal error.

After
----------------------------------------
Sorting by activity status works.

Technical Details
----------------------------------------
The underlying issue is that `prepareOrderBy()` hits `buildOptions()` with `activity_status`, but only `activity_status_id` or `status_id` would actually return the pseudoconstants. This builds on top of #15899 and sets `where` for the field as it would otherwise cause a DB error as well (since `activity_status` is not the name of the column).

Comments
----------------------------------------
Not entirely sure about this fix - perhaps there's a better place to apply these changes or set an alias for this column. The pseudoconstant bit of the fix could also be done by adding a special case for `activity_status` in `CRM_Activity_BAO_Activity::buildOptions()`, but that feels a bit hacky.

I put this against 5.20 since it's similar to #15899, but this regression has been around a bit longer (confirmed broken on 5.13), so I can rebase if needed.
