### PR TITLE
Allow Angular modules to provide dynamic HTML snippets

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2244,6 +2244,10 @@ abstract class CRM_Utils_Hook {
    *    - js: array, list of JS files or globs.
    *    - css: array, list of CSS files or globs.
    *    - partials: array, list of base-dirs containing HTML.
+   *    - partialsCallback: mixed, a callback function which generates a list of HTML
+   *        function(string $moduleName, array $moduleDefn) => array(string $file => string $html)
+   *        For future-proofing, use a serializable callback (e.g. string/array).
+   *        See also: Civi\Core\Resolver.
    *    - requires: array, list of required Angular modules.
    *    - basePages: array, uncondtionally load this module onto the given Angular pages. [v4.7.21+]
    *      If omitted, default to "array('civicrm/a')" for backward compat.

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -226,7 +226,7 @@ class Manager {
    */
   public function getRawPartials($name) {
     $module = $this->getModule($name);
-    $result = [];
+    $result = $module['snippets'] ?? [];
     if (isset($module['partials'])) {
       foreach ($module['partials'] as $partialDir) {
         $partialDir = $this->res->getPath($module['ext']) . '/' . $partialDir;

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -226,7 +226,9 @@ class Manager {
    */
   public function getRawPartials($name) {
     $module = $this->getModule($name);
-    $result = $module['snippets'] ?? [];
+    $result = !empty($module['partialsCallback'])
+      ? \Civi\Core\Resolver::singleton()->call($module['partialsCallback'], [$name, $module])
+      : [];
     if (isset($module['partials'])) {
       foreach ($module['partials'] as $partialDir) {
         $partialDir = $this->res->getPath($module['ext']) . '/' . $partialDir;


### PR DESCRIPTION
Overview
----------------------------------------
Supports afforms dynamic templates by allowing angular partials to be passed as strings not just file paths.

See https://lab.civicrm.org/extensions/afform/merge_requests/16

Before
----------------------------------------
An Angular module must put HTML partials into specific files that live adjacent to the extension (e.g. `files/civicrm/ext/myextension/ang/foo.html`).

After
----------------------------------------
An Angular module may generate HTML partials dynamically - using a callback function, e.g.

```php
function mymod_civicrm_angularModules(&$modules) {
  $modules['mymod'] = [
    // ...
    'partialsCallback' => 'mymod_get_partials',
  ];
}

function mymod_get_partials(string $moduleName, array $module) {
  return [
    '~/mymod/greeting.html' => '<p>Hello world!</p>',
  ];
}
```

Comments
----------------------------------------
I thought about a lot of clever ways to do this, settled on a one-liner. KISS.