### PR TITLE
dev/financial#117 - Add link metadata for payment edit link

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4135,7 +4135,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             [
               'id' => $resultDAO->id,
               'contribution_id' => $contributionId,
-            ]
+            ],
+            ts('more'),
+            FALSE,
+            'Payment.edit.action',
+            'Payment',
+            $resultDAO->id
           );
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds metadata to edit payment link so that hook_civicrm_links can be used.

Before
----------------------------------------
Edit payment link on View Contribution page cannot be modified by hook_civicrm_links

After
----------------------------------------
Edit payment link on View Contribution page can be modified by hook_civicrm_links

Comments
----------------------------------------
similar PR: https://github.com/civicrm/civicrm-core/pull/1851