### PR TITLE
dev/core#1472 fix price field money clean

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -610,10 +610,12 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
    * Process the form.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function postProcess() {
     // store the submitted values in an array
     $params = $this->controller->exportValues('Field');
+    $params['price'] = CRM_Utils_Rule::cleanMoney($params['price']);
 
     $params['is_display_amounts'] = CRM_Utils_Array::value('is_display_amounts', $params, FALSE);
     $params['is_required'] = CRM_Utils_Array::value('is_required', $params, FALSE);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug where price options with thousands operators didn't submit correctly

Before
----------------------------------------
From gitlab

This issue appears with price field values of 1000 and above.  It is reproducible as follows on dmaster:
I start by visiting Administer CiviCRM > Localization > Languages, Currency, Locations, and ensure the following settings:

Thousands Separator: ,
Decimal Delimiter: .

Then I take these steps:

Create a price field with an amount of 1200.00, and click Save
In the list of price fields, observe that the amount is correct: "1,200.00".
Edit that price field, and in the Edit form, the amount is displayed with decimal and thousands-separators, as "1,200.00"
Remove the comma and click Save.
In the list of price fields, observe that the amount is correct: "1,200.00".
Again edit that price field, and in the Edit form, the amount is again displayed with decimal and thousands-separators, as "1,200.00"
Change nothing in this form and merely press Save.
In the list of price fields, observe that the amount is now "1.00".


After
----------------------------------------
Above fixed

Technical Details
----------------------------------------
We should clean money fields as close to the form submit as possible

Comments
----------------------------------------

