### PR TITLE
dev/membership#21 Fix regression causing transfer of membership to another contact if they paid

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -327,23 +327,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $scTypes = CRM_Core_OptionGroup::values("soft_credit_type");
     $defaults['soft_credit_type_id'] = CRM_Utils_Array::value(ts('Gift'), array_flip($scTypes));
 
-    if (!empty($defaults['record_contribution']) && !$this->_mode) {
-      $contributionParams = ['id' => $defaults['record_contribution']];
-      $contributionIds = [];
-
-      //keep main object campaign in hand.
-      $memberCampaignId = CRM_Utils_Array::value('campaign_id', $defaults);
-
-      CRM_Contribute_BAO_Contribution::getValues($contributionParams, $defaults, $contributionIds);
-
-      //get back original object campaign id.
-      $defaults['campaign_id'] = $memberCampaignId;
-
-      // Contribution::getValues() over-writes the membership record's source field value - so we need to restore it.
-      if (!empty($defaults['membership_source'])) {
-        $defaults['source'] = $defaults['membership_source'];
-      }
-    }
     //CRM-13420
     if (empty($defaults['payment_instrument_id'])) {
       $defaults['payment_instrument_id'] = key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where a membership associated with a contact is transferred to the contact who paid for it on edit, if that contact is different.

Before
----------------------------------------

1. Using default config membership type 'general' is inherited to the head of household - add head of household relationship to an individual
2. Create a membership for the household but check the record payment from a different contact and choose the related individual
<img width="700" alt="Screen Shot 2019-12-09 at 11 19 42 AM" src="https://user-images.githubusercontent.com/336308/70397282-d37e7f80-1a75-11ea-92ee-90c36880f90c.png">
3. Go to edit the relationship -note the wrong contact name 
<img width="308" alt="Screen Shot 2019-12-09 at 11 21 39 AM" src="https://user-images.githubusercontent.com/336308/70397324-26f0cd80-1a76-11ea-9711-0423d2dcf4d2.png">
<img width="497" alt="Screen Shot 2019-12-09 at 11 21 50 AM" src="https://user-images.githubusercontent.com/336308/70397325-26f0cd80-1a76-11ea-9069-bc42fb0f1ff7.png">
4. Edit the end date & save - membership has been transferred to the contact who paid for he membership


After
----------------------------------------
Contact remains attached to the correct member

Technical Details
----------------------------------------
This is a regression from work @yashodha  did in https://github.com/civicrm/civicrm-core/commit/ac0ef1dc0e997cfbd9817f2b3fd0c95f492b7bd2 to improve form consistency.

Reverting that change fixes this. However, I don't propose we do that because it's a good change and the lines I propose to remove follow a known bad pattern  - merging a bunch of parameters into a bunch of parameters with no clarity about what the reason is or why. In fact most of the remove lines exist to reverse the changes made in 
```CRM_Contribute_BAO_Contribution::getValues($contributionParams, $defaults, $contributionIds);```

I couldn't see any negative impact on the renew form & the fields being defaulted didn't even show up on edit

Comments
----------------------------------------
The gitlab also refers to editing by webform - not sure what that is about