### PR TITLE
[REF] Switch to using a non abandoned library for getting a mapping o…

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1083,14 +1083,8 @@ HTACCESS;
    * @return array
    */
   public static function getAcceptableExtensionsForMimeType($mimeType = NULL) {
-    $mapping = \MimeType\Mapping::$types;
-    $extensions = [];
-    foreach ($mapping as $extension => $type) {
-      if ($mimeType == $type) {
-        $extensions[] = $extension;
-      }
-    }
-    return $extensions;
+    $mimeRepostory = new \MimeTyper\Repository\ExtendedRepository();
+    return $mimeRepostory->findExtensions($mimeType);
   }
 
   /**

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.1",
-    "katzien/php-mime-type": "2.1.0",
+    "adrienrn/php-mimetyper": "0.2.2",
     "civicrm/composer-downloads-plugin": "^2.0",
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,44 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4461b6a9f42757ed76cbca218261acc3",
+    "content-hash": "790ef555de5c4f1ce33035b02aadcbcc",
     "packages": [
+        {
+            "name": "adrienrn/php-mimetyper",
+            "version": "0.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/adrienrn/php-mimetyper.git",
+                "reference": "702e00a604b4baed34d69730ce055e05c0f43932"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/adrienrn/php-mimetyper/zipball/702e00a604b4baed34d69730ce055e05c0f43932",
+                "reference": "702e00a604b4baed34d69730ce055e05c0f43932",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/apache-mime-types": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MimeTyper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Hussard",
+                    "email": "adrien.ricartnoblet@gmail.com"
+                }
+            ],
+            "description": "PHP mime type and extension mapping library: compatible with Symfony, powered by jshttp/mime-db",
+            "time": "2018-09-27T09:45:05+00:00"
+        },
         {
             "name": "cache/integration-tests",
             "version": "0.16.0",
@@ -258,6 +294,61 @@
             ],
             "description": "Provides a way to patch Composer packages.",
             "time": "2018-05-11T18:00:16+00:00"
+        },
+        {
+            "name": "dflydev/apache-mime-types",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-apache-mime-types.git",
+                "reference": "f30a57e59b7476e4c5270b6a0727d79c9c0eb861"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-apache-mime-types/zipball/f30a57e59b7476e4c5270b6a0727d79c9c0eb861",
+                "reference": "f30a57e59b7476e4c5270b6a0727d79c9c0eb861",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "twig/twig": "1.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Dflydev\\ApacheMimeTypes": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                }
+            ],
+            "description": "Apache MIME Types",
+            "keywords": [
+                "apache",
+                "mime",
+                "mimetypes"
+            ],
+            "time": "2013-05-14T02:02:01+00:00"
         },
         {
             "name": "dompdf/dompdf",
@@ -545,51 +636,6 @@
                 "url"
             ],
             "time": "2017-03-20T17:10:46+00:00"
-        },
-        {
-            "name": "katzien/php-mime-type",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/katzien/PhpMimeType.git",
-                "reference": "159dfbdcd5906442f3dad89951127f0b9dfa3b78"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/katzien/PhpMimeType/zipball/159dfbdcd5906442f3dad89951127f0b9dfa3b78",
-                "reference": "159dfbdcd5906442f3dad89951127f0b9dfa3b78",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "5.*",
-                "satooshi/php-coveralls": "1.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "MimeType\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kat Zien"
-                }
-            ],
-            "description": "A PHP library to detect the mime type of files.",
-            "homepage": "https://github.com/katzien/PhpMimeType",
-            "keywords": [
-                "mimetype",
-                "php"
-            ],
-            "abandoned": true,
-            "time": "2017-03-23T02:05:33+00:00"
         },
         {
             "name": "league/csv",

--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -115,7 +115,7 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
 
   public function mimeTypeToExtension() {
     $cases = [];
-    $cases[] = ['text/plain', ['txt', 'text', 'conf', 'def', 'list', 'log', 'in']];
+    $cases[] = ['text/plain', ['txt', 'text', 'conf', 'def', 'list', 'log', 'in', 'ini']];
     $cases[] = ['image/jpeg', ['jpeg', 'jpg', 'jpe']];
     $cases[] = ['image/png', ['png']];
     return $cases;


### PR DESCRIPTION
…f mimetpyes to extensions

Overview
----------------------------------------
As picked up by @stesi561  the current library we use for a mapping of mimetypes to file extensions is now abandoned this switches it to the library https://github.com/adrienrn/php-mimetyper

Before
----------------------------------------
Abandoned Library used

After
----------------------------------------
Non Abandoned library used

I believe that the unit tests added here https://github.com/civicrm/civicrm-core/commit/6cb3fe2e3cc8b91c88d69ab3443ffc4270804aad#diff-bc35985bf1e1cabd25b2ad862413d38eR98 ensure that we have sufficient coverage to prevent a regression in this area

ping @eileenmcnaughton @totten 