### PR TITLE
dev/core#1445 Related / Inherited Memberships: New Relationship added  to membership does not copy custom fields

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2427,6 +2427,9 @@ SELECT count(*)
     AND is_current_member = 1";
     $result = CRM_Core_DAO::singleValueQuery($query);
     if ($result < CRM_Utils_Array::value('max_related', $membershipValues, PHP_INT_MAX)) {
+      $values = [];
+      _civicrm_api3_custom_format_params($membershipValues, $values, 'Membership');
+      $membershipValues = array_merge($membershipValues, $values);
       CRM_Member_BAO_Membership::create($membershipValues);
     }
     return $membershipValues;


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a bug that is described in https://lab.civicrm.org/dev/core/issues/1445. When the creation of a new relationship makes a contact member of a shared membership, the custom fields of the membership should be copied

Before
----------------------------------------
They are not

After
----------------------------------------
They are.

Technical Details
----------------------------------------
It must be used in combination with https://github.com/civicrm/civicrm-core/pull/15884 which fixes another problem in copying custom member fields.

The cause of the bug is that the parent membership is retrieved with the API.  The copy is stored directly with the BAO. The API puts custom values in e `custom_<nr>` format. The BAO expects `[custom][nr]`. The fix consists of copying the lines from the API that do just this conversion.