### PR TITLE
Civi\Angular\ChangeSet - Allow list of partials to be modified

### DIFF
--- a/Civi/Angular/ChangeSet.php
+++ b/Civi/Angular/ChangeSet.php
@@ -13,11 +13,9 @@ class ChangeSet implements ChangeSetInterface {
    * @param array $resources
    *   The list of resources.
    * @return mixed
+   * @throws \CRM_Core_Exception
    */
   public static function applyResourceFilters($changeSets, $resourceType, $resources) {
-    if ($resourceType === 'partials') {
-      return self::applyHtmlFilters($changeSets, $resources);
-    }
     foreach ($changeSets as $changeSet) {
       /** @var ChangeSet $changeSet */
       foreach ($changeSet->resFilters as $filter) {
@@ -25,6 +23,9 @@ class ChangeSet implements ChangeSetInterface {
           $resources = call_user_func($filter['callback'], $resources);
         }
       }
+    }
+    if ($resourceType === 'partials') {
+      self::applyHtmlFilters($changeSets, $resources);
     }
     return $resources;
   }
@@ -35,12 +36,10 @@ class ChangeSet implements ChangeSetInterface {
    * @param array $changeSets
    *   Array(ChangeSet).
    * @param array $strings
-   *   Array(string $path => string $html).
-   * @return array
-   *   Updated list of $strings.
+   *   [string $path => string $html]
    * @throws \CRM_Core_Exception
    */
-  private static function applyHtmlFilters($changeSets, $strings) {
+  private static function applyHtmlFilters($changeSets, &$strings) {
     $coder = new Coder();
 
     foreach ($strings as $path => $html) {
@@ -65,7 +64,6 @@ class ChangeSet implements ChangeSetInterface {
         $strings[$path] = $coder->encode($doc);
       }
     }
-    return $strings;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Modifies the order in which Angular resource filters are applied to prevent an early return and allow the list of partials to be modified.

Before
----------------------------------------
An html partial could be modified with `phpQuery` but partials could not be dynamically added/removed from the list.

After
----------------------------------------
Partials can be added/removed dynamically, and then the updated list of partials is sent to `applyHtmlFilters` for modification with `phpQuery`.

Technical Details
----------------------------------------
I think this order of operations (evaluating `resFilters` first and then `htmlFilters` second) is preferable because the first is coarse-grained (adding removing files) and the second is about tweaking the contents of the files. 