### PR TITLE
Remove irrelevant code.

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1670,15 +1670,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $form->addElement('hidden', 'hidden_eventFullMsg', $eventfullMsg, ['id' => 'hidden_eventFullMsg']);
     }
 
-    if ($form->_pId) {
-      if (CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment',
-        $form->_pId, 'contribution_id', 'participant_id'
-      )
-      ) {
-        $form->_online = !$form->isBackOffice;
-      }
-    }
-
     if ($form->_isPaidEvent) {
       $params = ['id' => $form->_eventId];
       CRM_Event_BAO_Event::retrieve($params, $event);
@@ -1716,10 +1707,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           FALSE,
           ['class' => "crm-select2"]
         );
-
-        if ($form->_online) {
-          $element->freeze();
-        }
       }
       if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
         && !CRM_Utils_Array::value('fee', $form->_values)

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -372,9 +372,7 @@
           {if $urlPathVar}
           dataUrl += '&' + '{$urlPathVar}';
           {/if}
-          {if $isBackOffice}
-            dataUrl += '&' + 'is_backoffice=1';
-          {/if}
+          dataUrl += '&' + 'is_backoffice=1';
 
           {literal}
           var eventId = $('[name=event_id], #event_id', $form).val();


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/16337 we determined this function is not static & is only called by the backoffice participant form. If that is the case then isBackOffice is always true & these lines don't do anything.

Before
----------------------------------------
Extra lines for confusion

After
----------------------------------------
Lines gone

Technical Details
----------------------------------------
Note these lines were last touched here https://github.com/civicrm/civicrm-core/pull/14732/files - but that was actually as part of 'watering down' code that was probably written for the day when these lines were shared with another form

Comments
----------------------------------------
@demeritcowboy I think this is the next follow up that makes sense from making the fn static (note these lines give an enotice if I try to run tests through them currently)