### PR TITLE
dev/core#1589 avoid error when merging record with null create date

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1357,7 +1357,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       'id' => $otherId,
       'return' => ['created_date'],
     ])['created_date'];
-    if ($otherCreatedDate < $mainCreatedDate) {
+    if ($otherCreatedDate < $mainCreatedDate && !empty($otherCreatedDate)) {
       CRM_Core_DAO::executeQuery("UPDATE civicrm_contact SET created_date = %1 WHERE id = %2", [
         1 => [$otherCreatedDate, 'String'],
         2 => [$mainId, 'Positive'],


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/1589

Overview
----------------------------------------
When  merging records in which one record has a NULL create date, we get a back trace.

Before
----------------------------------------

```
UPDATE civicrm_contact SET created_date = '' WHERE id = 123 [nativecode=1292 ** Incorrect datetime value: '' for column `dev_civicrm`.`civicrm_contact`.`created_date` at row 1]
```

After
----------------------------------------
No errors - the records are merged

Technical Details
----------------------------------------
Bug introduced with: https://lab.civicrm.org/dev/core/issues/996 and https://github.com/civicrm/civicrm-core/pull/14325
Comments
----------------------------------------
The fix was made by iwilson
