### PR TITLE
dev/core#1520 Improve accessibility of membership edit form

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -11,7 +11,7 @@
 {if $cancelAutoRenew}
   <div class="messages status no-popup">
     <div class="icon inform-icon"></div>
-    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status. <a href="%1">Click here</a> if you want to cancel the automatic renewal option.{/ts}</p>
+    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status: <a href="%1">Cancel auto-renew</a>{/ts}</p>
   </div>
 {/if}
 <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
An alert that appears at the top of the membership edit form uses 'Click here' as the link text. This isn't good practice for accessibility. The link text should be meaningful.

Before
----------------------------------------
The link text isn't meaningful - it says 'Click here'.

![Before](https://user-images.githubusercontent.com/13518928/72171474-f54b8900-33ca-11ea-80bf-169a01494f28.png)


After
----------------------------------------
The link text is meaningful - it says 'Cancel auto-renew'.

![After](https://user-images.githubusercontent.com/13518928/72171510-098f8600-33cb-11ea-8007-6a5269acfc6d.png)


Technical Details
----------------------------------------
None

Comments
----------------------------------------
None
