### PR TITLE
Force reCaptcha is not working when pay later enabled

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -283,7 +283,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->buildComponentForm($this->_id, $this);
     }
 
-    if (count($this->_paymentProcessors) >= 1 && !isset($this->_paymentProcessors[0]) && !$this->get_template_vars("isCaptcha") && $this->hasToAddForcefully()) {
+    if (count($this->_paymentProcessors) >= 1 && !$this->get_template_vars("isCaptcha") && $this->hasToAddForcefully()) {
       if (!$this->_userID) {
         $this->enableCaptchaOnForm();
       }


### PR DESCRIPTION
Overview
----------------------------------------
We want to have reCaptcha always enabled even if the page only has pay later and no other payment method.

I got into the case that when I force the reCaptcha shows on every contribution page, the reCaptcha is not shown on a page that has pay later enabled.

However, if there is no payment option at all, it will not force the page to enable reCaptcha.

Before
----------------------------------------
ReCaptcha is off when pay later option enabled.

After
----------------------------------------
ReCaptcha always on even if only pay later enabled.

Comments
----------------------------------------
Related to #11197
pin @eileenmcnaughton @seamuslee001 @colemanw 

Agileware ref: CIVICRM-1417
