### PR TITLE
[REF] Cleanup CRM_Member_BAO_Membership::buildMembershipTypeValues

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -242,7 +242,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       $domain = defined('CIVICRM_DOMAIN_ID') ? CIVICRM_DOMAIN_ID : 1;
     }
 
-    return $domain;
+    return (int) $domain;
   }
 
   /**

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -818,7 +818,22 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    */
   public static function getAllMembershipTypes() {
     if (!Civi::cache('metadata')->has(__CLASS__ . __FUNCTION__)) {
-      Civi::cache('metadata')->set(__CLASS__ . __FUNCTION__, civicrm_api3('MembershipType', 'get', ['options' => ['limit' => 0, 'sort' => 'weight']])['values']);
+      $types = civicrm_api3('MembershipType', 'get', ['options' => ['limit' => 0, 'sort' => 'weight']])['values'];
+      $keys = ['description', 'relationship_type_id', 'relationship_direction', 'max_related'];
+      // In order to avoid down-stream e-notices we undo api v3 filtering of NULL values. This is covered
+      // in Unit tests & ideally we might switch to apiv4 but I would argue we should build caching
+      // of metadata entities like this directly into apiv4.
+      foreach ($types as $id => $type) {
+        foreach ($keys as $key) {
+          if (!isset($type[$key])) {
+            $types[$id][$key] = NULL;
+          }
+        }
+        if (isset($type['contribution_type_id'])) {
+          unset($types[$id]['contribution_type_id']);
+        }
+      }
+      Civi::cache('metadata')->set(__CLASS__ . __FUNCTION__, $types);
     }
     return Civi::cache('metadata')->get(__CLASS__ . __FUNCTION__);
   }
@@ -833,6 +848,23 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    */
   public static function getMembershipType($id) {
     return self::getAllMembershipTypes()[$id];
+  }
+
+  /**
+   * Get an array of all membership types the contact is permitted to access.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getPermissionedMembershipTypes() {
+    $types = self::getAllMembershipTypes();
+    $financialTypes = NULL;
+    $financialTypes = CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::ADD);
+    foreach ($types as $id => $type) {
+      if (!isset($financialTypes[$type['financial_type_id']])) {
+        unset($types[$id]);
+      }
+    }
+    return $types;
   }
 
 }

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -770,8 +770,11 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test the buildMembershipTypeValues function.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function testBuildMembershipTypeValues() {
+    $this->restoreMembershipTypes();
     $form = new CRM_Core_Form();
     $values = CRM_Member_BAO_Membership::buildMembershipTypeValues($form);
     $this->assertEquals([
@@ -783,11 +786,15 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'financial_type_id' => '2',
       'auto_renew' => '0',
       'member_of_contact_id' => $values[1]['member_of_contact_id'],
-      'relationship_type_id' => 7,
-      'relationship_direction' => 'b_a',
+      'relationship_type_id' => [7],
+      'relationship_direction' => ['b_a'],
       'max_related' => NULL,
       'duration_unit' => 'year',
       'duration_interval' => '2',
+      'domain_id' => '1',
+      'period_type' => 'rolling',
+      'visibility' => 'Public',
+      'weight' => '1',
     ], $values[1]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes function to be more readable, use caching & return more data

Before
----------------------------------------
- Function not using cached variables
- Function kinda long
- tax information not available
- No specific test cover

After
----------------------------------------
- MembershipTypes retrieved from cached function
- Additional tax info added to this cached function
- Various test bugs fixed & cover added

Technical Details
----------------------------------------
This is towards a fix for https://github.com/civicrm/civicrm-core/pull/15895 - I hit https://github.com/civicrm/civicrm-core/pull/16058 in the process. It doesn't fix #15895 but it points towards the solution which, to my mind, is assigning more useful values to the template & doing less in javascript. The next step is to use the correct tax_rate rather than have to use 2 arrays just to get the tax_rate - ie 

https://github.com/eileenmcnaughton/civicrm-core/commit/458a559a60e334b6897bec4542c594a9f34539c0#diff-fa0276456bc05f4629f775e6846f62ed

However, following that we can have the js use the figure which includes the tax, rather than having to calculate that in js with unknowns to deal with

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
