### PR TITLE
dev/core#1490 Fix syntax error in Membership Receipt

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -192,6 +192,13 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'test_preview', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '5.21.beta1',
+        'upgrade_descriptor' => ts('Fix Membership Receipt'),
+        'templates' => [
+          ['name' => 'membership_online_receipt', 'type' => 'html'],
+        ],
+      ],
 
     ];
   }

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -405,7 +405,7 @@
           {$email}
         </td>
       </tr>
-    {elseif $email}}
+    {elseif $email}
       <tr>
         <th {$headerStyle}>
           {ts}Registered Email{/ts}


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/issues/1490

To reproduce:

* Setup a membership form, basic settings, with a test gateway so that billing fields are enabled
* Enable email confirmation receipts

Result:

![](https://lab.civicrm.org/dev/core/uploads/107aadfced33fb28cb1dc22badc7c4dd/civicrm-html-receipt.jpg)

