### PR TITLE
dev/user-interface#13 fix regression where option to email is not lon…

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -608,8 +608,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('customDataSubType', $this->_contributionType);
     $this->assign('entityID', $this->_id);
 
-    $contactField = $this->addEntityRef('contact_id', ts('Contributor'), ['create' => TRUE], TRUE);
-    if ($this->_context != 'standalone') {
+    $contactField = $this->addEntityRef('contact_id', ts('Contributor'), ['create' => TRUE, 'api' => ['extra' => ['email']]], TRUE);
+    if ($this->_context !== 'standalone') {
       $contactField->freeze();
     }
 


### PR DESCRIPTION
…ger displayed.

The api parameter here was removed, seemingly unintentionally. It is picked up on by the script when it checks for email so
needs re-instating

backport of #16292 

ping @eileenmcnaughton 