### PR TITLE
Enable jQuery validate on register/contribution forms

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -397,11 +397,4 @@
   {/literal}
 </script>
 {/if}
-
-{* jQuery validate *}
-{* disabled because originally this caused problems with some credit cards.
-Likely it no longer has an problems but allowing conditional
- inclusion by extensions / payment processors for now in order to add in a conservative way *}
-{if $isJsValidate}
-  {include file="CRM/Form/validate.tpl"}
-{/if}
+{include file="CRM/Form/validate.tpl"}

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -247,3 +247,4 @@
 
 </script>
 {/literal}
+{include file="CRM/Form/validate.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
This makes jQuery validate available by default on frontend contribution / registration forms. Any site with Stripe enabled has been using this for about a year now.

Partial from https://github.com/civicrm/civicrm-core/pull/16488

Before
----------------------------------------
jQuery validate not available on frontend forms by default.

After
----------------------------------------
jQuery validate available on frontend forms.

Technical Details
----------------------------------------
This activates jquery validation (client-side validation) for forms. Which does nothing by itself but allows you to run eg. `CRM.$('#Main').valid()` and get a true/false response, also fields will show a "field is required" message.

Comments
----------------------------------------
@eileenmcnaughton Think you had an interest in the past?
