### PR TITLE
core#1420 Quicksearch with phone filter doesn't work with non-numeric character

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -758,6 +758,10 @@ function civicrm_api3_contact_getquick($params) {
     if ($field_name == 'contact_id') {
       $field_name = 'id';
     }
+    // core#1420 : trim non-numeric character from phone search string
+    elseif ($field_name == 'phone_numeric') {
+      $name = preg_replace('/[^\d]/', '', $name);
+    }
     if (isset($table_names[$field_name])) {
       $table_name = $table_names[$field_name];
     }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3238,6 +3238,65 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that getquick returns contacts with different cases of phone substring.
+   */
+  public function testGetQuickPhone() {
+    $this->getQuickSearchSampleData();
+    $criterias = [
+      [
+        'criteria' => [
+          'name' => '87-6',
+          'field_name' => 'phone_numeric',
+        ],
+        'count' => 2,
+        'sort_names' => [
+          'I Bobby, Bobby',
+          'J Bobby, Bobby',
+        ],
+      ],
+      [
+        'criteria' => [
+          'name' => '876-1',
+          'field_name' => 'phone_numeric',
+        ],
+        'count' => 1,
+        'sort_names' => [
+          'I Bobby, Bobby',
+        ],
+      ],
+      [
+        'criteria' => [
+          'name' => '87623',
+          'field_name' => 'phone_numeric',
+        ],
+        'count' => 1,
+        'sort_names' => [
+          'J Bobby, Bobby',
+        ],
+      ],
+      [
+        'criteria' => [
+          'name' => '8a7abc6',
+          'field_name' => 'phone_numeric',
+        ],
+        'count' => 2,
+        'sort_names' => [
+          'I Bobby, Bobby',
+          'J Bobby, Bobby',
+        ],
+      ],
+    ];
+
+    foreach ($criterias as $criteria) {
+      $result = $this->callAPISuccess('contact', 'getquick', $criteria['criteria']);
+      $this->assertEquals($result['count'], $criteria['count']);
+      foreach ($criteria['sort_names'] as $key => $sortName) {
+        $this->assertEquals($sortName, $result['values'][$key]['sort_name']);
+      }
+    }
+  }
+
+  /**
    * Test that getquick returns contacts with an exact first name match first.
    *
    * Depending on the setting the sort name sort might click in next or not - test!
@@ -3387,8 +3446,28 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       ['first_name' => 'Bobby', 'last_name' => 'F Bobby', 'external_identifier' => 'klm'],
       ['first_name' => 'Bobby', 'last_name' => 'G Bobby', 'external_identifier' => 'nop'],
       ['first_name' => 'Bobby', 'last_name' => 'H Bobby', 'external_identifier' => 'qrs', 'email' => 'bob@h.com'],
-      ['first_name' => 'Bobby', 'last_name' => 'I Bobby'],
-      ['first_name' => 'Bobby', 'last_name' => 'J Bobby'],
+      [
+        'first_name' => 'Bobby',
+        'last_name' => 'I Bobby',
+        'api.phone.create' => [
+          'phone' => '876-123',
+          'phone_ext' => '444',
+          "phone_type_id" => "Phone",
+          'location_type_id' => 1,
+          'is_primary' => 1,
+        ],
+      ],
+      [
+        'first_name' => 'Bobby',
+        'last_name' => 'J Bobby',
+        'api.phone.create' => [
+          'phone' => '87-6-234',
+          'phone_ext' => '134',
+          "phone_type_id" => "Phone",
+          'location_type_id' => 1,
+          'is_primary' => 1,
+        ],
+      ],
       ['first_name' => 'Bob', 'last_name' => 'K Bobby', 'external_identifier' => 'bcdef'],
       ['first_name' => 'Bob', 'last_name' => 'Aadvark'],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Say a contact A has a phone number : (867) 809-5412
2. Go to quicksearch bar and select 'Phone' filter
3. Type '867-8' in the search field.

Bug: It doesn't return contact A, because the code doesn't trim non-numeric character for the phone_numeric filter which expects only numeric digits.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/69527110-9bfdd680-0f91-11ea-85d8-6765fd003c7b.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/69527119-a324e480-0f91-11ea-8045-21f07c114bfc.gif)


Technical Details
----------------------------------------
Issue link https://lab.civicrm.org/dev/core/issues/1420 
There's another example where we trim the phone characters in finding duplicate contacts in [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Dedupe/Finder.php#L124)
 

Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @lcdservices 