### PR TITLE
Remove unused code in Case/Form/Activity postProcess

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -447,13 +447,6 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         }
       }
 
-      // build custom data getFields array
-      $customFields = CRM_Core_BAO_CustomField::getFields('Activity', FALSE, FALSE, $this->_activityTypeId);
-      $customFields = CRM_Utils_Array::crmArrayMerge($customFields,
-        CRM_Core_BAO_CustomField::getFields('Activity', FALSE, FALSE,
-          NULL, NULL, TRUE
-        )
-      );
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
         $this->_activityId,
         'Activity'


### PR DESCRIPTION
Overview
----------------------------------------
As identified by @demeritcowboy these lines of code are never used and can be removed.

Before
----------------------------------------
Code being run that assigns to an unused variable (and builds a cache that is not needed).

After
----------------------------------------
Code gone!

Technical Details
----------------------------------------

Comments
----------------------------------------
@demeritcowboy 