### PR TITLE
dev/core#1562 composer.json - Fix E2E tests run on D8 build (via "patches")

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
   },
   "require": {
     "php": "~7.0",
+    "cache/integration-tests": "~0.16.0",
     "dompdf/dompdf" : "0.8.*",
     "electrolinux/phpquery": "^0.9.6",
     "symfony/config": "^2.8.50 || ~3.0",
@@ -72,9 +73,6 @@
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",
     "xkerman/restricted-unserialize": "~1.1"
-  },
-  "require-dev": {
-    "cache/integration-tests": "dev-master"
   },
   "scripts": {
     "post-install-cmd": [
@@ -235,6 +233,11 @@
       }
     },
     "patches": {
+      "cache/integration-tests": {
+        "Allow adding tests": "tools/scripts/composer/patches/cache-integration-tests-protected.patch",
+        "Support PHPUnit 6+": "tools/scripts/composer/patches/cache-integration-tests-phpunit.patch",
+        "Add tests for binary data round trip": "tools/scripts/composer/patches/cache-integration-tests-binary.patch"
+      },
       "phpoffice/common": {
         "Fix handling of libxml_disable_entity_loader": "tools/scripts/composer/patches/phpoffice-common-xml-entity-fix.patch"
       },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,127 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3fb18d6fdb3244cc94be8eaa883b7ae",
+    "content-hash": "9cc5accb2a6bc22458dcd21c5d3228cd",
     "packages": [
+        {
+            "name": "cache/integration-tests",
+            "version": "0.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/integration-tests.git",
+                "reference": "a8d9538a44ed5a70d551f9b87f534c98dfe6b0ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/a8d9538a44ed5a70d551f9b87f534c98dfe6b0ee",
+                "reference": "a8d9538a44ed5a70d551f9b87f534c98dfe6b0ee",
+                "shasum": ""
+            },
+            "require": {
+                "cache/tag-interop": "^1.0",
+                "php": "^5.4|^7",
+                "psr/cache": "~1.0"
+            },
+            "require-dev": {
+                "cache/cache": "dev-master",
+                "illuminate/cache": "^5.0",
+                "madewithlove/illuminate-psr-cache-bridge": "^1.0",
+                "phpunit/phpunit": "^4.0|^5.0",
+                "symfony/cache": "^3.1",
+                "tedivm/stash": "dev-master"
+            },
+            "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "Support PHPUnit 6+": "tools/scripts/composer/patches/cache-integration-tests-phpunit.patch"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\IntegrationTests\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                }
+            ],
+            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
+            "homepage": "https://github.com/php-cache/integration-tests",
+            "keywords": [
+                "cache",
+                "psr16",
+                "psr6",
+                "test"
+            ],
+            "time": "2017-02-02T14:29:50+00:00"
+        },
+        {
+            "name": "cache/tag-interop",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/tag-interop.git",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/c7496dd81530f538af27b4f2713cde97bc292832",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\TagInterop\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com",
+                    "homepage": "https://github.com/nicolas-grekas"
+                }
+            ],
+            "description": "Framework interoperable interfaces for tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr6",
+                "tag"
+            ],
+            "time": "2017-03-13T09:14:27+00:00"
+        },
         {
             "name": "civicrm/civicrm-cxn-rpc",
             "version": "v0.19.01.08",
@@ -1474,6 +1593,52 @@
             "time": "2017-06-05T06:30:30+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -2519,176 +2684,11 @@
             "time": "2020-01-17T11:18:01+00:00"
         }
     ],
-    "packages-dev": [
-        {
-            "name": "cache/integration-tests",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/integration-tests.git",
-                "reference": "b97328797ab199f0ac933e39842a86ab732f21f9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/b97328797ab199f0ac933e39842a86ab732f21f9",
-                "reference": "b97328797ab199f0ac933e39842a86ab732f21f9",
-                "shasum": ""
-            },
-            "require": {
-                "cache/tag-interop": "^1.0",
-                "php": "^5.4|^7",
-                "psr/cache": "~1.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "require-dev": {
-                "cache/cache": "^1.0",
-                "illuminate/cache": "^5.4|^5.5|^5.6",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^4.8.35|^5.4.3",
-                "symfony/cache": "^3.1|^4.0|^5.0",
-                "tedivm/stash": "^0.14"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cache\\IntegrationTests\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Scherer",
-                    "email": "aequasi@gmail.com",
-                    "homepage": "https://github.com/aequasi"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
-                }
-            ],
-            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
-            "homepage": "https://github.com/php-cache/integration-tests",
-            "keywords": [
-                "cache",
-                "psr16",
-                "psr6",
-                "test"
-            ],
-            "time": "2019-05-28T15:23:38+00:00"
-        },
-        {
-            "name": "cache/tag-interop",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/tag-interop.git",
-                "reference": "c7496dd81530f538af27b4f2713cde97bc292832"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/c7496dd81530f538af27b4f2713cde97bc292832",
-                "reference": "c7496dd81530f538af27b4f2713cde97bc292832",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "psr/cache": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Cache\\TagInterop\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com",
-                    "homepage": "https://github.com/nicolas-grekas"
-                }
-            ],
-            "description": "Framework interoperable interfaces for tags",
-            "homepage": "http://www.php-cache.com/en/latest/",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr6",
-                "tag"
-            ],
-            "time": "2017-03-13T09:14:27+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "time": "2016-08-06T20:24:11+00:00"
-        }
-    ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "pear/validate_finance_creditcard": 20,
-        "cache/integration-tests": 20
+        "pear/validate_finance_creditcard": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/tools/scripts/composer/patches/cache-integration-tests-binary.patch
+++ b/tools/scripts/composer/patches/cache-integration-tests-binary.patch
@@ -1,0 +1,66 @@
+commit 89cd7068e83aa776774bfc44f6bcba858c085616
+Author: Stephen Clouse <stephenclouse@gmail.com>
+Date:   Tue Nov 7 04:49:12 2017 -0600
+
+    Add tests for binary data round trip (#85)
+
+diff --git a/src/CachePoolTest.php b/src/CachePoolTest.php
+index f16397f..f30121d 100644
+--- a/src/CachePoolTest.php
++++ b/src/CachePoolTest.php
+@@ -735,6 +735,27 @@ abstract class CachePoolTest extends TestCase
+         $this->assertTrue($item->isHit(), 'isHit() should return true when object are stored. ');
+     }
+ 
++    public function testBinaryData()
++    {
++        if (isset($this->skippedTests[__FUNCTION__])) {
++            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
++
++            return;
++        }
++
++        $data = '';
++        for ($i = 0; $i < 256; $i++) {
++            $data .= chr($i);
++        }
++
++        $item = $this->cache->getItem('key');
++        $item->set($data);
++        $this->cache->save($item);
++
++        $item = $this->cache->getItem('key');
++        $this->assertTrue($data === $item->get(), 'Binary data must survive a round trip.');
++    }
++
+     public function testIsHit()
+     {
+         if (isset($this->skippedTests[__FUNCTION__])) {
+diff --git a/src/SimpleCacheTest.php b/src/SimpleCacheTest.php
+index 8814221..fdb74fb 100644
+--- a/src/SimpleCacheTest.php
++++ b/src/SimpleCacheTest.php
+@@ -647,6 +647,23 @@ abstract class SimpleCacheTest extends TestCase
+         $this->assertEquals($object, $result);
+     }
+ 
++    public function testBinaryData()
++    {
++        if (isset($this->skippedTests[__FUNCTION__])) {
++            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
++        }
++
++        $data = '';
++        for ($i = 0; $i < 256; $i++) {
++            $data .= chr($i);
++        }
++
++        $array = ['a' => 'foo', 2 => 'bar'];
++        $this->cache->set('key', $data);
++        $result = $this->cache->get('key');
++        $this->assertTrue($data === $result, 'Binary data must survive a round trip.');
++    }
++
+     /**
+      * @dataProvider validKeys
+      */

--- a/tools/scripts/composer/patches/cache-integration-tests-phpunit.patch
+++ b/tools/scripts/composer/patches/cache-integration-tests-phpunit.patch
@@ -1,0 +1,52 @@
+diff --git a/src/CachePoolTest.php b/src/CachePoolTest.php
+index c2bc29e..5e98b8d 100644
+--- a/src/CachePoolTest.php
++++ b/src/CachePoolTest.php
+@@ -14,7 +14,7 @@ namespace Cache\IntegrationTests;
+ use Psr\Cache\CacheItemInterface;
+ use Psr\Cache\CacheItemPoolInterface;
+ 
+-abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
++abstract class CachePoolTest extends \PHPUnit\Framework\TestCase
+ {
+     /**
+      * @type array with functionName => reason.
+diff --git a/src/HierarchicalCachePoolTest.php b/src/HierarchicalCachePoolTest.php
+index a643d3e..f66aeac 100644
+--- a/src/HierarchicalCachePoolTest.php
++++ b/src/HierarchicalCachePoolTest.php
+@@ -16,7 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
+ /**
+  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+  */
+-abstract class HierarchicalCachePoolTest extends \PHPUnit_Framework_TestCase
++abstract class HierarchicalCachePoolTest extends \PHPUnit\Framework\TestCase
+ {
+     /**
+      * @type array with functionName => reason.
+diff --git a/src/SimpleCacheTest.php b/src/SimpleCacheTest.php
+index 45060a6..304dee1 100644
+--- a/src/SimpleCacheTest.php
++++ b/src/SimpleCacheTest.php
+@@ -13,7 +13,7 @@ namespace Cache\IntegrationTests;
+ 
+ use Psr\SimpleCache\CacheInterface;
+ 
+-abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
++abstract class SimpleCacheTest extends \PHPUnit\Framework\TestCase
+ {
+     /**
+      * @type array with functionName => reason.
+diff --git a/src/TaggableCachePoolTest.php b/src/TaggableCachePoolTest.php
+index 2a27341..cc98e3f 100644
+--- a/src/TaggableCachePoolTest.php
++++ b/src/TaggableCachePoolTest.php
+@@ -16,7 +16,7 @@ use Cache\TagInterop\TaggableCacheItemPoolInterface;
+ /**
+  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+  */
+-abstract class TaggableCachePoolTest extends \PHPUnit_Framework_TestCase
++abstract class TaggableCachePoolTest extends \PHPUnit\Framework\TestCase
+ {
+     /**
+      * @type array with functionName => reason.

--- a/tools/scripts/composer/patches/cache-integration-tests-protected.patch
+++ b/tools/scripts/composer/patches/cache-integration-tests-protected.patch
@@ -1,0 +1,60 @@
+commit 05f97174c09364dc10c084a38ba0cfd5124f4cec
+Author: Arnold Daniels <arnold@jasny.net>
+Date:   Fri Jun 15 13:33:12 2018 +0600
+
+    Allow adding tests (#93)
+    
+    Make the `cache` property protected, to allow additional tests for a cache implementation.
+
+diff --git a/src/CachePoolTest.php b/src/CachePoolTest.php
+index 2b44c51..8fd9cea 100644
+--- a/src/CachePoolTest.php
++++ b/src/CachePoolTest.php
+@@ -25,7 +25,7 @@ abstract class CachePoolTest extends TestCase
+     /**
+      * @type CacheItemPoolInterface
+      */
+-    private $cache;
++    protected $cache;
+ 
+     /**
+      * @return CacheItemPoolInterface that is used in the tests
+diff --git a/src/HierarchicalCachePoolTest.php b/src/HierarchicalCachePoolTest.php
+index 768d120..518bc10 100644
+--- a/src/HierarchicalCachePoolTest.php
++++ b/src/HierarchicalCachePoolTest.php
+@@ -27,7 +27,7 @@ abstract class HierarchicalCachePoolTest extends TestCase
+     /**
+      * @type CacheItemPoolInterface
+      */
+-    private $cache;
++    protected $cache;
+ 
+     /**
+      * @return CacheItemPoolInterface that is used in the tests
+diff --git a/src/SimpleCacheTest.php b/src/SimpleCacheTest.php
+index fdb74fb..f1cce7a 100644
+--- a/src/SimpleCacheTest.php
++++ b/src/SimpleCacheTest.php
+@@ -24,7 +24,7 @@ abstract class SimpleCacheTest extends TestCase
+     /**
+      * @type CacheInterface
+      */
+-    private $cache;
++    protected $cache;
+ 
+     /**
+      * @return CacheInterface that is used in the tests
+diff --git a/src/TaggableCachePoolTest.php b/src/TaggableCachePoolTest.php
+index 763b775..ec656e8 100644
+--- a/src/TaggableCachePoolTest.php
++++ b/src/TaggableCachePoolTest.php
+@@ -27,7 +27,7 @@ abstract class TaggableCachePoolTest extends TestCase
+     /**
+      * @type TaggableCacheItemPoolInterface
+      */
+-    private $cache;
++    protected $cache;
+ 
+     /**
+      * @return TaggableCacheItemPoolInterface that is used in the tests


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a dependency issue -- when using `civicrm-core` as a library, one cannot run the E2E suite because the library `cache/integration-tests` (`SimpleCacheTest.php`) is unavailable.

See also:
* https://lab.civicrm.org/dev/core/issues/1562
* https://chat.civicrm.org/civicrm/pl/rjkws48qz7bo3d4xwpgcuh33rh

Before
----------------------------------------

The `require-dev` specifies `cache/integration-tests@dev-master`, which happens to be locked (via `composer.lock`) to a specific commit.

After
----------------------------------------

The `require` specifies `cache/integration-tests@~0.16.0`, which is the newest published version. Never-the-less, it is a bit old (requires phpunit <= 5)

Comments
----------------------------------------

#16426 and #16427 are alternatives. Merits of this variant:

* __Strengths__: The "patches" construct is flexible and recognized by many composer users.
* __Weaknesses__: The "patches" does not actually work unless the downstream projects specifically opt-in. The patch files are longish.