### PR TITLE
dev/translation#35 Display the CiviCRM Resources dashlet in the user's language

### DIFF
--- a/CRM/Dashlet/Page/GettingStarted.php
+++ b/CRM/Dashlet/Page/GettingStarted.php
@@ -72,13 +72,15 @@ class CRM_Dashlet_Page_GettingStarted extends CRM_Core_Page {
    * @return array
    */
   private function _gettingStarted() {
-    $value = Civi::cache('community_messages')->get('dashboard_gettingStarted');
+    $tsLocale = CRM_Core_I18n::getLocale();
+    $key = 'dashboard_gettingStarted_' . $tsLocale;
+    $value = Civi::cache('community_messages')->get($key);
 
     if (!$value) {
       $value = $this->_getHtml($this->gettingStartedUrl());
 
       if ($value) {
-        Civi::cache('community_messages')->set('dashboard_gettingStarted', $value, (60 * 60 * 24 * self::CACHE_DAYS));
+        Civi::cache('community_messages')->set($key, $value, (60 * 60 * 24 * self::CACHE_DAYS));
       }
     }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1786,13 +1786,14 @@ class CRM_Utils_System {
     }
     else {
       $config = CRM_Core_Config::singleton();
+      $tsLocale = CRM_Core_I18n::getLocale();
       $vars = [
         '{ver}' => CRM_Utils_System::version(),
         '{uf}' => $config->userFramework,
         '{php}' => phpversion(),
         '{sid}' => self::getSiteID(),
         '{baseUrl}' => $config->userFrameworkBaseURL,
-        '{lang}' => $config->lcMessages,
+        '{lang}' => $tsLocale,
         '{co}' => $config->defaultContactCountry,
       ];
       return strtr($url, array_map('urlencode', $vars));


### PR DESCRIPTION
Overview
----------------------------------------

This fixes the CiviCRM Resources dashlet language. It was previously not possible for users to understand it,  unless they understand English.

To reproduce:

* Go to Localization Settings: https://dmaster.demo.civicrm.org/civicrm/admin/setting/localization?reset=1
* Under "Available languages", add "French (France)"
* Switch languages: https://dmaster.demo.civicrm.org/civicrm?reset=1&lcMessages=fr_FR
* Click "configurer votre tableau de bord" (configure dashboard)
* Add "CiviCRM Resources"

Now notice that the dashlet is still in English.

Gitlab: https://lab.civicrm.org/dev/translation/issues/35

Before
----------------------------------------

The dashlet was always in English.

After
----------------------------------------

The dashlet might be available in other languages (at the moment, only fr_FR and fr_CA are available, but more will come soon).

Technical Details
----------------------------------------

This also changes the caching so that it caches per-language. Otherwise, the first user to load the dashlet wins.

* Resource on Transifex: https://www.transifex.com/civicrm/civicrm_misc/alerts/
* Example URL: https://alert.civicrm.org/welcome?prot=1&ver=5.22&uf=UnitTests&sid=12345678901234567890123456789012&lang=fr_FR&co=1013