### PR TITLE
dev/core/issues/1470, show labels instead name for activity type

### DIFF
--- a/ang/crmCaseType/activityTypesTable.html
+++ b/ang/crmCaseType/activityTypesTable.html
@@ -19,7 +19,7 @@ Required vars: caseType
     </td>
     <td>
       <i class="crm-i {{ activityTypes[activityType.name].icon }}"></i>
-      {{ activityType.name }}
+      {{ activityTypes[activityType.name].label }}
     </td>
     <td>
       <input class="crm-form-text number" type="text" ng-pattern="/^[1-9][0-9]*$/" ng-model="activityType.max_instances">


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1470

Before
----------------------------------------
![BeforeFix](https://user-images.githubusercontent.com/2053075/70705747-83e5c100-1ccc-11ea-9ec4-e7742d4e817d.gif)

After
----------------------------------------
![AfterFix](https://user-images.githubusercontent.com/2053075/70705777-9829be00-1ccc-11ea-807c-bec5788f9408.gif)


Technical Details
----------------------------------------
Changed the code to use label instead of name as the user gets confused when they change the label of activity type from front end form. 
