### PR TITLE
[REF] Move wrangling of Front end form contribution param for autoRenew back to form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1380,7 +1380,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // as a point of fragility rather than a logical 'if' clause.
     if ($priceSetId) {
       CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],
-        $submittedValues, $lineItem[$priceSetId], NULL, $priceSetId);
+        $submittedValues, $lineItem[$priceSetId], $priceSetId);
       // Unset tax amount for offline 'is_quick_config' contribution.
       // @todo WHY  - quick config was conceived as a quick way to configure contribution forms.
       // this is an example of 'other' functionality being hung off it.

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1967,7 +1967,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     $priceFields = $priceFields[$priceSetID]['fields'];
     $lineItems = [];
-    CRM_Price_BAO_PriceSet::processAmount($priceFields, $paramsProcessedForForm, $lineItems, 'civicrm_contribution', $priceSetID);
+    $form->processAmountAndGetAutoRenew($priceFields, $paramsProcessedForForm, $lineItems, $priceSetID);
     $form->_lineItem = [$priceSetID => $lineItems];
     $membershipPriceFieldIDs = [];
     foreach ((array) $lineItems as $lineItem) {

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1124,12 +1124,14 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           }
         }
       }
-      $component = '';
+
       if ($this->_membershipBlock) {
-        $component = 'membership';
+        $this->processAmountAndGetAutoRenew($this->_values['fee'], $params, $lineItem[$priceSetId], $priceSetId);
+      }
+      else {
+        CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetId], $priceSetId);
       }
 
-      CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetId], $component, $priceSetId);
       if ($params['tax_amount']) {
         $this->set('tax_amount', $params['tax_amount']);
       }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1403,4 +1403,33 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     return $params['amount'] ?? 0;
   }
 
+  /**
+   * Wrapper for processAmount that also sets autorenew.
+   *
+   * @param $fields
+   *   This is the output of the function CRM_Price_BAO_PriceSet::getSetDetail($priceSetID, FALSE, FALSE);
+   *   And, it would make sense to introduce caching into that function and call it from here rather than
+   *   require the $fields array which is passed from pillar to post around the form in order to pass it in here.
+   * @param array $params
+   *   Params reflecting form input e.g with fields 'price_5' => 7, 'price_8' => array(7, 8)
+   * @param $lineItems
+   *   Line item array to be altered.
+   * @param int $priceSetID
+   */
+  public function processAmountAndGetAutoRenew($fields, &$params, &$lineItems, $priceSetID = NULL) {
+    CRM_Price_BAO_PriceSet::processAmount($fields, $params, $lineItems, $priceSetID);
+    $autoRenew = [];
+    $autoRenew[0] = $autoRenew[1] = $autoRenew[2] = 0;
+    foreach ($lineItems as $lineItem) {
+      if (!empty($lineItem['auto_renew']) &&
+        is_numeric($lineItem['auto_renew'])
+      ) {
+        $autoRenew[$lineItem['auto_renew']] += $lineItem['line_total'];
+      }
+    }
+    if (count($autoRenew) > 1) {
+      $params['autoRenew'] = $autoRenew;
+    }
+  }
+
 }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -375,6 +375,9 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
   /**
    * Process the form submission.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
     $now = date('YmdHis');

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1153,7 +1153,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     // END Fix for dev/core/issues/860
 
     CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],
-      $formValues, $lineItem[$this->_priceSetId], NULL, $this->_priceSetId);
+      $formValues, $lineItem[$this->_priceSetId], $this->_priceSetId);
 
     if (!empty($formValues['tax_amount'])) {
       $params['tax_amount'] = $formValues['tax_amount'];

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -597,7 +597,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       $lineItem = [];
       $this->_params = $this->setPriceSetParameters($this->_params);
       CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],
-        $this->_params, $lineItem[$this->_priceSetId], NULL, $this->_priceSetId
+        $this->_params, $lineItem[$this->_priceSetId], $this->_priceSetId
       );
       //CRM-11529 for quick config backoffice transactions
       //when financial_type_id is passed in form, update the


### PR DESCRIPTION
Overview
----------------------------------------
Refactoring towards cleaning up processAmount function

Before
----------------------------------------
$component is a param that is code for 'add autoRenew elements to the array'

After
----------------------------------------
$component is no longer a param. The places where this is needed are now calculated on the form

Technical Details
----------------------------------------
The processAmount function is really problematic because it's trying to do several disparate things & is called from
all over the place with unclear intent. From looking at it I see it does a few things. It reformats line items,
it does some obscure & likely flawed filtering, it generates a total cost & a tax cost and it generates a very
specifically formatted array of autoreneal properties,

The way I see this going is
1) Move the formatting of the autorenewal back to the calling form (this PR) & simplify it
2) Split out the foreach so it goes through once & formats - this can be shoved out to a separate function
- and then it goes through the formatted array & calculates total_amount & tax_amount - we should
have a wrapper function that just returns these & we might see that is most of what is needed
3) Move all that awful partial_payment_total stuff back to the event form. Note that we are working
to entirely remove that from here are it makes so much less than no sense.
4) Calculates amount_level text - that should have it's own function.

It worth noting all of this does very little intensive work - a DB lookup or 2 that  could be cached & an iteration
through a very small array so it would be fine to have 3 functions -
- getAmountTotal
- getTaxTotal
- getAmountText

that each go through the same process of generating a formatted array from price_x => 5 etc rather than trying
to pass the  array around for 'performance' or to 'save work'.

From previous refactorings I would suggest we add an Order class such as https://github.com/eileenmcnaughton/civicrm-core/commit/6d60f4f58c4dc8190218ae9473f279e9c4af6e8b where by you set the price fields
& then you can call 'getLineItems' - but that is a few steps after this....

Comments
----------------------------------------
@seamuslee001 @monishdeb @mattwire I'm hoping some combination of you can help work through this with me. I think that once we have a function to getTotalAmount from a set of price set params we'll be in a much better place to clean up a bunch of code. The confusion around passing things like line item by reference & why we have to pass in 'fields' & where that comes from has been holding us back IMHO
