### PR TITLE
CRM_Utils_XML::parseFile() - Fix obscure segfault

### DIFF
--- a/CRM/Utils/XML.php
+++ b/CRM/Utils/XML.php
@@ -36,9 +36,10 @@ class CRM_Utils_XML {
       $oldLibXMLErrors = libxml_use_internal_errors();
       libxml_use_internal_errors(TRUE);
 
-      $xml = simplexml_load_file($file,
-        'SimpleXMLElement', LIBXML_NOCDATA
-      );
+      // Note that under obscure circumstances calling simplexml_load_file
+      // hit https://bugs.php.net/bug.php?id=62577
+      $string = file_get_contents($file);
+      $xml = simplexml_load_string($string, 'SimpleXMLElement', LIBXML_NOCDATA);
       if ($xml === FALSE) {
         $error = self::formatErrors(libxml_get_errors());
       }


### PR DESCRIPTION


Overview
----------------------------------------
Fixes an obscure segfault

Before
----------------------------------------
Segfault in obscure config

After
----------------------------------------
Resolved

Technical Details
----------------------------------------
After upgrading to MacOS Catalina & MAMP 5.6 (latest) with php version 7.4.1 or 7.3.9
my site was unable to load CiviCRM with a segfault error. I traced it to this line & found that
phpstorm was highlighting the line it red as possibly subject to https://bugs.php.net/bug.php?id=62577

- taking phpstorm's recommendation allowed the site to load - the failure had been on parsing info.xml files

Comments
----------------------------------------

