### PR TITLE
[REF] Move handling of default payment instrument for a payment proc…

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -35,6 +35,13 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    * @throws Exception
    */
   public static function create($params) {
+    // If we are creating a new PaymentProcessor and have not specified the payment instrument to use, get the default from the Payment Processor Type.
+    if (empty($params['id']) && empty($params['payment_instrument_id'])) {
+      $params['payment_instrument_id'] = civicrm_api3('PaymentProcessorType', 'getvalue', [
+        'id' => $params['payment_processor_type_id'],
+        'return' => 'payment_instrument_id',
+      ]);
+    }
     $processor = new CRM_Financial_DAO_PaymentProcessor();
     $processor->copyValues($params);
 

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -24,12 +24,6 @@
  *   API result array
  */
 function civicrm_api3_payment_processor_create($params) {
-  if (empty($params['id']) && empty($params['payment_instrument_id'])) {
-    $params['payment_instrument_id'] = civicrm_api3('PaymentProcessorType', 'getvalue', [
-      'id' => $params['payment_processor_type_id'],
-      'return' => 'payment_instrument_id',
-    ]);
-  }
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'PaymentProcessor');
 }
 

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -33,6 +33,7 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
       'class_name' => 'CRM_Core_Payment_APITest',
       'billing_mode' => 'form',
       'is_recur' => 0,
+      'payment_instrument_id' => 2,
     ];
     $result = $this->callAPISuccess('payment_processor_type', 'create', $params);
     $this->_paymentProcessorType = $result['id'];
@@ -71,6 +72,7 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
       'frequency_interval' => 1,
     ]);
     $this->getAndCheck($params, $result['id'], 'PaymentProcessor');
+    $this->assertEquals(2, $result['values'][$result['id']]['payment_instrument_id']);
   }
 
   /**
@@ -80,6 +82,7 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
    */
   public function testPaymentProcessorUpdate() {
     $params = $this->_params;
+    $params['payment_instrument_id'] = 1;
     $result = $this->callAPISuccess('payment_processor', 'create', $params);
     $this->assertNotNull($result['id']);
 


### PR DESCRIPTION
…essor into the create function from API and expand tests

Overview
----------------------------------------
This moves the handling for the payment_instrument_id field for payment processors out of the API layer into the BAO create function so can be used by APIv4 as well

Before
----------------------------------------
Setting payment instrument id occurs in API Layer

After
----------------------------------------
Setting payment instrument id occurs in BAO Layer

ping @colemanw @eileenmcnaughton 