### PR TITLE
WIP Deprecate passing component to getPaymentInfo

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4013,22 +4013,24 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @return mixed
    */
   public static function getPaymentInfo($id, $component = 'contribution', $getTrxnInfo = FALSE, $usingLineTotal = FALSE) {
-    // @todo deprecate passing in component - always call with contribution.
-    if ($component == 'event') {
-      $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $id, 'contribution_id', 'participant_id');
+    if ($component !== 'contribution') {
+      CRM_Core_Error::deprecatedFunctionWarning('Support for passing anything other than "contribution" for getPaymentInfo will be removed soon');
+      if ($component == 'event') {
+        $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $id, 'contribution_id', 'participant_id');
 
-      if (!$contributionId) {
-        if ($primaryParticipantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Participant', $id, 'registered_by_id')) {
-          $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $primaryParticipantId, 'contribution_id', 'participant_id');
-          $id = $primaryParticipantId;
-        }
         if (!$contributionId) {
-          return;
+          if ($primaryParticipantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Participant', $id, 'registered_by_id')) {
+            $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $primaryParticipantId, 'contribution_id', 'participant_id');
+            $id = $primaryParticipantId;
+          }
+          if (!$contributionId) {
+            return;
+          }
         }
       }
-    }
-    elseif ($component == 'membership') {
-      $contributionId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $id, 'contribution_id', 'membership_id');
+      elseif ($component == 'membership') {
+        $contributionId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $id, 'contribution_id', 'membership_id');
+      }
     }
     else {
       $contributionId = $id;

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -722,7 +722,7 @@ WHERE  contribution_id = {$id}
    *   Block title.
    */
   protected function assignPaymentInfoBlock() {
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, TRUE);
+    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, 'contribution', TRUE);
     $title = ts('View Payment');
     if (!empty($this->_component) && $this->_component == 'event') {
       $info = CRM_Event_BAO_Participant::participantDetails($this->_id);

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -61,7 +61,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-
+    // id = contribution ID whether called from event or contribution forms
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
     parent::preProcess();
     $this->_contactId = $this->_contactID;
@@ -76,15 +76,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       CRM_Utils_System::setTitle($title);
       return;
     }
-    $entityType = 'contribution';
-    if ($this->_component == 'event') {
-      $entityType = 'participant';
-      $this->_contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $this->_id, 'contribution_id', 'participant_id');
-      $eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'event_id', 'id');
-    }
-    else {
-      $this->_contributionId = $this->_id;
-    }
+    $this->_contributionId = $this->_id;
 
     $paymentDetails = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, FALSE, TRUE);
     $paymentAmt = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_id);

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -83,16 +83,18 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $this->assign('contactId', $this->_contactId);
     $this->assign('id', $this->_participantId);
 
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_participantId, 'event');
-    $this->_paidAmount = $paymentInfo['paid'];
-    $this->assign('paymentInfo', $paymentInfo);
-    $this->assign('feePaid', $this->_paidAmount);
+    if ($this->_contributionId) {
+      $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_contributionId);
+      $this->_paidAmount = $paymentInfo['paid'];
+      $this->assign('paymentInfo', $paymentInfo);
+      $this->assign('feePaid', $this->_paidAmount);
 
-    $ids = CRM_Event_BAO_Participant::getParticipantIds($this->_contributionId);
-    if (count($ids) > 1) {
-      $total = CRM_Price_BAO_LineItem::getLineTotal($this->_contributionId);
-      $this->assign('totalLineTotal', $total);
-      $this->assign('lineItemTotal', $total);
+      $ids = CRM_Event_BAO_Participant::getParticipantIds($this->_contributionId);
+      if (count($ids) > 1) {
+        $total = CRM_Price_BAO_LineItem::getLineTotal($this->_contributionId);
+        $this->assign('totalLineTotal', $total);
+        $this->assign('lineItemTotal', $total);
+      }
     }
 
     $title = ts("Change selections for %1", [1 => $this->_contributorDisplayName]);

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -110,13 +110,22 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
       $row->tokens($entity, $field, \CRM_Utils_Date::customFormat($actionSearchResult->$field));
     }
     elseif ($field == 'balance') {
+      $balancePay = NULL;
       if ($actionSearchResult->entityTable == 'civicrm_contact') {
         $balancePay = 'N/A';
       }
       elseif (!empty($actionSearchResult->entityID)) {
-        $info = \CRM_Contribute_BAO_Contribution::getPaymentInfo($actionSearchResult->entityID, 'event');
-        $balancePay = \CRM_Utils_Array::value('balance', $info);
-        $balancePay = \CRM_Utils_Money::format($balancePay);
+        $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $actionSearchResult->entityID, 'contribution_id', 'participant_id');
+        if (!$contributionId) {
+          if ($primaryParticipantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Participant', $actionSearchResult->entityID, 'registered_by_id')) {
+            $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $primaryParticipantId, 'contribution_id', 'participant_id');
+          }
+        }
+        if ($contributionId) {
+          $info = \CRM_Contribute_BAO_Contribution::getPaymentInfo($contributionId);
+          $balancePay = \CRM_Utils_Array::value('balance', $info);
+          $balancePay = \CRM_Utils_Money::format($balancePay);
+        }
       }
       $row->tokens($entity, $field, $balancePay);
     }

--- a/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
@@ -137,7 +137,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
     $contributionID = $result['contribution']['id'];
 
     // check payment info
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($result['participant']['id'], 'event');
+    $paymentInfo = api_v3_ParticipantPaymentTest::getPaymentInfo($result['participant']['id']);
     $this->assertEquals($feeAmt, round($paymentInfo['total']), 'Total amount recorded is not correct');
     $this->assertEquals($amtPaid, round($paymentInfo['paid']), 'Amount paid is not correct');
     $this->assertEquals($feeAmt, round($paymentInfo['balance']), 'Balance amount is not proper');
@@ -159,7 +159,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
     $form->testSubmit($submitParams);
 
     // check payment info again and see if the payment is completed
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($result['participant']['id'], 'event');
+    $paymentInfo = api_v3_ParticipantPaymentTest::getPaymentInfo($result['participant']['id']);
     $this->assertEquals(round($paymentInfo['total']), $feeAmt, 'Total amount recorded is not proper');
     $this->assertEquals(round($paymentInfo['paid']), $feeAmt, 'Amount paid is not proper');
     $this->assertEquals(round($paymentInfo['balance']), 0, 'Balance amount is not proper');
@@ -178,7 +178,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
     $amtPaid = 60;
     $balance = $feeAmt - $amtPaid;
     $result = $this->addParticipantWithPayment($feeAmt, $amtPaid);
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($result['participant']['id'], 'event');
+    $paymentInfo = api_v3_ParticipantPaymentTest::getPaymentInfo($result['participant']['id']);
 
     // amount checking
     $this->assertEquals($feeAmt, round($paymentInfo['total']), 'Total amount recorded is not correct');
@@ -219,7 +219,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
       'participant_id' => $result['participant']['id'],
       'payment_instrument_id' => 3,
     ]);
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($result['participant']['id'], 'event', TRUE);
+    $paymentInfo = api_v3_ParticipantPaymentTest::getPaymentInfo($result['participant']['id'], TRUE);
     $transaction = $paymentInfo['transaction'];
 
     //Assert all transaction(owed and refund) are listed on view payments.

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -612,7 +612,8 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccessGetSingle('Contribution', [
       'contact_id' => $this->_individualId,
     ]);
-    $payment = CRM_Contribute_BAO_Contribution::getPaymentInfo($membership['id'], 'membership', FALSE, TRUE);
+    $contributionId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $membership['id'], 'contribution_id', 'membership_id');
+    $payment = api_v3_ParticipantPaymentTest::getPaymentInfo($contributionId, FALSE, TRUE);
     // Check the contribution status on membership type change whose minimum fee was less than earlier memebership
     $this->assertEquals('Pending refund', $contribution['contribution_status']);
     // Earlier paid amount

--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -61,6 +61,28 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Get the paymentInfo array
+   *
+   * @param int $participantID
+   * @param bool $getTrxnInfo
+   * @param bool $usingLineTotal
+   *
+   * @return array
+   */
+  public static function getPaymentInfo($participantID, $getTrxnInfo = FALSE, $usingLineTotal = FALSE): array {
+    $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $participantID, 'contribution_id', 'participant_id');
+    if (!$contributionId) {
+      if ($primaryParticipantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Participant', $participantID, 'registered_by_id')) {
+        $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $primaryParticipantId, 'contribution_id', 'participant_id');
+      }
+    }
+    if ($contributionId) {
+      return CRM_Contribute_BAO_Contribution::getPaymentInfo($contributionId, 'contribution', $getTrxnInfo, $usingLineTotal);
+    }
+    return [];
+  }
+
+  /**
    * Test civicrm_participant_payment_create with empty params.
    */
   public function testPaymentCreateEmptyParams() {
@@ -115,7 +137,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     $this->callAPISuccess('participant_payment', 'create', $params);
 
     //Check if participant payment is correctly retrieved.
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_participantID4, 'event');
+    $paymentInfo = api_v3_ParticipantPaymentTest::getPaymentInfo($this->_participantID4);
     $this->assertEquals('Completed', $paymentInfo['contribution_status']);
     $this->assertEquals('100.00', $paymentInfo['total']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
I'm working towards https://lab.civicrm.org/dev/financial/issues/103 and the code for getting information about payments is very messy and you have to call lot's of different functions to get the required info.  This is a first step in cleaning some of it up - and follows through with existing code cleanup comments.

Before
----------------------------------------
getPaymentInfo does some extra bits depending on which component param you pass in.

After
----------------------------------------
Only the contribution ID is ever passed in, any extra work is done by the calling function.

Technical Details
----------------------------------------
Simplifies this function per comments

Comments
----------------------------------------
