### PR TITLE
composer.json - Relax psr/log constraint. Improve D8 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "symfony/event-dispatcher": "^2.8.50 || ~3.0",
     "symfony/filesystem": "^2.8.50 || ~3.0",
     "symfony/process": "^2.8.50 || ~3.0",
-    "psr/log": "~1.1",
+    "psr/log": "~1.0",
     "symfony/finder": "^2.8.50 || ~3.0",
     "tecnickcom/tcpdf" : "6.2.*",
     "totten/ca-config": "~17.05",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36eeb97f14e2af530920b89c59124de3",
+    "content-hash": "6b2ec4d9dc608f8b2e0def4af6d7bafb",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -1525,16 +1525,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
                 "shasum": ""
             },
             "require": {
@@ -1543,7 +1543,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1568,7 +1568,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2019-11-01T11:05:21+00:00"
         },
         {
             "name": "psr/simple-cache",


### PR DESCRIPTION
Overview
--------

This addresses a composer conflict that's reported when trying to install
on Drupal 8.7. For example, run these commands:

```
drush8 dl drupal-8.7.x
cd drupal-8*
composer require civicrm/civicrm-core:5.22.x-dev
```

This is a port of #16470 for `master`.

Before
------

The install fails because `civicrm-core` requires `psr/log:~1.1`, and something else
is prodding us to use `psr/log:1.0.2`.

```
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for civicrm/civicrm-core 5.22.x-dev -> satisfiable by civicrm/civicrm-core[5.22.x-dev].
    - Conclusion: remove psr/log 1.0.2
    - Conclusion: don't install psr/log 1.0.2
    - civicrm/civicrm-core 5.22.x-dev requires psr/log ~1.1 -> satisfiable by psr/log[1.1.0, 1.1.1, 1.1.2, 1.1.x-dev].
    - Can only install one of: psr/log[1.1.0, 1.0.2].
    - Can only install one of: psr/log[1.1.1, 1.0.2].
    - Can only install one of: psr/log[1.1.2, 1.0.2].
    - Can only install one of: psr/log[1.1.x-dev, 1.0.2].
    - Installation request for psr/log (locked at 1.0.2) -> satisfiable by psr/log[1.0.2].

Installation failed, reverting ./composer.json to its original content.
```

After
-----

It should work.  However, this is hard to demonstrate via `r-run` without merging.

Comments
--------

The substantive differences between `psr/log` in v1.0 and v1.1 relate to `LoggerInterfaceTest` and `TestLogger`:

https://github.com/php-fig/log/compare/1.0.2...1.1.2

However, `civicrm-core` does not use `LoggerInterfaceTest` or `TestLogger`, so it shouldn't matter.

For the standard tarballs which use `composer.lock`, this does have the side-effect of bumping up from 1.1.0 to 1.1.2.
