### PR TITLE
dev/core#392 Fix FTS INNDOB indexer query to work in MySQL 8 as well …

### DIFF
--- a/CRM/Core/InnoDBIndexer.php
+++ b/CRM/Core/InnoDBIndexer.php
@@ -169,10 +169,17 @@ class CRM_Core_InnoDBIndexer {
     }
 
     // Note: this only works in MySQL 5.6,  but this whole system is intended to only work in MySQL 5.6
+    // Note: In MYSQL 8 the Tables have been renamed from INNODB_SYS_TABLES and INNODB_SYS_INDEXES to INNODB_TABLES and INNODB_INDEXES
+    $innodbTable = "innodb_sys_tables";
+    $innodbIndex = "innodb_sys_indexes";
+    if (version_compare($mysqlVersion, '8.0', '>=')) {
+      $innodbTable = "innodb_tables";
+      $innodbIndex = "innodb_indexes";
+    }
     $sql = "
-      SELECT i.name as index_name
-      FROM information_schema.innodb_sys_tables t
-      JOIN information_schema.innodb_sys_indexes i USING (table_id)
+      SELECT i.name as `index_name`
+      FROM information_schema.$innodbTable t
+      JOIN information_schema.$innodbIndex i USING (table_id)
       WHERE t.name = concat(database(),'/$table')
       AND i.name like '" . self::IDX_PREFIX . "%'
       ";


### PR DESCRIPTION
…as previous MySQL versions

Overview
----------------------------------------
In MySQL 8 the INNODB tables in the information schema have had the `_SYS_` removed from them as per https://dev.mysql.com/doc/refman/8.0/en/mysql-nutshell.html#mysql-nutshell-removals 

Before
----------------------------------------
CRM_Utils_QueryFormatterTest fails on MySQL 8

After
----------------------------------------
CRM_Utils_QueryFormatterTest passes on MySQL 8

ping @totten @eileenmcnaughton @monishdeb @JoeMurray 