### PR TITLE
WIP Make case activity form respect the civicaseActivityRevisions setting

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -355,7 +355,11 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
 
     // check and attach and files as needed
-    CRM_Core_BAO_File::processAttachment($params, 'civicrm_activity', $activityId);
+    // copy files attached to old activity if any, to new one,
+    // as long as users have not selected the 'delete attachment' option.
+    if (empty($params['is_delete_attachment']) && ($params['original_id'] != $activityId)) {
+      CRM_Core_BAO_File::processAttachment($params, 'civicrm_activity', $activityId);
+    }
 
     // attempt to save activity assignment
     $resultAssignment = NULL;

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -1200,7 +1200,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    * needed, after the activity has been added/updated
    *
    * @param array $params
-   * @param $activity
+   * @param object $activity
    */
   public function endPostProcess(&$params, &$activity) {
     if ($this->_activityTypeFile) {

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -447,13 +447,6 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         }
       }
 
-      // build custom data getFields array
-      $customFields = CRM_Core_BAO_CustomField::getFields('Activity', FALSE, FALSE, $this->_activityTypeId);
-      $customFields = CRM_Utils_Array::crmArrayMerge($customFields,
-        CRM_Core_BAO_CustomField::getFields('Activity', FALSE, FALSE,
-          NULL, NULL, TRUE
-        )
-      );
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
         $this->_activityId,
         'Activity'

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -536,13 +536,6 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         $activityObject->find();
         $this->endPostProcess($newActParams, $activityObject);
       }
-      // copy files attached to old activity if any, to new one,
-      // as long as users have not selected the 'delete attachment' option.
-      if (empty($newActParams['is_delete_attachment']) && ($this->_activityId != $activity['id'])) {
-        CRM_Core_BAO_File::copyEntityFile('civicrm_activity', $this->_activityId,
-          'civicrm_activity', $activity['id']
-        );
-      }
 
       // copy back params to original var
       $params = $newActParams;

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -192,7 +192,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     $activity->priority_id = $params['priority_id'];
 
     foreach ($form->_oldCaseStatus as $statuskey => $statusval) {
-      if ($activity->subject == 'null') {
+      if ($activity->subject === NULL) {
         $activity->subject = ts('Case status changed from %1 to %2', [
           1 => CRM_Utils_Array::value($statusval, $form->_caseStatus),
           2 => CRM_Utils_Array::value($params['case_status_id'], $form->_caseStatus),

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -325,8 +325,6 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
       'activity_date_time' => $now_date,
       'target_contact_id' => $client_id,
       'source_contact_id' => $loggedInUser,
-      // yeah this is extra weird, but without it you get the wrong subject
-      'subject' => 'null',
     ];
 
     $form->postProcess($actParams);


### PR DESCRIPTION
Overview
----------------------------------------
The setting `civicaseActivityRevisions` in core is ignored via the CiviCase UI and only respected when using the API:
![image](https://user-images.githubusercontent.com/2052161/72249734-e1ce3700-35f1-11ea-9747-8799bd3f0f5b.png)

This means that when administering a case with "Embedded activity revisions" enabled you lose the history when making changes to an activity.

Before
----------------------------------------
Setting in core but not respected by core UI.

After
----------------------------------------
Setting in core is respected by core UI. Do not lose data when editing activities on cases if setting enabled.

Technical Details
----------------------------------------
By switching all create calls to the API we automatically respect the setting as well as calling pre/post hooks in all cases (instead of bypasses when using the DAO directly).

Comments
----------------------------------------
For new installs it is *preferred* to use extended logging. But for existing systems it is not necessarily a simple process to change.  A core setting should work as expected in core! And for the kind of uses cases are intended losing history is a bad thing!

@demeritcowboy 