### PR TITLE
dev/financial#87 make it possible to add a payment to a fully paid contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5363,33 +5363,41 @@ LIMIT 1;";
       return [];
     }
     $actionLinks = [];
+    $actionLinks[] = [
+      'url' => CRM_Utils_System::url('civicrm/payment', [
+        'action' => 'add',
+        'reset' => 1,
+        'id' => $id,
+        'is_refund' => 0,
+      ]),
+      'title' => ts('Record Payment'),
+    ];
+
     if ((int) $balance > 0) {
+      // @todo - this should be possible even if not > 0 - test & remove this if.
+      // it is possible to 'overpay' in the real world & we honor that.
       if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
         $actionLinks[] = [
           'url' => CRM_Utils_System::url('civicrm/payment', [
             'action' => 'add',
             'reset' => 1,
+            'is_refund' => 0,
             'id' => $id,
             'mode' => 'live',
           ]),
           'title' => ts('Submit Credit Card payment'),
         ];
       }
-      $actionLinks[] = [
-        'url' => CRM_Utils_System::url('civicrm/payment', [
-          'action' => 'add',
-          'reset' => 1,
-          'id' => $id,
-        ]),
-        'title' => ts('Record Payment'),
-      ];
     }
     elseif ((int) $balance < 0) {
+      // @todo - in the future remove this IF - OK to refund money even when not due since
+      // ... life.
       $actionLinks[] = [
         'url' => CRM_Utils_System::url('civicrm/payment', [
           'action' => 'add',
           'reset' => 1,
           'id' => $id,
+          'is_refund' => 1,
         ]),
         'title' => ts('Record Refund'),
       ];

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -48,7 +48,7 @@
     <tr class="crm-payment-form-block-total_amount">
       <td class="label">{$form.total_amount.label}</td>
       <td>
-        <span id='totalAmount'>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.total_amount.html|crmAddClass:eight}</span>&nbsp; <span class="status">{if $paymentType EQ 'refund'}{ts}Refund Due{/ts}{else}{ts}Balance Owed{/ts}{/if}:&nbsp;{$paymentAmt|crmMoney}</span>
+        <span id='totalAmount'>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.total_amount.html|crmAddClass:eight}</span>&nbsp; <span class="status">{if $paymentType EQ 'refund' || $paymentAmt < 0}{ts}Refund Due :&nbsp;{$absolutePaymentAmount|crmMoney} {/ts}{else}{ts}Balance Owed{/ts} :&nbsp;{$paymentAmt|crmMoney}{/if}</span>
       </td>
       {if $email and $outBound_option != 2}
         <tr class="crm-payment-form-block-is_email_receipt">


### PR DESCRIPTION
Overview
----------------------------------------
This alters the Add Payment form to permit payments to be added even if a contribution is  fully paid - this reflects the  'real  world' & has  been previously discussed & agreed - e.g  Barcelona

Before
----------------------------------------
'Add  payment'  link only displayed & works  if a payment is  'due'

After
----------------------------------------
Add payment  link always  visible  & works

<img width="765" alt="Screen Shot 2020-02-13 at 5 00 20 PM" src="https://user-images.githubusercontent.com/336308/74400709-ab4f3a80-4e83-11ea-9146-55078455ab67.png">


Technical Details
----------------------------------------
 Note  that  if a payment  is made as an  overpayment it  is  not  allocated to a line item (per  the spec)  so it  shows as having  no financial type - this is not a  bug
<img width="764" alt="Screen Shot 2020-02-06 at 12 06 43 PM" src="https://user-images.githubusercontent.com/336308/73891493-37d48880-48d9-11ea-9a5e-fdafcab0444a.png">


Comments
----------------------------------------
I  looked at this  after @alifrumin pinged on https://lab.civicrm.org/dev/financial/issues/87 - I believe   cleaning up this form is  the first step. We need  to separate 'view  payments' to it's own  form & stop overloading  this one,  ensure  contribution_id is always passed in  & stop passing  in 'component' , pass in  'refund' or  payment  (default,  not required) as a url parameter & not calculate which one it is, simplify the form & then  we  should be  able to add the 'submit' functionality fairly cleanly