### PR TITLE
dev/core#1499 - Case Resource shows contact names that are not access…

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1511,7 +1511,7 @@ HERESQL;
           $groupInfo['title'] = $results['title'];
           $params = [['group', '=', $groupInfo['id'], 0, 0]];
           $return = ['contact_id' => 1, 'sort_name' => 1, 'display_name' => 1, 'email' => 1, 'phone' => 1];
-          list($globalContacts) = CRM_Contact_BAO_Query::apiQuery($params, $return, NULL, $sort, $offset, $rowCount, TRUE, $returnOnlyCount);
+          list($globalContacts) = CRM_Contact_BAO_Query::apiQuery($params, $return, NULL, $sort, $offset, $rowCount, TRUE, $returnOnlyCount, FALSE);
 
           if ($returnOnlyCount) {
             return $globalContacts;

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -369,6 +369,34 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test getGlobalContacts
+   */
+  public function testGetGlobalContacts() {
+    //Add contact to case resource.
+    $caseResourceContactID = $this->individualCreate();
+    $this->callAPISuccess('GroupContact', 'create', [
+      'group_id' => "Case_Resources",
+      'contact_id' => $caseResourceContactID,
+    ]);
+
+    //No contact should be returned.
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+    $groupInfo = [];
+    $groupContacts = CRM_Case_BAO_Case::getGlobalContacts($groupInfo);
+    $this->assertEquals(count($groupContacts), 0);
+
+    //Verify if contact is returned correctly.
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'view all contacts',
+    ];
+    $groupInfo = [];
+    $groupContacts = CRM_Case_BAO_Case::getGlobalContacts($groupInfo);
+    $this->assertEquals(count($groupContacts), 1);
+    $this->assertEquals(key($groupContacts), $caseResourceContactID);
+  }
+
+  /**
    * Test max_instances
    */
   public function testMaxInstances() {


### PR DESCRIPTION
…ible to logged in user

Overview
----------------------------------------
Fix case resource section from loading inaccessible contacts.

Before
----------------------------------------
Replicate the problem by following the below steps -

1. Add contact A, B and C to case resource group.
2. Create a case for User1 and make sure that user1 is able to access only contact A (add appropriate ACL or relationships, etc).
3. Log in as User1 and navigate to Manage case screen -> open "Other relationship" panel. 
4. Notice that "Case Resources" section displays all the 3 contacts A, B and C in the list instead of showing only A to the user. 

![image](https://user-images.githubusercontent.com/5929648/71415001-aa6a0b80-267f-11ea-8193-4db63924eac9.png)


After
----------------------------------------
as admin, I can see all contacts. 

![image](https://user-images.githubusercontent.com/5929648/71415007-b35add00-267f-11ea-854d-27acc91ef9ca.png)

Masquerading as User1, I can see only accessible contacts from case resources -

![image](https://user-images.githubusercontent.com/5929648/71415029-cf5e7e80-267f-11ea-8400-00cde621e8c7.png)

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1499

Added unit test.