### PR TITLE
Reporting#25: Sort report list alphabetically, not by report template ID

### DIFF
--- a/CRM/Report/Page/InstanceList.php
+++ b/CRM/Report/Page/InstanceList.php
@@ -120,7 +120,7 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
 
           WHERE v.is_active = 1 {$report}
                 AND inst.domain_id = %9
-          ORDER BY  v.weight ASC, inst.title ASC";
+          ORDER BY  inst.title ASC";
     $queryParams[9] = [CRM_Core_Config::domainID(), 'Integer'];
 
     $dao = CRM_Core_DAO::executeQuery($sql, $queryParams);


### PR DESCRIPTION
Overview
----------------------------------------
Report instance listings are currently sorted by a criterium that's not obvious to the user, nor does it make a lot of sense.

Before
----------------------------------------
![Selection_772](https://user-images.githubusercontent.com/1796012/72094655-d83c8a80-32e4-11ea-913b-5be48ea8dace.png)


After
----------------------------------------
![Selection_771](https://user-images.githubusercontent.com/1796012/72094661-dd013e80-32e4-11ea-84aa-4402a23678e0.png)


Technical Details
----------------------------------------
We're just removing one of the sort criteria.  Exact details are on the lab.c.o ticket: https://lab.civicrm.org/dev/report/issues/25

Comments
----------------------------------------
I realize that this will change existing instances in a way that might give folks a moment of confusion.  However, a) this grants more flexibility for users to control report order, b) folks with large numbers of reports aren't going to be looking for a single report without doing some sort of "find" or filter, c) folks with small number of reports will see their report anyway, d) alphabetical order makes enough sense that many users will simply pick up on the change.
