### PR TITLE
dev/core#1508 Regression/E_NOTICE - Missing table on contribution view

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -210,7 +210,8 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       NULL,
       $recentOther
     );
-    $contributionStatus = $status[$values['contribution_status_id']];
+    $statusOptionValueNames = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    $contributionStatus = $statusOptionValueNames[$values['contribution_status_id']];
     if (in_array($contributionStatus, ['Partially paid', 'Pending refund'])
         || ($contributionStatus == 'Pending' && $values['is_pay_later'])
         ) {


### PR DESCRIPTION
Overview
----------------------------------------
A variable was mistakenly removed, leading to a missing table on the contribution view page for Pending/PayLater and E_NOTICE's on _ALL_ contribution views (but the notice is hidden if you have the default setting to use popups in Display Preferences).

`Notice: Undefined variable: status in CRM_Contribute_Form_ContributionView->preProcess() (line 213 of blah/CRM/Contribute/Form/ContributionView.php).`

https://lab.civicrm.org/dev/core/issues/1508

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2967821/71929762-558ec080-3168-11ea-8118-d64e7f72b8c8.gif)

After
----------------------------------------
This is how it used to look. Table is now back.

![after](https://user-images.githubusercontent.com/2967821/71929751-532c6680-3168-11ea-9f8d-1475f17a1248.gif)


Technical Details
----------------------------------------
Also took the opportunity to rename the variable which was called $status but was actually an array of status machine names.

Comments
----------------------------------------
Affects 5.21 but not 5.20.
