### PR TITLE
dev/core#1425 More aggressively deprecate old setItem & setOptionValue functions on BAO_Setting

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -125,8 +125,6 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
   /**
    * Store an item in the setting table.
    *
-   * _setItem() is the common logic shared by setItem() and setItems().
-   *
    * @param $value
    *   (required) The value that will be serialized and stored.
    * @param string $group
@@ -140,6 +138,10 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *   An optional ID to assign the creator to. If not set, retrieved from session.
    *
    * @param int $domainID
+   *
+   * @throws \CRM_Core_Exception
+   *
+   * @deprecated - refer docs https://docs.civicrm.org/dev/en/latest/framework/setting/
    */
   public static function setItem(
     $value,
@@ -150,6 +152,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     $createdID = NULL,
     $domainID = NULL
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('refer docs for correct methods https://docs.civicrm.org/dev/en/latest/framework/setting/');
+
     /** @var \Civi\Core\SettingsManager $manager */
     $manager = \Civi::service('settings_manager');
     $settings = ($contactID === NULL) ? $manager->getBagByDomain($domainID) : $manager->getBagByContact($domainID, $contactID);
@@ -162,8 +166,6 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *  'name' setting's name
    *  'config_key' = the config key is different to the settings key - e.g. debug where there was a conflict
    *  'legacy_key' = rename from config or setting with this name
-   *
-   * _setItem() is the common logic shared by setItem() and setItems().
    *
    * @param array $params
    *   (required) An api formatted array of keys and values.
@@ -421,6 +423,10 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    * @param bool $system
    * @param int $userID
    * @param string $keyField
+   *
+   * @throws \CRM_Core_Exception
+   *
+   * @deprecated
    */
   public static function setValueOption(
     $group,
@@ -430,6 +436,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     $userID = NULL,
     $keyField = 'name'
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('refer docs for correct methods https://docs.civicrm.org/dev/en/latest/framework/setting/');
     if (empty($value)) {
       $optionValue = NULL;
     }

--- a/tests/phpunit/CRM/Core/BAO/PreferencesTest.php
+++ b/tests/phpunit/CRM/Core/BAO/PreferencesTest.php
@@ -30,20 +30,4 @@ class CRM_Core_BAO_PreferencesTest extends CiviUnitTestCase {
     $this->assertEquals($addressOptions['country'], 1, 'Country is not set in address options');
   }
 
-  public function testSetValueOptions() {
-    $addressOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-      'address_options'
-    );
-    $addressOptions['county'] = 1;
-    CRM_Core_BAO_Setting::setValueOption(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-      'address_options',
-      $addressOptions
-    );
-    $addressOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-      'address_options'
-    );
-
-    $this->assertEquals($addressOptions['county'], 1, 'County was set but did not stick in db');
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
Increases noisiness of long-standing deprecation of BAO_Setting::setItem & setOptionValue

Before
----------------------------------------
We have long documented our preferred methods but have not presented deprecation notices

After
----------------------------------------
People who call those methods with dev settings (enotices on etc ) will see deprecation notices

Technical Details
----------------------------------------
There is still one core place that calls setItem - but it's BAO_Navigation::resetNavigation so it's called very infrequently & I think it's
OK to deprecate first - although I suspect tests will fail & then we'll have to fix

Comments
----------------------------------------
