### PR TITLE
core#1588: fix validation for interval on one-off payments

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -48,6 +48,16 @@ class CRM_Contribute_BAO_Contribution_Utils {
     CRM_Core_Payment_Form::mapParams($form->_bltID, $form->_params, $paymentParams, TRUE);
     $isPaymentTransaction = self::isPaymentTransaction($form);
 
+    if (!$isRecur) {
+      // https://lab.civicrm.org/dev/core/issues/1588
+      // This is not a recurring payment. Therefore the following will not be
+      // needed, but may still cause validation to fail, so we remove them.
+      //
+      // @todo We should be moving to setting the expected parameters on a
+      // PropertyBag instead of chucking them all in an array.
+      unset($paymentParams['frequency_interval'], $paymentParams['frequency_unit']);
+    }
+
     $financialType = new CRM_Financial_DAO_FinancialType();
     $financialType->id = $financialTypeID;
     $financialType->find(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------

As described at: https://lab.civicrm.org/dev/core/issues/1588

Before
----------------------------------------

Contribution forms cause exception because they ask PropertyBag to validate an invalid recurring interval because it's not set for non-recurring contrib.s


After
----------------------------------------

We remove the offending and irrelevant data from the params that PropertyBag has to coerce into properties. ie. we stop trying to validate something we don't need or use.


Technical Details
----------------------------------------

I prefer this to weakening the validation in PropertyBag (e.g. allowing ZLS) because the point of PropertyBag was to tighten up on validation and specification - we should know what data is needed, and then we should be assured that what we have provided is valid.

While merging from array is for backwards compatibility anyway, it's still better IMO to move in the direction of higher specificity/accuracy.
