### PR TITLE
Check field to carry over custom data by default when the other contact has none

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1383,12 +1383,13 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           $rows["move_custom_$fid"]['title'] = $field['label'];
 
           $elements[] = [
-            'advcheckbox',
-            "move_custom_$fid",
-            NULL,
-            NULL,
-            NULL,
-            $value,
+            0 => 'advcheckbox',
+            1 => "move_custom_$fid",
+            2 => NULL,
+            3 => NULL,
+            4 => NULL,
+            5 => $value,
+            'is_checked' => (!isset($rows["move_custom_$fid"]['main']) || $rows["move_custom_$fid"]['main'] === ''),
           ];
           $migrationInfo["move_custom_$fid"] = $value;
         }


### PR DESCRIPTION
Overview
----------------------------------------
This alter's the defaults on the contact merge screen to check the checkbox for carrying over custom data by default when the contact to be deleted has a value in a custom field and the other contact does not.

This partially addresses reviewer feedback about the limitations of https://github.com/civicrm/civicrm-core/pull/15595

Before
----------------------------------------
![Screen Shot 2020-01-09 at 3 51 47 PM](https://user-images.githubusercontent.com/336308/72035256-37f26000-32fc-11ea-9497-d04318078b42.png)


After
----------------------------------------
![Screen Shot 2020-01-09 at 4 17 12 PM](https://user-images.githubusercontent.com/336308/72035263-3e80d780-32fc-11ea-9863-b0c49dbe9343.png)


Technical Details
----------------------------------------
Note reviewer feedback touched on some other fields too - I've left them out of scope for now.

Comments
----------------------------------------

