### PR TITLE
dev/report#23 - Fix contact sub-type 'is not one of' filtering

### DIFF
--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1146,6 +1146,44 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test contact subtype filter on summary report.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testContactSubtypeIn() {
+    $this->individualCreate(['contact_sub_type' => ['Student', 'Parent']]);
+    $this->individualCreate();
+
+    $rows = $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => 'contact/summary',
+      'contact_sub_type_op' => 'in',
+      'contact_sub_type_value' => ['Student'],
+      'contact_type_op' => 'in',
+      'contact_type_value' => 'Individual',
+    ]);
+    $this->assertEquals(1, $rows['count']);
+  }
+
+  /**
+   * Test contact subtype filter on summary report.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testContactSubtypeNotIn() {
+    $this->individualCreate(['contact_sub_type' => ['Student', 'Parent']]);
+    $this->individualCreate();
+
+    $rows = $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => 'contact/summary',
+      'contact_sub_type_op' => 'notin',
+      'contact_sub_type_value' => ['Student'],
+      'contact_type_op' => 'in',
+      'contact_type_value' => 'Individual',
+    ]);
+    $this->assertEquals(1, $rows['count']);
+  }
+
+  /**
    * Test PCP report to ensure total donors and total committed is accurate.
    */
   public function testPcpReportTotals() {


### PR DESCRIPTION
Overview
----------------------------------------
When filtering by contact sub-type using 'is not one of' do not exclude where sub-type is null.

Before
----------------------------------------
When filtering by contact sub-type in a report using 'is not one of', only contacts with a sub-type are returned.  For example, 'is not one of' 'Student' excludes Students and all those with no sub-type.

After
----------------------------------------
Contacts with no sub-type are included, so the only ones excluded are the Students.

Technical Details
----------------------------------------
This adds unit tests for contact sub-type 'is one of' and 'is not one of'.

It also tightens the matching on sub-type to avoid problems where one contact sub-type is a substring of another.

Comments
----------------------------------------
See also https://lab.civicrm.org/dev/report/issues/23
https://lab.civicrm.org/dev/report/issues/15#note_25491
