### PR TITLE
Update Export unit test to pass on MySQL 8

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1151,7 +1151,11 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'Tag(s)' => '',
       'Note(s)' => '',
     ];
-    $this->assertExpectedOutput($expected, $this->csv->fetchOne());
+    // Include both possible options as we rely on implicit order here and MySQL 8 in testing is returning a different value for some fields.
+    $this->assertExpectedOutput($expected, $this->csv->fetchOne(), [
+      'Email' => ['home@example.com', 'work@example.com'],
+      'Location Type' => ['Home', 'Work'],
+    ]);
   }
 
   /**
@@ -2924,12 +2928,16 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    *
    * @param array $expected
    * @param array $row
+   * @param array $alternatives
    */
-  protected function assertExpectedOutput(array $expected, array $row) {
+  protected function assertExpectedOutput(array $expected, array $row, array $alternatives = []) {
     $variableFields = ['Created Date', 'Modified Date', 'Contact Hash'];
     foreach ($expected as $key => $value) {
       if (in_array($key, $variableFields)) {
         $this->assertTrue(!empty($row[$key]));
+      }
+      elseif (array_key_exists($key, $alternatives)) {
+        $this->assertContains($row[$key], $alternatives[$key]);
       }
       else {
         $this->assertEquals($value, $row[$key]);


### PR DESCRIPTION
Overview
----------------------------------------
This updates the unit test for testMergeSameAddress, The issue Eileen and I suspect is that there is an implicit order used here that is changed in MySQL 8 leading to different data returned

ping @eileenmcnaughton thoughts on this?