### PR TITLE
[REF] Move single-use complexity out of heavily used processPriceSet function

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -446,16 +446,19 @@ WHERE li.contribution_id = %1";
           $line['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $line['price_field_value_id'], 'financial_type_id');
         }
         $createdLineItem = CRM_Price_BAO_LineItem::create($line);
-        if (!$update && $contributionDetails) {
-          $financialItem = CRM_Financial_BAO_FinancialItem::add($createdLineItem, $contributionDetails);
-          $line['financial_item_id'] = $financialItem->id;
-          if (!empty($line['tax_amount'])) {
-            CRM_Financial_BAO_FinancialItem::add($createdLineItem, $contributionDetails, TRUE);
-          }
-        }
+        $line['id'] = $createdLineItem->id;
       }
     }
     if (!$update && $contributionDetails) {
+      foreach ($lineItems as &$lineItem) {
+        $lineItemBAO = new CRM_Price_BAO_LineItem();
+        $lineItemBAO->copyValues($lineItem);
+        $financialItem = CRM_Financial_BAO_FinancialItem::add($lineItemBAO, $contributionDetails);
+        $lineItem['financial_item_id'] = $financialItem->id;
+        if (!empty($lineItem['tax_amount'])) {
+          CRM_Financial_BAO_FinancialItem::add($lineItemBAO, $contributionDetails, TRUE);
+        }
+      }
       CRM_Core_BAO_FinancialTrxn::createDeferredTrxn($lineItems, $contributionDetails);
     }
   }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -397,16 +397,17 @@ WHERE li.contribution_id = %1";
    * @param string $entityTable
    *   Entity table.
    *
-   * @param bool $update
+   * @return array
+   *   Updated lineItems array.
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function processPriceSet($entityId, $lineItems, $contributionDetails = NULL, $entityTable = 'civicrm_contribution', $update = FALSE) {
+  public static function processPriceSet($entityId, $lineItems, $contributionDetails = NULL, $entityTable = 'civicrm_contribution') {
     if (!$entityId || !is_array($lineItems)
       || CRM_Utils_System::isNull($lineItems)
     ) {
-      return;
+      return [];
     }
 
     foreach ($lineItems as $priceSetId => &$values) {
@@ -449,18 +450,7 @@ WHERE li.contribution_id = %1";
         $line['id'] = $createdLineItem->id;
       }
     }
-    if (!$update && $contributionDetails) {
-      foreach ($lineItems as &$lineItem) {
-        $lineItemBAO = new CRM_Price_BAO_LineItem();
-        $lineItemBAO->copyValues($lineItem);
-        $financialItem = CRM_Financial_BAO_FinancialItem::add($lineItemBAO, $contributionDetails);
-        $lineItem['financial_item_id'] = $financialItem->id;
-        if (!empty($lineItem['tax_amount'])) {
-          CRM_Financial_BAO_FinancialItem::add($lineItemBAO, $contributionDetails, TRUE);
-        }
-      }
-      CRM_Core_BAO_FinancialTrxn::createDeferredTrxn($lineItems, $contributionDetails);
-    }
+    return $lineItems;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup - remove non-shared code from heavily shared function

Before
----------------------------------------
processPriceSet receives $update as a parameter. This parameter is only passed in one instance whereas the function is called a lot & is hard to understand currently.

After
----------------------------------------
$update is removed as a parameter - the code for this parameter is moved back to the calling function.

Technical Details
----------------------------------------
Now that the function is readable it turns out to do a whole lot less that seemed to be the case. It's really just augmenting the line items array in a fairly fragile way & saving it. We should probably have 2 functions - 1 augment line item array, 2 save line item array - & try to only call the former when needed

Comments
----------------------------------------
