### PR TITLE
[REF] Reduce places where we pass ids into Mailing::create

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1514,7 +1514,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *
    * @return object
    *   $mailing      The new mailing object
-   * @throws \Exception
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function create(&$params, $ids = []) {
 
@@ -1546,8 +1548,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         $domain_name = 'EXAMPLE.ORG';
       }
       if (!isset($params['created_id'])) {
-        $session =& CRM_Core_Session::singleton();
-        $params['created_id'] = $session->get('userID');
+        $params['created_id'] = CRM_Core_Session::getLoggedInContactID();
       }
       $defaults = [
         // load the default config settings for each

--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -131,9 +131,9 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
   public function postProcess() {
     $params = [];
 
-    $params['mailing_id'] = $ids['mailing_id'] = $this->_mailingID;
+    $params['id'] = $this->_mailingID;
 
-    if (empty($params['mailing_id'])) {
+    if (empty($params['id'])) {
       CRM_Core_Error::statusBounce(ts('Could not find a mailing id'));
     }
 
@@ -157,7 +157,7 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
     }
 
     // Build the mailing object.
-    CRM_Mailing_BAO_Mailing::create($params, $ids);
+    CRM_Mailing_BAO_Mailing::create($params);
 
     $session = CRM_Core_Session::singleton();
     $session->pushUserContext(CRM_Utils_System::url('civicrm/mailing/browse/scheduled',

--- a/CRM/SMS/Form/Upload.php
+++ b/CRM/SMS/Form/Upload.php
@@ -144,7 +144,7 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
   }
 
   public function postProcess() {
-    $params = $ids = [];
+    $params = [];
     $uploadParams = ['from_name'];
 
     $formValues = $this->controller->exportValues($this->_name);
@@ -232,10 +232,10 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
       $this->set('template', $params['msg_template_id']);
     }
 
-    $ids['mailing_id'] = $this->_mailingID;
+    $params['id'] = $this->_mailingID;
 
     // Build SMS in mailing table.
-    CRM_Mailing_BAO_Mailing::create($params, $ids);
+    CRM_Mailing_BAO_Mailing::create($params);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In general the goal is to stop passing the ids variable. This removes a couple of places. Note
that the value in params should be id not mailing_id

Before
----------------------------------------
$ids passed in

After
----------------------------------------
$params['id'] set correctly, $ids not passed in

Technical Details
----------------------------------------
Part of an ongoing pattern cleanup

Comments
----------------------------------------

