### PR TITLE
composer.json - Explicitly set target PHP platform

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -35,6 +35,8 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
    * Minimum php version required to run (equal to or lower than the minimum install version)
    *
    * As of Civi 5.16, using PHP 5.x will lead to a hard crash during bootstrap.
+   *
+   * Tip: Keep in sync with composer.json ("config => platform => php")
    */
   const MINIMUM_PHP_VERSION = '7.0.0';
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,11 @@
     }
   },
   "include-path": ["vendor/tecnickcom"],
+  "config": {
+    "platform": {
+      "php": "7.0.10"
+    }
+  },
   "require": {
     "php": "~7.0",
     "dompdf/dompdf" : "0.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "112c1a1b713a206d1e9d5195f150fa32",
+    "content-hash": "b00b30a1ff5e53daf097978e3940c067",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -504,6 +504,7 @@
                 "mimetype",
                 "php"
             ],
+            "abandoned": true,
             "time": "2017-03-23T02:05:33+00:00"
         },
         {
@@ -2244,9 +2245,7 @@
             "version": "3.0.0+php53",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip",
-                "reference": null,
-                "shasum": null
+                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip"
             },
             "require": {
                 "php": ">=5.3.0"
@@ -2696,5 +2695,8 @@
     "platform": {
         "php": "~7.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.0.10"
+    }
 }


### PR DESCRIPTION
Overview
--------

This refines the way in which `composer` resolves dependencies - so as to prefer packages that are compatible with Civi's declared minimum requirement.

https://blog.martinhujer.cz/17-tips-for-using-composer-efficiently/#tip-%2315%3A-specify-the-production-php-version-in-%60composer.json%60

Before
------

Suppose that:

* The current minimum declared is PHP 7.0. (That happens to be the case at time of writing.)
* You locally use PHP 7.4.
* You wish to add or update a package.

`composer` may grab a version of a package that works on PHP 7.4 -- but is not available/compatible with PHP 7.0. Then you start developing things under the false expectation that the library will be usable -- and only discover the problem later.

After
-----

`composer` should grab packages that are compatible with the declared PHP version, regardless of the local PHP version.

Comment
-------

* This is orthogonal to the question of *which* PHP version should be the platform for CiviCRM. The patch doesn't change the target version. Regardless of which version is the target, you can have these dev/prod mismatches.
* The target version will undoubtedly change over time, which has a small maintenance  issue to keep the PHP constants in sync with the composer metadata.  KISS solution: add a comment!