### PR TITLE
dev/core#1535 - Fix missing address is_primary field

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -58,6 +58,7 @@ class CRM_Contact_Form_Edit_Address {
     $form->addField(
       "address[$blockId][is_primary]", [
         'entity' => 'address',
+        'type' => 'CheckBox',
         'label' => ts('Primary location for this contact'),
         'text' => ts('Primary location for this contact'),
       ] + $js);


### PR DESCRIPTION
Overview
----------------------------------------
Recent (unreleased) metadata change caused this field to disappear; this adds it back.

See https://lab.civicrm.org/dev/core/issues/1535

See https://github.com/civicrm/civicrm-core/pull/16312