### PR TITLE
dev/core#1489 do not reconcile managed entities whilst in upgrade mod…

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -112,10 +112,15 @@ class CRM_Core_ManagedEntities {
   /**
    * Identify any enabled/disabled modules. Add new entities, update
    * existing entities, and remove orphaned (stale) entities.
+   * @param bool $ignoreUpgradeMode
    *
    * @throws Exception
    */
-  public function reconcile() {
+  public function reconcile($ignoreUpgradeMode = FALSE) {
+    // Do not reconcile whilst we are in upgrade mode
+    if (CRM_Core_Config::singleton()->isUpgradeMode() && !$ignoreUpgradeMode) {
+      return;
+    }
     if ($error = $this->validate($this->getDeclarations())) {
       throw new Exception($error);
     }

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -794,6 +794,8 @@ SET    version = '$version'
     // Rebuild all triggers and re-enable logging if needed
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
+
+    CRM_Core_ManagedEntities::singleton(TRUE)->reconcile(TRUE);
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -160,7 +160,7 @@ abstract class CRM_Utils_Hook {
     // Instead of not calling any hooks we only call those we know to be frequently important - if a particular extension wanted
     // to avoid this they could do an early return on CRM_Core_Config::singleton()->isUpgradeMode
     // Futther discussion is happening at https://lab.civicrm.org/dev/core/issues/1460
-    $upgradeFriendlyHooks = ['civicrm_alterSettingsFolders', 'civicrm_alterSettingsMetaData', 'civicrm_triggerInfo', 'civicrm_alterLogTables', 'civicrm_container'];
+    $upgradeFriendlyHooks = ['civicrm_alterSettingsFolders', 'civicrm_alterSettingsMetaData', 'civicrm_triggerInfo', 'civicrm_alterLogTables', 'civicrm_container', 'civicrm_permission'];
     if (CRM_Core_Config::singleton()->isUpgradeMode() && !in_array($fnSuffix, $upgradeFriendlyHooks)) {
       return;
     }


### PR DESCRIPTION
…e and add in a step at the end of the upgrade process to reconcile managed entiies and add in civicrm_permissions hook to the whitelist of upgrade friendly hooks

Overview
----------------------------------------
This adds in code to ensure we do not reconcile managed entities until after the upgrade is run and also adds in the civicrm_permissions hook to the whitelist as i don't think that can be problematic

Before
----------------------------------------
Managed entities maybe reconciled during upgrade

After
----------------------------------------
Managed entities are not reconciled during upgrade

ping @eileenmcnaughton @totten @jusfreeman 