### PR TITLE
[NFC] cleanup to declared exceptions, quotes, strict mode.

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -304,8 +304,10 @@ class Kernel {
    *   An unhandled exception.
    * @param array $apiRequest
    *   The full description of the API request.
+   *
    * @return array
    *   API response.
+   * @throws \API_Exception
    */
   public function formatException($e, $apiRequest) {
     $data = [];
@@ -320,8 +322,10 @@ class Kernel {
    *   An unhandled exception.
    * @param array $apiRequest
    *   The full description of the API request.
+   *
    * @return array
    *   (API response)
+   * @throws \API_Exception
    */
   public function formatApiException($e, $apiRequest) {
     $data = $e->getExtraParams();
@@ -343,15 +347,18 @@ class Kernel {
    *   An unhandled exception.
    * @param array $apiRequest
    *   The full description of the API request.
+   *
    * @return array
    *   API response.
+   *
+   * @throws \API_Exception
    */
   public function formatPearException($e, $apiRequest) {
     $data = [];
     $error = $e->getCause();
     if ($error instanceof \DB_Error) {
-      $data["error_code"] = \DB::errorMessage($error->getCode());
-      $data["sql"] = $error->getDebugInfo();
+      $data['error_code'] = \DB::errorMessage($error->getCode());
+      $data['sql'] = $error->getDebugInfo();
     }
     if (!empty($apiRequest['params']['debug'])) {
       if (method_exists($e, 'getUserInfo')) {
@@ -363,7 +370,7 @@ class Kernel {
       $data['trace'] = $e->getTraceAsString();
     }
     else {
-      $data['tip'] = "add debug=1 to your API call to have more info about the error";
+      $data['tip'] = 'add debug=1 to your API call to have more info about the error';
     }
 
     return $this->createError($e->getMessage(), $data, $apiRequest);
@@ -385,7 +392,7 @@ class Kernel {
    */
   public function createError($msg, $data, $apiRequest, $code = NULL) {
     // FIXME what to do with $code?
-    if ($msg == 'DB Error: constraint violation' || substr($msg, 0, 9) == 'DB Error:' || $msg == 'DB Error: already exists') {
+    if ($msg === 'DB Error: constraint violation' || substr($msg, 0, 9) == 'DB Error:' || $msg == 'DB Error: already exists') {
       try {
         $fields = _civicrm_api3_api_getfields($apiRequest);
         _civicrm_api3_validate_foreign_keys($apiRequest['entity'], $apiRequest['action'], $apiRequest['params'], $fields);


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Exceptions not documented, double quotes used unnecessarily, strict comparison not used when it could be

After
----------------------------------------
Above remedied

Technical Details
----------------------------------------
This is towards improved coding standards

Comments
----------------------------------------
