### PR TITLE
Add api to check for missing indices

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -17,7 +17,10 @@
 class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
 
   /**
+   * Check defined indices exist.
+   *
    * @return array
+   * @throws \CiviCRM_API3_Exception
    */
   public function checkIndices() {
     $messages = [];
@@ -26,7 +29,7 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
     // unreliable. Bypass this check until CRM-20817 and CRM-20533 are resolved.
     return $messages;
 
-    $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
+    $missingIndices = civicrm_api3('System', 'getmissingindices', [])['values'];
     if ($missingIndices) {
       $html = '';
       foreach ($missingIndices as $tableName => $indices) {

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -418,6 +418,16 @@ function civicrm_api3_system_updateindexes() {
 }
 
 /**
+ * Get an array of indices that should be defined but are not.
+ *
+ * @return array
+ */
+function civicrm_api3_system_getmissingindices() {
+  $indices = CRM_Core_BAO_SchemaHandler::getMissingIndices(FALSE);
+  return civicrm_api3_create_success($indices);
+}
+
+/**
  * Creates missing log tables.
  *
  * CRM-20838 - This adds any missing log tables into the database.

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -169,7 +169,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
    */
   public function testGetMissingIndices() {
     $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
-    $this->assertTrue(empty($missingIndices));
+    $this->assertEmpty($missingIndices);
   }
 
   /**
@@ -211,10 +211,15 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
 
   /**
    * Check there are no missing indices
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testReconcileMissingIndices() {
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_contact DROP INDEX index_sort_name');
     $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
+    // Check the api also retrieves them.
+    $missingIndicesAPI = $this->callAPISuccess('System', 'getmissingindices', [])['values'];
+    $this->assertEquals($missingIndices, $missingIndicesAPI);
     $this->assertEquals([
       'civicrm_contact' => [
         [
@@ -227,7 +232,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
     ], $missingIndices);
     $this->callAPISuccess('System', 'updateindexes', []);
     $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
-    $this->assertTrue(empty($missingIndices));
+    $this->assertEmpty($missingIndices);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Adds an api to check for missing mysql indices. Currently there is an api to attempt to update / repair them but not just to check. This adds that. 

Before
----------------------------------------
No api to get a list of missing indices

After
----------------------------------------
```
$missingIndices = civicrm_api3('System', 'getmissingindices', [])['values'];
```

Technical Details
----------------------------------------
I intend for follow up with fixes so a single table can be queried and potentially repaired

Comments
----------------------------------------
