### PR TITLE
APIv4 - don't throw exception when updating/deleting 0 items

### DIFF
--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -64,10 +64,6 @@ class BasicUpdateAction extends AbstractUpdateAction {
     foreach ($this->getBatchRecords() as $item) {
       $result[] = $this->writeRecord($this->values + $item);
     }
-
-    if (!$result->count()) {
-      throw new \API_Exception('Cannot ' . $this->getActionName() . ' ' . $this->getEntityName() . ', no records found with ' . $this->whereClauseToString());
-    }
   }
 
   /**

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -32,19 +32,14 @@ class DAODeleteAction extends AbstractBatchAction {
    */
   public function _run(Result $result) {
     $defaults = $this->getParamDefaults();
-    if ($defaults['where'] && !array_diff_key($this->where, $defaults['where'])) {
+    if ($defaults['where'] && $this->where === $defaults['where']) {
       throw new \API_Exception('Cannot delete ' . $this->getEntityName() . ' with no "where" parameter specified');
     }
 
     $items = $this->getObjects();
-
-    if (!$items) {
-      throw new \API_Exception('Cannot delete ' . $this->getEntityName() . ', no records found with ' . $this->whereClauseToString());
+    if ($items) {
+      $result->exchangeArray($this->deleteObjects($items));
     }
-
-    $ids = $this->deleteObjects($items);
-
-    $result->exchangeArray($ids);
   }
 
   /**

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -71,10 +71,6 @@ class DAOUpdateAction extends AbstractUpdateAction {
       $item = $this->values + $item;
     }
 
-    if (!$items) {
-      throw new \API_Exception('Cannot ' . $this->getActionName() . ' ' . $this->getEntityName() . ', no records found with ' . $this->whereClauseToString());
-    }
-
     $result->exchangeArray($this->writeObjects($items));
   }
 

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -459,7 +459,7 @@ trait Api3TestTrait {
         break;
 
       case 'delete':
-        if (!empty($v3Params['id'])) {
+        if (isset($v3Params['id'])) {
           $v4Params['where'][] = ['id', '=', $v3Params['id']];
         }
         break;
@@ -531,7 +531,7 @@ trait Api3TestTrait {
       ];
     }
 
-    if (($v3Action == 'getsingle' || $v3Action == 'getvalue') && count($result) != 1) {
+    if (($v3Action == 'getsingle' || $v3Action == 'getvalue' || $v3Action == 'delete') && count($result) != 1) {
       return $onlySuccess ? 0 : [
         'is_error' => 1,
         'error_message' => "Expected one $v4Entity but found " . count($result),


### PR DESCRIPTION
Overview
----------------------------------------
When 0 items are found to be processed by batch actions, it's not really an error so we shouldn't throw an exception.

Before
----------------------------------------
`*UpdateAction` and `DAODeleteAction` throw exceptions when 0 items found.

After
----------------------------------------
No exception, just returns an empty result.