### PR TITLE
dev/core#1384 Joomla: fix JPATH_BASE when using a virtual directory on Windows

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -562,7 +562,9 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     if (!defined('_JEXEC') && $loadDefines) {
       define('_JEXEC', 1);
       define('DS', DIRECTORY_SEPARATOR);
-      define('JPATH_BASE', $joomlaBase . '/administrator');
+      // dev/core#1384 - Replace / by Ds to ensure correct value of JPATH_BASE in the
+      // Windows environment.
+      define('JPATH_BASE', $joomlaBase . DS . 'administrator');
       require $joomlaBase . '/administrator/includes/defines.php';
     }
 

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -559,11 +559,10 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
 
     // load BootStrap here if needed
     // We are a valid Joomla entry point.
+    // dev/core#1384 Use DS to ensure a correct JPATH_BASE in Windows
     if (!defined('_JEXEC') && $loadDefines) {
       define('_JEXEC', 1);
       define('DS', DIRECTORY_SEPARATOR);
-      // dev/core#1384 - Replace / by Ds to ensure correct value of JPATH_BASE in the
-      // Windows environment.
       define('JPATH_BASE', $joomlaBase . DS . 'administrator');
       require $joomlaBase . '/administrator/includes/defines.php';
     }


### PR DESCRIPTION
Overview
----------------------------------------
This is a repeat of PR 30660, which seems to have disappeared, possibly because I recreated the branch and where Jenkins threw up format errors. <Civiroot>/administrator/components/com_civicrm/civicrm/CRM/Utils/System/Joomla.php defines JPATH_BASE.  In a Windows environment where the Joomla CRM is in a subdirectory, JPATH_BASE was defined incorrectly and incorrectly parsed by other routines.

https://lab.civicrm.org/dev/core/issues/1384

Technical Details
----------------------------------------

We replace the leading / by DS, so in the Windows environment it becomes \.

Comments
----------------------------------------

We only need the DS here as JPATH_BASE is parsed in a way that assumes a directory path, we don't need to specify the directory separator elsewhere.