### PR TITLE
Scheduled jobs belonging to extensions cannot be disabled

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -265,8 +265,8 @@ class CRM_Core_ManagedEntities {
       $defaults = ['id' => $dao->entity_id, 'is_active' => 1];
       $params = array_merge($defaults, $todo['params']);
 
-      $moduleIsBeingEnabled = in_array($dao->module, Civi::$statics['CRM_Extension_Manager']['processing'] ?? []);
-      if ($dao->entity_type === 'Job' && !$moduleIsBeingEnabled) {
+      $manager = CRM_Extension_System::singleton()->getManager();
+      if ($dao->entity_type === 'Job' && !$manager->extensionIsBeingInstalledOrEnabled($dao->module)) {
         // Special treatment for scheduled jobs:
         //
         // If we're being called as part of enabling/installing a module then

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -13,6 +13,10 @@
  * The extension manager handles installing, disabling enabling, and
  * uninstalling extensions.
  *
+ * You should obtain a singleton of this class via
+ *
+ * $manager = CRM_Extension_Manager::singleton()->getManager();
+ *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
@@ -93,6 +97,34 @@ class CRM_Extension_Manager {
    * Note: Treat as private. This is only public to facilitate debugging.
    */
   public $statuses;
+
+  /**
+   * Live process(es) per extension.
+   *
+   * @var array
+   *
+   * Format is: {
+   *   extensionKey => [
+   *    ['operation' => 'install|enable|uninstall|disable', 'phase' => 'queued|live|completed'
+   *     ...
+   *   ],
+   *   ...
+   * }
+   *
+   * The inner array is a stack, so the most recent current operation is the
+   * last entry. As this manager handles multiple extensions at once, here's
+   * the flow for an install operation.
+   *
+   * $manager->install(['ext1', 'ext2']);
+   *
+   * 0. {}
+   * 1. { ext1: ['install'], ext2: ['install'] }
+   * 2. { ext1: ['install', 'installing'], ext2: ['install'] }
+   * 3. { ext1: ['install'], ext2: ['install', 'installing'] }
+   * 4. { ext1: ['install'], ext2: ['install'] }
+   * 5. {}
+   */
+  protected $processes = [];
 
   /**
    * Class constructor.
@@ -201,9 +233,10 @@ class CRM_Extension_Manager {
    *
    * @param string|array $keys
    *   One or more extension keys.
+   * @param string $mode install|enable
    * @throws CRM_Extension_Exception
    */
-  public function install($keys) {
+  public function install($keys, $mode = 'install') {
     $keys = (array) $keys;
     $origStatuses = $this->getStatuses();
 
@@ -221,10 +254,8 @@ class CRM_Extension_Manager {
       throw new CRM_Extension_Exception('Cannot install incompatible extension: ' . implode(', ', $incompatible));
     }
 
-    // Store a list of extensions that we're processing. This is referenced in
-    // CRM_Core_ManagedEntities which set entities belonging to these
-    // extensions as is_active.
-    Civi::$statics[__CLASS__]['processing'] = $keys;
+    // Keep state for these operations.
+    $this->addProcess($keys, $mode);
 
     foreach ($keys as $key) {
       /** @var CRM_Extension_Info $info */
@@ -233,11 +264,17 @@ class CRM_Extension_Manager {
 
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
-          // ok, nothing to do
+          // ok, nothing to do. As such the status of this process is no longer
+          // 'install' install was the intent, which might have resulted in
+          // changes but these changes will not be happening, so processes that
+          // are sensitive to installs (like the managed entities reconcile
+          // operation) should not assume that these changes have happened.
+          $this->popProcess([$key]);
           break;
 
         case self::STATUS_DISABLED:
           // re-enable it
+          $this->addProcess([$key], 'enabling');
           $typeManager->onPreEnable($info);
           $this->_setExtensionActive($info, 1);
           $typeManager->onPostEnable($info);
@@ -246,10 +283,13 @@ class CRM_Extension_Manager {
           // later extensions to access classes from earlier extensions.
           $this->statuses = NULL;
           $this->mapper->refresh();
+
+          $this->popProcess([$key]);
           break;
 
         case self::STATUS_UNINSTALLED:
           // install anew
+          $this->addProcess([$key], 'installing');
           $typeManager->onPreInstall($info);
           $this->_createExtensionEntry($info);
           $typeManager->onPostInstall($info);
@@ -258,6 +298,8 @@ class CRM_Extension_Manager {
           // later extensions to access classes from earlier extensions.
           $this->statuses = NULL;
           $this->mapper->refresh();
+
+          $this->popProcess([$key]);
           break;
 
         case self::STATUS_UNKNOWN:
@@ -269,9 +311,6 @@ class CRM_Extension_Manager {
     $this->statuses = NULL;
     $this->mapper->refresh();
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
-
-    // We no longer require this set.
-    unset(Civi::$statics[__CLASS__]['processing']);
 
     $schema = new CRM_Logging_Schema();
     $schema->fixSchemaDifferences();
@@ -291,7 +330,9 @@ class CRM_Extension_Manager {
 
         case self::STATUS_UNINSTALLED:
           // install anew
+          $this->addProcess([$key], 'installing');
           $typeManager->onPostPostInstall($info);
+          $this->popProcess([$key]);
           break;
 
         case self::STATUS_UNKNOWN:
@@ -300,6 +341,8 @@ class CRM_Extension_Manager {
       }
     }
 
+    // All processes for these keys
+    $this->popProcess($keys);
   }
 
   /**
@@ -310,7 +353,7 @@ class CRM_Extension_Manager {
    * @throws CRM_Extension_Exception
    */
   public function enable($keys) {
-    $this->install($keys);
+    $this->install($keys, 'enable');
   }
 
   /**
@@ -335,14 +378,18 @@ class CRM_Extension_Manager {
       throw new CRM_Extension_Exception_DependencyException("Cannot disable extension due to dependencies. Consider disabling all these: " . implode(',', $disableRequirements));
     }
 
+    $this->addProcess($keys, 'disable');
+
     foreach ($keys as $key) {
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
+          $this->addProcess([$key], 'disabling');
           // throws Exception
           list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
           $typeManager->onPreDisable($info);
           $this->_setExtensionActive($info, 0);
           $typeManager->onPostDisable($info);
+          $this->popProcess([$key]);
           break;
 
         case self::STATUS_INSTALLED_MISSING:
@@ -357,6 +404,8 @@ class CRM_Extension_Manager {
         case self::STATUS_DISABLED_MISSING:
         case self::STATUS_UNINSTALLED:
           // ok, nothing to do
+          // Remove the 'disable' process as we're not doing that.
+          $this - popProcess([$key]);
           break;
 
         case self::STATUS_UNKNOWN:
@@ -368,6 +417,8 @@ class CRM_Extension_Manager {
     $this->statuses = NULL;
     $this->mapper->refresh();
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+
+    $this - popProcess($keys);
   }
 
   /**
@@ -384,6 +435,8 @@ class CRM_Extension_Manager {
     // TODO: to mitigate the risk of crashing during installation, scan
     // keys/statuses/types before doing anything
 
+    $this->addProcess($keys, 'uninstall');
+
     foreach ($keys as $key) {
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
@@ -391,6 +444,7 @@ class CRM_Extension_Manager {
           throw new CRM_Extension_Exception("Cannot uninstall extension; disable it first: $key");
 
         case self::STATUS_DISABLED:
+          $this->addProcess([$key], 'uninstalling');
           // throws Exception
           list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
           $typeManager->onPreUninstall($info);
@@ -408,6 +462,8 @@ class CRM_Extension_Manager {
 
         case self::STATUS_UNINSTALLED:
           // ok, nothing to do
+          // remove the 'uninstall' process since we're not doing that.
+          $this->popProcess([$key]);
           break;
 
         case self::STATUS_UNKNOWN:
@@ -419,6 +475,7 @@ class CRM_Extension_Manager {
     $this->statuses = NULL;
     $this->mapper->refresh();
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+    $this->popProcess($keys);
   }
 
   /**
@@ -498,6 +555,34 @@ class CRM_Extension_Manager {
     // and, indirectly, defaultContainer
     $this->fullContainer->refresh();
     $this->mapper->refresh();
+  }
+
+  /**
+   * Return current processes for given extension.
+   *
+   * @param String $key extension key
+   *
+   * @return array
+   */
+  public function getActiveProcesses(string $key) :Array {
+    return $this->processes[$key] ?? [];
+  }
+
+  /**
+   * Determine if the extension specified is currently involved in an install
+   * or enable process. Just sugar code to make things more readable.
+   *
+   * @param String $key extension key
+   *
+   * @return bool
+   */
+  public function extensionIsBeingInstalledOrEnabled($key) :bool {
+    foreach ($this->getActiveProcesses($key) as $process) {
+      if (in_array($process, ['install', 'installing', 'enable', 'enabling'])) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   // ----------------------
@@ -721,6 +806,15 @@ class CRM_Extension_Manager {
   }
 
   /**
+   * Provides way to set processes property for phpunit tests - not for general use.
+   *
+   * @param $processes
+   */
+  public function setProcessesForTesting(array $processes) {
+    $this->processes = $processes;
+  }
+
+  /**
    * @param $infos
    * @param $filterStatuses
    * @return array
@@ -733,6 +827,31 @@ class CRM_Extension_Manager {
       }
     }
     return $matches;
+  }
+
+  /**
+   * Add a process to the stacks for the extensions.
+   *
+   * @param array $keys extensionKey
+   * @param string $process one of: install|uninstall|enable|disable|installing|uninstalling|enabling|disabling
+   */
+  protected function addProcess(array $keys, string $process) :void {
+    foreach ($keys as $key) {
+      $this->processes[$key][] = $process;
+    }
+  }
+
+  /**
+   * Pop the top op from the stacks for the extensions.
+   *
+   * @param array $keys extensionKey
+   */
+  protected function popProcess(array $keys) :void {
+    foreach ($keys as $key) {
+      if (!empty($this->process[$key])) {
+        array_pop($this->process[$key]);
+      }
+    }
   }
 
 }

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -221,6 +221,11 @@ class CRM_Extension_Manager {
       throw new CRM_Extension_Exception('Cannot install incompatible extension: ' . implode(', ', $incompatible));
     }
 
+    // Store a list of extensions that we're processing. This is referenced in
+    // CRM_Core_ManagedEntities which set entities belonging to these
+    // extensions as is_active.
+    Civi::$statics[__CLASS__]['processing'] = $keys;
+
     foreach ($keys as $key) {
       /** @var CRM_Extension_Info $info */
       /** @var CRM_Extension_Manager_Base $typeManager */
@@ -264,6 +269,10 @@ class CRM_Extension_Manager {
     $this->statuses = NULL;
     $this->mapper->refresh();
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+
+    // We no longer require this set.
+    unset(Civi::$statics[__CLASS__]['processing']);
+
     $schema = new CRM_Logging_Schema();
     $schema->fixSchemaDifferences();
 

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -405,7 +405,7 @@ class CRM_Extension_Manager {
         case self::STATUS_UNINSTALLED:
           // ok, nothing to do
           // Remove the 'disable' process as we're not doing that.
-          $this - popProcess([$key]);
+          $this->popProcess([$key]);
           break;
 
         case self::STATUS_UNKNOWN:
@@ -418,7 +418,7 @@ class CRM_Extension_Manager {
     $this->mapper->refresh();
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 
-    $this - popProcess($keys);
+    $this->popProcess($keys);
   }
 
   /**

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -835,7 +835,7 @@ class CRM_Extension_Manager {
    * @param array $keys extensionKey
    * @param string $process one of: install|uninstall|enable|disable|installing|uninstalling|enabling|disabling
    */
-  protected function addProcess(array $keys, string $process) :void {
+  protected function addProcess(array $keys, string $process) {
     foreach ($keys as $key) {
       $this->processes[$key][] = $process;
     }
@@ -846,7 +846,7 @@ class CRM_Extension_Manager {
    *
    * @param array $keys extensionKey
    */
-  protected function popProcess(array $keys) :void {
+  protected function popProcess(array $keys) {
     foreach ($keys as $key) {
       if (!empty($this->process[$key])) {
         array_pop($this->process[$key]);


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a gotcha whereby an administrator disables a scheduled job provided by an extension, only to find that next time they look it's been re-enabled! This can cause serious problems if the scheduled job has significant side effects!


Before
----------------------------------------

The managed entities were assumed to want to be `is_active=1` on every reconciliation, which happens every cache flush.

So:
1. enable extension with a scheduled job
2. manually disable the scheduled job
3. job is enabled again at some random point later on when cache is flushed!


After
----------------------------------------

Jobs will not be enabled on cache flushes, unless we were doing so as part of enabling/installing the extension that defines the job.

Means deactivated stuff stays deactivated, except if you disable and re-enable the extension.


Technical Details
----------------------------------------

This is implemented by having `CRM_Extension_Manager` store the extensions that it is enabling in `Civi::$statics`. `CRM_Extension_Manager` then checks whether the extension that owns the job entity is currently being installed. If so, then it sets the entity (i.e. the job) active, if not then it leaves the `is_active` in the previous state.

It's only implemented to save the `is_active` status of `Job` entities. This is because these entities usually have side effects, e.g. altering data or sending mail. So if an administrator thinks they have disabled that, it should stay disabled.

The PR includes 2 commits: one adds a failing test to show the problem; the next is the fix. We'll wait to see whether jenkins finds any other test results...

Comments
----------------------------------------

This is a *much-safer-than-before* but not all-perfect fix. There's more that could be done in terms of clarifying how things stay active or not. e.g. deactivated Jobs will still be re-activated if you disable then re-enable the extension. However, you probably don't do that often, and when you do, you're very aware that you're doing it; it's deliberate and you know it's being done. So that's much less risky than a cache flush which you probably don't know is being done.

Out of scope: we could theoretically extend the deactivated settings with a "user override" or something to further preserve admins' wishes.

See [mattermost chat](https://chat.civicrm.org/civicrm/pl/f5fmbqi15iy9mdxnhqz14h1mye) with @totten  and @mattwire .


