### PR TITLE
Add tax rates to metadata

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -795,6 +795,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'period_type' => 'rolling',
       'visibility' => 'Public',
       'weight' => '1',
+      'tax_rate' => 0.0,
+      'minimum_fee_with_tax' => 100.0,
     ], $values[1]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This doesn't do anything by itself but it lays the foundation for a solid fix for

https://github.com/civicrm/civicrm-core/pull/15895 - ie by having minimum_fee_with_tax as part of our
generally available metadata we get out of all the complexity of doing this in the js layer - which is what is driving that bug

Before
----------------------------------------
value for minimum_fee_with_tax for a membership type not easily available in the php layer. It is calculated (badly) in the js layer

After
----------------------------------------
Centralised cached function includes this calculated value

Technical Details
----------------------------------------


Comments
----------------------------------------
