### PR TITLE
Fix implementation of jQuery.validate

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -850,9 +850,9 @@ if (!CRM.vars) CRM.vars = {};
    */
   $.fn.crmValidate = function(params) {
     return $(this).each(function () {
-      var that = this,
-        settings = $.extend({}, CRM.validate._defaults, CRM.validate.params);
-      $(this).validate(settings);
+      var validator = $(this).validate();
+      var that = this;
+      validator.settings = $.extend({}, validator.settings, CRM.validate._defaults, CRM.validate.params);
       // Call any post-initialization callbacks
       if (CRM.validate.functions && CRM.validate.functions.length) {
         $.each(CRM.validate.functions, function(i, func) {

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -91,10 +91,9 @@
   {literal}
 
   var params = {
-    errorClass: 'crm-inline-error',
+    errorClass: 'crm-inline-error alert-danger',
     messages: {},
-    // TODO: remove after resolution of https://github.com/jzaefferer/jquery-validation/pull/1261
-    ignore: ":hidden, [readonly]"
+    ignore: ".select2-offscreen, [readonly], :hidden:not(.crm-select2)"
   };
 
   // use civicrm notifications when there are errors


### PR DESCRIPTION
Overview
----------------------------------------
Fix implementation of jQuery validate in CiviCRM so that it actually uses the CRM settings, validates select2 fields and uses Civi/bootstrap classes for errors.

Partial from https://github.com/civicrm/civicrm-core/pull/16488

Before
----------------------------------------
jQuery validate in CiviCRM did not work with select2. In Common.js there was code to load CiviCRM specific settings but they weren't actually being loaded!

After
----------------------------------------
select2 is validated (note that the error message is currently the label - that could be improved as could the positioning of some of the error messages - that's all possible but out of scope for this PR!):
![image](https://user-images.githubusercontent.com/2052161/74062729-ddc1e900-49e6-11ea-8729-ca11082d8d39.png)


Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------

Testing
----------------------------------------
For testing you can do in the browser console on a contribution page:
`var validator = CRM.$('#Main').validate();`
`validator.settings` - to show the settings that are loaded for the page.
`CRM.$('#Main').valid();` to check if the form is "valid" - returns true/false.

**Currently this will return valid for many required fields on the form if they are empty.** This is because CiviCRM is not setting them as required before creating the form - that will be fixed in https://github.com/civicrm/civicrm-core/pull/16488.
So to test you have to add the class "required" to the form fields once the page has loaded:
![image](https://user-images.githubusercontent.com/2052161/77310608-83f75300-6cf6-11ea-8e6e-9ba62b5eeccb.png)
![image](https://user-images.githubusercontent.com/2052161/77310633-8d80bb00-6cf6-11ea-838b-7ad15f33e335.png)

This is particularly a problem for any processor that has "billing address" fields.

