### PR TITLE
core#1557: respect non-primary details flag on quicksearch

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -819,7 +819,10 @@ function civicrm_api3_contact_getquick($params) {
         if ($value == 'phone') {
           $actualSelectElements[] = $select[] = 'phone_ext';
         }
-        $from[$value] = "LEFT JOIN civicrm_{$value} {$suffix} ON ( cc.id = {$suffix}.contact_id AND {$suffix}.is_primary = 1 ) ";
+        $from[$value] = "LEFT JOIN civicrm_{$value} {$suffix} ON cc.id = {$suffix}.contact_id ";
+        if (\Civi::settings()->get('searchPrimaryDetailsOnly') != 0) {
+          $from[$value] .= "AND {$suffix}.is_primary = 1 ";
+        }
         break;
 
       case 'country':
@@ -827,7 +830,10 @@ function civicrm_api3_contact_getquick($params) {
         $select[] = "{$suffix}.name as {$value}";
         $actualSelectElements[] = "{$suffix}.name";
         if (!in_array('address', $from)) {
-          $from['address'] = 'LEFT JOIN civicrm_address sts ON ( cc.id = sts.contact_id AND sts.is_primary = 1) ';
+          $from['address'] = 'LEFT JOIN civicrm_address sts ON cc.id = sts.contact_id ';
+          if (\Civi::settings()->get('searchPrimaryDetailsOnly') != 0) {
+            $from[$value] .= 'AND sts.is_primary = 1 ';
+          }
         }
         $from[$value] = " LEFT JOIN civicrm_{$value} {$suffix} ON ( sts.{$value}_id = {$suffix}.id  ) ";
         break;


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/1557

Overview
----------------------------------------
When using Quick Search for address/email/phone fields, it only searches primary address/email/phone regardless of the search setting "Search Primary Details Only".

Before
----------------------------------------
Only primary contact details can be found.

After
----------------------------------------
You can find contacts by non-primary contact details.

Comments
----------------------------------------
This is a very simple patch that crosses some controversial lines:
* It's about searching for non-primary details.
* It's in a deprecated API (`getquick`);

I'm going to argue that this avoids the normal concerns associated with those issues:
* `getquick` doesn't go through the search controller.  It's composing a raw SQL query.  As such, there's no necessity to change low-level code to fix this or worry about breaking unrelated functionality, which are the normal concerns about non-primary details.
* `getquick` is marked as deprecated, but it's been the mechanism behind QuickSearch for a while and there are no plans to change that.  Bugs have been fixed in this function as recently as 5.21 (#15955).
* Finally, this *is* a bug in that the expected behavior from setting "Search Primary Details Only" is that it would apply to Quick Search.

Finally - this deserves a big `needs-test` tag, but I wanted to get the concept approved first.