### PR TITLE
core#1411: Advanced Search crashes when some form values start with 1

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1023,11 +1023,11 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // the other alternative of running the FULL query will just be incredibly inefficient
     // and slow things down way too much on large data sets / complex queries
 
-    $selectSQL = "SELECT DISTINCT %1, contact_a.id, contact_a.sort_name";
+    $selectSQL = CRM_Core_DAO::composeQuery("SELECT DISTINCT %1, contact_a.id, contact_a.sort_name", [1 => [$cacheKey, 'String']]);
 
     $sql = str_ireplace(["SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"], $selectSQL, $sql);
     try {
-      Civi::service('prevnext')->fillWithSql($cacheKey, $sql, [1 => [$cacheKey, 'String']]);
+      Civi::service('prevnext')->fillWithSql($cacheKey, $sql);
     }
     catch (CRM_Core_Exception $e) {
       if ($coreSearch) {


### PR DESCRIPTION
Overview
----------------------------------------
Due to how the query that fills the SQL cache is built, it fails under some very common circumstances.  Some of those are hidden by the fact that Civi will fall back to an uncached search; some simply show no results.

Reproduction steps
----------------------------------------
1. Create a new activity with a subject of `12345`.
1. On **Advanced Search**, search **Activity Text** for `12345`.
1. Observe no results found.
1. Search **Activity Text** for `2345`.
1. Observe the the activity is found.

Why this happens
----------------------------------------
* The SQL created is something like `SELECT contact_a.id FROM civicrm_activity WHERE activity_subject like '%12345%'`.
* `CRM_Contact_Selector` has [this code snippet](https://github.com/civicrm/civicrm-core/blob/cf70a3eee02b1f46b23435b882d261fd400713b0/CRM/Contact/Selector.php#L1042-L1046) which replaces `SELECT contact_a.id` with  `"SELECT DISTINCT %1, contact_a.id, contact_a.sort_name"`, which yields `SELECT DISTINCT %1, contact_a.id, contact_a.sort_name FROM civicrm_activity WHERE activity_subject like '%12345%'`.
* It then passes this SQL to a function that does variable substitution - but the `%1` in `%12345%` gets substituted with the cache key!

This problem manifests with any Advanced Search field that prepends a wildcard (`%`) to the form value.  However, if you search for a contact named `12345` the search will still complete, because there's a fallback query in case of exceptions.


The fix
----------------------------------------
I do the variable substitution on the `$selectSQL` snippet BEFORE passing to `fillWithSql`, so we don't need to do variable substitution within `fillWithSql`.

Additional Note(s)
----------------------------------------
I'm going to break my PR into two parts to make it easier to review.  The first part will deal with the bug itself; I'll follow up with a cleanup PR to simplify the `fillWithSQL` signature to take one argument, not thre.

The `fillWithSQL` method is only called in [one other place in the code](https://github.com/civicrm/civicrm-core/blob/1cf214fd05844767bb1b9587cca796ac47102042/CRM/Campaign/Selector/Search.php#L268-L274), in CiviCampaign.  However, this query ALWAYS fails, because it puts `FROM` twice in a row.  So this will always fail to populate the cache.  I'll handle that in the second PR.