### PR TITLE
Civi\Test - Allow `headless()->apply()` (etc) to execute without setup.sh

### DIFF
--- a/CRM/Core/CodeGen/Main.php
+++ b/CRM/Core/CodeGen/Main.php
@@ -151,13 +151,17 @@ Alternatively you can get a version of CiviCRM that matches your PHP version
     return $this->sourceDigest;
   }
 
-  protected function init() {
+  /**
+   * @return static
+   */
+  public function init() {
     if (!$this->database || !$this->tables) {
       $specification = new CRM_Core_CodeGen_Specification();
       $specification->parse($this->schemaPath, $this->buildVersion);
       $this->database = $specification->database;
       $this->tables = $specification->tables;
     }
+    return $this;
   }
 
 }

--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -106,6 +106,23 @@ class CRM_Core_CodeGen_Util_Template {
   }
 
   /**
+   * Fetch multiple templates - and concatenate them.
+   *
+   * @see runConcat
+   * @param array $inputs
+   *   Template filenames.
+   * @return string
+   */
+  public function fetchConcat($inputs) {
+    $buf = '';
+    foreach ($inputs as $infile) {
+      $buf .= $this->smarty->fetch($infile);
+      $buf .= "\n";
+    }
+    return $buf;
+  }
+
+  /**
    * @param $key
    * @param $value
    */

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -420,17 +420,7 @@ class CRM_Core_I18n {
 
     // do all wildcard translations first
 
-    // FIXME: Is there a constant we can reference instead of hardcoding en_US?
-    $replacementsLocale = $this->locale ? $this->locale : 'en_US';
-    if (!isset(Civi::$statics[__CLASS__]) || !array_key_exists($replacementsLocale, Civi::$statics[__CLASS__])) {
-      if (defined('CIVICRM_DSN') && !CRM_Core_Config::isUpgradeMode()) {
-        Civi::$statics[__CLASS__][$replacementsLocale] = CRM_Core_BAO_WordReplacement::getLocaleCustomStrings($replacementsLocale);
-      }
-      else {
-        Civi::$statics[__CLASS__][$replacementsLocale] = [];
-      }
-    }
-    $stringTable = Civi::$statics[__CLASS__][$replacementsLocale];
+    $stringTable = $this->getWordReplacements();
 
     $exactMatch = FALSE;
     if (isset($stringTable['enabled']['exactMatch'])) {
@@ -735,6 +725,28 @@ class CRM_Core_I18n {
   public static function getLocale() {
     global $tsLocale;
     return $tsLocale ? $tsLocale : 'en_US';
+  }
+
+  /**
+   * @return array
+   *   Ex: $stringTable['enabled']['wildcardMatch']['foo'] = 'bar';
+   */
+  private function getWordReplacements() {
+    if (isset(Civi::$statics['testPreInstall'])) {
+      return [];
+    }
+
+    // FIXME: Is there a constant we can reference instead of hardcoding en_US?
+    $replacementsLocale = $this->locale ? $this->locale : 'en_US';
+    if ((!isset(Civi::$statics[__CLASS__]) || !array_key_exists($replacementsLocale, Civi::$statics[__CLASS__]))) {
+      if (defined('CIVICRM_DSN') && !CRM_Core_Config::isUpgradeMode()) {
+        Civi::$statics[__CLASS__][$replacementsLocale] = CRM_Core_BAO_WordReplacement::getLocaleCustomStrings($replacementsLocale);
+      }
+      else {
+        Civi::$statics[__CLASS__][$replacementsLocale] = [];
+      }
+    }
+    return Civi::$statics[__CLASS__][$replacementsLocale];
   }
 
 }

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -119,7 +119,7 @@ class Test {
         echo "Installing {$dbName} schema\n";
         \Civi\Test::schema()->dropAll();
       }, 'headless-drop')
-      ->sqlFile($civiRoot . "/sql/civicrm.mysql")
+      ->coreSchema()
       ->sql("DELETE FROM civicrm_extension")
       ->callback(function ($ctx) {
         \Civi\Test::data()->populate();
@@ -156,6 +156,19 @@ class Test {
       self::$singletons['schema'] = new \Civi\Test\Schema();
     }
     return self::$singletons['schema'];
+  }
+
+  /**
+   * @return \CRM_Core_CodeGen_Main
+   */
+  public static function codeGen() {
+    if (!isset(self::$singletons['codeGen'])) {
+      $civiRoot = dirname(__DIR__);
+      $codeGen = new \CRM_Core_CodeGen_Main("$civiRoot/CRM/Core/DAO", "$civiRoot/sql", $civiRoot, "$civiRoot/templates", NULL, "UnitTests", NULL, "$civiRoot/xml/schema/Schema.xml", NULL);
+      $codeGen->init();
+      self::$singletons['codeGen'] = $codeGen;
+    }
+    return self::$singletons['codeGen'];
   }
 
   /**

--- a/Civi/Test/CiviEnvBuilder.php
+++ b/Civi/Test/CiviEnvBuilder.php
@@ -2,6 +2,7 @@
 namespace Civi\Test;
 
 use Civi\Test\CiviEnvBuilder\CallbackStep;
+use Civi\Test\CiviEnvBuilder\CoreSchemaStep;
 use Civi\Test\CiviEnvBuilder\ExtensionsStep;
 use Civi\Test\CiviEnvBuilder\SqlFileStep;
 use Civi\Test\CiviEnvBuilder\SqlStep;
@@ -39,6 +40,15 @@ class CiviEnvBuilder {
 
   public function callback($callback, $signature = NULL) {
     return $this->addStep(new CallbackStep($callback, $signature));
+  }
+
+  /**
+   * Generate the core SQL tables.
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   */
+  public function coreSchema() {
+    return $this->addStep(new CoreSchemaStep());
   }
 
   public function sql($sql) {

--- a/Civi/Test/CiviEnvBuilder/CoreSchemaStep.php
+++ b/Civi/Test/CiviEnvBuilder/CoreSchemaStep.php
@@ -1,0 +1,50 @@
+<?php
+namespace Civi\Test\CiviEnvBuilder;
+
+/**
+ * Class CoreSchemaStep
+ * @package Civi\Test\CiviEnvBuilder
+ *
+ * An initialization step which loads the core SQL schema.
+ *
+ * Note that the computation of the schema is cached for the duration of
+ * the PHP process (\Civi\Test::$statics).
+ */
+class CoreSchemaStep implements StepInterface {
+
+  /**
+   * @return array
+   *   - digest: string
+   *   - content: string
+   */
+  public function getSql() {
+    if (!isset(\Civi\Test::$statics['core_schema_sql'])) {
+      $schema = new \CRM_Core_CodeGen_Schema(\Civi\Test::codeGen());
+      $files = $schema->generateCreateSql();
+      \Civi\Test::$statics['core_schema_sql'] = [
+        'digest' => md5($files['civicrm.mysql']),
+        'content' => $files['civicrm.mysql'],
+      ];
+    }
+    return \Civi\Test::$statics['core_schema_sql'];
+  }
+
+  public function getSig() {
+    return $this->getSql()['digest'];
+  }
+
+  public function isValid() {
+    return TRUE;
+  }
+
+  /**
+   * @param \Civi\Test\CiviEnvBuilder $ctx
+   */
+  public function run($ctx) {
+    $sql = $this->getSql();
+    if (\Civi\Test::execute($sql['content']) === FALSE) {
+      throw new \RuntimeException("Cannot execute SQL");
+    }
+  }
+
+}

--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -21,7 +21,12 @@ class Data {
       \Civi\Test::execute('SET NAMES utf8');
       $sqlDir = dirname(dirname(__DIR__)) . "/sql";
 
-      $query2 = file_get_contents("$sqlDir/civicrm_data.mysql");
+      if (!isset(\Civi\Test::$statics['locale_data'])) {
+        $schema = new \CRM_Core_CodeGen_Schema(\Civi\Test::codeGen());
+        \Civi\Test::$statics['locale_data'] = $schema->generateLocaleDataSql('en_US');
+      }
+
+      $query2 = \Civi\Test::$statics['locale_data']["civicrm_data.mysql"];
       $query3 = file_get_contents("$sqlDir/test_data.mysql");
       $query4 = file_get_contents("$sqlDir/test_data_second_domain.mysql");
       if (\Civi\Test::execute($query2) === FALSE) {

--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -12,30 +12,32 @@ class Data {
    * @return bool
    */
   public function populate() {
-    \Civi\Test::schema()->truncateAll();
+    \Civi\Test::asPreInstall(function() {
+      \Civi\Test::schema()->truncateAll();
 
-    \Civi\Test::schema()->setStrict(FALSE);
+      \Civi\Test::schema()->setStrict(FALSE);
 
-    // Ensure that when we populate the database it is done in utf8 mode
-    \Civi\Test::execute('SET NAMES utf8');
-    $sqlDir = dirname(dirname(__DIR__)) . "/sql";
+      // Ensure that when we populate the database it is done in utf8 mode
+      \Civi\Test::execute('SET NAMES utf8');
+      $sqlDir = dirname(dirname(__DIR__)) . "/sql";
 
-    $query2 = file_get_contents("$sqlDir/civicrm_data.mysql");
-    $query3 = file_get_contents("$sqlDir/test_data.mysql");
-    $query4 = file_get_contents("$sqlDir/test_data_second_domain.mysql");
-    if (\Civi\Test::execute($query2) === FALSE) {
-      throw new RuntimeException("Cannot load civicrm_data.mysql. Aborting.");
-    }
-    if (\Civi\Test::execute($query3) === FALSE) {
-      throw new RuntimeException("Cannot load test_data.mysql. Aborting.");
-    }
-    if (\Civi\Test::execute($query4) === FALSE) {
-      throw new RuntimeException("Cannot load test_data.mysql. Aborting.");
-    }
+      $query2 = file_get_contents("$sqlDir/civicrm_data.mysql");
+      $query3 = file_get_contents("$sqlDir/test_data.mysql");
+      $query4 = file_get_contents("$sqlDir/test_data_second_domain.mysql");
+      if (\Civi\Test::execute($query2) === FALSE) {
+        throw new RuntimeException("Cannot load civicrm_data.mysql. Aborting.");
+      }
+      if (\Civi\Test::execute($query3) === FALSE) {
+        throw new RuntimeException("Cannot load test_data.mysql. Aborting.");
+      }
+      if (\Civi\Test::execute($query4) === FALSE) {
+        throw new RuntimeException("Cannot load test_data.mysql. Aborting.");
+      }
 
-    unset($query, $query2, $query3);
+      unset($query, $query2, $query3);
 
-    \Civi\Test::schema()->setStrict(TRUE);
+      \Civi\Test::schema()->setStrict(TRUE);
+    });
 
     // Rebuild triggers
     civicrm_api('system', 'flush', ['version' => 3, 'triggers' => 1]);

--- a/tests/phpunit/E2E/Core/LocalizedDataTest.php
+++ b/tests/phpunit/E2E/Core/LocalizedDataTest.php
@@ -21,11 +21,8 @@ class LocalizedDataTest extends \CiviEndToEndTestCase {
    *   && phpunit6 tests/phpunit/E2E/Core/LocalizedDataTest.php
    */
   public function testLocalizedData() {
-    $getSql = function($locale) {
-      $path = \Civi::paths()->getPath("[civicrm.root]/sql/civicrm_data.{$locale}.mysql");
-      $this->assertFileExists($path);
-      return file_get_contents($path);
-    };
+    $getSql = $this->getSqlFunc();
+
     $sqls = [
       'de_DE' => $getSql('de_DE'),
       'fr_FR' => $getSql('fr_FR'),
@@ -43,6 +40,47 @@ class LocalizedDataTest extends \CiviEndToEndTestCase {
     $this->assertTrue($match('fr_FR', 'fr_FR'), 'The French SQL should match the French pattern.');
     $this->assertFalse($match('de_DE', 'fr_FR'), 'The German SQL should not match the French pattern.');
     $this->assertFalse($match('fr_FR', 'de_DE'), 'The French SQL should not match the German pattern.');
+  }
+
+  /**
+   * @return callable
+   *   The SQL loader -- function(string $locale): string
+   */
+  private function getSqlFunc() {
+    // Some deployment styles use stored files, and some generate SQL programmatically.
+    // This heuristic discerns the style by UF name, although a better heuristic might be to check
+    // for composer at CMS root. This works in a pinch.
+    $uf = CIVICRM_UF;
+    $installerTypes = [
+      'Drupal' => [$this, '_getSqlFile'],
+      'Drupal8' => [$this, '_getSqlLive'],
+      'WordPress' => [$this, '_getSqlFile'],
+      'Backdrop' => [$this, '_getSqlFile'],
+      'Joomla' => [$this, '_getSqlFile'],
+    ];
+    if (isset($installerTypes[$uf])) {
+      return $installerTypes[$uf];
+    }
+    else {
+      throw new \RuntimeException("Failed to determine installation type for $uf");
+    }
+  }
+
+  private function _getSqlFile($locale) {
+    $path = \Civi::paths()->getPath("[civicrm.root]/sql/civicrm_data.{$locale}.mysql");
+    $this->assertFileExists($path);
+    return file_get_contents($path);
+  }
+
+  private function _getSqlLive($locale) {
+    $schema = new \CRM_Core_CodeGen_Schema(\Civi\Test::codeGen());
+    $files = $schema->generateLocaleDataSql($locale);
+    foreach ($files as $file => $content) {
+      if (preg_match(';^civicrm_data\.;', $file)) {
+        return $content;
+      }
+    }
+    throw new \Exception("Faield to generate $locale");
   }
 
 }


### PR DESCRIPTION
Before
------

If you have a copy of the `git` codebase and wish to run any of the headless test suites, you *must* run `setup.sh` aka `GenCode` beforehand.

This is because certain files - `sql/civicrm.mysql` and `sql/civicrm_data.mysql` - are used in the headless suite.  As large auto-generated files, they are not provided in git.

After
-----

The files `sql/civicrm.mysql` and `sql/civicrm_data.mysql` are no longer required by the test suite -- the headless tests will directly use the `GenCode` classes to produce the needful.

Comments
--------

The general thrust of this commit is to find spots which read an SQL file, e.g.

```php
\Civi\Test::execute(file_get_contents("foobar.mysql"));
```

and instead call the generator for that file, e.g.:

```php
$schema = new \CRM_Core_CodeGen_Schema(\Civi\Test::codeGen());
$result = $schema->generateFooBar();
\Civi\Test::execute($result['foobar.mysql']);
});
```

In doing so, we incorporate a couple tricks:

* The SQL content is cached for the duration of the test-run (`Civi\Test::$statics`). Generating the SQL is not super expensive... but `Civi\Test::headless()->...apply()` may be called thousands of times, so it could add-up. Just cache it.
* Most of the `generateFooBar()` functions depend in some fashion on `ts()`. This commit depends on a preceding commit to make `ts()` more amenable to execution during early stages of the test.
    * Related discussion: https://chat.civicrm.org/civicrm/pl/ehohytqkf7bd5prg9w75dq4qqw

This PR is an extracted subset of #16328, which was an exploratory branch aimed at supporting deployment of Civi git repos in D8 via composer.  The changes are extracted to make the size of the review more manageable.  It's probably best to use this smaller PR to consider topics like regression-risk and general code convention rather than trying to assess the fuller aims of #16328.