### PR TITLE
Pass api4 getFields values through to getOptions

### DIFF
--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -52,7 +52,7 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
       $this->includeCustom = strpos(implode('', $fields), '.') !== FALSE;
     }
     $spec = $gatherer->getSpec($this->getEntityName(), $this->getAction(), $this->includeCustom, $this->values);
-    return SpecFormatter::specToArray($spec->getFields($fields), $this->loadOptions);
+    return SpecFormatter::specToArray($spec->getFields($fields), $this->loadOptions, $this->values);
   }
 
   public function fields() {

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -376,9 +376,10 @@ class FieldSpec {
   }
 
   /**
+   * @param array $values
    * @return array
    */
-  public function getOptions() {
+  public function getOptions($values = []) {
     if (!isset($this->options) || $this->options === TRUE) {
       $fieldName = $this->getName();
 
@@ -388,7 +389,7 @@ class FieldSpec {
       }
 
       $bao = CoreUtil::getBAOFromApiName($this->getEntity());
-      $options = $bao::buildOptions($fieldName);
+      $options = $bao::buildOptions($fieldName, NULL, $values);
 
       if (!is_array($options) || !$options) {
         $options = FALSE;

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -29,15 +29,16 @@ class SpecFormatter {
   /**
    * @param FieldSpec[] $fields
    * @param bool $includeFieldOptions
+   * @param array $values
    *
    * @return array
    */
-  public static function specToArray($fields, $includeFieldOptions = FALSE) {
+  public static function specToArray($fields, $includeFieldOptions = FALSE, $values = []) {
     $fieldArray = [];
 
     foreach ($fields as $field) {
       if ($includeFieldOptions) {
-        $field->getOptions();
+        $field->getOptions($values);
       }
       $fieldArray[$field->getName()] = $field->toArray();
     }

--- a/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
@@ -22,6 +22,7 @@
 namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
+use Civi\Api4\Address;
 use Civi\Api4\Contact;
 
 /**
@@ -40,6 +41,20 @@ class GetExtraFieldsTest extends UnitTestCase {
     $notReturned = array_diff($baseFieldNames, $returnedFieldNames);
 
     $this->assertEmpty($notReturned);
+  }
+
+  public function testGetOptionsAddress() {
+    $getFields = Address::getFields()->setCheckPermissions(FALSE)->addWhere('name', '=', 'state_province_id')->setLoadOptions(TRUE);
+
+    $usOptions = $getFields->setValues(['country_id' => 1228])->execute()->first();
+
+    $this->assertContains('Alabama', $usOptions['options']);
+    $this->assertNotContains('Alberta', $usOptions['options']);
+
+    $caOptions = $getFields->setValues(['country_id' => 1039])->execute()->first();
+
+    $this->assertNotContains('Alabama', $caOptions['options']);
+    $this->assertContains('Alberta', $caOptions['options']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allows option filtering in api4, similar to how it works in api3.

Before
----------------------------------------
No options filtering.

After
----------------------------------------
Values passed to getOptions, so that e.g. you can fetch the states for a particular country.

Notes
---------------------------------------
Test added to confirm states are filtered by country.