### PR TITLE
Always display amount paid even if it is 0.00. Blank looks like it's missing data rather than nothing paid

### DIFF
--- a/templates/CRM/Contribute/Page/PaymentInfo.tpl
+++ b/templates/CRM/Contribute/Page/PaymentInfo.tpl
@@ -47,7 +47,6 @@ CRM.$(function($) {
   <tr>
     <td>{$paymentInfo.total|crmMoney:$paymentInfo.currency}</td>
     <td class='right'>
-      {if $paymentInfo.paid > 0}
         {$paymentInfo.paid|crmMoney:$paymentInfo.currency}
         {if !$hideButtonLinks}
           <br/>
@@ -56,7 +55,6 @@ CRM.$(function($) {
             {ts}view payments{/ts}
           </a>
         {/if}
-      {/if}
     </td>
     <td class="right" id="payment-info-balance" data-balance="{$paymentInfo.balance}">{$paymentInfo.balance|crmMoney:$paymentInfo.currency}</td>
   </tr>


### PR DESCRIPTION
Overview
----------------------------------------
View a pending contribution and see that "total paid" is blank, which looks a bit like missing data. Instead display the actual amount (0.00).

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/70068979-e530d480-15e8-11ea-9cf6-e14e4c875748.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/70069031-fe398580-15e8-11ea-9438-da4b8f309935.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
@artfulrobot @JoeMurray Are you able to review this?
