### PR TITLE
[REF] Fix return value on deleting financial type

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -153,7 +153,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
     $entityFinancialType->entity_id = $financialTypeId;
     $entityFinancialType->entity_table = 'civicrm_financial_type';
     $entityFinancialType->delete();
-    return FALSE;
+    return TRUE;
   }
 
   /**

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -118,7 +118,7 @@ class CRM_Financial_Form_FinancialType extends CRM_Contribute_Form {
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       $errors = CRM_Financial_BAO_FinancialType::del($this->_id);
-      if (!empty($errors)) {
+      if (is_array($errors) && !empty($errors)) {
         CRM_Core_Error::statusBounce($errors['error_message'], CRM_Utils_System::url('civicrm/admin/financial/financialType', "reset=1&action=browse"), ts('Cannot Delete'));
       }
       CRM_Core_Session::setStatus(ts('Selected financial type has been deleted.'), ts('Record Deleted'), 'success');

--- a/tests/phpunit/api/v3/FinancialTypeTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeTest.php
@@ -86,6 +86,7 @@ class api_v3_FinancialTypeTest extends CiviUnitTestCase {
       $this->callAPISuccessGetSingle('FinancialType', [
         'id' => $financialType['id'],
       ], $expectedResult);
+      $this->callAPISuccess('FinancialType', 'delete', ['id' => $financialType['id']]);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The code in the API expects that if a deletion via the del method has been successful it should not return FALSE yet that is what financial Type does

Before
----------------------------------------
wrong return parameter used

After
----------------------------------------
correct return is used

ping @mattwire @eileenmcnaughton @colemanw 