### PR TITLE
[REF] Pass params into function rather than this weird check for whether params exists.

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1211,7 +1211,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       //CRM-15372 patch to fix fee amount replacing amount
       $this->_params['fee_amount'] = $this->_params['amount'];
 
-      $participants[] = $this->addParticipant($this, $contactID);
+      $participants[] = $this->addParticipant($this, $this->_params, $contactID);
 
       //add custom data for participant
       CRM_Core_BAO_CustomValueTable::postProcess($this->_params,
@@ -2083,11 +2083,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @return \CRM_Event_BAO_Participant
    * @throws \CiviCRM_API3_Exception
    */
-  protected function addParticipant(&$form, $contactID) {
-    if (empty($form->_params)) {
-      return NULL;
-    }
-    $params = $form->_params;
+  protected function addParticipant(&$form, $params, $contactID) {
     $transaction = new CRM_Core_Transaction();
 
     // handle register date CRM-4320

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -107,60 +107,70 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
   /**
    * If event is paid or unpaid.
+   *
    * @var bool
    */
   public $_isPaidEvent;
 
   /**
    * Page action.
+   *
    * @var int
    */
   public $_action;
 
   /**
    * Role Id.
+   *
    * @var int
    */
   protected $_roleId = NULL;
 
   /**
    * Event Type Id.
+   *
    * @var int
    */
   protected $_eventTypeId = NULL;
 
   /**
    * Participant status Id.
+   *
    * @var int
    */
   protected $_statusId = NULL;
 
   /**
    * Cache all the participant statuses.
+   *
    * @var array
    */
   protected $_participantStatuses;
 
   /**
    * Participant mode.
+   *
    * @var string
    */
   public $_mode = NULL;
 
   /**
    * Event ID preselect.
+   *
    * @var int
    */
   public $_eID = NULL;
 
   /**
    * Line Item for Price Set.
+   *
    * @var array
    */
   public $_lineItem = NULL;
 
   /**
    * Contribution mode for event registration for offline mode.
+   *
    * @var string
    * @deprecated
    */
@@ -170,30 +180,35 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
   /**
    * Store id of role custom data type ( option value )
+   *
    * @var int
    */
   protected $_roleCustomDataTypeID;
 
   /**
    * Store id of event Name custom data type ( option value)
+   *
    * @var int
    */
   protected $_eventNameCustomDataTypeID;
 
   /**
    * Selected discount id.
+   *
    * @var int
    */
   public $_originalDiscountId = NULL;
 
   /**
    * Event id.
+   *
    * @var int
    */
   public $_eventId = NULL;
 
   /**
    * Id of payment, if any
+   *
    * @var int
    */
   public $_paymentId = NULL;
@@ -2078,10 +2093,11 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * Process the participant.
    *
    * @param CRM_Core_Form $form
+   * @param array $params
    * @param int $contactID
    *
    * @return \CRM_Event_BAO_Participant
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function addParticipant(&$form, $params, $contactID) {
     $transaction = new CRM_Core_Transaction();
@@ -2099,7 +2115,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     $participantFields = CRM_Event_DAO_Participant::fields();
-    $participantParams = array(
+    $participantParams = [
       'id' => CRM_Utils_Array::value('participant_id', $params),
       'contact_id' => $contactID,
       'event_id' => $form->_eventId ? $form->_eventId : $params['event_id'],
@@ -2119,7 +2135,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'discount_id' => CRM_Utils_Array::value('discount_id', $params),
       'fee_currency' => CRM_Utils_Array::value('currencyID', $params),
       'campaign_id' => CRM_Utils_Array::value('campaign_id', $params),
-    );
+    ];
 
     if ($form->_action & CRM_Core_Action::PREVIEW || CRM_Utils_Array::value('mode', $params) == 'test') {
       $participantParams['is_test'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Minor code tidy up = This function used to be shared with the online form & hence this form had to work to make itself 'look' like the other form.

It is now free to be it's own form


Before
----------------------------------------
form does a weird check for $this->_params & then assigns them to params

After
----------------------------------------
we just pass them in as params

Technical Details
----------------------------------------


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
