### PR TITLE
allow PCP report to filter on contribution status

### DIFF
--- a/CRM/Report/Form/Contribute/PCP.php
+++ b/CRM/Report/Form/Contribute/PCP.php
@@ -173,6 +173,14 @@ class CRM_Report_Form_Contribute_PCP extends CRM_Report_Form {
             ],
           ],
         ],
+        'filters' => [
+          'contribution_status_id' => [
+            'title' => ts('Contribution Status'),
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => CRM_Contribute_PseudoConstant::contributionStatus(),
+            'default' => [1],
+          ],
+        ],
         'grouping' => 'pcp-fields',
       ],
       'civicrm_financial_trxn' => [


### PR DESCRIPTION
Without this filter, incomplete contributions are included in the report
which really throws off the total.

Overview
----------------------------------------
The PCP reports lists all PCP pages with total number of contributions made against each PCP page and total amount raised. Unfortunately, it totals all contributions, including cancelled ones.

Before
----------------------------------------
The totals for the PCP report are inaccurate becaues they include canceled contributions.

After
----------------------------------------

Now, users can filter based on contribution status to get the totals they want.


