### PR TITLE
Add more functionality to the api4 $index param

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -20,11 +20,13 @@
 class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
 
   public function run() {
+    $apiDoc = new ReflectionFunction('civicrm_api4');
     $vars = [
       'operators' => \CRM_Core_DAO::acceptedSQLOperators(),
       'basePath' => Civi::resources()->getUrl('civicrm'),
       'schema' => (array) \Civi\Api4\Entity::get()->setChain(['fields' => ['$name', 'getFields']])->execute(),
       'links' => (array) \Civi\Api4\Entity::getLinks()->execute(),
+      'docs' => \Civi\Api4\Utils\ReflectionUtils::parseDocBlock($apiDoc->getDocComment()),
     ];
     Civi::resources()
       ->addVars('api4', $vars)

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -411,6 +411,10 @@ trait Api3TestTrait {
       case 'get':
         if ($options['return'] && $v3Action !== 'getcount') {
           $v4Params['select'] = array_keys($options['return']);
+          // Ensure id field is returned as v3 always expects it
+          if ($v4Entity != 'Setting' && !in_array('id', $v4Params['select'])) {
+            $v4Params['select'][] = 'id';
+          }
           // Convert join syntax
           foreach ($v4Params['select'] as &$select) {
             if (strstr($select, '_id.')) {

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -2,7 +2,7 @@
   <div crm-ui-debug="availableParams"></div>
 
   <h1 crm-page-title>
-    {{ ts('CiviCRM API v4') }}{{ entity ? (' (' + entity + '::' + action + ')') : '' }}
+    {{ ts('CiviCRM APIv4') }}{{ entity ? (' (' + entity + '::' + action + ')') : '' }}
   </h1>
 
   <!--This warning will show if bootstrap is unavailable. Normally it will be hidden by the bootstrap .collapse class.-->
@@ -18,9 +18,13 @@
       <form name="api4-explorer" class="panel panel-default explorer-params-panel">
         <div class="panel-heading">
           <div class="form-inline">
-            <input class="collapsible-optgroups form-control" ng-model="entity" ng-disabled="!entities.length" ng-class="{loading: !entities.length}" crm-ui-select="{placeholder: ts('Entity'), data: entities}" />
-            <input class="collapsible-optgroups form-control" ng-model="action" ng-disabled="!entity || !actions.length" ng-class="{loading: entity && !actions.length}" crm-ui-select="{placeholder: ts('Action'), data: actions}" />
-            <input class="form-control api4-index" type="search" ng-model="index" ng-mouseenter="help('index', indexHelp)" ng-mouseleave="help()" placeholder="{{ ts('Index') }}" />
+            <span ng-mouseenter="help('entity', paramDoc('$entity'))" ng-mouseleave="help()">
+              <input class="collapsible-optgroups form-control" ng-model="entity" ng-disabled="!entities.length" ng-class="{loading: !entities.length}" crm-ui-select="{placeholder: ts('Entity'), data: entities}" />
+            </span>
+            <span ng-mouseenter="help('action', paramDoc('$action'))" ng-mouseleave="help()">
+              <input class="collapsible-optgroups form-control" ng-model="action" ng-disabled="!entity || !actions.length" ng-class="{loading: entity && !actions.length}" crm-ui-select="{placeholder: ts('Action'), data: actions}" />
+            </span>
+            <input class="form-control api4-index" type="search" ng-model="index" ng-mouseenter="help('index', paramDoc('$index'))" ng-mouseleave="help()" placeholder="{{ ts('Index') }}" />
             <button class="btn btn-success pull-right" crm-icon="fa-bolt" ng-disabled="!entity || !action || loading" ng-click="execute()">{{ ts('Execute') }}</button>
           </div>
         </div>
@@ -110,7 +114,12 @@
         <div class="panel-body">
           <h4>{{ helpContent.description }}</h4>
           <div ng-if="helpContent.comment">
-            <p ng-repeat='text in helpContent.comment.split("\n\n")'>{{ text }}</p>
+            <div ng-repeat='text in helpContent.comment.split("\n\n")'>
+              <p ng-if="text[0] !== '-' && text[0] !== '*'">{{ text }}</p>
+              <ul ng-if="text[0] === '-' || text[0] === '*'">
+                <li ng-repeat='item in text.split("\n")'>{{ item.substr(1) }}</li>
+              </ul>
+            </div>
           </div>
           <p ng-repeat="(key, item) in helpContent" ng-if="key !== 'description' && key !== 'comment'">
             <strong>{{ key }}:</strong> {{ item }}

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -20,7 +20,7 @@
           <div class="form-inline">
             <input class="collapsible-optgroups form-control" ng-model="entity" ng-disabled="!entities.length" ng-class="{loading: !entities.length}" crm-ui-select="{placeholder: ts('Entity'), data: entities}" />
             <input class="collapsible-optgroups form-control" ng-model="action" ng-disabled="!entity || !actions.length" ng-class="{loading: entity && !actions.length}" crm-ui-select="{placeholder: ts('Action'), data: actions}" />
-            <input class="form-control api4-index" ng-model="index" ng-mouseenter="help('index', indexHelp)" ng-mouseleave="help()" placeholder="{{ ts('Index') }}" />
+            <input class="form-control api4-index" type="search" ng-model="index" ng-mouseenter="help('index', indexHelp)" ng-mouseleave="help()" placeholder="{{ ts('Index') }}" />
             <button class="btn btn-success pull-right" crm-icon="fa-bolt" ng-disabled="!entity || !action || loading" ng-click="execute()">{{ ts('Execute') }}</button>
           </div>
         </div>

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -31,6 +31,7 @@
     $scope.index = '';
     var getMetaParams = {},
       objectParams = {orderBy: 'ASC', values: '', chain: ['Entity', '', '{}']},
+      docs = CRM.vars.api4.docs,
       helpTitle = '',
       helpContent = {};
     $scope.helpTitle = '';
@@ -550,8 +551,8 @@
     }
 
     if (!$scope.entity) {
-      $scope.helpTitle = helpTitle = ts('Help');
-      $scope.helpContent = helpContent = {description: ts('Welcome to the api explorer.'), comment: ts('Select an entity to begin.')};
+      $scope.helpTitle = helpTitle = ts('APIv4 Explorer');
+      $scope.helpContent = helpContent = {description: docs.description, comment: docs.comment};
     } else if (!actions.length && !getEntity().actions) {
       getMetaParams.actions = [$scope.entity, 'getActions', {chain: {fields: [$scope.entity, 'getFields', {action: '$name'}]}}];
       fetchMeta();
@@ -582,10 +583,8 @@
       }
     });
 
-    $scope.indexHelp = {
-      description: ts('(string|int) Index results or select by index.'),
-      comment: ts('Pass a string to index the results by a field value. E.g. index: "name" will return an associative array with names as keys.') + '\n\n' +
-        ts('Pass an integer to return a single result; e.g. index: 0 will return the first result, 1 will return the second, and -1 will return the last.')
+    $scope.paramDoc = function(name) {
+      return docs.params[name];
     };
 
     $scope.$watch('params', writeCode, true);

--- a/api/api.php
+++ b/api/api.php
@@ -24,15 +24,34 @@ function civicrm_api(string $entity = NULL, string $action, array $params, $extr
 }
 
 /**
- * Procedural wrapper for the OO api version 4.
+ * Calls the CiviCRM APIv4 with supplied parameters and returns a Result object.
  *
- * @param string $entity
- * @param string $action
- * @param array $params
- * @param string|int|array $index
- *   If $index is a string, the results array will be indexed by that key.
- *   If $index is an integer, only the result at that index will be returned.
- *   $index can also be a single-item array representing key|value pairs to be returned ex ['id' => 'title'].
+ * This API (Application Programming Interface) is used to access and manage data in CiviCRM.
+ *
+ * APIv4 is the latest stable version.
+ *
+ * @see http://example.com/civicrm/api4/explorer
+ *
+ * @param string $entity Name of the CiviCRM entity to access.
+ *   All entity names are capitalized CamelCase, e.g. "ContributionPage".
+ *   Most entities correspond to a database table (e.g. "Contact" is the table "civicrm_contact").
+ *   For a complete list of available entities, call civicrm_api4('Entity', 'get');
+ *
+ * @param string $action The "verb" of the api call.
+ *   For a complete list of actions for a given entity (e.g. Contact), call civicrm_api4('Contact', 'getActions');
+ *
+ * @param array $params An array of API input keyed by parameter name.
+ *   The easiest way to discover all available parameters is to visit the API Explorer on your CiviCRM site.
+ *   The API Explorer is listed in the CiviCRM menu under Support -> Developer.
+ *
+ * @param string|int|array $index Controls the Result array format.
+ *   By default the api Result contains a non-associative array of data. Passing an $index tells the api to
+ *   automatically reformat the array, depending on the variable type passed:
+ *
+ *     - Integer: return a single result array; e.g. index = 0 will return the first result, 1 will return the second, and -1 will return the last.
+ *     - String: index the results by a field value; e.g. index = "name" will return an associative array with the field 'name' as keys.
+ *     - Non-associative array: return a single value from each result; e.g. index = ['title'] will return a non-associative array of strings - the 'title' field from each result.
+ *     - Associative array: a combination of the previous two modes; e.g. index = ['name' => 'title'] will return an array of strings - the 'title' field keyed by the 'name' field.
  *
  * @return \Civi\Api4\Generic\Result
  * @throws \API_Exception

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -146,12 +146,11 @@
 
 #bootstrap-theme.api4-explorer-page .api4-operator,
 #bootstrap-theme.api4-explorer-page .api4-chain-index,
-#bootstrap-theme.api4-explorer-page .api4-index,
 #bootstrap-theme.api4-explorer-page .api4-chain-action {
   width: 90px;
 }
 #bootstrap-theme.api4-explorer-page .api4-chain-params {
-  width: calc(100% - 386px);
+  width: calc(100% - 390px);
 }
 
 #bootstrap-theme.api4-explorer-page .api4-add-where-group-menu {

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -22,7 +22,7 @@
 #bootstrap-theme.api4-explorer-page > div > .panel {
   flex: 1;
   margin: 10px;
-  min-height: 400px;
+  min-height: 500px;
 }
 #bootstrap-theme.api4-explorer-page > div > form.panel {
   flex: 2;
@@ -47,6 +47,11 @@
 
 #bootstrap-theme.api4-explorer-page .explorer-help-panel .panel-body {
   word-break: break-word;
+}
+
+/* because each help p is in a div, this undoes bootstrap removing margin from last-child */
+#bootstrap-theme.api4-explorer-page .explorer-help-panel .panel-body p {
+  margin-bottom: 10px;
 }
 
 #bootstrap-theme.api4-explorer-page form label {

--- a/tests/phpunit/api/v4/Action/IndexTest.php
+++ b/tests/phpunit/api/v4/Action/IndexTest.php
@@ -64,4 +64,9 @@ class IndexTest extends UnitTestCase {
     $this->assertContains('not found', $error);
   }
 
+  public function testIndexWithSelect() {
+    $result = civicrm_api4('Activity', 'getFields', ['select' => ['title'], 'where' => [['name', '=', 'subject']]], 'name');
+    $this->assertEquals(['subject' => ['title' => 'Subject']], (array) $result);
+  }
+
 }

--- a/tests/phpunit/api/v4/Action/IndexTest.php
+++ b/tests/phpunit/api/v4/Action/IndexTest.php
@@ -69,4 +69,14 @@ class IndexTest extends UnitTestCase {
     $this->assertEquals(['subject' => ['title' => 'Subject']], (array) $result);
   }
 
+  public function testArrayIndex() {
+    // Non-associative
+    $result = civicrm_api4('Activity', 'getFields', ['where' => [['name', '=', 'subject']]], ['name' => 'title']);
+    $this->assertEquals(['subject' => 'Subject'], (array) $result);
+
+    // Associative
+    $result = civicrm_api4('Activity', 'getFields', ['where' => [['name', '=', 'subject']]], ['title']);
+    $this->assertEquals(['Subject'], (array) $result);
+  }
+
 }

--- a/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
+++ b/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
@@ -62,4 +62,52 @@ This is the base class.';
     $this->assertEquals("In the child class, foo has been barred.\n\nIn general, you can do nothing with it.", $doc['comment']);
   }
 
+  public function docBlockExamples() {
+    return [
+      [
+        "/**
+          * This is a function.
+          *
+          * Comment.
+          * IDK
+          * @param int|string \$foo
+          *   Nothing interesting.
+          * @see 0
+          * @throws tantrums
+          * @param \$bar: - Has a title
+          * @return nothing
+          */
+        ",
+        [
+          'description' => 'This is a function.',
+          'comment' => "Comment.\nIDK",
+          'params' => [
+            '$foo' => [
+              'type' => ['int', 'string'],
+              'description' => '',
+              'comment' => "Nothing interesting.\n",
+            ],
+            '$bar' => [
+              'type' => NULL,
+              'description' => 'Has a title',
+              'comment' => '',
+            ],
+          ],
+          'see' => '0',
+          'throws' => ['tantrums'],
+          'return' => 'nothing',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider docBlockExamples
+   * @param $input
+   * @param $expected
+   */
+  public function testParseDocBlock($input, $expected) {
+    $this->assertEquals($expected, ReflectionUtils::parseDocBlock($input));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This improves `civicrm_api4()` and the Api Explorer to be more convenient and better documented.

Before
----------------------------------------
2 modes for the `civicrm_api4()` `$index` param. Minimal documentation.

After
----------------------------------------
4 modes for `$index` param.
Docblock added to `civicrm_api4()` function, and passed through to the api explorer.

Technical Details
----------------------------------------
The `$index` param now supports 4 modes:

 *  **Integer:** return a single result array; e.g. `index = 0` will return the first result, 1 will return the second, and -1 will return the last.
 *  **String:** index the results by a field value; e.g. `index = "name"` will return an associative array with the field 'name' as keys.
 *   **Non-associative array:** return a single value from each result; e.g. `index = ['title']` will return a non-associative array of strings - the 'title' field from each result.
 *  **Associative array:** a combination of the previous two modes; e.g. `index = ['name' => 'title']` will return an array of strings - the 'title' field keyed by the 'name' field.

The last 3 now automatically manage the "select" param to ensure the correct fields are selected.