### PR TITLE
REF Minor cleanup for Job/JobLog pages

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -118,12 +118,6 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
       $this, FALSE, 0
     );
 
-    // FIXME: Why are we comparing an integer with a string here?
-    if ($this->_action == 'export') {
-      $session = CRM_Core_Session::singleton();
-      $session->pushUserContext(CRM_Utils_System::url('civicrm/admin/job', 'reset=1'));
-    }
-
     if (($this->_action & CRM_Core_Action::COPY) && (!empty($this->_id))) {
       try {
         $jobResult = civicrm_api3('Job', 'clone', array('id' => $this->_id));

--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -142,10 +142,8 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
 
   /**
    * Browse all jobs.
-   *
-   * @param null $action
    */
-  public function browse($action = NULL) {
+  public function browse() {
     // check if non-prod mode is enabled.
     if (CRM_Core_Config::environment() != 'Production') {
       CRM_Core_Session::setStatus(ts('Execution of scheduled jobs has been turned off by default since this is a non-production environment. You can override this for particular jobs by adding runInNonProductionEnvironment=TRUE as a parameter.'), ts("Non-production Environment"), "warning", array('expires' => 0));

--- a/CRM/Admin/Page/JobLog.php
+++ b/CRM/Admin/Page/JobLog.php
@@ -71,11 +71,8 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
 
   /**
    * Browse all jobs.
-   *
-   * @param null $action
    */
-  public function browse($action = NULL) {
-
+  public function browse() {
     $jid = CRM_Utils_Request::retrieve('jid', 'Positive', $this);
 
     $sj = new CRM_Core_JobManager();


### PR DESCRIPTION
Overview
----------------------------------------
Remove never reached code + unused function parameters.

Before
----------------------------------------
Stuff we don't need

After
----------------------------------------
Less stuff we don't need

Technical Details
----------------------------------------

Comments
----------------------------------------
I have a follow-up PR that adds an "Execute Now" button to the log page.