### PR TITLE
Add caching to file scans.

### DIFF
--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -199,8 +199,8 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
       'api/v' . $apiRequest['version'] . '/' . $camelName . '/' . $actionCamelName . '.php',
     ];
     foreach ($stdFiles as $stdFile) {
-      if (\CRM_Utils_File::isIncludable($stdFile)) {
-        require_once $stdFile;
+      if (\CRM_Utils_File::isIncludable($stdFile, TRUE)) {
+        include_once $stdFile;
         if (function_exists($stdFunction)) {
           $this->cache[$cachekey] = ['function' => $stdFunction, 'is_generic' => FALSE];
           return $this->cache[$cachekey];
@@ -219,8 +219,8 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
       'api/v' . $apiRequest['version'] . '/Generic/' . $actionCamelName . '.php',
     ];
     foreach ($genericFiles as $genericFile) {
-      if (\CRM_Utils_File::isIncludable($genericFile)) {
-        require_once $genericFile;
+      if (\CRM_Utils_File::isIncludable($genericFile, TRUE)) {
+        include_once $genericFile;
         if (function_exists($genericFunction)) {
           $this->cache[$cachekey] = ['function' => $genericFunction, 'is_generic' => TRUE];
           return $this->cache[$cachekey];

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2443,8 +2443,8 @@ function _civicrm_api3_api_resolve_alias($entity, $fieldName, $action = 'create'
 function _civicrm_api3_deprecation_check($entity, $result = []) {
   if ($entity) {
     $apiFile = "api/v3/$entity.php";
-    if (CRM_Utils_File::isIncludable($apiFile)) {
-      require_once $apiFile;
+    if (CRM_Utils_File::isIncludable($apiFile, TRUE)) {
+      include_once $apiFile;
     }
     $lowercase_entity = _civicrm_api_get_entity_name_from_camel($entity);
     $fnName = "_civicrm_api3_{$lowercase_entity}_deprecation";


### PR DESCRIPTION
Overview
----------------------------------------
This is an alternative to https://github.com/civicrm/civicrm-core/pull/16011 intended to speed up file scans & in particular ones associated with api calls

Before
----------------------------------------
Constant scanning of core & extensions looking for api files


After
----------------------------------------
Presence of files is cached. The caching is in a static array by default but can be in a real cache (using Redis if not already in memory) if it is safe to do so.

Technical Details
----------------------------------------
After digging into this on https://github.com/civicrm/civicrm-core/pull/16011 I thought maybe the caching could be pushed down but I'm mindful of views hell on upgrade so though the more thorough caching should perhaps only be used with include_once.

I think MagicFunctionProvider & a couple more places could use this caching


Comments
----------------------------------------
