### PR TITLE
dev/core#1588 Fix regression where empty string is passed to PropertyBag

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2020,6 +2020,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param int $contactID
    *
    * @return array
+   * @throws \CRM_Core_Exception
    */
   protected function processFormSubmission($contactID) {
     if (!isset($this->_params['payment_processor_id'])) {

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -278,9 +278,9 @@ class PropertyBag implements \ArrayAccess {
    * @param array $data
    */
   public function mergeLegacyInputParams($data) {
-    $this->legacyWarning("We have merged input params into the property bag for now but please rewrite code to not use this.");
+    $this->legacyWarning('We have merged input params into the property bag for now but please rewrite code to not use this.');
     foreach ($data as $key => $value) {
-      if ($value !== NULL) {
+      if ($value !== NULL && $value !== '') {
         $this->offsetSet($key, $value);
       }
     }


### PR DESCRIPTION


Overview
----------------------------------------
Fixes a regression where a fatal error results when:

If you enabled the recurring option "Support recurring intervals" on a contribution page you can no longer submit the contribution form unless you enter a value for the recurring interval, even if you have not selected to make a recurring contribution.

Before
----------------------------------------
Fatal 
Error: recurFrequencyInterval must be a positive integer

After
----------------------------------------
No error

Technical Details
----------------------------------------
We have a scenario where the checkbox is presented but is optional. This is then in 'params' which is passed through to
PropertyBag. The value is equal to '' so it fails to validate when we use it to set the value on the PropertyBag.

I don't think we lose anything meaningful by not setting an empty string and it avoids this error so we should
merge & release as a regression fix IMHO. If we want to revist then we should do that in master

https://lab.civicrm.org/dev/core/issues/1588

Comments
----------------------------------------

@artfulrobot @mattwire 