### PR TITLE
Code style, remove typo, double ;; from code where it makes sense to do so

### DIFF
--- a/CRM/Contact/Form/Search/Custom/FullText/Activity.php
+++ b/CRM/Contact/Form/Search/Custom/FullText/Activity.php
@@ -121,7 +121,7 @@ AND    (ca.is_deleted = 0 OR ca.is_deleted IS NULL)
     ];
 
     $this->fillCustomInfo($tables, "( 'Activity' )");
-    return $tables;;
+    return $tables;
   }
 
   /**

--- a/CRM/Contact/Form/Task/HookSample.php
+++ b/CRM/Contact/Form/Task/HookSample.php
@@ -45,7 +45,7 @@ class CRM_Contact_Form_Task_HookSample extends CRM_Contact_Form_Task {
     parent::preProcess();
 
     // display name and email of all contact ids
-    $contactIDs = implode(',', $this->_contactIds);;
+    $contactIDs = implode(',', $this->_contactIds);
     $query = "
 SELECT c.id as contact_id, c.display_name as name,
        c.contact_type as contact_type, e.email as email

--- a/CRM/Contribute/ActionMapping/ByPage.php
+++ b/CRM/Contribute/ActionMapping/ByPage.php
@@ -195,7 +195,7 @@ class CRM_Contribute_ActionMapping_ByPage implements \Civi\ActionSchedule\Mappin
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    $query = \CRM_Utils_SQL_Select::from("civicrm_contribution e")->param($defaultParams);;
+    $query = \CRM_Utils_SQL_Select::from("civicrm_contribution e")->param($defaultParams);
     $query['casAddlCheckFrom'] = 'civicrm_contribution e';
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';

--- a/CRM/Contribute/ActionMapping/ByType.php
+++ b/CRM/Contribute/ActionMapping/ByType.php
@@ -203,7 +203,7 @@ class CRM_Contribute_ActionMapping_ByType implements \Civi\ActionSchedule\Mappin
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    $query = \CRM_Utils_SQL_Select::from("civicrm_contribution e")->param($defaultParams);;
+    $query = \CRM_Utils_SQL_Select::from("civicrm_contribution e")->param($defaultParams);
     $query['casAddlCheckFrom'] = 'civicrm_contribution e';
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -349,7 +349,7 @@ SELECT f.id, f.label, f.data_type,
 
           case 'Int':
             $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'Integer');
-            $this->_qill[$grouping][] = ts("%1 %2 %3", [1 => $field['label'], 2 => $qillOp, 3 => $qillValue]);;
+            $this->_qill[$grouping][] = ts("%1 %2 %3", [1 => $field['label'], 2 => $qillOp, 3 => $qillValue]);
             break;
 
           case 'Boolean':

--- a/CRM/Core/BAO/OptionGroup.php
+++ b/CRM/Core/BAO/OptionGroup.php
@@ -93,7 +93,7 @@ class CRM_Core_BAO_OptionGroup extends CRM_Core_DAO_OptionGroup {
       $params['id'] = $ids['optionGroup'];
     }
     $optionGroup = new CRM_Core_DAO_OptionGroup();
-    $optionGroup->copyValues($params);;
+    $optionGroup->copyValues($params);
     $optionGroup->save();
     return $optionGroup;
   }

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -203,7 +203,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
     else {
       $ufField->location_type_id = CRM_Utils_Array::value('location_type_id', $params);
     }
-    $ufField->phone_type_id = CRM_Utils_Array::value('phone_type_id', $params);;
+    $ufField->phone_type_id = CRM_Utils_Array::value('phone_type_id', $params);
 
     if (!empty($params['id'])) {
       $ufField->whereAdd("id <> " . $params['id']);

--- a/CRM/Core/Payment/Elavon.php
+++ b/CRM/Core/Payment/Elavon.php
@@ -77,7 +77,7 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
     $requestFields['ssl_ship_to_last_name'] = $params['last_name'];
     $requestFields['ssl_card_number'] = $params['credit_card_number'];
     $requestFields['ssl_amount'] = trim($params['amount']);
-    $requestFields['ssl_exp_date'] = sprintf('%02d', (int) $params['month']) . substr($params['year'], 2, 2);;
+    $requestFields['ssl_exp_date'] = sprintf('%02d', (int) $params['month']) . substr($params['year'], 2, 2);
     $requestFields['ssl_cvv2cvc2'] = $params['cvv2'];
     // CVV field passed to processor
     $requestFields['ssl_cvv2cvc2_indicator'] = "1";

--- a/CRM/Custom/Page/Group.php
+++ b/CRM/Custom/Page/Group.php
@@ -247,7 +247,7 @@ class CRM_Custom_Page_Group extends CRM_Core_Page {
     $subTypes['Grant'] = CRM_Core_OptionGroup::values('grant_type');
     $subTypes['Campaign'] = CRM_Campaign_PseudoConstant::campaignType();
     $subTypes['Participant'] = [];
-    $subTypes['ParticipantRole'] = CRM_Core_OptionGroup::values('participant_role');;
+    $subTypes['ParticipantRole'] = CRM_Core_OptionGroup::values('participant_role');
     $subTypes['ParticipantEventName'] = CRM_Event_PseudoConstant::event();
     $subTypes['ParticipantEventType'] = CRM_Core_OptionGroup::values('event_type');
     $subTypes['Individual'] = CRM_Contact_BAO_ContactType::subTypePairs('Individual', FALSE, NULL);

--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -151,7 +151,7 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    $query = \CRM_Utils_SQL_Select::from("{$this->entity} e")->param($defaultParams);;
+    $query = \CRM_Utils_SQL_Select::from("{$this->entity} e")->param($defaultParams);
     $query['casAddlCheckFrom'] = 'civicrm_event r';
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1910,7 +1910,7 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
     ];
 
     // create activity with target contacts
-    $id = CRM_Core_Session::singleton()->getLoggedInContactID();;
+    $id = CRM_Core_Session::singleton()->getLoggedInContactID();
     if ($id) {
       $activityParams['source_contact_id'] = $id;
       $activityParams['target_contact_id'][] = $contactId;

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -607,7 +607,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
 
         case 'participant_status':
           $status = CRM_Event_PseudoConstant::participantStatus();
-          $values['participant_status_id'] = CRM_Utils_Array::key($value, $status);;
+          $values['participant_status_id'] = CRM_Utils_Array::key($value, $status);
           break;
 
         case 'participant_role_id':

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -960,7 +960,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       $tmpContactField['external_identifier'] = $contactFields['external_identifier'];
       $tmpContactField['external_identifier']['title'] = $contactFields['external_identifier']['title'] . " " . ts('(match to contact)');
 
-      $tmpFields['membership_contact_id']['title'] = $tmpFields['membership_contact_id']['title'] . " " . ts('(match to contact)');;
+      $tmpFields['membership_contact_id']['title'] = $tmpFields['membership_contact_id']['title'] . " " . ts('(match to contact)');
 
       $fields = array_merge($fields, $tmpContactField);
       $fields = array_merge($fields, $tmpFields);

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -105,7 +105,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
     }
     // set financial type used for price set to set default for new option
     if (!$this->_oid) {
-      $defaults['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_sid, 'financial_type_id', 'id');;
+      $defaults['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_sid, 'financial_type_id', 'id');
     }
     if (!isset($defaults['weight']) || !$defaults['weight']) {
       $fieldValues = ['price_field_id' => $this->_fid];

--- a/CRM/UF/Form/Preview.php
+++ b/CRM/UF/Form/Preview.php
@@ -107,7 +107,7 @@ class CRM_UF_Form_Preview extends CRM_UF_Form_AbstractPreview {
       $fieldArray[$name] = $fields[$name];
 
       if ($fieldDAO->field_name == 'phone_and_ext') {
-        $phoneExtField = str_replace('phone', 'phone_ext', $name);;
+        $phoneExtField = str_replace('phone', 'phone_ext', $name);
         $fieldArray[$phoneExtField] = $fields[$phoneExtField];
       }
 

--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -123,7 +123,7 @@ class CRM_Upgrade_Incremental_SmartGroups {
             $hasRelative = TRUE;
           }
           if ($formValue[0] === $relativeFieldName && empty($formValue[2])) {
-            unset($formValues[$index]);;
+            unset($formValues[$index]);
           }
           elseif (in_array($formValue[0], $fieldPossibilities)) {
             if ($isRelative) {

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1565,7 +1565,7 @@ class CRM_Utils_Date {
 
           case 'greater':
             $from['d'] = 1;
-            $from['M'] = $now['mon'];;
+            $from['M'] = $now['mon'];
             $from['Y'] = $now['year'];
             unset($to);
             break;
@@ -1607,7 +1607,7 @@ class CRM_Utils_Date {
 
           case 'current':
             $from['d'] = 1;
-            $from['M'] = $now['mon'];;
+            $from['M'] = $now['mon'];
             $from['Y'] = $now['year'];
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
@@ -1843,7 +1843,7 @@ class CRM_Utils_Date {
 
           case 'greater':
             $from['d'] = $now['mday'];
-            $from['M'] = $now['mon'];;
+            $from['M'] = $now['mon'];
             $from['Y'] = $now['year'];
             unset($to);
             break;

--- a/templates/CRM/Admin/Page/Admin.tpl
+++ b/templates/CRM/Admin/Page/Admin.tpl
@@ -46,7 +46,7 @@
     <table class="form-layout">
     <tr>
         <td width="20%" class="font-size11pt" style="vertical-align: top;">{$group.show} {$group.title}</td>
-        <td width="80%" style="white-space: nowrap;;">
+        <td width="80%" style="white-space: nowrap;">
 
             <table class="form-layout" width="100%">
             <tr>

--- a/templates/CRM/common/additionalBlocks.tpl
+++ b/templates/CRM/common/additionalBlocks.tpl
@@ -56,7 +56,7 @@ function buildAdditionalBlocks( blockName, className ) {
         cj("#" + blockName + '-Primary-html').show( );
     }
 
-    var dataUrl = {/literal}"{crmURL h=0 q='snippet=4'}"{literal} + '&block=' + blockName + '&count=' + currentInstance;;
+    var dataUrl = {/literal}"{crmURL h=0 q='snippet=4'}"{literal} + '&block=' + blockName + '&count=' + currentInstance;
 
     if ( className == 'CRM_Event_Form_ManageEvent_Location' ) {
         dataUrl = ( currentInstance <= 2 ) ? dataUrl + '&subPage=Location' : '';

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -134,7 +134,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     // 5. Record the additional amount which $40 ($50-$10)
     // Expected : Check the amount of new Financial Item created is $40
     $this->createParticipantRecordsFromTwoFieldPriceSet();
-    $priceSetBlock = CRM_Price_BAO_PriceSet::getSetDetail($this->_ids['price_set'], TRUE, FALSE)[$this->_ids['price_set']]['fields'];;
+    $priceSetBlock = CRM_Price_BAO_PriceSet::getSetDetail($this->_ids['price_set'], TRUE, FALSE)[$this->_ids['price_set']]['fields'];
 
     $priceSetParams = [
       'priceSetId' => $this->_ids['price_set'],

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -371,7 +371,7 @@ class CiviMailUtils extends PHPUnit\Framework\TestCase {
       $this->_ut->assertContains($string, $mail, "$string .  not found in  $mail  $prefix");
     }
     foreach ($absentStrings as $string) {
-      $this->_ut->assertEmpty(strstr($mail, $string), "$string  incorrectly found in $mail $prefix");;
+      $this->_ut->assertEmpty(strstr($mail, $string), "$string  incorrectly found in $mail $prefix");
     }
     return $mail;
   }

--- a/tests/phpunit/api/v3/SystemCheckTest.php
+++ b/tests/phpunit/api/v3/SystemCheckTest.php
@@ -135,7 +135,7 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
         $testedCheck = [];
       }
     }
-    $this->assertEquals($testedCheck['is_visible'], '0', 'in line ' . __LINE__);;
+    $this->assertEquals($testedCheck['is_visible'], '0', 'in line ' . __LINE__);
   }
 
   /**


### PR DESCRIPTION
Code style, remove typo, double ;; from code where it makes sense to do so.

As noted whilst reviewing https://github.com/civicrm/civicrm-core/pull/15937

Agileware Ref: CIVICRM-1383