### PR TITLE
dev/core#1547 Add DT_RowClass CSS classes to nested group markup

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -213,7 +213,15 @@
             "success": function(response){
               var appendHTML = '';
               $.each( response.data, function( i, val ) {
-                appendHTML += '<tr id="row_'+val.group_id+'_'+parent_id+'" data-entity="group" data-id="'+val.group_id+'" class="crm-entity parent_is_'+parent_id+' crm-row-child">';
+                val.row_classes = [
+                  'crm-entity',
+                  'parent_is_' + parent_id,
+                  'crm-row-child'
+                ];
+                if ('DT_RowClass' in val) {
+                  val.row_classes = val.row_classes.concat(val.DT_RowClass.split(' ').filter((item) => val.row_classes.indexOf(item) < 0));
+                }
+                appendHTML += '<tr id="row_'+val.group_id+'_'+parent_id+'" data-entity="group" data-id="'+val.group_id+'" class="' + val.row_classes.join(' ') + '">';
                 if ( val.is_parent ) {
                   appendHTML += '<td class="crm-group-name crmf-title ' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span><div class="crmf-title {$editableClass}" style="display:inline">{literal}' + val.title + '</div></td>';
                 }


### PR DESCRIPTION
Overview
----------------------------------------
The Group search form template does not use jquery.datatables for loading child rows. That might be ok, since it's working without it, but there are CSS classes in each `response.data.DT_RowClass` and maybe other properties that are not being injected into the template.
This makes it difficult to distinguish nested groups from their parents and subsequent non-nested groups, since the CSS class `crm-group-child` (which actually has CSS for visual nesting) is being added to the `DT_RowClass` attribute in PHP code, but that is not added to the actual markup.

Before
----------------------------------------
Nested groups are not indented in the group list.

After
----------------------------------------
CSS for nesting child groups is now applied (since the CSS class is there) and nested groups are indented in the group list.

Technical Details
----------------------------------------
This adds all CSS classes in `DT_RowClass` to the actual markup, so that the class `crm-group-child`, which is added to that property in `CRM_Contact_BAO_Group::getGroupList()` gets actually printed to the markup.

Comments
----------------------------------------
Using jquery.datatables for loading child groups would be the better solution, as already noted in the `TODO` in the code.