### PR TITLE
dev/mail#59 - Fix use of useXOAUTH2 constant instead of var

### DIFF
--- a/CRM/Mailing/MailStore/Imap.php
+++ b/CRM/Mailing/MailStore/Imap.php
@@ -56,7 +56,7 @@ class CRM_Mailing_MailStore_Imap extends CRM_Mailing_MailStore {
       'uidReferencing' => TRUE,
     ];
     $this->_transport = new ezcMailImapTransport($host, NULL, $options);
-    if (useXOAUTH2) {
+    if ($useXOAUTH2) {
       $this->_transport->authenticate($username, $password, ezcMailImapTransport::AUTH_XOAUTH2);
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where a missing `$` before the `useXOAUTH2` variable prevents IMAP authentication with XOAUTH2 from working.

Before
----------------------------------------
XOAUTH2 IMAP authentication is not working because the if is never entered.

After
----------------------------------------
XOAUTH2 IMAP authentication works.
