### PR TITLE
dev/core#1579 CRM_Core_Payment_PayPalProIPN should not call getPayPalPaymentProcessorID() if processor_id is clearly provided in URL

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -457,7 +457,10 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
       }
     }
 
-    $paymentProcessorID = self::getPayPalPaymentProcessorID();
+    $paymentProcessorID = CRM_Utils_Array::value('processor_id', $this->_inputParameters);
+    if (!$paymentProcessorID) {
+      $paymentProcessorID = self::getPayPalPaymentProcessorID();
+    }
 
     if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
       return;


### PR DESCRIPTION
Overview
----------------------------------------
See issue description: https://lab.civicrm.org/dev/core/issues/1579

Before
----------------------------------------
Though processor_id is explicitly given in URL, warning message "Unreliable method used to get payment_processor_id for PayPal Pro IPN - this will cause problems if you have more than one instance" still appears in civicrm log file.

After
----------------------------------------
Needless warning messages are not logged, because this "unreliable method" is not invoked.

