### PR TITLE
Fix calls to Request::retrieve

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -65,7 +65,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
     try {
       // Call multiple
       if (empty($this->urlPath[3])) {
-        $calls = CRM_Utils_Request::retrieve('calls', 'String', CRM_Core_DAO::$_nullObject, TRUE, NULL, 'POST', TRUE);
+        $calls = CRM_Utils_Request::retrieve('calls', 'String', CRM_Core_DAO::$_nullObject, TRUE, NULL, 'POST');
         $calls = json_decode($calls, TRUE);
         $response = [];
         foreach ($calls as $index => $call) {

--- a/CRM/Contact/Page/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Page/Inline/CommunicationPreferences.php
@@ -24,10 +24,12 @@ class CRM_Contact_Page_Inline_CommunicationPreferences extends CRM_Core_Page {
    * Run the page.
    *
    * This method is called after the page is created.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
 
     $params = ['id' => $contactId];
 

--- a/CRM/Contact/Page/Inline/OpenID.php
+++ b/CRM/Contact/Page/Inline/OpenID.php
@@ -24,10 +24,12 @@ class CRM_Contact_Page_Inline_OpenID extends CRM_Core_Page {
    * Run the page.
    *
    * This method is called after the page is created.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
 
     $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'display_name']);
 

--- a/CRM/Contact/Page/Inline/Phone.php
+++ b/CRM/Contact/Page/Inline/Phone.php
@@ -24,10 +24,12 @@ class CRM_Contact_Page_Inline_Phone extends CRM_Core_Page {
    * Run the page.
    *
    * This method is called after the page is created.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
 
     $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'display_name']);
     $phoneTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');

--- a/CRM/Contact/Page/Inline/Website.php
+++ b/CRM/Contact/Page/Inline/Website.php
@@ -24,10 +24,12 @@ class CRM_Contact_Page_Inline_Website extends CRM_Core_Page {
    * Run the page.
    *
    * This method is called after the page is created.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieveValue('cid', 'Positive');
 
     $websiteTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Website', 'website_type_id');
 

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -167,6 +167,8 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     if ($this->_view == 'transaction' && ($this->_action & CRM_Core_Action::BROWSE)) {

--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -263,8 +263,7 @@ class CRM_Core_BAO_ConfigSetting {
       'Boolean',
       CRM_Core_DAO::$_nullArray,
       FALSE,
-      FALSE,
-      'REQUEST'
+      FALSE
     );
     if ($config->userSystem->is_drupal &&
       $resetSessionTable

--- a/CRM/Core/BAO/Log.php
+++ b/CRM/Core/BAO/Log.php
@@ -70,6 +70,8 @@ class CRM_Core_BAO_Log extends CRM_Core_DAO_Log {
    * @param string $tableName
    * @param int $tableID
    * @param int $userID
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function register(
     $contactID,

--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -28,6 +28,8 @@ class CRM_Core_Page_AJAX_Location {
    * obtain the location of given contact-id.
    * This method is used by on-behalf-of form to dynamically generate poulate the
    * location field values for selected permissioned contact.
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function getPermissionedLocation() {
     $cid = CRM_Utils_Request::retrieve('cid', 'Integer', CRM_Core_DAO::$_nullObject, TRUE);

--- a/CRM/SMS/Controller/Send.php
+++ b/CRM/SMS/Controller/Send.php
@@ -22,16 +22,16 @@ class CRM_SMS_Controller_Send extends CRM_Core_Controller {
    * @param string $title
    * @param bool|int $action
    * @param bool $modal
+   *
+   * @throws \CRM_Core_Exception
    */
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal, NULL, FALSE, TRUE);
 
-    $mailingID = CRM_Utils_Request::retrieve('mid', 'String', $this, FALSE, NULL);
+    $mailingID = CRM_Utils_Request::retrieve('mid', 'String', $this);
 
     // also get the text and html file
-    $txtFile = CRM_Utils_Request::retrieve('txtFile', 'String',
-      CRM_Core_DAO::$_nullObject, FALSE, NULL
-    );
+    $txtFile = CRM_Utils_Request::retrieveValue('txtFile', 'String');
 
     $config = CRM_Core_Config::singleton();
     if ($txtFile &&


### PR DESCRIPTION

Overview
----------------------------------------
Minor cleanup on calls to Request::retrieve

Before
----------------------------------------
Default params passed in, in some instances $_REQUEST is passed in - which is invalid but equivalent to not passing anything in. In some cases NULL object passed in

After
----------------------------------------
Where the defaults  for the signature is used they  are not also passed in
```
  public static function retrieve($name, $type, &$store = NULL, $abort = FALSE, $default = NULL, $method = 'REQUEST', $isThrowException = TRUE)
```

Technical Details
----------------------------------------
Do not pass in values that are set by default. Use retrieveValue  rather than passing in the NULL object

Comments
----------------------------------------
@seamuslee001 I found more instances than this but didn't want to create a big PR that would be a pain to review - however, the thing I was searching for was whether the last parameter ($useException)  is ever false - with a view to removing it if not. My searching suggests it can go 
