### PR TITLE
Added filter for soft credit on find contributions

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -179,6 +179,20 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         );
         return;
 
+      case 'contribution_contribution_has_soft_credits_is_not_null':
+          if ($value) {
+            $op = "IS NOT NULL";
+            $query->_qill[$grouping][] = ts('Contribution has a Soft credits');
+          }
+          else {
+            $op = "IS NULL";
+            $query->_qill[$grouping][] = ts('Contribution has not a Soft credits');
+          }
+          $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_soft.amount", $op);
+          $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
+          $query->_tables['civicrm_contribution_soft'] = $query->_whereTables['civicrm_contribution_soft'] = 1;
+          return;
+
       case 'contribution_thankyou_date_is_not_null':
         if ($value) {
           $op = "IS NOT NULL";
@@ -945,6 +959,9 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       ts('Contribution Status'), $statusValues,
       FALSE, ['class' => 'crm-select2', 'multiple' => 'multiple']
     );
+
+    // Add field for Soft credit.
+    $form->addYesNo('contribution_contribution_has_soft_credits_is_not_null', ts('Contribution has soft credit(s)?'), TRUE);
 
     // Add fields for thank you and receipt
     $form->addYesNo('contribution_thankyou_date_is_not_null', ts('Thank-you sent?'), TRUE);

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -75,6 +75,12 @@
     <table style="width:auto">
       <tbody>
       <tr>
+        <td>{$form.contribution_contribution_has_soft_credits_is_not_null.label}</td>
+        <td>
+          {$form.contribution_contribution_has_soft_credits_is_not_null.html}
+        </td>
+      </tr>
+      <tr>
         <td>{$form.contribution_thankyou_date_is_not_null.label}</td>
         <td>
           {$form.contribution_thankyou_date_is_not_null.html}


### PR DESCRIPTION
Overview
----------------------------------------
It will provide ablitiy to search only contributions who have soft credit on Find Contributions screen

Before
----------------------------------------
There is no way to find contributions who have attached soft credit. There is option for soft credit only which give you soft credit contributions.

After
----------------------------------------
It will add option to filter the contributions which haves soft credits.
<img width="1015" alt="Soft-Credit" src="https://user-images.githubusercontent.com/445545/71641704-41f5dc80-2cc6-11ea-8673-1b74144d254c.png">

