### PR TITLE
dev/core#1594 [TEST] Fix running of unit tests within an extension

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -163,7 +163,7 @@ class Test {
    */
   public static function codeGen() {
     if (!isset(self::$singletons['codeGen'])) {
-      $civiRoot = '.';
+      $civiRoot = str_replace(DIRECTORY_SEPARATOR, '/', dirname(__DIR__));
       $codeGen = new \CRM_Core_CodeGen_Main("$civiRoot/CRM/Core/DAO", "$civiRoot/sql", $civiRoot, "$civiRoot/templates", NULL, "UnitTests", NULL, "$civiRoot/xml/schema/Schema.xml", NULL);
       $codeGen->init();
       self::$singletons['codeGen'] = $codeGen;


### PR DESCRIPTION
Overview
----------------------------------------
This resolves the issue of running phpunit tests in extensions following the change in https://github.com/civicrm/civicrm-core/pull/16477

Before
----------------------------------------
tests fail to run in extensions

After
----------------------------------------
unit tests for extensions run successfully

ping @demeritcowboy @eileenmcnaughton @pfigel 