### PR TITLE
Fix fatal error when sorting by status in activity search

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2119,6 +2119,9 @@ AND cl.modified_id  = c.id
         'type' => CRM_Utils_Type::T_STRING,
       ];
 
+      // @todo - remove these - they are added by CRM_Core_DAO::appendPseudoConstantsToFields
+      // below. That search label stuff is referenced in search builder but is likely just
+      // a hack that duplicates, maybe differently, other functionality.
       $Activityfields = [
         'activity_type' => [
           'title' => ts('Activity Type'),
@@ -2189,7 +2192,7 @@ AND cl.modified_id  = c.id
 
     // add custom data for case activities
     $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Activity'));
-
+    CRM_Core_DAO::appendPseudoConstantsToFields($fields);
     self::$_exportableFields[$name] = $fields;
     return self::$_exportableFields[$name];
   }

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6934,7 +6934,7 @@ AND   displayRelType.is_active = 1
    *
    * @return array
    */
-  protected function getMetadataForRealField($fieldName) {
+  public function getMetadataForRealField($fieldName) {
     $field = $this->getMetadataForField($fieldName);
     if (!empty($field['is_pseudofield_for'])) {
       $field = $this->getMetadataForField($field['is_pseudofield_for']);
@@ -7031,7 +7031,11 @@ AND   displayRelType.is_active = 1
    */
   public function getFieldSpec($fieldName) {
     if (isset($this->_fields[$fieldName])) {
-      return $this->_fields[$fieldName];
+      $fieldSpec = $this->_fields[$fieldName];
+      if (!empty($fieldSpec['is_pseudofield_for'])) {
+        $fieldSpec = array_merge($this->_fields[$fieldSpec['is_pseudofield_for']], $this->_fields[$fieldName]);
+      }
+      return $fieldSpec;
     }
     $lowFieldName = str_replace('_low', '', $fieldName);
     if (isset($this->_fields[$lowFieldName])) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2475,7 +2475,7 @@ SELECT contact_id
    * @param array $fields
    */
   public static function appendPseudoConstantsToFields(&$fields) {
-    foreach ($fields as $field) {
+    foreach ($fields as $fieldUniqueName => $field) {
       if (!empty($field['pseudoconstant'])) {
         $pseudoConstant = $field['pseudoconstant'];
         if (!empty($pseudoConstant['optionGroupName'])) {
@@ -2483,7 +2483,7 @@ SELECT contact_id
             'title' => CRM_Core_BAO_OptionGroup::getTitleByName($pseudoConstant['optionGroupName']),
             'name' => $pseudoConstant['optionGroupName'],
             'data_type' => CRM_Utils_Type::T_STRING,
-            'is_pseudofield_for' => $field['name'],
+            'is_pseudofield_for' => $fieldUniqueName,
           ];
         }
         // We restrict to id + name + FK as we are extending this a bit, but cautiously.

--- a/tests/phpunit/CRM/Activity/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Selector/SearchTest.php
@@ -47,4 +47,42 @@ class CRM_Activity_Selector_SearchTest extends CiviUnitTestCase {
     $this->assertEquals("civicrm_activity.location = 'Baker Street'", $queryObject->_where[''][0]);
   }
 
+  public function testActivityOrderBy() {
+    $sortVars = [
+      1 => [
+        'name' => 'activity_date_time',
+        'sort' => 'activity_date_time',
+        'direction' => 2,
+        'title' => 'Date',
+      ],
+      2 => [
+        'name' => 'activity_type_id',
+        'sort' => 'activity_type_id',
+        'direction' => 4,
+        'title' => 'Type',
+      ],
+      3 => [
+        'name' => 'activity_subject',
+        'sort' => 'activity_subject',
+        'direction' => 4,
+        'title' => 'Subject',
+      ],
+      4 => [
+        'name' => 'source_contact',
+        'sort' => 'source_contact',
+        'direction' => 4,
+        'title' => 'Added By',
+      ],
+      5 => [
+        'name' => 'activity_status',
+        'sort' => 'activity_status',
+        'direction' => 1,
+        'title' => 'Status',
+      ],
+    ];
+    $sort = new CRM_Utils_Sort($sortVars, '5_u');
+    $searchSelector = new CRM_Activity_Selector_Search($queryParams, CRM_Core_Action::VIEW);
+    $searchSelector->getRows(4, 0, 50, $sort);
+  }
+
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1726,7 +1726,11 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     if ($dropCustomValueTables) {
       $optionGroupResult = CRM_Core_DAO::executeQuery('SELECT option_group_id FROM civicrm_custom_field');
       while ($optionGroupResult->fetch()) {
-        if (!empty($optionGroupResult->option_group_id)) {
+        // We have a test that sets the option_group_id for a custom group to that of 'activity_type'.
+        // Then test tearDown deletes it. This is all mildly terrifying but for the context here we can be pretty
+        // sure the low-numbered (50 is arbitrary) option groups are not ones to 'just delete' in a
+        // generic cleanup routine.
+        if (!empty($optionGroupResult->option_group_id) && $optionGroupResult->option_group_id > 50) {
           CRM_Core_DAO::executeQuery('DELETE FROM civicrm_option_group WHERE id = ' . $optionGroupResult->option_group_id);
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Alternate fix to https://github.com/civicrm/civicrm-core/pull/15911


Technical Details
----------------------------------------
This leverages the CRM_Core_DAO::appendPseudoConstantsToFields function (as does Contribution Search) which adds the metadata in a standardised way. It switches to referencing the $key rather than the name as $fields is keyed by uniqueNames & in the case of activity_status_id that is not the same as the field name
