### PR TITLE
[REF] Ensure that Custom tables are created with support for larger i…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1656,7 +1656,7 @@ SELECT $columnName
     $table = array(
       'name' => $params['name'],
       'is_multiple' => $params['is_multiple'],
-      'attributes' => "ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci",
+      'attributes' => "ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ROW_FORMAT=DYNAMIC",
       'fields' => array(
         array(
           'name' => 'id',


### PR DESCRIPTION
…ndexes

Overview
----------------------------------------
We have been experiencing a bunch of test failures https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=min,CIVIVER=master,label=bknix-tmp/7627/#showFailuresLink since enabling large index support in the 5.5 as per the standard suggestions. This alters the default custom table creation so that it works with Larger indexes such as for utf8mb4

Before
----------------------------------------
Test failures on min profile

After
----------------------------------------
No Test failures

ping @eileenmcnaughton 