### PR TITLE
CRM_Core_Menu - Fix warnings during local test run (dev/core#742)

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -96,7 +96,7 @@ class CRM_Core_Menu {
    * @throws Exception
    */
   public static function read($name, &$menu) {
-    $xml = simplexml_load_file($name);
+    $xml = simplexml_load_string(file_get_contents($name));
     self::readXML($xml, $menu);
   }
 


### PR DESCRIPTION
Before
------

In certain local OSX+D8 test environments, when running the full suite, I got a large number of warnings like this:

```
Warning: simplexml_load_file(): I/O warning : failed to load external entity "/Users/totten/bknix/build/drupal8-clean/web/vendor/civicrm/civicrm-core//CRM/Campaign/xml/Menu/Campaign.xml" in /Users/totten/bknix/build/drupal8-clean/web/vendor/civicrm/civicrm-core/CRM/Core/Menu.php on line 99
```

After
-----

Those warnings seem to have gone away.

The menu still seems to populate correctly.

Comments
--------

This smells a lot like `dev/core#742` -- e.g.  it's the same warning and (after adjusting for changes in line-numbering over the months) same line of code. However, in a quick check, my current local build didn't reproduce 742.

This PR is an extracted subset of #16328, which was an exploratory branch aimed at supporting deployment of Civi git repos in D8 via composer.  The changes are extracted to make the size of the review more manageable.  It's probably best to use this smaller PR to consider topics like regression-risk and general code convention rather than trying to assess the fuller aims of #16328.
