### PR TITLE
Update Smart Group form uses different labels for Group Title and Group Description

### DIFF
--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -74,11 +74,11 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     $formValues = $this->controller->exportValues();
 
     // the name and description are actually stored with the group and not the saved search
-    $this->add('text', 'title', ts('Name'),
+    $this->add('text', 'title', ts('Group Title'),
       CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Group', 'title'), TRUE
     );
 
-    $this->addElement('textarea', 'description', ts('Description'),
+    $this->addElement('textarea', 'description', ts('Group Description'),
       CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Group', 'description')
     );
 
@@ -121,7 +121,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
       $this->addDefaultButtons(ts('Save Smart Group'));
       $this->assign('partiallySelected', $formValues['radio_ts'] != 'ts_all');
     }
-    $this->addRule('title', ts('Name already exists in Database.'),
+    $this->addRule('title', ts('Group Title already exists in Database.'),
       'objectExists', ['CRM_Contact_DAO_Group', $groupID, 'title']
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
Update Smart Group form uses different labels for **Group Title** (_Name_) and **Group Description** (_Description_). Error message for duplicate group check also refers to _Name_.

The Group Edit form is shown below with the correct field labels.

![chrome_VSWSDnbEJD](https://user-images.githubusercontent.com/10555210/70384426-49310f80-19d2-11ea-8aaa-947912c4fd68.png)

Before
----------------------------------------

Incorrect field labels: _Name_ and _Description_

![chrome_kGQAj67CCf](https://user-images.githubusercontent.com/10555210/70384425-49310f80-19d2-11ea-98e4-2a3d591aaaff.png)


After
----------------------------------------

Corrected field labels: **Group Title** and **Group Description**. Error message for duplicate group check also refers to **Group Title**.

![chrome_vmnMC1EPVD](https://user-images.githubusercontent.com/10555210/70384439-77aeea80-19d2-11ea-9e1a-a36510e6aa70.png)

Agileware Ref: CIVICRM-1392