### PR TITLE
NFC Add parameter definition to membershipstatus.calc

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2259,10 +2259,9 @@ WHERE      civicrm_membership.is_test = 0
 
       // CRM-7248: added excludeIsAdmin param to the following fn call to prevent moving to admin statuses
       //get the membership status as per id.
-      $newStatus = civicrm_api('membership_status', 'calc',
+      $newStatus = civicrm_api3('membership_status', 'calc',
         [
           'membership_id' => $dao2->membership_id,
-          'version' => 3,
           'ignore_admin_only' => TRUE,
         ], TRUE
       );

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -173,4 +173,7 @@ SELECT start_date, end_date, join_date, membership_type_id
 function _civicrm_api3_membership_status_calc_spec(&$params) {
   $params['membership_id']['api.required'] = 1;
   $params['membership_id']['title'] = 'Membership ID';
+  $params['ignore_admin_only']['title'] = 'Ignore admin only statuses';
+  $params['ignore_admin_only']['description'] = 'Ignore statuses that are for admin/manual assignment only';
+  $params['ignore_admin_only']['type'] = CRM_Utils_Type::T_BOOLEAN;
 }


### PR DESCRIPTION
Overview
----------------------------------------
The parameter `ignore_admin_only` is already defined and used by `Membershipstatus.calc` API but it's not defined in the spec.

Before
----------------------------------------
Parameter not defined in API spec.

After
----------------------------------------
Parameter defined in API spec.

Technical Details
----------------------------------------
Marking as NFC as this is just adding metadata to something that already exists.

Comments
----------------------------------------
