### PR TITLE
[REF] Fix CRM_Core_BAO_UFGroup::createUFJoin to not receive by reference.

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1477,13 +1477,13 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
   /**
    * Make uf join entries for an uf group.
    *
-   * @param array $params
-   *   (reference) an assoc array of name/value pairs.
+   * @param int $weight
+   * @param array $groupTypes
+   *   An assoc array of name/value pairs.
    * @param int $ufGroupId
    *   Ufgroup id.
    */
-  public static function createUFJoin(&$params, $ufGroupId) {
-    $groupTypes = CRM_Utils_Array::value('uf_group_type', $params);
+  public static function createUFJoin($weight, $groupTypes, $ufGroupId) {
 
     // get ufjoin records for uf group
     $ufGroupRecord = CRM_Core_BAO_UFGroup::getUFJoinRecord($ufGroupId);
@@ -1507,7 +1507,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       $joinParams = [];
       $joinParams['uf_group_id'] = $ufGroupId;
       $joinParams['module'] = $key;
-      if ($key == 'User Account') {
+      if ($key === 'User Account') {
         $menuRebuild = TRUE;
       }
       if (array_key_exists($key, $groupTypes) && !in_array($key, $ufGroupRecord)) {
@@ -1521,14 +1521,14 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     }
 
     //update the weight
-    $query = "
+    $query = '
 UPDATE civicrm_uf_join
 SET    weight = %1
 WHERE  uf_group_id = %2
 AND    ( entity_id IS NULL OR entity_id <= 0 )
-";
+';
     $p = [
-      1 => [$params['weight'], 'Integer'],
+      1 => [$weight, 'Integer'],
       2 => [$ufGroupId, 'Integer'],
     ];
     CRM_Core_DAO::executeQuery($query, $p);

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -390,7 +390,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
 
       if (!empty($params['is_active'])) {
         //make entry in uf join table
-        CRM_Core_BAO_UFGroup::createUFJoin($params, $ufGroup->id);
+        CRM_Core_BAO_UFGroup::createUFJoin($params['weight'], $params['uf_group_type'] ?? [], $ufGroup->id);
       }
       elseif ($this->_id) {
         // this profile has been set to inactive, delete all corresponding UF Join's


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup - stop passing variable by reference, pass actually required values

Before
----------------------------------------
```
public static function createUFJoin(&$params, $ufGroupId) {
```
After
----------------------------------------
```
public static function createUFJoin($params, $ufGroupId) {
```
In addition a small array containing only the 2 params used by the function is passed to it, getting away from 're-using' $params


Technical Details
----------------------------------------
This function is called from one place. It gets passed a params variable that is 're-used' so this
change makes it clear what actually needs to be passed on. We have an anti-pattern in our code whereby params get
passed all sorts of places with it being confusing which ones actually need to receive what


Comments
----------------------------------------

