### PR TITLE
Fix js error on choosing membership type

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -219,6 +219,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
     $this->addPaymentProcessorSelect(TRUE, FALSE, TRUE);
     CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->getDefaultPaymentInstrumentId());
+    $this->assign('recurProcessor', json_encode($this->_recurPaymentProcessors));
     // Build the form for auto renew. This is displayed when in credit card mode or update mode.
     // The reason for showing it in update mode is not that clear.
     if ($this->_mode || ($this->_action & CRM_Core_Action::UPDATE)) {
@@ -233,7 +234,6 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
         $autoRenewElement->freeze();
       }
 
-      $this->assign('recurProcessor', json_encode($this->_recurPaymentProcessors));
       $this->addElement('checkbox',
         'auto_renew',
         ts('Membership renewed automatically')

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -510,8 +510,8 @@
     {/literal}
 
     {if $membershipMode or $action eq 2}
-
-    buildAutoRenew( null, null, '{$membershipMode}');
+      buildAutoRenew( null, null, '{$membershipMode}');
+    {/if}
     {literal}
     function buildAutoRenew( membershipType, processorId, mode ) {
       var action = {/literal}'{$action}'{literal};
@@ -574,10 +574,6 @@
       }
       showEmailOptions();
     }
-    {/literal}
-    {/if}
-
-    {literal}
 
     var customDataType = {/literal}{$customDataType|@json_encode}{literal};
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a js error I'm seeing when changing membership type in a back office form. I have 2 processors that support recurring configured

Before
----------------------------------------
Js error in console

<img width="1190" alt="Screen Shot 2019-12-09 at 11 04 01 PM" src="https://user-images.githubusercontent.com/336308/70428991-95687680-1adc-11ea-98cd-2f7859721a88.png">



After
----------------------------------------
Error gone

Technical Details
----------------------------------------
I'm seeing a js error when I select a membership type in the back end form. It seems I have recurProcessors assigned
& they have an onChange that calls
buildAutoRenew - which is non existant if the action is not 2. It seems to me that the code is simplest when functions
can be relied on to exist and aree called conditionally - this makes that change, also ensuring 'something' is
assigned for recurProcessors to prevent the error when it's not defined that probably let to the fn being encased in an if

I can't spot any obvious regression cause & perhaps there is something in my config but this might be a regression

Comments
----------------------------------------
No noted impacts other than the error in console
