### PR TITLE
dev/core#1474 - (On Hold) text missing from email column when custom …

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -195,6 +195,13 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       $this->_returnProperties['contact_type'] = 1;
       $this->_returnProperties['contact_sub_type'] = 1;
       $this->_returnProperties['sort_name'] = 1;
+      if (!empty($this->_returnProperties['location']) && is_array($this->_returnProperties['location'])) {
+        foreach ($this->_returnProperties['location'] as $key => $property) {
+          if (!empty($property['email'])) {
+            $this->_returnProperties['location'][$key]['on_hold'] = 1;
+          }
+        }
+      }
     }
 
     $displayRelationshipType = CRM_Utils_Array::value('display_relationship_type', $this->_formValues);
@@ -707,6 +714,15 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             $websiteUrl = "<a href=\"{$websiteValue}\">{$websiteValue}  ({$websiteType})</a>";
           }
           $row[$property] = $websiteUrl;
+        }
+        elseif (strpos($property, '-email') !== FALSE) {
+          list($locType) = explode("-email", $property);
+          $onholdProperty = "{$locType}-on_hold";
+
+          $row[$property] = isset($result->$property) ? $result->$property : NULL;
+          if (!empty($row[$property]) && !empty($result->$onholdProperty)) {
+            $row[$property] .= " (On Hold)";
+          }
         }
         else {
           $row[$property] = isset($result->$property) ? $result->$property : NULL;


### PR DESCRIPTION
…search profile is used in Advanced Search

Overview
----------------------------------------
Fix missing (on hold) text from advanced search

Before
----------------------------------------
To replicate

- Create a search profile with an email field.
- Use this profile to view Advanced Search results.

Eg - `jitendra@fuzion.co.nz` email is (on hold) on the contact -

![image](https://user-images.githubusercontent.com/5929648/70801426-e1fdcb80-1dd4-11ea-8eed-b37271ae4e4c.png)

but is not specified in Advanced Search results -

![image](https://user-images.githubusercontent.com/5929648/70801463-fe016d00-1dd4-11ea-9d40-1051ffc2511e.png)


After
----------------------------------------
On Hold is displayed in the Advanced Search results -

![image](https://user-images.githubusercontent.com/5929648/70801501-17a2b480-1dd5-11ea-851e-21ff4768b5b2.png)

Technical Details
----------------------------------------
This was handled for normal search profile used in Advanced search. Extended it to also display it under custom search profile.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1474

Added unit test.