### PR TITLE
dev/core#1019 Calculate.tpl: fix the Total Amount currency formatting.

### DIFF
--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -158,8 +158,8 @@ function display(totalfee) {
     // totalfee is monetary, round it to 2 decimal points so it can
     // go as a float - CRM-13491
     totalfee = Math.round(totalfee*100)/100;
-    var totalEventFee  = formatMoney( totalfee, 2, separator, thousandMarker);
-    document.getElementById('pricevalue').innerHTML = "<b>"+symbol+"</b> "+totalEventFee;
+    var totalFormattedFee = CRM.formatMoney(totalfee);
+    cj('#pricevalue').html(totalFormattedFee);
 
     cj('#total_amount').val( totalfee );
     cj('#pricevalue').data('raw-total', totalfee).trigger('change');
@@ -170,17 +170,6 @@ function display(totalfee) {
       // get an error on participant 2 of a event that requires approval & permits multiple registrants.
       skipPaymentMethod();
     }
-}
-
-//money formatting/localization
-function formatMoney (amount, c, d, t) {
-var n = amount,
-    c = isNaN(c = Math.abs(c)) ? 2 : c,
-    d = d == undefined ? "," : d,
-    t = t == undefined ? "." : t, s = n < 0 ? "-" : "",
-    i = parseInt(n = Math.abs(+n || 0).toFixed(c)) + "",
-    j = (j = i.length) > 3 ? j % 3 : 0;
-  return s + (j ? i.substr(0, j) + t : "") + i.substr(j).replace(/(\d{3})(?=\d)/g, "$1" + t) + (c ? d + Math.abs(n - i).toFixed(c).slice(2) : "");
 }
 
 {/literal}

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -154,22 +154,27 @@ function calculateTotalFee() {
  * Display calculated amount.
  */
 function display(totalfee) {
+  // totalfee is monetary, round it to 2 decimal points so it can
+  // go as a float - CRM-13491
+  totalfee = Math.round(totalfee*100)/100;
+  var totalFormattedFee = CRM.formatMoney(totalfee);
+  cj('#pricevalue').html(totalFormattedFee);
 
-    // totalfee is monetary, round it to 2 decimal points so it can
-    // go as a float - CRM-13491
-    totalfee = Math.round(totalfee*100)/100;
-    var totalFormattedFee = CRM.formatMoney(totalfee);
-    cj('#pricevalue').html(totalFormattedFee);
+  cj('#total_amount').val( totalfee );
+  cj('#pricevalue').data('raw-total', totalfee).trigger('change');
 
-    cj('#total_amount').val( totalfee );
-    cj('#pricevalue').data('raw-total', totalfee).trigger('change');
+  if (totalfee < 0) {
+    cj('table#pricelabel').addClass('disabled');
+  }
+  else {
+    cj('table#pricelabel').removeClass('disabled');
+  }
 
-    ( totalfee < 0 ) ? cj('table#pricelabel').addClass('disabled') : cj('table#pricelabel').removeClass('disabled');
-    if (typeof skipPaymentMethod == 'function') {
-      // Advice to anyone who, like me, feels hatred towards this if construct ... if you remove the if you
-      // get an error on participant 2 of a event that requires approval & permits multiple registrants.
-      skipPaymentMethod();
-    }
+  if (typeof skipPaymentMethod == 'function') {
+    // Advice to anyone who, like me, feels hatred towards this if construct ... if you remove the if you
+    // get an error on participant 2 of a event that requires approval & permits multiple registrants.
+    skipPaymentMethod();
+  }
 }
 
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------

Gitlab: https://lab.civicrm.org/dev/core/issues/1019

On contribution forms where the Total Amount is displayed (ex with a Price Set), the Total Amount did not respect the locale's money format. This can yield weird results:

![Capture d’écran de 2020-02-06 14-57-39](https://user-images.githubusercontent.com/254741/73973716-1c757780-48f1-11ea-9e69-182c4848ed1b.png)

To replicate (copied from Gitlab):

- Go to Administer > Localization > Language and Currency Change Monetary Amount Display to `%a %c`
- Configure price sets with some amounts
- Use this price set for any event/contribution,etc each item will respect the amount display but not the total(since it is auto calculated)

Before
----------------------------------------

Broken.

After
----------------------------------------

- Formats the Total Amount correctly
- Removes the bold around the currency, since it makes no sense either.

![Capture d’écran de 2020-02-06 15-01-00](https://user-images.githubusercontent.com/254741/73973921-842bc280-48f1-11ea-91d1-d688a204c47f.png)

Technical Details
----------------------------------------

- Removes code duplication.
- Two separate commits, one for the code reformatting.

Comments
----------------------------------------

Screenshot uses the [taxcalculator](https://lab.civicrm.org/extensions/taxcalculator/) extension, but it does not have an impact on the bug itself.