### PR TITLE
Set contribution status to refunded when it has been refunded

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -149,6 +149,11 @@ class CRM_Financial_BAO_Payment {
     elseif ($contributionStatus === 'Pending' && $params['total_amount'] > 0) {
       self::updateContributionStatus($contribution['id'], 'Partially Paid');
     }
+    elseif ($contributionStatus === 'Completed' && ((float) CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribution['id'], TRUE) === 0.0)) {
+      // If the contribution has previously been completed (fully paid) and now has total payments adding up to 0
+      //  change status to refunded.
+      self::updateContributionStatus($contribution['id'], 'Refunded');
+    }
     CRM_Contribute_BAO_Contribution::recordPaymentActivity($params['contribution_id'], CRM_Utils_Array::value('participant_id', $params), $params['total_amount'], $trxn->currency, $trxn->trxn_date);
     return $trxn;
   }


### PR DESCRIPTION
Overview
----------------------------------------
When a contribution is refunded via Payment.create, has been previously marked completed and the sum of all payments for that contribution add up to 0 it should show "Refunded".

Before
----------------------------------------
Contribution shows "Completed" when it has been fully refunded.

After
----------------------------------------
Contribution shows "Refunded" when it has been fully refunded.

Technical Details
----------------------------------------
The function `CRM_Financial_BAO_Payment::create` already handles changing the contribution status to various states but does nothing with "Refunded". For end users this is really confusing!

Comments
----------------------------------------
See (sort of) https://lab.civicrm.org/dev/financial/issues/87