### PR TITLE
dev/core#392 Ensure that a proper MySQL formatted date is passed thro…

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -324,8 +324,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
    */
   public function testgetMembershipStarts() {
     list($contactId, $membershipId) = $this->setupMembership();
-    $yearStart = date('Y') . '0101';
-    $currentDate = date('Ymd');
+    $yearStart = date('Y') . '-01-01';
+    $currentDate = date('Y-m-d');
     CRM_Member_BAO_Membership::getMembershipStarts($this->_membershipTypeID, $yearStart, $currentDate);
 
     $this->membershipDelete($membershipId);


### PR DESCRIPTION
…ugh so test doesn't error on MySQL 8

Overview
----------------------------------------
When i was running this test on a MySQL 8 database it complained the data was incorrectly formatted and grepping the actual function calls suggested the date was otherwise being correctly passed in apart from in the test

Before
----------------------------------------
Test fails on MySQL8 

After
----------------------------------------
Test Passes on MySQL 8

ping @totten @eileenmcnaughton @monishdeb @JoeMurray 