### PR TITLE
crmSelect2 - fix whitespace in tooltip

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -679,7 +679,7 @@ if (!CRM.vars) CRM.vars = {};
       '</div>' +
       '<div class="crm-select2-row-description">';
     $.each(row.description || [], function(k, text) {
-      markup += '<p>' + _.escape(text) + '</p>';
+      markup += '<p>' + _.escape(text) + '</p> ';
     });
     markup += '</div></div></div>';
     return markup;


### PR DESCRIPTION
Overview
----------------------------------------
Small followup tweak to #16507 - fix lack of whitespace in tooltip between description paragraphs.

Before
----------------------------------------
Tooltip smooshed (no whitespace between "5:00 PM" and the next sentence).
![image](https://user-images.githubusercontent.com/2874912/74284343-7d39f100-4cf1-11ea-99d0-9f8c4cad9aa4.png)


After
----------------------------------------
Tooltip better.
![image](https://user-images.githubusercontent.com/2874912/74284376-980c6580-4cf1-11ea-8fed-012cfb687776.png)

