### PR TITLE
[UI] Ensure that when sorting on columns in the find activity search …

### DIFF
--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -14,21 +14,23 @@
 
 {strip}
 <table class="selector row-highlight">
-   <tr class="sticky">
-     {if !$single and $context eq 'Search' }
-        <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
-     {/if}
-     {foreach from=$columnHeaders item=header}
-        <th scope="col">
-        {if $header.sort}
-          {assign var='key' value=$header.sort}
-          {$sort->_response.$key.link}
-        {else}
-          {$header.name}
-        {/if}
-        </th>
-     {/foreach}
-   </tr>
+   <thead>
+     <tr class="sticky">
+       {if !$single and $context eq 'Search' }
+          <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+       {/if}
+       {foreach from=$columnHeaders item=header}
+          <th scope="col">
+          {if $header.sort}
+            {assign var='key' value=$header.sort}
+            {$sort->_response.$key.link}
+          {else}
+            {$header.name}
+          {/if}
+          </th>
+       {/foreach}
+     </tr>
+   </thead>
 
 
   {counter start=0 skip=1 print=false}


### PR DESCRIPTION
…the arrow shows which field is being sorted and direction

Overview
----------------------------------------
Title says it all, the arrow currently doesn't show on the find activities search form

Before
----------------------------------------
![Activity Search pre](https://user-images.githubusercontent.com/6799125/69489027-f7af5d80-0ec6-11ea-8ae5-eae98c3cbcd0.jpg)


After
----------------------------------------
![Activity Search post](https://user-images.githubusercontent.com/6799125/69489031-fb42e480-0ec6-11ea-8715-6d6abb051a30.jpg)


ping @pfigel @eileenmcnaughton 
