### PR TITLE
[REF] step towards wiping out  $ids array in membership bao functions

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -51,7 +51,6 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
    */
   public static function add(&$params, $ids = []) {
     $oldStatus = $oldType = NULL;
-    $params['id'] = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('membership', $ids));
     if ($params['id']) {
       CRM_Utils_Hook::pre('edit', 'Membership', $params['id'], $params);
     }
@@ -306,7 +305,8 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     $transaction = new CRM_Core_Transaction();
 
-    // @todo remove $ids from here - $ids['contribution'] is not used or set by add. $ids['userId'] is used. $ids['membership'] is used if $params['id'] is not set
+    // @todo remove $ids from here $ids['userId'] is still used
+    $params['id'] = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('membership', $ids));
     $membership = self::add($params, $ids);
 
     if (is_a($membership, 'CRM_Core_Error')) {

--- a/CRM/Member/Form/Task/Batch.php
+++ b/CRM/Member/Form/Task/Batch.php
@@ -203,7 +203,7 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
     if (isset($params['field'])) {
       $customFields = [];
       foreach ($params['field'] as $key => $value) {
-        $ids['membership'] = $key;
+        $params['id'] = $key;
         if (!empty($value['membership_source'])) {
           $value['source'] = $value['membership_source'];
         }
@@ -244,7 +244,7 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
           $membershipTypeId
         );
 
-        $membership = CRM_Member_BAO_Membership::add($value, $ids);
+        $membership = CRM_Member_BAO_Membership::add($value);
 
         // add custom field values
         if (!empty($value['custom']) &&

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -530,7 +530,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'membership_type_id' => $membershipTypeId,
       'source' => 'Test suite',
       'start_date' => date('Y-m-d'),
-      'end_date' => "+1 year",
+      'end_date' => '+1 year',
     ];
     $OrganizationMembershipID = $this->contactMembershipCreate($params);
 
@@ -613,17 +613,15 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'is_pay_later' => 1,
       'status_id' => 5,
     ];
-    $organizationMembership = CRM_Member_BAO_Membership::add($params);
-    $organizationMembershipID = $organizationMembership->id;
+    $organizationMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
+
     $memberContactId[3] = $this->individualCreate(['employer_id' => $employerId[2]], 0);
     // Check that the employee inherited the membership
     $params = [
       'contact_id' => $memberContactId[3],
       'membership_type_id' => $membershipTypeId,
     ];
-    $result = $this->callAPISuccess('membership', 'get', $params);
-    $this->assertEquals(1, $result['count']);
-    $result = $result['values'][$result['id']];
+    $result = $this->callAPISuccessGetSingle('membership', $params);
     $this->assertEquals($organizationMembershipID, $result['owner_membership_id']);
 
     // Set up params for enable/disable checks


### PR DESCRIPTION
Overview
----------------------------------------
Reduces passing of $ids to BAO_Member::add

Before
----------------------------------------
$ids['membership'] is an optional param for add

After
----------------------------------------
create converts to $params['id'] - the only other place in core code that was passing $ids to add no longer does

Technical Details
----------------------------------------
We don't need to worry about non-core code calling add correctly. We've been clear about that not being supported for over 6 years - we just haven't fully eliminated direct add calls in core.

Comments
----------------------------------------

