### PR TITLE
dev/core#1517 - Permission error on event info page for anonymous users

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -338,7 +338,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     }
     $this->assign('location', $values['location']);
 
-    if (CRM_Core_Permission::check('access CiviEvent')) {
+    if (CRM_Core_Permission::check(['access CiviEvent', 'edit all events'])) {
       $enableCart = Civi::settings()->get('enable_cart');
       $this->assign('manageEventLinks', CRM_Event_Page_ManageEvent::tabs($enableCart));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix permission error on event info page.

Before
----------------------------------------
Giving anonymous "access CiviEvent" in addition to "view event info" cause them to get "API permission check failed for Event/get call; insufficient permission: require access CiviCRM".

![image](https://user-images.githubusercontent.com/5929648/72125011-e80fa980-338c-11ea-835e-6d22949bbc11.png)

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Manage event links should only be loaded for users having `edit all events` permission.

Comments
----------------------------------------
Gitlab  - https://lab.civicrm.org/dev/core/issues/1517