### PR TITLE
Enable Is Searchable by default for new Custom Fields

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -239,6 +239,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $defaults['note_columns'] = 60;
       $defaults['note_rows'] = 4;
       $defaults['is_view'] = 0;
+      $defaults['is_searchable'] = 1;
     }
 
     if (!empty($defaults['html_type'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Copy of the approved concept from https://lab.civicrm.org/dev/core/issues/445

When creating Custom Fields the option Is this Field Searchable? is disabled by default and as a result any new Custom Field is not searchable. This is frustrating since there is rarely a case when you would not want a field to be available in search.

This is further compounded by the field being displayed right at the bottom of the screen, which is only seen when the user scrolls down to Click Save.

For end users, the experience of adding a Custom Field in CiviCRM is like this:

1. Add the Custom Field
2. Add some data to CiviCRM using the new Custom Field
3. Open Search and try to search using the new Custom Field, it is not shown
4. Confusion about why it is not shown in Search
5. Finally, navigate back to the Custom Field and enable the option, Is this Field Searchable?
6. Return to Search and bingo! There it is.
7. Repeat steps for every Custom Field created.

Before
----------------------------------------
New Custom Fields are not searchable and do not appear in reports unless the user enables the Is Searchable option.

After
----------------------------------------
New Custom Fields ARE searchable and DO appear in reports by default.

Technical Details
----------------------------------------
Simply sets the default for the Is Searchable field.

Comments
----------------------------------------
See discussion on https://lab.civicrm.org/dev/core/issues/445

Agileware Ref: CIVICRM-964
