### PR TITLE
dev/core#1366 Bypass nonfunctioning case audit interactive screen and go straight to report

### DIFF
--- a/CRM/Case/Form/Report.php
+++ b/CRM/Case/Form/Report.php
@@ -106,13 +106,20 @@ class CRM_Case_Form_Report extends CRM_Core_Form {
     // store the submitted values in an array
     $params = $this->controller->exportValues($this->_name);
 
-    $xmlProcessor = new CRM_Case_XMLProcessor_Report();
-    $contents = $xmlProcessor->run($this->_clientID,
-      $this->_caseID,
-      $this->_activitySetName,
-      $params
+    // this is either a 1 or a 2, but the url expects a 1 or 0
+    $all = ($params['include_activities'] == 1) ? 1 : 0;
+
+    // similar but comes from a checkbox that's either 1 or not present
+    $is_redact = empty($params['is_redact']) ? 0 : 1;
+
+    $asn = rawurlencode($this->_activitySetName);
+
+    CRM_Utils_System::redirect(
+      CRM_Utils_System::url(
+        'civicrm/case/report/print',
+        "caseID={$this->_caseID}&cid={$this->_clientID}&asn={$asn}&redact={$is_redact}&all={$all}"
+      )
     );
-    $this->set('report', $contents);
   }
 
 }

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -131,7 +131,7 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
       foreach ($activitySetsXML->ActivitySet as $activitySetXML) {
         if ((string ) $activitySetXML->name == $activitySetName) {
           $activityTypes = array();
-          $allActivityTypes = &$this->allActivityTypes();
+          $allActivityTypes = CRM_Case_PseudoConstant::caseActivityType(TRUE, TRUE);
           foreach ($activitySetXML->ActivityTypes as $activityTypesXML) {
             foreach ($activityTypesXML as $activityTypeXML) {
               $activityTypeName = (string ) $activityTypeXML->name;
@@ -752,7 +752,7 @@ LIMIT  1
     $case = $form->caseInfo($clientID, $caseID);
     $template->assign_by_ref('case', $case);
 
-    if ($params['include_activities'] == 1) {
+    if (CRM_Utils_Array::value('include_activities', $params) == 1) {
       $template->assign('includeActivities', 'All');
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup to https://lab.civicrm.org/dev/core/issues/1366 and https://github.com/civicrm/civicrm-core/pull/15882. The first part was to make the case audit report do what it originally did which is use the selected timeline when outputting the report. This second part bypasses the nonfunctioning interactive onscreen page you get which hasn't been functioning since 2015 when the associated javascript file was deleted. So the PR makes it go straight to the associated print report (currently the button on the onscreen interactive page).

The third part would be to eventually remove any code only used for the onscreen interactive page.

Before
----------------------------------------
<img width="518" alt="Untitled" src="https://user-images.githubusercontent.com/2967821/69917086-65600a00-1430-11ea-9cb0-3db6d3f58127.png">

Choosing to run the audit report would take you to a screen that hasn't worked in years. Also even though the print button on that screen is back to mostly working it still isn't including all the right activities all the time.

After
----------------------------------------
Bypass nonfunctioning screen, go straight to report. Report includes all the right activities.

Technical Details
----------------------------------------
For the change in line 134 in CRM/Case/XMLProcessor/Report.php, it's less than it seems, because:

1. As the added test fails without changing this line, it shows that this line isn't including enough activity types and so the second parameter needs to be TRUE. Since allActivityTypes is mostly an alias for the pseudoconstant call, the only real change here is making the second parameter TRUE to include all the activity types.
2. Second, as noted in https://lab.civicrm.org/dev/core/issues/1433, the allActivityTypes function is weird and it would be nice to get rid of it. Since this line of code only ever executes when doing a case audit report, it seems a good place to start to try to replace calls to allActivityTypes.

Note also that if it's not obvious the CRM/Case/Form/Report.php file represents the popup options screen you get when you run the case audit report where you choose whether to redact etc, so all the lines being changed in this PR only touch the case audit report and nothing else.

Comments
----------------------------------------
@adam-devapp do you have some time to try this out?
