### PR TITLE
Update temp table handler to support utf8mb4 if that is the db collation

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -875,4 +875,22 @@ MODIFY      {$columnName} varchar( $length )
     return TRUE;
   }
 
+  /**
+   * Get the database collation.
+   *
+   * @return string
+   */
+  public static function getDBCollation() {
+    return CRM_Core_DAO::singleValueQuery('SELECT @@collation_database');
+  }
+
+  /**
+   * Get the database collation.
+   *
+   * @return string
+   */
+  public static function getDBCharset() {
+    return CRM_Core_DAO::singleValueQuery('SELECT @@character_set_database');
+  }
+
 }

--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -125,12 +125,35 @@ class CRM_Utils_SQL_TempTable {
     $sql = sprintf('%s %s %s AS %s',
       $this->toSQL('CREATE'),
       $this->memory ? self::MEMORY : self::INNODB,
-      $this->utf8 ? self::UTF8 : '',
+      $this->getUtf8String(),
       ($selectQuery instanceof CRM_Utils_SQL_Select ? $selectQuery->toSQL() : $selectQuery)
     );
     CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, TRUE, FALSE);
     $this->createSql = $sql;
     return $this;
+  }
+
+  /**
+   * Get the utf8 string for the table.
+   *
+   * If the db collation is already utf8 by default (either
+   * utf8 or utf84mb) then rely on that. Otherwise set to utf8.
+   *
+   * Respecting the DB collation supports utf8mb4 adopters, which is currently
+   * not the norm in civi installs.
+   *
+   * @return string
+   */
+  public function getUtf8String() {
+    if (!$this->utf8) {
+      return '';
+    }
+    $dbUTF = CRM_Core_BAO_SchemaHandler::getDBCollation();
+    if (in_array($dbUTF, ['utf8_unicode_ci', 'utf8mb4_unicode_ci'])
+      && in_array($dbUTF, ['utf8', 'utf8mb4'])) {
+      return '';
+    }
+    return self::UTF8;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Update temp table handler to support utf8mb4 if that is the db collation

Before
----------------------------------------
When temp tables are created using utf8 - the default & always the case AFAIK it is always utf8

After
----------------------------------------
If the DB is set to a default of UTF8MB4 (e.g as a result of running https://github.com/civicrm/civicrm-core/pull/15969 ) then that is respected

Technical Details
----------------------------------------
This is an alternate approach to @mfb's approach of trying to move the hard-coding to utf8mb4. When I looked at @mfb's excellent conversion script I realised he was changing the DB default & I started to think the right way to handle charset was to ensure the DB defaults were being set and only override them when we need to. This will only override if the default is not set

Comments
----------------------------------------

