### PR TITLE
Remove vestige of apiv2

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -167,7 +167,6 @@ class Kernel {
       throw new \API_Exception('Input variable `params` is not an array', 2000);
     }
     switch ($apiRequest['version']) {
-      case 2:
       case 3:
         require_once 'api/v3/utils.php';
         _civicrm_api3_initialize();


### PR DESCRIPTION
Overview
----------------------------------------
Removes code cruft left over from apiv2

Before
----------------------------------------
api v2 supported in an a switch (but not in general)

After
----------------------------------------
line gone

Technical Details
----------------------------------------


Comments
----------------------------------------

