### PR TITLE
(WIP) dev/core#1331 Don't freeze fields for auto-renew memberships

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -88,7 +88,14 @@
                 <div id="priceset" class="hiddenElement"></div>
               {/if}
             {/if}
-            {if $member_is_test} {ts}(test){/ts}{/if}<br />
+            {if $member_is_test} {ts}(test){/ts}{/if}
+            <span id="mem-type-override">
+              <a href="#" class="crm-hover-button action-item override-mem-type" id="show-mem-type">
+                {ts}Override organisation and type{/ts}
+              </a>
+              {help id="override_membership_type"}
+            </span>
+            <br />
             <span class="description">{ts}Select Membership Organization and then Membership Type.{/ts}{if $hasPriceSets} {ts}Alternatively, you can use a price set.{/ts}{/if}</span>
           </td>
         </tr>
@@ -126,7 +133,7 @@
           <td id="end-date-readonly">
               {$endDate|crmDate}
               <a href="#" class="crm-hover-button action-item override-date" id="show-end-date">
-                {ts}Over-ride end date{/ts}
+                {ts}Override end date{/ts}
               </a>
               {help id="override_end_date"}
           </td>
@@ -352,6 +359,22 @@
       setDifferentContactBlock();
       cj('#is_different_contribution_contact').change( function() {
         setDifferentContactBlock();
+      });
+
+      // give option to override membership type for auto-renew memberships - dev/core#1331
+      {/literal}
+      {if $isRecur && !$cancelAutoRenew}
+        cj('#mem_type_id select').attr("disabled","disabled");
+      {else}
+        cj('#mem-type-override').hide();
+      {/if}
+      {literal}
+
+      cj('#show-mem-type').click( function( e ) {
+        e.preventDefault();
+        // enable select buttons
+        cj('#mem_type_id select').removeAttr("disabled");
+        cj('#mem-type-override').hide();
       });
 
       // give option to override end-date for auto-renew memberships

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -13,6 +13,11 @@
     <div class="icon inform-icon"></div>
     <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status: <a href="%1">Cancel auto-renew</a>{/ts}</p>
   </div>
+{elseif $isRecur}
+  <div class="messages status no-popup">
+    <div class="icon inform-icon"></div>
+    <p>{ts}This membership is set to renew automatically. Please be aware that any changes that you make here may not be reflected in the payment processor. Please ensure that you alter the related subscription at the payment processor.{/ts}</p>
+  </div>
 {/if}
 <div class="spacer"></div>
 {if $priceSetId}

--- a/templates/CRM/Member/Page/Tab.hlp
+++ b/templates/CRM/Member/Page/Tab.hlp
@@ -23,8 +23,15 @@
 {/htxt}
 
 {htxt id="override_end_date-title"}
-  {ts}Override End Date for Auto-renew Memberships{/ts}
+  {ts}Override End Date for Auto-renew Membership{/ts}
 {/htxt}
 {htxt id="override_end_date"}
   <p>{ts}If CiviCRM's membership end-date is different from when the payment processor will next collect a payment, various problems can occur. Members may experience a gap in their membership, and the renewal date may get changed from what is manually entered. Use care when modifying the End Date value, and check the associated recurring payment in your payment processor system so they always match.{/ts}</p>
+{/htxt}
+
+{htxt id="override_membership_type-title"}
+{ts}Override Membership Type for Auto-renew Membership{/ts}
+{/htxt}
+{htxt id="override_membership_type"}
+  <p>{ts}This membership is set to renew automatically. Take care when you change the membership type. Make sure that you also change the related payment at the payment processor. Otherwise future payments may be for the wrong amount.{/ts}</p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------

If a membership is set to auto-renew some of the fields are frozen, which means that a user is unable to edit them when they visit the edit membership screen.

This PR changes this behaviour so that these fields are frozen only if the auto-renew can be cancelled. If the membership is auto-renew but can't be cancelled the fields aren't frozen and can be edited with an appropriate warning.

See https://lab.civicrm.org/dev/core/issues/1331 for more details and discussion.

Before
----------------------------------------
If the membership is set to auto-renew, the following fields are frozen (whether or not the auto-renew can be cancelled):

-  Membership organisation / Membership type
-  Membership status

![image](https://user-images.githubusercontent.com/13518928/72629878-140ccb00-3949-11ea-8595-e21c14ded00d.png)

After
----------------------------------------
If the membership is set to auto-renew and it is possible to cancel the auto-renewal the fields are frozen (no change).

![image](https://user-images.githubusercontent.com/13518928/72629797-ee7fc180-3948-11ea-8a87-add9012e3fee.png)

If the membership is set to auto-renew and it is _not_ possible to cancel the auto-renewal the fields are _not_ frozen  and the user has the ability to override them if required. Help text with an appropriate warning is displayed.

![image](https://user-images.githubusercontent.com/13518928/72629743-cf812f80-3948-11ea-8e2e-81bc677ac56c.png)

Technical Details
----------------------------------------
None

Comments
----------------------------------------
The end date field was unfrozen in #15505. See https://lab.civicrm.org/dev/core/issues/1126 for details.
