### PR TITLE
dev/core#1319 Fix regression with shared household address

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -788,7 +788,7 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
     // Normal update process will automatically create new address with submitted values
 
     // 1. loop through entire submitted address array
-    $skipFields = ['is_primary', 'location_type_id', 'is_billing', 'master_id', 'update_current_employer'];
+    $skipFields = ['is_primary', 'location_type_id', 'is_billing', 'master_id', 'add_relationship'];
     foreach ($address as & $values) {
       // 2. check if "Use another contact's address" is checked, if not continue
       // Additionally, if master_id is set (address was shared), set master_id to empty value.
@@ -799,8 +799,8 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
         continue;
       }
 
-      // Set update_current_employer checkbox value
-      $values['update_current_employer'] = !empty($values['update_current_employer']);
+      // Set add_relationship checkbox value
+      $values['add_relationship'] = !empty($values['add_relationship']);
 
       // 3. get the address details for master_id
       $masterAddress = new CRM_Core_BAO_Address();

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -170,7 +170,9 @@ class CRM_Contact_Form_Edit_Address {
       $form->addEntityRef("address[$blockId][master_contact_id]", ts('Share With'), ['create' => $profileLinks, 'api' => ['extra' => ['contact_type']]]);
 
       // do we want to update employer for shared address
-      $form->addElement('checkbox', "address[$blockId][add_relationship]", NULL, ts('Create a relationship with this contact'));
+      $employer_label = '<span class="addrel-employer">' . ts('Set this organization as current employer') . '</span>';
+      $household_label = '<span class="addrel-household">' . ts('Create a household member relationship with this contact') . '</span>';
+      $form->addElement('checkbox', "address[$blockId][add_relationship]", NULL, $employer_label . $household_label);
     }
   }
 

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -170,7 +170,7 @@ class CRM_Contact_Form_Edit_Address {
       $form->addEntityRef("address[$blockId][master_contact_id]", ts('Share With'), ['create' => $profileLinks, 'api' => ['extra' => ['contact_type']]]);
 
       // do we want to update employer for shared address
-      $form->addElement('checkbox', "address[$blockId][update_current_employer]", NULL, ts('Set this organization as current employer'));
+      $form->addElement('checkbox', "address[$blockId][add_relationship]", NULL, ts('Create a relationship with this contact'));
     }
   }
 

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1040,7 +1040,7 @@ SELECT is_primary,
     $dao = CRM_Core_DAO::executeQuery($query, [1 => [$addressId, 'Integer']]);
 
     // legacy - for api backward compatibility
-    if (!isset($params['add_relationship'] && isset($params['update_current_employer']))) {
+    if (!isset($params['add_relationship']) && isset($params['update_current_employer'])) {
       // warning
       CRM_Core_Error::deprecatedFunctionWarning('update_current_employer is deprecated, use add_relationship instead');
       $params['add_relationship'] = $params['update_current_employer'];

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1039,8 +1039,15 @@ SELECT is_primary,
     $query = 'SELECT id, contact_id FROM civicrm_address WHERE master_id = %1';
     $dao = CRM_Core_DAO::executeQuery($query, [1 => [$addressId, 'Integer']]);
 
+    // legacy - for api backward compatibility
+    if (!isset($params['add_relationship'] && isset($params['update_current_employer']))) {
+      // warning
+      CRM_Core_Error::deprecatedFunctionWarning('update_current_employer is deprecated, use add_relationship instead');
+      $params['add_relationship'] = $params['update_current_employer'];
+    }
+
     // Default to TRUE if not set to maintain api backward compatibility.
-    $createRelationship = isset($params['update_current_employer']) ? $params['update_current_employer'] : TRUE;
+    $createRelationship = isset($params['add_relationship']) ? $params['add_relationship'] : TRUE;
 
     // unset contact id
     $skipFields = ['is_primary', 'location_type_id', 'is_billing', 'contact_id'];

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -30,7 +30,7 @@
     <div id="shared-address-{$blockId}" class="form-layout-compressed">
       {$form.address.$blockId.master_contact_id.label}
       {$form.address.$blockId.master_contact_id.html}
-      <div class="shared-address-create-relationship" style="display: none;">
+      <div class="shared-address-add-relationship" style="display: none;">
         {$form.address.$blockId.add_relationship.html}
         {$form.address.$blockId.add_relationship.label}
         <div class="employer">{help id="id-sharedAddress-updateRelationships" file="CRM/Contact/Form/Contact"}</div>

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -57,6 +57,8 @@
       contactType = {/literal}{$contactType|@json_encode}{literal},
       $addRelationshipSection = $('#shared-address-' + blockNo + ' .shared-address-add-relationship'),
       $employerSection = $('#shared-address-' + blockNo + ' .shared-address-add-relationship .employer'),
+      $employerLabel = $('#shared-address-' + blockNo + ' .shared-address-add-relationship label .addrel-employer'),
+      $householdLabel = $('#shared-address-' + blockNo + ' .shared-address-add-relationship label .addrel-household'),
       $contentArea = $('#shared-address-' + blockNo + ' .shared-address-list'),
       $masterElement = $('input[name="address[' + blockNo + '][master_id]"]');
 
@@ -86,12 +88,19 @@
       if (!sharedContactId || isNaN(sharedContactId)) {
         $employerSection.hide();
         $addRelationshipSection.hide();
+        $employerLabel.hide();
+        $householdLabel.hide();
         return;
       }
 
       var otherContactType = $el.select2('data').extra.contact_type;
       $addRelationshipSection.toggle(contactType === 'Individual' && (otherContactType === 'Organization' || otherContactType === 'Household'));
       $employerSection.toggle(contactType === 'Individual' && otherContactType === 'Organization');
+
+      // use the appropriate label
+      $employerLabel.toggle(contactType === 'Individual' && otherContactType === 'Organization');
+      $householdLabel.toggle(contactType === 'Individual' && otherContactType === 'Household');
+
 
       $.post(CRM.url('civicrm/ajax/inline'), {
           'contact_id': sharedContactId,

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -33,7 +33,7 @@
       <div class="shared-address-add-relationship" style="display: none;">
         {$form.address.$blockId.add_relationship.html}
         {$form.address.$blockId.add_relationship.label}
-        <div class="employer">{help id="id-sharedAddress-updateRelationships" file="CRM/Contact/Form/Contact"}</div>
+        <span class="employer">{help id="id-sharedAddress-updateRelationships" file="CRM/Contact/Form/Contact"}</span>
       </div>
       <div class="shared-address-list">
         {if !empty($sharedAddresses.$blockId.shared_address_display)}

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -30,10 +30,10 @@
     <div id="shared-address-{$blockId}" class="form-layout-compressed">
       {$form.address.$blockId.master_contact_id.label}
       {$form.address.$blockId.master_contact_id.html}
-      <div class="shared-address-update-employer" style="display: none;">
-        {$form.address.$blockId.update_current_employer.html}
-        {$form.address.$blockId.update_current_employer.label}
-        {help id="id-sharedAddress-updateRelationships" file="CRM/Contact/Form/Contact"}
+      <div class="shared-address-create-relationship" style="display: none;">
+        {$form.address.$blockId.add_relationship.html}
+        {$form.address.$blockId.add_relationship.label}
+        <div class="employer">{help id="id-sharedAddress-updateRelationships" file="CRM/Contact/Form/Contact"}</div>
       </div>
       <div class="shared-address-list">
         {if !empty($sharedAddresses.$blockId.shared_address_display)}
@@ -55,7 +55,8 @@
   CRM.$(function($) {
     var blockNo = {/literal}{$blockId}{literal},
       contactType = {/literal}{$contactType|@json_encode}{literal},
-      $employerSection = $('#shared-address-' + blockNo + ' .shared-address-update-employer'),
+      $addRelationshipSection = $('#shared-address-' + blockNo + ' .shared-address-add-relationship'),
+      $employerSection = $('#shared-address-' + blockNo + ' .shared-address-add-relationship .employer'),
       $contentArea = $('#shared-address-' + blockNo + ' .shared-address-list'),
       $masterElement = $('input[name="address[' + blockNo + '][master_id]"]');
 
@@ -84,10 +85,12 @@
 
       if (!sharedContactId || isNaN(sharedContactId)) {
         $employerSection.hide();
+        $addRelationshipSection.hide();
         return;
       }
 
       var otherContactType = $el.select2('data').extra.contact_type;
+      $addRelationshipSection.toggle(contactType === 'Individual' && (otherContactType === 'Organization' || otherContactType === 'Household'));
       $employerSection.toggle(contactType === 'Individual' && otherContactType === 'Organization');
 
       $.post(CRM.url('civicrm/ajax/inline'), {

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -199,7 +199,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $individualParams = [
       'contact_id' => $individualID,
       'master_id' => $address['id'],
-      'update_current_employer' => 0,
+      'add_relationship' => 0,
     ];
     $this->callAPISuccess('address', 'create', array_merge($this->_params, $individualParams));
     $this->callAPISuccess('relationship', 'getcount', [


### PR DESCRIPTION
Overview
----------------------------------------
Regression since https://github.com/civicrm/civicrm-core/pull/13700
Using the UI, creating a shared address for a individual with a household, it doesn't create a relationship as it used to be.

Before
----------------------------------------
On an individual contact, add a shared address with a household -> no relationship created.

After
----------------------------------------
New checkbox for household as we did for organization so that user can choose if they want to create a relationship or not:

![Screenshot_2020-01-31 admin example com lab1319 dev501 symbiodev xyz(1)](https://user-images.githubusercontent.com/372004/73557003-76bc9700-441e-11ea-81b9-d5dd9c6b7e3a.png)

We keep the employer as is :
![Screenshot_2020-01-31 admin example com lab1319 dev501 symbiodev xyz](https://user-images.githubusercontent.com/372004/73557005-76bc9700-441e-11ea-80b2-f4c99af2e5ef.png)

Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1319#note_30628
