### PR TITLE
Remove additional display of buttons for events

### DIFF
--- a/CRM/Contribute/Page/PaymentInfo.php
+++ b/CRM/Contribute/Page/PaymentInfo.php
@@ -27,9 +27,6 @@ class CRM_Contribute_Page_PaymentInfo extends CRM_Core_Page {
     $this->assign('id', $this->_id);
     $this->assign('context', $this->_context);
     $this->assign('component', $this->_component);
-    if ($this->_component != 'event') {
-      $this->assign('hideButtonLinks', TRUE);
-    }
   }
 
   public function browse() {

--- a/templates/CRM/Contribute/Page/PaymentInfo.tpl
+++ b/templates/CRM/Contribute/Page/PaymentInfo.tpl
@@ -48,23 +48,8 @@ CRM.$(function($) {
     <td>{$paymentInfo.total|crmMoney:$paymentInfo.currency}</td>
     <td class='right'>
         {$paymentInfo.paid|crmMoney:$paymentInfo.currency}
-        {if !$hideButtonLinks}
-          <br/>
-          <a class="crm-hover-button action-item crm-popup medium-popup" href='{crmURL p="civicrm/payment" q="view=transaction&cid=`$cid`&id=`$paymentInfo.id`&component=`$paymentInfo.component`&action=browse"}'>
-            <i class="crm-i fa-list"></i>
-            {ts}view payments{/ts}
-          </a>
-        {/if}
     </td>
     <td class="right" id="payment-info-balance" data-balance="{$paymentInfo.balance}">{$paymentInfo.balance|crmMoney:$paymentInfo.currency}</td>
   </tr>
 </table>
-{if $paymentInfo.balance and !$paymentInfo.payLater && !$hideButtonLinks}
-  {if $paymentInfo.balance > 0}
-     {assign var=paymentButtonName value='Record Payment'}
-  {elseif $paymentInfo.balance < 0}
-     {assign var=paymentButtonName value='Record Refund'}
-  {/if}
-  <a class="action-item crm-hover-button" href='{crmURL p="civicrm/payment" q="action=add&reset=1&component=`$component`&id=`$id`&cid=`$cid`"}'><i class="crm-i fa-plus-circle"></i> {ts}{$paymentButtonName}{/ts}</a>
-{/if}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This removes duplicate payment info & links from the view Participant page. While my primary motivation for this is to remove a blocker to cleaning up code I think it makes sense from a UI POV too as there is already a list of payments at the bottom of the page so 'view payments' doesn't make sense and users should be used to adding payments from that block as it is also in contribution search, contribution tab, contribution recur tab & I think the membership view

Before
----------------------------------------
<img width="926" alt="Screen Shot 2020-02-15 at 12 46 41 PM" src="https://user-images.githubusercontent.com/336308/74577063-5e3da680-4ff2-11ea-9ab8-3c67d6344604.png">


After
----------------------------------------
<img width="933" alt="Screen Shot 2020-02-15 at 12 50 32 PM" src="https://user-images.githubusercontent.com/336308/74577053-57169880-4ff2-11ea-9206-84ff83166b3a.png">


Technical Details
----------------------------------------
@agh1 I know @alifrumin  has an interest in the code that is nasty in order to support this so this removes a blocker on that path

Comments
----------------------------------------
@MegaphoneJon @agh1 - do you have thoughts - 


Note the fact one place says record payment & the other says record refund is a bug https://github.com/civicrm/civicrm-core/pull/16546