### PR TITLE
[NFC] Test update following PR #16150, assertEquals first param is th…

### DIFF
--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -383,7 +383,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
     $groupInfo = [];
     $groupContacts = CRM_Case_BAO_Case::getGlobalContacts($groupInfo);
-    $this->assertEquals(count($groupContacts), 0);
+    $this->assertEquals(0, count($groupContacts));
 
     //Verify if contact is returned correctly.
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [
@@ -392,8 +392,8 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     ];
     $groupInfo = [];
     $groupContacts = CRM_Case_BAO_Case::getGlobalContacts($groupInfo);
-    $this->assertEquals(count($groupContacts), 1);
-    $this->assertEquals(key($groupContacts), $caseResourceContactID);
+    $this->assertEquals(1, count($groupContacts));
+    $this->assertEquals($caseResourceContactID, key($groupContacts));
   }
 
   /**


### PR DESCRIPTION
…e expected value not the current value

Overview
----------------------------------------
Updates the assertEquals function call such that it is more sensible as per @demeritcowboy https://github.com/civicrm/civicrm-core/pull/16150#issuecomment-568820256 

Before
----------------------------------------
Test function params around the wrong way

After
----------------------------------------
Test function params around the correct way

ping @eileenmcnaughton @demeritcowboy 