### PR TITLE
Update cancelSubscription  form to use updated methodology

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1314,6 +1314,34 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Cancel a recurring subscription.
+   *
+   * Payment processor classes should override this rather than implementing cancelSubscription.
+   *
+   * A PaymentProcessorException should be thrown if the update of the contribution_recur
+   * record should not proceed (in many cases this function does nothing
+   * as the payment processor does not need to take any action & this should silently
+   * proceed. Note the form layer will only call this after calling
+   * $processor->supports('cancelRecurring');
+   *
+   * @param \Civi\Payment\PropertyBag $propertyBag
+   *
+   * @return array
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function doCancelRecurring(PropertyBag $propertyBag) {
+    if (method_exists($this, 'cancelSubscription')) {
+      $message = NULL;
+      if ($this->cancelSubscription($message, $propertyBag)) {
+        return ['message' => $message];
+      }
+      throw new PaymentProcessorException($message);
+    }
+    return ['message' => ts('Recurring contribution cancelled')];
+  }
+
+  /**
    * Refunds payment
    *
    * Payment processors should set payment_status_id if it set the status to Refunded in case the transaction is successful

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -65,6 +65,7 @@ class PropertyBag implements \ArrayAccess {
     'frequency_interval'          => 'recurFrequencyInterval',
     'recurFrequencyUnit'          => TRUE,
     'frequency_unit'              => 'recurFrequencyUnit',
+    'subscriptionId'              => 'recurProcessorID',
     'recurProcessorID'            => TRUE,
     'transactionID'               => TRUE,
     'transaction_id'              => 'transactionID',


### PR DESCRIPTION

Overview
----------------------------------------
Updates our methodology on the cancelSubscription form (the only for that cancels  recurrings)

Before
----------------------------------------
- input params are a string passed as a reference and an array
- function is called cancelSubscription, which is inconsistent with our other 'action functions'
- function returns a bool - which is inconsistent with our other 'action functions'
- processors need to implement cancelSubscription for recurrings to be cancellable. If they support more than one processor & one supports cancel recurring & another doesn't this gets messy quickly as supportsCancelRecurring checks for the function existing so we recommend that both are implemented.


After
----------------------------------------
a) input params are a property bag
b) function is called doCancelRecur -  in line with our other 'action' functions.
c) function throws a PaymentProcessorException on error or returns a result array with additional information (the message) which is consistent with other action functions
d) processors can still implement cancelRecurring with no change. Or they can implement supportsCancelRecurring, and also doCancelRecurring
e) we have a path towards separating whether a checkbox should be displayed to 'send cancel request' to the processor and whether to permit cancelling (separate into 2 supports statements or rename the existing one)

Existing processors do not need to be altered although some deprecation may occur in future.


Technical Details
----------------------------------------
This came up after https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/149 was
logged & I thought it was time to pick this up again.

There is further cleanup to be done & I have deliberately left that out in order to keep this tightly related to the
decisions that need to be made.

1) This creates a new function more in line with our standards it starts with 'do', accepts a propertyBag,
expects a PaymentProcessorException to be thrown if there is a fail.
2) does not require PaymentProcessors to implement cancelSubscription. A common scenario is that a processor
supports recurrings being cancelled but does not need to do anything as updating the contribution
recur record is enough to achieve that. In this case processors should implement supportsCancelRecurring
but they do not need to implement this function. (Currently they are recommended to implement supportsCancelRecurring
in keeping with our standardised 'supports' pattern but the non-standard cancelSubscription is also required.
3) ensures that the only place in the core code that calls this passes the PropertyBag

However, this also introduces the parameter 'subscriptionId' to the PropertyBag. This is one we 'left for it's own discussion'
because - we all hate it.

The options as I see it are
1)  subscriptionId  - advantage  is this is what  is  already  in use  & we will need some transitioning if  we change it. Disadvantage is  that  it only really relates to paypal apart from that....
2) processor_id -  advantage is this i s  in the contribution_recur table, disadvantage is  that  it's a really silly  & confusing name for it
3) recur_profile_id, recur_gateway_id, other  we come up with - advantage is we could give it a meaningful name, disadvantage is yet
another terminology in the mix & we might be opening a whole new can of worms.....

At this stage I'm leaning to 1 on the basis that it's a baby step that complies with  existing code & doesn't open up a whole
new scope leap. But - open.....

Comments
----------------------------------------

@artfulrobot @mattwire 