### PR TITLE
Fix a PHP notice for users with limited permissions when loading cont…

### DIFF
--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -84,7 +84,7 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
 
     CRM_Utils_Hook::notePrivacy($noteValues);
 
-    if (!$noteValues['privacy']) {
+    if (empty($noteValues['privacy'])) {
       return FALSE;
     }
     elseif (isset($noteValues['notePrivacy_hidden'])) {


### PR DESCRIPTION
…act summary

Overview
----------------------------------------


Before
----------------------------------------

![image](https://user-images.githubusercontent.com/2052161/74350986-686f6300-4dae-11ea-9a86-8a7cf5129879.png)


After
----------------------------------------
Gone.

Technical Details
----------------------------------------
Privacy is normally set to 0. For a user with limited privileges this error comes up. Checking via empty clears the issue (and would still match the case that the field is set to 0).

Comments
----------------------------------------
