### PR TITLE
dev/core#1552 Fatal error using pager on Activity Detail Report when Include Case Activities is Yes

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -351,7 +351,8 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
 
   public function preProcess() {
     // Is "Include Case Activities" selected?  If yes, include the case_id as a hidden column
-    $includeCaseActivities = CRM_Utils_Request::retrieveValue('include_case_activities_value', 'Boolean');
+    $formToUse = $this->noController ? NULL : $this;
+    $includeCaseActivities = CRM_Utils_Request::retrieve('include_case_activities_value', 'Boolean', $formToUse);
     if (!empty($includeCaseActivities)) {
       $this->_columns['civicrm_case_activity'] = [
         'dao' => 'CRM_Case_DAO_CaseActivity',


### PR DESCRIPTION
Overview
----------------------------------------
On the filters tab on the Activity Detail CiviReport, choose Include Case Activities set to Yes.
Refresh results.
Click the Next pager button.
The symptom is Network error unable to reach server, but it's because of a fatal error.

Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1552

Comments
----------------------------------------
This is a quickie fix. It feels like there should be a better way.
