### PR TITLE
Make getTotalPayments return 0 instead of NULL

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4165,7 +4165,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     return (float) CRM_Utils_Money::subtractCurrencies(
       $contributionTotal,
-      CRM_Core_BAO_FinancialTrxn::getTotalPayments($contributionId, TRUE) ?: 0,
+      CRM_Core_BAO_FinancialTrxn::getTotalPayments($contributionId, TRUE),
       CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency')
     );
   }

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -479,12 +479,14 @@ WHERE ceft.entity_id = %1";
   }
 
   /**
+   * Get the total sum of all payments (and optionally refunds) for a contribution record
+   *
    * @param int $contributionID
    * @param bool $includeRefund
    *
-   * @return string
+   * @return float
    */
-  public static function getTotalPayments($contributionID, $includeRefund = FALSE) {
+  public static function getTotalPayments($contributionID, $includeRefund = FALSE): float {
     $statusIDs = [CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')];
 
     if ($includeRefund) {
@@ -495,7 +497,7 @@ WHERE ceft.entity_id = %1";
       INNER JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution')
       WHERE eft.entity_id = %1 AND ft.is_payment = 1 AND ft.status_id IN (%2) ";
 
-    return CRM_Core_DAO::singleValueQuery($sql, [
+    return (float) CRM_Core_DAO::singleValueQuery($sql, [
       1 => [$contributionID, 'Integer'],
       2 => [implode(',', $statusIDs), 'CommaSeparatedIntegers'],
     ]);

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -122,6 +122,10 @@ class CRM_Utils_Money {
   /**
    * Subtract currencies using integers instead of floats, to preserve precision
    *
+   * @param string|float $leftOp
+   * @param string|float $rightOp
+   * @param string $currency
+   *
    * @return float
    *   Result of subtracting $rightOp from $leftOp to the precision of $currency
    */


### PR DESCRIPTION
Overview
----------------------------------------
When the sum of all payments on a contribution = 0 the function returns NULL because it's returning the result of an SQL query. But that's not much use and means we have to do extra work to coalesce NULL into 0 when coding.

Before
----------------------------------------
NULL returned if no payments made on a contribution.

After
----------------------------------------
0 returned if no payments made on a contribution.

Technical Details
----------------------------------------
NULL != 0! Especially for money. This makes the function return what you'd expect it to return.

Comments
----------------------------------------
@eileenmcnaughton Related to #16025
