### PR TITLE
dev/core#1550 Invalid links to extension directory in popup help text

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Display.hlp
+++ b/templates/CRM/Admin/Form/Preferences/Display.hlp
@@ -17,7 +17,7 @@
   <ul>
     <li>{ts}Select 'CKEditor' for the built-in WYSIWYG option. You can customize the toolbar buttons and other settings by clicking "Configure CKEditor."{/ts}</li>
     <li>{ts}Select 'Textarea' if you want users to type text and/or HTML code into plain text fields.{/ts}</li>
-    <li>{ts 1='target="_blank" href="https://civicrm.org/extensions/home?body_value=wysiwyg&field_extension_cms_tid=127"'}Other WYSIWYG editors are available for download from the <a %1>CiviCRM Extension Directory</a>.{/ts}</li>
+    <li>{ts 1='target="_blank" href="https://civicrm.org/extensions?body_value=wysiwyg&field_extension_cms_tid=127"'}Other WYSIWYG editors are available for download from the <a %1>CiviCRM Extension Directory</a>.{/ts}</li>
   </ul>
 {/htxt}
 

--- a/templates/CRM/Admin/Page/PaymentProcessor.hlp
+++ b/templates/CRM/Admin/Page/PaymentProcessor.hlp
@@ -17,7 +17,7 @@
   <li>{docURL page="Payment Processors" text="Processor comparison and setup guide" resource="wiki"}</li>
 </ul>
 <p>{ts}If you're not sure which processor to use - we recommend reviewing terms, limitations and coverage areas on each processor's website before proceeding.{/ts}</p>
-<p>{ts 1="https://civicrm.org/extensions/civicrm?cat=125"}If your desired processor is not in the list, check the <a href="%1">Extensions Directory</a> for more payment processors you can download. If you still can't find it, consider partnering with a developer and contributing a new extension.{/ts}</p>
+<p>{ts 1="https://civicrm.org/extensions?tid_4[]=125"}If your desired processor is not in the list, check the <a href="%1">Extensions Directory</a> for more payment processors you can download. If you still can't find it, consider partnering with a developer and contributing a new extension.{/ts}</p>
 {/htxt}
 
 {htxt id='AuthNet-live-user-name'}


### PR DESCRIPTION
Overview
----------------------------------------
There's two places where the popup help text has invalid links.

https://lab.civicrm.org/dev/core/issues/1550

Before
----------------------------------------
At administer - customize - display preferences:

![wysiwig](https://user-images.githubusercontent.com/2967821/73219153-732cc580-4129-11ea-9c58-cd1088a80724.gif)

----
And at administer - system settings - payment processors:

![paymentprocessor](https://user-images.githubusercontent.com/2967821/73219166-77f17980-4129-11ea-89c4-0018b79b0168.gif)


After
----------------------------------------
Good links


Comments
----------------------------------------
I waffled over whether to change these to just links to https://civicrm.org/extensions, which will be more maintainable, and when civicrm.org changes to drupal 8 these might change again so the bare link might be more easily redirectable. For now I've kept their original intent but will do whatever.