### PR TITLE
(NFC) Civi/*.php - Update for Drupal.Commenting.VariableComment.IncorrectVarType

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -28,7 +28,7 @@ class Kernel {
   protected $dispatcher;
 
   /**
-   * @var array<ProviderInterface>
+   * @var \Civi\API\Provider\ProviderInterface[]
    */
   protected $apiProviders;
 

--- a/Civi/API/Provider/AdhocProvider.php
+++ b/Civi/API/Provider/AdhocProvider.php
@@ -37,7 +37,11 @@ class AdhocProvider implements EventSubscriberInterface, ProviderInterface {
   }
 
   /**
-   * @var array (string $name => array('perm' => string, 'callback' => callable))
+   * List of adhoc actions
+   *
+   * array(string $ame => array('perm' => string, 'callback' => callable))
+   *
+   * @var array
    */
   protected $actions = [];
 

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -32,7 +32,11 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
   }
 
   /**
-   * @var array (string $cachekey => array('function' => string, 'is_generic' => bool))
+   * Local cache of function-mappings.
+   *
+   * array(string $cacheKey => array('function' => string, 'is_generic' => bool))
+   *
+   * @var array
    */
   private $cache;
 

--- a/Civi/API/Provider/ReflectionProvider.php
+++ b/Civi/API/Provider/ReflectionProvider.php
@@ -41,7 +41,11 @@ class ReflectionProvider implements EventSubscriberInterface, ProviderInterface 
   private $apiKernel;
 
   /**
-   * @var array (string $entityName => array(string $actionName))
+   * List of all entities and their supported actions
+   *
+   * array(string $entityName => string[] $actionNames).
+   *
+   * @var array
    */
   private $actions;
 

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -50,17 +50,21 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
   public $kernel;
 
   /**
-   * @var string, the entity for which we want to manage permissions
+   * The entity for which we want to manage permissions.
+   *
+   * @var string
    */
   protected $entityName;
 
   /**
-   * @var array <string> the actions for which we want to manage permissions
+   * The actions for which we want to manage permissions
+   *
+   * @var string[]
    */
   protected $actions;
 
   /**
-   * @var string, SQL. Given a file ID, determine the entity+table it's attached to.
+   * SQL SELECT query - Given a file ID, determine the entity+table it's attached to.
    *
    * ex: "SELECT if(cf.id,1,0) as is_valid, cef.entity_table, cef.entity_id
    * FROM civicrm_file cf
@@ -72,14 +76,18 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
    *  - is_valid: "1" if %1 identifies an actual record; otherwise "0"
    *  - entity_table: NULL or the name of a related table
    *  - entity_id: NULL or the ID of a row in the related table
+   *
+   * @var string
    */
   protected $lookupDelegateSql;
 
   /**
-   * @var string, SQL. Get a list of (field_name, table_name, extends) tuples.
+   * SQL SELECT query. Get a list of (field_name, table_name, extends) tuples.
    *
    * For example, one tuple might be ("custom_123", "civicrm_value_mygroup_4",
    * "Activity").
+   *
+   * @var string
    */
   protected $lookupCustomFieldSql;
 
@@ -91,7 +99,9 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
   protected $lookupCustomFieldCache;
 
   /**
-   * @var array list of related tables for which FKs are allowed
+   * List of related tables for which FKs are allowed.
+   *
+   * @var array
    */
   protected $allowedDelegates;
 

--- a/Civi/API/Subscriber/TransactionSubscriber.php
+++ b/Civi/API/Subscriber/TransactionSubscriber.php
@@ -41,15 +41,21 @@ class TransactionSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * @var array (scalar $apiRequestId => CRM_Core_Transaction $tx)
+   * List of active transaction objects.
+   *
+   * array(scalar $apiRequestId => CRM_Core_Transaction $tx)
+   *
+   * @var array
    */
   private $transactions = [];
 
   /**
-   * @var array (scalar $apiRequestId => bool)
-   *
-   * A list of requests which should be forcibly rolled back to
+   * (Unused?) A list of requests which should be forcibly rolled back to
    * their save points.
+   *
+   * array (scalar $apiRequestId => bool)
+   *
+   * @var array
    */
   private $forceRollback = [];
 

--- a/Civi/API/Subscriber/WrapperAdapter.php
+++ b/Civi/API/Subscriber/WrapperAdapter.php
@@ -32,7 +32,7 @@ class WrapperAdapter implements EventSubscriberInterface {
   }
 
   /**
-   * @var array(\API_Wrapper)
+   * @var \API_Wrapper[]
    */
   protected $defaults;
 

--- a/Civi/CCase/Analyzer.php
+++ b/Civi/CCase/Analyzer.php
@@ -22,7 +22,9 @@ class Analyzer {
   private $caseId;
 
   /**
-   * @var array per APIv3
+   * The "Case" data, formatted per APIv3.
+   *
+   * @var array
    */
   private $case;
 
@@ -32,7 +34,9 @@ class Analyzer {
   private $caseType;
 
   /**
-   * @var array per APIv3
+   * List of activities, formatted per APIv3.
+   *
+   * @var array
    */
   private $activities;
 
@@ -42,7 +46,12 @@ class Analyzer {
   private $xml;
 
   /**
-   * @var array<string,array>
+   * A list of activity indices, which sort the various activities by some set of keys.
+   *
+   * Each index is identified by its key-set - e.g. "activity_type_id;source_contact_id" would be a
+   * two-dimensional index listing activities by their type ID and their source.
+   *
+   * @var array
    */
   private $indices;
 

--- a/Civi/CCase/Events.php
+++ b/Civi/CCase/Events.php
@@ -16,10 +16,14 @@ namespace Civi\CCase;
  * @package Civi\CCase
  */
 class Events {
+
   /**
-   * @var array (int $caseId => bool $active) list of cases for which we are actively firing case-change event
-   *
+   * List of cases for which we are actively firing case-change event
    * We do not want to fire case-change events recursively.
+   *
+   * array (int $caseId => bool $active)
+   *
+   * @var array
    */
   public static $isActive = [];
 

--- a/Civi/Core/DAO/Event/PostDelete.php
+++ b/Civi/Core/DAO/Event/PostDelete.php
@@ -18,12 +18,12 @@ namespace Civi\Core\DAO\Event;
 class PostDelete extends \Symfony\Component\EventDispatcher\Event {
 
   /**
-   * @var DAO Object
+   * @var \CRM_Core_DAO
    */
   public $object;
 
   /**
-   * @var DAO delete result
+   * @var mixed
    */
   public $result;
 

--- a/Civi/Core/DAO/Event/PostUpdate.php
+++ b/Civi/Core/DAO/Event/PostUpdate.php
@@ -18,7 +18,7 @@ namespace Civi\Core\DAO\Event;
 class PostUpdate extends \Symfony\Component\EventDispatcher\Event {
 
   /**
-   * @var DAO Object
+   * @var \CRM_Core_DAO
    */
   public $object;
 

--- a/Civi/Core/DAO/Event/PreDelete.php
+++ b/Civi/Core/DAO/Event/PreDelete.php
@@ -18,7 +18,7 @@ namespace Civi\Core\DAO\Event;
 class PreDelete extends \Symfony\Component\EventDispatcher\Event {
 
   /**
-   * @var DAO Object
+   * @var \CRM_Core_DAO
    */
   public $object;
 

--- a/Civi/Core/Event/PostEvent.php
+++ b/Civi/Core/Event/PostEvent.php
@@ -29,7 +29,9 @@ class PostEvent extends GenericHookEvent {
   }
 
   /**
-   * @var string 'create'|'edit'|'delete' etc
+   * One of: 'create'|'edit'|'delete'
+   *
+   * @var string
    */
   public $action;
 

--- a/Civi/Core/Event/PreEvent.php
+++ b/Civi/Core/Event/PreEvent.php
@@ -29,7 +29,9 @@ class PreEvent extends GenericHookEvent {
   }
 
   /**
-   * @var string 'create'|'edit'|'delete' etc
+   * One of: 'create'|'edit'|'delete'
+   *
+   * @var string
    */
   public $action;
 

--- a/Civi/Core/Event/UnhandledExceptionEvent.php
+++ b/Civi/Core/Event/UnhandledExceptionEvent.php
@@ -23,7 +23,9 @@ class UnhandledExceptionEvent extends GenericHookEvent {
   public $exception;
 
   /**
-   * @var mixed reserved for future use
+   * Reserved for future use.
+   *
+   * @var mixed
    */
   public $request;
 

--- a/Civi/Core/Transaction/Frame.php
+++ b/Civi/Core/Transaction/Frame.php
@@ -29,17 +29,23 @@ class Frame {
   private $dao;
 
   /**
-   * @var string|null e.g. "BEGIN" or "SAVEPOINT foo"
+   * The statement used to start this transaction - e.g. "BEGIN" or "SAVEPOINT foo"
+   *
+   * @var string|null
    */
   private $beginStmt;
 
   /**
-   * @var string|null e.g. "COMMIT"
+   * The statement used to commit this transaction - e.g. "COMMIT"
+   *
+   * @var string|null
    */
   private $commitStmt;
 
   /**
-   * @var string|null e.g. "ROLLBACK" or "ROLLBACK TO SAVEPOINT foo"
+   * The statement used to rollback this transaction - e.g. "ROLLBACK" or "ROLLBACK TO SAVEPOINT foo"
+   *
+   * @var string|null
    */
   private $rollbackStmt;
 

--- a/Civi/Core/Transaction/Manager.php
+++ b/Civi/Core/Transaction/Manager.php
@@ -26,7 +26,9 @@ class Manager {
   private $dao;
 
   /**
-   * @var array<Frame> stack of SQL transactions/savepoints
+   * Stack of SQL transactions/savepoints.
+   *
+   * @var \Civi\Core\Transaction\Frame[]
    */
   private $frames = [];
 

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -87,7 +87,9 @@ class PropertyBag implements \ArrayAccess {
   }
 
   /**
-   * @var string Just for unit testing.
+   * Just for unit testing.
+   *
+   * @var string
    */
   public $lastWarning;
 

--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -14,7 +14,7 @@ class System {
   private static $singleton;
 
   /**
-   * @var array cache
+   * @var array
    */
   private $cache = [];
 

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -35,7 +35,7 @@ else {
     private $cache = [];
 
     /**
-     * @var \CRM_Core_Transaction|NULL
+     * @var \CRM_Core_Transaction|null
      */
     private $tx;
 

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -28,7 +28,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
   private $cache = [];
 
   /**
-   * @var \CRM_Core_Transaction|NULL
+   * @var \CRM_Core_Transaction|null
    */
   private $tx;
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a corollary to https://github.com/civicrm/coder/pull/7 which brings things closer to the Drupal code conventions. It only changes docblocks.

The goal of the rule is validate variable types. It did identify a couple incorrect types, but its impact was mostly to force substantive documentation onto another line.