### PR TITLE
dev/core#1562 composer.json - Fix E2E tests run on D8 build (via "downloads")

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ authors.txt
 WordPress
 joomla
 packages/
+tests/extern/
 tests/output
 tests/phpunit/CiviTest/civicrm.settings.local.php
 tests/phpunit/CiviTest/truncate.xml

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
       "PHPUnit_": ["packages/"],
       "Civi": "",
       "Civi\\": [".", "tests/phpunit/"]
+    },
+    "psr-4": {
+      "Cache\\IntegrationTests\\": "tests/extern/Cache/IntegrationTests"
     }
   },
   "include-path": ["vendor/tecnickcom"],
@@ -72,9 +75,6 @@
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",
     "xkerman/restricted-unserialize": "~1.1"
-  },
-  "require-dev": {
-    "cache/integration-tests": "dev-master"
   },
   "scripts": {
     "post-install-cmd": [
@@ -232,6 +232,10 @@
       "smartmenus": {
         "url": "https://github.com/vadikom/smartmenus/archive/1.1.0.zip",
         "ignore": [".gitignore", "Gruntfile.js"]
+      },
+      "cache/integration-tests": {
+        "url": "https://raw.githubusercontent.com/php-cache/integration-tests/b97328797ab199f0ac933e39842a86ab732f21f9/src/SimpleCacheTest.php",
+        "path": "tests/extern/Cache/IntegrationTests/SimpleCacheTest.php"
       }
     },
     "patches": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3fb18d6fdb3244cc94be8eaa883b7ae",
+    "content-hash": "a5aa69115caa463d7db0b838187c63ba",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -2519,176 +2519,11 @@
             "time": "2020-01-17T11:18:01+00:00"
         }
     ],
-    "packages-dev": [
-        {
-            "name": "cache/integration-tests",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/integration-tests.git",
-                "reference": "b97328797ab199f0ac933e39842a86ab732f21f9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/b97328797ab199f0ac933e39842a86ab732f21f9",
-                "reference": "b97328797ab199f0ac933e39842a86ab732f21f9",
-                "shasum": ""
-            },
-            "require": {
-                "cache/tag-interop": "^1.0",
-                "php": "^5.4|^7",
-                "psr/cache": "~1.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "require-dev": {
-                "cache/cache": "^1.0",
-                "illuminate/cache": "^5.4|^5.5|^5.6",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^4.8.35|^5.4.3",
-                "symfony/cache": "^3.1|^4.0|^5.0",
-                "tedivm/stash": "^0.14"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cache\\IntegrationTests\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Scherer",
-                    "email": "aequasi@gmail.com",
-                    "homepage": "https://github.com/aequasi"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
-                }
-            ],
-            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
-            "homepage": "https://github.com/php-cache/integration-tests",
-            "keywords": [
-                "cache",
-                "psr16",
-                "psr6",
-                "test"
-            ],
-            "time": "2019-05-28T15:23:38+00:00"
-        },
-        {
-            "name": "cache/tag-interop",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/tag-interop.git",
-                "reference": "c7496dd81530f538af27b4f2713cde97bc292832"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/c7496dd81530f538af27b4f2713cde97bc292832",
-                "reference": "c7496dd81530f538af27b4f2713cde97bc292832",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "psr/cache": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Cache\\TagInterop\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com",
-                    "homepage": "https://github.com/nicolas-grekas"
-                }
-            ],
-            "description": "Framework interoperable interfaces for tags",
-            "homepage": "http://www.php-cache.com/en/latest/",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr6",
-                "tag"
-            ],
-            "time": "2017-03-13T09:14:27+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "time": "2016-08-06T20:24:11+00:00"
-        }
-    ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "pear/validate_finance_creditcard": 20,
-        "cache/integration-tests": 20
+        "pear/validate_finance_creditcard": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a dependency issue -- when using `civicrm-core` as a library, one cannot run the E2E suite because the library `cache/integration-tests` (`SimpleCacheTest.php`) is unavailable.

See also:
* https://lab.civicrm.org/dev/core/issues/1562
* https://chat.civicrm.org/civicrm/pl/rjkws48qz7bo3d4xwpgcuh33rh

Before
----------------------------------------

The `require-dev` specifies `cache/integration-tests@dev-master`, which happens to be locked (via `composer.lock`) to a specific commit.

After
----------------------------------------

The `downloads` specifies an equivalent revision of the `SimpleCacheTest.php`, and `autoload` section enables it.

Comments
----------------------------------------

#16426 and #16427 are alternatives. Merits of this variant:

* __Strengths__: Downstream projects don't need to opt-in. Less content copied into civicrm-core.
* __Weaknesses__: Technique is less familiar. `composer` tooling won't report about old-versions/upgrades.