### PR TITLE
[REF] Remove enclosed & escaped variables

### DIFF
--- a/CRM/Core/Report/Excel.php
+++ b/CRM/Core/Report/Excel.php
@@ -40,13 +40,11 @@ class CRM_Core_Report_Excel {
 
     $config = CRM_Core_Config::singleton();
     $seperator = $config->fieldSeparator;
-    $enclosed = '"';
-    $escaped = $enclosed;
     $add_character = "\015\012";
 
     $schema_insert = '';
     foreach ($header as $field) {
-      $schema_insert .= $enclosed . str_replace($enclosed, $escaped . $enclosed, stripslashes($field)) . $enclosed;
+      $schema_insert .= '"' . str_replace('"', '""', stripslashes($field)) . '"';
       $schema_insert .= $seperator;
     }
     // end while
@@ -87,7 +85,7 @@ class CRM_Core_Report_Excel {
             $value = &$str;
           }
 
-          $schema_insert .= $enclosed . str_replace($enclosed, $escaped . $enclosed, $value) . $enclosed;
+          $schema_insert .= '"' . str_replace('"', '""', $value) . '"';
         }
 
         if ($colNo < $fields_cnt - 1) {


### PR DESCRIPTION
Overview
----------------------------------------
This makes the code a little more readable by using the string '"' instead of assigning the value to a variable

Before
----------------------------------------
$enclosed & $escaped used in place of '"'

After
----------------------------------------
'"' used - easier to see what is going on

Technical Details
----------------------------------------
It's easier to see what is being replaced when we use strings than variables - given the variables never change

Comments
----------------------------------------

