### PR TITLE
Add user friendly error message on merge error

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -87,11 +87,16 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       if (!$this->_rgid) {
         // Unset browse URL as we have come from the search screen.
         $browseUrl = '';
-        $this->_rgid = civicrm_api3('RuleGroup', 'getvalue', [
-          'contact_type' => $this->_contactType,
-          'used' => 'Supervised',
-          'return' => 'id',
-        ]);
+        try {
+          $this->_rgid = civicrm_api3('RuleGroup', 'getvalue', [
+            'contact_type' => $this->_contactType,
+            'used' => 'Supervised',
+            'return' => 'id',
+          ]);
+        }
+        catch (Exception $e) {
+          throw new CRM_Core_Exception(ts('There is no Supervised dedupe rule configured for contact type %1.', [1 => $this->_contactType]));
+        }
       }
       $this->assign('browseUrl', $browseUrl);
       if ($browseUrl) {


### PR DESCRIPTION
Overview
----------------------------------------
Add user friendly error message on merge error.

Before
----------------------------------------
When a user tries to merge 2 contacts from an Advanced search screen, the following error is displayed if there is no Supervised rule present on the site.

![image](https://user-images.githubusercontent.com/5929648/72702340-57994c00-3b78-11ea-8ad2-1e9e9d886415.png)

After
----------------------------------------
Display user-friendly error message -

![image](https://user-images.githubusercontent.com/5929648/72702312-44867c00-3b78-11ea-9ee9-ae4fea41325c.png)

Comments
----------------------------------------
Gitlab -  https://lab.civicrm.org/dev/core/issues/1540