### PR TITLE
Move  settings definition on contribution settings form to metadata.

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -50,14 +50,6 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $filter = $this->getSettingPageFilter();
-    $settings = civicrm_api3('Setting', 'getfields', [])['values'];
-    foreach ($settings as $key => $setting) {
-      if (isset($setting['settings_pages'][$filter])) {
-        $this->_settings[$key] = $setting;
-      }
-    }
-
     $this->addFieldsDefinedInSettingsMetadata();
 
     // @todo look at sharing the code below in the settings trait.

--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -19,15 +19,6 @@
  * This class generates form components for the display preferences.
  */
 class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
-  protected $_settings = [
-    'cvv_backoffice_required' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'update_contribution_on_membership_type_change' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'acl_financial_type' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'always_post_to_accounts_receivable' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'deferred_revenue_enabled' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'default_invoice_page' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-    'invoicing' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-  ];
 
   /**
    * Our standards for settings are to have a setting per value with defined metadata.
@@ -35,7 +26,10 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
    * Unfortunately the 'contribution_invoice_settings' has been added in non-compliance.
    * We use this array to hack-handle.
    *
-   * I think the best way forwards would be to covert to multiple individual settings.
+   * These are now stored as individual settings but this form still does weird & wonderful things.
+   *
+   * Note the 'real' settings on this form are added via metadata definition - ie
+   * 'settings_pages' => ['contribute' => ['weight' => 1]], in their metadata.
    *
    * @var array
    */
@@ -43,22 +37,18 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
 
   /**
    * Build the form object.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $config = CRM_Core_Config::singleton();
     $this->invoiceSettings = [
       'invoice_prefix' => [
         'html_type' => 'text',
         'title' => ts('Invoice Prefix'),
         'weight' => 1,
         'description' => ts('Enter prefix to be display on PDF for invoice'),
-      ],
-      'credit_notes_prefix' => [
-        'html_type' => 'text',
-        'title' => ts('Credit Notes Prefix'),
-        'weight' => 2,
-        'description' => ts('Enter prefix to be display on PDF for credit notes.'),
       ],
       'due_date' => [
         'html_type' => 'text',

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -153,8 +153,10 @@ trait CRM_Admin_Form_SettingTrait {
    * Add fields in the metadata to the template.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   protected function addFieldsDefinedInSettingsMetadata() {
+    $this->addSettingsToFormFromMetadata();
     $settingMetaData = $this->getSettingsMetaData();
     $descriptions = [];
     foreach ($settingMetaData as $setting => $props) {
@@ -370,6 +372,21 @@ trait CRM_Admin_Form_SettingTrait {
     $order = array_keys(\CRM_Utils_Request::retrieve($setting, 'String'));
     $settingValueKeys = array_keys($settingValue);
     return array_intersect($order, $settingValueKeys);
+  }
+
+  /**
+   * Add settings to form if the metadata designates they should be on the page.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function addSettingsToFormFromMetadata() {
+    $filter = $this->getSettingPageFilter();
+    $settings = civicrm_api3('Setting', 'getfields', [])['values'];
+    foreach ($settings as $key => $setting) {
+      if (isset($setting['settings_pages'][$filter])) {
+        $this->_settings[$key] = $setting;
+      }
+    }
   }
 
 }

--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -32,6 +32,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Is the CVV code required for back office credit card transactions'),
     'help_text' => 'If set it back-office credit card transactions will required a cvv code. Leave as required unless you have a very strong reason to change',
+    'settings_pages' => ['contribute' => ['weight' => 10]],
   ],
   'contribution_invoice_settings' => [
     // @todo our standard is to have a setting per item not to hide settings in an array with
@@ -70,6 +71,7 @@ return [
     'on_change' => [
       'CRM_Invoicing_Utils::onToggle',
     ],
+    'settings_pages' => ['contribute' => ['weight' => 90]],
   ],
   'credit_notes_prefix' => [
     'group_name' => 'Contribute Preferences',
@@ -85,6 +87,7 @@ return [
     'description' => ts('Prefix to be prepended to credit note ids'),
     'default' => 'CN_',
     'help_text' => ts('The credit note ID is generated when a contribution is set to Refunded, Cancelled or Chargeback. It is visible on invoices, if invoices are enabled'),
+    'settings_pages' => ['contribute' => ['weight' => 80]],
   ],
   'invoice_prefix' => [
     'html_type' => 'text',
@@ -176,6 +179,7 @@ return [
     'is_contact' => 0,
     'help_text' => NULL,
     'help' => ['id' => 'acl_financial_type'],
+    'settings_pages' => ['contribute' => ['weight' => 30]],
   ],
   'deferred_revenue_enabled' => [
     'group_name' => 'Contribute Preferences',
@@ -190,6 +194,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 50]],
   ],
   'default_invoice_page' => [
     'group_name' => 'Contribute Preferences',
@@ -208,6 +213,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 70]],
   ],
   'always_post_to_accounts_receivable' => [
     'group_name' => 'Contribute Preferences',
@@ -222,6 +228,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 40]],
   ],
   'update_contribution_on_membership_type_change' => [
     'group_name' => 'Contribute Preferences',
@@ -237,5 +244,6 @@ return [
     'is_contact' => 0,
     'description' => ts('Enabling this setting will update related contribution of membership(s) except if the membership is paid for with a recurring contribution.'),
     'help_text' => NULL,
+    'settings_pages' => ['contribute' => ['weight' => 20]],
   ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
This moves the code that allows settings to be added to forms by metadata from the Generic setting form to the setting trait.

This means many more forms will support injecting settings by metadata. Specifically we switch across the Contribution preferences form,
making credit_note_prefix a metadata-added field. This is preliminary to moving that to an extension & allows us to inject it
in by simply defining the metadata in a hook

Before
----------------------------------------
Hard coded settings on form

After
----------------------------------------
Setting spec for adding settings to form used & respected

Technical Details
----------------------------------------
Pre the setting spec the preferred way to add a setting to a setting page is through metadata
-ie
 'settings_pages' => ['contribute' => ['weight' => 80]],

Note that some pages are fully converted to the extent there is no actual php class for them - this doesn't do that :-) - It allows settings to be added by metadata to non fully converted forms

Comments
----------------------------------------
Credit notes prefix is pulled out of the invoicing section and into the metadata-defined section - as disabling invoicing does not enable the credit not prefix usage 