### PR TITLE
dev/core/1412  CiviMail sent via wp-cli and cron mangles mailing urls…

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -558,23 +558,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       }
     }
     else {
-      $pathVars = explode('/', str_replace('\\', '/', $_SERVER['SCRIPT_FILENAME']));
-
-      //might be windows installation.
-      $firstVar = array_shift($pathVars);
-      if ($firstVar) {
-        $cmsRoot = $firstVar;
-      }
-
-      //start w/ csm dir search.
-      foreach ($pathVars as $var) {
-        $cmsRoot .= "/$var";
-        if ($this->validInstallDir($cmsRoot)) {
-          //stop as we found bootstrap.
-          $valid = TRUE;
-          break;
-        }
-      }
+      $setting = Civi::settings()->get('wpLoadPhp');
+      $path = str_replace('wp-load.php', '', $setting);
+      $cmsRoot = rtrim($path, '/\\');
+      $valid = TRUE;
     }
 
     return ($valid) ? $cmsRoot : NULL;


### PR DESCRIPTION
… on WP

Patch created by @christianwach 

https://lab.civicrm.org/dev/core/issues/1412

Overview
----------------------------------------
Starting in 5.19 we have an issue with URLs in CiviMail.  If Track links is on the URLs get mangled.  Dradt Emails are fine, as well as if you kick off the scheduled job manually (UI or CLI).

However, if cron runs the job the URLS are broken:

Mailing Urls expected:

https://example.org//wp-content/plugins/civicrm/civicrm/extern/url.php?u=19&qid=31

But we get:

https://example.org/home/example/public_html/wp-content/plugins/civicrm/civicrm/extern/url.php?u=19&qid=31

Before
----------------------------------------
Mangled URLs

After
----------------------------------------
Proper URls



