### PR TITLE
dev/core#1551 regression fix

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1791,6 +1791,10 @@ class CRM_Contact_BAO_Query {
       (substr($values[0], 0, 10) === 'financial_') ||
       (substr($values[0], 0, 8) === 'payment_') ||
       (substr($values[0], 0, 11) === 'membership_')
+      // temporary fix for regression https://lab.civicrm.org/dev/core/issues/1551
+      //  ideally the metadata would allow  this field to be parsed below & the special handling would not
+      // be needed.
+      || $values[0] === 'mailing_id'
     ) {
       return;
     }


### PR DESCRIPTION


Overview
----------------------------------------
Fixes a regression where this  url gives a fatal error : civicrm/contact/search/advanced?force=1&mailing_id=1

Before
----------------------------------------
Fatal error

After
----------------------------------------
Query resolves (if there IS a mailing id 1...)

Technical Details
----------------------------------------
Now that mailing_id is defined as field metadata the form main metadata fn is trying to handle it, However
the form is casting it to the wrong array format -https://github.com/civicrm/civicrm-core/blob/86f20cc17dde028977130f84feaf3b1d760ca57d/CRM/Contact/Form/Search.php#L649

We could fix  this & rip it out of Mailing_BAO_Query::where but there is still a gap  in  that
there is no pseudoconstant recorded for the field so the qill doesn't work & there is a gap in
pre-parsing for the form 'IN'

Hence this seems like a good approach to remove the regression in the immediate term

Comments
----------------------------------------

