### PR TITLE
Fix loading with alternate packages path (system-level)

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -124,7 +124,13 @@ class CRM_Core_ClassLoader {
     $this->initHtmlPurifier($prepend);
 
     $this->_registered = TRUE;
-    $packages_path = implode(DIRECTORY_SEPARATOR, [$civicrm_base_path, 'packages']);
+    // The ClassLoader runs before the classes are available. Approximate Civi::paths()->get('[civicrm.packages]').
+    if (isset($GLOBALS['civicrm_paths']['civicrm.packages']['path'])) {
+      $packages_path = rtrim($GLOBALS['civicrm_paths']['civicrm.packages']['path'], DIRECTORY_SEPARATOR);
+    }
+    else {
+      $packages_path = implode(DIRECTORY_SEPARATOR, [$civicrm_base_path, 'packages']);
+    }
     $include_paths = [
       '.',
       $civicrm_base_path,
@@ -177,7 +183,12 @@ class CRM_Core_ClassLoader {
     // we do this to prevent a autoloader errors with joomla / 3rd party packages
     // Use absolute path, since we don't know the content of include_path yet.
     // CRM-11304
-    $file = dirname(__FILE__) . '/../../packages/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php';
+    if (isset($GLOBALS['civicrm_paths']['civicrm.packages']['path'])) {
+      $file = rtrim($GLOBALS['civicrm_paths']['civicrm.packages']['path'], DIRECTORY_SEPARATOR) . '/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php';
+    }
+    else {
+      $file = dirname(__FILE__) . '/../../packages/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php';
+    }
     if (file_exists($file)) {
       return $file;
     }

--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -103,14 +103,14 @@ class CRM_Core_IDS {
   public static function createBaseConfig() {
     $config = \CRM_Core_Config::singleton();
     $tmpDir = empty($config->uploadDir) ? Civi::paths()->getVariable('civicrm.compile', 'path') : $config->uploadDir;
-    global $civicrm_root;
+    $pkgs = Civi::paths()->getVariable('civicrm.packages', 'path');
 
     return [
       'General' => [
         'filter_type' => 'xml',
-        'filter_path' => "{$civicrm_root}/packages/IDS/default_filter.xml",
+        'filter_path' => "{$pkgs}/IDS/default_filter.xml",
         'tmp_path' => $tmpDir,
-        'HTML_Purifier_Path' => $civicrm_root . 'packages/IDS/vendors/htmlpurifier/HTMLPurifier.auto.php',
+        'HTML_Purifier_Path' => $pkgs . '/IDS/vendors/htmlpurifier/HTMLPurifier.auto.php',
         'HTML_Purifier_Cache' => $tmpDir,
         'scan_keys' => '',
         'exceptions' => ['__utmz', '__utmc'],

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -818,6 +818,19 @@ class CRM_Core_Resources {
     // Allow hooks to modify this list
     CRM_Utils_Hook::coreResourceList($items, $region);
 
+    // Oof, existing listeners would expect $items to typically begin with 'bower_components/' or 'packages/'
+    // (using an implicit base of `[civicrm.root]`). We preserve the hook contract and cleanup $items post-hook.
+    $map = [
+      'bower_components' => rtrim(Civi::paths()->getUrl('[civicrm.bower]/.', 'absolute'), '/'),
+      'packages' => rtrim(Civi::paths()->getUrl('[civicrm.packages]/.', 'absolute'), '/'),
+    ];
+    $filter = function($m) use ($map) {
+      return $map[$m[1]] . $m[2];
+    };
+    $items = array_map(function($item) use ($filter) {
+      return is_array($item) ? $item : preg_replace_callback(';^(bower_components|packages)(/.*);', $filter, $item);
+    }, $items);
+
     return $items;
   }
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -118,7 +118,8 @@ class CRM_Core_Smarty extends Smarty {
       }
     }
 
-    $smartyDir = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'packages' . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR;
+    $pkgsDir = Civi::paths()->getVariable('civicrm.packages', 'path');
+    $smartyDir = $pkgsDir . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR;
     $pluginsDir = __DIR__ . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR;
 
     if ($customPluginsDir) {

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -433,7 +433,7 @@ class CRM_Utils_String {
    *   the converted string
    */
   public static function htmlToText($html) {
-    require_once 'packages/html2text/rcube_html2text.php';
+    require_once 'html2text/rcube_html2text.php';
     $token_html = preg_replace('!\{([a-z_.]+)\}!i', 'token:{$1}', $html);
     $converter = new rcube_html2text($token_html);
     $token_text = $converter->get_text();


### PR DESCRIPTION
Overview
----------------------------------------

The configuration option `$civicrm_paths['civicrm.packages']` allows one to specify the local path and remote URL of the `packages` folder. This is not done often, but it is helpful for the composer/D8/git deployment styles. Alas, there are still sundry hard-coded references to the `packages` folder.

This fixes some (but not all) references to `packages`. It generally focuses on classes that are used in universal/system-level processes (such as the class-loader).

Before
----------------------------------------

`CRM_Core_Resources`, `CRM_Core_Smarty`, `CRM_Core_IDS`, `CRM_Core_ClassLoader`, and `CRM_Utils_String` have path references which assume that `civicrm-packages.git` lives directly under `[civicrm.root]/packages`.

After
----------------------------------------

Each of these references has been updated to relax that expectation. 

Comments
----------------------------------------

Generally, it's preferable to either:

* Remove any explicit reference to `packages` and just rely on the include-path (for `*.php` files)
* Construct references to `packages` using the "paths" subsystem (e.g. `Civi::paths()->getPath('[civicrm.packages]/foobar')`.

However, some files have peculiar issues which make that problematic -- so several of these items required alternative solutions.

This PR is an extracted subset of #16328, which was an exploratory branch aimed at supporting deployment of Civi git repos in D8 via composer.  The changes are extracted to make the size of the review more manageable.  It's probably best to use this smaller PR to consider topics like regression-risk and general code convention rather than trying to assess the fuller aims of #16328.

