### PR TITLE
loadServices: tighten up file match regex

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -86,7 +86,7 @@ class CRM_Api4_Services {
         $container->addResource($resource);
         foreach (glob("$path*.php") as $file) {
           $matches = [];
-          preg_match('/(\w*).php/', $file, $matches);
+          preg_match('/(\w*)\.php$/', $file, $matches);
           $serviceName = $namespace . array_pop($matches);
           $serviceClass = new \ReflectionClass($serviceName);
           if ($serviceClass->isInstantiable()) {


### PR DESCRIPTION
Overview
----------------------------------------
Tighten up a regular expression used to find files so that it doesn't match a partial path.

Before
----------------------------------------
Civi code living under a path containing the characters 'php'
(such as ~/src/php/civicrm) will crash trying to load services with
a message like the following:
   ReflectionException: Class Civi\Api4\Service\Spec\Provider\src
   does not exist in ReflectionClass->__construct()

After
----------------------------------------
Civi loads services normally no matter what the enclosing path

Technical Details
----------------------------------------
The regex needs a $ anchor at the end because it's looking for files ending in php. It also needed the '.' escaped so it only matches a literal '.' and not any character.

Comments
----------------------------------------
There's another PR against master: #16376
