### PR TITLE
Add setEntityId() to entityForm

### DIFF
--- a/CRM/Admin/Form.php
+++ b/CRM/Admin/Form.php
@@ -25,7 +25,7 @@ class CRM_Admin_Form extends CRM_Core_Form {
    *
    * @var int
    */
-  protected $_id;
+  public $_id;
 
   /**
    * The default values for form fields.

--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -19,7 +19,7 @@
  * Class for configuring jobs.
  */
 class CRM_Admin_Form_Job extends CRM_Admin_Form {
-  protected $_id = NULL;
+  public $_id = NULL;
 
   public function preProcess() {
 

--- a/CRM/Admin/Form/LabelFormats.php
+++ b/CRM/Admin/Form/LabelFormats.php
@@ -41,7 +41,7 @@ class CRM_Admin_Form_LabelFormats extends CRM_Admin_Form {
    * Label Format ID.
    * @var int
    */
-  protected $_id = NULL;
+  public $_id = NULL;
 
   /**
    * Group name, label format or name badge

--- a/CRM/Admin/Form/PaymentProcessorType.php
+++ b/CRM/Admin/Form/PaymentProcessorType.php
@@ -19,7 +19,7 @@
  * This class generates form components for Location Type.
  */
 class CRM_Admin_Form_PaymentProcessorType extends CRM_Admin_Form {
-  protected $_id = NULL;
+  public $_id = NULL;
 
   protected $_fields = NULL;
 

--- a/CRM/Admin/Form/PdfFormats.php
+++ b/CRM/Admin/Form/PdfFormats.php
@@ -41,7 +41,7 @@ class CRM_Admin_Form_PdfFormats extends CRM_Admin_Form {
    * PDF Page Format ID.
    * @var int
    */
-  protected $_id = NULL;
+  public $_id = NULL;
 
   /**
    * Build the form object.

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -24,7 +24,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
    * Scheduled Reminder ID.
    * @var int
    */
-  protected $_id = NULL;
+  public $_id = NULL;
 
   public $_freqUnits;
 

--- a/CRM/Campaign/Form/SurveyType.php
+++ b/CRM/Campaign/Form/SurveyType.php
@@ -29,13 +29,6 @@ class CRM_Campaign_Form_SurveyType extends CRM_Admin_Form {
   protected $_gName;
 
   /**
-   * Id
-   *
-   * @var int
-   */
-  protected $_id;
-
-  /**
    * Action
    *
    * @var int

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -78,13 +78,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $_paymentObject;
 
   /**
-   * The id of the contribution that we are processing.
-   *
-   * @var int
-   */
-  public $_id;
-
-  /**
    * Entity that $this->_id relates to.
    *
    * If set the contact id is not required in the url.

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -17,6 +17,13 @@
 trait CRM_Core_Form_EntityFormTrait {
 
   /**
+   * The id of the object being edited / created.
+   *
+   * @var int
+   */
+  public $_id;
+
+  /**
    * The entity subtype ID (eg. for Relationship / Activity)
    *
    * @var int
@@ -69,6 +76,15 @@ trait CRM_Core_Form_EntityFormTrait {
    */
   public function getEntityId() {
     return $this->_id;
+  }
+
+  /**
+   * Set the entity ID
+   *
+   * @param int $id The entity ID
+   */
+  public function setEntityId($id) {
+    $this->_id = $id;
   }
 
   /**

--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -21,13 +21,6 @@
 class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
 
   /**
-   * The financial batch id, used when editing the field
-   *
-   * @var int
-   */
-  protected $_id;
-
-  /**
    * Set variables up before form is built.
    */
   public function preProcess() {

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -23,13 +23,6 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
   use CRM_Core_Form_EntityFormTrait;
 
   /**
-   * The group id, used when editing a group
-   *
-   * @var int
-   */
-  protected $_id;
-
-  /**
    * The group object, if an id is present
    *
    * @var object

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -22,12 +22,6 @@
 class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
   use CRM_Core_Form_EntityFormTrait;
-  /**
-   * The id of the object being edited / created
-   *
-   * @var int
-   */
-  public $_id;
 
   /**
    * Membership Type ID

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -91,13 +91,6 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
   }
 
   /**
-   * The form id saved to the session for an update.
-   *
-   * @var int
-   */
-  protected $_id;
-
-  /**
    * The title for group.
    *
    * @var int


### PR DESCRIPTION
Overview
----------------------------------------
Add a function to set the entity ID - we can already get it via `getEntityID()` but not set.

Before
----------------------------------------
No function to set entity ID on the form.

After
----------------------------------------
Function to set the entity ID on the form.

Technical Details
----------------------------------------


Comments
----------------------------------------
I'm looking at making some improvements / conversion to contributionview form and this is a pre-requisite to doing it properly.
