### PR TITLE
Add require_once to api3TestTrait

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -4,6 +4,7 @@ namespace Civi\Test;
 
 use Civi\API\Exception\NotImplementedException;
 
+require_once 'api/v3/utils.php';
 /**
  * Class Api3TestTrait
  * @package Civi\Test


### PR DESCRIPTION


Overview
----------------------------------------
Ensures the api3TestTrait includes the file for the _civicrm_api3_get_options_from_params function

Before
----------------------------------------
File does not require  'api/v3/utils.php'; - relies on it being otherwise loaded due to run order

After
----------------------------------------
 'api/v3/utils.php'; explicitly required

Technical Details
----------------------------------------
I used this trait from an extension but it was used with apiv4 before apiv3 (it supports both).

I got an error because utils.php is not included by this file. It 'freeloads' off the fact apiv3 initialises
the file - but in fact the file that includes a function requiring a function
should have the require once - reduces risk & cognitive load

<img width="837" alt="Screen Shot 2020-02-04 at 3 08 02 PM" src="https://user-images.githubusercontent.com/336308/73707833-75160a80-4761-11ea-8890-4fecedf6d70e.png">

Comments
----------------------------------------

