### PR TITLE
dev/core#1425 Remove misleading type hint for Setting value parameter

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -127,7 +127,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *
    * _setItem() is the common logic shared by setItem() and setItems().
    *
-   * @param object $value
+   * @param $value
    *   (required) The value that will be serialized and stored.
    * @param string $group
    *   The group name of the item (deprecated).


### PR DESCRIPTION
Overview
----------------------------------------
Removes a misleading PHPDoc type hint for the `$value` parameter in `CRM_Core_BAO_Setting::setItem()`

Before
----------------------------------------
IDEs following PHPDoc type hinting expect the `$value` parameter to be of type `object`, which is neither the only allowed type for settings values, but especially wrong since [CIVI-SA-2019-21](https://civicrm.org/advisory/civi-sa-2019-21-poi-saved-search-and-report-instance-apis) does not allow PHP objects at all in serialized settings values.

After
----------------------------------------
The type hint is gone, IDEs are happy, erroneous code will be avoided.

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/15975#discussion_r352069764

Comments
----------------------------------------
n/a
