### PR TITLE
dev/financial#109 Fix country/province assignation in the contribution invoice

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -495,15 +495,17 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       if (!empty($address->state_province_id)) {
         $address->state = CRM_Core_PseudoConstant::stateProvinceAbbreviation($address->state_province_id, FALSE);
         $address->state_name = CRM_Core_PseudoConstant::stateProvince($address->state_province_id, FALSE);
+        $values['state_province_abbreviation'] = $address->state;
+        $values['state_province'] = $address->state_name;
       }
 
       if (!empty($address->country_id)) {
         $address->country = CRM_Core_PseudoConstant::country($address->country_id);
+        $values['country'] = $address->country;
 
         //get world region
         $regionId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Country', $address->country_id, 'region_id');
-
-        $address->world_region = CRM_Core_PseudoConstant::worldregion($regionId);
+        $values['world_region'] = CRM_Core_PseudoConstant::worldregion($regionId);
       }
 
       $address->addDisplay($microformat);

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -261,6 +261,9 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $address = CRM_Core_BAO_Address::getValues($entityBlock);
     $this->assertEquals($address[1]['id'], $addressId);
     $this->assertEquals($address[1]['contact_id'], $contactId);
+    $this->assertEquals($address[1]['state_province_abbreviation'], 'AL');
+    $this->assertEquals($address[1]['state_province'], 'Alabama');
+    $this->assertEquals($address[1]['country'], 'United States');
     $this->assertEquals($address[1]['street_address'], 'Oberoi Garden');
     $this->contactDelete($contactId);
   }


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

* Enable Taxes and Invoicing
* Edit the "Contribution Invoice Receipt" message template to include `{$country}` (other related contact tokens are called `{$street_address}`, `{$email}`, etc.
* Go to a contact, create a contribution, and from "view contribution", click "print PDF invoice" to view an invoice.

The country will be empty.

https://lab.civicrm.org/dev/financial/issues/109

Technical Details
----------------------------------------

* `CRM_Contribute_Form_Task_Invoice`: I did a bit of code cleanup because the invoice code did not make a ton of sense, and presumably `CRM_Core_BAO_Address::getValues()` has changed a fair amount since this invoice code was first written. Notably the loop for finding the billing address seemed over-complex.
* `CRM_Contribute_Form_Task_Invoice` also had an array for `billingAddress`, which hinted that there could be something more going on, but given that the variable is initialized inside the loop, I could not figure out its purpose.
* `CRM_Core_BAO_Address::getValues() was doing state/province lookup, but it was not storing it in the right variable, so it was not getting returned to the caller.