### PR TITLE
dev/core#392 Fix handling of dates in getMembershipStarts function to…

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -996,6 +996,13 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
    *   start_date is between $startDate and $endDate
    */
   public static function getMembershipStarts($membershipTypeId, $startDate, $endDate, $isTest = 0, $isOwner = 0) {
+    // Ensure that the dates that are passed to the query are in the format of yyyy-mm-dd
+    $dates = ['startDate', 'endDate'];
+    foreach ($dates as $date) {
+      if (strlen($$date) === 8) {
+        $$date = date('Y-m-d', strtotime($$date));
+      }
+    }
 
     $testClause = 'membership.is_test = 1';
     if (!$isTest) {


### PR DESCRIPTION
… ensure date is passed to query as yyyy-mm-dd to fix test failure on MySQL 8

Overview
----------------------------------------
This is an alternate to https://github.com/civicrm/civicrm-core/pull/16205 moves the handling of date into the main function

Before
----------------------------------------
date passed as yyyymmdd in the function fails on MySQL8

After
----------------------------------------
date passed into the function as yyymmdd in the function now passes on MySQL 8

ping @eileenmcnaughton 