### PR TITLE
dev/core#1463 Fix record payment form errors

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -76,18 +76,15 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       CRM_Utils_System::setTitle($title);
       return;
     }
-    $entityType = 'contribution';
     if ($this->_component == 'event') {
-      $entityType = 'participant';
       $this->_contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $this->_id, 'contribution_id', 'participant_id');
-      $eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'event_id', 'id');
     }
     else {
       $this->_contributionId = $this->_id;
     }
 
     $paymentDetails = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, FALSE, TRUE);
-    $paymentAmt = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_id);
+    $paymentAmt = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_contributionId);
 
     $this->_amtPaid = $paymentDetails['paid'];
     $this->_amtTotal = $paymentDetails['total'];
@@ -272,7 +269,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
    */
   public static function formRule($fields, $files, $self) {
     $errors = [];
-    if ($self->_paymentType == 'owed' && $fields['total_amount'] > $self->_owed) {
+    if ($self->_paymentType == 'owed' && (int) $fields['total_amount'] > (int) $self->_owed) {
       $errors['total_amount'] = ts('Payment amount cannot be greater than owed amount');
     }
     if ($self->_paymentType == 'refund' && $fields['total_amount'] != abs($self->_refund)) {


### PR DESCRIPTION
Overview
----------------------------------------
1. Record Payment form does not load.
2. Record payment fails when Amount Owed is a decimal point number. Eg 264.65

Before
----------------------------------------
1. Register a contact for an event with Fee Amount = $264.65. 
1. Keep the status as Partially Paid and pay only part of the above amount. Eg 100. Amount owed = $164.65.
1. Save.
1. Click "Record Payment" and try to pay the remaining amount. The form does not load which seem to be a regression from https://github.com/civicrm/civicrm-core/pull/15465

![image](https://user-images.githubusercontent.com/5929648/70523322-d1491d80-1b68-11ea-81d6-f4432e34959c.png)
 
1. Select payment method and click save.

![image](https://user-images.githubusercontent.com/5929648/70523337-d8702b80-1b68-11ea-966f-1431d317996c.png)

After
----------------------------------------
Form loads fine and accept the decimal amount as it is equal to the remaining amount that needs to be paid.

Comments
----------------------------------------
This isn't included in 5.20 released tarball but occurs in the 5.21 rc version.  Probably, the first issue needs an rc fix? Hence an rc PR.

Gitlab - https://lab.civicrm.org/dev/core/issues/1463