### PR TITLE
[REF] Move the storing of custom data into the add function rather th…

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -138,6 +138,13 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     if (!empty($params['is_for_organization'])) {
       $targetContactID = CRM_Utils_Array::value('userId', $ids);
     }
+
+    // add custom field values
+    if (!empty($params['custom']) && is_array($params['custom'])
+    ) {
+      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_membership', $membership->id);
+    }
+
     if ($id) {
       if ($membership->status_id != $oldStatus) {
         CRM_Activity_BAO_Activity::addActivity($membership,
@@ -305,12 +312,6 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     if (is_a($membership, 'CRM_Core_Error')) {
       $transaction->rollback();
       return $membership;
-    }
-
-    // add custom field values
-    if (!empty($params['custom']) && is_array($params['custom'])
-    ) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_membership', $membership->id);
     }
 
     $params['membership_id'] = $membership->id;


### PR DESCRIPTION
…an in the create function so it is processed before the post hook

Overview
----------------------------------------
This moves the saving of custom data to within the add() function from the create() function so that any custom data that is processed with the original create is processed before any custom data processing in post hooks. This is similar to https://github.com/civicrm/civicrm-core/pull/16061 

Before
----------------------------------------
Submitted custom data processed after post hook invocation

After
----------------------------------------
Submitted custom data is processed before post hook is invoked

ping @eileenmcnaughton 