### PR TITLE
dev/event#25 Fix regression on billing name overwrite

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -70,17 +70,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $this->assign('hookDiscount', $this->_params[0]['discount']);
     }
 
-    if (!$this->preProcessExpress()) {
-      //process only primary participant params.
-      $registerParams = $this->_params[0];
-      $registerParams = $this->prepareParamsForPaymentProcessor($registerParams);
-
-      if ($this->_values['event']['is_monetary']) {
-        $registerParams['currencyID'] = $this->_params[0]['currencyID'];
-      }
-      //assign back primary participant params.
-      $this->_params[0] = $registerParams;
-    }
+    $this->preProcessExpress();
 
     if ($this->_values['event']['is_monetary']) {
       $this->_params[0]['invoiceID'] = $this->get('invoiceID');
@@ -1294,7 +1284,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
    */
   private function processPayment($payment, $value) {
     try {
-      $result = $payment->doPayment($value, 'event');
+      $params = $this->prepareParamsForPaymentProcessor($value);
+      $result = $payment->doPayment($params, 'event');
       return [$result, $value];
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -1069,9 +1069,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       // assumptions we are working to remove.
       $this->set('contributeMode', 'direct');
 
-      // This code is duplicated multiple places and should be consolidated.
-      $params = $this->prepareParamsForPaymentProcessor($params);
-
       if ($this->_values['event']['is_monetary']) {
         $params['currencyID'] = $config->defaultCurrency;
         $params['invoiceID'] = $invoiceID;
@@ -1119,6 +1116,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $params['invoiceID'] = $invoiceID;
 
         $params['component'] = 'event';
+        // This code is duplicated multiple places and should be consolidated.
+        $params = $this->prepareParamsForPaymentProcessor($params);
         $this->handlePreApproval($params);
       }
       elseif ($this->_paymentProcessor &&


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/event/issues/25 - where billing name can overwrite the first name

Before
----------------------------------------
See https://lab.civicrm.org/dev/event/issues/25 for good description

After
----------------------------------------
Doesn't overwrite first name.

Technical Details
----------------------------------------
https://lab.civicrm.org/dev/event/issues/25 was caused by https://github.com/civicrm/civicrm-core/commit/b1b7f4e35bbe566d9efccac1055d311245420974
where it started overwriting the name in that function.

In digging in the code I found that it seems that as long as we call this function before the processor all is
good so we should call right before the processor rather than broader contamination.

Also note ideally the settings bag would be used.

Comments
----------------------------------------
@mattwire 
