### PR TITLE
Respect form value for register_date on partipant form

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1040,7 +1040,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     //participant method (addParticipant)
     $this->_params['participant_status_id'] = $params['status_id'];
     $this->_params['participant_role_id'] = is_array($params['role_id']) ? $params['role_id'] : explode(',', $params['role_id']);
-    $this->_params['participant_register_date'] = $params['register_date'];
     $roleIdWithSeparator = implode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_params['participant_role_id']);
 
     $now = date('YmdHis');
@@ -1066,8 +1065,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       // set email for primary location.
       $fields['email-Primary'] = 1;
       $params['email-Primary'] = $params["email-{$this->_bltID}"] = $this->_contributorEmail;
-
-      $params['register_date'] = $now;
 
       // now set the values for the billing location.
       foreach ($this->_fields as $name => $dontCare) {
@@ -2090,18 +2087,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $params = $form->_params;
     $transaction = new CRM_Core_Transaction();
 
-    // handle register date CRM-4320
-    $registerDate = NULL;
-    if (!empty($form->_allowConfirmation) && $form->_participantId) {
-      $registerDate = $params['participant_register_date'];
-    }
-    elseif (!empty($params['participant_register_date']) &&
-      is_array($params['participant_register_date']) &&
-      !empty($params['participant_register_date'])
-    ) {
-      $registerDate = CRM_Utils_Date::format($params['participant_register_date']);
-    }
-
     $participantFields = CRM_Event_DAO_Participant::fields();
     $participantParams = array(
       'id' => CRM_Utils_Array::value('participant_id', $params),
@@ -2111,7 +2096,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $params, 1
       ),
       'role_id' => CRM_Utils_Array::value('participant_role_id', $params) ?: self::getDefaultRoleID(),
-      'register_date' => ($registerDate) ? $registerDate : date('YmdHis'),
+      'register_date' => $params['register_date'],
       'source' => CRM_Utils_String::ellipsify(
         isset($params['participant_source']) ? CRM_Utils_Array::value('participant_source', $params) : CRM_Utils_Array::value('description', $params),
         $participantFields['participant_source']['maxlength']

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -199,6 +199,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $paymentProcessorID = $this->processorCreate(['is_test' => 0]);
     $form->submit($this->getSubmitParams($form->_eventId, $paymentProcessorID));
     $participant = $this->callAPISuccessGetSingle('Participant', []);
+    $this->assertEquals('2018-09-04 00:00:00', $participant['participant_register_date']);
     $this->assertEquals('Offline Registration for Event: Annual CiviCRM meet by: ', $participant['participant_source']);
     $contribution = $this->callAPISuccessGetSingle('Contribution', []);
     $this->assertEquals(1550.55, $contribution['total_amount']);
@@ -460,7 +461,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    */
   private function getSubmitParams(int $eventID, int $paymentProcessorID): array {
     $submitParams = [
-      'register_date' => date('Ymd'),
+      'register_date' => '2018-09-04',
       'status_id' => 1,
       'role_id' => 1,
       'event_id' => $eventID,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby the participant registration date is exposed on a field on the backoffice event form, but when a credit card payment is being submitted it is ignored

Before
----------------------------------------
Registration date field always present, but ignored in credit card mode

<img width="483" alt="Screen Shot 2020-01-31 at 5 55 30 PM" src="https://user-images.githubusercontent.com/336308/73513592-ed738780-4452-11ea-9db3-474ad9c3a42b.png">


After
----------------------------------------
Value entered is used

Technical Details
----------------------------------------
The backoffice event registration form has a register_date field. In credit card mode it
does an awful lot of handling which is mostly for legacy code reasons but the net result is to ignore it
& set it to now. However, the field defaults to now & if someone actually changed it they would expect their change to
be respected. This removes that handling & just uses the field value entered. The field is always present from my
digging


Comments
----------------------------------------

