### PR TITLE
[REF] Interim code cleanup - make the usage of addPayments clearer

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4834,38 +4834,31 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *
    * Replace with Order.create->Payment.create flow.
    *
-   * @param array $contributions
+   * @param array $contribution
    *
    * @throws \CiviCRM_API3_Exception
    */
-  public static function addPayments($contributions) {
+  public static function addPayments($contribution) {
     // get financial trxn which is a payment
     $ftSql = "SELECT ft.id, ft.total_amount
       FROM civicrm_financial_trxn ft
       INNER JOIN civicrm_entity_financial_trxn eft ON eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution'
       WHERE eft.entity_id = %1 AND ft.is_payment = 1 ORDER BY ft.id DESC LIMIT 1";
-    $contributionStatus = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'contribution_status_id', [
-      'labelColumn' => 'name',
-    ]);
-    foreach ($contributions as $contribution) {
-      if ($contributionStatus[$contribution->contribution_status_id] !== 'Partially paid') {
-        continue;
-      }
-      $ftDao = CRM_Core_DAO::executeQuery($ftSql, [
-        1 => [
-          $contribution->id,
-          'Integer',
-        ],
-      ]);
-      $ftDao->fetch();
 
-      // store financial item Proportionaly.
-      $trxnParams = [
-        'total_amount' => $ftDao->total_amount,
-        'contribution_id' => $contribution->id,
-      ];
-      self::assignProportionalLineItems($trxnParams, $ftDao->id, $contribution->total_amount);
-    }
+    $ftDao = CRM_Core_DAO::executeQuery($ftSql, [
+      1 => [
+        $contribution->id,
+        'Integer',
+      ],
+    ]);
+    $ftDao->fetch();
+
+    // store financial item Proportionaly.
+    $trxnParams = [
+      'total_amount' => $ftDao->total_amount,
+      'contribution_id' => $contribution->id,
+    ];
+    self::assignProportionalLineItems($trxnParams, $ftDao->id, $contribution->total_amount);
   }
 
   /**

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -161,6 +161,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *   Array of arrays as would be passed into create
    * @param array $defaults
    *  Default parameters to be be merged into each of the params.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function bulkSave($bulkParams, $defaults = []) {
     $addedColumns = $sql = $tables = $customFields = [];

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1410,8 +1410,12 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
               $lineItem[$this->_priceSetId][$lineKey] = $line;
             }
             CRM_Price_BAO_LineItem::processPriceSet($participants[$num]->id, $lineItem, CRM_Utils_Array::value($num, $contributions, NULL), 'civicrm_participant');
-            CRM_Contribute_BAO_Contribution::addPayments($contributions);
           }
+        }
+      }
+      foreach ($contributions as $contribution) {
+        if ('Partially paid' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id)) {
+          CRM_Contribute_BAO_Contribution::addPayments($contribution);
         }
       }
     }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -683,7 +683,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     // want to deprecate & remove & the test relies on bad data asa starting point.
     // End goal is the Order.create->Payment.create flow.
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_entity_financial_trxn WHERE entity_table = "civicrm_financial_item"');
-    CRM_Contribute_BAO_Contribution::addPayments([$contribution]);
+    CRM_Contribute_BAO_Contribution::addPayments($contribution);
     $this->checkItemValues($contribution);
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Minor code cleanup  - separates some narrow handling for Partially Paid from a main loop

Before
----------------------------------------
Not clear what addPayments does

After
----------------------------------------
The status check is called before addPayments - it is clearly specific to 'Partially  paid'

Technical Details
----------------------------------------
The intention is to switch this to creating pending & adding payments per our preferred flow.  This is just a step on that  path - tests have been added here https://github.com/civicrm/civicrm-core/pull/16437

Comments
----------------------------------------

