### PR TITLE
Fix year typo.

### DIFF
--- a/release-notes/5.21.1.md
+++ b/release-notes/5.21.1.md
@@ -1,6 +1,6 @@
 # CiviCRM 5.21.1
 
-Released January 10, 2019
+Released January 10, 2020
 
 - **[Synopsis](#synopsis)**
 - **[Bugs resolved](#bugs)**


### PR DESCRIPTION
Overview
----------------------------------------
Year typo in release notes.

Before
----------------------------------------
Year = 2019

After
----------------------------------------
Year = 2020