### PR TITLE
[REF] return determination of whether to show expired fields to the calling function

### DIFF
--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -136,6 +136,11 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     return $defaults;
   }
 
+  /**
+   * Build form.
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function buildQuickForm() {
 
     $statuses = CRM_Event_PseudoConstant::participantStatus();
@@ -152,7 +157,8 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
 
     //retrieve custom information
     $this->_values = [];
-    CRM_Event_Form_Registration::initEventFee($this, $event['id']);
+
+    CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE);
     CRM_Event_Form_Registration_Register::buildAmount($this, TRUE);
 
     if (!CRM_Utils_System::isNull(CRM_Utils_Array::value('line_items', $this->_values))) {
@@ -217,6 +223,12 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     return $errors;
   }
 
+  /**
+   * Post process form.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -600,10 +600,12 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    *
    * @param CRM_Core_Form $form
    * @param int $eventID
+   * @param bool $includeExpiredFields
+   *   See CRM-16456.
    *
    * @throws Exception
    */
-  public static function initEventFee(&$form, $eventID) {
+  public static function initEventFee(&$form, $eventID, $includeExpiredFields = TRUE) {
     // get price info
 
     // retrive all active price set fields.
@@ -612,20 +614,13 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $discountId = $form->_discountId;
     }
 
-    //CRM-16456 get all price field including expired one.
-    $getAllPriceField = TRUE;
-    $className = CRM_Utils_System::getClassName($form);
-    if ($className == 'CRM_Event_Form_ParticipantFeeSelection' && $form->_action == CRM_Core_Action::UPDATE) {
-      $getAllPriceField = FALSE;
-    }
-
     if ($discountId) {
       $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_Discount', $discountId, 'price_set_id');
-      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $getAllPriceField, $priceSetId);
+      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $includeExpiredFields, $priceSetId);
     }
     else {
       $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $eventID);
-      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $getAllPriceField, $priceSetId);
+      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $includeExpiredFields, $priceSetId);
     }
 
     if (property_exists($form, '_context') && ($form->_context == 'standalone'


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup towards larger effort of making amount handling accurately tested

Before
----------------------------------------
initEventFee determines whether to include expired fields based on a determination of which class is calling it

After
----------------------------------------
$includeExpiredFields is an input parameter

Technical Details
----------------------------------------
As part of my efforts to ensure we are consistency creating valid transactions I'm trying to sort out the way we calculate
amounts to be re-usable from tests but I feel stymied at every turn by spaghetti code.

This unravels a small piece

Comments
----------------------------------------

