### PR TITLE
dev/core#1482 Remove lines of code that appear to relate to legacy logic

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -393,16 +393,6 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_contact', $contact->id);
     }
 
-    // make a civicrm_subscription_history entry only on contact create (CRM-777)
-    if (empty($params['contact_id'])) {
-      $subscriptionParams = [
-        'contact_id' => $contact->id,
-        'status' => 'Added',
-        'method' => 'Admin',
-      ];
-      CRM_Contact_BAO_SubscriptionHistory::create($subscriptionParams);
-    }
-
     $transaction->commit();
 
     // CRM-6367: fetch the right label for contact type’s display


### PR DESCRIPTION
Overview
----------------------------------------
Removes some obsolete code, and, in doing so a query

Before
----------------------------------------
Entry in subscription_history created with no group_id on new contact create

After
----------------------------------------
Above removed

Technical Details
----------------------------------------
As discussed in https://lab.civicrm.org/dev/core/issues/1482 the subscription history table appears to still be used for
recording group history but this business of creating a row with no attached group appears to be from a logic flow that
is long-superceded by change log & db logging

Comments
----------------------------------------

