### PR TITLE
Sort CMS Database Table list

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -81,6 +81,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
     ) {
       $dsnArray = DB::parseDSN($config->dsn);
       $tableNames = CRM_Core_DAO::getTableNames();
+      asort($tableNames);
       $tablePrefixes = '$databases[\'default\'][\'default\'][\'prefix\']= array(';
       if ($config->userFramework === 'Backdrop') {
         $tablePrefixes = '$database_prefix = array(';


### PR DESCRIPTION
Overview
----------------------------------------
Sort the CMS Database Tables list (the one for settings.php) for more clarity

Before
----------------------------------------
The CMS Database Tables list to be included in settings.php was not sorted.

After
----------------------------------------
The CMS Database Tables list to be included in settings.php was is sorted alphabetically.

Technical Details
----------------------------------------
simple array sort

Comments
----------------------------------------