### PR TITLE
dev/core#1577 : Custom Group Types not filterable

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -99,12 +99,10 @@
         "url": {/literal}'{crmURL p="civicrm/ajax/grouplist" h=0 q="snippet=4"}'{literal},
         "data": function (d) {
 
-          var groupTypes = ($('.crm-group-search-form-block #group_type_search_1').prop('checked')) ? '1' : '';
-          if (groupTypes) {
-            groupTypes = ($('.crm-group-search-form-block #group_type_search_2').prop('checked')) ? groupTypes + ',2' : groupTypes;
-          } else {
-            groupTypes = ($('.crm-group-search-form-block #group_type_search_2').prop('checked')) ? '2' : '';
-          }
+          var groupTypes = '';
+          $('input[id*="group_type_search_"]:checked').each(function(e) {
+            groupTypes += $(this).attr('id').replace(/group_type_search_/, groupTypes == '' ? '' : ',');
+          });
 
           var groupStatus = ($('.crm-group-search-form-block #group_status_1').prop('checked')) ? 1 : '';
           if (groupStatus) {


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Create a custom group type via Option Group
2. Create a regular/smart group using that custom group type
3. Go to 'Manage Group' and select the custom group type in search criteria

https://lab.civicrm.org/dev/core/issues/1577

Before
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/73842626-f1344f00-4842-11ea-97b6-78383b6ff57b.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/73842781-42444300-4843-11ea-8564-418192cf012b.gif)


Comments
----------------------------------------
ping @eileenmcnaughton @lcdservices 

