### PR TITLE
WIP Use CMS language on wordpress

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -190,7 +190,9 @@ class CRM_Core_BAO_ConfigSetting {
     global $dbLocale;
 
     // try to inherit the language from the hosting CMS
-    if ($settings->get('inheritLocale')) {
+    // @fixme On wordpress isFrontEndPage() has not yet been set so we can't use it to trigger frontend pages to follow CMS language.
+    //   Is there anything we can use, or can we set userFrameworkFrontend earlier in the bootstrap?
+    //if ($settings->get('inheritLocale') || CRM_Core_Config::singleton()->userSystem->isFrontEndPage()) {
       // FIXME: On multilanguage installs, CRM_Utils_System::getUFLocale() in many cases returns nothing if $dbLocale is not set
       $lcMessages = $settings->get('lcMessages');
       $dbLocale = $multiLang && $lcMessages ? "_{$lcMessages}" : '';
@@ -198,7 +200,7 @@ class CRM_Core_BAO_ConfigSetting {
       if ($activatedLocales and !in_array($chosenLocale, explode(CRM_Core_DAO::VALUE_SEPARATOR, $activatedLocales))) {
         $chosenLocale = NULL;
       }
-    }
+    //}
 
     if (empty($chosenLocale)) {
       //CRM-11993 - if a single-lang site, use default


### PR DESCRIPTION
Overview
----------------------------------------
This PR is an attempt to get wordpress frontend pages to follow the CMS language instead of using the default CiviCRM language.

Configuration:
* Inherit CMS Language = No.
* Available languages = English/Portuguese (does not matter which as long as more than one).
* Default language = Portuguese.

The problem is that if you enable "Inherit CMS language" you cannot specify which languages should be available for the backend.

Before
----------------------------------------
CiviCRM contribution pages etc. viewed via CMS frontend do not use CMS language.

After
----------------------------------------
CiviCRM contribution pages etc. viewed via CMS frontend use CMS language.

Technical Details
----------------------------------------
The change in `CRM/Utils/System/WordPress.php` passes the language code through to CiviCRM if there are no language plugins installed - previously CiviCRM received "NULL" as the language code if wordpress was in standard single language mode.

The change in `CRM/Core/BAO/ConfigSetting.php` needs a bit of work - at the point that `applyLocale` is called `isFrontEndPage()` has not been set and returns false. Ideally we need some way of setting this BEFORE calling applyLocale - @christianwach thoughts?

Comments
----------------------------------------
@bjendres @aydun Comments welcome as I know you both have an interest in translation