### PR TITLE
Fix deprecation warning on Price Set report

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1016,6 +1016,8 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    * @param string $cacheKey
    * @param int $start
    * @param int $end
+   *
+   * @throws \CRM_Core_Exception
    */
   public function fillupPrevNextCache($sort, $cacheKey, $start = 0, $end = self::CACHE_SIZE) {
     $coreSearch = TRUE;
@@ -1041,7 +1043,9 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     $selectSQL = CRM_Core_DAO::composeQuery("SELECT DISTINCT %1, contact_a.id, contact_a.sort_name", [1 => [$cacheKey, 'String']]);
 
-    $sql = str_ireplace(["SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"], $selectSQL, $sql);
+    $sql = str_ireplace(['SELECT contact_a.id as contact_id', 'SELECT contact_a.id as id'], $selectSQL, $sql);
+    $sql = str_ireplace('ORDER BY `contact_id`', 'ORDER BY `id`', $sql, $sql);
+
     try {
       Civi::service('prevnext')->fillWithSql($cacheKey, $sql);
     }


### PR DESCRIPTION

Overview
----------------------------------------
Removes a new deprecation notice from PriceSet Search

Before
----------------------------------------

<img width="867" alt="Screen Shot 2019-11-25 at 3 38 40 PM" src="https://user-images.githubusercontent.com/336308/69509671-b9856d00-0f9e-11ea-8d28-035edac1696d.png">


After
----------------------------------------
<img width="821" alt="Screen Shot 2019-11-25 at 4 08 51 PM" src="https://user-images.githubusercontent.com/336308/69509539-4c71d780-0f9e-11ea-964a-c53f265c559f.png">


Technical Details
----------------------------------------
In 5.20 we added a deprecation warning on searches that are borked WRT filling the prev_next
cache & hence doing searches. The price set search falls into this camp & while it has
been broken forever the deprecation notice is new (& the fix is safe) so targetting 5.20

Comments
----------------------------------------
@seamuslee001 - this is the one you found
