### PR TITLE
Remove legacy_redirect_path handling

### DIFF
--- a/CRM/Core/LegacyErrorHandler.php
+++ b/CRM/Core/LegacyErrorHandler.php
@@ -20,18 +20,6 @@ class CRM_Core_LegacyErrorHandler {
         CRM_Utils_Array::value('message_title', $params),
         CRM_Utils_Array::value('message_type', $params, 'error')
       );
-
-      // @todo remove this code - legacy redirect path is an interim measure for moving redirects out of BAO
-      // to somewhere slightly more acceptable. they should not be part of the exception class & should
-      // be managed @ the form level - if you find a form that is triggering this piece of code
-      // you should log a ticket for it to be removed with details about the form you were on.
-      if (!empty($params['legacy_redirect_path'])) {
-        if (CRM_Utils_System::isDevelopment()) {
-          $intentionalENotice = "How did you get HERE?! - Please log in JIRA";
-          // here we could set a message telling devs to log it per above
-        }
-        CRM_Utils_System::redirect($params['legacy_redirect_path'], $params['legacy_redirect_query']);
-      }
     }
   }
 

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -269,16 +269,6 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
         'today', $excludeIsAdmin, CRM_Utils_Array::value('membership_type_id', $params), $params
       );
       if (empty($calcStatus)) {
-        // Redirect the form in case of error
-        // @todo this redirect in the BAO layer is really bad & should be moved to the form layer
-        // however since we have no idea how (if) this is triggered we can't safely move / remove it
-        // NB I tried really hard to trigger this error from backoffice membership form in order to test it
-        // and am convinced form validation is complete on that form WRT this error.
-        $errorParams = [
-          'message_title' => ts('No valid membership status for given dates.'),
-          'legacy_redirect_path' => 'civicrm/contact/view',
-          'legacy_redirect_query' => "reset=1&force=1&cid={$params['contact_id']}&selectedChild=member",
-        ];
         throw new CRM_Core_Exception(ts(
           "The membership cannot be saved because the status cannot be calculated for start_date: $start_date end_date $end_date join_date $join_date as at " . date('Y-m-d H:i:s')),
           0,


### PR DESCRIPTION
Overview
----------------------------------------
Remove old code to handle fall out when moving re-directs back to the form layer

Before
----------------------------------------
Never hit code present

After
----------------------------------------
Never hit code removed. If it were to be hit they would see an error rather than get redirected which is at least as good given this should not be encountered anyway

Technical Details
----------------------------------------
This has been hanging around for a long time & no-one has logged a JIRA (or pointed out that JIRA is now
defunct) so the initial analysis of it being unreachable makes sense

Comments
----------------------------------------

