### PR TITLE
Include Metadata on advanced search form for membership, grant, pledg…

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -901,6 +901,10 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     $this->addSearchFieldMetadata(['Contribution' => CRM_Contribute_BAO_Query::getSearchFieldMetadata()]);
     $this->addSearchFieldMetadata(['ContributionRecur' => CRM_Contribute_BAO_ContributionRecur::getContributionRecurSearchFieldMetadata()]);
     $this->addSearchFieldMetadata(['Participant' => CRM_Event_BAO_Query::getSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['Membership' => CRM_Member_BAO_Query::getSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['Pledge' => CRM_Pledge_BAO_Query::getSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['PledgePayment' => CRM_Pledge_BAO_Query::getPledgePaymentSearchFieldMetadata()]);
+    $this->addSearchFieldMetadata(['Grant' => CRM_Grant_BAO_Query::getSearchFieldMetadata()]);
   }
 
 }


### PR DESCRIPTION
…e, fields

Overview
----------------------------------------
This adds into advanced search the ability to use fields like membership_join_date and pledg_payment_start_date and the like into urls for filtering of search results

Before
----------------------------------------
No filtering able to be done on advanced search by url for these categories

After
----------------------------------------
Filtering able to be done

ping @demeritcowboy @eileenmcnaughton 
