### PR TITLE
Permit modified_id as a parameter for membership create api

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -105,12 +105,15 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       'max_related' => $membership->max_related,
     ];
 
-    $session = CRM_Core_Session::singleton();
+    if (!empty($params['modified_id'])) {
+      $membershipLog['modified_id'] = $params['modified_id'];
+    }
     // If we have an authenticated session, set modified_id to that user's contact_id, else set to membership.contact_id
-    if ($session->get('userID')) {
-      $membershipLog['modified_id'] = $session->get('userID');
+    elseif (CRM_Core_Session::singleton()->get('userID')) {
+      $membershipLog['modified_id'] = CRM_Core_Session::singleton()->get('userID');
     }
     elseif (!empty($ids['userId'])) {
+      // @todo deprecated this - transform in create as a transitional measure.
       $membershipLog['modified_id'] = $ids['userId'];
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Adds modified_id as a parameter to CRM_Member_BAO_Membership::create (this is available via apiv3 & can be available for apiv4 too with some discussion about how best to do so).

Before
----------------------------------------
Setting modified_id only possible by calling the BAO create (or add) function & passing in the deprecated $ids array

After
----------------------------------------
modified_id is a key in $params

Technical Details
----------------------------------------
The key goal here is really about deprecating the $ids array so we can remove it as a parameter from the add function and work to remove it from create. I will follow on with that once this is merged

There is quite a bit of inconsistency with member.create & for apiv3 there is stuff in the api layer that should be in the BAO. There is also some stuff that should go.

 Note this PR does nothing at the api level to make it available - it just takes advantage of apiv3 passing params through to the BAO. 

 I think we should add formal apiv4 support for modified_id
as a parameter for Membership.create - only issue is that of course it's not a 'real' param so we need to discuss /
understand how that needs to look. In general I think there are a few BAO that store modified_id

Comments
----------------------------------------

