### PR TITLE
Allow any casting done in Type::validate to bubble up to Request::retrieveValue

### DIFF
--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -88,10 +88,8 @@ class CRM_Utils_Request {
         break;
     }
 
-    if (isset($value) &&
-      (CRM_Utils_Type::validate($value, $type, $abort, $name) === NULL)
-    ) {
-      $value = NULL;
+    if (isset($value)) {
+      $value = CRM_Utils_Type::validate($value, $type, $abort, $name);
     }
 
     if (!isset($value) && $store) {


### PR DESCRIPTION


Overview
----------------------------------------
The validate function returns
- NULL if the passed in value is not valid
- THe passed in value if valid or
 - The passed in value cast to an integer if the value is valid and the type is Int or Integer

By always using the returned value we allow it to be cast, where appropriate

Before
----------------------------------------
Valid integer  returned as string

After
----------------------------------------
Valid integer  returned as integer

Technical Details
----------------------------------------


Comments
----------------------------------------
