### PR TITLE
Pass template_type through to alterMailing hook

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -690,6 +690,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
       }
 
       $this->templates['mailingID'] = $this->id;
+      $this->templates['template_type'] = $this->template_type;
       CRM_Utils_Hook::alterMailContent($this->templates);
     }
     return $this->templates;


### PR DESCRIPTION
Overview
----------------------------------------
Follow on from #15306. Knowing the type of template (ie. traditional or mosaico) allows us to behave differently depending on the type of template.

Before
----------------------------------------
template_type available but not passed to hook.

After
----------------------------------------
template_type passed to hook.

Technical Details
----------------------------------------


Comments
----------------------------------------
@bhahumanists Please can you create a docs PR for this?