### PR TITLE
Enotice fix

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -74,6 +74,9 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
    *
    * @return array
    *   the values of the posted saved search used as default values in various Search Form
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getFormValues($id) {
     $specialDateFields = [
@@ -82,7 +85,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
     ];
 
     $fv = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch', $id, 'form_values');
-    $result = NULL;
+    $result = [];
     if ($fv) {
       // make sure u CRM_Utils_String::unserialize - since it's stored in serialized form
       $result = CRM_Utils_String::unserialize($fv);
@@ -200,6 +203,9 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
    * @param int $id
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getSearchParams($id) {
     $fv = self::getFormValues($id);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a warning

Before
----------------------------------------
![Screen Shot 2020-01-15 at 10 26 53 AM](https://user-images.githubusercontent.com/336308/72384417-52a45900-3782-11ea-8e77-19d5c7023892.png)

After
----------------------------------------
Notices gone

Technical Details
----------------------------------------
Note I suspect that $fv should not actually be empty & am digging - nevertheless $result is not expected to be NULL later on & the functions that call this seem to expect the promised array 

Comments
----------------------------------------
