### PR TITLE
Add "Contributor Name" to Offline Contribution Receipts

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -199,6 +199,14 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'membership_online_receipt', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '5.23.alpha1',
+        'upgrade_descriptor' => ts('Add Contributor Name to Offline Contribution receipts'),
+        'templates' => [
+          ['name' => 'contribution_offline_receipt', 'type' => 'text'],
+          ['name' => 'contribution_offline_receipt', 'type' => 'html'],
+        ],
+      ],
 
     ];
   }

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -39,6 +39,14 @@
      </tr>
      <tr>
       <td {$labelStyle}>
+       {ts}Contributor Name{/ts}
+      </td>
+      <td {$valueStyle}>
+       {contact.display_name}
+      </td>
+     </tr>
+     <tr>
+      <td {$labelStyle}>
        {ts}Financial Type{/ts}
       </td>
       <td {$valueStyle}>

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -8,6 +8,7 @@
 {ts}Contribution Information{/ts}
 
 ===========================================================
+{ts}Contributor{/ts}: {contact.display_name}
 {ts}Financial Type{/ts}: {$formValues.contributionType_name}
 {if $lineItem}
 {foreach from=$lineItem item=value key=priceset}


### PR DESCRIPTION
Overview
----------------------------------------
Adds the display name of the contributor to the Offline Contribution Receipt.

Offline Contribution Receipts can be triggered by going to a contacts "Contributions" tab and clicking the "Record Contribution (Check, Cash, EFT)" button or the "Submit Credit Card Contribution" button, entering information for a contribution, checking the "Send Receipt?" checkbox and submitting the form. 

Before
----------------------------------------
Without this change Offline Contribution Receipts do not include the Contributors name. See screenshot of a receipt generated from the "Record Contribution (Check, Cash, EFT)" form:
![before](https://user-images.githubusercontent.com/11323624/72285700-a9d6ec00-3611-11ea-8209-4a4d6ac57ded.png)

After
----------------------------------------
With this change they do see screenshot below:
![receiptAfter](https://user-images.githubusercontent.com/11323624/72285718-b22f2700-3611-11ea-9d22-5e6bd3a7fd6e.png)
