### PR TITLE
Implement more nuanced 'Administer CiviCRM permisions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -927,7 +927,7 @@ class CRM_Core_Permission {
     return [
       'administer CiviCRM' => ['administer CiviCRM system', 'administer CiviCRM data'],
       'administer CiviCRM data' => ['edit message templates', 'administer dedupe rules'],
-      'administer CiviCRM system' => ['edit api keys', 'edit system workflow message templates', 'administer payment processors'],
+      'administer CiviCRM system' => ['edit system workflow message templates'],
     ];
   }
 

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -259,7 +259,7 @@
      <desc>Schedule Reminders.</desc>
      <page_callback>CRM_Admin_Page_ScheduleReminders</page_callback>
      <access_callback>1</access_callback>
-     <access_arguments>administer CiviCRM;edit all events</access_arguments>
+     <access_arguments>administer CiviCRM data;edit all events</access_arguments>
      <adminGroup>Communications</adminGroup>
      <weight>40</weight>
   </item>
@@ -397,7 +397,7 @@
      <title>Manage Extensions</title>
      <page_callback>CRM_Admin_Page_Extensions</page_callback>
      <desc></desc>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM system</access_arguments>
      <adminGroup>System Settings</adminGroup>
      <weight>120</weight>
   </item>
@@ -405,7 +405,7 @@
      <path>civicrm/admin/extensions/upgrade</path>
      <title>Database Upgrades</title>
      <page_callback>CRM_Admin_Page_ExtensionsUpgrade</page_callback>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM system</access_arguments>
   </item>
   <item>
      <path>civicrm/admin/setting/smtp</path>
@@ -413,6 +413,7 @@
      <page_callback>CRM_Admin_Form_Setting_Smtp</page_callback>
      <adminGroup>System Settings</adminGroup>
      <weight>20</weight>
+    <access_arguments>administer CiviCRM system</access_arguments>
   </item>
   <item>
      <path>civicrm/admin/paymentProcessor</path>
@@ -535,14 +536,14 @@
      <path>civicrm/admin/runjobs</path>
      <desc>URL used for running scheduled jobs.</desc>
      <page_callback>CRM_Utils_System::executeScheduledJobs</page_callback>
-     <access_arguments>access CiviCRM,administer CiviCRM</access_arguments>
+     <access_arguments>access CiviCRM,administer CiviCRM system</access_arguments>
   </item>
   <item>
      <path>civicrm/admin/job</path>
      <title>Scheduled Jobs</title>
      <desc>Managing periodially running tasks.</desc>
      <page_callback>CRM_Admin_Page_Job</page_callback>
-     <access_arguments>access CiviCRM,administer CiviCRM</access_arguments>
+     <access_arguments>access CiviCRM,administer CiviCRM system</access_arguments>
      <adminGroup>System Settings</adminGroup>
      <weight>1370</weight>
   </item>
@@ -551,7 +552,7 @@
      <title>Scheduled Jobs Log</title>
      <desc>Browsing the log of periodially running tasks.</desc>
      <page_callback>CRM_Admin_Page_JobLog</page_callback>
-     <access_arguments>access CiviCRM,administer CiviCRM</access_arguments>
+     <access_arguments>access CiviCRM,administer CiviCRM system</access_arguments>
      <adminGroup>Manage</adminGroup>
      <weight>1380</weight>
   </item>
@@ -573,7 +574,7 @@
   <item>
      <path>civicrm/admin</path>
      <title>Administer CiviCRM</title>
-     <access_arguments>administer CiviCRM,access CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM system,administer CiviCRM data,access CiviCRM</access_arguments>
      <page_type>1</page_type>
      <page_callback>CRM_Admin_Page_Admin</page_callback>
      <is_ssl>true</is_ssl>

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -180,7 +180,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     $ufEdit = CRM_ACL_API::group(CRM_Core_Permission::EDIT, NULL, 'civicrm_uf_group', $ufGroups);
     $checkPermission = [
       [
-        'administer CiviCRM',
+        'administer CiviCRM data',
         'manage event profiles',
       ],
     ];

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -70,7 +70,7 @@ class CRM_Event_Form_ManageEvent_TabHeader {
     $tabs['registration'] = ['title' => ts('Online Registration')] + $default;
     // @fixme I don't understand the event permissions check here - can we just get rid of it?
     $permissions = CRM_Event_BAO_Event::getAllPermissions();
-    if (CRM_Core_Permission::check('administer CiviCRM') || !empty($permissions[CRM_Core_Permission::EDIT])) {
+    if (CRM_Core_Permission::check('administer CiviCRM data') || !empty($permissions[CRM_Core_Permission::EDIT])) {
       $tabs['reminder'] = ['title' => ts('Schedule Reminders'), 'class' => 'livePage'] + $default;
     }
     $tabs['conference'] = ['title' => ts('Conference Slots')] + $default;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -563,7 +563,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
       // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions
       $adminFieldVisible = FALSE;
-      if (CRM_Core_Permission::check('administer CiviCRM')) {
+      if (CRM_Core_Permission::check('administer CiviCRM data')) {
         $adminFieldVisible = TRUE;
       }
 

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -165,7 +165,7 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
 
       // @fixme I don't understand the event permissions check here - can we just get rid of it?
       $permissions = CRM_Event_BAO_Event::getAllPermissions();
-      if (CRM_Core_Permission::check('administer CiviCRM') || !empty($permissions[CRM_Core_Permission::EDIT])) {
+      if (CRM_Core_Permission::check('administer CiviCRM data') || !empty($permissions[CRM_Core_Permission::EDIT])) {
         self::$_tabLinks[$cacheKey]['reminder']
           = [
             'title' => ts('Schedule Reminders'),

--- a/CRM/Grant/Page/DashBoard.php
+++ b/CRM/Grant/Page/DashBoard.php
@@ -27,7 +27,7 @@ class CRM_Grant_Page_DashBoard extends CRM_Core_Page {
    * @return void
    */
   public function preProcess() {
-    $admin = CRM_Core_Permission::check('administer CiviCRM');
+    $admin = CRM_Core_Permission::check('administer CiviCRM data');
 
     $grantSummary = CRM_Grant_BAO_Grant::getGrantSummary($admin);
 

--- a/CRM/UF/Form/Inline/Preview.php
+++ b/CRM/UF/Form/Inline/Preview.php
@@ -29,7 +29,7 @@ class CRM_UF_Form_Inline_Preview extends CRM_UF_Form_AbstractPreview {
     // Inline forms don't get menu-level permission checks
     $checkPermission = [
       [
-        'administer CiviCRM',
+        'administer CiviCRM data',
         'manage event profiles',
       ],
     ];

--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -64,7 +64,7 @@ class CRM_Utils_Check {
    * Display daily system status alerts (admin only).
    */
   public function showPeriodicAlerts() {
-    if (CRM_Core_Permission::check('administer CiviCRM')) {
+    if (CRM_Core_Permission::check('administer CiviCRM system')) {
       $session = CRM_Core_Session::singleton();
       if ($session->timer('check_' . __CLASS__, self::CHECK_TIMER)) {
 

--- a/tests/phpunit/CRM/Core/Permission/BaseTest.php
+++ b/tests/phpunit/CRM/Core/Permission/BaseTest.php
@@ -6,6 +6,8 @@
  */
 class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
 
+  use CRMTraits_ACL_PermissionTrait;
+
   /**
    * @return array
    *   (0 => input to translatePermission, 1 => expected output from translatePermission)
@@ -13,13 +15,13 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
   public function translateData() {
     $cases = [];
 
-    $cases[] = ["administer CiviCRM", "administer CiviCRM"];
-    $cases[] = ["cms:universal name", "local name"];
-    $cases[] = ["cms:universal name2", "local name2"];
-    $cases[] = ["cms:unknown universal name", CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
-    $cases[] = ["myruntime:foo", "foo"];
-    $cases[] = ["otherruntime:foo", CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
-    $cases[] = ["otherruntime:foo:bar", CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
+    $cases[] = ['administer CiviCRM', 'administer CiviCRM'];
+    $cases[] = ['cms:universal name', 'local name'];
+    $cases[] = ['cms:universal name2', 'local name2'];
+    $cases[] = ['cms:unknown universal name', CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
+    $cases[] = ['myruntime:foo', 'foo'];
+    $cases[] = ['otherruntime:foo', CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
+    $cases[] = ['otherruntime:foo:bar', CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
     $cases[] = [CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION, CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION];
 
     return $cases;
@@ -27,6 +29,7 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
 
   /**
    * @dataProvider translateData
+   *
    * @param string $input
    *   The name of a permission which should be translated.
    * @param string $expected
@@ -34,12 +37,23 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
    */
   public function testTranslate($input, $expected) {
     $perm = new CRM_Core_Permission_Base();
-    $actual = $perm->translatePermission($input, "myruntime", [
+    $actual = $perm->translatePermission($input, 'myruntime', [
       'universal name' => 'local name',
       'universal name2' => 'local name2',
       'gunk' => 'gunky',
     ]);
     $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Test that the user has the implied permission of administer CiviCRM data by virtue of having administer CiviCRM.
+   */
+  public function testImpliedPermission() {
+    $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'administer CiviCRM',
+    ];
+    $this->assertTrue(CRM_Core_Permission::check('administer CiviCRM data'));
   }
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
This picks up on an idea Tim has pushed several times - ie that instead of giving out 'Administer CiviCRM' willy nilly
we could deprioritise it in favour of 2 more granular permission bundles - ie Administer CiviCRM data & administer CiviCRM system.

This allows us to make some permissions more 'locked away' without endlessly adding new 'administer Payment Processors' level permissions
because we've realised not everyone who can create profiles needs to be able to see payment processor credentials.

It also allows us to make system checks less broadly visible where they are not appropriate.

Note that this is non-breaking. However, we would want to fairly quickly ensure that all places currently assigned to 'Administer CiviCRM' are assigned to one of the 2 roles. At the point where people's opinions start diverging about how to allocate them we will probably want to add a hook to give some flexibility - although I think we should have the conversations first so we don't just by-pass trying to get it right


Before
----------------------------------------
Administer CiviCRM required for so many things it tends to be allocated aggressively

After
----------------------------------------
No change in behaviour for users with Administer CiviCRM but 2 new sub-administer permissions exist - each of which has a subset of administer permission

'administer CiviCRM system'
'administer CiviCRM data' 

These have implicit rights to some other permissions - currently defined in the getImpliedPemissions function (below). I addition various urls have been assigned to one or the other in this PR eg. Schedule Reminders is assigned to 
administer CiviCRM data and administer extensions is assigned to administer CiviCRM system

Note Administer CiviCRM has all the permissions it currently has



Technical Details
----------------------------------------
When a permission is checked it is expanded into it's 'implied permissions' so 'administer CiviCRM' implies any of the following
 - administer CiviCRM
 - administer CiviCRM system
 - administer CiviCRM data

and administer CiviCRM data has  

- 'edit message templates
- administer dedupe rules

Thos permissions don't actually bubble up to administer CiviCRM

```
  public static function getImpliedPermissions() {
    return [
      'administer CiviCRM' => ['administer CiviCRM system',  'administer CiviCRM data'],
      'administer CiviCRM data' => ['edit message templates', 'administer dedupe rules'],
      'administer CiviCRM system' => ['edit api keys', 'edit system workflow message templates', 'administer payment processors'],
    ];
  }
```

Comments
----------------------------------------
These new permissions are effectively roles - as could be the existing 'Administer CiviCRM' permission - I can see purist arguments against that - but not practical ones