### PR TITLE
Pass required attribute for quickform fields through to form

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -780,25 +780,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $qf->add('text', $elementName . '_to', ts('To'), $field->attributes);
         }
         else {
-          $choice = [];
           parse_str($field->attributes, $radioAttributes);
           $radioAttributes = array_merge($radioAttributes, $customFieldAttributes);
-
-          foreach ($options as $v => $l) {
-            $choice[] = $qf->createElement('radio', NULL, '', $l, (string) $v, $radioAttributes);
-          }
-          $element = $qf->addGroup($choice, $elementName, $label);
-          $optionEditKey = 'data-option-edit-path';
-          if (isset($selectAttributes[$optionEditKey])) {
-            $element->setAttribute($optionEditKey, $selectAttributes[$optionEditKey]);
-          }
-
-          if ($useRequired && !$search) {
-            $qf->addRule($elementName, ts('%1 is a required field.', [1 => $label]), 'required');
-          }
-          else {
-            $element->setAttribute('allowClear', TRUE);
-          }
+          $qf->addRadio($elementName, $label, $options, $radioAttributes, NULL, $useRequired);
         }
         break;
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -419,6 +419,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       unset($extra['option_context']);
     }
 
+    $this->addRequiredAttribute($required, $extra);
     $element = $this->addElement($type, $name, CRM_Utils_String::purifyHTML($label), $attributes, $extra);
     if (HTML_QuickForm::isError($element)) {
       CRM_Core_Error::fatal(HTML_QuickForm::errorMessage($element));
@@ -1146,6 +1147,20 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
+   * jQuery validate prefers to see a validation rule as a class (eg. "required").
+   * We can't add a class at the quickform level but jQuery validate also works with HTML5:
+   * HTML5 validation requires a separate attribute "required".
+   *
+   * @param $required
+   * @param $attributes
+   */
+  private function addRequiredAttribute($required, $attributes) {
+    // Ideally we do this by adding "required" as a class on the radio but we can't
+    // But adding the attribute "required" directly to the element also works.
+    $required ? $attributes['required'] = 1 : NULL;
+  }
+
+  /**
    * @param string $name
    * @param $title
    * @param $values
@@ -1162,6 +1177,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $allowClear = !empty($attributes['allowClear']);
     unset($attributes['allowClear']);
     $attributes['id_suffix'] = $name;
+    // For jquery validate we need to flag the actual radio as required.
+    $this->addRequiredAttribute($required, $attributes);
     foreach ($values as $key => $var) {
       $optAttributes = $attributes;
       if (!empty($optionAttributes[$key])) {

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -109,7 +109,7 @@ class CRM_Core_Payment_Form {
           $field['name'],
           $field['title'],
           $field['attributes'],
-          FALSE,
+          $field['is_required'],
           $field['extra']
         );
       }

--- a/js/Common.js
+++ b/js/Common.js
@@ -850,9 +850,9 @@ if (!CRM.vars) CRM.vars = {};
    */
   $.fn.crmValidate = function(params) {
     return $(this).each(function () {
-      var that = this,
-        settings = $.extend({}, CRM.validate._defaults, CRM.validate.params);
-      $(this).validate(settings);
+      var validator = $(this).validate();
+      var that = this;
+      validator.settings = $.extend({}, validator.settings, CRM.validate._defaults, CRM.validate.params);
       // Call any post-initialization callbacks
       if (CRM.validate.functions && CRM.validate.functions.length) {
         $.each(CRM.validate.functions, function(i, func) {

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -20,9 +20,7 @@
         {foreach from=$paymentFields item=paymentField}
           {assign var='name' value=$form.$paymentField.name}
           <div class="crm-section {$form.$paymentField.name}-section">
-            <div class="label">{$form.$paymentField.label}
-              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
-            </div>
+            <div class="label">{$form.$paymentField.label}</div>
             <div class="content">
                 {$form.$paymentField.html}
               {if $paymentFieldsMetadata.$name.description}
@@ -51,9 +49,7 @@
         {foreach from=$billingDetailsFields item=billingField}
           {assign var='name' value=$form.$billingField.name}
           <div class="crm-section {$form.$billingField.name}-section">
-            <div class="label">{$form.$billingField.label}
-              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
-            </div>
+            <div class="label">{$form.$billingField.label}</div>
             {if $form.$billingField.type == 'text'}
               <div class="content">{$form.$billingField.html}</div>
             {else}

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -93,10 +93,9 @@
   {literal}
 
   var params = {
-    errorClass: 'crm-inline-error',
+    errorClass: 'crm-inline-error alert-danger',
     messages: {},
-    // TODO: remove after resolution of https://github.com/jzaefferer/jquery-validation/pull/1261
-    ignore: ":hidden, [readonly]"
+    ignore: ".select2-offscreen, [readonly], :hidden:not(.crm-select2)"
   };
 
   // use civicrm notifications when there are errors


### PR DESCRIPTION
Overview
----------------------------------------
In quite a few cases the required attribute is not passed through to the actual form element via quickform. This happens in at least two situations:
1. Billing address fields block.
2. *Any* radio element in profiles.

Before
----------------------------------------
"Required" attribute not passed through. Elements don't have "required" as a class on the <input>.

After
----------------------------------------
"Required" attribute passed through. Elements (except radio) have "required" element as a class on the <input>.
For radio elements we can't set the class required so we set the attribute "required=1" directly on the input: `<input required="1"`>. jQuery validate picks this up too and flags the field as required.

Technical Details
----------------------------------------
This library https://jqueryvalidation.org/ is part of CiviCRM core and is loaded automatically on various pages including contribution pages.
To test you can use the browser console and type (for a contribution page): `CRM.$('#Main').valid()`.

Comments
----------------------------------------
This has been a bit of a nightmare! Tracked down from https://lab.civicrm.org/extensions/stripe/issues/147  In practise this generally only affects Stripe and other payment processors that use javascript based submission methods (in particular the javascript pre-auth) but it also improves our support for client-side validation of forms which would be nice :-)

@seamuslee001 this is what @JoeMurray pinged you on previously :-)
