### PR TITLE
dev/core#1425 Replace deprecated settings fns in test suite

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -171,8 +171,8 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
    *
    */
   public function testSetCivicrmEnvironment() {
-    CRM_Core_BAO_Setting::setItem('Staging', CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME, 'environment');
-    $values = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME, 'environment');
+    Civi::settings()->set('environment', 'Staging');
+    $values = Civi::settings()->get('environment');
     $this->assertEquals('Staging', $values);
     global $civicrm_setting;
     $civicrm_setting[CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME]['environment'] = 'Development';

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -110,7 +110,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
    * Set ACLs for Financial Types()
    */
   public function setACL() {
-    CRM_Core_BAO_Setting::setItem(['acl_financial_type' => 1], NULL, 'contribution_invoice_settings');
+    Civi::settings()->set('acl_financial_type', 1);
   }
 
   /**
@@ -293,17 +293,6 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
     ]);
     $perm = CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributions->id, 'view');
     $this->assertEquals($perm, TRUE, 'Verify that lineitems now have permission.');
-  }
-
-  /**
-   * Check method testisACLFinancialTypeStatus()
-   */
-  public function testisACLFinancialTypeStatus() {
-    $isACL = CRM_Core_BAO_Setting::getItem(NULL, 'contribution_invoice_settings');
-    $this->assertEquals(array_search('acl_financial_type', $isACL), NULL);
-    $this->setACL();
-    $isACL = CRM_Core_BAO_Setting::getItem(NULL, 'contribution_invoice_settings');
-    $this->assertEquals($isACL, ['acl_financial_type' => 1]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Replaces a couple of deprecated function calls in the test suite

Before
----------------------------------------
CRM_Core_BAO_Setting::setItem

After
----------------------------------------
Civi::settings()->get

Technical Details
----------------------------------------
Only tests affected

Comments
----------------------------------------

