### PR TITLE
[REF] move sessionStart functionality to System subclass

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -108,17 +108,7 @@ class CRM_Core_Session {
         if ($isRead) {
           return;
         }
-        // FIXME: This belongs in CRM_Utils_System_*
-        if (CRM_Core_Config::singleton()->userSystem->is_drupal && function_exists('drupal_session_start')) {
-          // https://issues.civicrm.org/jira/browse/CRM-14356
-          if (!(isset($GLOBALS['lazy_session']) && $GLOBALS['lazy_session'] == TRUE)) {
-            drupal_session_start();
-          }
-          $_SESSION = [];
-        }
-        else {
-          session_start();
-        }
+        CRM_Core_Config::singleton()->userSystem->sessionStart();
       }
       $this->_session =& $_SESSION;
     }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -974,4 +974,11 @@ abstract class CRM_Utils_System_Base {
     CRM_Utils_System::civiExit();
   }
 
+  /**
+   * Start a new session.
+   */
+  public function sessionStart() {
+    session_start();
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 /**
@@ -665,6 +663,22 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Start a new session.
+   */
+  public function sessionStart() {
+    if (function_exists('drupal_session_start')) {
+      // https://issues.civicrm.org/jira/browse/CRM-14356
+      if (!(isset($GLOBALS['lazy_session']) && $GLOBALS['lazy_session'] == TRUE)) {
+        drupal_session_start();
+      }
+      $_SESSION = [];
+    }
+    else {
+      session_start();
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
From Preparatory to https://github.com/civicrm/civicrm-core/pull/15131 & discussions with @kcristiano it seems there are still issues around sessions on different CMS - this moves the handling of sessionStart to the over-rideable system subclass. No change in this PR but changes to Joomla! & WP expected to follow

Before
----------------------------------------
Lots of if/then in CRM_Core_Session

After
----------------------------------------
Decisions moved to CMS subclasses

Technical Details
----------------------------------------
This should be a pretty safe change

Comments
----------------------------------------
