### PR TITLE
Conditionally add metadata for advanced search only if the user has a…

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -907,15 +907,29 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
+   * Check Access for a component
+   * @param string $component
+   * @return bool
+   */
+  protected static function checkComponentAccess($component) {
+    $enabledComponents = CRM_Core_Component::getEnabledComponents();
+    if (!array_key_exists($component, $enabledComponents)) {
+      return FALSE;
+    }
+    return CRM_Core_Permission::access($component);
+  }
+
+  /**
    * Load metadata for fields on the form.
    *
    * @throws \CiviCRM_API3_Exception
    */
   protected function loadMetadata() {
-    // @todo - check what happens if the person does not have 'access civicontribute' - make sure they
     // can't by pass acls by passing search criteria in the url.
-    $this->addSearchFieldMetadata(['Contribution' => CRM_Contribute_BAO_Query::getSearchFieldMetadata()]);
-    $this->addSearchFieldMetadata(['ContributionRecur' => CRM_Contribute_BAO_ContributionRecur::getContributionRecurSearchFieldMetadata()]);
+    if (self::checkComponentAccess('CiviContribute')) {
+      $this->addSearchFieldMetadata(['Contribution' => CRM_Contribute_BAO_Query::getSearchFieldMetadata()]);
+      $this->addSearchFieldMetadata(['ContributionRecur' => CRM_Contribute_BAO_ContributionRecur::getContributionRecurSearchFieldMetadata()]);
+    }
   }
 
 }


### PR DESCRIPTION
…ccess for searching to that perticular component

Overview
Following a comment by @demeritcowboy on this PR https://github.com/civicrm/civicrm-core/pull/15942 i figured i should check what happens and currently if you pass in `&force=1&contribution_receive_date_relative=this.month` on the advanced search form it will add that to the query no matter if you have the CiviContribute Component enabled or if your user can actually access that component.  This PR alters it so we only conditionally add in the relevant search field metadata

Before
----------------------------------------
In force=1 mode the parameters are automatically added to the query without checking if the user has the appropriate access

After
----------------------------------------
URL parameters are only added if user has appropriate access

ping @eileenmcnaughton @monishdeb @demeritcowboy 