### PR TITLE
dev/user-interface#13 fix regression where option to email is not longer displayed

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -607,8 +607,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('customDataSubType', $this->_contributionType);
     $this->assign('entityID', $this->_id);
 
-    $contactField = $this->addEntityRef('contact_id', ts('Contributor'), ['create' => TRUE], TRUE);
-    if ($this->_context != 'standalone') {
+    $contactField = $this->addEntityRef('contact_id', ts('Contributor'), ['create' => TRUE, 'api' => ['extra' => ['email']]], TRUE);
+    if ($this->_context !== 'standalone') {
       $contactField->freeze();
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes recent regression where option to send an email is no longer offered on standalone contribution form

https://lab.civicrm.org/dev/user-interface/issues/13

Before
----------------------------------------
Option to send an email missing

After
----------------------------------------
![Screen Shot 2020-01-15 at 10 02 52 AM](https://user-images.githubusercontent.com/336308/72382478-38687c00-377e-11ea-8a3c-064a5bcdd74b.png)


Technical Details
----------------------------------------

The api parameter here was removed, seemingly unintentionally. It is picked up on by the script when it checks for email here https://github.com/civicrm/civicrm-core/blob/1188c7a8512382b1cb588b6a1ea4b13aa9587bc9/templates/CRM/Contribute/Form/Contribution.tpl#L379 - so
needs re-instating

Comments
----------------------------------------

