### PR TITLE
Api4 - Filter returned fields by contact type

### DIFF
--- a/tests/phpunit/api/v4/Entity/ContactTypeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactTypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ * $Id$
+ *
+ */
+
+
+namespace api\v4\Entity;
+
+use Civi\Api4\Contact;
+use api\v4\UnitTestCase;
+
+/**
+ * @group headless
+ */
+class ContactTypeTest extends UnitTestCase {
+
+  public function testContactGetReturnsFieldsAppropriateToEachContactType() {
+    $indiv = Contact::create()
+      ->setValues(['first_name' => 'Joe', 'last_name' => 'Tester', 'contact_type' => 'Individual'])
+      ->setCheckPermissions(FALSE)
+      ->execute()->first()['id'];
+
+    $org = Contact::create()
+      ->setValues(['organization_name' => 'Tester Org', 'contact_type' => 'Organization'])
+      ->setCheckPermissions(FALSE)
+      ->execute()->first()['id'];
+
+    $hh = Contact::create()
+      ->setValues(['household_name' => 'Tester Family', 'contact_type' => 'Household'])
+      ->setCheckPermissions(FALSE)
+      ->execute()->first()['id'];
+
+    $result = Contact::get()
+      ->setCheckPermissions(FALSE)
+      ->addWhere('id', 'IN', [$indiv, $org, $hh])
+      ->execute()
+      ->indexBy('id');
+
+    $this->assertArrayHasKey('first_name', $result[$indiv]);
+    $this->assertArrayNotHasKey('first_name', $result[$org]);
+    $this->assertArrayNotHasKey('first_name', $result[$hh]);
+
+    $this->assertArrayHasKey('organization_name', $result[$org]);
+    $this->assertArrayNotHasKey('organization_name', $result[$indiv]);
+    $this->assertArrayNotHasKey('organization_name', $result[$hh]);
+
+    $this->assertArrayHasKey('sic_code', $result[$org]);
+    $this->assertArrayNotHasKey('sic_code', $result[$indiv]);
+    $this->assertArrayNotHasKey('sic_code', $result[$hh]);
+
+    $this->assertArrayHasKey('household_name', $result[$hh]);
+    $this->assertArrayNotHasKey('household_name', $result[$org]);
+    $this->assertArrayNotHasKey('household_name', $result[$indiv]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
When you do `civicrm_api4('Contact', 'get' ...)` and don't specify a `select` param, all core fields are returned. However, not all contact fields are relevant to all contact types. This changes the default to return fields appropriate to each contact retrieved.

Before/After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/72455572-07457700-3791-11ea-8cb3-0551976860b4.png)


Technical Details
----------------------------------------
Works even if a mix of contact types is returned.