### PR TITLE
Fix CiviCRM mail settings when saving/altering system settings

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -521,9 +521,14 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       CRM_Core_Session::setStatus(ts('Outbound emails have been disabled. Scheduled jobs will not run unless runInNonProductionEnvironment=TRUE is added as a parameter for a specific job'), ts("Non-production environment set"), "success");
     }
     else {
-      $mailing = Civi::settings()->get('mailing_backend_store');
+      $mailing = Civi::settings()->get('mailing_backend');
       if ($mailing) {
         Civi::settings()->set('mailing_backend', $mailing);
+      } else {
+        $mailing = Civi::settings()->get('mailing_backend_store');
+        if ($mailing) {
+          Civi::settings()->set('mailing_backend', $mailing);
+        }
       }
     }
   }

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -524,7 +524,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       $mailing = Civi::settings()->get('mailing_backend');
       if ($mailing) {
         Civi::settings()->set('mailing_backend', $mailing);
-      } else {
+      }
+      else {
         $mailing = Civi::settings()->get('mailing_backend_store');
         if ($mailing) {
           Civi::settings()->set('mailing_backend', $mailing);


### PR DESCRIPTION
Overview
----------------------------------------
On production sites coming from non-production suddenly having their "Outbound Email Settings" reset from SMTP to mail() when saving settings like 'Debugging and Error Handling'

Before
----------------------------------------
- Go to Administer -> System Settings -> Debugging and Error Handling 
- Edit/Change any option and save the changes
- Go to Administer -> System Settings -> Outbound Mail
- Your mailer Configuration will be reset to the value saved in `mailing_backend_store` when your site was non-production.

After
----------------------------------------
- Go to Administer -> System Settings -> Debugging and Error Handling 
- Edit/Change any option and save the changes
- Go to Administer -> System Settings -> Outbound Mail
- Your mailer Configuration will remain with no changes

Technical Details
----------------------------------------
This issue is happening because on non-production sites when you change the mailer configuration and then another settings page changes the mailer configuration will be saved from `mailing_backend` to `mailing_backend_store` into civicrm_setting table and then that live site will be copying from `mailing_backend_store` to `mailing_backend` on any settings change.

This approach is to verify first if there is a value set for `mailing_backend`, if not perform the previous logic.

