### PR TITLE
dev/core#1144 (NFC) Handle fact that MySQL 8 always returns the colum…

### DIFF
--- a/Civi/Test/Schema.php
+++ b/Civi/Test/Schema.php
@@ -27,7 +27,7 @@ class Schema {
     $tables = $pdo->query($query);
     $result = [];
     foreach ($tables as $table) {
-      $result[] = $table['table_name'];
+      $result[] = isset($table['TABLE_NAME']) ? $table['TABLE_NAME'] : $table['table_name'];
     }
     return $result;
   }


### PR DESCRIPTION
…n name as it is in the DB not as it is in the query

Overview
----------------------------------------
In MySQL 8 the query outputs TABLE_NAME as the selector rather than table_name as it does in 5.7 and earlier.

Before
----------------------------------------
Tests cannot run on MySQL 8

After
----------------------------------------
Tests run on MySQL 8

ping @totten @eileenmcnaughton 