### PR TITLE
dev/core#1424 Support MS Excel for Diacritic Characters when exporting a report to CSV

### DIFF
--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -212,6 +212,10 @@ WHERE  inst.report_id = %1";
     //Force a download and name the file using the current timestamp.
     $datetime = date('Ymd-Gi', $_SERVER['REQUEST_TIME']);
     CRM_Utils_System::setHttpHeader('Content-Disposition', 'attachment; filename=Report_' . $datetime . '.csv');
+    // Output UTF BOM so that MS Excel copes with diacritics. This is recommended as
+    // the Windows variant but is tested with MS Excel for Mac (Office 365 v 16.31)
+    // and it continues to work on Libre Office, Numbers, Notes etc.
+    echo "\xEF\xBB\xBF";
     echo self::makeCsv($form, $rows);
     CRM_Utils_System::civiExit();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Achieves the same result as https://github.com/civicrm/civicrm-core/pull/15968 but for generating a CSV from reports

Before
----------------------------------------
Diacritic characters not properly formatted in MS Excel from Report CSV Exports

After
----------------------------------------
Correctly formatted

ping @mlutfy @eileenmcnaughton @demeritcowboy @kcristiano 