### PR TITLE
Fix backoffice participant partial payments to be stdised & not miscalculate net_amount

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4829,40 +4829,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   }
 
   /**
-   * Function to add payments for contribution for Partially Paid status
-   *
-   * @deprecated this is known to be flawed and possibly buggy.
-   *
-   * Replace with Order.create->Payment.create flow.
-   *
-   * @param array $contribution
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  public static function addPayments($contribution) {
-    // get financial trxn which is a payment
-    $ftSql = "SELECT ft.id, ft.total_amount
-      FROM civicrm_financial_trxn ft
-      INNER JOIN civicrm_entity_financial_trxn eft ON eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution'
-      WHERE eft.entity_id = %1 AND ft.is_payment = 1 ORDER BY ft.id DESC LIMIT 1";
-
-    $ftDao = CRM_Core_DAO::executeQuery($ftSql, [
-      1 => [
-        $contribution->id,
-        'Integer',
-      ],
-    ]);
-    $ftDao->fetch();
-
-    // store financial item Proportionaly.
-    $trxnParams = [
-      'total_amount' => $ftDao->total_amount,
-      'contribution_id' => $contribution->id,
-    ];
-    self::assignProportionalLineItems($trxnParams, $ftDao->id, $contribution->total_amount);
-  }
-
-  /**
    * Function use to store line item proportionally in in entity financial trxn table
    *
    * @param array $trxnParams

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -45,6 +45,8 @@ class CRM_Financial_BAO_Payment {
     $whiteList = ['check_number', 'payment_processor_id', 'fee_amount', 'total_amount', 'contribution_id', 'net_amount', 'card_type_id', 'pan_truncation', 'trxn_result_code', 'payment_instrument_id', 'trxn_id', 'trxn_date'];
     $paymentTrxnParams = array_intersect_key($params, array_fill_keys($whiteList, 1));
     $paymentTrxnParams['is_payment'] = 1;
+    // Really we should have a DB default.
+    $paymentTrxnParams['fee_amount'] = $paymentTrxnParams['fee_amount'] ?? 0;
 
     if (isset($paymentTrxnParams['payment_processor_id']) && empty($paymentTrxnParams['payment_processor_id'])) {
       // Don't pass 0 - ie the Pay Later processor as it is  a pseudo-processor.

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -156,16 +156,17 @@ trait ContactTestTrait {
    *   For civicrm_contact_add api function call.
    *
    * @return int
-   *   id of Household created
-   * @throws \CRM_Core_Exception
+   *   id of contact created
    *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   private function _contactCreate($params) {
     $result = civicrm_api3('contact', 'create', $params);
     if (!empty($result['is_error']) || empty($result['id'])) {
       throw new \CRM_Core_Exception('Could not create test contact, with message: ' . \CRM_Utils_Array::value('error_message', $result) . "\nBacktrace:" . \CRM_Utils_Array::value('trace', $result));
     }
-    return $result['id'];
+    return (int) $result['id'];
   }
 
   /**

--- a/api/v3/Participant.php
+++ b/api/v3/Participant.php
@@ -23,6 +23,9 @@
  *
  * @return array
  *   API result array
+ *
+ * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_participant_create($params) {
   // Check that event id is not an template - should be done @ BAO layer.

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -673,21 +673,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * addPayments() method (add and edit modes of participant).
-   *
-   * Add Payments is part of an old, flawed, code flow.
-   */
-  public function testAddPayments() {
-    $contribution = $this->addParticipantWithContribution();
-    // Delete existing financial_trxns. This is because we are testing a code flow we
-    // want to deprecate & remove & the test relies on bad data asa starting point.
-    // End goal is the Order.create->Payment.create flow.
-    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_entity_financial_trxn WHERE entity_table = "civicrm_financial_item"');
-    CRM_Contribute_BAO_Contribution::addPayments($contribution);
-    $this->checkItemValues($contribution);
-  }
-
-  /**
    * checks db values for financial item
    */
   public function checkItemValues($contribution) {

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -589,7 +589,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'contact_id' => $form->_contactID,
       'total_amount' => '1550.55',
       'fee_amount' => '0.00',
-      'net_amount' => '20.00',
+      'net_amount' => '1550.55',
       'contribution_source' => 'I wrote this',
       'amount_level' => '',
       'is_template' => '0',
@@ -630,18 +630,6 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'tax_amount' => '0.00',
     ], $lineItem);
 
-    $financialTrxn = $this->callAPISuccessGetSingle('FinancialTrxn', ['is_payment' => 0]);
-    $this->assertAttributesEquals([
-      'to_financial_account_id' => '7',
-      'total_amount' => '1550.55',
-      'fee_amount' => '0.00',
-      'net_amount' => '1550.55',
-      'currency' => 'USD',
-      'status_id' => '1',
-      'payment_instrument_id' => $paymentInstrumentID,
-      'check_number' => '879',
-    ], $financialTrxn);
-
     $payment = $this->callAPISuccessGetSingle('FinancialTrxn', ['is_payment' => 1]);
     $this->assertAttributesEquals([
       'to_financial_account_id' => 6,
@@ -661,7 +649,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'contact_id' => $form->_contactID,
       'amount' => 1550.55,
       'currency' => 'USD',
-      'status_id' => 2,
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Financial_BAO_FinancialItem', 'status_id', 'Unpaid'),
       'entity_table' => 'civicrm_line_item',
       'entity_id' => $lineItem['id'],
       'financial_account_id' => 4,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the 3 flows to create a backoffice partially paid event registration. The  goal of this PR is that these 3 flows would have the same result in terms of entities created

    1) creating a partially paid registration with a pending contribution & then adding a payment to  that contribution
    2) creating a partially paid registration with a completed contribution for a partial amount
    3) created a pending registration with a pending contribution & adding a payment to the contribution.

    Note that the following bugs previously affected these flows
     - flow 1 & 2 net_amount was incorrect
     - flow 1, an extraneous payment was added
     - flow 3, participant status was not updated from pending to partially paid on adding a payment


Before
----------------------------------------
Do a back-office registration, selecting 'Partially paid' for the participant status & 'record_contribution'. Manually enter an amount that is less than   the cost  of the  event.

View the contribution - notice that  total_amount is  the cost of the event & net_amount is  wildly incorrect (the cost of the event minus the amount paid  - because the way the params  are bodged in Contribution::create leads to this

After
----------------------------------------
Net   amount correctly  calculated. 

The  financial entities created are consistent with other flows through the code base. Arguably it would be better to alter those flows but as  an outlier flow it's better to bring this into line &  if we  want to change the main flow later we can


Technical Details
----------------------------------------
Use correct...er flow to create partial payments on events

This fixes the methodology for recording partial payments on the backoffice contribution form to create a pending contribution (order)
and then add a payment. The previous method was our first cut at supporting partial payments (before the Order+Payment flow) and
relies on some handling in the BAO which is crufty & has proven unreliable. This allows us to deprecate that handling & remove the
now unused addPayments function.

Prior to this PR I wrote a test for current behaviour & I had to alter that test for this as follows

1) prior to this change net_amount was clearly miscalculated & hence this fixes & I updated the test
2) prior to this change a financial transaction was created for the contribution. Now only the payment financial transaction is made.
3) prior to this change the financial item was set to partially paid, not it is still 'unpaid'

Items 1 is clearly a bug fix whereas 2 & 3 are a bit borderline.

Item 2 is the fact that for pending contributions (in general) we don't create financial items when creating them. We do for (some) other
statuses. This was  discussed here civicrm/civicrm-dev-docs#712 (comment) & the summary was
'it would be better to change this but this is what was the scope /how it is'. I added unit tests for the 2 other flows that create partial paid events & changing this to what is documented brings it into line with these 2 flows

Item 3 is discussed in https://docs.civicrm.org/dev/en/latest/financial/financialentities/ with the summary  being that in any other path
to creating a partial payment the financial item would be left at 'Unpaid' - hopefully until it's fully paid. 

Item 1 is a clear bug fix & I think the fact no-one picked it up is material because it gives us a clue as to how many
people use this rather obscure flow that requires an admin user to alter the status to 'partially  paid' and alter the amount.

Given the above we have a choice
1) Make this flow behave like other flows, despite this flow being arguably correct or
2) Hack away to keep the current quirks

I've come down on the side of 1 as a standardisation. I think changing it so items 2 & 3 behave differently is worth pursuing but it's better
for this edge case flow to do the same as our approved flow & if we want to iterate on that we can

Comments
----------------------------------------
Merging https://github.com/civicrm/civicrm-core/pull/16441 first will make this a little easier to read (if I also rebase)

I noted there  is some receipt-leakage which might be worth investigating as a follow up, also as a follow up I think the  scenario where a pending contribution is  created against a partially paid event registration appears as if the contribution is completed in the email
