### PR TITLE
Count refunds when calculating amount due for an invoice

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -286,24 +286,13 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       $invoiceDate = date("F j, Y");
       $dueDate = date('F j, Y', strtotime($contributionReceiveDate . "+" . $prefixValue['due_date'] . "" . $prefixValue['due_date_period']));
 
-      $lineItem = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contribID);
-
-      $resultPayments = civicrm_api3('Payment', 'get', [
-        'sequential' => 1,
-        'contribution_id' => $contribID,
-      ]);
-      $amountPaid = 0;
-      foreach ($resultPayments['values'] as $singlePayment) {
-        // Only count payments that have been (status =) completed.
-        if ($singlePayment['status_id'] == 1) {
-          $amountPaid += $singlePayment['total_amount'];
-        }
-      }
+      $amountPaid = CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribID, TRUE);
       $amountDue = ($input['amount'] - $amountPaid);
 
       // retrieving the subtotal and sum of same tax_rate
       $dataArray = [];
       $subTotal = 0;
+      $lineItem = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contribID);
       foreach ($lineItem as $taxRate) {
         if (isset($dataArray[(string) $taxRate['tax_rate']])) {
           $dataArray[(string) $taxRate['tax_rate']] = $dataArray[(string) $taxRate['tax_rate']] + CRM_Utils_Array::value('tax_amount', $taxRate);


### PR DESCRIPTION
Overview
----------------------------------------
Refunds are not being counted. So if you do something like this:

Contribution amount = £9.30.
1. Add payment for £9.30.
1. Add payment for £10.
1. Refund payment for £10.

You end up with an invoice that shows "Amount Due: £-10.00".

Before
----------------------------------------
If contribution payments include a refund, incorrect amount shown for "Amount Due":
![image](https://user-images.githubusercontent.com/2052161/74250249-3d1f4200-4ce2-11ea-80e0-1468e2faeffd.png)


After
----------------------------------------
If contribution payments include a refund, correct amount shown for "Amount Due":
![image](https://user-images.githubusercontent.com/2052161/74250437-8079b080-4ce2-11ea-9062-44df389e6022.png)



Technical Details
----------------------------------------
Explained in overview - we need to count both "Completed" and "Refunded" as actual payments when doing the calculation.

Comments
----------------------------------------
@eileenmcnaughton @monishdeb 
