### PR TITLE
dev/core#1444 Permit activities with campaigns on contact tab for contacts without 'administer CiviCampaign'

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2436,14 +2436,9 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
 
     $activityParams['activity_type_id'] = self::filterActivityTypes($params);
     $enabledComponents = self::activityComponents();
-    // @todo - should we move this to activity get api.
-    foreach ([
-      'case_id' => 'CiviCase',
-      'campaign_id' => 'CiviCampaign',
-    ] as $attr => $component) {
-      if (!in_array($component, $enabledComponents)) {
-        $activityParams[$attr] = ['IS NULL' => 1];
-      }
+    // @todo - this appears to be duplicating the activity api.
+    if (!in_array('CiviCase', $enabledComponents)) {
+      $activityParams['case_id'] = ['IS NULL' => 1];
     }
     return $activityParams;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug that restricts viewing activities with a campaign on the contact tab but not other places

Before
----------------------------------------
Contact listing on contact activity tab excludes any activities with a campaign if user does not have 'administer CiviCampaign'. Activities can be found in search & viewed / edited from there

After
----------------------------------------
Administer CiviCampaign not required to see activities in tab

Technical Details
----------------------------------------

Comments
----------------------------------------

