### PR TITLE
Link to docs.civicrm.org instead of wiki

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -136,7 +136,7 @@ class CRM_Upgrade_Incremental_General {
     }, array_keys($messages), $messages);
 
     $message .= '<br />' . ts("The default copies of the message templates listed below will be updated to handle new features or correct a problem. Your installation has customized versions of these message templates, and you will need to apply the updates manually after running this upgrade. <a href='%1' style='color:white; text-decoration:underline; font-weight:bold;' target='_blank'>Click here</a> for detailed instructions. %2", [
-      1 => 'http://wiki.civicrm.org/confluence/display/CRMDOC/Message+Templates#MessageTemplates-UpgradesandCustomizedSystemWorkflowTemplates',
+      1 => 'https://docs.civicrm.org/user/en/latest/email/message-templates/#modifying-system-workflow-message-templates',
       2 => '<ul>' . implode('', $messagesHtml) . '</ul>',
     ]);
 
@@ -213,7 +213,7 @@ class CRM_Upgrade_Incremental_General {
       $html = "<ul>" . $html . "<ul>";
 
       $message .= '<br />' . ts("The default copies of the message templates listed below will be updated to handle new features or correct a problem. Your installation has customized versions of these message templates, and you will need to apply the updates manually after running this upgrade. <a href='%1' style='color:white; text-decoration:underline; font-weight:bold;' target='_blank'>Click here</a> for detailed instructions. %2", [
-        1 => 'http://wiki.civicrm.org/confluence/display/CRMDOC/Message+Templates#MessageTemplates-UpgradesandCustomizedSystemWorkflowTemplates',
+        1 => 'https://docs.civicrm.org/user/en/latest/email/message-templates/#modifying-system-workflow-message-templates',
         2 => $html,
       ]);
     }


### PR DESCRIPTION
Overview
----------------------------------------
5.20 has many template changes.  Current upgrade message links to the deprectaed wiki.  This changes to link to docs.civicrm.org

Before
----------------------------------------
The redirect from wiki.civicrm.org to docs.civicrm.org does not take the user to the relevant section, just the page regarding Message templates

After
----------------------------------------
The link now goes to the correct section


