### PR TITLE
[REF] Remove apparent copy & paste code.

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -71,7 +71,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     $this->set('searchFormName', 'Search');
 
     // set the button names
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -58,7 +58,6 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     $this->_defaults = array();
 
     //set the button name.
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_printButtonName = $this->getButtonName('next', 'print');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -75,7 +75,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     /**
      * set the button names
      */
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -530,7 +530,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     /**
      * set the button names
      */
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->assign('actionButtonName', $this->_actionButtonName);
@@ -793,7 +792,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       return;
     }
     else {
-      if (array_key_exists($this->_searchButtonName, $_POST) ||
+      if (array_key_exists($this->getButtonName('refresh'), $_POST) ||
         ($this->_force && !$crmPID)
       ) {
         //reset the cache table for new search

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -63,7 +63,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
   public function preProcess() {
     $this->set('searchFormName', 'Search');
 
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -22,13 +22,6 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   protected $_force;
 
   /**
-   * Name of search button
-   *
-   * @var string
-   */
-  protected $_searchButtonName;
-
-  /**
    * Name of action button
    *
    * @var string

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -84,7 +84,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     /**
      * set the button names
      */
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -72,7 +72,6 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
     /**
      * set the button names
      */
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -65,7 +65,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
   public function preProcess() {
     $this->set('searchFormName', 'Search');
 
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -59,7 +59,6 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
    */
   public function preProcess() {
 
-    $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->_done = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Removes a property that is set much more often than it is used

Before
----------------------------------------
All search forms have apparent copy & paste to set $this->_searchButtonName

After
----------------------------------------
Property removed, the one place it is used just calls getButtonName

Technical Details
----------------------------------------
In code familiarisation to tackle dev#core/1217 I looked at this var & concluded that the var is set in 9 places but in 8 of those it is never used. In the last place (CRM_Contact_Form_Search) it is used to determine whether to build the pre-next cache/ whether this is an 'original search'. I swapped it over to just doing a getButton without any
change - I stepped through in advanced search, search builder, custom search, basic search it still enters the cache lines of code. In Contribution, event search it doesn't (before & after).

Part of just making code semi-readable

Comments
----------------------------------------

