### PR TITLE
avoid undefined offset and uninitialized key errors on upgrade - dev/core#1555

### DIFF
--- a/CRM/Upgrade/Incremental/SmartGroups.php
+++ b/CRM/Upgrade/Incremental/SmartGroups.php
@@ -287,7 +287,7 @@ class CRM_Upgrade_Incremental_SmartGroups {
       foreach ($savedSearches as $savedSearch) {
         $form_values = $savedSearch['form_values'];
         foreach ($form_values as $index => $formValues) {
-          if ($formValues[0] === 'custom_' . $custom_date_fields->id && is_array($formValues[2])) {
+          if (isset($formValues[0]) && $formValues[0] === 'custom_' . $custom_date_fields->id && is_array($formValues[2])) {
             if (isset($formValues[2]['BETWEEN'])) {
               $form_values[] = ['custom_' . $custom_date_fields->id . '_low', '=', $this->getConvertedDateValue($formValues[2]['BETWEEN'][0], FALSE)];
               $form_values[] = ['custom_' . $custom_date_fields->id . '_high', '=', $this->getConvertedDateValue($formValues[2]['BETWEEN'][1], TRUE)];


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/1555

Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1555

When upgrading, there are a lot of php notices along the lines of:

```
Undefined offset: 0 SmartGroups.php:290                           
Uninitialized string offset: 0 SmartGroups.php:290
```

Before
----------------------------------------
The errors fill the screen.

After
----------------------------------------
The errors do not show up.

Technical Details
----------------------------------------
The SmartGroup upgrade code makes an assumption about the formValues in a given database that is not true for all data.

