### PR TITLE
Update Smart Group form unsets the existing Group Types

### DIFF
--- a/CRM/Contact/Form/Task/SaveSearch/Update.php
+++ b/CRM/Contact/Form/Task/SaveSearch/Update.php
@@ -47,6 +47,15 @@ class CRM_Contact_Form_Task_SaveSearch_Update extends CRM_Contact_Form_Task_Save
     $params = ['saved_search_id' => $this->_id];
     CRM_Contact_BAO_Group::retrieve($params, $defaults);
 
+    if (!empty($defaults['group_type'])) {
+      $types = explode(CRM_Core_DAO::VALUE_SEPARATOR,
+        substr($defaults['group_type'], 1, -1)
+      );
+      $defaults['group_type'] = array();
+      foreach ($types as $type) {
+        $defaults['group_type'][$type] = 1;
+      }
+    }
     return $defaults;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Update Smart Group form unsets the existing Group Types, which will cause the Group Type values to be lost when Smart Group is updated.

The screenshot below, Group has the Mailing List group type set.

![chrome_VSWSDnbEJD](https://user-images.githubusercontent.com/10555210/70384761-636dec00-19d8-11ea-8bcd-e355d7070722.png)

Before
----------------------------------------

When using the Update Smart Group form, it unsets the Mailing List group type.

![chrome_0eM51qvWxM](https://user-images.githubusercontent.com/10555210/70384762-67017300-19d8-11ea-850b-5607c30ca269.png)

After
----------------------------------------

With this PR, Mailing List group type remains set on the Update Smart Group form.

![chrome_jNrGdwMgaF](https://user-images.githubusercontent.com/10555210/70384770-a5972d80-19d8-11ea-8db8-a2364d586f2b.png)


Agileware Ref: CIVICRM-1391
