### PR TITLE
Allow values to be passed to api4 GetFields

### DIFF
--- a/Civi/Api4/Action/CustomValue/GetFields.php
+++ b/Civi/Api4/Action/CustomValue/GetFields.php
@@ -32,7 +32,7 @@ class GetFields extends \Civi\Api4\Generic\DAOGetFieldsAction {
     $fields = $this->_itemsToGet('name');
     /** @var \Civi\Api4\Service\Spec\SpecGatherer $gatherer */
     $gatherer = \Civi::container()->get('spec_gatherer');
-    $spec = $gatherer->getSpec('Custom_' . $this->getCustomGroup(), $this->getAction(), $this->includeCustom);
+    $spec = $gatherer->getSpec('Custom_' . $this->getCustomGroup(), $this->getAction(), $this->includeCustom, $this->values);
     return SpecFormatter::specToArray($spec->getFields($fields), $this->loadOptions);
   }
 

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -30,6 +30,9 @@ use Civi\Api4\Utils\ActionUtil;
  * @method $this setLoadOptions(bool $value)
  * @method bool getLoadOptions()
  * @method $this setAction(string $value)
+ * @method $this addValue(string $value)
+ * @method $this setValues(array $values)
+ * @method array getValues()
  */
 class BasicGetFieldsAction extends BasicGetAction {
 
@@ -41,9 +44,18 @@ class BasicGetFieldsAction extends BasicGetAction {
   protected $loadOptions = FALSE;
 
   /**
+   * Fields will be returned appropriate to the specified action (get, create, delete, etc.)
+   *
    * @var string
    */
   protected $action = 'get';
+
+  /**
+   * Fields will be returned appropriate to the specified values (e.g. ['contact_type' => 'Individual'])
+   *
+   * @var array
+   */
+  protected $values = [];
 
   /**
    * To implement getFields for your own entity:

--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -51,7 +51,7 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
     if ($fields) {
       $this->includeCustom = strpos(implode('', $fields), '.') !== FALSE;
     }
-    $spec = $gatherer->getSpec($this->getEntityName(), $this->getAction(), $this->includeCustom);
+    $spec = $gatherer->getSpec($this->getEntityName(), $this->getAction(), $this->includeCustom, $this->values);
     return SpecFormatter::specToArray($spec->getFields($fields), $this->loadOptions);
   }
 

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -74,7 +74,7 @@
             <legend>values<span class="crm-marker" ng-if="availableParams.values.required"> *</span></legend>
             <div class="api4-input form-inline" ng-repeat="clause in params.values" ng-mouseenter="help('value: ' + clause[0], fieldHelp(clause[0]))" ng-mouseleave="help('values', availableParams.values)">
               <input class="collapsible-optgroups form-control" ng-model="clause[0]" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: valuesFields, allowClear: true, placeholder: 'Field'}" />
-              <input class="form-control" ng-model="clause[1]" api4-exp-value="{field: clause[0]}" />
+              <input class="form-control" ng-model="clause[1]" api4-exp-value="{field: clause[0], action: action === 'getFields' ? params.action || 'get' : action}" />
             </div>
             <div class="api4-input form-inline">
               <input class="collapsible-optgroups form-control" ng-model="controls.values" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: valuesFields}" placeholder="Add value" />

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -105,9 +105,9 @@
       return container;
     }
 
-    function getFieldList(source) {
+    function getFieldList(action) {
       var fields = [],
-        fieldInfo = _.findWhere(getEntity().actions, {name: $scope.action}).fields;
+        fieldInfo = _.findWhere(getEntity().actions, {name: action}).fields;
       formatForSelect2(fieldInfo, fields, 'name', ['description', 'required', 'default_value']);
       return fields;
     }
@@ -159,7 +159,7 @@
     };
 
     $scope.valuesFields = function() {
-      var fields = _.cloneDeep($scope.fields);
+      var fields = _.cloneDeep($scope.action === 'getFields' ? getFieldList($scope.params.action || 'get') : $scope.fields);
       // Disable fields that are already in use
       _.each($scope.params.values || [], function(val) {
         (_.findWhere(fields, {id: val[0]}) || {}).disabled = true;
@@ -265,7 +265,7 @@
       }
       if ($scope.action) {
         var actionInfo = _.findWhere(actions, {id: $scope.action});
-        $scope.fields = getFieldList();
+        $scope.fields = getFieldList($scope.action);
         if (_.contains(['get', 'update', 'delete', 'replace'], $scope.action)) {
           $scope.fieldsAndJoins = addJoins($scope.fields);
         } else {
@@ -658,7 +658,7 @@
         var ts = scope.ts = CRM.ts(),
           multi = _.includes(['IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN'], scope.data.op),
           entity = $routeParams.api4entity,
-          action = $routeParams.api4action;
+          action = scope.data.action || $routeParams.api4action;
 
         function destroyWidget() {
           var $el = $(element);

--- a/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
@@ -43,7 +43,7 @@ abstract class BaseCustomValueTest extends UnitTestCase {
       ],
     ];
 
-    $this->dropByPrefix('civicrm_value_mycontact');
+    $this->dropByPrefix('civicrm_value_my');
     $this->cleanup($cleanup_params);
   }
 

--- a/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
@@ -34,8 +34,8 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
 
     $customGroup = CustomGroup::create()
       ->setCheckPermissions(FALSE)
-      ->addValue('name', 'MyContactFields')
-      ->addValue('extends', 'Contact')
+      ->addValue('name', 'MyIndividualFields')
+      ->addValue('extends', 'Individual')
       ->execute()
       ->first();
 
@@ -47,39 +47,45 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
+    // Individual fields should show up when contact_type = null|Individual but not other contact types
+    $getFields = Contact::getFields()->setCheckPermissions(FALSE);
+    $this->assertContains('MyIndividualFields.FavColor', $getFields->execute()->column('name'));
+    $this->assertContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type' => 'Individual'])->execute()->column('name'));
+    $this->assertNotContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type' => 'Household'])->execute()->column('name'));
+
     $contactId = Contact::create()
       ->setCheckPermissions(FALSE)
       ->addValue('first_name', 'Johann')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactFields.FavColor', 'Red')
+      ->addValue('MyIndividualFields.FavColor', 'Red')
       ->execute()
       ->first()['id'];
 
     $contact = Contact::get()
       ->setCheckPermissions(FALSE)
       ->addSelect('first_name')
-      ->addSelect('MyContactFields.FavColor')
+      ->addSelect('MyIndividualFields.FavColor')
       ->addWhere('id', '=', $contactId)
-      ->addWhere('MyContactFields.FavColor', '=', 'Red')
+      ->addWhere('MyIndividualFields.FavColor', '=', 'Red')
       ->execute()
       ->first();
 
-    $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
+    $this->assertEquals('Red', $contact['MyIndividualFields.FavColor']);
 
     Contact::update()
       ->addWhere('id', '=', $contactId)
-      ->addValue('MyContactFields.FavColor', 'Blue')
+      ->addValue('MyIndividualFields.FavColor', 'Blue')
       ->execute();
 
     $contact = Contact::get()
       ->setCheckPermissions(FALSE)
-      ->addSelect('MyContactFields.FavColor')
+      ->addSelect('MyIndividualFields.FavColor')
       ->addWhere('id', '=', $contactId)
       ->execute()
       ->first();
 
-    $this->assertEquals('Blue', $contact['MyContactFields.FavColor']);
+    $this->assertEquals('Blue', $contact['MyIndividualFields.FavColor']);
   }
 
   public function testWithTwoFields() {


### PR DESCRIPTION
Overview
----------------------------------------
When doing GetFields from the api, some fields only apply to certain contact types.
This is a step toward getting filtering on api4 getFields by accepting `values` as a param.

Before
----------------------------------------
GetFields returns all fields.

After
----------------------------------------
It's now possible to filter getFields by contact type, only returning custom fields appropriate to certain contact types.

Technical Details
----------------------------------------
This also fixes a bug where multi-record custom sets were being returned in contact getFields.

Comments
----------------------------------------
So far this only filters custom fields by contact type, but values is now being passed to allow more filtering in future.

