### PR TITLE
dev/core#1143 enable auto adding of backticks when doing an insert() or update() function

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -144,6 +144,7 @@ class CRM_Core_DAO extends DB_DataObject {
     Civi::$statics[__CLASS__]['init'] = 1;
     $options = &PEAR::getStaticProperty('DB_DataObject', 'options');
     $options['database'] = $dsn;
+    $options['quote_identifiers'] = TRUE;
     if (defined('CIVICRM_DAO_DEBUG')) {
       self::DebugLevel(CIVICRM_DAO_DEBUG);
     }


### PR DESCRIPTION
Overview
----------------------------------------
To support MySQL 8 there are a number of new reserved words such as `grouping` which need to be handled sensibly when inserting or updating or querying data. This change will when we do a create api call or similar that the DB_DataObject automatically adds backticks around the table field names and values which stops issues

Before
----------------------------------------
`CRM_Core_BAO_MappingTest` fails on MySQL8 

After
----------------------------------------
`CRM_Core_BAO-MappingTest` passes on MySQL 8 

ping @eileenmcnaughton @monishdeb @JoeMurray @totten 