### PR TITLE
dev/core#1364 Merge all addresses on export should INCLUDE merging households

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1248,10 +1248,10 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'ids' => $contactIDs,
       'mergeSameAddress' => TRUE,
     ]);
-    // @todo - the below is commented out because it does not yet work.
-    //$this->assertCount(1, $this->csv);
+
+    $this->assertCount(1, $this->csv);
     $row = $this->csv->fetchOne();
-    //$this->assertEquals('Household', $this->csv->fetchOne()['Contact Type']);
+    $this->assertEquals('Household', $this->csv->fetchOne()['Contact Type']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes Merge Same Address behaviour to be per the help text

"Use one of the merge contact options when exporting records to reduce your mailing size by sending a single piece of mail to each address.

Merge Contacts with the Same Address will combine any records having the same address (street address, city, postal code, country) into a single record. If a household record already exists in which multiple individuals share an address, the household will be exported as the combined record. If no household record exists, the records will be combined and the Addressee field will list the contact names, comma-separated.

Merge Household Members into their Households will export the household record for any contacts sharing a household address."


Before
----------------------------------------
This part of the help text does not happen. Merge same address is exclusive of mergeSameHousehold

" If a household record already exists in which multiple individuals share an address, the household will be exported as the combined record."

After
----------------------------------------
 Merge same address is inclusive of mergeSameHousehold

Technical Details
----------------------------------------
This is an alternate to https://github.com/civicrm/civicrm-core/pull/15725 that still achieves the goal in
https://github.com/civicrm/civicrm-core/pull/15725#issuecomment-572408173 of making is so that the
mergeSharedAddress option mergesHouseholds first & then merges sharedAddresses.

In #15725 @monishdeb was fixing the code that differentiated between how master_id was treated
versus otherwise merged addresses. However that code 'broke' a long time ago and the arguably
broken behaviour is locked in by unit tests. Fixing it has not been requested - in this
issue or any other in the past year or 2 when it has been broken so I opted to remove the broken
code entirely & to open up the next query such that it does not exclude household addresses.
This didn't break any tests (woot) and also allowed me to enable the test rows @monishdeb wrote
to test this issue


Comments
----------------------------------------

