### PR TITLE
REF Extract code to build pcp_supporter_text and enable translation

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -438,13 +438,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       }
     }
     if ($this->_pcpId && empty($this->_ccid)) {
-      if ($pcpSupporter = CRM_PCP_BAO_PCP::displayName($this->_pcpId)) {
-        $pcp_supporter_text = ts('This contribution is being made thanks to the effort of <strong>%1</strong>, who supports our campaign.', [1 => $pcpSupporter]);
-        // Only tell people that can also create a PCP if the contribution page has a non-empty value in the "Create Personal Campaign Page link" field.
-        $text = CRM_PCP_BAO_PCP::getPcpBlockStatus($this->_id, 'contribute');
-        if (!empty($text)) {
-          $pcp_supporter_text .= ts("You can support it as well - once you complete the donation, you will be able to create your own Personal Campaign Page!");
-        }
+      if (CRM_PCP_BAO_PCP::displayName($this->_pcpId)) {
+        $pcp_supporter_text = CRM_PCP_BAO_PCP::getPcpSupporterText($this->_pcpId, $this->_id, 'contribute');
         $this->assign('pcpSupporterText', $pcp_supporter_text);
       }
       $prms = ['id' => $this->_pcpId];


### PR DESCRIPTION
Overview
----------------------------------------
Extract code to build the pcp_supporter_text which is duplicated in two places and only translated in one of them.

Before
----------------------------------------
Code duplication, missing translation.

After
----------------------------------------
Single function in BAO object to generate pcp_supporter_text. All strings translateable.

Technical Details
----------------------------------------

Comments
----------------------------------------
