### PR TITLE
dev/core#1537 Don't append multiple copies of the eligible related contacts text

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -90,7 +90,7 @@
         <tr id="maxRelated" class="crm-membership-form-block-max_related">
           <td class="label">{$form.max_related.label}</td>
           <td>{$form.max_related.html}<br />
-            <span class="description">{ts}Maximum number of related memberships (leave blank for unlimited).{/ts}</span>
+            <span class="description">{ts}Maximum number of related memberships (leave blank for unlimited).{/ts} <span id="eligibleRelated"></span></span>
           </td>
         </tr>
         {if $action eq 1}
@@ -664,7 +664,7 @@
                 relatable = '{/literal}{ts escape='js' 1='%1'}%1 contacts are currently eligible to inherit this relationship.{/ts}{literal}';
                 relatable = ts(relatable, {1: result});
               }
-              cj('#max_related').siblings('.description').append(' ' + relatable);
+              cj('#eligibleRelated').text(relatable);
             }
           });
         }


### PR DESCRIPTION
Overview
----------------------------------------
Prevent multiple copies of the eligible related contacts text appearing on the edit membership page.

See https://lab.civicrm.org/dev/core/issues/1537

Before
----------------------------------------
If you look at the text next to the 'Max Related' field you will see multiple copies of 'One contact is currently eligible to inherit this relationship.'

![image](https://user-images.githubusercontent.com/13518928/72647100-9dcf8f00-396f-11ea-921d-e422867137c3.png)

After
----------------------------------------
Only one copy of this text is displayed.

![image](https://user-images.githubusercontent.com/13518928/72647138-b475e600-396f-11ea-9bb9-eb5bd5c24293.png)

Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.
