### PR TITLE
[NFC] throw exceptions, single quotes, declare exceptions, remove unused param

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -151,6 +151,8 @@ trait CRM_Admin_Form_SettingTrait {
 
   /**
    * Add fields in the metadata to the template.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function addFieldsDefinedInSettingsMetadata() {
     $settingMetaData = $this->getSettingsMetaData();
@@ -178,7 +180,7 @@ trait CRM_Admin_Form_SettingTrait {
         }
 
         $add = 'add' . $quickFormType;
-        if ($add == 'addElement') {
+        if ($add === 'addElement') {
           $this->$add(
             $props['html_type'],
             $setting,
@@ -187,13 +189,13 @@ trait CRM_Admin_Form_SettingTrait {
             ($options !== NULL) ? CRM_Utils_Array::value('html_attributes', $props, []) : NULL
           );
         }
-        elseif ($add == 'addSelect') {
+        elseif ($add === 'addSelect') {
           $this->addElement('select', $setting, $props['title'], $options, CRM_Utils_Array::value('html_attributes', $props));
         }
-        elseif ($add == 'addCheckBox') {
+        elseif ($add === 'addCheckBox') {
           $this->addCheckBox($setting, '', $options, NULL, CRM_Utils_Array::value('html_attributes', $props), NULL, NULL, ['&nbsp;&nbsp;']);
         }
-        elseif ($add == 'addCheckBoxes') {
+        elseif ($add === 'addCheckBoxes') {
           $newOptions = array_flip($options);
           $classes = 'crm-checkbox-list';
           if (!empty($props['sortable'])) {
@@ -208,12 +210,12 @@ trait CRM_Admin_Form_SettingTrait {
             '</li><li>'
           );
         }
-        elseif ($add == 'addChainSelect') {
+        elseif ($add === 'addChainSelect') {
           $this->addChainSelect($setting, [
             'label' => $props['title'],
           ]);
         }
-        elseif ($add == 'addMonthDay') {
+        elseif ($add === 'addMonthDay') {
           $this->add('date', $setting, $props['title'], CRM_Core_SelectValues::date(NULL, 'M d'));
         }
         elseif ($add === 'addEntityRef') {
@@ -232,15 +234,15 @@ trait CRM_Admin_Form_SettingTrait {
         $description = CRM_Utils_Array::value('description', $props);
         $descriptions[$setting] = $description;
         $this->assign("{$setting}_description", $description);
-        if ($setting == 'max_attachments') {
+        if ($setting === 'max_attachments') {
           //temp hack @todo fix to get from metadata
           $this->addRule('max_attachments', ts('Value should be a positive number'), 'positiveInteger');
         }
-        if ($setting == 'max_attachments_backend') {
+        if ($setting === 'max_attachments_backend') {
           //temp hack @todo fix to get from metadata
           $this->addRule('max_attachments_backend', ts('Value should be a positive number'), 'positiveInteger');
         }
-        if ($setting == 'maxFileSize') {
+        if ($setting === 'maxFileSize') {
           //temp hack
           $this->addRule('maxFileSize', ts('Value should be a positive number'), 'positiveInteger');
         }
@@ -293,12 +295,15 @@ trait CRM_Admin_Form_SettingTrait {
    * Get the defaults for all fields defined in the metadata.
    *
    * All others are pending conversion.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function setDefaultsForMetadataDefinedFields() {
     CRM_Core_BAO_ConfigSetting::retrieve($this->_defaults);
     foreach (array_keys($this->_settings) as $setting) {
       $this->_defaults[$setting] = civicrm_api3('setting', 'getvalue', ['name' => $setting]);
-      $spec = $this->getSettingsMetadata()[$setting];
+      $spec = $this->getSettingsMetaData()[$setting];
       if (!empty($spec['serialize'])) {
         $this->_defaults[$setting] = CRM_Core_DAO::unSerializeField($this->_defaults[$setting], $spec['serialize']);
       }
@@ -355,6 +360,8 @@ trait CRM_Admin_Form_SettingTrait {
    * @param array $settingValue
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
    */
   private function getReorderedSettingData($setting, $settingValue) {
     // Get order from $_POST as $_POST maintains the order the sorted setting

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -87,7 +87,7 @@ class CRM_Core_SelectValues {
       'month' => ts('month'),
       'year' => ts('year'),
     ];
-    if ($unitType == 'duration') {
+    if ($unitType === 'duration') {
       $unitList['lifetime'] = ts('lifetime');
     }
     return $unitList;
@@ -121,10 +121,10 @@ class CRM_Core_SelectValues {
    */
   public static function emailSelectMethods() {
     return [
-      'automatic' => ts("Automatic"),
-      'location-only' => ts("Only send to email addresses assigned to the specified location"),
-      'location-prefer' => ts("Prefer email addresses assigned to the specified location"),
-      'location-exclude' => ts("Exclude email addresses assigned to the specified location"),
+      'automatic' => ts('Automatic'),
+      'location-only' => ts('Only send to email addresses assigned to the specified location'),
+      'location-prefer' => ts('Prefer email addresses assigned to the specified location'),
+      'location-exclude' => ts('Exclude email addresses assigned to the specified location'),
     ];
   }
 
@@ -294,7 +294,7 @@ class CRM_Core_SelectValues {
    *
    * @return array
    *   the date array
-   * @throws \Exception
+   * @throws CRM_Core_Exception
    */
   public static function date($type = NULL, $format = NULL, $minOffset = NULL, $maxOffset = NULL, $context = 'display') {
     // These options are deprecated. Definitely not used in datepicker. Possibly not even in jcalendar+addDateTime.
@@ -312,7 +312,7 @@ class CRM_Core_SelectValues {
         $dao = new CRM_Core_DAO_PreferencesDate();
         $dao->name = $type;
         if (!$dao->find(TRUE)) {
-          CRM_Core_Error::fatal();
+          throw new CRM_Core_Exception('Date preferences not configured.');
         }
         if (!$maxOffset) {
           $maxOffset = $dao->end;
@@ -326,7 +326,7 @@ class CRM_Core_SelectValues {
       }
 
       if (empty($date['format'])) {
-        if ($context == 'Input') {
+        if ($context === 'Input') {
           $date['format'] = Civi::settings()->get('dateInputFormat');
         }
         else {
@@ -866,7 +866,7 @@ class CRM_Core_SelectValues {
    *
    * @return array
    */
-  public static function getSearchBuilderOperators($fieldType = NULL) {
+  public static function getSearchBuilderOperators() {
     return [
       '=' => '=',
       '!=' => '≠',
@@ -1099,6 +1099,7 @@ class CRM_Core_SelectValues {
    * Dropdown options for quicksearch in the menu
    *
    * @return array
+   * @throws \CiviCRM_API3_Exception
    */
   public static function quicksearchOptions() {
     $includeEmail = civicrm_api3('setting', 'getvalue', ['name' => 'includeEmailInName', 'group' => 'Search Preferences']);

--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -39,6 +39,9 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
   protected $_yearStatisticsTo = '';
 
   /**
+   * Class constructor.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function __construct() {
     $this->_autoIncludeIndexedFieldsAsOrderBys = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup to known conventions

Before
----------------------------------------
- exceptions not declared
- non-strict checking used when one side is clearly a string
- a mis-cased function call
- double quotes when a single will do
- a function takes a parameter & entirely ignores it. This class is not extending anything

After
----------------------------------------
Above fixed

Technical Details
----------------------------------------
All minor stuff - fixing to reduce distractions

Comments
----------------------------------------

