### PR TITLE
dev/core#874 [UI] Fix styling of the menubar colour picker in joomla

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -371,6 +371,11 @@ div#toolbar-box, div#toolbar-box div.m{
   display: block;
 }
 
+/* dev/core#874 the width:auto styling above causes the menubar colour picker to be squeezed */
+.crm-container input.crm-form-color {
+  width: 3.6em;
+}
+
 /* Remove Joomla subhead toolbar & whitespace border */
 	
 body.admin.com_civicrm .subhead-collapse {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the display of the menubar colour picker on Joomla so it looks more like the other CMSes

Before
----------------------------------------
![Joomla_color_before_patch](https://user-images.githubusercontent.com/6799125/69501234-2248f700-0f57-11ea-9af4-fc62697dd934.jpg)


After
----------------------------------------
![Joomla_color_post_patch](https://user-images.githubusercontent.com/6799125/69501239-2e34b900-0f57-11ea-9229-1f63ec4fd888.jpg)


ping @lcdservices @colemanw @kcristiano 