### PR TITLE
dev/core#1426 Return correct manager role info during Case api get

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1141,7 +1141,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
 
     $values = [];
     $query = <<<HERESQL
-    SELECT cc.display_name as name, cc.sort_name as sort_name, cc.id, cr.relationship_type_id, crt.label_b_a as role, crt.name_b_a as role_name, ce.email, cp.phone
+    SELECT cc.display_name as name, cc.sort_name as sort_name, cc.id, cr.relationship_type_id, crt.label_b_a as role, crt.name_b_a as role_name, crt.name_a_b as role_name_reverse, ce.email, cp.phone
     FROM civicrm_relationship cr
     JOIN civicrm_relationship_type crt
      ON crt.id = cr.relationship_type_id
@@ -1158,7 +1158,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
      AND cr.is_active
      AND cc.id NOT IN (%2)
     UNION
-    SELECT cc.display_name as name, cc.sort_name as sort_name, cc.id, cr.relationship_type_id, crt.label_a_b as role, crt.name_a_b as role_name, ce.email, cp.phone
+    SELECT cc.display_name as name, cc.sort_name as sort_name, cc.id, cr.relationship_type_id, crt.label_a_b as role, crt.name_a_b as role_name, crt.name_b_a as role_name_reverse, ce.email, cp.phone
     FROM civicrm_relationship cr
     JOIN civicrm_relationship_type crt
      ON crt.id = cr.relationship_type_id
@@ -1196,7 +1196,8 @@ HERESQL;
           'phone' => $dao->phone,
         ];
         // Add more info about the role (creator, manager)
-        $role = CRM_Utils_Array::value($dao->role_name, $caseRoles);
+        // The XML historically has the reverse direction, so look up reverse.
+        $role = CRM_Utils_Array::value($dao->role_name_reverse, $caseRoles);
         if ($role) {
           unset($role['name']);
           $details += $role;

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -651,15 +651,19 @@ class api_v3_CaseTest extends CiviCaseTestCase {
       'status_id' => "Open",
       'return' => ['contacts'],
     ]);
+
+    $foundManager = FALSE;
     foreach ($result['contacts'] as $contact) {
       if ($contact['role'] == 'Client') {
         $this->assertEquals(17, $contact['contact_id']);
       }
-      elseif ($contact['role'] == 'Homeless Services Coordinator') {
+      elseif ($contact['role'] == 'Homeless Services Coordinator is') {
         $this->assertEquals(1, $contact['creator']);
         $this->assertEquals(1, $contact['manager']);
+        $foundManager = TRUE;
       }
     }
+    $this->assertTrue($foundManager);
   }
 
   public function testCaseGetWithDefinition() {


### PR DESCRIPTION
Overview
----------------------------------------
Case api get is supposed to return manager and creator flags in the 'contacts' element in the array. It stopped doing that in 5.16.

Before
----------------------------------------

Before 5.16:
```
                            [0] => Array
                                (
                                    [contact_id] => 2
                                    [display_name] => Something
                                    [sort_name] => Something
                                    [relationship_type_id] => 9
                                    [role] => Case Coordinator
                                    [email] => demo@example.com
                                    [phone] =>
                                    [creator] => 1
                                    [manager] => 1
                                )
```

5.16+
```
                            [0] => Array
                                (
                                    [contact_id] => 2
                                    [display_name] => Something
                                    [sort_name] => Something
                                    [relationship_type_id] => 9
                                    [role] => Case Coordinator is
                                    [email] => demo@example.com
                                    [phone] =>
                                )
```

After
----------------------------------------
```
                            [0] => Array
                                (
                                    [contact_id] => 2
                                    [display_name] => Something
                                    [sort_name] => Something
                                    [relationship_type_id] => 9
                                    [role] => Case Coordinator is
                                    [email] => demo@example.com
                                    [phone] =>
                                    [creator] => 1
                                    [manager] => 1
                                )
```

Technical Details
----------------------------------------
There is an existing unit test but it doesn't trigger because the role is no longer present so it doesn't even check. Have updated the test to additionally confirm the role is present. The test might still be problematic because "role" in the array is the label not the name so it's comparing against label, but leaving that out of this PR since the test is at least comparing against fixed things.

I reviewed where the api/manager info might elsewhere be used in a comment at https://lab.civicrm.org/dev/core/issues/1426#note_28318. It's mostly red herrings though so not reposting here.

Comments
----------------------------------------
Ping @tunbola @alifrumin @agh1