### PR TITLE
[REF] Move some of the Pear Mail package patching into core

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -168,7 +168,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         $mailer = Mail::factory($mailerName, $params);
 
         $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-        $result = $mailer->send($toEmail, $headers, $message);
+        $result = CRM_Utils_Mail::mailerSend($mailer, $toEmail, $headers, $message);
         unset($errorScope);
         if (defined('CIVICRM_MAIL_LOG') && defined('CIVICRM_MAIL_LOG_AND_SEND')) {
           $testMailStatusMsg .= '<br />' . ts('You have defined CIVICRM_MAIL_LOG_AND_SEND - mail will be logged.') . '<br /><br />';

--- a/CRM/Mailing/Event/BAO/Reply.php
+++ b/CRM/Mailing/Event/BAO/Reply.php
@@ -186,7 +186,7 @@ class CRM_Mailing_Event_BAO_Reply extends CRM_Mailing_Event_DAO_Reply {
 
     if (is_object($mailer)) {
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-      $mailer->send($mailing->replyto_email, $h, $b);
+      CRM_Utils_Mail::mailerSend($mailer, $mailing->replyto_email, $h, $b);
       unset($errorScope);
     }
   }

--- a/CRM/Mailing/Event/BAO/Resubscribe.php
+++ b/CRM/Mailing/Event/BAO/Resubscribe.php
@@ -266,7 +266,7 @@ class CRM_Mailing_Event_BAO_Resubscribe {
 
     if (is_object($mailer)) {
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-      $mailer->send($eq->email, $h, $b);
+      CRM_Utils_Mail::mailerSend($mailer, $eq->email, $h, $b);
       unset($errorScope);
     }
   }

--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -261,7 +261,7 @@ SELECT     civicrm_email.id as email_id
 
     if (is_object($mailer)) {
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-      $mailer->send($email, $h, $b);
+      CRM_Utils_Mail::mailerSend($mailer, $email, $h, $b);
       unset($errorScope);
     }
   }

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -404,7 +404,7 @@ WHERE  email = %2
 
     if (is_object($mailer)) {
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-      $mailer->send($eq->email, $h, $b);
+      CRM_Utils_Mail::mailerSend($mailer, $eq->email, $h, $b);
       unset($errorScope);
     }
   }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -129,6 +129,25 @@ class CRM_Utils_Mail {
   }
 
   /**
+   * Either log email when being sent and don't send it if specific defines are set or call the send function on the Mailer object
+   * @param object $mailer Mailer Object
+   * @param string $recipients Recipients of this email
+   * @param array $headers
+   * @param string $body
+   *
+   * @return bool|Object
+   */
+  public static function mailerSend($mailer, $recipients, $headers, $body) {
+    if (defined('CIVICRM_MAIL_LOG')) {
+      CRM_Utils_Mail::logger($recipients, $headers, $body);
+      if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
+        return TRUE;
+      }
+    }
+    return $mailer->send($recipients, $headers, $body);
+  }
+
+  /**
    * Wrapper function to send mail in CiviCRM. Hooks are called from this function. The input parameter
    * is an associateive array which holds the values of field needed to send an email. These are:
    *
@@ -282,7 +301,7 @@ class CRM_Utils_Mail {
 
     if (is_object($mailer)) {
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-      $result = $mailer->send($to, $headers, $message);
+      $result = self::mailerSend($mailer, $to, $headers, $message);
       if (is_a($result, 'PEAR_Error')) {
         $message = self::errorMessage($mailer, $result);
         // append error message in case multiple calls are being made to

--- a/tools/scripts/composer/patches/pear-mail.patch.txt
+++ b/tools/scripts/composer/patches/pear-mail.patch.txt
@@ -17,21 +17,6 @@ diff --git a/Mail/mail.php b/Mail/mail.php
 index ee1ecef..ae6e2e8 100644
 --- a/Mail/mail.php
 +++ b/Mail/mail.php
-@@ -114,6 +114,14 @@ class Mail_mail extends Mail {
-      */
-     public function send($recipients, $headers, $body)
-     {
-+        if (defined('CIVICRM_MAIL_LOG')) {
-+            CRM_Utils_Mail::logger($recipients, $headers, $body);
-+            // Note: "CIVICRM_MAIL_LOG_AND SEND" (space not underscore) was a typo that existed for some years, so kept here for compatibility, but it should not be used.
-+            if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
-+                return true;
-+            }
-+        }
-+
-         if (!is_array($headers)) {
-             return PEAR::raiseError('$headers must be an array');
-         }
 @@ -145,7 +153,12 @@ class Mail_mail extends Mail {
          if (is_a($headerElements, 'PEAR_Error')) {
              return $headerElements;
@@ -46,41 +31,3 @@ index ee1ecef..ae6e2e8 100644
  
          // We only use mail()'s optional fifth parameter if the additional
          // parameters have been provided and we're not running in safe mode.
-diff --git a/Mail/sendmail.php b/Mail/sendmail.php
-index 7e8f804..e0300a0 100644
---- a/Mail/sendmail.php
-+++ b/Mail/sendmail.php
-@@ -132,6 +132,14 @@ class Mail_sendmail extends Mail {
-      */
-     public function send($recipients, $headers, $body)
-     {
-+        if (defined('CIVICRM_MAIL_LOG')) {
-+            CRM_Utils_Mail::logger($recipients, $headers, $body);
-+            // Note: "CIVICRM_MAIL_LOG_AND SEND" (space not underscore) was a typo that existed for some years, so kept here for compatibility, but it should not be used.
-+            if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
-+                return true;
-+            }
-+        }
-+
-         if (!is_array($headers)) {
-             return PEAR::raiseError('$headers must be an array');
-         }
-diff --git a/Mail/smtp.php b/Mail/smtp.php
-index 5e698fe..5f057e2 100644
---- a/Mail/smtp.php
-+++ b/Mail/smtp.php
-@@ -255,6 +255,14 @@ class Mail_smtp extends Mail {
-      */
-     public function send($recipients, $headers, $body)
-     {
-+        if (defined('CIVICRM_MAIL_LOG')) {
-+            CRM_Utils_Mail::logger($recipients, $headers, $body);
-+            // Note: "CIVICRM_MAIL_LOG_AND SEND" (space not underscore) was a typo that existed for some years, so kept here for compatibility, but it should not be used.
-+            if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
-+                return true;
-+            }
-+        }
-+
-         $result = $this->send_or_fail($recipients, $headers, $body);
- 
-         /* If persistent connections are disabled, destroy our SMTP object. */


### PR DESCRIPTION
Overview
----------------------------------------
This moves some of our custom patching from within the Pear/Mail package patch into core function to better manage with the Pear/Mail package

Before
----------------------------------------
CiviCRM Code for determining if we should log and or log and send emails in the library

After
----------------------------------------
Code to determine if we should log and or log and send emails in core

ping @eileenmcnaughton @totten @mfb 