### PR TITLE
dev/core#1217 Fix for failure to respect event_id (or any?) criteria in smart groups

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -362,9 +362,9 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     }
 
     $this->_done = TRUE;
-    $formValues = $this->getFormValues();
+    $this->setFormValues();
 
-    $this->submit($formValues);
+    $this->submit($this->_formValues);
   }
 
   /**
@@ -441,7 +441,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    *   the default array reference
    */
   public function setDefaultValues() {
-    $this->_defaults = parent::setDefaultValues();
+    $this->_defaults = array_merge(parent::setDefaultValues(), (array) $this->_formValues);
     $event = CRM_Utils_Request::retrieve('event', 'Positive');
     if ($event) {
       $this->_defaults['event_id'] = $event;

--- a/CRM/Event/Form/Task/SaveSearch.php
+++ b/CRM/Event/Form/Task/SaveSearch.php
@@ -99,12 +99,10 @@ class CRM_Event_Form_Task_SaveSearch extends CRM_Event_Form_Task {
     // saved search form values
     $formValues = $this->controller->exportValues();
 
-    $session = CRM_Core_Session::singleton();
-
     //save the search
     $savedSearch = new CRM_Contact_BAO_SavedSearch();
     $savedSearch->id = $this->_id;
-    $savedSearch->form_values = serialize($this->get('formValues'));
+    $savedSearch->form_values = serialize($this->get('queryParams'));
     $savedSearch->save();
     $this->set('ssID', $savedSearch->id);
     CRM_Core_Session::setStatus(ts("Your smart group has been saved as '%1'.", [1 => $formValues['title']]), ts('Saved'), 'success');


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a regression on creating a smart group from event search

Before
----------------------------------------
1) search by 2 events in event search
2) create a smart group from the results
3) reload the group- criteria are not respected

After
----------------------------------------
![Screen Shot 2020-01-17 at 4 46 48 PM](https://user-images.githubusercontent.com/336308/72583173-2d624700-394a-11ea-9a4d-f8d49fbdbce5.png)


Technical Details
----------------------------------------
From what I can tell it's possible to create smart groups from Advanced search & other contact searches & Membership Search & Event search.

Membership search actually just leverages advanced search but Event Search smart group has it's own code & reloads into Event search.

This has been flawed for months but the current iteration is the criteria are not respected. On digging I found the decision was made in
contact search to store the parsed QueryParams (in [field_name, 'IN', [1,2]] format not the formValues. I think this was probably a mistake.

However, by adjusting the event code to do the same & ensuring the defaults are set it starts working again

Comments
----------------------------------------

