### PR TITLE
dev/core#1473 - Missing address on /user when location type label dif…

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1781,7 +1781,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    *   A hierarchical property tree if appropriate
    */
   public static function &makeHierReturnProperties($fields, $contactId = NULL) {
-    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $locationTypes = CRM_Core_BAO_Address::buildOptions('location_type_id', 'validate');
 
     $returnProperties = [];
 

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -989,11 +989,10 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       }
     }
     $query->convertToPseudoNames($details);
-    $config = CRM_Core_Config::singleton();
 
-    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
-    $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
-    $websiteTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Website', 'website_type_id');
+    $locationTypes = CRM_Core_BAO_Address::buildOptions('location_type_id', 'validate');
+    $imProviders = CRM_Core_DAO_IM::buildOptions('provider_id');
+    $websiteTypes = CRM_Core_DAO_Website::buildOptions('website_type_id');
 
     $multipleFields = ['url'];
 


### PR DESCRIPTION
…fers from its name

Overview
----------------------------------------
Missing address on `/user` when location type label differs from its name.

Before
----------------------------------------
To replicate -

- Update label of some location type. Eg Home -> HomeEdited
- Visit /user and notice the warnings displayed on the page.

![image](https://user-images.githubusercontent.com/5929648/70792983-5bd78a00-1dc0-11ea-8718-633dda282723.png)

- No address is printed for the contact -

![image](https://user-images.githubusercontent.com/5929648/70793012-6a25a600-1dc0-11ea-8972-dbc69fa58675.png)

After
----------------------------------------
Notice Error fixed which displays the address values correctly -

![image](https://user-images.githubusercontent.com/5929648/70793044-7e69a300-1dc0-11ea-8dbc-2c197a55cf5c.png)

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1473