### PR TITLE
Fix failing tests on edge based on number formatting by using the Num…

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -62,9 +62,12 @@ class CRM_Utils_Money {
     }
 
     if ($onlyNumber) {
+      if ($valueFormat === '!%i') {
+        $amount = self::formatNumericByNumberFormatter($amount);
+      }
       // money_format() exists only in certain PHP install (CRM-650)
       if (is_numeric($amount) and function_exists('money_format')) {
-        $amount = money_format($valueFormat, $amount);
+        $amount = self::formatNumericByFormat($amount, $valueFormat);
       }
       return $amount;
     }
@@ -86,7 +89,12 @@ class CRM_Utils_Money {
       throw new CRM_Core_Exception("Invalid currency \"{$currency}\"");
     }
 
-    $amount = self::formatNumericByFormat($amount, $valueFormat);
+    if ($valueFormat === '!%i') {
+      $amount = self::formatNumericByNumberFormatter($amount);
+    }
+    else {
+      $amount = self::formatNumericByFormat($amount, $valueFormat);
+    }
     // If it contains tags, means that HTML was passed and the
     // amount is already converted properly,
     // so don't mess with it again.
@@ -176,7 +184,11 @@ class CRM_Utils_Money {
    * @return string
    */
   protected static function formatLocaleNumeric($amount) {
-    return self::formatNumericByFormat($amount, CRM_Core_Config::singleton()->moneyvalueformat);
+    $moneyValueFormat = CRM_Core_Config::singleton()->moneyvalueformat;
+    if ($moneyValueFormat === '%!i') {
+      return self::formatNumericByNumberFormatter($amount);
+    }
+    return self::formatNumericByFormat($amount, $moneyValueFormat);
   }
 
   /**
@@ -263,6 +275,18 @@ class CRM_Utils_Money {
       setlocale(LC_MONETARY, $lc);
     }
     return $amount;
+  }
+
+  /**
+   * Format numeric part of currency by using the NumberFormatter class
+   * @param string $amount
+   * @param int $numberFormatterType
+   *
+   * @return string
+   */
+  protected static function formatNumericByNumberFormatter($amount, $numberFormatterType = NumberFormatter::DECIMAL) {
+    $formatter = new NumberFormatter('en_US', $numberFormatterType);
+    return $formatter->format($amount);
   }
 
 }


### PR DESCRIPTION
…berFormatter class

Overview
----------------------------------------
This aims to fix the following tests that failed on edge which is running PHP7.3, i can't get them to fail on my local php7.3 instance however money_format is deprecated as of PHP7.4

* https://test.civicrm.org/job/CiviCRM-Core-Edge/4/CIVIVER=master,label=test-3/testReport/(root)/CRM_Core_Smarty_plugins_CrmMoneyTest/testMoney_with_data_set__1/
* https://test.civicrm.org/job/CiviCRM-Core-Edge/4/CIVIVER=master,label=test-3/testReport/(root)/CRM_Utils_MoneyTest/testFormatLocaleNumericRoundedByCurrency/
* https://test.civicrm.org/job/CiviCRM-Core-Edge/4/CIVIVER=master,label=test-3/testReport/(root)/CRM_Utils_MoneyTest/testFormatLocaleNumericRoundedByCurrencyEuroThousand/
* https://test.civicrm.org/job/CiviCRM-Core-Edge/4/CIVIVER=master,label=test-3/testReport/(root)/CRM_Utils_MoneyTest/testSpaceCurrency/

Before
----------------------------------------
Tests fail on edge profile

After
----------------------------------------
Tests pass on edge profile

ping @eileenmcnaughton @monishdeb @mattwire @totten @JoeMurray 