### PR TITLE
5.13 ESR regression: Fix error on submitting credit card renewals

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -529,6 +529,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       $this->_params['description'] = ts("Contribution submitted by a staff person using member's credit card for renewal");
       $this->_params['amount'] = $this->_params['total_amount'];
       $this->_params['payment_instrument_id'] = $this->_paymentProcessor['payment_instrument_id'];
+      $this->_params['receive_date'] = $now;
 
       // at this point we've created a contact and stored its address etc
       // all the payment processors expect the name and address to be in the passed params


### PR DESCRIPTION
Overview
----------------------------------------

This is a 5.13 (ESR) backport of #14412.

> "Backend -> Contacts' Memberships tab -> hit Renew on a Membership -> Renew Credit Card is what I used to be specific. The payment goes through fine, the Membership is renewed but -> Contribution Receive Date is empty -> so the Contribution ends up at the very bottom of the Contact's Contributions Tab and with no Receive Date"

Reported and tested by @KarinG and @jmcclelland.