### PR TITLE
dev/core#1506 Fix blank group title in recent items list when editing description inline

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -334,6 +334,21 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       CRM_Utils_Hook::pre('create', 'Group', NULL, $params);
     }
 
+    // If title isn't specified, retrieve it because we use it later, e.g.
+    // for RecentItems. But note we use array_key_exists not isset or empty
+    // since otherwise there would be no way to blank out an existing title.
+    // I'm not sure what the use-case is for that, but you're allowed to do it
+    // currently.
+    if (!empty($params['id']) && !array_key_exists('title', $params)) {
+      try {
+        $groupTitle = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $params['id'], 'title', 'id');
+        $params['title'] = $groupTitle;
+      }
+      catch (CRM_Core_Exception $groupTitleException) {
+        // don't set title
+      }
+    }
+
     // dev/core#287 Disable child groups if all parents are disabled.
     if (!empty($params['id'])) {
       $allChildGroupIds = self::getChildGroupIds($params['id']);

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -259,4 +259,42 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
     $this->assertEquals(1, $recipients['count'], 'Check recipient count');
   }
 
+  /**
+   * Test updating a group with just description and check the recent items
+   * list has the right title.
+   */
+  public function testGroupUpdateDescription() {
+    // Create a group. Copied from $this->testAddSimple().
+    // Note we need $checkParams because the function call changes $params.
+    $checkParams = $params = [
+      'title' => 'Group Uno',
+      'description' => 'Group One',
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+    ];
+    $group = CRM_Contact_BAO_Group::create($params);
+
+    // Update the group with just id and description.
+    $newParams = [
+      'id' => $group->id,
+      'description' => 'The first group',
+    ];
+    CRM_Contact_BAO_Group::create($newParams);
+
+    // Check it against original array, except description.
+    $result = $this->callAPISuccess('Group', 'getsingle', ['id' => $group->id]);
+    foreach ($checkParams as $key => $value) {
+      if ($key === 'description') {
+        $this->assertEquals($newParams[$key], $result[$key], "$key doesn't match");
+      }
+      else {
+        $this->assertEquals($checkParams[$key], $result[$key], "$key doesn't match");
+      }
+    }
+
+    // Check recent items list.
+    $recentItems = CRM_Utils_Recent::get();
+    $this->assertEquals($checkParams['title'], $recentItems[0]['title']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1506
On the Manage Groups screen if you edit the description inline the recent items list will contain a blank entry when you reload the page or then visit another page.

Before
----------------------------------------
Blank entry in recent items list.

After
----------------------------------------
Words appear.

Technical Details
----------------------------------------
Title isn't passed in with the params in the ajax call but it uses title to add to the recent items list. This also affects any Group create api call (v3, or v4 Group update) where you've passed in an id but not a title.

Comments
----------------------------------------
Has test.
