### PR TITLE
Fixes for Auto renew Membership

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -266,7 +266,18 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     $template->assign('refId', substr($this->_getParam('invoiceID'), 0, 20));
 
     //for recurring, carry first contribution id
-    $template->assign('invoiceNumber', $this->_getParam('contributionID'));
+    if (!empty($this->_getParam('contributionID'))) {
+      $template->assign('invoiceNumber', $this->_getParam('contributionID'));
+    }
+    else {
+      // Get the contribution from recurring id.
+      $contribution_recur_id = $this->_getParam('contributionRecurID');
+      $contribution_result = civicrm_api3('Contribution', 'getsingle', array(
+        'contribution_recur_id' => $contribution_recur_id,
+        'return' => array('id'),
+      ));
+      $template->assign('invoiceNumber', $contribution_result['id']);
+    }
     $firstPaymentDate = $this->_getParam('receive_date');
     if (!empty($firstPaymentDate)) {
       //allow for post dated payment if set in form

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2227,7 +2227,7 @@ WHERE      civicrm_membership.is_test = 0
       self::processOverriddenUntilDateMembership($dao1);
     }
 
-    $query = $baseQuery . " AND (civicrm_membership.is_override = 0 OR civicrm_membership.is_override IS NULL) 
+    $query = $baseQuery . " AND (civicrm_membership.is_override = 0 OR civicrm_membership.is_override IS NULL)
      AND civicrm_membership.status_id NOT IN (%1, %2, %3, %4)
      AND civicrm_membership.owner_membership_id IS NULL ";
     $params = [
@@ -2438,6 +2438,11 @@ WHERE      civicrm_membership.is_test = 0
     // make entry in batch entity batch table
     if (!empty($params['batch_id'])) {
       $contributionParams['batch_id'] = $params['batch_id'];
+    }
+
+    // for existing contributions.
+    if (!empty($params['id'])) {
+      $contributionParams['id'] = $params['id'];
     }
 
     if (!empty($params['contribution_contact_id'])) {

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -382,6 +382,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       'is_email_receipt' => $paymentParams['is_email_receipt'],
       'payment_instrument_id' => $paymentParams['payment_instrument_id'],
       'invoice_id' => $paymentParams['invoice_id'],
+      'auto_renew' => $paymentParams['auto_renew'],
     ];
 
     $mapping = [


### PR DESCRIPTION
Overview
----------------------------------------
When a membership that was created without auto-renew is renewed with auto-renew, the information that is sent to Authorize.net is missing the invoice number.

Before
----------------------------------------
When a membership that was created without auto renew and renewed with auto-renew, the auto-renew flag on the recurring contribution does not get updated in the database and CiviCRM doesn't know how to associate subsequent instalments when they are successfully processed by the payment processor.
Current Problem:
1. Created membership using Submit Credit Card Membership button & keep Membership renewed automatically **checked**.
2. After processing, a **Recurring Contribution** & **Contribution** are created.
3. The submit function from CRM/Member/Form/Membership.php was executed which creates contribution & also recur contribution is created (since auto_renew is checked).
4. After this, doPayment method is called therefore we get Contribution ID in that method and that goes in Auth.net.
5. Renew the membership with Renew Credit Card link & keep Membership renewed automatically *checked*.
6. While renew, submit function from CRM/Member/Form/MembershipRenewal.php is called.
7. This function first creates recurring contribution & then doPayment method is called. At this stage, no contribution is created.
8. The contribution is created later.
9. Since doPayment method is called before creating contribution, we don't get contribution id which can be passed as invoice number. This contribution is created later after request is sent to Authnet.
10. In step 1, if we keep Membership renewed automatically **unchecked**, the only difference is recurring contribution is not created. Other things are same as per above.
After
----------------------------------------
All works as expected and recurring contribution is created for renewed membership.
