### PR TITLE
Add in searchFieldMetadata for contact_tags, contact_type, group and …

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -75,6 +75,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
+    $this->sortNameOnly = TRUE;
 
     parent::preProcess();
 

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -79,6 +79,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
+    $this->sortNameOnly = TRUE;
 
     parent::preProcess();
 

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -434,6 +434,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
           'class' => 'crm-select2',
         ]
       );
+      $this->searchFieldMetadata['Contact']['group'] = ['name' => 'group', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'html' => ['type' => 'Select']];
     }
 
     $contactTags = CRM_Core_BAO_Tag::getTags();
@@ -446,10 +447,13 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
         ]
       );
     }
+    $this->searchFieldMetadata['Contact']['contact_tags'] = ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'html' => ['type' => 'Select']];
     $this->addField('contact_type', ['entity' => 'Contact']);
+    $this->searchFieldMetadata['contact']['contact_type'] = CRM_Contact_DAO_Contact::fields()['contact_type'];
 
     if (CRM_Core_Permission::check('access deleted contacts') && Civi::settings()->get('contact_undelete')) {
       $this->addElement('checkbox', 'deleted_contacts', ts('Search in Trash') . '<br />' . ts('(deleted contacts)'));
+      $this->searchFieldMetadata['Contact']['deleted_contacts'] = ['name' => 'deleted_contacts', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'html' => ['type' => 'Checkbox']];
     }
 
   }

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -86,6 +86,13 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   }
 
   /**
+   * Should we be adding all the metadata for contact search fields or just for the sort name.
+   *
+   * @var bool
+   */
+  protected $sortNameOnly = FALSE;
+
+  /**
    * Metadata for fields on the search form.
    *
    * Instantiate with empty array for contact to prevent e-notices.
@@ -424,6 +431,9 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       return;
     }
     $this->addSortNameField();
+    if ($this->sortNameOnly) {
+      return;
+    }
 
     $this->_group = CRM_Core_PseudoConstant::nestedGroup();
     if ($this->_group) {
@@ -449,7 +459,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
     }
     $this->searchFieldMetadata['Contact']['contact_tags'] = ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'html' => ['type' => 'Select']];
     $this->addField('contact_type', ['entity' => 'Contact']);
-    $this->searchFieldMetadata['contact']['contact_type'] = CRM_Contact_DAO_Contact::fields()['contact_type'];
+    $this->searchFieldMetadata['Contact']['contact_type'] = CRM_Contact_DAO_Contact::fields()['contact_type'];
 
     if (CRM_Core_Permission::check('access deleted contacts') && Civi::settings()->get('contact_undelete')) {
       $this->addElement('checkbox', 'deleted_contacts', ts('Search in Trash') . '<br />' . ts('(deleted contacts)'));

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -76,6 +76,7 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;
+    $this->sortNameOnly = TRUE;
 
     parent::preProcess();
 


### PR DESCRIPTION
…deleted_contacts fields for contribute, pledge searches

Overview
----------------------------------------
This adds search field metadata so that on search forms other than search builder, and find contacts you can use urls like `&force=1&contact_tags=4` or `&force=1&group=4` or `&force=1&contact_type=Individual`

Before
----------------------------------------
No URL support for these fields

After
----------------------------------------
URL support for these fields

ping @demeritcowboy @eileenmcnaughton 