### PR TITLE
core#1568: Show recipientListing to non-admins

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -685,7 +685,7 @@
   <item>
      <path>civicrm/ajax/recipientListing</path>
      <page_callback>CRM_Admin_Page_AJAX::recipientListing</page_callback>
-     <access_arguments>administer CiviCRM,access CiviCRM</access_arguments>
+     <access_arguments>access CiviEvent,access CiviCRM</access_arguments>
   </item>
   <item>
      <path>civicrm/admin/sms/provider</path>


### PR DESCRIPTION
Overview
----------------------------------------
There's a bug report that the permissions were wrong when setting scheduled reminders as a non-administrator (via **Manage Events**) that you can't limit by participant role.

Before
----------------------------------------
![Selection_796](https://user-images.githubusercontent.com/1796012/73614972-2b4aea00-45d2-11ea-8133-15814f26e2e0.png)

After
----------------------------------------
![Selection_797](https://user-images.githubusercontent.com/1796012/73614975-2ede7100-45d2-11ea-83cd-2d8ba99bde91.png)

Technical Details
----------------------------------------
There's no reason for this route to require `Administer CiviCRM` and is surely an artifact of the time before Scheduled Reminders were opened up to non-administrators.