### PR TITLE
Fix regression from fixing relative key handling where custom field no longer exists in the database

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4786,8 +4786,13 @@ civicrm_relationship.start_date > {$today}
     if (($customFieldID = CRM_Core_BAO_CustomField::getKeyID($fieldName)) == FALSE) {
       return FALSE;
     }
-    if ('Date' == civicrm_api3('CustomField', 'getvalue', ['id' => $customFieldID, 'return' => 'data_type'])) {
-      return TRUE;
+    try {
+      $customFieldDataType = civicrm_api3('CustomField', 'getvalue', ['id' => $customFieldID, 'return' => 'data_type']);
+      if ('Date' == $customFieldDataType) {
+        return TRUE;
+      }
+    }
+    catch (CiviCRM_API3_Exception $e) {
     }
     return FALSE;
   }

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -96,6 +96,9 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     $defaults = $sg->setDefaultValues();
 
     $this->checkArrayEquals($defaults, $formValues);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $this->ids['CustomField']['int']]);
+    $defaults = $sg->setDefaultValues();
+    print_r($defaults);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -97,8 +97,9 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
 
     $this->checkArrayEquals($defaults, $formValues);
     $this->callAPISuccess('CustomField', 'delete', ['id' => $this->ids['CustomField']['int']]);
+    unset($this->ids['CustomField']['int']);
     $defaults = $sg->setDefaultValues();
-    print_r($defaults);
+    $this->checkArrayEquals($defaults, $formValues);
   }
 
   /**


### PR DESCRIPTION
… to load if a custom field has been deleted which was stored in the form values array

Overview
----------------------------------------
@eileenmcnaughton this is the regression i have found, we will need to backport the fix to 5.19 (fix incoming)
