### PR TITLE
Call hook_civicrm_copy for RecurringEntity

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -586,6 +586,8 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
 
       CRM_Core_BAO_RecurringEntity::quickAdd($object->id, $newObject->id, $entityTable);
     }
+
+    CRM_Utils_Hook::copy(CRM_Core_DAO_AllCoreTables::getBriefName($daoName), $newObject);
     return $newObject;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When an entity is copied within CiviCRM core the hook_civicrm_copy *should* be called.

Before
----------------------------------------
`hook_civicrm_copy` not called when entities are copied via RecurringEntity (Activity/Event + related entities).

After
----------------------------------------
`hook_civicrm_copy` called when entities are copied via RecurringEntity (Activity/Event + related entities).

Technical Details
----------------------------------------
RecurringEntity uses copyGeneric directly and bypasses any entity specific copy functions. This should be resolved one day but is a much bigger project! For now this is a good thing because it means that hook_civicrm_copy will never be called twice - because it is only ever called from entity specific copy functions.

Comments
----------------------------------------
This allows for extensions to perform specific actions when an entity is copied.