### PR TITLE
dev/membership#21 fix regression on membership handling

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -96,8 +96,7 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
     // be more complete.
     if (!empty($params['credit_card_exp_date']['Y']) && date('Y') >
       CRM_Core_Payment_Form::getCreditCardExpirationYear($params)) {
-      $error = new CRM_Core_Error(ts('transaction failed'));
-      return $error;
+      throw new PaymentProcessorException(ts('Invalid expiry date'));
     }
     //end of hook invocation
     if (!empty($this->_doDirectPaymentResult)) {

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -477,6 +477,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
    * This function is also accessed by a unit test.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   protected function submit() {
     $this->storeContactFields($this->_params);

--- a/CRM/Member/Utils/RelationshipProcessor.php
+++ b/CRM/Member/Utils/RelationshipProcessor.php
@@ -87,7 +87,7 @@ class CRM_Member_Utils_RelationshipProcessor {
       'options' => ['limit' => 0],
     ])['values'];
     foreach ($memberships as $id => $membership) {
-      if (!isset($membership['inheriting_membership_ids'])) {
+      if (!isset($memberships[$id]['inheriting_membership_ids'])) {
         $memberships[$id]['inheriting_membership_ids'] = [];
         $memberships[$id]['inheriting_contact_ids'] = [];
       }

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -124,7 +124,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
           'cvv2' => '123',
           'credit_card_exp_date' => [
             'M' => '1',
-            'Y' => '2019',
+            'Y' => date('Y') + 1,
           ],
           'credit_card_type' => 'Visa',
           'billing_first_name' => 'p',
@@ -207,7 +207,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     ], $entityFinancialTrxns[2], ['id', 'entity_id']);
     $mut->checkMailLog([
       'Event Information and Location', 'Registration Confirmation - Annual CiviCRM meet',
-      'Expires: January 2019',
+      'Expires: January ' . (date('Y') + 1),
       'Visa',
       '************1111',
       'This is a confirmation that your registration has been received and your status has been updated to <strong> Registered</strong>',

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -234,8 +234,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'cvv2' => '123',
       'credit_card_exp_date' => [
         'M' => '9',
-        // TODO: Future proof
-        'Y' => '2019',
+        'Y' => date('Y') + 1,
       ],
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',
@@ -357,6 +356,9 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
    * @param string $thousandSeparator
    *
    * @dataProvider getThousandSeparators
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function testSubmitRecurCompleteInstantWithMail($thousandSeparator) {
     $this->setCurrencySeparators($thousandSeparator);
@@ -614,8 +616,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'cvv2' => '123',
       'credit_card_exp_date' => [
         'M' => '9',
-        // TODO: Future proof
-        'Y' => '2019',
+        'Y' => date('Y') + 1,
       ],
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1195,8 +1195,7 @@ Expires: ',
       'cvv2' => '123',
       'credit_card_exp_date' => [
         'M' => '9',
-        // TODO: Future proof
-        'Y' => '2019',
+        'Y' => date('Y') + 1,
       ],
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',


### PR DESCRIPTION


Overview
----------------------------------------
Fixes an obscure regression - best to refer to git lab on it

Before
----------------------------------------
Checks $membership for values

After
----------------------------------------
Checks $memberships['id'] - which is the outer value

Technical Details
----------------------------------------
This turns https://lab.civicrm.org/dev/membership/issues/21#note_29439 into a patch. As new code it seems to
have triggered an underlying issue. I also have https://github.com/civicrm/civicrm-core/pull/16139 open but
would be happy to see this hit the rc & the other have a full rc cycle.

The logic for this change makes sense as described & it is trivial. This has been a very hard bug
to reproduce so I'm unable to give full steps

Comments
----------------------------------------
@seamuslee001 based on the work done in gitlab & the fact this part of the puzzle is recent I think we should merge this