### PR TITLE
dev/core#1592 fix regression on relation active period

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4215,7 +4215,7 @@ WHERE  $smartGroupClause
         }
         $this->_qill[$grouping][] = 'Relationship Type(s) ' . $relQill . " $name";
       }
-      else {
+      elseif ($name) {
         $this->_qill[$grouping][] = $name;
       }
     }
@@ -7074,22 +7074,22 @@ AND   displayRelType.is_active = 1
       $secondWhere = str_replace('civicrm_contact.', 'contact_a.', $secondWhere);
     }
 
+    $this->_qill[$grouping][] = $this->getQillForRelativeDateRange($dates[0], $dates[1], $fieldSpec['title'], $filters[$value]);
+    if ($fieldName === 'relation_active_period_date') {
+      // Hack this to fix regression https://lab.civicrm.org/dev/core/issues/1592
+      // Not sure the  'right' fix.
+      $this->_where[$grouping] = [self::getRelationshipActivePeriodClauses($dates[0], $dates[1], TRUE)];
+      return;
+    }
+
     if (empty($dates[0])) {
       // ie. no start date we only have end date
       $this->_where[$grouping][] = $secondWhere . " <= '{$dates[1]}'";
-
-      $this->_qill[$grouping][] = ts('%1 is ', [$fieldSpec['title']]) . $filters[$value] . ' (' . ts("to %1", [
-        CRM_Utils_Date::customFormat($dates[1]),
-      ]) . ')';
     }
     elseif (empty($dates[1])) {
 
       // ie. no end date we only have start date
       $this->_where[$grouping][] = $where . " >= '{$dates[0]}'";
-
-      $this->_qill[$grouping][] = ts('%1 is ', [$fieldSpec['title']]) . $filters[$value] . ' (' . ts("from %1", [
-        CRM_Utils_Date::customFormat($dates[0]),
-      ]) . ')';
     }
     else {
       // we have start and end dates.
@@ -7099,11 +7099,6 @@ AND   displayRelType.is_active = 1
       else {
         $this->_where[$grouping][] = $where . " BETWEEN '{$dates[0]}' AND '{$dates[1]}'";
       }
-
-      $this->_qill[$grouping][] = ts('%1 is ', [$fieldSpec['title']]) . $filters[$value] . ' (' . ts("between %1 and %2", [
-        CRM_Utils_Date::customFormat($dates[0]),
-        CRM_Utils_Date::customFormat($dates[1]),
-      ]) . ')';
     }
   }
 
@@ -7229,6 +7224,29 @@ AND   displayRelType.is_active = 1
     if (!isset($this->_whereTables[$fieldSpec['table_name']])) {
       $this->_whereTables[$fieldSpec['table_name']] = 1;
     }
+  }
+
+  /**
+   * Get the qill for the relative date range.
+   *
+   * @param string|null $from
+   * @param string|null $to
+   * @param string $fieldTitle
+   * @param string $relativeRange
+   *
+   * @return string
+   */
+  protected function getQillForRelativeDateRange($from, $to, string $fieldTitle, string $relativeRange): string {
+    if (!$from) {
+      return ts('%1 is ', [$fieldTitle]) . $relativeRange . ' (' . ts('to %1', [CRM_Utils_Date::customFormat($to)]) . ')';
+    }
+    if (!$to) {
+      return ts('%1 is ', [$fieldTitle]) . $relativeRange . ' (' . ts('from %1', [CRM_Utils_Date::customFormat($from)]) . ')';
+    }
+    return ts('%1 is ', [$fieldTitle]) . $relativeRange . ' (' . ts('between %1 and %2', [
+      CRM_Utils_Date::customFormat($from),
+      CRM_Utils_Date::customFormat($to),
+    ]) . ')';
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/1592 the custom query  for this field is being
ignored now it's using datepicker with relevant format changes. This  causes the
custom function for the field to  be called

Before
----------------------------------------
Searching for relationships with an active period of 'Today' does not return results

After
----------------------------------------
Results returned (if relationships are active today)

Technical Details
----------------------------------------
This points the relativeDateQuery off to the field's special handling. It might be we have something else for 'is active' queries but this is enough for a regression fix. Note I had to extract the qill code to be shared with this FN

Comments
----------------------------------------

