### PR TITLE
[REF] Remove setting of unused function.

### DIFF
--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -246,8 +246,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       $prefix
     );
     $controller->setEmbedded(TRUE);
-
-    $query = &$selector->getQuery();
     $controller->run();
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Removes a line which sets a variable which is unused

Before
----------------------------------------
Variable set, not used

After
----------------------------------------
poof

Technical Details
----------------------------------------
The called function ONLY returns the query so nothing gained by getting a throw-away variable. 

Looks a lot like copy & pasta - see https://github.com/civicrm/civicrm-core/blob/804beb78d22830ffdfb702bff0637f5b0cfb15f6/CRM/Case/Form/Search.php#L253

Comments
----------------------------------------

