### PR TITLE
[REF] Remove unused parameter

### DIFF
--- a/CRM/Core/Report/Excel.php
+++ b/CRM/Core/Report/Excel.php
@@ -27,20 +27,16 @@ class CRM_Core_Report_Excel {
    * @param array $rows
    *   result set rows.
    * @param string $titleHeader
-   * @param bool $print
-   *   Should the output be printed.
    * @param bool $outputHeader
    *
    * @return mixed
    *   empty if output is printed, else output
    *
    */
-  public static function makeCSVTable($header, $rows, $titleHeader = NULL, $print = TRUE, $outputHeader = TRUE) {
+  public static function makeCSVTable($header, $rows, $titleHeader = NULL, $outputHeader = TRUE) {
     if ($titleHeader) {
       echo $titleHeader;
     }
-
-    $result = '';
 
     $config = CRM_Core_Config::singleton();
     $seperator = $config->fieldSeparator;
@@ -59,12 +55,7 @@ class CRM_Core_Report_Excel {
       // need to add PMA_exportOutputHandler functionality out here, rather than
       // doing it the moronic way of assembling a buffer
       $out = trim(substr($schema_insert, 0, -1)) . $add_character;
-      if ($print) {
-        echo $out;
-      }
-      else {
-        $result .= $out;
-      }
+      echo $out;
     }
 
     $fields_cnt = count($header);
@@ -110,19 +101,7 @@ class CRM_Core_Report_Excel {
       // end for
 
       $out = $schema_insert . $add_character;
-      if ($print) {
-        echo $out;
-      }
-      else {
-        $result .= $out;
-      }
-    }
-
-    if ($print) {
-      return;
-    }
-    else {
-      return $result;
+      echo $out;
     }
   }
 
@@ -189,7 +168,7 @@ class CRM_Core_Report_Excel {
     }
 
     if (!empty($rows)) {
-      return self::makeCSVTable($header, $rows, $titleHeader, TRUE, $outputHeader);
+      return self::makeCSVTable($header, $rows, $titleHeader, $outputHeader);
     }
   }
 

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2387,7 +2387,7 @@ LIMIT $offset, $limit
       'csv',
       FALSE
     );
-    CRM_Core_Report_Excel::makeCSVTable($headerRows, [], NULL, TRUE, TRUE);
+    CRM_Core_Report_Excel::makeCSVTable($headerRows, [], NULL, TRUE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This parameter is always TRUE so it adds no value, removing

Before
----------------------------------------
$print is a parameter on makeCSVTable but it is always TRUE so it is meaningless

After
----------------------------------------
$print removed

Technical Details
----------------------------------------
A cleanup recently merged by @colemanw removed an upstream scenario where it in theory might not have been true - but in practice was

Comments
----------------------------------------

