### PR TITLE
Api4 - Use explicit adder functions rather than magicMethod

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -132,12 +132,12 @@ class Kernel {
   }
 
   /**
-   * Execute an API request.
+   * Execute an API v3 or v4 request.
    *
    * The request must be in canonical format. Exceptions will be propagated out.
    *
-   * @param array $apiRequest
-   * @return array
+   * @param array|\Civi\Api4\Generic\AbstractAction $apiRequest
+   * @return array|\Civi\Api4\Generic\Result
    * @throws \API_Exception
    * @throws \Civi\API\Exception\NotImplementedException
    * @throws \Civi\API\Exception\UnauthorizedException

--- a/Civi/Api4/Action/Setting/Get.php
+++ b/Civi/Api4/Action/Setting/Get.php
@@ -26,8 +26,7 @@ use Civi\Api4\Generic\Result;
  * Get the value of one or more CiviCRM settings.
  *
  * @method array getSelect
- * @method $this addSelect(string $name)
- * @method $this setSelect(array $select)
+ * @method $this setSelect(array $settingNames)
  */
 class Get extends AbstractSettingAction {
 
@@ -69,6 +68,16 @@ class Get extends AbstractSettingAction {
         $setting['value'] = \CRM_Core_DAO::unSerializeField($setting['value'], $meta[$name]['serialize']);
       }
     }
+  }
+
+  /**
+   * Add one or more settings to be selected
+   * @param string ...$settingNames
+   * @return $this
+   */
+  public function addSelect(string ...$settingNames) {
+    $this->select = array_merge($this->select, $settingNames);
+    return $this;
   }
 
 }

--- a/Civi/Api4/Action/Setting/Revert.php
+++ b/Civi/Api4/Action/Setting/Revert.php
@@ -26,8 +26,7 @@ use Civi\Api4\Generic\Result;
  * Revert one or more CiviCRM settings to their default value.
  *
  * @method array getSelect
- * @method $this addSelect(string $name)
- * @method $this setSelect(array $select)
+ * @method $this setSelect(array $settingNames) Set settings to be reverted
  */
 class Revert extends AbstractSettingAction {
 
@@ -60,6 +59,16 @@ class Revert extends AbstractSettingAction {
         $setting['value'] = \CRM_Core_DAO::unSerializeField($setting['value'], $meta[$name]['serialize']);
       }
     }
+  }
+
+  /**
+   * Add one or more settings to be reverted
+   * @param string ...$settingNames
+   * @return $this
+   */
+  public function addSelect(string ...$settingNames) {
+    $this->select = array_merge($this->select, $settingNames);
+    return $this;
   }
 
 }

--- a/Civi/Api4/Action/Setting/Set.php
+++ b/Civi/Api4/Action/Setting/Set.php
@@ -27,7 +27,6 @@ use Civi\Api4\Generic\Result;
  *
  * @method array getValues
  * @method $this setValues(array $value)
- * @method $this addValue(string $name, mixed $value)
  */
 class Set extends AbstractSettingAction {
 
@@ -58,6 +57,17 @@ class Set extends AbstractSettingAction {
         'domain_id' => $domain,
       ];
     }
+  }
+
+  /**
+   * Add an item to the values array
+   * @param string $settingName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue($settingName, $value) {
+    $this->values[$settingName] = $value;
+    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -25,7 +25,6 @@ namespace Civi\Api4\Generic;
  * Base class for all "Create" api actions.
  *
  * @method $this setValues(array $values) Set all field values from an array of key => value pairs.
- * @method $this addValue($field, $value) Set field value.
  * @method array getValues() Get field values.
  *
  * @package Civi\Api4\Generic
@@ -40,12 +39,22 @@ abstract class AbstractCreateAction extends AbstractAction {
   protected $values = [];
 
   /**
-   * @param string $key
-   *
+   * @param string $fieldName
    * @return mixed|null
    */
-  public function getValue($key) {
-    return isset($this->values[$key]) ? $this->values[$key] : NULL;
+  public function getValue(string $fieldName) {
+    return isset($this->values[$fieldName]) ? $this->values[$fieldName] : NULL;
+  }
+
+  /**
+   * Add a field value.
+   * @param string $fieldName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue(string $fieldName, $value) {
+    $this->values[$fieldName] = $value;
+    return $this;
   }
 
   /**

--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -28,8 +28,7 @@ use Civi\Api4\Utils\SelectUtil;
  *
  * @package Civi\Api4\Generic
  *
- * @method $this addSelect(string $select)
- * @method $this setSelect(array $selects)
+ * @method $this setSelect(array $selects) Set array of fields to be selected (wildcard * allowed)
  * @method array getSelect()
  */
 abstract class AbstractGetAction extends AbstractQueryAction {
@@ -152,6 +151,16 @@ abstract class AbstractGetAction extends AbstractQueryAction {
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Add one or more fields to be selected (wildcard * allowed)
+   * @param string ...$fieldNames
+   * @return $this
+   */
+  public function addSelect(string ...$fieldNames) {
+    $this->select = array_merge($this->select, $fieldNames);
+    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/AbstractQueryAction.php
+++ b/Civi/Api4/Generic/AbstractQueryAction.php
@@ -79,17 +79,17 @@ abstract class AbstractQueryAction extends AbstractAction {
   protected $offset = 0;
 
   /**
-   * @param string $field
+   * @param string $fieldName
    * @param string $op
    * @param mixed $value
    * @return $this
    * @throws \API_Exception
    */
-  public function addWhere($field, $op, $value = NULL) {
+  public function addWhere(string $fieldName, string $op, $value = NULL) {
     if (!in_array($op, \CRM_Core_DAO::acceptedSQLOperators())) {
       throw new \API_Exception('Unsupported operator');
     }
-    $this->where[] = [$field, $op, $value];
+    $this->where[] = [$fieldName, $op, $value];
     return $this;
   }
 
@@ -103,7 +103,7 @@ abstract class AbstractQueryAction extends AbstractAction {
    * @return $this
    * @throws \API_Exception
    */
-  public function addClause($operator, $condition1) {
+  public function addClause(string $operator, $condition1) {
     if (!is_array($condition1[0])) {
       $condition1 = array_slice(func_get_args(), 1);
     }
@@ -112,17 +112,18 @@ abstract class AbstractQueryAction extends AbstractAction {
   }
 
   /**
-   * @param string $field
+   * Adds to the orderBy clause
+   * @param string $fieldName
    * @param string $direction
    * @return $this
    */
-  public function addOrderBy($field, $direction = 'ASC') {
-    $this->orderBy[$field] = $direction;
+  public function addOrderBy(string $fieldName, $direction = 'ASC') {
+    $this->orderBy[$fieldName] = $direction;
     return $this;
   }
 
   /**
-   * A human-readable where clause, for the reading enjoyment of you humans.
+   * Produces a human-readable where clause, for the reading enjoyment of you humans.
    *
    * @param array $whereClause
    * @param string $op

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -24,11 +24,9 @@ namespace Civi\Api4\Generic;
 /**
  * Base class for all "Save" api actions.
  *
- * @method $this setRecords(array $records) Array of records.
- * @method $this addRecord($record) Add a record to update.
+ * @method $this setRecords(array $records) Set array of records to be saved.
  * @method array getRecords()
  * @method $this setDefaults(array $defaults) Array of defaults.
- * @method $this addDefault($name, $value) Add a default value.
  * @method array getDefaults()
  * @method $this setReload(bool $reload) Specify whether complete objects will be returned after saving.
  * @method bool getReload()
@@ -104,6 +102,27 @@ abstract class AbstractSaveAction extends AbstractAction {
    */
   protected function getIdField() {
     return $this->idField;
+  }
+
+  /**
+   * Add one or more records to be saved.
+   * @param array ...$records
+   * @return $this
+   */
+  public function addRecord(array ...$records) {
+    $this->records = array_merge($this->records, $records);
+    return $this;
+  }
+
+  /**
+   * Set default value for a field.
+   * @param string $fieldName
+   * @param mixed $defaultValue
+   * @return $this
+   */
+  public function addDefault(string $fieldName, $defaultValue) {
+    $this->defaults[$fieldName] = $defaultValue;
+    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -25,7 +25,6 @@ namespace Civi\Api4\Generic;
  * Base class for all "Update" api actions
  *
  * @method $this setValues(array $values) Set all field values from an array of key => value pairs.
- * @method $this addValue($field, $value) Set field value.
  * @method array getValues() Get field values.
  * @method $this setReload(bool $reload) Specify whether complete objects will be returned after saving.
  * @method bool getReload()
@@ -53,12 +52,23 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
   protected $reload = FALSE;
 
   /**
-   * @param string $key
+   * @param string $fieldName
    *
    * @return mixed|null
    */
-  public function getValue($key) {
-    return isset($this->values[$key]) ? $this->values[$key] : NULL;
+  public function getValue(string $fieldName) {
+    return isset($this->values[$fieldName]) ? $this->values[$fieldName] : NULL;
+  }
+
+  /**
+   * Add an item to the values array
+   * @param string $fieldName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue(string $fieldName, $value) {
+    $this->values[$fieldName] = $value;
+    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -30,7 +30,6 @@ use Civi\Api4\Utils\ActionUtil;
  * @method $this setLoadOptions(bool $value)
  * @method bool getLoadOptions()
  * @method $this setAction(string $value)
- * @method $this addValue(string $value)
  * @method $this setValues(array $values)
  * @method array getValues()
  */
@@ -125,6 +124,17 @@ class BasicGetFieldsAction extends BasicGetAction {
       'replace' => 'create',
     ];
     return $sub[$this->action] ?? $this->action;
+  }
+
+  /**
+   * Add an item to the values array
+   * @param string $fieldName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue(string $fieldName, $value) {
+    $this->values[$fieldName] = $value;
+    return $this;
   }
 
   public function fields() {

--- a/Civi/Api4/Generic/BasicReplaceAction.php
+++ b/Civi/Api4/Generic/BasicReplaceAction.php
@@ -28,10 +28,8 @@ use Civi\Api4\Utils\ActionUtil;
  * Given a set of records, will appropriately update the database.
  *
  * @method $this setRecords(array $records) Array of records.
- * @method $this addRecord($record) Add a record to update.
  * @method array getRecords()
  * @method $this setDefaults(array $defaults) Array of defaults.
- * @method $this addDefault($name, $value) Add a default value.
  * @method array getDefaults()
  * @method $this setReload(bool $reload) Specify whether complete objects will be returned after saving.
  * @method bool getReload()
@@ -128,6 +126,27 @@ class BasicReplaceAction extends AbstractBatchAction {
         'checkPermissions' => $this->getCheckPermissions(),
       ]);
     }
+  }
+
+  /**
+   * Set default value for a field.
+   * @param string $fieldName
+   * @param mixed $defaultValue
+   * @return $this
+   */
+  public function addDefault(string $fieldName, $defaultValue) {
+    $this->defaults[$fieldName] = $defaultValue;
+    return $this;
+  }
+
+  /**
+   * Add one or more records
+   * @param array ...$records
+   * @return $this
+   */
+  public function addRecord(array ...$records) {
+    $this->records = array_merge($this->records, $records);
+    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/DAOEntity.php
+++ b/Civi/Api4/Generic/DAOEntity.php
@@ -34,7 +34,7 @@ abstract class DAOEntity extends AbstractEntity {
   }
 
   /**
-   * @return DAOGetAction
+   * @return DAOSaveAction
    */
   public static function save() {
     return new DAOSaveAction(static::class, __FUNCTION__);


### PR DESCRIPTION
Overview
----------------------------------------
Improves the way some Api4 action classes receive their parameters.

Before
----------------------------------------
Api Actions had been relying on a magic method to provide getter/setter functions for params.
That works fine for simple get/set operations but it was also attempting to provide adder functions.
Those are more nuanced and the magic method didn't do a good job of understanding whether the param was an indexed or unindexed array, and didn't do strict type checking.

After
----------------------------------------
Making our own adder functions gives better documentation, stricter checking of inputs and also
the convenience of variadic functions for adding several values at once.
Magic "addFoo" removed.
