### PR TITLE
Remove calls to deprecated pseudoconstant activityType, test

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6189,10 +6189,9 @@ AND   displayRelType.is_active = 1
       return [CRM_Utils_Array::value($op, $qillOperators, $op), ''];
     }
 
-    if ($fieldName == 'activity_type_id') {
-      $pseudoOptions = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE);
-    }
-    elseif ($fieldName == 'country_id') {
+    // @todo - if the right BAO is passed in special handling for the below
+    // fields should not be required. testQillOptions.
+    if ($fieldName == 'country_id') {
       $pseudoOptions = CRM_Core_PseudoConstant::country();
     }
     elseif ($fieldName == 'county_id') {

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -1080,4 +1080,15 @@ civicrm_relationship.is_active = 1 AND
     ]);
   }
 
+  /**
+   * Test the options are handled for the qill.
+   */
+  public function testQillOptions() {
+    $qill = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Activity_BAO_Activity', 'activity_type_id', 2, '=');
+    $this->assertEquals(['=', 'Phone Call'], $qill);
+
+    $qill = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Activity_BAO_Activity', 'priority_id', 2, '=');
+    $this->assertEquals(['=', 'Normal'], $qill);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code fix up  removes an unnecessary call to a deprecated function

Before
----------------------------------------
$pseudoOptions = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE);

After
----------------------------------------
$pseudoOptions retrieved using generic metadata based handling

Technical Details
----------------------------------------


Comments
----------------------------------------
