### PR TITLE
[NFC] Remove unused local variables from CRM_Contribute_Form_AdditionalPayment::processCreditCard

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -362,8 +362,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $config = CRM_Core_Config::singleton();
     $session = CRM_Core_Session::singleton();
 
-    $now = date('YmdHis');
-
     // we need to retrieve email address
     if ($this->_context == 'standalone' && !empty($this->_params['is_email_receipt'])) {
       list($this->userDisplayName,

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -363,7 +363,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $session = CRM_Core_Session::singleton();
 
     $now = date('YmdHis');
-    $fields = [];
 
     // we need to retrieve email address
     if ($this->_context == 'standalone' && !empty($this->_params['is_email_receipt'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused local variable $fields in \CRM_Contribute_Form_AdditionalPayment::processCreditCard. Hinted by PHPStorm unused ocal variable code inspection, and checked manually.
