### PR TITLE
dev/core#1449 Do not dispatch pre/post hooks during upgrade

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -159,6 +159,7 @@ abstract class CRM_Utils_Hook {
     // quantities of low-importance data or the table not having an id field, which could cause a fatal error.
     // Instead of not calling any hooks we only call those we know to be frequently important - if a particular extension wanted
     // to avoid this they could do an early return on CRM_Core_Config::singleton()->isUpgradeMode
+    // Futther discussion is happening at https://lab.civicrm.org/dev/core/issues/1460
     $upgradeFriendlyHooks = ['civicrm_alterSettingsFolders', 'civicrm_alterSettingsMetaData', 'civicrm_triggerInfo', 'civicrm_alterLogTables', 'civicrm_container'];
     if (CRM_Core_Config::singleton()->isUpgradeMode() && !in_array($fnSuffix, $upgradeFriendlyHooks)) {
       return;
@@ -355,6 +356,11 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function pre($op, $objectName, $id, &$params) {
+    // Dev/core#1449 DO not dispatch hook_civicrm_pre if we are in an upgrade as this cases the upgrade to fail
+    // Futher discussion is happening at https://lab.civicrm.org/dev/core/issues/1460
+    if (CRM_Core_Config::singleton()->isUpgradeMode()) {
+      return;
+    }
     $event = new \Civi\Core\Event\PreEvent($op, $objectName, $id, $params);
     \Civi::dispatcher()->dispatch('hook_civicrm_pre', $event);
     return $event->getReturnValues();
@@ -377,6 +383,11 @@ abstract class CRM_Utils_Hook {
    *                           an error message which aborts the operation
    */
   public static function post($op, $objectName, $objectId, &$objectRef = NULL) {
+    // Dev/core#1449 DO not dispatch hook_civicrm_post if we are in an upgrade as this cases the upgrade to fail
+    // Futher discussion is happening at https://lab.civicrm.org/dev/core/issues/1460
+    if (CRM_Core_Config::singleton()->isUpgradeMode()) {
+      return;
+    }
     $event = new \Civi\Core\Event\PostEvent($op, $objectName, $objectId, $objectRef);
     \Civi::dispatcher()->dispatch('hook_civicrm_post', $event);
     return $event->getReturnValues();


### PR DESCRIPTION
Overview
----------------------------------------
This prevents a fatal error in the 5.20 Upgrade and makes sure it works. when you have a Case Type with the benefit specalist role in it and you have an extension e.g. CiviRules or MailChimp that use within a hook_post a call to another class within the extension.

https://lab.civicrm.org/dev/core/issues/1449

Before
----------------------------------------
Error about class missing class 

After
----------------------------------------
No error and upgrade succeeds.

In https://github.com/civicrm/civicrm-core/pull/13551 the main invoke function for hooks was changed so that only certain hooks would be run in upgrade mode. However the Pre and Post hooks don't go through the invoke function which is why the upgrade is failing 

ping @stesi561 @eileenmcnaughton @totten 