### PR TITLE
dev/core#1522 Handle space as thousand separator

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -596,19 +596,6 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function money($value) {
-    $config = CRM_Core_Config::singleton();
-
-    // only edge case when we have a decimal point in the input money
-    // field and not defined in the decimal Point in config settings
-    if ($config->monetaryDecimalPoint &&
-      $config->monetaryDecimalPoint != '.' &&
-      // CRM-7122 also check for Thousands Separator in config settings
-      $config->monetaryThousandSeparator != '.' &&
-      substr_count($value, '.')
-    ) {
-      return FALSE;
-    }
-
     $value = self::cleanMoney($value);
 
     if (self::integer($value)) {

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -84,7 +84,10 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
    * @param $inputData
    * @param $expectedResult
    */
-  public function testMoney($inputData, $expectedResult) {
+  public function testMoney($inputData, $decimalPoint, $thousandSeparator, $currency, $expectedResult) {
+    $this->setDefaultCurrency($currency);
+    $this->setMonetaryDecimalPoint($decimalPoint);
+    $this->setMonetaryThousandSeparator($thousandSeparator);
     $this->assertEquals($expectedResult, CRM_Utils_Rule::money($inputData));
   }
 
@@ -93,22 +96,56 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
    */
   public function moneyDataProvider() {
     return [
-      [10, TRUE],
-      ['145.0E+3', FALSE],
-      ['10', TRUE],
-      [-10, TRUE],
-      ['-10', TRUE],
-      ['-10foo', FALSE],
-      ['-10.0345619', TRUE],
-      ['-10.010,4345619', TRUE],
-      ['10.0104345619', TRUE],
-      ['-0', TRUE],
-      ['-.1', TRUE],
-      ['.1', TRUE],
+      [10, '.', ',', 'USD', TRUE],
+      ['145.0E+3', '.', ',', 'USD', FALSE],
+      ['10', '.', ',', 'USD', TRUE],
+      [-10, '.', ',', 'USD', TRUE],
+      ['-10', '.', ',', 'USD', TRUE],
+      ['-10foo', '.', ',', 'USD', FALSE],
+      ['-10.0345619', '.', ',', 'USD', TRUE],
+      ['-10.010,4345619', '.', ',', 'USD', TRUE],
+      ['10.0104345619', '.', ',', 'USD', TRUE],
+      ['-0', '.', ',', 'USD', TRUE],
+      ['-.1', '.', ',', 'USD', TRUE],
+      ['.1', '.', ',', 'USD', TRUE],
       // Test currency symbols too, default locale uses $, so if we wanted to test others we'd need to reconfigure locale
-      ['$500.3333', TRUE],
-      ['-$500.3333', TRUE],
-      ['$-500.3333', TRUE],
+      ['$1,234,567.89', '.', ',', 'USD', TRUE],
+      ['-$1,234,567.89', '.', ',', 'USD', TRUE],
+      ['$-1,234,567.89', '.', ',', 'USD', TRUE],
+      ['1234567.89', '.', ',', 'USD', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, '.', ',', 'USD', TRUE], // This is the float format.
+      // Test EURO currency
+      ['€1,234,567.89', '.', ',', 'EUR', TRUE],
+      ['-€1,234,567.89', '.', ',', 'EUR', TRUE],
+      ['€-1,234,567.89', '.', ',', 'EUR', TRUE],
+      ['1234567.89', '.', ',', 'EUR', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, '.', ',', 'EUR', TRUE], // This is the float format.
+      // Test Norwegian KR currency
+      ['kr1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['kr 1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['-kr1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['-kr 1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['kr-1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['kr -1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['1234567.89', '.', ',', 'NOK', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, '.', ',', 'NOK', TRUE], // This is the float format.
+      // Test different localization options: , as decimal separator and dot as thousand separator
+      ['$1.234.567,89', ',', '.', 'USD', TRUE],
+      ['-$1.234.567,89', ',', '.', 'USD', TRUE],
+      ['$-1.234.567,89', ',', '.', 'USD', TRUE],
+      ['1.234.567,89', ',', '.', 'USD', TRUE],
+      ['1234567.89', ',', '.', 'USD', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, ',', '.', 'USD', TRUE], // This is the float format.
+      ['$1,234,567.89', ',', '.', 'USD', FALSE],
+      ['-$1,234,567.89', ',', '.', 'USD', FALSE],
+      ['$-1,234,567.89', ',', '.', 'USD', FALSE],
+      // Now with a space as thousand separator
+      ['$1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['-$1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['$-1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['1234567.89', ',', ' ', 'USD', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, ',', ' ', 'USD', TRUE], // This is the float format.
     ];
   }
 

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -82,6 +82,9 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
   /**
    * @dataProvider moneyDataProvider
    * @param $inputData
+   * @param $decimalPoint
+   * @param $thousandSeparator
+   * @param $currency
    * @param $expectedResult
    */
   public function testMoney($inputData, $decimalPoint, $thousandSeparator, $currency, $expectedResult) {

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -115,14 +115,18 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
       ['$1,234,567.89', '.', ',', 'USD', TRUE],
       ['-$1,234,567.89', '.', ',', 'USD', TRUE],
       ['$-1,234,567.89', '.', ',', 'USD', TRUE],
-      ['1234567.89', '.', ',', 'USD', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, '.', ',', 'USD', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', '.', ',', 'USD', TRUE],
+      // This is the float format.
+      [1234567.89, '.', ',', 'USD', TRUE],
       // Test EURO currency
       ['€1,234,567.89', '.', ',', 'EUR', TRUE],
       ['-€1,234,567.89', '.', ',', 'EUR', TRUE],
       ['€-1,234,567.89', '.', ',', 'EUR', TRUE],
-      ['1234567.89', '.', ',', 'EUR', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, '.', ',', 'EUR', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', '.', ',', 'EUR', TRUE],
+      // This is the float format.
+      [1234567.89, '.', ',', 'EUR', TRUE],
       // Test Norwegian KR currency
       ['kr1,234,567.89', '.', ',', 'NOK', TRUE],
       ['kr 1,234,567.89', '.', ',', 'NOK', TRUE],
@@ -130,15 +134,19 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
       ['-kr 1,234,567.89', '.', ',', 'NOK', TRUE],
       ['kr-1,234,567.89', '.', ',', 'NOK', TRUE],
       ['kr -1,234,567.89', '.', ',', 'NOK', TRUE],
-      ['1234567.89', '.', ',', 'NOK', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, '.', ',', 'NOK', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', '.', ',', 'NOK', TRUE],
+      // This is the float format.
+      [1234567.89, '.', ',', 'NOK', TRUE],
       // Test different localization options: , as decimal separator and dot as thousand separator
       ['$1.234.567,89', ',', '.', 'USD', TRUE],
       ['-$1.234.567,89', ',', '.', 'USD', TRUE],
       ['$-1.234.567,89', ',', '.', 'USD', TRUE],
       ['1.234.567,89', ',', '.', 'USD', TRUE],
-      ['1234567.89', ',', '.', 'USD', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, ',', '.', 'USD', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', ',', '.', 'USD', TRUE],
+      // This is the float format.
+      [1234567.89, ',', '.', 'USD', TRUE],
       ['$1,234,567.89', ',', '.', 'USD', FALSE],
       ['-$1,234,567.89', ',', '.', 'USD', FALSE],
       ['$-1,234,567.89', ',', '.', 'USD', FALSE],
@@ -147,8 +155,10 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
       ['-$1 234 567,89', ',', ' ', 'USD', TRUE],
       ['$-1 234 567,89', ',', ' ', 'USD', TRUE],
       ['1 234 567,89', ',', ' ', 'USD', TRUE],
-      ['1234567.89', ',', ' ', 'USD', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, ',', ' ', 'USD', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', ',', ' ', 'USD', TRUE],
+      // This is the float format.
+      [1234567.89, ',', ' ', 'USD', TRUE],
     ];
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3247,12 +3247,50 @@ VALUES
   /**
    * Set the separators for thousands and decimal points.
    *
+   * Use setMonetaryDecimalPoint and setMonetaryThousandSeparator instead
+   *
    * @param string $thousandSeparator
+   * @deprecated
    */
   protected function setCurrencySeparators($thousandSeparator) {
+    // Jaap Jansma: I do think the code below is a bit useless. It does an assumption
+    // that when the thousand separator is a comma, the decimal is point. It
+    // does not cater for a situation where the thousand separator is a [space]
+    // Latter is the Norwegian localization.
     Civi::settings()->set('monetaryThousandSeparator', $thousandSeparator);
     Civi::settings()
       ->set('monetaryDecimalPoint', ($thousandSeparator === ',' ? '.' : ','));
+  }
+
+  /**
+   * Sets the thousand separator.
+   *
+   * If you use this function also set the decimal separator: setMonetaryDecimalSeparator
+   *
+   * @param $thousandSeparator
+   */
+  protected function setMonetaryThousandSeparator($thousandSeparator) {
+    Civi::settings()->set('monetaryThousandSeparator', $thousandSeparator);
+  }
+
+  /**
+   * Sets the decimal separator.
+   *
+   * If you use this function also set the thousand separator setMonetaryDecimalPoint
+   *
+   * @param $thousandSeparator
+   */
+  protected function setMonetaryDecimalPoint($decimalPoint) {
+    Civi::settings()->set('monetaryDecimalPoint', $decimalPoint);
+  }
+
+  /**
+   * Sets the default currency.
+   *
+   * @param $currency
+   */
+  protected function setDefaultCurrency($currency) {
+    Civi::settings()->set('defaultCurrency', $currency);
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3278,7 +3278,7 @@ VALUES
    *
    * If you use this function also set the thousand separator setMonetaryDecimalPoint
    *
-   * @param $thousandSeparator
+   * @param $decimalPoint
    */
   protected function setMonetaryDecimalPoint($decimalPoint) {
     Civi::settings()->set('monetaryDecimalPoint', $decimalPoint);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -706,6 +706,93 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * @dataProvider createLocalizedContributionDataProvider
+   * @param $inputData
+   * @param $decimalPoint
+   * @param $thousandSeparator
+   * @param $currency
+   * @param $expectedResult
+   * @throws \Exception
+   */
+  public function testCreateLocalizedContribution($totalAmount, $decimalPoint, $thousandSeparator, $currency, $expectedResult) {
+    $this->setDefaultCurrency($currency);
+    $this->setMonetaryDecimalPoint($decimalPoint);
+    $this->setMonetaryThousandSeparator($thousandSeparator);
+
+    $_params = [
+      'contact_id' => $this->_individualId,
+      'receive_date' => '20120511',
+      'total_amount' => $totalAmount,
+      'financial_type_id' => $this->_financialTypeId,
+      'contribution_status_id' => 1,
+    ];
+
+    if ($expectedResult) {
+      $this->callAPISuccess('Contribution', 'create', $_params);
+    } else {
+      $this->callAPIFailure('Contribution', 'create', $_params);
+    }
+  }
+
+  /**
+   * @return array
+   */
+  public function createLocalizedContributionDataProvider() {
+    return [
+      [10, '.', ',', 'USD', TRUE],
+      ['145.0E+3', '.', ',', 'USD', FALSE],
+      ['10', '.', ',', 'USD', TRUE],
+      [-10, '.', ',', 'USD', TRUE],
+      ['-10', '.', ',', 'USD', TRUE],
+      ['-10foo', '.', ',', 'USD', FALSE],
+      ['-10.0345619', '.', ',', 'USD', TRUE],
+      ['-10.010,4345619', '.', ',', 'USD', TRUE],
+      ['10.0104345619', '.', ',', 'USD', TRUE],
+      ['-0', '.', ',', 'USD', TRUE],
+      ['-.1', '.', ',', 'USD', TRUE],
+      ['.1', '.', ',', 'USD', TRUE],
+      // Test currency symbols too, default locale uses $, so if we wanted to test others we'd need to reconfigure locale
+      ['$1,234,567.89', '.', ',', 'USD', TRUE],
+      ['-$1,234,567.89', '.', ',', 'USD', TRUE],
+      ['$-1,234,567.89', '.', ',', 'USD', TRUE],
+      ['1234567.89', '.', ',', 'USD', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, '.', ',', 'USD', TRUE], // This is the float format.
+      // Test EURO currency
+      ['€1,234,567.89', '.', ',', 'EUR', TRUE],
+      ['-€1,234,567.89', '.', ',', 'EUR', TRUE],
+      ['€-1,234,567.89', '.', ',', 'EUR', TRUE],
+      ['1234567.89', '.', ',', 'EUR', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, '.', ',', 'EUR', TRUE], // This is the float format.
+      // Test Norwegian KR currency
+      ['kr1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['kr 1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['-kr1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['-kr 1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['kr-1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['kr -1,234,567.89', '.', ',', 'NOK', TRUE],
+      ['1234567.89', '.', ',', 'NOK', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, '.', ',', 'NOK', TRUE], // This is the float format.
+      // Test different localization options: , as decimal separator and dot as thousand separator
+      ['$1.234.567,89', ',', '.', 'USD', TRUE],
+      ['-$1.234.567,89', ',', '.', 'USD', TRUE],
+      ['$-1.234.567,89', ',', '.', 'USD', TRUE],
+      ['1.234.567,89', ',', '.', 'USD', TRUE],
+      ['1234567.89', ',', '.', 'USD', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, ',', '.', 'USD', TRUE], // This is the float format.
+      ['$1,234,567.89', ',', '.', 'USD', FALSE],
+      ['-$1,234,567.89', ',', '.', 'USD', FALSE],
+      ['$-1,234,567.89', ',', '.', 'USD', FALSE],
+      // Now with a space as thousand separator
+      ['$1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['-$1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['$-1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['1 234 567,89', ',', ' ', 'USD', TRUE],
+      ['1234567.89', ',', ' ', 'USD', TRUE], // This is the float format. Encapsulated in strings
+      [1234567.89, ',', ' ', 'USD', TRUE], // This is the float format.
+    ];
+  }
+
+  /**
    * Create test with unique field name on source.
    */
   public function testCreateContributionSource() {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -707,7 +707,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * @dataProvider createLocalizedContributionDataProvider
-   * @param $inputData
+   * @param $totalAmount
    * @param $decimalPoint
    * @param $thousandSeparator
    * @param $currency
@@ -729,7 +729,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     if ($expectedResult) {
       $this->callAPISuccess('Contribution', 'create', $_params);
-    } else {
+    }
+    else {
       $this->callAPIFailure('Contribution', 'create', $_params);
     }
   }
@@ -755,14 +756,18 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       ['$1,234,567.89', '.', ',', 'USD', TRUE],
       ['-$1,234,567.89', '.', ',', 'USD', TRUE],
       ['$-1,234,567.89', '.', ',', 'USD', TRUE],
-      ['1234567.89', '.', ',', 'USD', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, '.', ',', 'USD', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', '.', ',', 'USD', TRUE],
+      // This is the float format.
+      [1234567.89, '.', ',', 'USD', TRUE],
       // Test EURO currency
       ['€1,234,567.89', '.', ',', 'EUR', TRUE],
       ['-€1,234,567.89', '.', ',', 'EUR', TRUE],
       ['€-1,234,567.89', '.', ',', 'EUR', TRUE],
-      ['1234567.89', '.', ',', 'EUR', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, '.', ',', 'EUR', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', '.', ',', 'EUR', TRUE],
+      // This is the float format.
+      [1234567.89, '.', ',', 'EUR', TRUE],
       // Test Norwegian KR currency
       ['kr1,234,567.89', '.', ',', 'NOK', TRUE],
       ['kr 1,234,567.89', '.', ',', 'NOK', TRUE],
@@ -770,15 +775,19 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       ['-kr 1,234,567.89', '.', ',', 'NOK', TRUE],
       ['kr-1,234,567.89', '.', ',', 'NOK', TRUE],
       ['kr -1,234,567.89', '.', ',', 'NOK', TRUE],
-      ['1234567.89', '.', ',', 'NOK', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, '.', ',', 'NOK', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', '.', ',', 'NOK', TRUE],
+      // This is the float format.
+      [1234567.89, '.', ',', 'NOK', TRUE],
       // Test different localization options: , as decimal separator and dot as thousand separator
       ['$1.234.567,89', ',', '.', 'USD', TRUE],
       ['-$1.234.567,89', ',', '.', 'USD', TRUE],
       ['$-1.234.567,89', ',', '.', 'USD', TRUE],
       ['1.234.567,89', ',', '.', 'USD', TRUE],
-      ['1234567.89', ',', '.', 'USD', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, ',', '.', 'USD', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', ',', '.', 'USD', TRUE],
+      // This is the float format.
+      [1234567.89, ',', '.', 'USD', TRUE],
       ['$1,234,567.89', ',', '.', 'USD', FALSE],
       ['-$1,234,567.89', ',', '.', 'USD', FALSE],
       ['$-1,234,567.89', ',', '.', 'USD', FALSE],
@@ -787,8 +796,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       ['-$1 234 567,89', ',', ' ', 'USD', TRUE],
       ['$-1 234 567,89', ',', ' ', 'USD', TRUE],
       ['1 234 567,89', ',', ' ', 'USD', TRUE],
-      ['1234567.89', ',', ' ', 'USD', TRUE], // This is the float format. Encapsulated in strings
-      [1234567.89, ',', ' ', 'USD', TRUE], // This is the float format.
+      // This is the float format. Encapsulated in strings
+      ['1234567.89', ',', ' ', 'USD', TRUE],
+      // This is the float format.
+      [1234567.89, ',', ' ', 'USD', TRUE],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
, as decimal separator, and [space] as thousand separators leads to api errors
This PR fixes that. It also includes tests for testing different localization.

[Issue 1522](https://lab.civicrm.org/dev/core/issues/1522) contains a table of the analyses of which localized options are going wrong.

Before
----------------------------------------
* No tests for localization of currency with euro, different decimal and thousand separators
* Api error when creating a contribution with , is a decimal separtor and [space] a thousand separator 

After
----------------------------------------

* Added a localized Contribution Create Api v3 test
* Added a localized test for `CRM_Utils_Rule::money`
* Changed `CRM_Utils_Rule::money` so it accepts different localized options. 
* Api error is gone

Comments
----------------------------------------
Added deprecated flag to `setCurrencySeparators` in test/phpunit/CiviTest/CiviUnitTestCase.php

Also added three new functions `setMonetaryThousandSeparator`, `setMonetaryDecimalPoint` and `setDefaultCurrency` 

The reasoning behind this is that the setCurrencySeperator only sets the thousand seperator and somehow magically decides what than the decimal seperator is. 
I need more control of setting each of those, including the currency. 

If necessary I can create a separate PR which removed the `setCurrencySeparators` from all tests and replace them by the new functions. I can and will do that after this PR has been approved and merged. 