### PR TITLE
Fix potential test glitch when repeatedly calling createLoggedInUser

### DIFF
--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -31,6 +31,7 @@ trait ContactTestTrait {
       'domain_id' => \CRM_Core_Config::domainID(),
     ];
     $contactID = $this->individualCreate($params);
+    $this->callAPISuccess('UFMatch', 'get', ['uf_id' => 6, 'api.UFMatch.delete' => []]);
     $this->callAPISuccess('UFMatch', 'create', [
       'contact_id' => $contactID,
       'uf_name' => 'superman',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a potential unit test glitch.

Comments
----------------------------------------
I ran into this when repeatedly running unit tests - if a particular test doesn't clean up UF_Match records after itself then we end up with a constraint violation trying to create a new one that already exists.

I think if this passes Jenkins then it should be harmless, just a safeguard to make the tests more stable.