### PR TITLE
Api4 - Make abstract function abstract

### DIFF
--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -52,13 +52,9 @@ abstract class AbstractEntity {
   }
 
   /**
-   * Should return \Civi\Api4\Generic\BasicGetFieldsAction
-   * @todo make this function abstract when we require php 7.
-   * @throws \Civi\API\Exception\NotImplementedException
+   * @return \Civi\Api4\Generic\BasicGetFieldsAction
    */
-  public static function getFields() {
-    throw new NotImplementedException(self::getEntityName() . ' should implement getFields action.');
-  }
+  abstract public static function getFields();
 
   /**
    * Returns a list of permissions needed to access the various actions in this api.


### PR DESCRIPTION
Overview
----------------------------------------
This makes a function abstract that was behaving as if it was but not actually declared abstract because php 5.x didn't support that.

Before
----------------------------------------
Abstract function not really abstract for php 5.x support.

After
----------------------------------------
Bye bye PHP 5. Hello abstract static functions.
