### PR TITLE
dev/WordPress#2 Modify the WordPress plugin version using distmaker

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -190,6 +190,7 @@ function dm_install_wordpress() {
   ## Need --exclude=civicrm for self-building on WP site
 
   dm_preg_edit '/^Version: [0-9\.]+/m' "Version: $DM_VERSION" "$to/civicrm.php"
+  dm_preg_edit "/^define\( \'CIVICRM_PLUGIN_VERSION\',\W'[0-9\.]+/m" "define( 'CIVICRM_PLUGIN_VERSION', '$DM_VERSION" "$to/civicrm.php"
 }
 
 ## Generate the composer "vendor" folder


### PR DESCRIPTION
Overview
----------------------------------------
I noticed that the define statement wasn't being modified by dismaker when it runs this fixes it ot modify it when running distmaker, It doesn't solve everything as part of Wordpress#2 but improves the situation IMO

Before
----------------------------------------
Wordpress plugin version define is not updated by distmaker

After
----------------------------------------
Wordpress plugin version is updated by distmaker

ping @totten @kcristiano @christianwach 