### PR TITLE
[REF] Eliminate silly parameter from function signature.

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1184,7 +1184,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $contributions[] = $contribution = CRM_Event_Form_Registration_Confirm::processContribution(
         $this, $this->_params,
         $result, $contactID,
-        FALSE, FALSE,
+        FALSE,
         $this->_paymentProcessor
       );
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -576,13 +576,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           // if paid event add a contribution record
           //if primary participant contributing additional amount
           //append (multiple participants) to its fee level. CRM-4196.
-          $isAdditionalAmount = FALSE;
           if (count($params) > 1) {
-            $isAdditionalAmount = TRUE;
+            $value['amount_level'] .= ts(' (multiple participants)') . CRM_Core_DAO::VALUE_SEPARATOR;
           }
 
           //passing contribution id is already registered.
-          $contribution = self::processContribution($this, $value, $result, $contactID, $pending, $isAdditionalAmount, $this->_paymentProcessor);
+          $contribution = self::processContribution($this, $value, $result, $contactID, $pending, $this->_paymentProcessor);
           $value['contributionID'] = $contribution->id;
           $value['contributionTypeID'] = $contribution->financial_type_id;
           $value['receive_date'] = $contribution->receive_date;
@@ -904,7 +903,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
    * @param array $result
    * @param int $contactID
    * @param bool $pending
-   * @param bool $isAdditionalAmount
    * @param array $paymentProcessor
    *
    * @return \CRM_Contribute_BAO_Contribution
@@ -914,7 +912,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
    */
   public static function processContribution(
     &$form, $params, $result, $contactID,
-    $pending = FALSE, $isAdditionalAmount = FALSE,
+    $pending = FALSE,
     $paymentProcessor = NULL
   ) {
     $transaction = new CRM_Core_Transaction();
@@ -924,10 +922,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
     if (!empty($form->_values['event']['is_email_confirm'])) {
       $receiptDate = $now;
-    }
-    //CRM-4196
-    if ($isAdditionalAmount) {
-      $params['amount_level'] = $params['amount_level'] . ts(' (multiple participants)') . CRM_Core_DAO::VALUE_SEPARATOR;
     }
 
     // CRM-20264: fetch CC type ID and number (last 4 digit) and assign it back to $params


### PR DESCRIPTION
Overview
----------------------------------------
Removes the isAdditionalAmount parameter which is only used to adjust the amount key on the value variable.



Before
----------------------------------------
Parameter set, passed through, used to set array key

After
----------------------------------------
Array key set

Technical Details
----------------------------------------
Value is reset each participant so we don't need to worry about it being 'cumulative'

Comments
----------------------------------------

