### PR TITLE
dev/core#1587 Select2 - Use description as title for each option

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -404,6 +404,7 @@ if (!CRM.vars) CRM.vars = {};
       return $(this).each(function() {
         $(this)
           .removeClass('crm-ajax-select')
+          .off('.crmSelect2')
           .select2('destroy');
       });
     }
@@ -438,6 +439,13 @@ if (!CRM.vars) CRM.vars = {};
           return out;
         };
       }
+
+      // Use description as title for each option
+      $el.on('select2-loaded.crmSelect2', function() {
+        $('.crm-select2-row-description', '#select2-drop').each(function() {
+          $(this).closest('.select2-result-label').attr('title', $(this).text());
+        });
+      });
 
       // Defaults for single-selects
       if ($el.is('select:not([multiple])')) {


### PR DESCRIPTION
Overview
----------------------------------------
In the select2 dropdown, shows full description as a tooltip when hovering over each option.

Before
----------------------------------------
Descriptions are limited to one line and can be truncated.

After
----------------------------------------
The full description is shown as a tooltip.
![Screenshot from 2020-02-11 15-10-10](https://user-images.githubusercontent.com/2874912/74274809-bd44a800-4ce0-11ea-93b8-9b8f58a70e95.png)

