### PR TITLE
Throwing API_Exception is file fails to copy when creating attachment…

### DIFF
--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -145,8 +145,10 @@ function civicrm_api3_attachment_create($params) {
   }
   elseif (is_string($moveFile)) {
     // CRM-17432 Do not use rename() since it will break file permissions.
-    // Also avoid move_uplaoded_file() because the API can use options.move-file.
-    copy($moveFile, $path);
+    // Also avoid move_uploaded_file() because the API can use options.move-file.
+    if (!copy($moveFile, $path)) {
+      throw new API_Exception("Cannot copy uploaded file ".$moveFile." to ".$path);
+    }
     unlink($moveFile);
   }
 

--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -147,7 +147,7 @@ function civicrm_api3_attachment_create($params) {
     // CRM-17432 Do not use rename() since it will break file permissions.
     // Also avoid move_uploaded_file() because the API can use options.move-file.
     if (!copy($moveFile, $path)) {
-      throw new API_Exception("Cannot copy uploaded file ".$moveFile." to ".$path);
+      throw new API_Exception("Cannot copy uploaded file $moveFile to $path");
     }
     unlink($moveFile);
   }


### PR DESCRIPTION
Overview
----------------------------------------
When creating an attachment using APIv3, the `civicrm_api3_attachment_create` function copies the file to the custom file upload directory. However, there is no error checking currently.

Before
----------------------------------------
The file would attempt to be copied and the original removed.
`
copy($moveFile, $path);
unlink($moveFile);
`

If the directory is non-writable, the file would be lost.

After
----------------------------------------
`if (!copy($moveFile, $path)) {
  throw new API_Exception("Cannot copy uploaded file ".$moveFile." to ".$path);
}
unlink($moveFile);`

Now, an API_Exception is thrown before the file is removed.