### PR TITLE
[REF] Move assignment of BalanceAmount

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1343,6 +1343,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
             $contributionParams['partial_payment_total'] = $amountOwed;
             // the actual amount paid
             $contributionParams['partial_amount_to_pay'] = $params['total_amount'];
+            $this->assign('balanceAmount', $contributionParams['partial_payment_total'] - $contributionParams['partial_amount_to_pay']);
           }
         }
 
@@ -1446,11 +1447,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         }
 
         $this->assign('totalAmount', $contributionParams['total_amount']);
-        if (isset($contributionParams['partial_payment_total'])) {
-          // balance amount
-          $balanceAmount = $contributionParams['partial_payment_total'] - $contributionParams['partial_amount_to_pay'];
-          $this->assign('balanceAmount', $balanceAmount);
-        }
         $this->assign('isPrimary', 1);
         $this->assign('checkNumber', CRM_Utils_Array::value('check_number', $params));
       }


### PR DESCRIPTION


Overview
----------------------------------------
This moves the assignment of balanceAmount to where the partial_payment_total is  determined.

Before
----------------------------------------
Partial_amount details determined in one place in the code & relevant assignments done in another

After
----------------------------------------
Handling of partial_amount_to_pay done in one place

Technical Details
----------------------------------------


Template assignments happen all over the place so it makes more sense to group this
which where the values are determined

Comments
----------------------------------------
Note that this is part of cleanup towards handling 'partial_amount_to_pay' in the form layer & deprecating it out of BAO_Contribution::create. It relates to an early concept of partial payments before the Order->Payment flow was decided on & in unit tests has been buggy as well as creating a lot of complexity in the financial code
