### PR TITLE
dev/drupal#85 Drupal8: Fix bug with empty language prefix mangling https:// to http:/

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -761,7 +761,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
             if ($addLanguagePart && !empty($config['prefixes'][$language])) {
               $url .= $config['prefixes'][$language] . '/';
             }
-            if ($removeLanguagePart) {
+            if ($removeLanguagePart && !empty($config['prefixes'][$language])) {
               $url = str_replace("/" . $config['prefixes'][$language] . "/", '/', $url);
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------

On a Drupal 8 multilingual site, if you are using URL "Path prefix" language negotiation, and set one of the prefixes to empty (so, for that language, there is no prefix), then CiviCRM resource URLs will get mangled to be "https:/" (one slash) instead of "https://" (two slashes)

Here's what the config would look like:

![Selection_058](https://user-images.githubusercontent.com/191561/69352794-1ef5f880-0c43-11ea-978c-29b2426c6191.png)

Before
----------------------------------------

On CiviCRM pages, it's trying to load CSS and JS from URLs like "https:/example.org" (one slash) rather than "https://example.org" (two slashes)

After
----------------------------------------

The right URL gets used!

Technical Details
----------------------------------------

The problem is in `CRM_Utils_System_Drupal8::languageNegotiationURL()`:

```
            if ($removeLanguagePart) {
              $url = str_replace("/" . $config['prefixes'][$language] . "/", '/', $url);
            }
```

If `$config['prefixes'][$language]` is an empty string, then we end up with `str_replace("//", "/", $url)` which is taking the double slash in "https://" and turning it into "https:/"

