### PR TITLE
APIv3 - Only scan files for deprecation checks in Entity.get

### DIFF
--- a/api/v3/Entity.php
+++ b/api/v3/Entity.php
@@ -14,6 +14,8 @@ function _civicrm_api3_entity_deprecation($entities) {
   $deprecated = [];
   if (!empty($entities['values'])) {
     foreach ($entities['values'] as $entity) {
+      $apiFile = "api/v3/$entity.php";
+      @include_once $apiFile;
       if (is_string(_civicrm_api3_deprecation_check($entity))) {
         $deprecated[] = $entity;
       }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2442,10 +2442,6 @@ function _civicrm_api3_api_resolve_alias($entity, $fieldName, $action = 'create'
  */
 function _civicrm_api3_deprecation_check($entity, $result = []) {
   if ($entity) {
-    $apiFile = "api/v3/$entity.php";
-    if (CRM_Utils_File::isIncludable($apiFile)) {
-      require_once $apiFile;
-    }
     $lowercase_entity = _civicrm_api_get_entity_name_from_camel($entity);
     $fnName = "_civicrm_api3_{$lowercase_entity}_deprecation";
     if (function_exists($fnName)) {


### PR DESCRIPTION
Overview
----------------------------------------
APIv3 performance enhancement. Reduces needless scanning of nonexistant files.

Before
----------------------------------------
Lots of files being scanned on every api call.

After
----------------------------------------
Only scan files when we actually need to.

Technical Details
----------------------------------------
This is a replacement for #16011 and #16012 - I think this will be more performant as it eliminates the file scanning altogether, except in the one spot it's actually called for - the api explorer.
