### PR TITLE
dev/core#1434 Fix table alias used in select when ouputting as a chart

### DIFF
--- a/CRM/Report/Form/Mailing/Clicks.php
+++ b/CRM/Report/Form/Mailing/Clicks.php
@@ -238,7 +238,7 @@ class CRM_Report_Form_Mailing_Clicks extends CRM_Report_Form {
     }
 
     if (!empty($this->_params['charts'])) {
-      $select[] = "COUNT({$this->_aliases['civicrm_event_trackable_url_open']}.id) as civicrm_mailing_click_count";
+      $select[] = "COUNT({$this->_aliases['civicrm_mailing_event_trackable_url_open']}.id) as civicrm_mailing_click_count";
       $this->_columnHeaders["civicrm_mailing_click_count"]['title'] = ts('Click Count');
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a DB syntax error when trying to output the click through mailing report as a bar / pie chart

Before
----------------------------------------
DB Syntax Error

After
----------------------------------------
No Error

ping @eileenmcnaughton @xurizaemon @demeritcowboy 
