### PR TITLE
Make the Payment Details actions on Contributions accessible by hook_civicrm_links

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4123,7 +4123,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             [
               'id' => $resultDAO->id,
               'contribution_id' => $contributionId,
-            ]
+            ],
+            'more',
+            FALSE,
+            'payment.manage.action',
+            'Payment',
+            $resultDAO->id
           );
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
This change makes it so that developers can access the actions in the "Payment Details"  table on Contributions (the pencil icon in the screenshot below) using the [hook_civicrm_links](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/)

![view](https://user-images.githubusercontent.com/11323624/73299179-b300b500-41dc-11ea-9e18-3222a43d6f47.png)

Before
----------------------------------------
No way for developers to add or edit the links in the Payment Details table on Contributions

After
----------------------------------------
Developers can use the [hook_civicrm_links](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/) to add actions to the links in the Payment Details table on Contributions.