### PR TITLE
Remove unreachable code lines.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1106,12 +1106,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     if (self::isContributionUpdateARefund($params['prevContribution']->contribution_status_id, $params['contribution']->contribution_status_id)) {
       // @todo we should stop passing $params by reference - splitting this out would be a step towards that.
       $params['trxnParams']['total_amount'] = -$params['total_amount'];
-      if (empty($params['contribution']->creditnote_id)) {
-        // This is always set in the Contribution::create function.
-        CRM_Core_Error::deprecatedFunctionWarning('Logic says this line is never reached & can be removed');
-        $creditNoteId = self::createCreditNoteId();
-        CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution']->id, 'creditnote_id', $creditNoteId);
-      }
     }
     elseif (($previousContributionStatus == 'Pending'
         && $params['prevContribution']->is_pay_later) || $previousContributionStatus == 'In Progress'
@@ -1123,12 +1117,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         // @todo we should stop passing $params by reference - splitting this out would be a step towards that.
         $params['trxnParams']['to_financial_account_id'] = $arAccountId;
         $params['trxnParams']['total_amount'] = -$params['total_amount'];
-        if (empty($params['contribution']->creditnote_id)) {
-          // This is always set in the Contribution::create function.
-          CRM_Core_Error::deprecatedFunctionWarning('Logic says this line is never reached & can be removed');
-          $creditNoteId = self::createCreditNoteId();
-          CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution']->id, 'creditnote_id', $creditNoteId);
-        }
       }
       else {
         // @todo we should stop passing $params by reference - splitting this out would be a step towards that.

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -268,14 +268,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       }
 
       if ($contribution->contribution_status_id == $refundedStatusId || $contribution->contribution_status_id == $cancelledStatusId) {
-        if (is_null($contribution->creditnote_id)) {
-          CRM_Core_Error::deprecatedFunctionWarning('This it the wrong place to add a credit note id since the id is added when the status is changed in the Contribution::Create function- hopefully it is never hit');
-          $creditNoteId = CRM_Contribute_BAO_Contribution::createCreditNoteId();
-          CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $contribution->id, 'creditnote_id', $creditNoteId);
-        }
-        else {
-          $creditNoteId = $contribution->creditnote_id;
-        }
+        $creditNoteId = $contribution->creditnote_id;
       }
       if (!$contribution->invoice_number) {
         $contribution->invoice_number = CRM_Contribute_BAO_Contribution::getInvoiceNumber($contribution->id);


### PR DESCRIPTION
Overview
----------------------------------------
Removes lines of code for setting credit-note-id that were previously identified as unreachable

Before
----------------------------------------
Lines present - deprecation notices would have been seen if anyone hit them over the last few months (in a dev env or a unit test at least)

After
----------------------------------------
Lines gone - note that they call a very slow function that we aspire to moving out to an optional extension

Technical Details
----------------------------------------
We were very precautionary in Barcelona & deprecated rather than removing these line. However, we've had
several releases including a security release & an ESR since then with no one reporting hitting these so
they can go now

Comments

