### PR TITLE
(dev/core#1567) Make sure mailing titles are always rendered properly

### DIFF
--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -153,6 +153,8 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     if (isset($mailing['body_html']) && empty($_GET['text'])) {
       $header = 'text/html; charset=utf-8';
       $content = $mailing['body_html'];
+      $content = preg_replace(';(\<head.*\<title\>\s*)TITLE(\s*\</title\>.*\</head\>);ms', "\\1{$this->_mailing->subject}\\2", $content, 1);
+
       if (strpos($content, '<head>') === FALSE && strpos($content, '<title>') === FALSE) {
         $title = '<head><title>' . $mailing['subject'] . '</title></head>';
       }


### PR DESCRIPTION
Overview
----------------------------------------
Make sure mailing titles are always rendered properly so that 'TITLE' is replaced by mail subject when viewing the mailing public link.

Before
----------------------------------------
![mailing_before](https://user-images.githubusercontent.com/3455173/73537372-4ee52780-444e-11ea-99b6-c7b45976700c.png)


After
----------------------------------------
![mailing_after](https://user-images.githubusercontent.com/3455173/73537377-54427200-444e-11ea-963d-218e163632c6.png)

