### PR TITLE
[REF] Remove never-passed param from getLineItems

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -181,11 +181,10 @@ WHERE li.contribution_id = %1";
    * @param bool $isQtyZero
    * @param bool $relatedEntity
    *
-   * @param bool $invoice
    * @return array
    *   Array of line items
    */
-  public static function getLineItems($entityId, $entity = 'participant', $isQuick = FALSE, $isQtyZero = TRUE, $relatedEntity = FALSE, $invoice = FALSE) {
+  public static function getLineItems($entityId, $entity = 'participant', $isQuick = FALSE, $isQtyZero = TRUE, $relatedEntity = FALSE) {
     $whereClause = $fromClause = NULL;
     $selectClause = "
       SELECT    li.id,
@@ -218,17 +217,7 @@ WHERE li.contribution_id = %1";
       LEFT JOIN civicrm_line_item li ON ({$condition})
       LEFT JOIN civicrm_price_field_value pfv ON ( pfv.id = li.price_field_value_id )
       LEFT JOIN civicrm_price_field pf ON (pf.id = li.price_field_id )";
-    $whereClause = "
-      WHERE     %2.id = %1";
-
-    // CRM-16250 get additional participant's fee selection details only for invoice PDF (if any)
-    if ($entity == 'participant' && $invoice) {
-      $additionalParticipantIDs = CRM_Event_BAO_Participant::getAdditionalParticipantIds($entityId);
-      if (!empty($additionalParticipantIDs)) {
-        $whereClause = "WHERE %2.id IN (%1, " . implode(', ', $additionalParticipantIDs) . ")";
-      }
-    }
-
+    $whereClause = " WHERE     %2.id = %1";
     $orderByClause = " ORDER BY pf.weight, pfv.weight";
 
     if ($isQuick) {


### PR DESCRIPTION
Overview
----------------------------------------
Minor tidy up in getLineItems

Before
----------------------------------------
$invoice is in fn signature & has handling in fn but is never used

After
----------------------------------------
Parameter $invoice fully removed

Technical Details
----------------------------------------
Parameter  was added to getLineItems in https://github.com/civicrm/civicrm-core/commit/25d0c6478ee236a4ac150e8d2b39614602ca4ae8
to support invoicing. However that function no longer calls getLineItems & has not for some time (at least a year). No other functions
pass in this parameter so we can remove it_

Comments
----------------------------------------

The code comment suggests something might be broken here but it broke a long time ago & had no tests so at this stage we should clean it up & if comes back with tests then all good.