### PR TITLE
[NFC] If statement is always true

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -102,35 +102,30 @@ class CRM_Report_Form_Instance {
       $form->freeze('is_reserved');
     }
 
-    $config = CRM_Core_Config::singleton();
-    if ($config->userFramework != 'Joomla' ||
-      $config->userFramework != 'WordPress'
-    ) {
-      $form->addElement('select',
-        'permission',
-        ts('Permission'),
-        ['0' => ts('Everyone (includes anonymous)')] + CRM_Core_Permission::basicPermissions()
-      );
+    $form->addElement('select',
+      'permission',
+      ts('Permission'),
+      ['0' => ts('Everyone (includes anonymous)')] + CRM_Core_Permission::basicPermissions()
+    );
 
-      // prepare user_roles to save as names not as ids
-      if (function_exists('user_roles')) {
-        $user_roles_array = user_roles();
-        foreach ($user_roles_array as $key => $value) {
-          $user_roles[$value] = $value;
-        }
-        $grouprole = &$form->addElement('advmultiselect',
-          'grouprole',
-          ts('ACL Group/Role'),
-          $user_roles,
-          [
-            'size' => 5,
-            'style' => 'width:240px',
-            'class' => 'advmultiselect',
-          ]
-        );
-        $grouprole->setButtonAttributes('add', ['value' => ts('Add >>')]);
-        $grouprole->setButtonAttributes('remove', ['value' => ts('<< Remove')]);
+    // prepare user_roles to save as names not as ids
+    if (function_exists('user_roles')) {
+      $user_roles_array = user_roles();
+      foreach ($user_roles_array as $key => $value) {
+        $user_roles[$value] = $value;
       }
+      $grouprole = $form->addElement('advmultiselect',
+        'grouprole',
+        ts('ACL Group/Role'),
+        $user_roles,
+        [
+          'size' => 5,
+          'style' => 'width:240px',
+          'class' => 'advmultiselect',
+        ]
+      );
+      $grouprole->setButtonAttributes('add', ['value' => ts('Add >>')]);
+      $grouprole->setButtonAttributes('remove', ['value' => ts('<< Remove')]);
     }
 
     // navigation field


### PR DESCRIPTION
Overview
----------------------------------------
This line is always true. It uses boolean OR and has been that way since it was added 8 years ago.

```
   if ($config->userFramework != 'Joomla' ||
     $config->userFramework != 'WordPress'
   ) {
```

Before
----------------------------------------
TRUE

After
----------------------------------------
TRUE

Technical Details
----------------------------------------
To be super-picky, if userFramework was numeric 0 the line would be false, but userFramework shouldn't be numeric 0.

Comments
----------------------------------------
If you look at the diff ignoring whitespace it's easier to see the change. The rest is indentation.

While the line was likely intended to be boolean AND, the scope of this PR is just to remove a line that does nothing and has been doing nothing for 8 years. There is [another related line](https://github.com/civicrm/civicrm-core/blob/5.20.2/templates/CRM/Report/Form/Tabs/Instance.tpl#L81) but even when that is removed it doesn't make report permissions fully work for Joomla, likely because of yet more lines elsewhere. This PR doesn't address that.