### PR TITLE
dev/core#1564 Fix category name for a/b test temporary table

### DIFF
--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -100,7 +100,7 @@ WHERE  r.mailing_id = %1
       $limitString = "LIMIT 0, $totalLimit";
     }
     $temporaryTable = CRM_Utils_SQL_TempTable::build()
-      ->setCategory('srcmailing' . $sourceMailingId)
+      ->setCategory('sr' . $sourceMailingId)
       ->setMemory()
       ->createWithColumns("mailing_recipient_id int unsigned, id int PRIMARY KEY AUTO_INCREMENT, INDEX(mailing_recipient_id)");
     $temporaryTableName = $temporaryTable->getName();

--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -275,7 +275,7 @@ class CRM_Utils_SQL_TempTable {
    */
   public function setCategory($category) {
     if ($category && !preg_match(self::CATEGORY_REGEXP, $category) || strlen($category) > self::CATEGORY_LENGTH) {
-      throw new \RuntimeException("Malformed temp table category");
+      throw new \RuntimeException("Malformed temp table category $category");
     }
     $this->category = $category;
     return $this;


### PR DESCRIPTION
We should create category name of temporary table for max of INT(10) UNSIGNED field civicrm_mailing.id.

This is a regression due to change in https://github.com/civicrm/civicrm-core/commit/cc06bec0e5142e58af80c3fab841b4f8ec08138e

```php
// CRM/Mailing/BAO/Recipients.php
->setCategory('srcmailing' . $sourceMailingId) // longer than 12 chars when mailing_id > 99
```

More info is here https://lab.civicrm.org/dev/core/issues/1564