### PR TITLE
(dev/core#1546) Fix translation of seed data

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -774,10 +774,6 @@ function ts($text, $params = []) {
         $function = $config->customTranslateFunction;
       }
     }
-    else {
-      // don't _translate_ anything until bootstrap has progressed enough
-      $params['skip_translation'] = 1;
-    }
   }
 
   $activeLocale = CRM_Core_I18n::getLocale();

--- a/tests/phpunit/E2E/Core/LocalizedDataTest.php
+++ b/tests/phpunit/E2E/Core/LocalizedDataTest.php
@@ -12,6 +12,13 @@ class LocalizedDataTest extends \CiviEndToEndTestCase {
   /**
    * Smoke test to check that "civicrm_data*.mysql" files contain
    * translated strings.
+   *
+   * Note: As currently written, this test relies on the output of setup.sh/GenCode.
+   * Consequently, if you're running locally while iterating on the code, you may find
+   * the following command helps with your dev-test loop:
+   *
+   * $ env CIVICRM_LOCALES=en_US,fr_FR,de_DE ./bin/setup.sh -g \
+   *   && phpunit6 tests/phpunit/E2E/Core/LocalizedDataTest.php
    */
   public function testLocalizedData() {
     $getSql = function($locale) {

--- a/tests/phpunit/E2E/Core/LocalizedDataTest.php
+++ b/tests/phpunit/E2E/Core/LocalizedDataTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace E2E\Core;
+
+/**
+ * Class LocalizedDataTest
+ * @package E2E\Core
+ * @group e2e
+ */
+class LocalizedDataTest extends \CiviEndToEndTestCase {
+
+  /**
+   * Smoke test to check that "civicrm_data*.mysql" files contain
+   * translated strings.
+   */
+  public function testLocalizedData() {
+    $getSql = function($locale) {
+      $path = \Civi::paths()->getPath("[civicrm.root]/sql/civicrm_data.{$locale}.mysql");
+      $this->assertFileExists($path);
+      return file_get_contents($path);
+    };
+    $sqls = [
+      'de_DE' => $getSql('de_DE'),
+      'fr_FR' => $getSql('fr_FR'),
+    ];
+    $pats = [
+      'de_DE' => '/new_organization.*Neue Organisation/i',
+      'fr_FR' => '/new_organization.*Nouvelle organisation/i',
+    ];
+
+    $match = function($sqlLocale, $patLocale) use ($pats, $sqls) {
+      return (bool) preg_match($pats[$patLocale], $sqls[$sqlLocale]);
+    };
+
+    $this->assertTrue($match('de_DE', 'de_DE'), 'The German SQL should match the German pattern.');
+    $this->assertTrue($match('fr_FR', 'fr_FR'), 'The French SQL should match the French pattern.');
+    $this->assertFalse($match('de_DE', 'fr_FR'), 'The German SQL should not match the French pattern.');
+    $this->assertFalse($match('fr_FR', 'de_DE'), 'The French SQL should not match the German pattern.');
+  }
+
+}


### PR DESCRIPTION
Overview
--------

This fixes a regression in which seed data is not translated.

See also: https://lab.civicrm.org/dev/core/issues/1546

Before
------

The `civicrm_data.*.mysql` files are not translated.

After
-----

The `civicrm_data.*.mysql` files are translated.

There's a unit-test to check this.

Comments
--------

This regression stems from #15411, which aimed to allow extensions to define custom variants of `ts()`.  The crux of the issue is "What happens if you try to translate a string before the system is bootstrapped - before the extension is loaded?  What's your fallback behavior?"

In #15411, it used a fallback behavior of "do no translation".  In theory, you shouldn't really get into this scenario since UIs are pretty much always generated post-boot. So that seems reasonable enough.

However, it turns out that there is a situation where you have an un-booted system and need to translate strings -- i.e. when generating the localized `civicrm_data.*.mysql` data.  Hence the bug.

This patch preserves most of the changes from #15411, but it changes the fallback behavior from "do no translation" to "use the built-in/default translator".