### PR TITLE
Pass language code to CiviCRM for Wordpress

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -417,8 +417,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     elseif (defined('ICL_LANGUAGE_CODE')) {
       $language = ICL_LANGUAGE_CODE;
     }
-
-    // TODO: set language variable for others WordPress plugin
+    // Wordpress "standard" single language mode
+    // We still have to check if the function exists as it may not during bootstrap
+    elseif (function_exists('get_locale')) {
+      $language = get_locale();
+    }
 
     if (!empty($language)) {
       return CRM_Core_I18n_PseudoConstant::longForShort(substr($language, 0, 2));


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a @todo in the code :-)

Wordpress still has a language even if it only has one. Pass that language to CiviCRM instead of NULL.

Before
----------------------------------------
We don't pass the configured language to CiviCRM

After
----------------------------------------
We pass the configured language to CiviCRM

Technical Details
----------------------------------------
Comes out of #16289

Comments
----------------------------------------
@christianwach @kcristiano This is pretty straightforward and fixes a todo in the code. It means CiviCRM will always pick up the language that wordpress is configured instead of having to configure both separately!