### PR TITLE
Update BAO_Acl internal functions to protected & unused to deprecated

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -34,6 +34,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
    * @return array|null
    */
   public static function entityTable() {
+    CRM_Core_Error::deprecatedFunctionWarning('unused function to be removed');
     if (!self::$_entityTable) {
       self::$_entityTable = [
         'civicrm_contact' => ts('Contact'),
@@ -47,6 +48,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
    * @return array|null
    */
   public static function objectTable() {
+    CRM_Core_Error::deprecatedFunctionWarning('unused function to be removed');
     if (!self::$_objectTable) {
       self::$_objectTable = [
         'civicrm_contact' => ts('Contact'),
@@ -59,7 +61,9 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
   }
 
   /**
-   * @return array|null
+   * Available operations for  pseudoconstant.
+   *
+   * @return array
    */
   public static function operation() {
     if (!self::$_operation) {
@@ -92,6 +96,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
    * @throws \CRM_Core_Exception
    */
   public static function getClause($table, $id, &$tables) {
+    CRM_Core_Error::deprecatedFunctionWarning('unused function to be removed');
     $table = CRM_Utils_Type::escape($table, 'String');
     $id = CRM_Utils_Type::escape($id, 'Integer');
     $whereTables = [];
@@ -150,7 +155,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function getACLs($contact_id = NULL) {
+  protected static function getACLs($contact_id = NULL) {
     $results = [];
 
     if (empty($contact_id)) {
@@ -196,7 +201,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function getACLRoles($contact_id = NULL) {
+  protected static function getACLRoles($contact_id = NULL) {
     $contact_id = CRM_Utils_Type::escape($contact_id, 'Integer');
 
     $rule = new CRM_ACL_BAO_ACL();
@@ -233,7 +238,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
    *   Assoc array of ACL rules
    * @throws \CRM_Core_Exception
    */
-  public static function getGroupACLs($contact_id, $aclRoles = FALSE) {
+  protected static function getGroupACLs($contact_id, $aclRoles = FALSE) {
     $contact_id = CRM_Utils_Type::escape($contact_id, 'Integer');
 
     $rule = new CRM_ACL_BAO_ACL();
@@ -278,7 +283,7 @@ SELECT      acl.*
    *   Array of assoc. arrays of ACL rules
    * @throws \CRM_Core_Exception
    */
-  public static function getGroupACLRoles($contact_id) {
+  protected static function getGroupACLRoles($contact_id) {
     $contact_id = CRM_Utils_Type::escape($contact_id, 'Integer');
 
     $rule = new CRM_ACL_BAO_ACL();
@@ -632,7 +637,7 @@ ORDER BY a.object_id
    *
    * @return bool
    */
-  public static function matchType($type, $operation) {
+  protected static function matchType($type, $operation) {
     $typeCheck = FALSE;
     switch ($operation) {
       case 'All':


### PR DESCRIPTION
Overview
----------------------------------------
Deprecates a couple of unused functions & updates internal functions to protected

Before
----------------------------------------
public ./ not deprecated

After
----------------------------------------
protected/deprecated

Technical Details
----------------------------------------
I checked which functions were being called & reflected their use in visibility

Comments
----------------------------------------

