### PR TITLE
dev/core#1477 Fix fatal error when editing reserved option group settings

### DIFF
--- a/CRM/Admin/Form/OptionGroup.php
+++ b/CRM/Admin/Form/OptionGroup.php
@@ -74,7 +74,7 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
       $this->freeze('is_reserved');
 
       if (!empty($this->_values['is_reserved'])) {
-        $this->freeze(['name', 'is_active', 'data_type']);
+        $this->freeze(['is_active', 'data_type']);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1477
When visiting /civicrm/admin/options if you try to edit the settings for reserved option group you get a fatal error.

Before
----------------------------------------
Network Error
Unable to reach the server. Please refresh this page in your browser and try again.

After
----------------------------------------
Can eat dinner without popups.

Technical Details
----------------------------------------
It looks like in https://github.com/civicrm/civicrm-core/pull/15937 the `name` textbox was removed from the form but it tries to "freeze" it later if the option group is reserved.