### PR TITLE
dev/financial#105 Add CSS class onto the radio button payment processor options

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -320,10 +320,18 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->add('text', 'total_amount', ts('Total Amount'), ['readonly' => TRUE], FALSE);
     }
     $pps = $this->getProcessors();
-
+    $optAttributes = [];
+    foreach ($pps as $ppKey => $ppval) {
+      if ($ppKey > 0) {
+        $optAttributes[$ppKey]['class'] = 'payment_processor_' . strtolower($this->_paymentProcessors[$ppKey]['payment_processor_type']);
+      }
+      else {
+        $optAttributes[$ppKey]['class'] = 'payment_processor_paylater';
+      }
+    }
     if (count($pps) > 1) {
       $this->addRadio('payment_processor_id', ts('Payment Method'), $pps,
-        NULL, "&nbsp;"
+        NULL, "&nbsp;", FALSE, $optAttributes
       );
     }
     elseif (!empty($pps)) {

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1150,17 +1150,29 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param array $attributes
    * @param null $separator
    * @param bool $required
+   * @param array $optionAttributes - Option specific attributes
    *
    * @return HTML_QuickForm_group
    */
-  public function &addRadio($name, $title, $values, $attributes = [], $separator = NULL, $required = FALSE) {
+  public function &addRadio($name, $title, $values, $attributes = [], $separator = NULL, $required = FALSE, $optionAttributes = []) {
     $options = [];
     $attributes = $attributes ? $attributes : [];
     $allowClear = !empty($attributes['allowClear']);
     unset($attributes['allowClear']);
     $attributes['id_suffix'] = $name;
     foreach ($values as $key => $var) {
-      $options[] = $this->createElement('radio', NULL, NULL, $var, $key, $attributes);
+      $optAttributes = $attributes;
+      if (!empty($optionAttributes[$key])) {
+        foreach ($optionAttributes[$key] as $optAttr => $optVal) {
+          if (!empty($optAttributes[$optAttr])) {
+            $optAttributes[$optAttr] .= ' ' . $optVal;
+          }
+          else {
+            $optAttributes[$optAttr] = $optVal;
+          }
+        }
+      }
+      $options[] = $this->createElement('radio', NULL, NULL, $var, $key, $optAttributes);
     }
     $group = $this->addGroup($options, $name, $title, $separator);
 

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -398,9 +398,18 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
 
     if ($this->_values['event']['is_monetary']) {
+      $optAttributes = [];
+      foreach ($pps as $ppKey => $ppval) {
+        if ($ppKey > 0) {
+          $optAttributes[$ppKey]['class'] = 'payment_processor_' . strtolower($this->_paymentProcessors[$ppKey]['payment_processor_type']);
+        }
+        else {
+          $optAttributes[$ppKey]['class'] = 'payment_processor_paylater';
+        }
+      }
       if (count($pps) > 1) {
         $this->addRadio('payment_processor_id', ts('Payment Method'), $pps,
-          NULL, "&nbsp;"
+          NULL, "&nbsp;", FALSE, $optAttributes
         );
       }
       elseif (!empty($pps)) {


### PR DESCRIPTION
…nt processor options to differenciate between the different options for themers

Overview
----------------------------------------
This adds in an additional class to the radio button options for choosing your payment processor with the payment processor type in the class. To allow themers to change the styling for each radio button depending on the payment processor type e.g. use the PayPal logo as the radio button perhaps for PayPal ones. 

Before
----------------------------------------
No unique class between the options

After
----------------------------------------
Unique class

ping @mattwire @MikeyMJCO @agileware-fj 
