### PR TITLE
Update civicrm.settings.php.template to default to CLEANURL for WP

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -505,6 +505,9 @@ if (!defined('CIVICRM_CLEANURL')) {
   elseif ( function_exists('config_get') && config_get('system.core', 'clean_url') != 0) {
     define('CIVICRM_CLEANURL', 1 );
   }
+  elseif( function_exists('get_option') && get_option('permalink_structure') != '' ) {
+    define('CIVICRM_CLEANURL', 1 );
+  }
   else {
     define('CIVICRM_CLEANURL', 0);
   }


### PR DESCRIPTION
Signed-off-by: Kevin Cristiano <kcristiano@kcristiano.com>

Overview
----------------------------------------
An Option for CLEANURLs was added to 5.13, but had to be manually turned on.  This PR adds the setting to the template file for new sites.

Before
----------------------------------------
To enable CLEANURLs on a new site one had to follow the instructions detailed at https://docs.civicrm.org/sysadmin/en/latest/install/wordpress/#enabling-cleaner-urls-for-wordpress

After
----------------------------------------
This PR adds the setting for new installs

Comments
----------------------------------------
This setting has been in the wild for over 6 months and has been working well.   Existing sites will still have to manually turn CLEANURLs on, but new sites will have it on by default