### PR TITLE
Fix typo, Mailign should be Mailing

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -208,10 +208,10 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
     ) {
       $groupTypes = CRM_Core_OptionGroup::values('group_type', TRUE);
       if ($defaults['group_type'][$groupTypes['Mailing List']] == 1) {
-        $this->assign('freezeMailignList', $groupTypes['Mailing List']);
+        $this->assign('freezeMailingList', $groupTypes['Mailing List']);
       }
       else {
-        $this->assign('hideMailignList', $groupTypes['Mailing List']);
+        $this->assign('hideMailingList', $groupTypes['Mailing List']);
       }
     }
 

--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -99,12 +99,12 @@
 
   {literal}
   <script type="text/javascript">
-    {/literal}{if $freezeMailignList}{literal}
-    cj('input[type=checkbox][name="group_type[{/literal}{$freezeMailignList}{literal}]"]').prop('disabled',true);
+    {/literal}{if $freezeMailingList}{literal}
+    cj('input[type=checkbox][name="group_type[{/literal}{$freezeMailingList}{literal}]"]').prop('disabled',true);
     {/literal}{/if}{literal}
-    {/literal}{if $hideMailignList}{literal}
-    cj('input[type=checkbox][name="group_type[{/literal}{$hideMailignList}{literal}]"]').hide();
-    cj('label[for="group_type[{/literal}{$hideMailignList}{literal}]"]').hide();
+    {/literal}{if $hideMailingList}{literal}
+    cj('input[type=checkbox][name="group_type[{/literal}{$hideMailingList}{literal}]"]').hide();
+    cj('label[for="group_type[{/literal}{$hideMailingList}{literal}]"]').hide();
     {/literal}{/if}{literal}
   </script>
   {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
This was bugging me because it reads like "Maligned" which is really not good.
Fixes typo in the code "Mailign" should be "Mailing".

Before
----------------------------------------
Typo in code.

After
----------------------------------------
Typo gone.

Technical Details
----------------------------------------
Fat fingers and late nights cause typos.

Comments
----------------------------------------
Happy Christmas!

Agileware Ref: CIVICRM-1389