### PR TITLE
dev/core#1422 Ensure that the form values are correctly passed onto t…

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -496,4 +496,16 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     return ts('Find Participants');
   }
 
+  /**
+   * Set the default form values.
+   *
+   *
+   * @return array
+   *   the default array reference
+   */
+  public function setDefaultValues() {
+    parent::setDefaultValues();
+    return $this->_formValues;
+  }
+
 }


### PR DESCRIPTION
…he Badge label task and others

Overview
----------------------------------------
This resolves an issue where by the formValues were not being correctly passed through to the relevant task so that when you went to print name badges it was showing 18 instead of 8 records that should have been selected

Before
----------------------------------------
Wrong count of participants was showing when generating name badges

After
----------------------------------------
Correct count of participants showing

ping @eileenmcnaughton @AlainBenbassat This also seemed to resolve an e-notice that was showing on the form as well but not sure if that was just coincidental or not 