### PR TITLE
dev/event#23 Don't count non-counted participants on Confirm Registration screen

### DIFF
--- a/CRM/Event/Form/Registration/ParticipantConfirm.php
+++ b/CRM/Event/Form/Registration/ParticipantConfirm.php
@@ -98,7 +98,7 @@ class CRM_Event_Form_Registration_ParticipantConfirm extends CRM_Event_Form_Regi
 
       //need to confirm that though participant confirming
       //registration - but is there enough space to confirm.
-      $emptySeats = CRM_Event_BAO_Participant::pendingToConfirmSpaces($this->_eventId);
+      $emptySeats = CRM_Event_BAO_Participant::eventFull($this->_eventId, TRUE, FALSE, TRUE, FALSE, TRUE);
       $additonalIds = CRM_Event_BAO_Participant::getAdditionalParticipantIds($this->_participantId);
       $requireSpace = 1 + count($additonalIds);
       if ($emptySeats !== NULL && ($requireSpace > $emptySeats)) {


### PR DESCRIPTION
on screen

Overview
----------------------------------------
If you have an event with a waitlist, and some participant roles are counted (e.g. attendee) and some are not (e.g. host), someone attempting to confirm that they're coming off the waitlist will be unable to, because that screen counts all participants, whether they're countable or not.

Detailed replicated instructions are on the ticket: https://lab.civicrm.org/dev/event/issues/23
As side effect, this also fixes [dev/event#7](https://lab.civicrm.org/dev/event/issues/7), where the same screen counts deleted contacts if they're registered for the event.

Before
----------------------------------------
Unable to come off the waitlist if the total participants, *including non-counted participants*, exceed the max participants.

After
----------------------------------------
Only participants with "counted" roles are counted.
 
Technical Details
----------------------------------------
I ripped out `CRM_Event_BAO_Participant::pendingToConfirmSpaces()`, which calculates the participant count in a faulty way (and is untested) in favor of `CRM_Event_BAO_Participant::eventFull()`, which counts correctly, is tested, and is used everywhere else in the codebase (`pendingToConfirmSpaces()` was only used once).