### PR TITLE
Remove function that exactly matches parent class.

### DIFF
--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -167,8 +167,7 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
   }
 
   /**
-   * Simple shell that derived classes can call to add buttons to
-   * the form with a customized title for the main Submit
+   * Add buttons to the form.
    *
    * @param string $title
    *   Title of the main button.

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -120,30 +120,4 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
     );
   }
 
-  /**
-   * Simple shell that derived classes can call to add buttons to.
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   * @param string $backType
-   * @param bool $submitOnce
-   *
-   * @return void
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-      [
-        'type' => $nextType,
-        'name' => $title,
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => $backType,
-        'name' => ts('Cancel'),
-      ],
-    ]);
-  }
-
 }


### PR DESCRIPTION


Overview
----------------------------------------
Removes override function that matches parent

Before
----------------------------------------
Same function exists in child & parent

After
----------------------------------------
I moved it over onto  the parent class fn & apart from minor comment block differences it matches. 

Technical Details
----------------------------------------


Comments
----------------------------------------

