### PR TITLE
dev/core#522 CRM-19767 dev/core#204 Add Case Tokens to emails

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -979,12 +979,13 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    * @param string $additionalDetails
    * @param int $campaignID
    * @param array $attachments
+   * @param int $caseID
    *
    * @return int
    *   The created activity ID
    * @throws \CRM_Core_Exception
    */
-  public static function createEmailActivity($userID, $subject, $html, $text, $additionalDetails, $campaignID, $attachments) {
+  public static function createEmailActivity($userID, $subject, $html, $text, $additionalDetails, $campaignID, $attachments, $caseID) {
     $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email');
 
     // CRM-6265: save both text and HTML parts in details (if present)
@@ -1006,6 +1007,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed'),
       'campaign_id' => $campaignID,
     ];
+    if (!empty($caseID)) {
+      $activityParams['case_id'] = $caseID;
+    }
 
     // CRM-5916: strip [case #…] before saving the activity (if present in subject)
     $activityParams['subject'] = preg_replace('/\[case #([0-9a-h]{7})\] /', '', $activityParams['subject']);
@@ -1016,9 +1020,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $activityParams = array_merge($activityParams, $attachments);
     }
 
-    $activity = self::create($activityParams);
-
-    return $activity->id;
+    $activity = civicrm_api3('Activity', 'create', $activityParams);
+    return $activity['id'];
   }
 
   /**
@@ -1099,7 +1102,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
 
     //create the meta level record first ( email activity )
-    $activityID = self::createEmailActivity($userID, $subject, $html, $text, $additionalDetails, $campaignId, $attachments);
+    $activityID = self::createEmailActivity($userID, $subject, $html, $text, $additionalDetails, $campaignId, $attachments, $caseId);
 
     $returnProperties = [];
     if (isset($messageToken['contact'])) {

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1049,6 +1049,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    *   The additional information of CC and BCC appended to the activity Details.
    * @param array $contributionIds
    * @param int $campaignId
+   * @param int $caseId
    *
    * @return array
    *   ( sent, activityId) if any email is sent and activityId
@@ -1069,7 +1070,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     $contactIds = NULL,
     $additionalDetails = NULL,
     $contributionIds = NULL,
-    $campaignId = NULL
+    $campaignId = NULL,
+    $caseId = NULL
   ) {
     // get the contact details of logged in contact, which we set as from email
     if ($userID == NULL) {
@@ -1186,6 +1188,12 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
       else {
         $tokenHtml = NULL;
+      }
+
+      if ($caseId) {
+        $tokenSubject = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenSubject, $subjectToken, $escapeSmarty);
+        $tokenText = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenText, $messageToken, $escapeSmarty);
+        $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenHtml, $messageToken, $escapeSmarty);
       }
 
       if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -476,7 +476,8 @@ class CRM_Contact_Form_Task_EmailCommon {
       array_keys($form->_toContactDetails),
       $additionalDetails,
       $contributionIds,
-      CRM_Utils_Array::value('campaign_id', $formValues)
+      CRM_Utils_Array::value('campaign_id', $formValues),
+      $form->getVar('_caseId')
     );
 
     $followupStatus = '';

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -104,8 +104,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    * Process the form after the input has been submitted and validated.
    *
    * @param CRM_Core_Form $form
-   *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function postProcess(&$form) {
     $formValues = $form->controller->exportValues($form->getName());
@@ -127,6 +127,14 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       $caseId = NULL;
       $params = ['contact_id' => $contactId];
 
+      $caseId = $form->getVar('_caseId');
+      if (empty($caseId) && !empty($form->_caseIds[$item])) {
+        $caseId = $form->_caseIds[$item];
+      }
+      if ($caseId) {
+        $params['case_id'] = $caseId;
+      }
+
       list($contact) = CRM_Utils_Token::getTokenDetails($params,
         $returnProperties,
         $skipOnHold,
@@ -142,12 +150,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       }
 
       $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
-      if (!empty($form->_caseId)) {
-        $caseId = $form->_caseId;
-      }
-      if (empty($caseId) && !empty($form->_caseIds[$item])) {
-        $caseId = $form->_caseIds[$item];
-      }
+
       if ($caseId) {
         $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenHtml, $messageToken);
       }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1603,7 +1603,7 @@ class CRM_Utils_Token {
 
   /**
    * @param int $caseId
-   * @param int $str
+   * @param string $str
    * @param array $knownTokens
    * @param bool $escapeSmarty
    * @return string
@@ -1875,7 +1875,7 @@ class CRM_Utils_Token {
       else {
         $split = explode('.', trim($k, '{}'));
         if (isset($split[1])) {
-          $entity = array_key_exists($split[1], CRM_Core_DAO_Address::export()) ? 'Address' : ucfirst($split[0]);
+          $entity = array_key_exists($split[1], CRM_Core_DAO_Address::export()) ? 'Address' : ucwords(str_replace('_', ' ', $split[0]));
         }
         else {
           $entity = 'Contact';

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1350,66 +1350,71 @@ $text
     $contactId = $this->individualCreate();
 
     // create a case for this user
-    $result = civicrm_api3('Case', 'create', array(
+    $result = $this->callAPISuccess('Case', 'create', [
       'contact_id' => $contactId,
       'case_type_id' => '1',
       'subject' => "my case",
       'status_id' => "Open",
-    ));
+    ]);
 
     $caseId = $result['id'];
     $html_message = "<p>This is a test case with id: {case.id} and subject: {case.subject}</p>";
     $html_message = CRM_Utils_Token::replaceCaseTokens($caseId, $html_message);
 
-    $this->assertTrue(strpos($html_message, 'id: '.$caseId) !== 0);
+    $this->assertTrue(strpos($html_message, 'id: ' . $caseId) !== 0);
     $this->assertTrue(strpos($html_message, 'subject: my case') !== 0);
+    $caseTest->tearDown();
   }
 
   public function testSendEmailWithCaseId() {
+    $caseTest = new CiviCaseTestCase();
+    $caseTest->setUp();
     // Create a contact and contactDetails array.
     $contactId = $this->individualCreate();
+    $contact = $this->callAPISuccess('Contact', 'get', ['id' => $contactId]);
 
     // create a logged in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view all contacts', 'access CiviCRM', 'access all cases and activities', 'administer CiviCase'];
     $session = CRM_Core_Session::singleton();
     $loggedInUser = $session->get('userID');
 
-    $contact = $this->civicrm_api('contact', 'getsingle', array('id' => $contactId, 'version' => $this->_apiversion));
-
     // create a case for this user
-    $result = civicrm_api3('Case', 'create', array(
+    $result = $this->callAPISuccess('Case', 'create', [
       'contact_id' => $contactId,
       'case_type_id' => 1,
       'subject' => "my case",
       'status_id' => "Open",
-    ));
+    ]);
 
     $caseId = $result['id'];
 
-    $subject = __FUNCTION__ . ' subject';
-    $html = __FUNCTION__ . ' html';
+    $subject = __FUNCTION__ . ' subject {case.subject}';
+    $html = __FUNCTION__ . ' html {case.subject}';
     $text = __FUNCTION__ . ' text';
-    $userID = $loggedInUser;
 
+    $mut = new CiviMailUtils($this, TRUE);
     list($sent, $activity_id) = $email_result = CRM_Activity_BAO_Activity::sendEmail(
-      $contactDetails,
+      $contact['values'],
       $subject,
       $text,
       $html,
-      $contact['email'],
-      $userID,
+      $contact['values'][$contactId]['email'],
+      $loggedInUser,
       $from = __FUNCTION__ . '@example.com',
-      $attachments = NULL,
-      $cc = NULL,
-      $bcc = NULL,
-      $contactIds = NULL,
-      $additionalDetails = NULL,
       NULL,
-      $campaign_id = NULL,
+      NULL,
+      NULL,
+      [$contactId],
+      NULL,
+      NULL,
+      NULL,
       $caseId
     );
-    $activity = $this->civicrm_api('activity', 'getsingle', array('id' => $activity_id, 'version' => $this->_apiversion));
-    $this->assertEquals($activity['case_id'], $caseId, 'Activity case_id does not match.');
+    $activity = $this->callAPISuccess('Activity', 'getsingle', ['id' => $activity_id, 'return' => ['case_id']]);
+    $this->assertEquals($caseId, $activity['case_id'][0], 'Activity case_id does not match.');
+    $mut->checkMailLog(['subject my case']);
+    $mut->stop();
   }
 
 }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1343,4 +1343,73 @@ $text
     }
   }
 
+  public function testCaseTokens() {
+    $caseTest = new CiviCaseTestCase();
+    $caseTest->setUp();
+    // Create a contact and contactDetails array.
+    $contactId = $this->individualCreate();
+
+    // create a case for this user
+    $result = civicrm_api3('Case', 'create', array(
+      'contact_id' => $contactId,
+      'case_type_id' => '1',
+      'subject' => "my case",
+      'status_id' => "Open",
+    ));
+
+    $caseId = $result['id'];
+    $html_message = "<p>This is a test case with id: {case.id} and subject: {case.subject}</p>";
+    $html_message = CRM_Utils_Token::replaceCaseTokens($caseId, $html_message);
+
+    $this->assertTrue(strpos($html_message, 'id: '.$caseId) !== 0);
+    $this->assertTrue(strpos($html_message, 'subject: my case') !== 0);
+  }
+
+  public function testSendEmailWithCaseId() {
+    // Create a contact and contactDetails array.
+    $contactId = $this->individualCreate();
+
+    // create a logged in USER since the code references it for sendEmail user.
+    $this->createLoggedInUser();
+    $session = CRM_Core_Session::singleton();
+    $loggedInUser = $session->get('userID');
+
+    $contact = $this->civicrm_api('contact', 'getsingle', array('id' => $contactId, 'version' => $this->_apiversion));
+
+    // create a case for this user
+    $result = civicrm_api3('Case', 'create', array(
+      'contact_id' => $contactId,
+      'case_type_id' => 1,
+      'subject' => "my case",
+      'status_id' => "Open",
+    ));
+
+    $caseId = $result['id'];
+
+    $subject = __FUNCTION__ . ' subject';
+    $html = __FUNCTION__ . ' html';
+    $text = __FUNCTION__ . ' text';
+    $userID = $loggedInUser;
+
+    list($sent, $activity_id) = $email_result = CRM_Activity_BAO_Activity::sendEmail(
+      $contactDetails,
+      $subject,
+      $text,
+      $html,
+      $contact['email'],
+      $userID,
+      $from = __FUNCTION__ . '@example.com',
+      $attachments = NULL,
+      $cc = NULL,
+      $bcc = NULL,
+      $contactIds = NULL,
+      $additionalDetails = NULL,
+      NULL,
+      $campaign_id = NULL,
+      $caseId
+    );
+    $activity = $this->civicrm_api('activity', 'getsingle', array('id' => $activity_id, 'version' => $this->_apiversion));
+    $this->assertEquals($activity['case_id'], $caseId, 'Activity case_id does not match.');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds in the case tokens to emails as per PR https://github.com/civicrm/civicrm-core/pull/11291 also incorporates the unit tests for that PR from @varshith in ticket https://lab.civicrm.org/dev/core/issues/204

Before
----------------------------------------
No case tokens can be used in PDF letters or once off emails

After
----------------------------------------
This adds the ability to use case tokens on PDF Letters and single emails

ping @colemanw @jamienovick @eileenmcnaughton 
