### PR TITLE
Finish removal of deferred_revenue_enabled from non-standard setting

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -165,10 +165,9 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
 
     // assign values to the template
     $this->assign($values);
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
     $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();
     $this->assign('invoicing', $invoicing);
-    $this->assign('isDeferred', CRM_Utils_Array::value('deferred_revenue_enabled', $invoiceSettings));
+    $this->assign('isDeferred', Civi::settings()->get('deferred_revenue_enabled'));
     if ($invoicing && isset($values['tax_amount'])) {
       $this->assign('totalTaxAmount', $values['tax_amount']);
     }

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -116,7 +116,7 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreateDeferredTrxn() {
-    Civi::settings()->set('contribution_invoice_settings', ['deferred_revenue_enabled' => '1']);
+    Civi::settings()->set('deferred_revenue_enabled', TRUE);
     $cid = $this->individualCreate();
     $params = [
       'contact_id' => $cid,

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -258,9 +258,11 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
 
   /**
    * Test for validating financial type has deferred revenue account relationship.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testcheckFinancialTypeHasDeferred() {
-    Civi::settings()->set('deferred_revenue_enabled', 1);
+    Civi::settings()->set('deferred_revenue_enabled', TRUE);
     $params = [];
     $valid = CRM_Financial_BAO_FinancialAccount::checkFinancialTypeHasDeferred($params);
     $this->assertFalse($valid, "This should have been false");
@@ -341,7 +343,7 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
    * CRM-20037: Test balance due amount, if contribution is done using deferred Financial Type
    */
   public function testBalanceDueIfDeferredRevenueEnabled() {
-    Civi::settings()->set('contribution_invoice_settings', ['deferred_revenue_enabled' => '1']);
+    Civi::settings()->set('deferred_revenue_enabled', TRUE);
     $deferredFinancialTypeID = $this->_createDeferredFinancialAccount();
 
     $totalAmount = 100.00;

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -842,16 +842,13 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
   /**
    * Test Deferred Revenue Report.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testDeferredRevenueReport() {
     $indv1 = $this->individualCreate();
     $indv2 = $this->individualCreate();
-    $params = [
-      'contribution_invoice_settings' => [
-        'deferred_revenue_enabled' => '1',
-      ],
-    ];
-    $this->callAPISuccess('Setting', 'create', $params);
+    Civi::settings()->set('deferred_revenue_enabled', TRUE);
     $this->contributionCreate(
       [
         'contact_id' => $indv1,


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup on setting for deferred_revenue_enabled

Before
----------------------------------------
Although we converted this setting from a non-standard setting to a real setting a while back https://github.com/civicrm/civicrm-core/pull/14267 there are still a couple of old references in the code.

After
----------------------------------------
Old references tidied up

Technical Details
----------------------------------------
Per #14267 the 'invoice settings' should have followed our standards rather than made up a new one. I'm doing a push to get them to be how they should be

Comments
----------------------------------------

