### PR TITLE
Make php 7.3 the recommended php version

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -25,7 +25,7 @@ class CRM_Upgrade_Incremental_General {
   /**
    * The recommended PHP version.
    */
-  const RECOMMENDED_PHP_VER = '7.2';
+  const RECOMMENDED_PHP_VER = '7.3';
 
   /**
    * The previous recommended PHP version.


### PR DESCRIPTION


Overview
----------------------------------------
Fixes recommended php version from 7.2 to 7.3

Before
----------------------------------------
Recommended version in system check is php 7.2

After
----------------------------------------
Recommended version is php 7.3

Technical Details
----------------------------------------
We definitely should be recommending the latest version we know it works on

Comments
----------------------------------------

