### PR TITLE
Fix output display in api4 explorer

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -400,7 +400,7 @@
           code.php += ', ' + phpFormat(index);
         }
         code.php += ");";
-        
+
         // Write oop code
         if (entity.substr(0, 7) !== 'Custom_') {
           code.oop = '$' + results + " = \\Civi\\Api4\\" + entity + '::' + action + '()';
@@ -445,7 +445,7 @@
         code.cli = 'cv api4 ' + entity + '.' + action + " '" + stringify(params) + "'";
       }
       _.each(code, function(val, type) {
-        $scope.code[type] = prettyPrintOne(val);
+        $scope.code[type] = prettyPrintOne(_.escape(val));
       });
     }
 
@@ -466,7 +466,7 @@
           ret += (ret.length ? ', ' : '') + key + ': ' + (_.isArray(val) ? '[' + val + ']' : val);
         }
       });
-      return prettyPrintOne(ret);
+      return prettyPrintOne(_.escape(ret));
     }
 
     $scope.execute = function() {
@@ -482,11 +482,11 @@
       }).then(function(resp) {
           $scope.loading = false;
           $scope.status = 'success';
-          $scope.result = [formatMeta(resp.data), prettyPrintOne(JSON.stringify(resp.data.values, null, 2), 'js', 1)];
+          $scope.result = [formatMeta(resp.data), prettyPrintOne(_.escape(JSON.stringify(resp.data.values, null, 2)), 'js', 1)];
         }, function(resp) {
           $scope.loading = false;
           $scope.status = 'danger';
-          $scope.result = [formatMeta(resp), prettyPrintOne(JSON.stringify(resp.data, null, 2))];
+          $scope.result = [formatMeta(resp), prettyPrintOne(_.escape(JSON.stringify(resp.data, null, 2)))];
         });
     };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the display of api explorer output which contains html entities.

Before
----------------------------------------
Output such as `<i>test</i>` appears as italicized text in the explorer.

After
----------------------------------------
Output displays html entities properly.

Comments
----------------------------------------
Easiest way to test this is by doing contact.get in the api explorer, add a text field such as first_name to the WHERE clause, and type something like `<i>test</i>`. Observe the generated code below.