### PR TITLE
Link to current docs on scheduled job edit form

### DIFF
--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -86,7 +86,7 @@ CRM.$(function($) {
       </td>
     </tr>
     <tr class="crm-job-form-block-parameters">
-      <td class="label">{$form.parameters.label}<br />{docURL page="Managing Scheduled Jobs" resource="wiki"}</td>
+      <td class="label">{$form.parameters.label}<br />{docURL page="user/initial-set-up/scheduled-jobs/#parameters" text="(parameters documentation&hellip;)"}</td>
       <td>{$form.parameters.html}</td>
     </tr>
     <tr class="crm-job-form-block-scheduled-run-date">


### PR DESCRIPTION
Before: broken link to wiki

<img width="765" alt="Screen Shot 2019-12-10 at 9 58 29 PM" src="https://user-images.githubusercontent.com/336308/70514306-45e78080-1b98-11ea-9682-21e84f142643.png">



After: working link to relevant section of current docs

<img width="730" alt="Screen Shot 2019-12-10 at 9 58 10 PM" src="https://user-images.githubusercontent.com/336308/70514296-3ec07280-1b98-11ea-8170-1dfc1f8e673a.png">
