### PR TITLE
dev/core#1511 Expose option to show event location on configuration tab

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Location.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Location.hlp
@@ -1,0 +1,24 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="id-is_show_location-title"}
+  {ts}Show Location{/ts}
+{/htxt}
+{htxt id="id-is_show_location"}
+  {ts}If this option is selected, the location will be shown in various places including:
+    <ul>
+      <li>Event information page</li>
+      <li>Event registration confirmation emails</li>
+      <li>HTML, RSS and ICALENDAR feeds of event information</li>
+    </ul>
+  Normally location information is made publicly available.  By deselecting this box, the location is only available to event administrators.{/ts}
+  <br />
+  {ts}Note that if 'Show Location' is not set a map will not be shown, regardless of the setting of 'Include Map to Event Location'.{/ts}
+{/htxt}
+

--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -40,6 +40,14 @@
         <td id="locUsedMsg" colspan="3">
         </td>
       </tr>
+      <tr id="is_show_location" class="crm-event-manage-location-form-block-is_show_location">
+        <td class="labels">
+          {$form.is_show_location.label}
+        </td>
+        <td class="values">
+          {$form.is_show_location.html}
+        </td>
+      </tr>
     </table>
   {/if}
 

--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -42,7 +42,7 @@
       </tr>
       <tr id="is_show_location" class="crm-event-manage-location-form-block-is_show_location">
         <td class="labels">
-          {$form.is_show_location.label}
+          {$form.is_show_location.label} {help id="id-is_show_location"}
         </td>
         <td class="values">
           {$form.is_show_location.html}


### PR DESCRIPTION
Overview
----------------------------------------
Add a checkbox on the Event Location configuration tab to control whether the location is displayed to users.

The functionality already exists and the field can be configured by API.  This enables configuration via the GUI.

Before
----------------------------------------
The option can only be configured by API.

After
----------------------------------------
Option can also be configured via GUI.

![image](https://user-images.githubusercontent.com/2730045/71994839-59d2e080-3231-11ea-9b2f-84aa02e64675.png)

Technical Details
----------------------------------------
The logic for the use of the option already exists.  This change just exposes it via GUI.

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1511
