### PR TITLE
Add function to set entitySubType for entity forms

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -94,20 +94,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
   }
 
   /**
-   * Get the entity subtype ID being edited
-   *
-   * @param $subTypeId
-   *
-   * @return int|null
-   */
-  public function getEntitySubTypeId($subTypeId) {
-    if ($subTypeId) {
-      return $subTypeId;
-    }
-    return $this->_caseTypeId;
-  }
-
-  /**
    * Build the form object.
    */
   public function preProcess() {

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -21,7 +21,7 @@ trait CRM_Core_Form_EntityFormTrait {
    *
    * @var int
    */
-  protected $_entitySubTypeId;
+  protected $_entitySubTypeId = NULL;
 
   /**
    * Get entity fields for the entity to be added to the form.
@@ -83,15 +83,19 @@ trait CRM_Core_Form_EntityFormTrait {
   /**
    * Get the entity subtype ID being edited
    *
-   * @param $subTypeId
-   *
    * @return int|null
    */
-  public function getEntitySubTypeId($subTypeId) {
-    if ($subTypeId) {
-      return $subTypeId;
-    }
+  public function getEntitySubTypeId() {
     return $this->_entitySubTypeId;
+  }
+
+  /**
+   * Set the entity subtype ID being edited
+   *
+   * @param $subTypeId
+   */
+  public function setEntitySubTypeId($subTypeId) {
+    $this->_entitySubTypeId = $subTypeId;
   }
 
   /**
@@ -103,7 +107,7 @@ trait CRM_Core_Form_EntityFormTrait {
     }
     $customisableEntities = CRM_Core_SelectValues::customGroupExtends();
     if (isset($customisableEntities[$this->getDefaultEntity()])) {
-      CRM_Custom_Form_CustomData::addToForm($this);
+      CRM_Custom_Form_CustomData::addToForm($this, $this->getEntitySubTypeId());
     }
   }
 

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -29,7 +29,7 @@ class CRM_Custom_Form_CustomData {
    *   $params['custom'] = CRM_Core_BAO_CustomField::postProcess($submitted, $this->_id, $this->getDefaultEntity());
    *
    * @param CRM_Core_Form $form
-   * @param null|string $subType values stored in civicrm_custom_group.extends_entity_column_value
+   * @param null|string $entitySubType values stored in civicrm_custom_group.extends_entity_column_value
    *   e.g Student for contact type
    * @param null|string $subName value in civicrm_custom_group.extends_entity_column_id
    * @param null|int $groupCount number of entities that could have custom data
@@ -37,15 +37,12 @@ class CRM_Custom_Form_CustomData {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function addToForm(&$form, $subType = NULL, $subName = NULL, $groupCount = 1, $contact_id = NULL) {
+  public static function addToForm(&$form, $entitySubType = NULL, $subName = NULL, $groupCount = 1, $contact_id = NULL) {
     $entityName = $form->getDefaultEntity();
     $entityID = $form->getEntityId();
-    // FIXME: If the form has been converted to use entityFormTrait then getEntitySubTypeId() will exist.
-    // However, if it is only partially converted (ie. we've switched customdata to use CRM_Custom_Form_CustomData)
-    // it won't, so we check if we have a subtype before calling the function.
-    $entitySubType = NULL;
-    if ($subType) {
-      $entitySubType = $form->getEntitySubTypeId($subType);
+    // If the form has been converted to use entityFormTrait then getEntitySubTypeId() will exist.
+    if (method_exists($form, 'getEntitySubTypeId') && empty($entitySubType)) {
+      $entitySubType = $form->getEntitySubTypeId();
     }
 
     if ($form->getAction() == CRM_Core_Action::VIEW) {

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -179,7 +179,6 @@
       {if $action eq 4}
         {include file="CRM/Custom/Page/CustomDataView.tpl"}
       {else}
-        <div id="customData"></div>
         {include file="CRM/common/customDataBlock.tpl"}
       {/if}
     </td>


### PR DESCRIPTION
Overview
----------------------------------------
I originally added the functions and comments for this and it's only use on the case form. But the way I did it doesn't make sense to me! This makes it actually useful.  Most forms actually load the custom data via javascript so never actually use the subtype at the form level - I'm doing some work on civibooking and converting that to entityform requires a specific activity type.

Before
----------------------------------------
Not possible to set the entity subtype on an entity form.

After
----------------------------------------
Entity subtype can be set in a standard way and is used if set.

Technical Details
----------------------------------------
Implement `setEntitySubType()` and check if `getEntitySubType()` method exists before using it.

Comments
----------------------------------------
@eileenmcnaughton As the resident entityform expert would you be able to take a look?