### PR TITLE
Proper Fix for dev/core#1422

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -289,7 +289,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
 
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, ['event_id']);
 
-    $this->set('formValues', $this->_formValues);
     $this->set('queryParams', $this->_queryParams);
 
     $buttonName = $this->controller->getButtonName();
@@ -382,29 +381,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     // if this search has been forced
     // then see if there are any get values, and if so over-ride the post values
     // note that this means that GET over-rides POST :)
-    $event = CRM_Utils_Request::retrieve('event', 'Positive');
-    if ($event) {
-      $this->_formValues['event_id'] = $event;
-      $this->_formValues['event_name'] = CRM_Event_PseudoConstant::event($event, TRUE);
-    }
-
-    $status = CRM_Utils_Request::retrieve('status', 'String');
-
-    if (isset($status)) {
-      if ($status === 'true') {
-        $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1");
-      }
-      elseif ($status === 'false') {
-        $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 0");
-      }
-      elseif (is_numeric($status)) {
-        $statusTypes = (int) $status;
-      }
-      elseif (is_array($status) && !array_key_exists('IN', $status)) {
-        $statusTypes = array_keys($status);
-      }
-      $this->_formValues['participant_status_id'] = is_array($statusTypes) ? ['IN' => array_keys($statusTypes)] : $statusTypes;
-    }
 
     $role = CRM_Utils_Request::retrieve('role', 'String');
 
@@ -465,8 +441,30 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    *   the default array reference
    */
   public function setDefaultValues() {
-    parent::setDefaultValues();
-    return $this->_formValues;
+    $this->_defaults = parent::setDefaultValues();
+    $event = CRM_Utils_Request::retrieve('event', 'Positive');
+    if ($event) {
+      $this->_defaults['event_id'] = $event;
+      $this->_defaults['event_name'] = CRM_Event_PseudoConstant::event($event, TRUE);
+    }
+
+    $status = CRM_Utils_Request::retrieve('status', 'String');
+    if (isset($status)) {
+      if ($status === 'true') {
+        $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1");
+      }
+      elseif ($status === 'false') {
+        $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 0");
+      }
+      elseif (is_numeric($status)) {
+        $statusTypes = (int) $status;
+      }
+      elseif (is_array($status) && !array_key_exists('IN', $status)) {
+        $statusTypes = array_keys($status);
+      }
+      $this->_defaults['participant_status_id'] = is_array($statusTypes) ? array_keys($statusTypes) : $statusTypes;
+    }
+    return $this->_defaults;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is a much better and more standardised fix for the issue raised in https://lab.civicrm.org/dev/core/issues/1422

Before
----------------------------------------
Odd ball fix

After
----------------------------------------
More stable fix

Technical Details
----------------------------------------
The issue is of course when repeating the steps it uses not the standard participant_status_id and event_id url variables but some non standard and then in the original fix we are basically just clobbering the `_formValues`. This fix also ensures that using `&sort_name=x` in urls with force=1 for event search works again

ping @eileenmcnaughton @demeritcowboy
