### PR TITLE
Settings Fix setting readonly attribute

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -174,7 +174,7 @@ trait CRM_Admin_Form_SettingTrait {
         }
 
         //Load input as readonly whose values are overridden in civicrm.settings.php.
-        if (Civi::settings()->getMandatory($setting)) {
+        if (Civi::settings()->getMandatory($setting) !== NULL) {
           $props['html_attributes']['readonly'] = TRUE;
           $this->includesReadOnlyFields = TRUE;
         }
@@ -222,7 +222,7 @@ trait CRM_Admin_Form_SettingTrait {
           $this->$add($setting, $props['title'], $props['entity_reference_options']);
         }
         elseif ($add === 'addYesNo' && ($props['type'] === 'Boolean')) {
-          $this->addRadio($setting, $props['title'], [1 => 'Yes', 0 => 'No'], NULL, '&nbsp;&nbsp;');
+          $this->addRadio($setting, $props['title'], [1 => 'Yes', 0 => 'No'], CRM_Utils_Array::value('html_attributes', $props), '&nbsp;&nbsp;');
         }
         elseif ($add === 'add') {
           $this->add($props['html_type'], $setting, $props['title'], $options);


### PR DESCRIPTION
Overview
----------------------------------------
When the value of a mandatory setting (ie. defined via civicrm.settings.php) is 0 - eg. for `empoweredBy` and other radio elements the check incorrectly sets them as not readonly.

Before
----------------------------------------
Attribute readonly not set on input elements that have a mandatory value of 0.

After
----------------------------------------
Attribute readonly set correctly.

Technical Details
----------------------------------------
The `if` needs to explicitly check for NULL. Note that for radio input elements setting attribute readonly is not enough for them to actually be readonly... But this adds the attribute indicating that they *should* be readonly and you can then do something like:
```
$(document).ready(function() {
  CRM.$('input[readonly]').attr('disabled', true);
});
```
(I'm currently doing this in https://lab.civicrm.org/extensions/haystacktheme).

Comments
----------------------------------------
You'll need to use the browser console to inspect the element and see that it has `readonly="1"` set after this PR if you've defined it in civicrm.settings.php. Eg.
`$civicrm_setting['core']['empoweredBy'] = 0;`