### PR TITLE
Move credit_note_definition on contribution settings form to metadata.

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -50,14 +50,6 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $filter = $this->getSettingPageFilter();
-    $settings = civicrm_api3('Setting', 'getfields', [])['values'];
-    foreach ($settings as $key => $setting) {
-      if (isset($setting['settings_pages'][$filter])) {
-        $this->_settings[$key] = $setting;
-      }
-    }
-
     $this->addFieldsDefinedInSettingsMetadata();
 
     // @todo look at sharing the code below in the settings trait.

--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -19,15 +19,6 @@
  * This class generates form components for the display preferences.
  */
 class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
-  protected $_settings = [
-    'cvv_backoffice_required' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'update_contribution_on_membership_type_change' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'acl_financial_type' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'always_post_to_accounts_receivable' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'deferred_revenue_enabled' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'default_invoice_page' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'invoicing' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-  ];
 
   /**
    * Our standards for settings are to have a setting per value with defined metadata.
@@ -35,7 +26,10 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
    * Unfortunately the 'contribution_invoice_settings' has been added in non-compliance.
    * We use this array to hack-handle.
    *
-   * I think the best way forwards would be to covert to multiple individual settings.
+   * These are now stored as individual settings but this form still does weird & wonderful things.
+   *
+   * Note the 'real' settings on this form are added via metadata definition - ie
+   * 'settings_pages' => ['contribute' => ['weight' => 1]], in their metadata.
    *
    * @var array
    */
@@ -43,22 +37,18 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
 
   /**
    * Build the form object.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $config = CRM_Core_Config::singleton();
     $this->invoiceSettings = [
       'invoice_prefix' => [
         'html_type' => 'text',
         'title' => ts('Invoice Prefix'),
         'weight' => 1,
         'description' => ts('Enter prefix to be display on PDF for invoice'),
-      ],
-      'credit_notes_prefix' => [
-        'html_type' => 'text',
-        'title' => ts('Credit Notes Prefix'),
-        'weight' => 2,
-        'description' => ts('Enter prefix to be display on PDF for credit notes.'),
       ],
       'due_date' => [
         'html_type' => 'text',

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -153,8 +153,10 @@ trait CRM_Admin_Form_SettingTrait {
    * Add fields in the metadata to the template.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   protected function addFieldsDefinedInSettingsMetadata() {
+    $this->addSettingsToFormFromMetadata();
     $settingMetaData = $this->getSettingsMetaData();
     $descriptions = [];
     foreach ($settingMetaData as $setting => $props) {
@@ -370,6 +372,21 @@ trait CRM_Admin_Form_SettingTrait {
     $order = array_keys(\CRM_Utils_Request::retrieve($setting, 'String'));
     $settingValueKeys = array_keys($settingValue);
     return array_intersect($order, $settingValueKeys);
+  }
+
+  /**
+   * Add settings to form if the metadata designates they should be on the page.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function addSettingsToFormFromMetadata() {
+    $filter = $this->getSettingPageFilter();
+    $settings = civicrm_api3('Setting', 'getfields', [])['values'];
+    foreach ($settings as $key => $setting) {
+      if (isset($setting['settings_pages'][$filter])) {
+        $this->_settings[$key] = $setting;
+      }
+    }
   }
 
 }

--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -32,6 +32,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Is the CVV code required for back office credit card transactions'),
     'help_text' => 'If set it back-office credit card transactions will required a cvv code. Leave as required unless you have a very strong reason to change',
+    'settings_pages' => ['contribute' => ['weight' => 1]],
   ],
   'contribution_invoice_settings' => [
     // @todo our standard is to have a setting per item not to hide settings in an array with
@@ -70,6 +71,7 @@ return [
     'on_change' => [
       'CRM_Invoicing_Utils::onToggle',
     ],
+    'settings_pages' => ['contribute' => ['weight' => 9]],
   ],
   'credit_notes_prefix' => [
     'group_name' => 'Contribute Preferences',
@@ -85,6 +87,7 @@ return [
     'description' => ts('Prefix to be prepended to credit note ids'),
     'default' => 'CN_',
     'help_text' => ts('The credit note ID is generated when a contribution is set to Refunded, Cancelled or Chargeback. It is visible on invoices, if invoices are enabled'),
+    'settings_pages' => ['contribute' => ['weight' => 8]],
   ],
   'invoice_prefix' => [
     'html_type' => 'text',
@@ -176,6 +179,7 @@ return [
     'is_contact' => 0,
     'help_text' => NULL,
     'help' => ['id' => 'acl_financial_type'],
+    'settings_pages' => ['contribute' => ['weight' => 3]],
   ],
   'deferred_revenue_enabled' => [
     'group_name' => 'Contribute Preferences',
@@ -190,6 +194,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 5]],
   ],
   'default_invoice_page' => [
     'group_name' => 'Contribute Preferences',
@@ -208,6 +213,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 7]],
   ],
   'always_post_to_accounts_receivable' => [
     'group_name' => 'Contribute Preferences',
@@ -222,6 +228,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 4]],
   ],
   'update_contribution_on_membership_type_change' => [
     'group_name' => 'Contribute Preferences',
@@ -237,5 +244,6 @@ return [
     'is_contact' => 0,
     'description' => ts('Enabling this setting will update related contribution of membership(s) except if the membership is paid for with a recurring contribution.'),
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 2]],
   ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
Further step towards more metadata driven forms & moving sequential credit notes out of core. This makes it possible to inject settings into most settings forms using metadata & switches the methodology for adding fields on the contribution settings form to use that, including the credit_note_prefix field which was previously part of the hacked-in-set

Before
----------------------------------------
- Only forms using the Generic settings forms could have settings added by metadata.
- Credit note prefix part of hacky-invoicing set of fields.
- All contribution form settings hard coded onto the form

<img width="655" alt="Screen Shot 2020-01-31 at 12 33 03 PM" src="https://user-images.githubusercontent.com/336308/73499860-26493780-4426-11ea-8288-c55d362e2efc.png">


After
----------------------------------------
- Possible to use the (documented) key of settings_page to inject settings into more/most settings pages
- List of fields removed from contribution form & instead defined through metadata.
- Credit_note_prefix separated from invoicing set - this is preliminary to moving the non-performant credit note code to an extension - https://lab.civicrm.org/dev/core/issues/1308 and is also more appropriate in the meantime as use of this setting does not depend  on whether invoicing is enabled

<img width="764" alt="Screen Shot 2020-01-31 at 12 37 05 PM" src="https://user-images.githubusercontent.com/336308/73499969-6c9e9680-4426-11ea-8f40-b00dfa541a49.png">



Technical Details
----------------------------------------


Comments
----------------------------------------
