### PR TITLE
[REF] Replace Deprecated function CRM_Core_BAO_Setting::setItem with …

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -468,14 +468,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       $contact = new CRM_Contact_DAO_Contact();
       $contact->id = $contactID;
       if ($contact->find(TRUE)) {
-        CRM_Core_BAO_Setting::setItem(
-          $newKey,
-          CRM_Core_BAO_Setting::PERSONAL_PREFERENCES_NAME,
-          'navigation',
-          NULL,
-          $contactID,
-          $contactID
-        );
+        Civi::contactSettings($contactID)->set('navigation', $newKey);
       }
     }
 


### PR DESCRIPTION
…the relevant Civi::contactSettings function

Overview
----------------------------------------
This removes usage of the deprecated function `CRM_Core_BAO_Setting::setItem` in favour of the relevant Civi:: facade function

Before
----------------------------------------
Deprecated function used

After
----------------------------------------
Civi::facade used

ping @eileenmcnaughton @colemanw @demeritcowboy 