### PR TITLE
Add MessageTemplate.clone API

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -586,4 +586,25 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     return [$sent, $mailContent['subject'], $mailContent['text'], $mailContent['html']];
   }
 
+  /**
+   * Make a copy.
+   *
+   * @param int $id The entity id to copy.
+   * @param array $params
+   * @return CRM_Core_DAO
+   */
+  public static function copy($id, $params = []) {
+    $fieldsFix = [
+      'suffix' => [
+        'msg_title' => ' - ' . ts('Copy'),
+      ],
+      'replace' => $params,
+    ];
+    $copy = CRM_Core_DAO::copyGeneric('CRM_Core_DAO_MessageTemplate', ['id' => $id], NULL, $fieldsFix);
+    $copy->save();
+    CRM_Utils_Hook::copy('MessageTemplate', $copy);
+
+    return $copy;
+  }
+
 }

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -185,3 +185,36 @@ function _civicrm_api3_message_template_send_spec(&$params) {
   $params['pdf_filename']['api.aliases'] = ['PDFFilename'];
   $params['pdf_filename']['type'] = CRM_Utils_Type::T_STRING;
 }
+
+/**
+ * Adjust metadata for clone spec action.
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_message_template_clone_spec(&$spec) {
+  $spec['id']['title'] = 'ID to clone';
+  $spec['id']['type'] = CRM_Utils_Type::T_INT;
+  $spec['id']['api.required'] = 1;
+}
+
+/**
+ * Clone Entity.
+ *
+ * @param array $params
+ *
+ * @return array
+ * @throws \API_Exception
+ * @throws \CiviCRM_API3_Exception
+ */
+function civicrm_api3_message_template_clone($params) {
+  if (empty($params['id'])) {
+    throw new API_Exception("Mandatory key(s) missing from params array: id field is required");
+  }
+  $id = $params['id'];
+  unset($params['id']);
+  $params['workflow_id'] = 'null';
+  $params['is_reserved'] = 0;
+  $params['is_default'] = 0;
+  $newDAO = CRM_Core_BAO_MessageTemplate::copy($id, $params);
+  return civicrm_api3('MessageTemplate', 'get', ['id' => $newDAO->id]);
+}

--- a/tests/phpunit/api/v3/MessageTemplateTest.php
+++ b/tests/phpunit/api/v3/MessageTemplateTest.php
@@ -64,6 +64,26 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test cloning of message templates.
+   */
+  public function testClone() {
+    $main = $this->createTestEntity();
+    $clone = $this->callAPIAndDocument('MessageTemplate', 'clone', ['id' => $main['id']], __FUNCTION__, __FILE__);
+
+    $mainTemplate = $main['values'][$main['id']];
+    $cloneTemplate = $clone['values'][$clone['id']];
+
+    //Verify if values are equal.
+    $this->assertEquals($mainTemplate['msg_title'] . " - Copy", $cloneTemplate['msg_title']);
+    $this->assertEquals($mainTemplate['msg_subject'], $cloneTemplate['msg_subject']);
+    $this->assertEquals($mainTemplate['msg_text'], $cloneTemplate['msg_text']);
+    $this->assertEquals($mainTemplate['msg_html'], $cloneTemplate['msg_html']);
+    $this->assertEquals($mainTemplate['is_active'], $cloneTemplate['is_active']);
+    $this->assertEquals(0, $cloneTemplate['is_default']);
+    $this->assertEquals(0, $cloneTemplate['is_reserved']);
+  }
+
+  /**
    * Check the delete function succeeds.
    */
   public function testDelete() {


### PR DESCRIPTION
Overview
----------------------------------------
Just like we did for scheduled jobs. It's pretty useful to be able to copy a messagetemplate (to use as a new template / to create a backup etc).

Before
----------------------------------------
Cannot copy messagetemplate

After
----------------------------------------
Can copy messagetemplate via API

Technical Details
----------------------------------------
This is implemented in exactly the same way as the scheduled job "Job.clone" function.

Comments
----------------------------------------
This is just the API. A follow-up PR could add this as a UI option.
