### PR TITLE
When viewing a membership show if the status is overridden

### DIFF
--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -44,7 +44,7 @@
         {if $has_related}
             <tr><td class="label">{ts}Max related{/ts}</td><td>{$max_related}</td></tr>
         {/if}
-        <tr><td class="label">{ts}Status{/ts}</td><td>{$status}</td></tr>
+        <tr><td class="label">{ts}Status{/ts}</td><td>{$status} {if $member_is_override}({ts}Overridden{/ts}){/if}</td></tr>
         <tr><td class="label">{ts}Source{/ts}</td><td>{$source}</td></tr>
   {if $campaign}<tr><td class="label">{ts}Campaign{/ts}</td><td>{$campaign}</td></tr>{/if}
         <tr><td class="label">{ts}Member Since{/ts}</td><td>{$join_date|crmDate}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
When viewing a membership there is no (simple) way of knowing if the membership status has been overridden.

Before
----------------------------------------
Cannot see if status is overridden.

After
----------------------------------------
Can easily see if status is overridden:
![image](https://user-images.githubusercontent.com/2052161/72737826-3f392980-3b98-11ea-85ad-c2b11c29eef2.png)


Technical Details
----------------------------------------
Just a one line tpl change

Comments
----------------------------------------
@wmortada Would you be able to review this one?