### PR TITLE
Make else statement more legible

### DIFF
--- a/CRM/Core/Report/Excel.php
+++ b/CRM/Core/Report/Excel.php
@@ -64,10 +64,10 @@ class CRM_Core_Report_Excel {
       $colNo = 0;
 
       foreach ($row as $j => $value) {
-        if (!isset($value) || is_null($value)) {
+        if (!isset($value) || is_null($value) || $value === '') {
           $schema_insert .= '';
         }
-        elseif ($value == '0' || $value != '') {
+        else {
           // loic1 : always enclose fields
           //$value = ereg_replace("\015(\012)?", "\012", $value);
           $value = preg_replace("/\015(\012)?/", "\012", $value);
@@ -88,9 +88,6 @@ class CRM_Core_Report_Excel {
           }
 
           $schema_insert .= $enclosed . str_replace($enclosed, $escaped . $enclosed, $value) . $enclosed;
-        }
-        else {
-          $schema_insert .= '';
         }
 
         if ($colNo < $fields_cnt - 1) {


### PR DESCRIPTION
Overview
----------------------------------------
Minor readability cleanup  part of WTF-reduction regime

Before
----------------------------------------
We see the equivalent of 
```
if ($a or $b) {
  $x = 1;
}
elseif ($value == '0' || $value !== '') {
 $x = 2;
}
else {
  $x = 1;
}
```
The 2 statements in the second part overlap - ie if value  == 0 is redundant & the final else only applies when $value !== ''

After
----------------------------------------
We see the equivalent of 
```
if ($a or $b  || $value !== '') {
  $x = 1;
}
else  {
 $x = 2;
}
```

Technical Details
----------------------------------------
This just condenses the statement since  != '' is so broad we know the final
else is only when that is true - ergo it's the same as above

Comments
----------------------------------------

