### PR TITLE
[TEST] dev/core#1572 Unit test environment not working on windows after recent CodeGen updates

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -163,7 +163,7 @@ class Test {
    */
   public static function codeGen() {
     if (!isset(self::$singletons['codeGen'])) {
-      $civiRoot = dirname(__DIR__);
+      $civiRoot = '.';
       $codeGen = new \CRM_Core_CodeGen_Main("$civiRoot/CRM/Core/DAO", "$civiRoot/sql", $civiRoot, "$civiRoot/templates", NULL, "UnitTests", NULL, "$civiRoot/xml/schema/Schema.xml", NULL);
       $codeGen->init();
       self::$singletons['codeGen'] = $codeGen;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1572
Previously it loaded the database from sql files. Now it does it on the fly compiling the schema xml files, but the path used doesn't work on windows.

Before
----------------------------------------
Screen fills with errors trying to run a unit test.

After
----------------------------------------
Works like it used to.

Technical Details
----------------------------------------
`DomDocument->xinclude()` in CRM_Core_CodeGen_Util_Xml is the main problem that doesn't work with backslashes. It's being passed a path that includes backslashes because the process gets started using `__DIR__` as the root, which on windows comes through with backslashes, and then it can't find the schema files to include. Except for system calls out to batch files and such where it's windows itself consuming the parameters, php works better on windows using forward slashes same as unix.

Comments
----------------------------------------
Another option if it's desired to have absolute paths is to use `str_replace("\\", '/', $civiRoot)`.
