### PR TITLE
[REF] Eliminate ['userID'] as an input for BAO_Membership::create

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -296,7 +296,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     // @todo remove $ids from here $ids['userId'] is still used
     $params['id'] = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('membership', $ids));
     if (empty($params['modified_id']) && !empty($ids['userID'])) {
-      // @todo add deprecation notice here.
+      CRM_Core_Error::deprecatedFunctionWarning('$ids["userID"] no longer supported - use $params["modified_id"]');
       $params['modified_id'] = $ids['userID'];
     }
     $membership = self::add($params);
@@ -2011,12 +2011,10 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
 
     //CRM-4027, create log w/ individual contact.
     if ($modifiedID) {
-      $ids['userId'] = $modifiedID;
+      // @todo this param is likely unused now.
       $memParams['is_for_organization'] = TRUE;
     }
-    else {
-      $ids['userId'] = $contactID;
-    }
+    $params['modified_id'] = $modifiedID ?? $contactID;
 
     //inherit campaign from contrib page.
     if (isset($campaignId)) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1082,7 +1082,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     if ($this->_id) {
       $ids['membership'] = $params['id'] = $this->_id;
     }
-    $ids['userId'] = CRM_Core_Session::singleton()->get('userID');
 
     // Set variables that we normally get from context.
     // In form mode these are set in preProcess.
@@ -1241,7 +1240,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $membershipType = implode(', ', $membershipTypes);
 
     // Retrieve the name and email of the current user - this will be the FROM for the receipt email
-    list($userName) = CRM_Contact_BAO_Contact_Location::getEmailDetails($ids['userId']);
+    list($userName) = CRM_Contact_BAO_Contact_Location::getEmailDetails(CRM_Core_Session::getLoggedInContactID());
 
     //CRM-13981, allow different person as a soft-contributor of chosen type
     if ($this->_contributorContactID != $this->_contactID) {

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -66,6 +66,9 @@ function civicrm_api3_membership_delete($params) {
  *
  * @return array
  *   API result array.
+ *
+ * @throws \CRM_Core_Exception
+ * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_membership_create($params) {
   // check params for membership id during update
@@ -121,10 +124,6 @@ function civicrm_api3_membership_create($params) {
   $ids = [];
   if (empty($params['id'])) {
     $params['action'] = CRM_Core_Action::ADD;
-    // we need user id during add mode
-    if (!empty($params['contact_id'])) {
-      $ids['userId'] = $params['contact_id'];
-    }
   }
   else {
     // edit mode
@@ -134,7 +133,7 @@ function civicrm_api3_membership_create($params) {
   }
 
   // @todo stop passing $ids (membership and userId may be set above)
-  $membershipBAO = CRM_Member_BAO_Membership::create($params, $ids, TRUE);
+  $membershipBAO = CRM_Member_BAO_Membership::create($params, $ids);
 
   if (array_key_exists('is_error', $membershipBAO)) {
     // In case of no valid status for given dates, $membershipBAO


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup on deprecated input param

Before
----------------------------------------
``$ids['userID'] ```passed & supported

After
----------------------------------------
``$ids['userID'] ```not passed & deprecated

Technical Details
----------------------------------------
Continuation of standardisation - $params['modified_id'] is now preferred

Comments
----------------------------------------

