### PR TITLE
dev/core#1116 Wrong linebreaks viewing Inbound Emails when activity type label is changed

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -42,7 +42,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
   public $_activityTypeId;
 
   /**
-   * The name of activity type.
+   * The label of the activity type.
+   * Unfortunately this variable is called Name but don't want to change it
+   * since it's public and might be commonly used in customized code. See also
+   * activityTypeNameAndLabel used in the smarty template.
    *
    * @var string
    */

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -134,13 +134,11 @@
   </tr>
   <tr class="crm-activity-form-block-details">
     <td class="label">{$form.details.label}</td>
-    {* activityTypeName means label here not name, but it should be name (dev/core#1116-fixme) *}
-    {if $activityTypeName eq "Print PDF Letter"}
+    {if $activityTypeNameAndLabel.machineName eq "Print PDF Letter"}
       <td class="view-value">
       {$form.details.html}
       </td>
-    {* activityTypeName means label here not name, but it should be name (dev/core#1116-fixme) *}
-    {elseif $activityTypeName eq "Inbound Email"}
+    {elseif $activityTypeNameAndLabel.machineName eq "Inbound Email"}
       <td class="view-value">
        {$form.details.html|crmStripAlternatives|nl2br}
       </td>

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -63,6 +63,9 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
     $form->_allContactIds = $form->_toContactIds = $form->_contactIds;
     $form->_emails = [$loggedInEmail['id'] => 'mickey@mouse.com'];
     $form->_fromEmails = [$loggedInEmail['id'] => 'mickey@mouse.com'];
+    // This rule somehow disappears if there's a form-related test before us,
+    // so register it again. See packages/HTML/QuickForm/file.php.
+    $form->registerRule('maxfilesize', 'callback', '_ruleCheckMaxFileSize', 'HTML_QuickForm_file');
     CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($form);
     CRM_Contact_Form_Task_EmailCommon::buildQuickForm($form);
     CRM_Contact_Form_Task_EmailCommon::submit($form, array_merge($form->_defaultValues, [


### PR DESCRIPTION
Overview
----------------------------------------
Another variation of incorrect use of name vs label.

Inbound emails don't have the correct line breaks when viewing the activity if you've changed the label.

https://lab.civicrm.org/dev/core/issues/1116#note_30276

Before
----------------------------------------
Why so squishy?

<img width="512" alt="before" src="https://user-images.githubusercontent.com/2967821/72784399-be5d4a80-3bf6-11ea-80ff-c3a27c438003.png">

After
----------------------------------------
Not so squishy. Looks awesome.

<img width="510" alt="after" src="https://user-images.githubusercontent.com/2967821/72784407-c321fe80-3bf6-11ea-99b7-5b900f472af5.png">


Technical Details
----------------------------------------
Name. Label.

Comments
----------------------------------------
Has test. It's awful but open to ideas.
