### PR TITLE
WIP dev/core#1331 Don't freeze fields for auto-renew memberships

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -78,7 +78,14 @@
         </tr>
         <tr class="crm-membership-form-block-membership_type_id">
           <td class="label">{$form.membership_type_id.label}</td>
-          <td><span id='mem_type_id'>{$form.membership_type_id.html}</span>
+          <td id="mem_type_id-readonly">
+            {$form.membership_type_id}
+            <a href="#" class="crm-hover-button action-item override-membership-type" id="show-mem-type">
+              {ts}Override membership type{/ts}
+            </a>
+            {help id="override_membership_type"}
+          </td>
+          <td id="mem_type_id-editable"><span id='mem_type_id'>{$form.membership_type_id.html}</span>
             {if $hasPriceSets}
               <span id='totalAmountORPriceSet'> {ts}OR{/ts}</span>
               <span id='selectPriceSet'>{$form.price_set_id.html}</span>
@@ -126,7 +133,7 @@
           <td id="end-date-readonly">
               {$endDate|crmDate}
               <a href="#" class="crm-hover-button action-item override-date" id="show-end-date">
-                {ts}Over-ride end date{/ts}
+                {ts}Override end date{/ts}
               </a>
               {help id="override_end_date"}
           </td>
@@ -342,6 +349,23 @@
       setDifferentContactBlock();
       cj('#is_different_contribution_contact').change( function() {
         setDifferentContactBlock();
+      });
+
+      // give option to override membership type for auto-renew memberships - dev/core#1331
+      {/literal}
+      {if $isRecur}
+      cj('#mem_type_id-readonly').show();
+      cj('#mem_type_id-editable').hide();
+      {else}
+      cj('#mem_type_id-readonly').hide();
+      cj('#mem_type_id-editable').show();
+      {/if}
+      {literal}
+
+      cj('#show-mem-type').click( function( e ) {
+        e.preventDefault();
+        cj('#mem_type_id-readonly').hide();
+        cj('#mem_type_id-editable').show();
       });
 
       // give option to override end-date for auto-renew memberships

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -11,7 +11,7 @@
 {if $cancelAutoRenew}
   <div class="messages status no-popup">
     <div class="icon inform-icon"></div>
-    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status. <a href="%1">Click here</a> if you want to cancel the automatic renewal option.{/ts}</p>
+    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status: <a href="%1">Cancel auto-renew</a>{/ts}</p>
   </div>
 {/if}
 <div class="spacer"></div>

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -13,6 +13,11 @@
     <div class="icon inform-icon"></div>
     <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status: <a href="%1">Cancel auto-renew</a>{/ts}</p>
   </div>
+{elseif $isRecur}
+  <div class="messages status no-popup">
+    <div class="icon inform-icon"></div>
+    <p>{ts}This membership is set to renew automatically. Please be aware that any changes that you make here may not be reflected in the payment processor. Please ensure that you alter the related subscription at the payment processor.{/ts}</p>
+  </div>
 {/if}
 <div class="spacer"></div>
 {if $priceSetId}

--- a/templates/CRM/Member/Page/Tab.hlp
+++ b/templates/CRM/Member/Page/Tab.hlp
@@ -23,8 +23,15 @@
 {/htxt}
 
 {htxt id="override_end_date-title"}
-  {ts}Override End Date for Auto-renew Memberships{/ts}
+  {ts}Override End Date for Auto-renew Membership{/ts}
 {/htxt}
 {htxt id="override_end_date"}
   <p>{ts}If CiviCRM's membership end-date is different from when the payment processor will next collect a payment, various problems can occur. Members may experience a gap in their membership, and the renewal date may get changed from what is manually entered. Use care when modifying the End Date value, and check the associated recurring payment in your payment processor system so they always match.{/ts}</p>
+{/htxt}
+
+{htxt id="override_membership_type-title"}
+{ts}Override Membership Type for Auto-renew Membership{/ts}
+{/htxt}
+{htxt id="override_membership_type"}
+  <p>{ts}This membership is set to renew automatically. Take care when you change the membership type. Make sure that you also change the related payment at the payment processor. Otherwise future payments may be for the wrong amount.{/ts}</p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1331

If a membership is linked to a recurring payment some of the fields are frozen, which means that a user is unable to edit them when they visit the edit membership screen.

Before
----------------------------------------
The following fields are frozen:

- Membership organisation / Membership type
- Membership status

![image](https://user-images.githubusercontent.com/13518928/71835541-b86d5280-30a9-11ea-9fcd-c1772447a9df.png)

After
----------------------------------------
These fields are no longer frozen and the user has the ability to override them if required. Help text with an appropriate warning is displayed.

![image](https://user-images.githubusercontent.com/13518928/71835440-7b08c500-30a9-11ea-82bf-a1cf87cdbdf5.png)

Technical Details
----------------------------------------
None

Comments
----------------------------------------
The end date field was unfrozen in #15505. See https://lab.civicrm.org/dev/core/issues/1126 for details.
