### PR TITLE
report#24 - Case Detail report - fix 'Active role?' when no relationships

### DIFF
--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -44,12 +44,6 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
       $this->rel_types[$relid] = $v['label_b_a'];
     }
 
-    $this->deleted_labels = [
-      '' => ts('- select -'),
-      0 => ts('No'),
-      1 => ts('Yes'),
-    ];
-
     $this->caseActivityTypes = [];
     foreach (CRM_Case_PseudoConstant::caseActivityType() as $typeDetail) {
       $this->caseActivityTypes[$typeDetail['id']] = $typeDetail['label'];
@@ -81,7 +75,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
           'is_deleted' => [
             'title' => ts('Deleted?'),
             'default' => FALSE,
-            'type' => CRM_Utils_Type::T_INT,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
           ],
         ],
         'filters' => [
@@ -109,9 +103,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
           ],
           'is_deleted' => [
             'title' => ts('Deleted?'),
-            'type' => CRM_Utils_Type::T_INT,
-            'operatorType' => CRM_Report_Form::OP_SELECT,
-            'options' => $this->deleted_labels,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
             'default' => 0,
           ],
         ],
@@ -173,8 +165,6 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
           'is_active' => [
             'title' => ts('Active Role?'),
             'type' => CRM_Utils_Type::T_BOOLEAN,
-            'default' => TRUE,
-            'options' => CRM_Core_SelectValues::boolean(),
           ],
         ],
       ],
@@ -672,12 +662,6 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
           }
           $rows[$rowNum]['case_activity_all_dates'] = implode('; ', $activityDates);
         }
-        $entryFound = TRUE;
-      }
-
-      if (array_key_exists('civicrm_case_is_deleted', $row)) {
-        $value = $row['civicrm_case_is_deleted'];
-        $rows[$rowNum]['civicrm_case_is_deleted'] = $this->deleted_labels[$value];
         $entryFound = TRUE;
       }
 

--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -33,12 +33,6 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
       $this->rel_types[$relid] = $v['label_b_a'];
     }
 
-    $this->deleted_labels = [
-      '' => ts('- select -'),
-      0 => ts('No'),
-      1 => ts('Yes'),
-    ];
-
     $this->_columns = [
       'civicrm_c2' => [
         'dao' => 'CRM_Contact_DAO_Contact',
@@ -97,7 +91,7 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
           'is_deleted' => [
             'title' => ts('Deleted?'),
             'default' => FALSE,
-            'type' => CRM_Utils_Type::T_INT,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
           ],
         ],
         'filters' => [
@@ -125,9 +119,7 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
           ],
           'is_deleted' => [
             'title' => ts('Deleted?'),
-            'type' => CRM_Report_Form::OP_INT,
-            'operatorType' => CRM_Report_Form::OP_SELECT,
-            'options' => $this->deleted_labels,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
             'default' => 0,
           ],
         ],
@@ -170,9 +162,6 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
           'is_active' => [
             'title' => ts('Active Relationship?'),
             'type' => CRM_Utils_Type::T_BOOLEAN,
-            //MV dev/core#603, not set default values Yes/No, this cause issue when relationship fields are not selected
-            // 'default' => TRUE,
-            'options' => ['' => ts('- Select -')] + CRM_Core_SelectValues::boolean(),
           ],
         ],
       ],
@@ -376,12 +365,6 @@ inner join civicrm_contact $c2 on ${c2}.id=${ccc}.contact_id
         );
         $rows[$rowNum]['civicrm_case_subject_link'] = $url;
         $rows[$rowNum]['civicrm_case_subject_hover'] = ts("Manage Case");
-        $entryFound = TRUE;
-      }
-
-      if (array_key_exists('civicrm_case_is_deleted', $row)) {
-        $value = $row['civicrm_case_is_deleted'];
-        $rows[$rowNum]['civicrm_case_is_deleted'] = $this->deleted_labels[$value];
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
The 'Active Role?' filter assumes relationships will exist and wrongly excludes them

Before
----------------------------------------
The 'Active Role?' filter only offers 'Yes' or 'No' - but both options exclude cases without relationships.

After
----------------------------------------
The 'Active Role?' filter offers 'Yes', 'No' or 'Any' - 'Yes' & 'No' operate as before when relationships exist.  'Any' does not exclude cases where no relationships exist.

Technical Details
----------------------------------------
Changes 'Active Role?' and 'Is Deleted?' to use default behaviour for booleans.

Comments
----------------------------------------
https://lab.civicrm.org/dev/report/issues/24
