### PR TITLE
release-notes: Late changes for 5.22 release notes

### DIFF
--- a/release-notes/5.22.0.md
+++ b/release-notes/5.22.0.md
@@ -17,7 +17,7 @@ Released February 5, 2020
 | **Change the database schema?**                                 | **yes** |
 | **Alter the API?**                                              | **yes** |
 | Require attention to configuration options?                     |   no    |
-| Fix problems installing or upgrading to a previous version?     |   no    |
+| **Fix problems installing or upgrading to a previous version?** | **yes** |
 | **Introduce features?**                                         | **yes** |
 | **Fix bugs?**                                                   | **yes** |
 
@@ -156,6 +156,12 @@ Released February 5, 2020
   Ensures the Mailing List group type remains set on the Update Smart Group
   form.
 
+- **loadServices: tighten up file match regex
+  ([16377](https://github.com/civicrm/civicrm-core/pull/16377))**
+
+  Ensures that CiviCRM code living under a path containing the characters 'php'
+  does not crash when loading services.
+
 - **Activity type listing shows name instead label
   ([dev/core#1470](https://lab.civicrm.org/dev/core/issues/1470):
   [16094](https://github.com/civicrm/civicrm-core/pull/16094))**
@@ -170,6 +176,10 @@ Released February 5, 2020
   ([dev/core#1474](https://lab.civicrm.org/dev/core/issues/1474):
   [16101](https://github.com/civicrm/civicrm-core/pull/16101))**
 
+- **Undefined offset and uninitialized string offset notices on upgrade to 5.21
+  ([dev/core#1555](https://lab.civicrm.org/dev/core/issues/1555):
+  [16417](https://github.com/civicrm/civicrm-core/pull/16417))**
+
 ### CiviCase
 
 - **Add case activity action links to activity report
@@ -178,6 +188,11 @@ Released February 5, 2020
   Ensures if an activity is linked to a case the "case activity" actions are
   displayed instead of the standard activity actions (eg. move/copy to case
   instead of file on case).
+
+- **Activity Details CiviReport gives network error when paging to next page if
+  choose filter to include case activities
+  ([dev/core#1552](https://lab.civicrm.org/dev/core/issues/1552):
+  [16393](https://github.com/civicrm/civicrm-core/pull/16393))**
 
 - **Case Detail 'Active Role?' filter excludes cases without relationships
   ([dev/report#24](https://lab.civicrm.org/dev/report/issues/24):
@@ -214,6 +229,15 @@ Released February 5, 2020
 
   Ensures that the actions menu on the participant search form respects search
   criteria.
+
+### CiviMail
+
+- **Exception Malformed temp table category on New A/B Test
+  ([dev/core#1564](https://lab.civicrm.org/dev/core/issues/1564):
+  [16464](https://github.com/civicrm/civicrm-core/pull/16464))**
+
+  Fixes a regression in 5.21.2 where creating a new A/B Test resulted in a
+  session status Exception Malformed temp table.
 
 ### CiviMember
 
@@ -360,6 +384,10 @@ Released February 5, 2020
 
 - **[Ref] Remove php4 support from BAO_Acl class
   ([16119](https://github.com/civicrm/civicrm-core/pull/16119))**
+
+- **(NFC) Civi, CRM, tests - Update for
+  Drupal.Commenting.VariableComment.IncorrectVarType
+  ([16384](https://github.com/civicrm/civicrm-core/pull/16384))**
 
 - **[NFC] Test clean up.
   ([16133](https://github.com/civicrm/civicrm-core/pull/16133))**


### PR DESCRIPTION
Overview
----------------------------------------
Adding late changes to 5.22 to the release notes. With these changes the 5.22 release notes are ready for release from AGH's perspective.