### PR TITLE
dev/core#1143 dev/core#1480 Permit CiviCRM installation and running o…

### DIFF
--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -121,7 +121,7 @@ class CRM_Core_OptionGroup {
     }
 
     $query = "
-SELECT  v.{$labelColumnName} as {$labelColumnName} ,v.{$keyColumnName} as value, v.grouping as grouping
+SELECT  v.{$labelColumnName} as {$labelColumnName} ,v.{$keyColumnName} as value, v.grouping as `grouping`
 FROM   civicrm_option_value v,
        civicrm_option_group g
 WHERE  v.option_group_id = g.id
@@ -225,7 +225,7 @@ WHERE  v.option_group_id = g.id
       }
     }
     $query = "
-SELECT  v.{$labelColumnName} as {$labelColumnName} ,v.value as value, v.grouping as grouping
+SELECT  v.{$labelColumnName} as {$labelColumnName} ,v.value as value, v.grouping as `grouping`
 FROM   civicrm_option_value v,
        civicrm_option_group g
 WHERE  v.option_group_id = g.id


### PR DESCRIPTION
…n MySQL 8 by adding backticks around grouping

Overview
----------------------------------------
This allows CiviCRM installation to run on MySQL 8. The issue is as documentation that grouping is now a keyword so we need to add backticks around it to work

Before
----------------------------------------
CiviCRM Installation fails on MySQL 8

After
----------------------------------------
CiviCRM Installation works on MySQL 8

ping @eileenmcnaughton @totten @JoeMurray @monishdeb 