### PR TITLE
Mailing Subscribe Form: remove nbsp from descriptions

### DIFF
--- a/templates/CRM/Mailing/Form/Subscribe.tpl
+++ b/templates/CRM/Mailing/Form/Subscribe.tpl
@@ -32,7 +32,7 @@
                 {assign var=cbName value=$row.checkbox}
                 <td class="crm-mailing-subscribe-form-block-{$cbName}">{$form.$cbName.html}</td>
                 <td class="crm-mailing-subscribe-form-block-title"><label for="{$cbName}"><strong>{$row.title}</strong></label></td>
-                <td class="crm-mailing-subscribe-form-block-description">&nbsp;&nbsp;{$row.description}&nbsp;</td>
+                <td class="crm-mailing-subscribe-form-block-description">{$row.description}</td>
             </tr>
             {/foreach}
             </table>


### PR DESCRIPTION
Overview
----------------------------------------

Removes excess spaces from the descriptions of the "Mailing List Subscriptions" form.

Example: https://civicrm.org/civicrm/mailing/subscribe?reset=1

Before
----------------------------------------

![Capture d’écran de 2020-01-02 09-21-44](https://user-images.githubusercontent.com/254741/71671554-51fed200-2d41-11ea-86d9-d12979553df7.png)

After
----------------------------------------

Notice two extra spaces before the descriptions of the mailing groups ("Contributor News keeps you.."):

![Capture d’écran de 2020-01-02 09-22-34](https://user-images.githubusercontent.com/254741/71671598-70fd6400-2d41-11ea-9b4b-ff56226d3090.png)

Technical Details
----------------------------------------

The tpl had 'nbsp' in them and they have been there for a very long time, according to the git log.

Comments
----------------------------------------

Part of the "civicrm.org should use CiviCRM" initiative ;-)