### PR TITLE
CSV Export: Add deprecation warning

### DIFF
--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -308,6 +308,7 @@ class CRM_Core_Selector_Controller {
       CRM_Utils_Hook::searchColumns($contextName, $columnHeaders, $rows, $this);
       if ($this->_output == self::EXPORT) {
         // export the rows.
+        CRM_Core_Error::deprecatedFunctionWarning('This code is believed to be unreachable & to be later removed. Please log how you reached it in gitlab');
         CRM_Core_Report_Excel::writeCSVFile($this->_object->getExportFileName(),
           $columnHeaders,
           $rows


### PR DESCRIPTION
Overview
----------------------------------------
Adds a deprecation warning on code I believe to be unreachable

Before
----------------------------------------


After
----------------------------------------
A deprecation message would show up (on dev sites) if this code is ever hit

Technical Details
----------------------------------------
On digging into this export function I cannot find any way to access these lines.

If no-one else can spot a way I propose adding a deprecation notice & later removing

Comments
----------------------------------------

