### PR TITLE
dev/core#1405 Strip any spaces from Option Group name parameter and r…

### DIFF
--- a/CRM/Admin/Form/OptionGroup.php
+++ b/CRM/Admin/Form/OptionGroup.php
@@ -38,17 +38,6 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
     CRM_Utils_System::setTitle(ts('Dropdown Options'));
 
     $this->applyFilter('__ALL__', 'trim');
-    $this->add('text',
-      'name',
-      ts('Name'),
-      CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionGroup', 'name'),
-      TRUE
-    );
-    $this->addRule('name',
-      ts('Name already exists in Database.'),
-      'objectExists',
-      ['CRM_Core_DAO_OptionGroup', $this->_id]
-    );
 
     $this->add('text',
       'title',
@@ -90,6 +79,33 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
     }
 
     $this->assign('id', $this->_id);
+    $this->addFormRule(['CRM_Admin_Form_OptionGroup', 'formRule'], $this);
+  }
+
+  /**
+   * Global form rule.
+   *
+   * @param array $fields
+   *   The input form values.
+   *
+   * @param $files
+   * @param $self
+   *
+   * @return bool|array
+   *   true if no errors, else array of errors
+   */
+  public static function formRule($fields, $files, $self) {
+    $errors = [];
+    if ($self->_id) {
+      $name = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $self->_id, 'name');
+    }
+    else {
+      $name = CRM_Utils_String::titleToVar(strtolower($fields['title']));
+    }
+    if (!CRM_Core_DAO::objectExists($name, 'CRM_Core_DAO_OptionGroup', $self->_id)) {
+      $errors['title'] = ts('Option Group name ' . $name . ' already exists in the database. Option Group Names need to be unique');
+    }
+    return empty($errors) ? TRUE : $errors;
   }
 
   /**

--- a/CRM/Core/BAO/OptionGroup.php
+++ b/CRM/Core/BAO/OptionGroup.php
@@ -76,6 +76,15 @@ class CRM_Core_BAO_OptionGroup extends CRM_Core_DAO_OptionGroup {
       CRM_Core_Error::deprecatedFunctionWarning('no $ids array');
       $params['id'] = $ids['optionGroup'];
     }
+    if (empty($params['name']) && empty($params['id'])) {
+      $params['name'] = CRM_Utils_String::titleToVar(strtolower($params['title']));
+    }
+    elseif (!empty($params['name']) && strpos($params['name'], ' ')) {
+      $params['name'] = CRM_Utils_String::titleToVar(strtolower($params['name']));
+    }
+    elseif (!empty($params['name'])) {
+      $params['name'] = strtolower($params['name']);
+    }
     $optionGroup = new CRM_Core_DAO_OptionGroup();
     $optionGroup->copyValues($params);;
     $optionGroup->save();

--- a/tests/phpunit/CRM/Core/BAO/OptionGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/OptionGroupTest.php
@@ -40,11 +40,11 @@ class CRM_Core_BAO_OptionGroupTest extends CiviUnitTestCase {
   public function testEnsureOptionGroupExistsNewValue() {
     CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(['name' => 'Bombed']);
     $optionGroups = $this->callAPISuccess('OptionValue', 'getoptions', ['field' => 'option_group_id'])['values'];
-    $this->assertTrue(in_array('Bombed', $optionGroups));
+    $this->assertTrue(in_array('bombed', $optionGroups));
 
     CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(['name' => 'Bombed Again']);
     $optionGroups = $this->callAPISuccess('OptionValue', 'getoptions', ['field' => 'option_group_id'])['values'];
-    $this->assertTrue(in_array('Bombed Again', $optionGroups));
+    $this->assertTrue(in_array('bombed_again', $optionGroups));
   }
 
 }

--- a/tests/phpunit/api/v3/OptionGroupTest.php
+++ b/tests/phpunit/api/v3/OptionGroupTest.php
@@ -94,7 +94,7 @@ class api_v3_OptionGroupTest extends CiviUnitTestCase {
   public function testGetOptionCreateFailOnDuplicate() {
     $params = [
       'sequential' => 1,
-      'name' => 'civicrm_dup entry',
+      'name' => 'civicrm_dup_entry',
       'is_reserved' => 1,
       'is_active' => 1,
     ];

--- a/tests/phpunit/api/v3/OptionValueTest.php
+++ b/tests/phpunit/api/v3/OptionValueTest.php
@@ -393,7 +393,7 @@ class api_v3_OptionValueTest extends CiviUnitTestCase {
 
   public function testCreateOptionValueWithSameValueDiffOptionGroup() {
     $og = $this->callAPISuccess('option_group', 'create', [
-      'name' => 'our test Option Group for with group id',
+      'name' => 'our test Option Group',
       'is_active' => 1,
     ]);
     // create a option value
@@ -401,7 +401,7 @@ class api_v3_OptionValueTest extends CiviUnitTestCase {
       ['option_group_id' => $og['id'], 'label' => 'test option value']
     );
     $og2 = $this->callAPISuccess('option_group', 'create', [
-      'name' => 'our test Option Group for with group id 2',
+      'name' => 'our test Option Group 2',
       'is_active' => 1,
     ]);
     // update option value without 'option_group_id'


### PR DESCRIPTION
…emove the name field from front end form as will be auto generated

Overview
----------------------------------------
This removes the name field from the form to add a new option group as really it should be a calculated field. It also Ensures that option values are fixed on upgrade

Before
----------------------------------------
Option group names can be created with a space in it causing errors when trying to add new option valuse

After
----------------------------------------
All option group names are lower case and for new option groups created primarily on the basis of the title of the option group.

Agileware Ref: CIVICRM-1373

ping @eileenmcnaughton @colemanw @jusfreeman 