### PR TITLE
Enable Case search metadata on Advanced Search Form

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -905,6 +905,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     $this->addSearchFieldMetadata(['Pledge' => CRM_Pledge_BAO_Query::getSearchFieldMetadata()]);
     $this->addSearchFieldMetadata(['PledgePayment' => CRM_Pledge_BAO_Query::getPledgePaymentSearchFieldMetadata()]);
     $this->addSearchFieldMetadata(['Grant' => CRM_Grant_BAO_Query::getSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['Case' => CRM_Case_BAO_Query::getSearchFieldMetadata()]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Enables urls like `civicrm/contact/search/advanced?reset=1&force=1&case_subject=test` to work

Before
----------------------------------------
Case parameters don't work on Advanced Search

After
----------------------------------------
Do work

ping @eileenmcnaughton @demeritcowboy 

One thing tho the case_subject one does generate the notice `htmlspecialchars() expects parameter 1 to be string, array given in HTML_Common->_getAttrString() (line 144 of /home/seamus/buildkit/build/47-test/sites/all/modules/civicrm/packages/HTML/Common.php).` but only on Advanced Search with this PR. 