### PR TITLE
composer.json - Relax psr/log constraint. Improve D8 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "symfony/event-dispatcher": "^2.8.50 || ~3.0",
     "symfony/filesystem": "^2.8.50 || ~3.0",
     "symfony/process": "^2.8.50 || ~3.0",
-    "psr/log": "~1.1",
+    "psr/log": "~1.0",
     "symfony/finder": "^2.8.50 || ~3.0",
     "tecnickcom/tcpdf" : "6.2.*",
     "totten/ca-config": "~17.05",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78720e4ea4f746b3244c8275f05d6d1b",
+    "content-hash": "1802a4c8eb543bd4acbb33b1672b2b12",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -504,6 +504,7 @@
                 "mimetype",
                 "php"
             ],
+            "abandoned": true,
             "time": "2017-03-23T02:05:33+00:00"
         },
         {
@@ -1524,16 +1525,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
                 "shasum": ""
             },
             "require": {
@@ -1542,7 +1543,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1567,7 +1568,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2019-11-01T11:05:21+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -2244,9 +2245,7 @@
             "version": "3.0.0+php53",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip",
-                "reference": null,
-                "shasum": null
+                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip"
             },
             "require": {
                 "php": ">=5.3.0"
@@ -2372,6 +2371,7 @@
                 "escaper",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-escaper",
             "time": "2015-05-07T14:55:31+00:00"
         },
         {
@@ -2444,12 +2444,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zetacomponents/Mail.git",
-                "reference": "b60e9a543f6c3d9a9ec74452d4ff5736a1c63a77"
+                "reference": "4dc71ccbcc8b67951a2efe47d3fcc2aeaa7f530d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/b60e9a543f6c3d9a9ec74452d4ff5736a1c63a77",
-                "reference": "b60e9a543f6c3d9a9ec74452d4ff5736a1c63a77",
+                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/4dc71ccbcc8b67951a2efe47d3fcc2aeaa7f530d",
+                "reference": "4dc71ccbcc8b67951a2efe47d3fcc2aeaa7f530d",
                 "shasum": ""
             },
             "require": {
@@ -2460,9 +2460,7 @@
             },
             "type": "library",
             "extra": {
-                "patches_applied": {
-                    "CiviCRM Custom Patches for ZetaCompoents mail": "tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch"
-                }
+                "patches_applied": []
             },
             "autoload": {
                 "classmap": [
@@ -2505,18 +2503,18 @@
                     "name": "Alexandru Stanoi"
                 },
                 {
-                    "name": "Christian Michel"
-                },
-                {
                     "name": "Sinisa Dukaric"
                 },
                 {
                     "name": "Mikko Koppanen"
+                },
+                {
+                    "name": "Christian Michel"
                 }
             ],
             "description": "The component allows you construct and/or parse Mail messages conforming to  the mail standard. It has support for attachments, multipart messages and HTML  mail. It also interfaces with SMTP to send mail or IMAP, POP3 or mbox to  retrieve e-mail.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2019-02-13T11:33:09+00:00"
+            "time": "2020-01-17T11:18:01+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Overview
--------

This addresses a composer conflict that's reported when trying to install on (eg) Drupal 8.7. For example, run these commands:

```
drush8 dl drupal-8.7.x
cd drupal-8*
composer require civicrm/civicrm-core:5.22.x-dev
```

Before
------

The install fails because `civicrm-core` requires `psr/log:~1.1`, and something else
is prodding us to use `psr/log:1.0.2`.

```
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for civicrm/civicrm-core 5.22.x-dev -> satisfiable by civicrm/civicrm-core[5.22.x-dev].
    - Conclusion: remove psr/log 1.0.2
    - Conclusion: don't install psr/log 1.0.2
    - civicrm/civicrm-core 5.22.x-dev requires psr/log ~1.1 -> satisfiable by psr/log[1.1.0, 1.1.1, 1.1.2, 1.1.x-dev].
    - Can only install one of: psr/log[1.1.0, 1.0.2].
    - Can only install one of: psr/log[1.1.1, 1.0.2].
    - Can only install one of: psr/log[1.1.2, 1.0.2].
    - Can only install one of: psr/log[1.1.x-dev, 1.0.2].
    - Installation request for psr/log (locked at 1.0.2) -> satisfiable by psr/log[1.0.2].

Installation failed, reverting ./composer.json to its original content.
```

Ex: https://test.civicrm.org/job/CiviCRM-D8-Matrix/4/BKPROF=max,BLDTYPE=drupal8-clean_8.7.x,CIVIVER=5.22,SUITES=phpunit-api4,label=bknix-tmp/console

After
-----

It should work.  However, this is hard to demonstrate via `r-run` without merging.

Comments
--------

The substantive differences between `psr/log` in v1.0 and v1.1 relate to `LoggerInterfaceTest` and `TestLogger`:

https://github.com/php-fig/log/compare/1.0.2...1.1.2

However, `civicrm-core` does not use `LoggerInterfaceTest` or `TestLogger`, so it shouldn't matter.

For the standard tarballs which use `composer.lock`, this does have the side-effect of bumping up from 1.1.0 to 1.1.2.

