### PR TITLE
dev/core#560 Replace instances of CRM_Core_Error::fatal with Exceptio…

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -558,12 +558,17 @@ FROM civicrm_action_schedule cas
 
     $activity = CRM_Activity_BAO_Activity::create($activityParams);
 
-    CRM_Activity_BAO_Activity::sendSMSMessage($tokenRow->context['contactId'],
-      $sms_body_text,
-      $smsParams,
-      $activity->id,
-      $userID
-    );
+    try {
+      CRM_Activity_BAO_Activity::sendSMSMessage($tokenRow->context['contactId'],
+        $sms_body_text,
+        $smsParams,
+        $activity->id,
+        $userID
+      );
+    }
+    catch (CRM_Core_Exception $e) {
+      return ["sms_send_error" => $e->getMessage()];
+    }
 
     return [];
   }

--- a/CRM/SMS/BAO/Provider.php
+++ b/CRM/SMS/BAO/Provider.php
@@ -123,11 +123,11 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
    * @param int $providerID
    *
    * @return null
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   public static function del($providerID) {
     if (!$providerID) {
-      CRM_Core_Error::fatal(ts('Invalid value passed to delete function.'));
+      throw new CRM_Core_Exception(ts('Invalid value passed to delete function.'));
     }
 
     $dao = new CRM_SMS_DAO_Provider();

--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -25,7 +25,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
    */
   public function preProcess() {
     if (!CRM_SMS_BAO_Provider::activeProviderCount()) {
-      CRM_Core_Error::fatal(ts('The <a href="%1">SMS Provider</a> has not been configured or is not active.', [1 => CRM_Utils_System::url('civicrm/admin/sms/provider', 'reset=1')]));
+      CRM_Core_Error::statusBounce(ts('The <a href="%1">SMS Provider</a> has not been configured or is not active.', [1 => CRM_Utils_System::url('civicrm/admin/sms/provider', 'reset=1')]));
     }
 
     $session = CRM_Core_Session::singleton();

--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -134,7 +134,7 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
     $params['mailing_id'] = $ids['mailing_id'] = $this->_mailingID;
 
     if (empty($params['mailing_id'])) {
-      CRM_Core_Error::fatal(ts('Could not find a mailing id'));
+      CRM_Core_Error::statusBounce(ts('Could not find a mailing id'));
     }
 
     $params['send_option'] = $this->controller->exportValue($this->_name, 'send_option');

--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -32,6 +32,7 @@ abstract class CRM_SMS_Provider {
    * @param bool $force
    *
    * @return object
+   * @throws CRM_Core_Exception
    */
   public static function &singleton($providerParams = array(), $force = FALSE) {
     $mailingID = CRM_Utils_Array::value('mailing_id', $providerParams);
@@ -47,7 +48,7 @@ abstract class CRM_SMS_Provider {
     }
 
     if (!$providerName) {
-      CRM_Core_Error::fatal('Provider not known or not provided.');
+      throw new CRM_Core_Exception('Provider not known or not provided.');
     }
 
     $providerName = CRM_Utils_Type::escape($providerName, 'String');
@@ -62,7 +63,7 @@ abstract class CRM_SMS_Provider {
       else {
         // If we are running unit tests we simulate an SMS provider with the name "CiviTestSMSProvider"
         if ($providerName !== 'CiviTestSMSProvider') {
-          CRM_Core_Error::fatal("Could not locate extension for {$providerName}.");
+          throw new CRM_Core_Exception("Could not locate extension for {$providerName}.");
         }
         $providerClass = 'CiviTestSMSProvider';
       }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1178,7 +1178,7 @@ $text
     $this->assertEquals($activity['status_id'], $activityStatusCompleted, 'Expected activity status Completed.');
     $this->assertEquals($activity['subject'], 'createSendSmsTest subject', 'Activity subject does not match.');
     $this->assertEquals($activity['details'], $details, 'Activity details does not match.');
-    $this->assertEquals("Recipient phone number is invalid or recipient does not want to receive SMS", $sent[0]->message, "Expected error doesn't match");
+    $this->assertEquals("Recipient phone number is invalid or recipient does not want to receive SMS", $sent[0], "Expected error doesn't match");
     $this->assertEquals(0, $success, "Expected success to be 0");
   }
 
@@ -1193,7 +1193,7 @@ $text
     $this->assertEquals($activity['status_id'], $activityStatusCompleted, 'Expected activity status Completed.');
     $this->assertEquals($activity['subject'], 'createSendSmsTest subject', 'Activity subject does not match.');
     $this->assertEquals($activity['details'], $details, 'Activity details does not match.');
-    $this->assertEquals("Recipient phone number is invalid or recipient does not want to receive SMS", $sent[0]->message, "Expected error doesn't match");
+    $this->assertEquals("Recipient phone number is invalid or recipient does not want to receive SMS", $sent[0], "Expected error doesn't match");
     $this->assertEquals(0, $success, "Expected success to be 0");
   }
 
@@ -1229,7 +1229,7 @@ $text
   public function testSendSMSMobileInToProviderParamWithDoNotSMS() {
     list($sent, $activityId, $success) = $this->createSendSmsTest(2, TRUE, ['do_not_sms' => 1]);
     foreach ($sent as $error) {
-      $this->assertEquals('Contact Does not accept SMS', $error->getMessage());
+      $this->assertEquals('Contact Does not accept SMS', $error);
     }
     $this->assertEquals(1, count($sent), "Expected sent should a PEAR Error");
     $this->assertEquals(0, $success, "Expected success to be 0");


### PR DESCRIPTION
…ns or Status bounces in SMS processing and appropriately handle error after

Overview
----------------------------------------
This replaces instances of `CRM_Core_Error::fatal` in the SMS subsystem with CRM_Core_Exceptions or CRM_Core_Error::statusBounce as appropriate and updates the relevant functions to handle the change in error handling

Before
----------------------------------------
Legacy function used

After
----------------------------------------
Modern functions used

ping @eileenmcnaughton @mattwire 