### PR TITLE
Fix misleading error message on deadlock

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1639,7 +1639,7 @@ function _civicrm_api3_validate_foreign_keys($entity, $action, &$params, $fields
     if (!empty($fieldInfo['FKClassName'])) {
       if (!empty($params[$fieldName])) {
         foreach ((array) $params[$fieldName] as $fieldValue) {
-          _civicrm_api3_validate_constraint($fieldValue, $fieldName, $fieldInfo);
+          _civicrm_api3_validate_constraint($fieldValue, $fieldName, $fieldInfo, $entity);
         }
       }
       elseif (!empty($fieldInfo['required'])) {
@@ -1731,16 +1731,21 @@ function _civicrm_api3_getValidDate($dateValue, $fieldName, $fieldType) {
  *
  * @param mixed $fieldValue
  * @param string $fieldName
- *   Uniquename of field being checked.
+ *   Unique name of field being checked.
  * @param array $fieldInfo
  *   Array of fields from getfields function.
+ * @param string $entity
  *
  * @throws \API_Exception
  */
-function _civicrm_api3_validate_constraint(&$fieldValue, &$fieldName, &$fieldInfo) {
+function _civicrm_api3_validate_constraint($fieldValue, $fieldName, $fieldInfo, $entity) {
   $daoName = $fieldInfo['FKClassName'];
+  $fieldInfo = [$fieldName => $fieldInfo];
+  $params = [$fieldName => $fieldValue];
+  _civicrm_api3_validate_fields($entity, NULL, $params, $fieldInfo);
+  /* @var CRM_Core_DAO $dao*/
   $dao = new $daoName();
-  $dao->id = $fieldValue;
+  $dao->id = $params[$fieldName];
   $dao->selectAdd();
   $dao->selectAdd('id');
   if (!$dao->find()) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue where deadlocks could result in misleading error messages

Before
----------------------------------------
If an API is called with the name of the option (e.g Donation for financial_type_id) and a deadlock is hit the error message is misleading /confusing:

API_Exception : financial_type_id is not valid : Donation

After
----------------------------------------
Deadlock error message not overwritten unless the deadlock really has caused a constraint error.

Technical Details
----------------------------------------
We were seeing error messages like
API_Exception : financial_type_id is not valid : Donation
when a deadlock was hit. The error made not sense as 'Donation' DID exist and did not help us
to identify the issue as a deadlock. It's still helpful with a deadlock to know if
a real constraint violation is hit as per https://lab.civicrm.org/dev/core/issues/1481 sometimes
a disturbing amount of queries have been rolled back.

Let's fix to handle pseudoconstants here & give a useful message.
The previously converted params did not get to this point but we can re-do that work in this low
volume function rather than do a lot of re-thinking


Comments
----------------------------------------

