### PR TITLE
dev/core#1143 Ensure that columns that are reserved words e.g. groupi…

### DIFF
--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -487,17 +487,17 @@ class CRM_Core_I18n_Schema {
       if (!in_array($dao->Field, array_keys($columns[$table])) and
         !preg_match('/_[a-z][a-z]_[A-Z][A-Z]$/', $dao->Field)
       ) {
-        $cols[] = $dao->Field;
+        $cols[] = '`' . $dao->Field . '`';
       }
       $tableCols[] = $dao->Field;
     }
     // view intrernationalized columns through an alias
     foreach ($columns[$table] as $column => $_) {
       if (!$isUpgradeMode) {
-        $cols[] = "{$column}_{$locale} {$column}";
+        $cols[] = "`{$column}_{$locale}` `{$column}`";
       }
       elseif (in_array("{$column}_{$locale}", $tableCols)) {
-        $cols[] = "{$column}_{$locale} {$column}";
+        $cols[] = "`{$column}_{$locale}` `{$column}`";
       }
     }
     return "CREATE OR REPLACE VIEW {$table}_{$locale} AS SELECT " . implode(', ', $cols) . " FROM {$table}";


### PR DESCRIPTION
…ng are quoted for use in MySQL 8 when creating the view generation queries

Overview
----------------------------------------
As we have a field called grouping in a translated table, when the system goes to build the create view query we need to ensure that the field names are properly escaped

Before
----------------------------------------
I18n tests fail on MySQL8

After
----------------------------------------
I18n tests Pass on MySQL8

ping @eileenmcnaughton @JoeMurray @totten @monishdeb 