### PR TITLE
Remove skipCleanMoney - this is set where contributionParams is used

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1844,7 +1844,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   protected function preparePaidEventProcessing($params): array {
     $participantStatus = CRM_Event_PseudoConstant::participantStatus();
-    $contributionParams = ['skipCleanMoney' => TRUE];
     $lineItem = [];
     $additionalParticipantDetails = [];
     if (Civi::settings()->get('deferred_revenue_enabled')) {


### PR DESCRIPTION
Overview
----------------------------------------
Removes duplicate setting of an array property

Before
----------------------------------------
$contributionParams['skipCleanMoney'] set early on & again  shortly before it is used

After
----------------------------------------
Only set once, shortly before it is used

Technical Details
----------------------------------------
$contributionParams is used to create a contribution & skipCleanMoney is set again here
https://github.com/civicrm/civicrm-core/blob/cf419834f90e9bdfc109b6c50c89f5cd37706183/CRM/Event/Form/Participant.php#L1314

Comments
----------------------------------------
The code that $contributionParams is used in can be extracted but first I want to remove / move a few places that set variables to do with it for a cleaner extraction
