### PR TITLE
dev/core#1485 Fix field name for join_date to be membership_join_date…

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -145,7 +145,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
     $errorMessage = NULL;
 
     //To check whether start date or join date is provided
-    if (empty($params['membership_start_date']) && empty($params['join_date'])) {
+    if (empty($params['membership_start_date']) && empty($params['membership_join_date'])) {
       $errorMessage = 'Membership Start Date is required to create a memberships.';
       CRM_Contact_Import_Parser_Contact::addToErrorMsg('Start Date', $errorMessage);
     }
@@ -157,7 +157,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
 
       if ($val) {
         switch ($key) {
-          case 'join_date':
+          case 'membership_join_date':
             if (CRM_Utils_Date::convertToDefaultDate($params, $dateType, $key)) {
               if (!CRM_Utils_Rule::date($params[$key])) {
                 CRM_Contact_Import_Parser_Contact::addToErrorMsg('Member Since', $errorMessage);
@@ -263,8 +263,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
       $params = $this->getActiveFieldParams();
 
       //assign join date equal to start date if join date is not provided
-      if (empty($params['join_date']) && !empty($params['membership_start_date'])) {
-        $params['join_date'] = $params['membership_start_date'];
+      if (empty($params['membership_join_date']) && !empty($params['membership_start_date'])) {
+        $params['membership_join_date'] = $params['membership_start_date'];
       }
 
       $session = CRM_Core_Session::singleton();
@@ -276,14 +276,14 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
       // don't add to recent items, CRM-4399
       $formatted['skipRecentView'] = TRUE;
       $dateLabels = [
-        'join_date' => ts('Member Since'),
+        'membership_join_date' => ts('Member Since'),
         'membership_start_date' => ts('Start Date'),
         'membership_end_date' => ts('End Date'),
       ];
       foreach ($params as $key => $val) {
         if ($val) {
           switch ($key) {
-            case 'join_date':
+            case 'membership_join_date':
             case 'membership_start_date':
             case 'membership_end_date':
               if (CRM_Utils_Date::convertToDefaultDate($params, $dateType, $key)) {
@@ -701,11 +701,12 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
     _civicrm_api3_custom_format_params($params, $values, 'Membership');
 
     if ($create) {
-      // CRM_Member_BAO_Membership::create() handles membership_start_date,
+      // CRM_Member_BAO_Membership::create() handles membership_start_date, membership_join_date,
       // membership_end_date and membership_source. So, if $values contains
-      // membership_start_date, membership_end_date  or membership_source,
-      // convert it to start_date, end_date or source
+      // membership_start_date, membership_end_date, membership_join_date or membership_source,
+      // convert it to start_date, end_date, join_date or source
       $changes = [
+        'membership_join_date' => 'join_date',
         'membership_start_date' => 'start_date',
         'membership_end_date' => 'end_date',
         'membership_source' => 'source',


### PR DESCRIPTION
… in line with the DAO schema

Overview
----------------------------------------
This matches the changes for start_date and end_date as per https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/php/FiveEighteen.php#L75 

Before
----------------------------------------
Join date ignored when importing memberships

After
----------------------------------------
Join date if supplied in the file is respected

ping @eileenmcnaughton 