### PR TITLE
setup.sh - Fixes for running in basic composer file-structure

### DIFF
--- a/CRM/Core/CodeGen/Config.php
+++ b/CRM/Core/CodeGen/Config.php
@@ -39,6 +39,10 @@ class CRM_Core_CodeGen_Config extends CRM_Core_CodeGen_BaseTask {
    *   path to config template
    */
   public function findConfigTemplate($cms) {
+    if (getenv('GENCODE_CONFIG_TEMPLATE')) {
+      return getenv('GENCODE_CONFIG_TEMPLATE');
+    }
+
     $candidates = [];
     switch ($cms) {
       case 'backdrop':

--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -46,11 +46,12 @@ class CRM_Core_CodeGen_Util_Smarty {
    */
   public function createSmarty() {
     $base = dirname(dirname(dirname(dirname(__DIR__))));
+    $pkgs = file_exists(dirname($base) . "/civicrm-packages") ? dirname($base) . "/civicrm-packages" : "$base/packages";
 
     require_once 'Smarty/Smarty.class.php';
     $smarty = new Smarty();
     $smarty->template_dir = "$base/xml/templates";
-    $smarty->plugins_dir = ["$base/packages/Smarty/plugins", "$base/CRM/Core/Smarty/plugins"];
+    $smarty->plugins_dir = ["$pkgs/Smarty/plugins", "$base/CRM/Core/Smarty/plugins"];
     $smarty->compile_dir = $this->getCompileDir();
     $smarty->clear_all_cache();
 
@@ -58,6 +59,8 @@ class CRM_Core_CodeGen_Util_Smarty {
 
     require_once 'CRM/Core/Smarty/plugins/block.localize.php';
     $smarty->register_block('localize', 'smarty_block_localize');
+
+    $smarty->assign('gencodeXmlDir', dirname(dirname(dirname(dirname(__DIR__)))) . '/xml');
 
     return $smarty;
   }

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -141,8 +141,10 @@ set -x
 
 if [ -n "$DO_DOWNLOAD" ]; then
   pushd "$CALLEDPATH/.."
-    COMPOSER=$(pickcmd composer composer.phar)
-    $COMPOSER install
+    if [ "$GENCODE_CMS" != "Drupal8" ]; then
+      COMPOSER=$(pickcmd composer composer.phar)
+      $COMPOSER install
+    fi
 
     if has_commands karma ; then
       ## dev dependencies have been installed globally; don't force developer to redownload

--- a/xml/GenCode.php
+++ b/xml/GenCode.php
@@ -4,7 +4,8 @@ if (PHP_SAPI !== 'cli') {
   die("GenCode can only be run from command line.");
 }
 
-ini_set('include_path', '.' . PATH_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'packages' . PATH_SEPARATOR . '..');
+$includes = ['.', '../packages', '../../civicrm-packages', '..'];
+ini_set('include_path', implode(PATH_SEPARATOR, $includes));
 // make sure the memory_limit is at least 512 MB
 $memLimitString = trim(ini_get('memory_limit'));
 $memLimitUnit = strtolower(substr($memLimitString, -1));

--- a/xml/templates/civicrm_msg_template.tpl
+++ b/xml/templates/civicrm_msg_template.tpl
@@ -106,16 +106,16 @@ INSERT INTO civicrm_msg_template
   (msg_title,      msg_subject,                  msg_text,                  msg_html,                  workflow_id,        is_default, is_reserved) VALUES
 {foreach from=$ovNames key=gName item=ovs name=for_groups}
 {foreach from=$ovs key=vName item=title name=for_values}
-      {fetch assign=subject file="`$smarty.const.SMARTY_DIR`/../../xml/templates/message_templates/`$vName`_subject.tpl"}
-      {fetch assign=text    file="`$smarty.const.SMARTY_DIR`/../../xml/templates/message_templates/`$vName`_text.tpl"}
-      {fetch assign=html    file="`$smarty.const.SMARTY_DIR`/../../xml/templates/message_templates/`$vName`_html.tpl"}
+      {fetch assign=subject file="`$gencodeXmlDir`/templates/message_templates/`$vName`_subject.tpl"}
+      {fetch assign=text    file="`$gencodeXmlDir`/templates/message_templates/`$vName`_text.tpl"}
+      {fetch assign=html    file="`$gencodeXmlDir`/templates/message_templates/`$vName`_html.tpl"}
       ('{$title}', '{$subject|escape:"quotes"}', '{$text|escape:"quotes"}', '{$html|escape:"quotes"}', @tpl_ovid_{$vName}, 1,          0),
       ('{$title}', '{$subject|escape:"quotes"}', '{$text|escape:"quotes"}', '{$html|escape:"quotes"}', @tpl_ovid_{$vName}, 0,          1) {if $smarty.foreach.for_groups.last and $smarty.foreach.for_values.last};{else},{/if}
 {/foreach}
 {/foreach}
 
 {php}
-  $dir = SMARTY_DIR . '/../../xml/templates/message_templates/sample';
+  $dir = $this->_tpl_vars['gencodeXmlDir'] . '/templates/message_templates/sample';
   $templates = array();
   foreach (preg_grep('/\.tpl$/', scandir($dir)) as $filename) {
     $templates[] = array('name' => basename($filename, '.tpl'), 'filename' => "$dir/$filename");


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you make a build of the form:

```
composer init
composer require civicrm/civicrm-core civicrm/civicrm-packages --prefer-source
```

which gives you folders

```
./vendor/civicrm/civicrm-core
./vendor/civicrm/civicrm-packages
```

If you do development on this build, you may need to run `bin/setup.sh` (aka `xml/GenCode.php`) periodically to update the DAO files.

Before
----------------------------------------

`bin/setup.sh` raises multiple errors.

After
----------------------------------------

`bin/setup.sh` is able to run (with caveats).

Comments
----------------------------------------

The example steps in the "Overview" are just a communication aide to describe the file-structure/context - they're not actual instructions.

This PR is an extracted subset of #16328, which was an exploratory branch aimed at supporting deployment of Civi git repos in D8 via composer.  The changes are extracted to make the size of the review more manageable.  It's probably best to use this smaller PR to consider topics like regression-risk and general code convention rather than trying to assess the fuller aims.
