### PR TITLE
dev/core#1113 - Decimal Separator - Invalid value "total_amount" (NaN,N) creating or editing a membership

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -504,7 +504,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $totalAmount = CRM_Utils_Array::value('minimum_fee', $values);
       //CRM-18827 - override the default value if total_amount is submitted
       if (!empty($this->_submitValues['total_amount'])) {
-        $totalAmount = $this->_submitValues['total_amount'];
+        $totalAmount = CRM_Utils_Rule::cleanMoney($this->_submitValues['total_amount']);
       }
       // build membership info array, which is used when membership type is selected to:
       // - set the payment information block


### PR DESCRIPTION

Overview
----------------------------------------
Invalid value in filed "total_amount" (NaN,N) when creating or editing a membership in some cases, more info here and steps to reproduce this error: https://lab.civicrm.org/dev/core/issues/1113

Before
----------------------------------------

If you dont remove the value (NaN,N) you cannot create or edit membreship.

After
----------------------------------------

The value is in correct format and you can create or edit a membership