### PR TITLE
dev/core#183 Ensure that having a rule where each field is the same w…

### DIFF
--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -234,6 +234,8 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
           $query = array_shift($tableQueries);
 
           if ($searchWithinDupes) {
+            // drop dedupe_copy table just in case if its already there.
+            $dedupeCopyTemporaryTableObject->drop();
             // get prepared to search within already found dupes if $searchWithinDupes flag is set
             $dedupeCopyTemporaryTableObject->createWithQuery("SELECT * FROM {$this->temporaryTables['dedupe']} WHERE weight >= {$weightSum}");
 

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -141,6 +141,33 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test rule from Richard
+   */
+  public function testRuleThreeContactFieldsEqualWeightWIthThresholdtheTotalSumOfAllWeight() {
+    $this->setupForGroupDedupe();
+
+    $ruleGroup = $this->callAPISuccess('RuleGroup', 'create', [
+      'contact_type' => 'Individual',
+      'threshold' => 30,
+      'used' => 'General',
+      'name' => 'TestRule',
+      'title' => 'TestRule',
+      'is_reserved' => 0,
+    ]);
+
+    foreach (['first_name', 'last_name', 'birth_date'] as $field) {
+      $rules[$field] = $this->callAPISuccess('Rule', 'create', [
+        'dedupe_rule_group_id' => $ruleGroup['id'],
+        'rule_table' => 'civicrm_contact',
+        'rule_weight' => 10,
+        'rule_field' => $field,
+      ]);
+    }
+    $foundDupes = CRM_Dedupe_Finder::dupesInGroup($ruleGroup['id'], $this->groupID);
+    $this->assertEquals(1, count($foundDupes));
+  }
+
+  /**
    * Test a custom rule with a non-default field.
    */
   public function testInclusiveRule() {


### PR DESCRIPTION
…eight with the threshold being the total sum of the weights does not cause a fatal error when searching for dupes

Overview
----------------------------------------
This fixes a fatal error that Richard @magnolia61 found as per comment on https://github.com/civicrm/civicrm-core/pull/15826. I think the main difference here is that no dupes will have been found with the first 2 rules i think but not sure however when I put Richard's rule into a unit test it failed and this fixed the unit test

Before
----------------------------------------
DB error already exist can occur with the given rule

After
----------------------------------------
No DB error and dupes can be found

ping @eileenmcnaughton @totten @mattwire @magnolia61 