### PR TITLE
Ensure that we always return a raw urlencoded url for extenal urls to…

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -298,6 +298,8 @@ class CRM_Utils_System {
    *   URI-scheme such as 'http:').
    * @param bool $isSSL
    *   NULL to autodetect. TRUE to force to SSL.
+   *
+   * @return string rawencoded URL.
    */
   public static function externUrl($path = NULL, $query = NULL, $fragment = NULL, $absolute = TRUE, $isSSL = NULL) {
     $query = self::makeQueryString($query);
@@ -316,7 +318,7 @@ class CRM_Utils_System {
       'isSSL' => $isSSL,
     ]);
     Civi::service('dispatcher')->dispatch('hook_civicrm_alterExternUrl', $event);
-    return CRM_Utils_Url::unparseUrl($event->url);
+    return urldecode(CRM_Utils_Url::unparseUrl($event->url));
   }
 
   /**


### PR DESCRIPTION
… fix Flexmailer tests

Overview
----------------------------------------
This fixes the flexmailer tests here https://test.civicrm.org/job/CiviCRM-Ext-Matrix/BKPROF=min,BUILDTYPE=git,CIVIVER=master,EXTKEY=org.civicrm.flexmailer,label=bknix-tmp/lastCompletedBuild/testReport/ which were caused by the PR https://github.com/civicrm/civicrm-core/pull/15475 being merged and picking up the comment here

Before
----------------------------------------
In flexmailer url is returned encoded

After
----------------------------------------
For flexmailer url is returned is raw decoded

ping @kcristiano @eileenmcnaughton @mecachisenros 