### PR TITLE
dev/core#1519 Fix auto renew text

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -163,15 +163,25 @@
         {include file="CRM/Member/Form/MembershipCommon.tpl"}
         {if $emailExists and $isEmailEnabledForSite}
           <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
-            <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
-            <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1? OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
-            <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
+            <td class="label">{$form.send_receipt.label}</td>
+            <td>
+              {$form.send_receipt.html}<br />
+              <span class="description">
+                {ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1? OR if the payment is from a different contact, this email will only go to them.{/ts}
+                <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
+              </span>
+            </td>
           </tr>
-          {elseif $context eq 'standalone' and $isEmailEnabledForSite}
+        {elseif $context eq 'standalone' and $isEmailEnabledForSite}
           <tr id="email-receipt" style="display:none;">
-            <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
-            <span class="description">{ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>? {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
-            <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
+            <td class="label">{$form.send_receipt.label}</td>
+            <td>
+              {$form.send_receipt.html}<br />
+              <span class="description">
+                {ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>? {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}
+                <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
+              </span>
+            </td>
           </tr>
         {/if}
         <tr id="fromEmail" style="display: none" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">


### PR DESCRIPTION
Overview
----------------------------------------
A line of text appears at the top of the membership edit form when editing an auto-renewing membership:

For auto-renewing memberships the emails are sent when each payment is received

This text should appear lower down next to the 'Send Confirmation and Receipt?' text box. It appears that the HTML is incorrectly nested which is why the browser places this text out of the normal flow.

https://lab.civicrm.org/dev/core/issues/1519

Before
----------------------------------------
![Before](https://user-images.githubusercontent.com/13518928/72158606-895d2680-33b2-11ea-8e6d-1f6ad19ce8e7.png)


After
----------------------------------------
![After](https://user-images.githubusercontent.com/13518928/72158618-8f530780-33b2-11ea-8d55-baa02b4eb594.png)
