### PR TITLE
[NFC] Ensure that annon permissions are correctly assigned when enabl…

### DIFF
--- a/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
+++ b/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
@@ -8,7 +8,7 @@ function civicrm_webtest_enable() {
   
   // If Backdrop
   if (function_exists('config_get')) {
-    $anonymous = 'Anonymous';
+    $anonymous = 'anonymous';
   }
 
   user_role_grant_permissions($anonymous, [


### PR DESCRIPTION
…ing civicrm webtest module in backdrop

Overview
----------------------------------------
This is currently affecting E2E test matrix on 5.23 and master hence putting it against 5.23

Before
----------------------------------------
E2E Unit tests fail on backdrop

After
----------------------------------------
E2E Unit Tests pass on backdrop

ping @totten @eileenmcnaughton @herbdool 