### PR TITLE
Test on behalf of organization contributions

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1016,6 +1016,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     //create contribution activity w/ individual and target
     //activity w/ organisation contact id when onbelf, CRM-4027
+    // FIXME: This IF statement can't be reached (that array element doesn't exist).  This should be
+    // revisited when "on behalf of" tests can accurately create activities.
     $targetContactID = NULL;
     if (!empty($params['hidden_onbehalf_profile'])) {
       $targetContactID = $contribution->contact_id;
@@ -1904,13 +1906,14 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * Submit function.
    *
    * @param array $params
+   * @param array $fields
    *
    * @throws CiviCRM_API3_Exception
    */
-  public static function submit($params) {
+  public static function submit($params, $fields = NULL) {
     $form = new CRM_Contribute_Form_Contribution_Confirm();
     $form->_id = $params['id'];
-
+    $form->_fields = $fields;
     CRM_Contribute_BAO_ContributionPage::setValues($form->_id, $form->_values);
     $form->_separateMembershipPayment = CRM_Contribute_BAO_ContributionPage::getIsMembershipPayment($form->_id);
     //this way the mocked up controller ignores the session stuff


### PR DESCRIPTION
Overview
----------------------------------------
Currently, there are no tests for contributions made on behalf of an organization.  This adds the basic test.

Before
----------------------------------------
No test.

After
----------------------------------------
Test.

Technical Details
----------------------------------------
I've added a new argument to `CRM_Contribute_Form_Contribution_Confirm::submit()` called `$fields`.  As best I can tell, `$submit` isn't actually used except by unit tests - and while I imagine there's an effort to change that, I don't think there's a way to test a number of contribution page workflows without being able to submit fields.  I welcome feedback though.

Comments
----------------------------------------
The test workflow doesn't generate an activity - and "on behalf of" receipts rely on the activity to determine the original contact.
