### PR TITLE
Fix activity search to work by url params

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -151,11 +151,13 @@ class CRM_Activity_BAO_Query {
   /**
    * Given a list of conditions in query generate the required where clause.
    *
-   * @param $query
+   * @param \CRM_Contact_BAO_Query $query
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function where(&$query) {
     foreach (array_keys($query->_params) as $id) {
-      if (substr($query->_params[$id][0], 0, 9) == 'activity_') {
+      if (substr($query->_params[$id][0], 0, 9) === 'activity_') {
         if ($query->_mode == CRM_Contact_BAO_Query::MODE_CONTACTS) {
           $query->_useDistinct = TRUE;
         }
@@ -457,6 +459,9 @@ class CRM_Activity_BAO_Query {
       'title' => ts('Activity Text'),
       'type' => CRM_Utils_Type::T_STRING,
       'is_pseudofield' => TRUE,
+      'html' => [
+        'type' => 'Text',
+      ],
     ];
     return $metadata;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes activity search for url params

Before
----------------------------------------
civicrm/activity/search?reset=1&force=1&activity_date_time_high=20180101 does not apply a filter

After
----------------------------------------
civicrm/activity/search?reset=1&force=1&activity_date_time_high=20180101 applies a filter

Technical Details
----------------------------------------
It seems to be missing the call to the parent fn

Note I feel like the parent should also handle some of the rows below in future

Comments
----------------------------------------
@seamuslee001 in response to your comment here https://github.com/civicrm/civicrm-core/pull/15942#issuecomment-559228615