### PR TITLE
mailing#60: Fix regression where multiple bulk recipient option isn't respected

### DIFF
--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -64,7 +64,7 @@ WHERE  mailing_id = %1
       // if any email is marked on_hold =1 or contact is deceased after mailing is submitted
       // then it should be get skipped while preparing event_queue
       // event_queue list is prepared when mailing job gets started.
-      $additionalJoin = " INNER JOIN civicrm_email e ON (r.email_id = e.id AND e.on_hold = 0 AND e.is_primary = 1)
+      $additionalJoin = " INNER JOIN civicrm_email e ON (r.email_id = e.id AND e.on_hold = 0)
                           INNER JOIN civicrm_contact c on (c.id = r.contact_id AND c.is_deceased <> 1 AND c.do_not_email = 0 AND c.is_opt_out = 0)
 ";
     }


### PR DESCRIPTION
Overview
----------------------------------------
A regression in Civi 5.19+ causes "Enable bulk email recipients" setting in CiviMail to not be respected.  In fact, the "bulk email' value isn't respected at all.

Before
----------------------------------------
Only a primary email address can receive a CiviMail email.

After
----------------------------------------
Original behavior restored.

Technical Details
----------------------------------------
The PR introducing the regression filters out emails from a mailing where e.g. a contact was marked as deceased after the mailing was queued but before it was sent.  It also filters out folks who were marked "do not mail" or "on hold" between scheduling and sending.  However, it erroneously includes a requirement that the email address be primary.