### PR TITLE
Remove old defines for flexmailer that haven't been required since CiviCRM 5.x

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -310,9 +310,6 @@ class Container {
       ))->addTag('kernel.event_subscriber');
     }
 
-    if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_SERVICES')) {
-      \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_SERVICES, [$container]);
-    }
     \CRM_Api4_Services::hook_container($container);
 
     \CRM_Utils_Hook::container($container);
@@ -365,10 +362,6 @@ class Container {
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Contribute_ActionMapping_ByType', 'onRegisterActionMappings']);
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Event_ActionMapping', 'onRegisterActionMappings']);
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Member_ActionMapping', 'onRegisterActionMappings']);
-
-    if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_LISTENERS')) {
-      \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_LISTENERS, [$dispatcher]);
-    }
 
     return $dispatcher;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Remove defines that have not been required since CiviCRM 5.x

Before
----------------------------------------
Old code

After
----------------------------------------
Old code gone

Technical Details
----------------------------------------
See https://github.com/civicrm/org.civicrm.flexmailer/commit/17f142e1539ac2e507d35b837607b8fad965b6a5

Comments
----------------------------------------
