### PR TITLE
dev/drupal#89 Drupal 8 version of checkGroupRole

### DIFF
--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -92,4 +92,31 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
     }
   }
 
+  /**
+   * Given a roles array, check user has at least one of those roles
+   *
+   * @param array $roles_to_check
+   *   The roles to check. An array indexed starting at 0, e.g. [0 => 'administrator']
+   *
+   * @return bool
+   *   true if user has at least one of the roles, else false
+   */
+  public function checkGroupRole($roles_to_check) {
+    if (isset($roles_to_check)) {
+
+      // This returns an array indexed starting at 0 of role machine names, e.g.
+      // [
+      //   0 => 'authenticated',
+      //   1 => 'administrator',
+      // ]
+      // or
+      // [ 0 => 'anonymous' ]
+      $user_roles = \Drupal::currentUser()->getRoles();
+
+      $roles_in_both = array_intersect($user_roles, $roles_to_check);
+      return !empty($roles_in_both);
+    }
+    return FALSE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Follow-on from https://github.com/civicrm/civicrm-core/pull/15318. The UI for the roles widget on the Access tab of CiviReports is fixed by that PR but it doesn't actually have any effect on access because the implementation of CRM_Core_Permission::checkGroupRole ends up using the D6/D7 version which doesn't work in D8. So that needed updating too, which is this PR.

Before
----------------------------------------
You can select a role but it doesn't affect access.

After
----------------------------------------
Role-based access works like in D7.

Technical Details
----------------------------------------
$GLOBALS['user'] doesn't exist in D8. This adds an override version of checkGroupRole in Drupal8.php.

Comments
----------------------------------------
If you're testing note that if the user has Administer Reports permission in the CMS then that overrides anything on the access tab of a report.

@jitendrapurohit 