### PR TITLE
Fix e-notice on case search when using sort_name as a url parameter

### DIFF
--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -96,12 +96,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
 
     $this->_done = FALSE;
 
-    $this->loadStandardSearchOptionsFromUrl();
-    $this->loadFormValues();
-
-    if ($this->_force) {
-      $this->handleForcedSearch();
-    }
+    parent::preProcess();
 
     $sortID = NULL;
     if ($this->get(CRM_Utils_Sort::SORT_ID)) {
@@ -231,7 +226,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
 
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
 
-    $this->set('formValues', $this->_formValues);
     $this->set('queryParams', $this->_queryParams);
 
     $buttonName = $this->controller->getButtonName();


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an e-notice when searching on the sort_name field or case_subject field using url parameters e.g. `&force=1&sort_name=test`

Before
----------------------------------------
![Case sort_name notice fix](https://user-images.githubusercontent.com/6799125/69576163-df9f2180-101f-11ea-92fa-f2cf90a6cd0f.jpg)


After
----------------------------------------
![Case sort_name notice fix_2](https://user-images.githubusercontent.com/6799125/69576172-e332a880-101f-11ea-9e79-840f27a48d48.jpg)


Technical Details
----------------------------------------
This is a smaller subset of https://github.com/civicrm/civicrm-core/pull/15920/files

I also tested the sort_name parameter in Find Activitys, Find Contributions, Find Participants, Find Mailings, etc and this is the only form that generated an e-notice the others were either fixed or just didn't handle the search field in force mode

ping @eileenmcnaughton @demeritcowboy 