### PR TITLE
dev/core#1436 Do not CC or BCC Contribution invoice

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -340,15 +340,11 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
           'title',
           'confirm_from_name',
           'confirm_from_email',
-          'cc_confirm',
-          'bcc_confirm',
         ];
         CRM_Core_DAO::commonRetrieveAll($daoName, 'id', $pageId, $mailDetails, $mailElements);
         $values['title'] = CRM_Utils_Array::value('title', $mailDetails[$contribution->_relatedObjects['event']->id]);
         $values['confirm_from_name'] = CRM_Utils_Array::value('confirm_from_name', $mailDetails[$contribution->_relatedObjects['event']->id]);
         $values['confirm_from_email'] = CRM_Utils_Array::value('confirm_from_email', $mailDetails[$contribution->_relatedObjects['event']->id]);
-        $values['cc_confirm'] = CRM_Utils_Array::value('cc_confirm', $mailDetails[$contribution->_relatedObjects['event']->id]);
-        $values['bcc_confirm'] = CRM_Utils_Array::value('bcc_confirm', $mailDetails[$contribution->_relatedObjects['event']->id]);
 
         $title = CRM_Utils_Array::value('title', $mailDetails[$contribution->_relatedObjects['event']->id]);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Contribution Invoices were send to CC and BCC email adress that were configured only for Event Confirmation purposes.

Opinions and discussion over at: https://lab.civicrm.org/dev/core/issues/1436

Before
----------------------------------------
When sending an invoice to a user it automatically also got send to the CC and BCC email that were configured for Event Confirmation purposes. While these email addresses are in use to let the event leaders know how many participants can be expected and info on their diet etcetera, it is an unexpected and undesered result when sensitive contribution details (payment arrangements etcetera) are automatically send by CC and BCC to these people. 

After
----------------------------------------
Only the contribution contact gets the contribution invoice.

Technical Details
----------------------------------------
just removed CC and BCC from the function

Comments
----------------------------------------
I can understand some organizations would feel the need to have CC of BCC options for the contribution invoice mechanism. If so, that should be coded. But automatically (and non-configurable) send contribution invoices to people not configured to receive these should not happen.