### PR TITLE
Country/State PseudoConstant not sorted according to the locale

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -374,7 +374,7 @@ class CRM_Core_PseudoConstant {
             $i18n->localizeArray($output, $I18nParams);
             // Maintain sort by label
             if ($order == "ORDER BY %2") {
-              CRM_Utils_Array::asort($output);
+              $output = CRM_Utils_Array::asort($output);
             }
           }
           CRM_Utils_Hook::fieldOptions($entity, $fieldName, $output, $params);


### PR DESCRIPTION
Overview
----------------------------------------
In dropdown list like the one in search builder, the country and state fields are not sorted according to the current locale.

Before
----------------------------------------
![Peek 09-01-2020 13-04](https://user-images.githubusercontent.com/372004/72092595-a5909300-32e0-11ea-8832-f1358dac7bea.gif)

After
----------------------------------------
![Peek 09-01-2020 13-05](https://user-images.githubusercontent.com/372004/72092654-c5c05200-32e0-11ea-877d-f4909e7ab5d4.gif)

Technical Details
----------------------------------------
The code assume that CRM_Utils_Array::asort works like standard asort but it's not.

