### PR TITLE
Rename activity search field from status_id to activity_status_id

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -443,11 +443,12 @@ class CRM_Activity_BAO_Query {
   /**
    * Get the metadata for fields to be included on the activity search form.
    *
+   * @throws \CiviCRM_API3_Exception
    * @todo ideally this would be a trait included on the activity search & advanced search
    * rather than a static function.
    */
   public static function getSearchFieldMetadata() {
-    $fields = ['activity_type_id', 'activity_date_time', 'priority_id', 'activity_location'];
+    $fields = ['activity_type_id', 'activity_date_time', 'priority_id', 'activity_location', 'activity_status_id'];
     $metadata = civicrm_api3('Activity', 'getfields', [])['values'];
     $metadata = array_intersect_key($metadata, array_flip($fields));
     $metadata['activity_text'] = [
@@ -462,6 +463,9 @@ class CRM_Activity_BAO_Query {
    * Add all the elements shared between case activity search and advanced search.
    *
    * @param CRM_Core_Form_Search $form
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function buildSearchForm(&$form) {
     $form->addSearchFieldMetadata(['Activity' => self::getSearchFieldMetadata()]);
@@ -484,21 +488,13 @@ class CRM_Activity_BAO_Query {
       'flip' => 1,
       'labelColumn' => 'name',
     ]);
-    $form->addSelect('status_id',
-      [
-        'entity' => 'activity',
-        'multiple' => 'multiple',
-        'option_url' => NULL,
-        'placeholder' => ts('- any -'),
-      ]
-    );
     $ssID = $form->get('ssID');
     $status = [$activityStatus['Completed'], $activityStatus['Scheduled']];
     //If status is saved in smart group.
     if (!empty($ssID) && !empty($form->_formValues['activity_status_id'])) {
       $status = $form->_formValues['activity_status_id'];
     }
-    $form->setDefaults(['status_id' => $status]);
+    $form->setDefaults(['activity_status_id' => $status]);
 
     $form->addElement('text', 'activity_text', ts('Activity Text'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
 

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -173,6 +173,8 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
    *
    * The processing consists of using a Selector / Controller framework for getting the
    * search results.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
     if ($this->_done) {
@@ -184,11 +186,9 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     if (!empty($_POST)) {
       $specialParams = [
         'activity_type_id',
-        'status_id',
         'priority_id',
       ];
       $changeNames = [
-        'status_id' => 'activity_status_id',
         'priority_id' => 'activity_priority_id',
       ];
 

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -323,7 +323,6 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       'participant_status_id',
       'contribution_trxn_id',
       'activity_type_id',
-      'status_id',
       'priority_id',
       'contribution_product_id',
       'payment_instrument_id',
@@ -332,7 +331,6 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       'preferred_communication_method',
     ];
     $changeNames = [
-      'status_id' => 'activity_status_id',
       'priority_id' => 'activity_priority_id',
     ];
     CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);

--- a/CRM/Contact/Form/Search/Custom/ActivitySearch.php
+++ b/CRM/Contact/Form/Search/Custom/ActivitySearch.php
@@ -24,6 +24,8 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
    * Class constructor.
    *
    * @param array $formValues
+   *
+   * @throws \CRM_Core_Exception
    */
   public function __construct(&$formValues) {
     $this->_formValues = self::formatSavedSearchFields($formValues);
@@ -145,6 +147,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
    * @param bool $justIDs
    *
    * @return string
+   * @throws \CRM_Core_Exception
    */
   public function all(
     $offset = 0, $rowcount = 0, $sort = NULL,
@@ -188,7 +191,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
     $groupTree = CRM_Core_BAO_CustomGroup::getTree('Activity');
 
     foreach ($groupTree as $key) {
-      if (!empty($key['extends']) && $key['extends'] == 'Activity') {
+      if (!empty($key['extends']) && $key['extends'] === 'Activity') {
         $select .= ", " . $key['table_name'] . ".*";
         $from .= " LEFT JOIN " . $key['table_name'] . " ON " . $key['table_name'] . ".entity_id = activity.id";
       }
@@ -348,6 +351,8 @@ ORDER BY contact_a.sort_name';
 
   /**
    * @inheritDoc
+   *
+   * @throws \CRM_Core_Exception
    */
   public function count() {
     $sql = $this->all();

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -143,7 +143,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   /**
    * Set the form values based on input and preliminary processing.
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   protected function setFormValues() {
     $this->_formValues = $this->getFormValues();

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -80,8 +80,8 @@
     {$form.activity_option.html}<br/>
   </td>
   <td colspan="2">
-    {$form.status_id.label}<br/>
-    {$form.status_id.html}
+    {$form.activity_status_id.label}<br/>
+    {$form.activity_status_id.html}
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Overview
----------------------------------------
Renames form field status_id to activity_status_id in advanced search - mostly for code simplification.

Before
----------------------------------------
Field called status_id, renamed as soon as submitted to activity_status_id

After
----------------------------------------
Field called activity_status_id

Technical Details
----------------------------------------
Currently this is on the form as 'status_id' but as soon as it's submitted the value is renamed - I think
we might not even need to change the smart group for this one.

The other field that is being renamed is 'priority_id'. Unless we have an appetite to
add a uniqueName for this field (which I kind of feel like not doing more of for some
cycles), I think we could stop renaming it & rely on the default where handling for the
where clause. From what I can see the reason for prefixing is not about
uniqueness but rather about adding a prefix so it gets handled by
Activity_BAO_Query - but in fact Contact_BAO_Query should handle it just fine
based on metadata

Comments
----------------------------------------
@seamuslee001 when I looked at https://github.com/civicrm/civicrm-core/pull/15928 I tried to unravel what was happening with $_formValues & this seems like an easy simplification. I signposted what I think we can do to eliminate priority_id too. 

It looks like it works fine with some complexity removed. 