### PR TITLE
Duplicate code (for real)

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -692,7 +692,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
 
     // add participant record
-    $participant = CRM_Event_Form_Registration::addParticipant($this, $contactID);
+    $participant = $this->addParticipant($this, $contactID);
     $this->_participantIDS[] = $participant->id;
 
     //setting register_by_id field and primaryContactId
@@ -778,10 +778,11 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @return \CRM_Event_BAO_Participant
    * @throws \CiviCRM_API3_Exception
    */
-  public static function addParticipant(&$form, $contactID) {
+  protected function addParticipant(&$form, $contactID) {
     if (empty($form->_params)) {
       return NULL;
     }
+    // Note this used to be shared with the backoffice form & no longer is, some code may no longer be required.
     $params = $form->_params;
     $transaction = new CRM_Core_Transaction();
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -581,7 +581,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           }
 
           //passing contribution id is already registered.
-          $contribution = self::processContribution($this, $value, $result, $contactID, $pending, $this->_paymentProcessor);
+          $contribution = $this->processContribution($this, $value, $result, $contactID, $pending, $this->_paymentProcessor);
           $value['contributionID'] = $contribution->id;
           $value['contributionTypeID'] = $contribution->financial_type_id;
           $value['receive_date'] = $contribution->receive_date;
@@ -910,11 +910,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function processContribution(
+  protected function processContribution(
     &$form, $params, $result, $contactID,
     $pending = FALSE,
     $paymentProcessor = NULL
   ) {
+    // Note this used to be shared with the backoffice form & no longer is, some code may no longer be required.
     $transaction = new CRM_Core_Transaction();
 
     $now = date('YmdHis');


### PR DESCRIPTION
Overview
----------------------------------------
Work towards code cleanup by separating backoffice event form code from online event form

Before
----------------------------------------
Static Function shared between the 2 forms

After
----------------------------------------
Protected non-static function exists on each form.

Technical Details
----------------------------------------
This is going to seem unintuitive but I'm sure the path to cleaning up the participant form starts with
increasing code duplication.

Currently the code is sharing 2 functions with the front end form. The functions don't do a lot of actual processing
but they do do a lot of preparing parameters. The calling functions do a lot of pre-work to call them - so
we are not getting much benefit from the sharing. On the other hand having this code tied up with another form makes
it hard for us to do the 'right' sharing - ie. currently the code to create a contribution paid by credit card & participant record is totally different to another payment method & we should work to share these bits of functionality

Comments
----------------------------------------

