### PR TITLE
[REF] remove CRM_Core_Error check

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1367,14 +1367,11 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
       $expiredStatusId = array_search('Expired', CRM_Member_PseudoConstant::membershipStatus());
     }
 
-    $allRelatedContacts = [];
     $relatedContacts = [];
-    if (!is_a($membership, 'CRM_Core_Error')) {
-      $allRelatedContacts = CRM_Member_BAO_Membership::checkMembershipRelationship($membership->membership_type_id,
-        $membership->contact_id,
-        CRM_Utils_Array::value('action', $params)
-      );
-    }
+    $allRelatedContacts = CRM_Member_BAO_Membership::checkMembershipRelationship($membership->membership_type_id,
+      $membership->contact_id,
+      CRM_Utils_Array::value('action', $params)
+    );
 
     // CRM-4213, CRM-19735 check for loops, using static variable to record contacts already processed.
     // Remove repeated related contacts, which already inherited membership of this type.


### PR DESCRIPTION
Overview
----------------------------------------
Remove an IF that should always be true

Before
----------------------------------------
Handling for CRM_Core_Error when calling a function not expected to return a core error.

After
----------------------------------------
Handling removed, code easier to understand

Technical Details
----------------------------------------
I'm convinced there is no reason why find() should return a core_error & hence if it did we wouldn't want
to keep calm & carry on - smells a lot like copy & paste. Also makes code hard to understand

Comments
----------------------------------------

