### PR TITLE
dev/core#1438 Enable matching on contact phone when importing contributions

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -211,7 +211,11 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
     $ruleBao->find();
     $ruleFields = [];
     while ($ruleBao->fetch()) {
-      $ruleFields[] = $ruleBao->rule_field;
+      $field_name = $ruleBao->rule_field;
+      if ($field_name == 'phone_numeric') {
+        $field_name = 'phone';
+      }
+      $ruleFields[] = $field_name;
     }
     return $ruleFields;
   }

--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -429,7 +429,11 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
     $ruleBao->find();
     $ruleFields = [];
     while ($ruleBao->fetch()) {
-      $ruleFields[$ruleBao->rule_field] = $ruleBao->rule_weight;
+      $field_name = $ruleBao->rule_field;
+      if ($field_name == 'phone_numeric') {
+        $field_name = 'phone';
+      }
+      $ruleFields[$field_name] = $ruleBao->rule_weight;
     }
 
     return [$ruleFields, $rgBao->threshold];

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -180,6 +180,40 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test phone is included if it is part of dedupe rule. 
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPhoneMatchOnContact() {
+    // Update existing unsupervised rule, change to general.
+    $unsupervisedRuleGroup = $this->callApiSuccess('RuleGroup', 'getsingle', [
+      'used' => 'Unsupervised',
+      'contact_type' => 'Individual'
+    ]);
+    $this->callApiSuccess('RuleGroup', 'create', [
+      'id' => $unsupervisedRuleGroup['id'],
+      'used' => 'General'
+    ]);
+
+    // Create new unsupervised rule with Phone field.
+    $ruleGroup = $this->callAPISuccess('RuleGroup', 'create', [
+      'contact_type' => 'Individual',
+      'threshold' => 10,
+      'used' => 'Unsupervised',
+      'name' => 'MatchingPhone',
+      'title' => 'Matching Phone',
+      'is_reserved' => 0,
+    ]);
+    $this->callAPISuccess('Rule', 'create', [
+      'dedupe_rule_group_id' => $ruleGroup['id'],
+      'rule_table' => 'civicrm_phone',
+      'rule_weight' => 10,
+      'rule_field' => 'phone_numeric',
+    ]);
+    $fields = CRM_Contribute_BAO_Contribution::importableFields();
+    $this->assertTrue(array_key_exists('phone', $fields));
+  }
+  /**
    * Run the import parser.
    *
    * @param array $originalValues

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -180,7 +180,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test phone is included if it is part of dedupe rule. 
+   * Test phone is included if it is part of dedupe rule.
    *
    * @throws \CRM_Core_Exception
    */
@@ -188,11 +188,11 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     // Update existing unsupervised rule, change to general.
     $unsupervisedRuleGroup = $this->callApiSuccess('RuleGroup', 'getsingle', [
       'used' => 'Unsupervised',
-      'contact_type' => 'Individual'
+      'contact_type' => 'Individual',
     ]);
     $this->callApiSuccess('RuleGroup', 'create', [
       'id' => $unsupervisedRuleGroup['id'],
-      'used' => 'General'
+      'used' => 'General',
     ]);
 
     // Create new unsupervised rule with Phone field.
@@ -213,6 +213,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $fields = CRM_Contribute_BAO_Contribution::importableFields();
     $this->assertTrue(array_key_exists('phone', $fields));
   }
+
   /**
    * Run the import parser.
    *


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/issues/1438

When importing contributions, you can't match an existing contact using a phone number, even when the default unsupervised rule specified the phone field. It is because the dedupe rule calls the phone field "phone_numeric" yet the contact list of importable fields lists the field as "phone" - so no match is every made.

Before
----------------------------------------
When the field mapper screen appears and you have an supervised dedupe rule with a phone field, you get a missing index error, a phantom "match to contact" option in the field list, and the phone field is not listed.

After
----------------------------------------
The contribution import field lists the Phone number field and it properly matches.

Technical Details
----------------------------------------
I've implemented the change in the Dedupe matcher code so it adjusts to return `phone` instead of `phone_numeric`. I'm not sure what impact this might have on other code - so suggestions appreciated!

