### PR TITLE
Resolve notices if first donation amount and date columns were disabled

### DIFF
--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -657,8 +657,8 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
           if ($contactId = $row['civicrm_contact_id']) {
             if ($rowNum == 0) {
               $pcid = $contactId;
-              $fAmt = $row['first_donation_first_donation_amount'];
-              $fDate = $row['first_donation_first_donation_date'];
+              $fAmt = $row['first_donation_first_donation_amount'] ?? '';
+              $fDate = $row['first_donation_first_donation_date'] ?? '';
             }
             else {
               if ($pcid == $contactId) {
@@ -667,8 +667,8 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
                 $pcid = $contactId;
               }
               else {
-                $fAmt = $row['first_donation_first_donation_amount'];
-                $fDate = $row['first_donation_first_donation_date'];
+                $fAmt = $row['first_donation_first_donation_amount'] ?? '';
+                $fDate = $row['first_donation_first_donation_date'] ?? '';
                 $pcid = $contactId;
               }
             }


### PR DESCRIPTION
Overview
----------------------------------------
Contribution and Membership Details expects some columns are present, but they could have been disabled. This results in error messages like Notice: Undefined index: first_donation_first_donation_date in CRM_Report_Form_Member_ContributionDetail->alterDisplay() 

Before
----------------------------------------
PHP notices, one or two per row (could be thousands of notices)

After
----------------------------------------
No notices!