### PR TITLE
dev/core#1467 - Multiple participant registration sends only p1 amoun…

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -723,8 +723,11 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       // CRM-10032
       $this->processFirstParticipant($participant->id);
     }
-    $this->_params['participantID'] = $participant->id;
-    $this->set('primaryParticipant', $this->_params);
+
+    if (!empty($this->_params['is_primary'])) {
+      $this->_params['participantID'] = $participant->id;
+      $this->set('primaryParticipant', $this->_params);
+    }
 
     CRM_Core_BAO_CustomValueTable::postProcess($this->_params,
       'civicrm_participant',


### PR DESCRIPTION
…t to the processor

Overview
----------------------------------------
Multiple participant registration sends only last participant amount to the processor.

Before
----------------------------------------
To replicate -

- Create an event with multiple participant.
- Register atleast 2 participants to the event.
- Correct fees shown on the confirmation page -

![image](https://user-images.githubusercontent.com/5929648/70619362-eaba9a00-1c3a-11ea-9773-d622da116e37.png)

- When the page is submitted, the processor site only shows the last participant amount.

![image](https://user-images.githubusercontent.com/5929648/70619385-f3ab6b80-1c3a-11ea-8881-246ccbebc3e3.png)

It seems to be a problem with the processors that do a checkout to their site for payment.

After
----------------------------------------
Payment amount sent correctly.

![image](https://user-images.githubusercontent.com/5929648/70619519-2ce3db80-1c3b-11ea-927f-fa2bae06c3c9.png)

Comments
----------------------------------------
Seems related to https://github.com/civicrm/civicrm-core/pull/15458 changes.

Gitlab - https://lab.civicrm.org/dev/core/issues/1467