### PR TITLE
[NFC] Add test on buildMembershipTypeValues & cleanup class

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -410,7 +410,8 @@ WHERE li.contribution_id = %1";
    *
    * @param bool $update
    *
-   * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function processPriceSet($entityId, $lineItem, $contributionDetails = NULL, $entityTable = 'civicrm_contribution', $update = FALSE) {
     if (!$entityId || !is_array($lineItem)

--- a/tests/phpunit/CRM/Member/BAO/MembershipLogTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipLogTest.php
@@ -91,20 +91,23 @@ class CRM_Member_BAO_MembershipLogTest extends CiviUnitTestCase {
       'visibility' => 'Public',
       'is_active' => 1,
     ];
-    $ids = [];
-    $membershipType = CRM_Member_BAO_MembershipType::add($params, $ids);
+    $membershipType = CRM_Member_BAO_MembershipType::add($params);
     $this->membershipTypeID = $membershipType->id;
     $this->membershipStatusID = $this->membershipStatusCreate('test status');
   }
 
   /**
    * Tears down the fixture.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function tearDown() {
     $this->relationshipTypeDelete($this->relationshipTypeID);
-    $this->membershipTypeDelete(['id' => $this->membershipTypeID]);
     $this->membershipStatusDelete($this->membershipStatusID);
+    $this->quickCleanUpFinancialEntities();
+    $this->restoreMembershipTypes();
     $this->contactDelete($this->organizationContactID);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -114,33 +114,37 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $this->assertEquals(empty($result), TRUE, 'Verify membership status record deletion.');
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
   public function testExpiredDisabled() {
-    $result = civicrm_api3('MembershipStatus', 'get', [
-      'name' => "Expired",
+    $this->callAPISuccess('MembershipStatus', 'get', [
+      'name' => 'Expired',
       'api.MembershipStatus.create' => ['label' => 'Expiiiired'],
     ]);
 
     // Calling it 'Expiiiired' is OK.
-    $result = $this->callAPISuccess('job', 'process_membership', []);
+    $this->callAPISuccess('job', 'process_membership', []);
 
-    $result = civicrm_api3('MembershipStatus', 'get', [
-      'name' => "Expired",
+    $this->callAPISuccess('MembershipStatus', 'get', [
+      'name' => 'Expired',
       'api.MembershipStatus.create' => ['is_active' => 0],
     ]);
 
     // Disabling 'Expired' is OK.
-    $result = $this->callAPISuccess('job', 'process_membership', []);
+    $this->callAPISuccess('job', 'process_membership', []);
 
-    $result = civicrm_api3('MembershipStatus', 'get', [
-      'name' => "Expired",
+    $this->callAPISuccess('MembershipStatus', 'get', [
+      'name' => 'Expired',
       'api.MembershipStatus.delete' => [],
     ]);
 
     // Deleting 'Expired' is OK.
-    $result = $this->callAPISuccess('job', 'process_membership', []);
+    $this->callAPISuccess('job', 'process_membership', []);
 
     // Put things back like normal
-    $result = civicrm_api3('MembershipStatus', 'create', [
+    $this->callAPISuccess('MembershipStatus', 'create', [
       'name' => 'Expired',
       'label' => 'Expired',
       'start_event' => 'end_date',

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1805,6 +1805,8 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
 
   /**
    * Clean up financial entities after financial tests (so we remember to get all the tables :-))
+   *
+   * @throws \CRM_Core_Exception
    */
   public function quickCleanUpFinancialEntities() {
     $tablesToTruncate = [
@@ -1847,11 +1849,28 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     CRM_Contribute_BAO_Query::$_contribOrSoftCredit = 'only contribs';
   }
 
+  /**
+   * Reset the price set config so results exist.
+   */
   public function restoreDefaultPriceSetConfig() {
     CRM_Core_DAO::executeQuery("DELETE FROM civicrm_price_set WHERE name NOT IN('default_contribution_amount', 'default_membership_type_amount')");
     CRM_Core_DAO::executeQuery("UPDATE civicrm_price_set SET id = 1 WHERE name ='default_contribution_amount'");
     CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_price_field` (`id`, `price_set_id`, `name`, `label`, `html_type`, `is_enter_qty`, `help_pre`, `help_post`, `weight`, `is_display_amounts`, `options_per_line`, `is_active`, `is_required`, `active_on`, `expire_on`, `javascript`, `visibility_id`) VALUES (1, 1, 'contribution_amount', 'Contribution Amount', 'Text', 0, NULL, NULL, 1, 1, 1, 1, 1, NULL, NULL, NULL, 1)");
     CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_price_field_value` (`id`, `price_field_id`, `name`, `label`, `description`, `amount`, `count`, `max_value`, `weight`, `membership_type_id`, `membership_num_terms`, `is_default`, `is_active`, `financial_type_id`, `non_deductible_amount`) VALUES (1, 1, 'contribution_amount', 'Contribution Amount', NULL, '1', NULL, NULL, 1, NULL, NULL, 0, 1, 1, 0.00)");
+  }
+
+  /**
+   * Recreate default membership types.
+   */
+  public function restoreMembershipTypes() {
+    CRM_Core_DAO::executeQuery(
+      "REPLACE INTO civicrm_membership_type
+    (id, domain_id, name, description, member_of_contact_id, financial_type_id, minimum_fee, duration_unit, duration_interval, period_type, fixed_period_start_day, fixed_period_rollover_day, relationship_type_id, relationship_direction, visibility, weight, is_active)
+VALUES
+    (1, 1, 'General', 'Regular annual membership.', 1, 2, 100.00, 'year', 2, 'rolling', NULL, NULL, 7, 'b_a', 'Public', 1, 1),
+    (2, 1, 'Student', 'Discount membership for full-time students.', 1, 2, 50.00, 'year', 1, 'rolling', NULL, NULL, NULL, NULL, 'Public', 2, 1),
+    (3, 1, 'Lifetime', 'Lifetime membership.', 1, 2, 1200.00, 'lifetime', 1, 'rolling', NULL, NULL, 7, 'b_a', 'Admin', 3, 1);
+    ");
   }
 
   /*


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup on test class + add a new test - I found the class wasn't running reliably in isolation so had to strip out some invalid things

Before
----------------------------------------
Various code nastinesses - cleanup issues, wrong params passed, unnecessary double quotes. Incorrect setup resulting in invalid financial entities (line items, transaction)

After
----------------------------------------
Improved, uses order api

Technical Details
----------------------------------------


Comments
----------------------------------------

