### PR TITLE
dev/core#1570 Manage primary fields even if the P is lowercase

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -251,7 +251,7 @@ class CRM_Dedupe_Finder {
     // the -digit to civicrm_address.location_type_id and -Primary to civicrm_address.is_primary
     foreach ($flat as $key => $value) {
       $matches = [];
-      if (preg_match('/(.*)-(Primary-[\d+])$|(.*)-(\d+|Primary)$/', $key, $matches)) {
+      if (preg_match('/(.*)-(primary-[\d+])$|(.*)-(\d+|primary)$/', strtolower($key), $matches)) {
         $return = array_values(array_filter($matches));
         // make sure the first occurrence is kept, not the last
         $flat[$return[1]] = empty($flat[$return[1]]) ? $value : $flat[$return[1]];


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/issues/1570

Overview
----------------------------------------
When deduping a field with a location value that has "Primary" in it, we don't properly find the duplicates if the field name is passed in using a lower case p.

Before
----------------------------------------

If you try to dedupe a field called email-Primary you will probably find dupes. If you use a field called email-primary it won't work.

After
----------------------------------------
Dedupes can be found regardless of the case of the word Primiary.

