### PR TITLE
APIv4 Explorer css tweaks

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -34,10 +34,10 @@
               <input type="checkbox" id="api4-param-{{ name }}" ng-model="params[name]"/>
               {{ name }}<span class="crm-marker" ng-if="param.required"> *</span>
             </label>
-            <div class="form-control" ng-mouseenter="help('selectRowCount', availableParams.select)" ng-mouseleave="help()" ng-class="{'api4-option-selected': isSelectRowCount()}" ng-if="availableParams.select">
+            <label class="form-control" ng-mouseenter="help('selectRowCount', availableParams.select)" ng-mouseleave="help()" ng-class="{'api4-option-selected': isSelectRowCount()}" ng-if="availableParams.select">
               <input type="checkbox" id="api4-param-selectRowCount" ng-checked="isSelectRowCount()" ng-click="selectRowCount()" />
-              <label for="api4-param-selectRowCount">SelectRowCount</label>
-            </div>
+              SelectRowCount
+            </label>
           </div>
           <div class="api4-input form-inline" ng-mouseenter="help(name, param)" ng-mouseleave="help()" ng-repeat="(name, param) in availableParams" ng-if="!isSpecial(name) && param.type[0] === 'bool' && param.default === null">
             <label>{{ name }}<span class="crm-marker" ng-if="param.required"> *</span></label>

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -108,15 +108,19 @@
   background-color: rgba(255, 255, 255, .9);
 }
 
-#bootstrap-theme.api4-explorer-page div.api4-input.form-inline .form-control {
+#bootstrap-theme.api4-explorer-page div.api4-input.form-inline label.form-control {
   margin-right: 6px;
 }
+#bootstrap-theme.api4-explorer-page div.api4-input.form-inline label.form-control input[type=checkbox] {
+  margin: 0 2px 0 0;
+}
 
-#bootstrap-theme.api4-explorer-page div.api4-input.form-inline .form-control:not(.api4-option-selected) {
+#bootstrap-theme.api4-explorer-page div.api4-input.form-inline label.form-control:not(.api4-option-selected) {
   transition: none;
   box-shadow: none;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
+  font-weight: normal;
 }
 
 #bootstrap-theme.api4-explorer-page div.api4-input.form-inline .form-control label {


### PR DESCRIPTION
Overview
----------------------------------------
Makes the checkboxes line up better in the Api Explorer, and makes them bold when checked.

Before
----------------------------------------
Misaligned checkboxes. Always bold except for `selectRowCount` was always not bold:

![image](https://user-images.githubusercontent.com/2874912/73463455-435d0800-434b-11ea-933f-d161602dfa08.png)


After
----------------------------------------
All aligned. Bold when checked:

![image](https://user-images.githubusercontent.com/2874912/73463269-f9742200-434a-11ea-85c1-7f13ffebf8f9.png)

