### PR TITLE
(dev/core#1580) Allow to search on contribution id

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -954,7 +954,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     $form->addYesNo('contribution_recurring', ts('Contribution is Recurring?'), TRUE);
 
     $form->addYesNo('contribution_test', ts('Contribution is a Test?'), TRUE);
-
+    $form->add('number', 'contribution_id', ts('Contribution ID'), ['class' => 'four', 'min' => 1]);
     // Add field for transaction ID search
     $form->addElement('text', 'contribution_trxn_id', ts("Transaction ID"));
     $form->addElement('text', 'contribution_check_number', ts('Check Number'));

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -157,6 +157,9 @@
     {$form.cancel_reason.html}
   </td>
 </tr>
+<tr>
+  <td><label>{$form.contribution_id.label}</label> {$form.contribution_id.html}</td>
+</tr>
 
 {* campaign in contribution search *}
 {include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignContext="componentSearch"


### PR DESCRIPTION
Overview
----------------------------------------
Allow to search on contribution id.
The contribution search doesn't have an option to quickly search on ID, this should fix that.


Before
----------------------------------------
![contri_before](https://user-images.githubusercontent.com/3455173/73910814-67ce5c80-48d6-11ea-9c7c-f86442c373c4.png)

After
----------------------------------------
![contri_after](https://user-images.githubusercontent.com/3455173/73910822-6d2ba700-48d6-11ea-8c4c-f9e9181c7921.png)

