### PR TITLE
dev/core#1558 retrieve setting credit_notes_prefix as  a 'real' setting.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4693,16 +4693,17 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *
    * @return string
    *   Credit Note Id.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function createCreditNoteId() {
-    $prefixValue = Civi::settings()->get('contribution_invoice_settings');
 
     $creditNoteNum = CRM_Core_DAO::singleValueQuery("SELECT count(creditnote_id) as creditnote_number FROM civicrm_contribution WHERE creditnote_id IS NOT NULL");
     $creditNoteId = NULL;
 
     do {
       $creditNoteNum++;
-      $creditNoteId = CRM_Utils_Array::value('credit_notes_prefix', $prefixValue) . "" . $creditNoteNum;
+      $creditNoteId = Civi::settings()->get('credit_notes_prefix') . '' . $creditNoteNum;
       $result = civicrm_api3('Contribution', 'getcount', [
         'sequential' => 1,
         'creditnote_id' => $creditNoteId,

--- a/api/v3/examples/Setting/GetFields.ex.php
+++ b/api/v3/examples/Setting/GetFields.ex.php
@@ -234,7 +234,6 @@ function setting_getfields_expectedresult() {
         'type' => 'Array',
         'default' => [
           'invoice_prefix' => 'INV_',
-          'credit_notes_prefix' => 'CN_',
           'due_date' => '10',
           'due_date_period' => 'days',
           'notes' => '',

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3025,7 +3025,6 @@ VALUES
       [
         'invoicing' => 1,
         'invoice_prefix' => 'INV_',
-        'credit_notes_prefix' => 'CN_',
         'due_date' => 10,
         'due_date_period' => 'days',
         'notes' => '',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1645,12 +1645,11 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Function tests that financial records are added when Pending Contribution is Canceled.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreateUpdateContributionCancelPending() {
-    // Enable & disable invoicing just to standardise the credit note id setting.
-    // Longer term we want to separate that setting from 'taxAndInvoicing'.
-    // and / or remove from core.
-    $this->enableTaxAndInvoicing();
+    Civi::settings()->set('credit_notes_prefix', 'CN_');
     $contribParams = [
       'contact_id' => $this->_individualId,
       'receive_date' => '2012-01-01',
@@ -1675,7 +1674,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->_checkFinancialTrxn($contribution, 'cancelPending', NULL, $checkTrxnDate);
     $this->_checkFinancialItem($contribution['id'], 'cancelPending');
     $this->assertEquals('CN_1', $contribution['values'][$contribution['id']]['creditnote_id']);
-    $this->disableTaxAndInvoicing();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is part of work to convert the non-standard contribution_invoice_settings array of settings into settings in line
with our standards


Before
----------------------------------------
Setting for credit_notes_prefix is now defined, as it's own setting thanks to https://github.com/civicrm/civicrm-core/pull/16424 but it is still not being retrieved 'the right way'

After
----------------------------------------
credit_notes_prefix is retrieved the right way

Technical Details
----------------------------------------
I'm going to convert the other settings too.

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1558
