### PR TITLE
dev/core#392 Ensure that the log_date column on logging tables is NOT…

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -774,7 +774,7 @@ WHERE  table_schema IN ('{$this->db}', '{$civiDB}')";
     // rewrite the queries into CREATE TABLE queries for log tables:
     $cols = <<<COLS
             ,
-            log_date    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            log_date    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             log_conn_id VARCHAR(17),
             log_user_id INTEGER,
             log_action  ENUM('Initialization', 'Insert', 'Update', 'Delete')


### PR DESCRIPTION
… NULL in MySQL 8

Overview
----------------------------------------
When running the CRM_Logging_xxx tests on MySQL 8 i found that this test was failing because the schema was being set to NULL rather than NOT NULL in MySQL 8

Before
----------------------------------------
Logging tests fail on MySQL 8 

After
----------------------------------------
Logging tests pass on MySQL 8

ping @monishdeb @eileenmcnaughton @totten @JoeMurray 