### PR TITLE
WIP Fix retrieving latest case activity ID for forms

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1918,33 +1918,23 @@ AND cl.modified_id  = c.id
    * Find the latest revision of a given activity.
    *
    * @param int $activityID
-   *   Prior activity id.
+   *   Prior (or current) activity id.
    *
    * @return int
-   *   current activity id.
+   *   latest activity id.
    */
   public static function getLatestActivityId($activityID) {
-    static $latestActivityIds = [];
-
-    $activityID = CRM_Utils_Type::escape($activityID, 'Integer');
-
-    if (!array_key_exists($activityID, $latestActivityIds)) {
-      $latestActivityIds[$activityID] = [];
-
-      $originalID = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity',
-        $activityID,
-        'original_id'
-      );
-      if ($originalID) {
-        $activityID = $originalID;
-      }
-      $params = [1 => [$activityID, 'Integer']];
-      $query = "SELECT id from civicrm_activity where original_id = %1 and is_current_revision = 1";
-
-      $latestActivityIds[$activityID] = CRM_Core_DAO::singleValueQuery($query, $params);
+    try {
+      $activity = civicrm_api3('Activity', 'getsingle', [
+        'original_id' => $activityID,
+        'is_current_revision' => 1,
+        'return' => 'original_id',
+      ]);
     }
-
-    return $latestActivityIds[$activityID];
+    catch (Exception $e) {
+      return $activityID;
+    }
+    return $activity['id'];
   }
 
   /**

--- a/templates/CRM/Case/Form/ActivityView.tpl
+++ b/templates/CRM/Case/Form/ActivityView.tpl
@@ -22,7 +22,7 @@
           <tr {if $row.id EQ $latestRevisionID}style="font-weight: bold;"{/if}>
             <td class="crm-case-activityview-form-block-name">{$row.name}</td>
             <td class="crm-case-activityview-form-block-date">{$row.date|crmDate}</td>
-            <td class="crm-case-activityview-form-block-{$row.id}"><a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid="}{$row.id}" title="{ts}View this revision of the activity record.{/ts}">{if $row.id != $latestRevisionID}View Prior Revision{else}View Current Revision{/if}</a></td>
+            <td class="crm-case-activityview-form-block-{$row.id}"><a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid="}{$row.id}" title="{ts}View this revision of the activity record.{/ts}">{if $row.id != $latestRevisionID}{ts}View (Prior Revision){/ts}{else}{ts}View (Current Revision){/ts}{/if}</a></td>
           </tr>
         {/foreach}
       </table>


### PR DESCRIPTION
Overview
----------------------------------------
Using the case activity UI it gets confused with latest/prior revision in some cases. To reproduce create a case activity with two or more revisions and then click between "View Current / View Prior" and check that it's the right thing.

Before
----------------------------------------
Clicking between revisions doesn't always display the right one because `$latestActivityID` is not always set properly.

After
----------------------------------------
Clicking between revisions always selects the right one! And the strings are translateable.
![image](https://user-images.githubusercontent.com/2052161/71772446-e8e6ac80-2f42-11ea-9049-dfa8b0b1ef27.png)

Technical Details
----------------------------------------
Rewrites an overly complicated function to make it more logical and ensure that it works properly!

Comments
----------------------------------------

