### PR TITLE
Fix 5.20 regression on retrieving template transaction with no logged  in user

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -426,6 +426,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    *
    * @return array
    * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function getTemplateContribution($id, $overrides = []) {
     // use api3 because api4 doesn't handle ContributionRecur yet...
@@ -435,6 +436,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     ]);
     // First look for new-style template contribution with is_template=1
     $templateContributions = \Civi\Api4\Contribution::get()
+      ->setCheckPermissions(FALSE)
       ->addWhere('contribution_recur_id', '=', $id)
       ->addWhere('is_template', '=', 1)
       ->addWhere('is_test', '=', $is_test)
@@ -444,6 +446,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     if (!$templateContributions->count()) {
       // Fall back to old style template contributions
       $templateContributions = \Civi\Api4\Contribution::get()
+        ->setCheckPermissions(FALSE)
         ->addWhere('contribution_recur_id', '=', $id)
         ->addWhere('is_test', '=', $is_test)
         ->addOrderBy('id', 'DESC')


### PR DESCRIPTION
Overview
----------------------------------------
Fixes 5.20 regression where repeattransaction was failing based on user permissions

Before
----------------------------------------
failed to load related objectsAuthorization

After
----------------------------------------
works

Technical Details
----------------------------------------
Ug - we are going to have to get used to passing setCheckPermissions for apiv4

Comments
----------------------------------------
