### PR TITLE
Remove unnecessary query when updating org, if no name update.

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -364,7 +364,7 @@ WHERE contact_a.id ={$contactId} AND contact_b.id={$orgId}; ";
 SET contact_a.organization_name=contact_b.organization_name
 WHERE contact_a.employer_id=contact_b.id AND contact_b.id={$organizationId}; ";
 
-    $dao = CRM_Core_DAO::executeQuery($query);
+    CRM_Core_DAO::executeQuery($query);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Adds some php checks to reduce unnecessary queries

Before
----------------------------------------
2 extra sql queries done on creating new organizations that are not required. Specifically we fetch employer_id but this is only relevant for individuals and we update organization_name for employees but this is only relevant for updates where the org name is potentially being changed

After
----------------------------------------
Queries only done as appropriate.

Technical Details
----------------------------------------
This removes an unnecessary query that can be locking at high volume.

The updateCurrentEmployer function sets the organization_name for any related contacts. We don't need to
do this if we are creating the organization for the first time, or updating the organization but not setting (passing in)
organization_name. We can check & avoid in php.

Also we don't need to check for an existing employer_id unless we are dealing with an Individual record. We can
skip that query for Orgs & Households.

These are cheap queries but at high volume can contribute to locks

Comments
----------------------------------------

