### PR TITLE
Ensure that Relative key is not added for non Select Date is_search_range custom fields

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -169,14 +169,11 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
           }
         }
       }
-      if (substr($element, 0, 7) == 'custom_' &&
-        (substr($element, -5, 5) == '_from' || substr($element, -3, 3) == '_to')
-      ) {
-        // Ensure the _relative field is set if from or to are set to ensure custom date
-        // fields with 'from' or 'to' values are displayed when the are set in the smart group
-        // being loaded. (CRM-17116)
-        if (!isset($result[CRM_Contact_BAO_Query::getCustomFieldName($element) . '_relative'])) {
-          $result[CRM_Contact_BAO_Query::getCustomFieldName($element) . '_relative'] = 0;
+      // We should only set the relative key for custom date fields if it is not already set in the array.
+      $realField = str_replace(['_relative', '_low', '_high', '_to', '_high'], '', $element);
+      if (substr($element, 0, 7) == 'custom_' && CRM_Contact_BAO_Query::isCustomDateField($realField)) {
+        if (!isset($result[$realField . '_relative'])) {
+          $result[$realField . '_relative'] = 0;
         }
       }
       // check to see if we need to convert the old privacy array

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -33,6 +33,8 @@
  */
 class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
 
+  use CRMTraits_Custom_CustomDataTrait;
+
   /**
    * Sets up the fixture, for example, opens a network connection.
    *
@@ -48,11 +50,20 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
    * This method is called after a test is executed.
    */
   protected function tearDown() {
+    if (!empty($this->ids['CustomField'])) {
+      foreach ($this->ids['CustomField'] as $type => $id) {
+        $field = civicrm_api3('CustomField', 'getsingle', ['id' => $id]);
+        $group = civicrm_api3('CustomGroup', 'getsingle', ['id' => $field['custom_group_id']]);
+        CRM_Core_DAO::executeQuery("DROP TABLE IF Exists {$group['table_name']}");
+      }
+    }
     $this->quickCleanup([
       'civicrm_mapping_field',
       'civicrm_mapping',
       'civicrm_group',
       'civicrm_saved_search',
+      'civicrm_custom_field',
+      'civicrm_custom_group',
     ]);
   }
 
@@ -62,6 +73,7 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function testDefaultValues() {
+    $this->createCustomGroupWithFieldOfType([], 'int');
     $sg = new CRM_Contact_Form_Search_Advanced();
     $sg->controller = new CRM_Core_Controller();
     $formValues = [
@@ -71,6 +83,8 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
       'privacy_toggle' => 2,
       'operator' => 'AND',
       'component_mode' => 1,
+      'custom_' . $this->ids['CustomField']['int'] . '_from' => 0,
+      'custom_' . $this->ids['CustomField']['int'] . '_to' => '',
     ];
     CRM_Core_DAO::executeQuery(
       "INSERT INTO civicrm_saved_search (form_values) VALUES('" . serialize($formValues) . "')"
@@ -82,6 +96,35 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     $defaults = $sg->setDefaultValues();
 
     $this->checkArrayEquals($defaults, $formValues);
+  }
+
+  /**
+   * Test setDefaults for privacy radio buttons.
+   *
+   * @throws \Exception
+   */
+  public function testGetFormValuesWithCustomFields() {
+    $this->createCustomGroupWithFieldsOfAllTypes();
+    $sg = new CRM_Contact_Form_Search_Advanced();
+    $sg->controller = new CRM_Core_Controller();
+    $formValues = [
+      'group_search_selected' => 'group',
+      'privacy_options' => ['do_not_email'],
+      'privacy_operator' => 'OR',
+      'privacy_toggle' => 2,
+      'operator' => 'AND',
+      'component_mode' => 1,
+      'custom_' . $this->ids['CustomField']['int'] . '_from' => 0,
+      'custom_' . $this->ids['CustomField']['int'] . '_to' => '',
+      'custom_' . $this->ids['CustomField']['select_date'] . '_high' => '2019-06-30',
+      'custom_' . $this->ids['CustomField']['select_date'] . '_low' => '2019-06-30',
+    ];
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_saved_search (form_values) VALUES('" . serialize($formValues) . "')"
+    );
+    $returnedFormValues = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
+    $checkFormValues = $formValues + ['custom_' . $this->ids['CustomField']['select_date'] . '_relative' => 0];
+    $this->checkArrayEquals($returnedFormValues, $checkFormValues);
   }
 
   /**


### PR DESCRIPTION
…ate range search

Overview
----------------------------------------
the relative key is only useful for Select Dates not any other is_search_range. Dates also used to be _to and _from but that has been changed

Before
----------------------------------------
Incorrectly adds in the relative key

After
----------------------------------------
Only adds relative key if still in old format for some reason and its a date custom field


ping @eileenmcnaughton let me know if you think this should be against the RC