### PR TITLE
Allow most values of $civicrm_paths['XXX']['url'] to be relative 

### DIFF
--- a/tests/phpunit/Civi/Core/ThemesTest.php
+++ b/tests/phpunit/Civi/Core/ThemesTest.php
@@ -50,7 +50,7 @@ class ThemesTest extends \CiviUnitTestCase {
       ],
     ];
 
-    $civicrmBaseUrl = "";
+    $civicrmBaseUrl = rtrim(\Civi::paths()->getVariable('civicrm.root', 'url'), '/');
 
     // --- Library of tests ---
 
@@ -62,7 +62,7 @@ class ThemesTest extends \CiviUnitTestCase {
       [
         'civicrm-css/civicrm.css' => ["$civicrmBaseUrl/css/civicrm.css"],
         'civicrm-css/joomla.css' => ["$civicrmBaseUrl/css/joomla.css"],
-        'test.extension.uitest-files/foo.css' => ["/tests/extensions/test.extension.uitest/files/foo.css"],
+        'test.extension.uitest-files/foo.css' => ["$civicrmBaseUrl/tests/extensions/test.extension.uitest/files/foo.css"],
       ],
     ];
 
@@ -76,7 +76,7 @@ class ThemesTest extends \CiviUnitTestCase {
       [
         'civicrm-css/civicrm.css' => ["$civicrmBaseUrl/tests/phpunit/Civi/Core/Theme/judy/css/civicrm.css"],
         'civicrm-css/joomla.css' => ["$civicrmBaseUrl/css/joomla.css"],
-        'test.extension.uitest-files/foo.css' => ["/tests/extensions/test.extension.uitest/files/foo.css"],
+        'test.extension.uitest-files/foo.css' => ["$civicrmBaseUrl/tests/extensions/test.extension.uitest/files/foo.css"],
         // excluded
         'test.extension.uitest-files/ignoreme.css' => [],
       ],
@@ -90,7 +90,7 @@ class ThemesTest extends \CiviUnitTestCase {
       [
         'civicrm-css/civicrm.css' => ["$civicrmBaseUrl/css/civicrm.css"],
         'civicrm-css/joomla.css' => ["$civicrmBaseUrl/css/joomla.css"],
-        'test.extension.uitest-files/foo.css' => ["/tests/extensions/test.extension.uitest/files/foo.css"],
+        'test.extension.uitest-files/foo.css' => ["$civicrmBaseUrl/tests/extensions/test.extension.uitest/files/foo.css"],
       ],
     ];
 
@@ -102,7 +102,7 @@ class ThemesTest extends \CiviUnitTestCase {
       [
         'civicrm-css/civicrm.css' => [],
         'civicrm-css/joomla.css' => ["$civicrmBaseUrl/css/joomla.css"],
-        'test.extension.uitest-files/foo.css' => ["/tests/extensions/test.extension.uitest/files/foo.css"],
+        'test.extension.uitest-files/foo.css' => ["$civicrmBaseUrl/tests/extensions/test.extension.uitest/files/foo.css"],
       ],
     ];
 
@@ -116,7 +116,7 @@ class ThemesTest extends \CiviUnitTestCase {
         'civicrm-css/civicrm.css' => ["$civicrmBaseUrl/tests/phpunit/Civi/Core/Theme/liza/css/civicrm.css"],
         'civicrm-css/civicrm.min.css' => ["$civicrmBaseUrl/tests/phpunit/Civi/Core/Theme/liza/css/civicrm.min.css"],
         'civicrm-css/joomla.css' => ["$civicrmBaseUrl/css/joomla.css"],
-        'test.extension.uitest-files/foo.css' => ["/tests/phpunit/Civi/Core/Theme/liza/test.extension.uitest-files/foo.css"],
+        'test.extension.uitest-files/foo.css' => ["$civicrmBaseUrl/tests/phpunit/Civi/Core/Theme/liza/test.extension.uitest-files/foo.css"],
       ],
     ];
 

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace E2E\Core;
+
+use Civi\Core\Url;
+
+/**
+ * Class PathUrlTest
+ * @package E2E\Core
+ * @group e2e
+ *
+ * Check that various paths and URLs are generated correctly.
+ */
+class PathUrlTest extends \CiviEndToEndTestCase {
+
+  /**
+   * `CRM_Utils_System::url()` should generate working URLs.
+   */
+  public function testSystemRouter() {
+    $this->assertUrlContentRegex(';class="CRM_Mailing_Form_Subscribe";',
+      \CRM_Utils_System::url('civicrm/mailing/subscribe', 'reset=1', TRUE, NULL, FALSE));
+  }
+
+  /**
+   * `Civi::paths()->getUrl()` should generate working URLs.
+   */
+  public function testPaths_getUrl() {
+    $p = \Civi::paths();
+
+    $this->assertUrlContentRegex(';MIT-LICENSE.txt;',
+      $p->getUrl('[civicrm.packages]/jquery/plugins/jquery.timeentry.js', 'absolute'));
+    $this->assertUrlContentRegex(';https://civicrm.org/licensing;',
+      $p->getUrl('[civicrm.root]/js/Common.js', 'absolute'));
+    $this->assertUrlContentRegex(';Copyright jQuery Foundation;',
+      $p->getUrl('[civicrm.bower]/jquery/dist/jquery.js', 'absolute'));
+  }
+
+  /**
+   * `Civi::paths()->getPath()` should generate working paths.
+   */
+  public function testPaths_getPath() {
+    $p = \Civi::paths();
+
+    $this->assertFileContentRegex(';MIT-LICENSE.txt;',
+      $p->getPath('[civicrm.packages]/jquery/plugins/jquery.timeentry.js'));
+    $this->assertFileContentRegex(';https://civicrm.org/licensing;',
+      $p->getPath('[civicrm.root]/js/Common.js'));
+    $this->assertFileContentRegex(';Copyright jQuery Foundation;',
+      $p->getPath('[civicrm.bower]/jquery/dist/jquery.js'));
+  }
+
+  /**
+   * `Civi::paths()->getVariable()` should generate working paths+URLs.
+   */
+  public function testPaths_getVariable() {
+    $pathAndUrl = ['cms.root', 'civicrm.root', 'civicrm.packages', 'civicrm.files'];
+    $pathOnly = ['civicrm.private', 'civicrm.log', 'civicrm.compile'];
+    $urlOnly = [];
+
+    foreach (array_merge($pathOnly, $pathAndUrl) as $var) {
+      $path = \Civi::paths()->getVariable($var, 'path');
+      $this->assertTrue(file_exists($path) && is_dir($path), "The path for $var should be a valid directory.");
+    }
+
+    foreach (array_merge($urlOnly, $pathAndUrl) as $var) {
+      $url = \Civi::paths()->getVariable($var, 'url');
+      $this->assertRegExp(';^https?:;', $url, "The URL for $var should resolve a URL.");
+    }
+  }
+
+  /**
+   * @param string $expectContentRegex
+   * @param string $url
+   */
+  private function assertUrlContentRegex($expectContentRegex, $url) {
+    $this->assertRegexp(';^https?:;', $url, "The URL ($url) should be absolute.");
+    $content = file_get_contents($url);
+    $this->assertRegexp($expectContentRegex, $content);
+  }
+
+  /**
+   * @param string $expectContentRegex
+   * @param string $file
+   */
+  private function assertFileContentRegex($expectContentRegex, $file) {
+    $this->assertFileExists($file);
+    $content = file_get_contents($file);
+    $this->assertRegexp($expectContentRegex, $content);
+  }
+
+}


### PR DESCRIPTION
Overview
--------

The `$civicrm_paths` variable allows a sysadmin to override various path and URL computations.

```php
$civicrm_paths['civicrm.packages']['url'] = 'https://example.com/libraries/civicrm/packages';
```

These values are used to generate addresses, as in:

```php
$abs = Civi::paths()->getUrl('[civicrm.packages]/foo.js', 'absolute');
$rel = Civi::paths()->getUrl('[civicrm.packages]/foo.js', 'relative');
```

The variable was originally tested with absolute URLs, and the subsequent examples/docs use absolute URLs (https://docs.civicrm.org/dev/en/latest/framework/filesystem/).

The patch allows more values in `$civicrm_paths` while ensuring that `getUrl()` works as expected.

Before
------

The `getUrl()` requests only behave correctly if the override is an absolute URL - not if it's relative.

After
-----

The `getUrl()` requests behave correctly if the override is either an absolute URL or a relative URL.

```php
$civicrm_paths['civicrm.packages']['url'] = 'https://example.com/libraries/civicrm/packages';
$civicrm_paths['civicrm.packages']['url'] = '/libraries/civicrm/packages';
```

Comments
--------

* This PR is an extracted subset of #16328, which was an exploratory branch aimed at supporting deployment of Civi git repos in D8 via composer.  The changes are extracted to make the size of the review more manageable.  It's probably best to use this smaller PR to consider topics like regression-risk and general code convention rather than trying to assess the fuller aims of #16328.
* `toAbsoluteUrl()` needs a base to prepend. I initially used `HTTP_HOST` but switched to `cms.root`. Why? Correctly inferring scheme and host and port and path prefixes would be more complex - esp when you consider background/CLI jobs and firewalls/proxies. Using `cms.root` as the base is simpler. This leaves us with a limitation -- if one were to override `$civicrm_packages['cms.root']['url']`, then *that one* would still need to be an absolute URL. However, that's no worse than today and doesn't impede my use-case.
* It's tempting to allow recursive variables. But it's not actually needed for my purposes, and it would add complexity/maintenance. If it's really needed, one could add that at a later time. But for now... I think the simpler format is fine.
