### PR TITLE
event#32: Fix bad variable in message template

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -201,10 +201,11 @@ class CRM_Upgrade_Incremental_MessageTemplates {
       ],
       [
         'version' => '5.23.alpha1',
-        'upgrade_descriptor' => ts('Add Contributor Name to Offline Contribution receipts'),
+        'upgrade_descriptor' => ts('Add Contributor Name to Offline Contribution receipts; fix bad event self-service URL'),
         'templates' => [
           ['name' => 'contribution_offline_receipt', 'type' => 'text'],
           ['name' => 'contribution_offline_receipt', 'type' => 'html'],
+          ['name' => 'participant_confirm', 'type' => 'html'],
         ],
       ],
 

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -39,7 +39,7 @@
   {/if}
   {if $event.allow_selfcancelxfer }
   {ts}This event allows for{/ts}
-  {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participantID`&{contact.checksum}" h=0 a=1 fe=1}{/capture}
+  {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}" h=0 a=1 fe=1}{/capture}
        <a href="{$selfService}"> {ts}self service cancel or transfer{/ts}</a>
   {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
There's an incorrect variable in the "Confirm Invitation" message template.

Before
----------------------------------------
Bad URL for self-service updates.

After
----------------------------------------
Good URL for self-service updates.