### PR TITLE
dev/core#1507 Fix recent items for viewing Email activities from contact activities tab

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -95,13 +95,13 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     $values['attachment'] = CRM_Core_BAO_File::attachmentInfo('civicrm_activity', $activityId);
     $this->assign('values', $values);
 
-    $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$activityId}&action=view&cid={$values['source_contact_id']}");
-    CRM_Utils_Recent::add($this->_values['subject'],
+    $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$activityId}&action=view&cid={$defaults['source_contact_id']}");
+    CRM_Utils_Recent::add($defaults['subject'],
       $url,
-      $values['id'],
+      $activityId,
       'Activity',
-      $values['source_contact_id'],
-      $values['source_contact']
+      $defaults['source_contact_id'],
+      $defaults['source_contact']
     );
   }
 

--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    $tablesToTruncate = [
+      'civicrm_activity',
+      'civicrm_activity_contact',
+    ];
+    $this->quickCleanup($tablesToTruncate);
+  }
+
+  /**
+   * Test that the smarty template for ActivityView contains what we expect
+   * after preProcess().
+   */
+  public function testActivityViewPreProcess() {
+    // create activity
+    $activity = $this->activityCreate();
+
+    // $activity doesn't contain everything we need, so do another get call
+    $activityMoreInfo = $this->callAPISuccess('activity', 'getsingle', ['id' => $activity['id']]);
+
+    // do preProcess
+    $activityViewForm = new CRM_Activity_Form_ActivityView();
+    $activityViewForm->controller = new CRM_Core_Controller_Simple('CRM_Activity_Form_ActivityView', 'Activity');
+    $activityViewForm->set('id', $activity['id']);
+    $activityViewForm->set('context', 'activity');
+    $activityViewForm->set('cid', $activity['target_contact_id']);
+    $activityViewForm->preProcess();
+
+    // check one of the smarty template vars
+    // not checking EVERYTHING
+    $templateVar = $activityViewForm->getTemplate()->get_template_vars('values');
+    $expected = [
+      'assignee_contact' => [0 => $activity['target_contact_id']],
+      // it's always Julia
+      'assignee_contact_value' => 'Anderson, Julia',
+      'target_contact' => [0 => $activity['target_contact_id']],
+      'target_contact_value' => 'Anderson, Julia',
+      'source_contact' => $activityMoreInfo['source_contact_sort_name'],
+      'case_subject' => NULL,
+      'id' => (int) $activity['id'],
+      'subject' => $activity['values'][$activity['id']]['subject'],
+      'activity_subject' => $activity['values'][$activity['id']]['subject'],
+      'activity_date_time' => $activityMoreInfo['activity_date_time'],
+      'location' => $activity['values'][$activity['id']]['location'],
+      'activity_location' => $activity['values'][$activity['id']]['location'],
+      'details' => $activity['values'][$activity['id']]['details'],
+      'activity_details' => $activity['values'][$activity['id']]['details'],
+      'is_test' => '0',
+      'activity_is_test' => '0',
+      'is_auto' => '0',
+      'is_current_revision' => '1',
+      'is_deleted' => '0',
+      'activity_is_deleted' => '0',
+      'is_star' => '0',
+      'created_date' => $activityMoreInfo['created_date'],
+      'activity_created_date' => $activityMoreInfo['created_date'],
+      'modified_date' => $activityMoreInfo['modified_date'],
+      'activity_modified_date' => $activityMoreInfo['modified_date'],
+      'attachment' => NULL,
+    ];
+
+    $this->assertEquals($expected, $templateVar);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Go to someone's activity tab who has an activity of type `Email` and click to view it. Then refresh the page or go somewhere else and notice that the recent items list has a blank entry. There's also E_NOTICE's but you don't see them if you're using the default setting for popups.

https://lab.civicrm.org/dev/core/issues/1507

Before
----------------------------------------
Recent Items item in left sidebar is blank with incomplete url.

After
----------------------------------------
Correct item.

Technical Details
----------------------------------------
Looking at https://github.com/civicrm/civicrm-core/pull/11891/files the code that was used in Activity.php seems to have been copy/pasted into ActivityView.php but the variables aren't valid there - you can still see it even has a reference to the original `$this->_values` which isn't a thing.

So this only comes up for CRM_Activity_Form_ActivityView, which is only used for Email and sparsely used elsewhere.

Comments
----------------------------------------
The test doesn't test this specific recent items issue, but it fails without the patch, and adds at least some coverage to something not covered anywhere else.
