### PR TITLE
Do not fatally fail on angular pages if an extension is missing

### DIFF
--- a/CRM/Extension/Container/Interface.php
+++ b/CRM/Extension/Container/Interface.php
@@ -43,6 +43,8 @@ interface CRM_Extension_Container_Interface {
    *
    * @param string $key
    *   Fully-qualified extension name.
+   *
+   * @throws \CRM_Extension_Exception_MissingException
    */
   public function getResUrl($key);
 

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -236,9 +236,11 @@ class CRM_Extension_Mapper {
    *
    * @return string
    *   url for resources in this extension
+   *
+   * @throws \CRM_Extension_Exception_MissingException
    */
   public function keyToUrl($key) {
-    if ($key == 'civicrm') {
+    if ($key === 'civicrm') {
       // CRM-12130 Workaround: If the domain's config_backend is NULL at the start of the request,
       // then the Mapper is wrongly constructed with an empty value for $this->civicrmUrl.
       if (empty($this->civicrmUrl)) {
@@ -339,6 +341,8 @@ class CRM_Extension_Mapper {
    *
    * @return array
    *   (string $extKey => string $baseUrl)
+   *
+   * @throws \CRM_Extension_Exception_MissingException
    */
   public function getActiveModuleUrls() {
     // TODO optimization/caching
@@ -347,7 +351,12 @@ class CRM_Extension_Mapper {
     foreach ($this->getModules() as $module) {
       /** @var $module CRM_Core_Module */
       if ($module->is_active) {
-        $urls[$module->name] = $this->keyToUrl($module->name);
+        try {
+          $urls[$module->name] = $this->keyToUrl($module->name);
+        }
+        catch (CRM_Extension_Exception_MissingException $e) {
+          CRM_Core_Session::setStatus(ts('An enabled extension is missing from the extensions directory') . ':' . $module->name);
+        }
       }
     }
     return $urls;


### PR DESCRIPTION


Overview
----------------------------------------
If an extension is missing trying to create a new mailing will totally fail - on QF pages we just get a
not-very-clear message - now we have parity

Before
----------------------------------------
<img width="964" alt="Screen Shot 2020-02-14 at 3 05 37 PM" src="https://user-images.githubusercontent.com/336308/74495319-6affc300-4f3c-11ea-9f85-1dc0d9b3f178.png">



After
----------------------------------------
<img width="388" alt="Screen Shot 2020-02-14 at 3 05 57 PM" src="https://user-images.githubusercontent.com/336308/74495310-5fac9780-4f3c-11ea-885b-dbdaa84d51c9.png">


Technical Details
----------------------------------------


Comments
----------------------------------------
@MegaphoneJon I feel we've discussed this before
