### PR TITLE
Fix tests to use buildFeeFn

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -22,6 +22,20 @@
  */
 class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment {
 
+  /**
+   * Participant ID - use getParticipantID.
+   *
+   * @var int
+   */
+  public $_pId;
+
+  /**
+   * ID of discount record.
+   *
+   * @var int
+   */
+  public $_discountId;
+
   public $useLivePageJS = TRUE;
 
   /**
@@ -1669,7 +1683,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $form->addElement('hidden', 'hidden_feeblock', 1);
       }
 
-      $eventfullMsg = CRM_Event_BAO_Participant::eventFullMessage($form->_eventId, $form->_pId);
+      $eventfullMsg = CRM_Event_BAO_Participant::eventFullMessage($form->_eventId, $this->getParticipantID());
       $form->addElement('hidden', 'hidden_eventFullMsg', $eventfullMsg, ['id' => 'hidden_eventFullMsg']);
     }
 
@@ -1811,7 +1825,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    *
    * @return array
    *
-   * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
   protected function preparePaidEventProcessing($params): array {
@@ -2212,7 +2225,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @return int|null
    */
   protected function getParticipantID() {
-    return $this->_id;
+    return $this->_id ?? $this->_pId;
   }
 
 }

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -316,8 +316,8 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $form->_eventId = $event['id'];
     if (!empty($eventParams['is_monetary'])) {
       $form->_bltID = 5;
-      $form->_values['fee'] = [];
       $form->_isPaidEvent = TRUE;
+      $form->buildEventFeeForm($form);
     }
     return $form;
   }

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -14,6 +14,18 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
+   * CHeck that all tests that have created payments have created them with the right financial entities.
+   *
+   * Ideally this would be on CiviUnitTestCase but many classes would still fail. Also, it might
+   * be good if it only ran on tests that created at least one contribution.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function assertPostConditions() {
+    $this->validateAllPayments();
+  }
+
+  /**
    * Initial test of submit function.
    *
    * @throws \Exception


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the tests on the backoffice participant form to use the 'real' function to set up for tests (now we have cleaned up that function a bit). This means the transactions created are now valid and we can lock that in with 
```
 protected function assertPostConditions() {
    $this->validateAllPayments();
  }
```

Before
----------------------------------------
Tests are creating invalid transactions due to invalid set up, not tested

After
----------------------------------------
Valid transactions are tested

Technical Details
----------------------------------------
I'm working on this for 2 reasons
1) I want to start doing the validation on all tests that create financial entities, I'm already aware that one test that fails when I add this to all tests is a true bug
2) I'm trying to cleanup the back office form to the point where I can use a valid method to set up partial payments & deprecate the hacks in the BAO layer to support our 'first attempt approach' at partial payments - as represented in this form

Comments
----------------------------------------

