### PR TITLE
dev/membership#21 fix bug where inherited memberships get inappropriately deleted

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5401,10 +5401,6 @@ LIMIT 1;";
       $membershipParams['is_override'] = FALSE;
       $membershipParams['status_override_end_date'] = 'null';
 
-      //CRM-17723 - reset static $relatedContactIds array()
-      // @todo move it to Civi Statics.
-      $var = TRUE;
-      CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
       civicrm_api3('Membership', 'create', $membershipParams);
     }
   }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1324,25 +1324,14 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @param CRM_Core_DAO $dao
    *   Membership object.
    *
-   * @param bool $reset
-   *
    * @return array|null
    *   Membership details, if created.
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function createRelatedMemberships(&$params, &$dao, $reset = FALSE) {
-    // CRM-4213 check for loops, using static variable to record contacts already processed.
-    if (!isset(\Civi::$statics[__CLASS__]['related_contacts'])) {
-      \Civi::$statics[__CLASS__]['related_contacts'] = [];
-    }
-    if ($reset) {
-      // CRM-17723.
-      unset(\Civi::$statics[__CLASS__]['related_contacts']);
-      return FALSE;
-    }
-    $relatedContactIds = &\Civi::$statics[__CLASS__]['related_contacts'];
+  public static function createRelatedMemberships(&$params, &$dao) {
+    $relatedContactIds = [];
 
     $membership = new CRM_Member_DAO_Membership();
     $membership->id = $dao->id;
@@ -1350,7 +1339,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
     // required since create method doesn't return all the
     // parameters in the returned membership object
     if (!$membership->find(TRUE)) {
-      return;
+      return NULL;
     }
     $deceasedStatusId = array_search('Deceased', CRM_Member_PseudoConstant::membershipStatus());
     // FIXME : While updating/ renewing the
@@ -1404,6 +1393,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
 
     //lets cleanup related membership if any.
     if (empty($relatedContacts)) {
+      // This is deeply truely madly wrong - refer to function name....
       self::deleteRelatedMemberships($membership->id);
     }
     else {

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -2041,10 +2041,6 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->assertEquals($organizationMembershipID, $expiredInheritedRelationship['owner_membership_id']);
     $this->assertMembershipStatus('Grace', (int) $expiredInheritedRelationship['status_id']);
 
-    // Reset static $relatedContactIds array in createRelatedMemberships(),
-    // to avoid bug where inherited membership gets deleted.
-    $var = TRUE;
-    CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
     // Check that after running process_membership job, statuses are correct.
     $this->callAPISuccess('Job', 'process_membership', []);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where inheritted memberships can be deleted when the parent is edited

Before
----------------------------------------
I managed to replicate this in the altered test in this line https://github.com/civicrm/civicrm-core/pull/16139/files#diff-3cd3f80dd69269a09e1d88996ce92f6fR1083 - basically it involves creating a couple of memberships that inherit and then updating one of them - all in the same php session - this results in the inherited relationship being deleted.

After
----------------------------------------
Inherited relationship is not deleted.

Technical Details
----------------------------------------
In https://issues.civicrm.org/jira/browse/CRM-4213 code was added to 'prevent loops'. The code caches memberships that have been processed to a static array. When the membership is processed again it only processes it if it's not in that array.... otherwise it .... deletes it .. because.... erm... yeah.

This has led to multiple bugs 
https://lab.civicrm.org/dev/membership/issues/21
https://issues.civicrm.org/jira/browse/CRM-19735
https://issues.civicrm.org/jira/browse/CRM-17723
https://issues.civicrm.org/jira/browse/CRM-20955

I tried removing the original loop handling with a view to fixing it better - but so far I have not been able to re-replicate the loop (the rest of the code has changed a lot in the 10-year interim)

Comments
----------------------------------------
This was reported as a regression but given the change could do with some tyre-kicking I think master is right @davejenx you were involved in QA in one of the above

@agileware-pengyi @agh1  FYI