### PR TITLE
Make the 'billing address is the same' checkbox respond to the change event

### DIFF
--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -158,10 +158,18 @@
         });
       }
 
-
       // toggle show/hide
-      $('#billingcheckbox').click(function () {
-        if (this.checked) {
+      var billingCheckboxElement = $('#billingcheckbox');
+      billingCheckboxElement.click(function() {
+        billingCheckboxChanged(billingCheckboxElement);
+      });
+
+      billingCheckboxElement.change(function() {
+        billingCheckboxChanged(billingCheckboxElement);
+      });
+
+      function billingCheckboxChanged(billingCheckbox) {
+        if (billingCheckbox.prop('checked')) {
           if (!CRM.billing || CRM.billing.billingProfileIsHideable) {
             $('.billing_name_address-group').hide(200);
           }
@@ -180,7 +188,7 @@
         } else {
           $('.billing_name_address-group').show(200);
         }
-      });
+      }
 
       // remove spaces, dashes from credit card number
       $('#credit_card_number').change(function () {


### PR DESCRIPTION
Overview
----------------------------------------
Checking and unchecking the "My Billing Address is the same" only works if you actually "click" on the checkbox and not if you change it via any other method (eg. javascript). This makes it a little more robust so that it also responds to the change event. You can, for example, trigger change and it will update the billing fields if it is already checked.

Before
----------------------------------------
Does not always seem to work - difficult to know because the fields are hidden if it is checked.

After
----------------------------------------
Works in most cases. If the checkbox is "clicked" on or "changed" by any other method.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
Partial from https://github.com/civicrm/civicrm-core/pull/16488