### PR TITLE
Remove reference to mysql 5.0 & 5.1

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -75,7 +75,7 @@ class CRM_Logging_Schema {
     $domain = new CRM_Core_DAO_Domain();
     $domain->find(TRUE);
     if (!(CRM_Core_DAO::checkTriggerViewPermission(FALSE)) && $value) {
-      throw new API_Exception("In order to use this functionality, the installation's database user must have privileges to create triggers (in MySQL 5.0 – and in MySQL 5.1 if binary logging is enabled – this means the SUPER privilege). This install either does not seem to have the required privilege enabled.");
+      throw new API_Exception(ts("In order to use this functionality, the installation's database user must have privileges to create triggers and views (if binary logging is enabled – this means the SUPER privilege). This install does not have the required privilege(s) enabled."));
     }
     return TRUE;
   }

--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -124,7 +124,7 @@
         {else}
           <tr class="crm-localization-form-block-description">
               <td>
-              <span class="description">{ts}In order to use this functionality, the installation's database user must have privileges to create triggers and views (in MySQL 5.0 – and in MySQL 5.1 if binary logging is enabled – this means the SUPER privilege). This install either does not seem to have the required privilege enabled.{/ts} {ts}(Multilingual support currently cannot be enabled on installations with enabled logging.){/ts}</span><br /><br />
+              <span class="description">{ts}In order to use this functionality, the installation's database user must have privileges to create triggers and views (if binary logging is enabled – this means the SUPER privilege). This install does not have the required privilege(s) enabled.{/ts} {ts}(Multilingual support currently cannot be enabled on installations with enabled logging.){/ts}</span><br /><br />
               <span class="description font-red">{$warning}</span></td>
           </tr>
         {/if}


### PR DESCRIPTION


Overview
----------------------------------------
This PR updates the messaging around enabling logging and/or multilingual capabilities.

Subset of https://github.com/civicrm/civicrm-core/pull/16084 - the parts that didn't seem contentious

Before
----------------------------------------
* References to unsupported MySQL versions are present.
* An API exception isn't translatable.
* Poor grammar is present.

After
----------------------------------------
All fixed.
