### PR TITLE
dev/core#1143 Fix Upgrade tests on MySQL 8 by quoting reserved words

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.3.4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.4.mysql.tpl
@@ -9,8 +9,8 @@ VALUES
 SELECT @option_group_id_csgOpt := max(id) FROM civicrm_option_group WHERE name = 'contact_smart_group_display';
 
 INSERT INTO
-civicrm_option_value (option_group_id, {localize field='label'}label{/localize}, value, name, grouping, filter,
-is_default, weight)
+civicrm_option_value (`option_group_id`, {localize field='label'}label{/localize}, `value`, `name`, `grouping`, `filter`,
+`is_default`, `weight`)
 VALUES
 (@option_group_id_csgOpt, {localize}'Show Smart Groups on Demand'{/localize}, 1, 'showondemand', NULL, 0, 0, 1),
 (@option_group_id_csgOpt, {localize}'Always Show Smart Groups'{/localize}, 2, 'alwaysshow', NULL, 0, 0, 2),

--- a/CRM/Upgrade/Incremental/sql/4.7.10.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.10.mysql.tpl
@@ -3,7 +3,7 @@ SELECT @option_group_id_report := max(id) from civicrm_option_group where name =
 SELECT @contributeCompId := max(id) FROM civicrm_component where name = 'CiviContribute';
 SELECT @option_group_id_report_wt  := MAX(weight) FROM civicrm_option_value WHERE option_group_id = @option_group_id_report;
 INSERT INTO
-   civicrm_option_value (option_group_id, {localize field='label'}label{/localize}, value, name, grouping, filter, is_default, weight, {localize field='description'}description{/localize}, is_optgroup, is_reserved, is_active, component_id, visibility_id)
+   civicrm_option_value (`option_group_id`, {localize field='label'}label{/localize}, `value`, `name`, `grouping`, `filter`, `is_default`, `weight`, {localize field='description'}description{/localize}, `is_optgroup`, `is_reserved`, `is_active`, `component_id`, `visibility_id`)
 VALUES
    (@option_group_id_report, {localize}'{ts escape="sql"}Deferred Revenue Details{/ts}'{/localize}, 'contribute/deferredrevenue', 'CRM_Report_Form_Contribute_DeferredRevenue', NULL, 0, NULL, @option_group_id_report_wt+1, {localize}'{ts escape="sql"}Deferred Revenue Details Report{/ts}'{/localize}, 0, 0, 1, @contributeCompId, NULL);
 

--- a/CRM/Upgrade/Incremental/sql/4.7.25.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.25.mysql.tpl
@@ -8,7 +8,7 @@ INSERT INTO civicrm_option_group
   (name, {localize field='title'}title{/localize}, is_reserved, is_active) VALUES ('environment', {localize}'{ts escape="sql"}Environment{/ts}'{/localize}, 0, 1);
 
 SELECT @option_group_id_env := max(id) from civicrm_option_group where name = 'environment';
-INSERT INTO civicrm_option_value (option_group_id, {localize field='label'}label{/localize}, value, name, grouping, filter, is_default, weight, {localize field='description'}description{/localize}, is_optgroup, is_reserved, is_active, component_id, visibility_id)
+INSERT INTO civicrm_option_value (`option_group_id`, {localize field='label'}label{/localize}, `value`, `name`, `grouping`, `filter`, `is_default`, `weight`, {localize field='description'}description{/localize}, `is_optgroup`, `is_reserved`, `is_active`, `component_id`, `visibility_id`)
  VALUES
     (@option_group_id_env, {localize}'{ts escape="sql"}Production{/ts}'{/localize}, 'Production', 'Production', NULL, 0, 1, 1, {localize}'{ts escape="sql"}Production Environment{/ts}'{/localize}, 0, 0, 1, NULL, NULL),
     (@option_group_id_env, {localize}'{ts escape="sql"}Staging{/ts}'{/localize}, 'Staging', 'Staging', NULL, 0, NULL, 2, {localize}'{ts escape="sql"}Staging Environment{/ts}'{/localize}, 0, 0, 1, NULL, NULL),

--- a/CRM/Upgrade/Incremental/sql/4.7.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.beta1.mysql.tpl
@@ -4,7 +4,7 @@
 SELECT @option_group_id_report := max(id) from civicrm_option_group where name = 'report_template';
 SELECT @contributeCompId := max(id) FROM civicrm_component where name = 'CiviContribute';
 INSERT INTO
-   civicrm_option_value (option_group_id, {localize field='label'}label{/localize}, value, name, grouping, filter, is_default, weight, {localize field='description'}description{/localize}, is_optgroup, is_reserved, is_active, component_id, visibility_id)
+   civicrm_option_value (`option_group_id`, {localize field='label'}label{/localize}, `value`, `name`, `grouping`, `filter`, `is_default`, `weight`, {localize field='description'}description{/localize}, `is_optgroup`, `is_reserved`, `is_active`, `component_id`, `visibility_id`)
 VALUES
    (@option_group_id_report, {localize}'{ts escape="sql"}Recurring Contributions Summary{/ts}'{/localize}, 'contribute/recursummary', 'CRM_Report_Form_Contribute_RecurSummary',               NULL, 0, NULL, 49, {localize}'{ts escape="sql"}Provides simple summary for each payment instrument for which there are recurring contributions (e.g. Credit Card, Standing Order, Direct Debit etc.), showing within a given date range.{/ts}'{/localize}, 0, 0, 1, @contributeCompId, NULL);
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the upgrade tests that failed as per https://test.civicrm.org/job/CiviCRM-Core-Edge/4/CIVIVER=master,label=test-3/testReport/ by quoting necessary reserved words in backticks

Before
----------------------------------------
DB Upgrade tests fail on MySQL 8 

After
----------------------------------------
DB Upgrade tests pass

ping @eileenmcnaughton @JoeMurray @monishdeb @totten 