### PR TITLE
info.xml - Allow extensions to define a list of tags

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -45,6 +45,12 @@ class CRM_Extension_Info {
   public $requires = [];
 
   /**
+   * @var array
+   *   List of strings (tag-names).
+   */
+  public $tags = [];
+
+  /**
    * Load extension info an XML file.
    *
    * @param $file
@@ -153,6 +159,12 @@ class CRM_Extension_Info {
             'prefix' => (string) $psr4->attributes()->prefix,
             'path' => (string) $psr4->attributes()->path,
           ];
+        }
+      }
+      elseif ($attr === 'tags') {
+        $this->tags = [];
+        foreach ($val->tag as $tag) {
+          $this->tags[] = (string) $tag;
         }
       }
       elseif ($attr === 'requires') {

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -389,6 +389,42 @@ class CRM_Extension_Mapper {
   }
 
   /**
+   * Get a list of extensions which match a given tag.
+   *
+   * @param string $tag
+   *   Ex: 'foo'
+   * @return array
+   *   Array(string $key).
+   *   Ex: array("org.foo.bar").
+   */
+  public function getKeysByTag($tag) {
+    $allTags = $this->getAllTags();
+    return $allTags[$tag] ?? [];
+  }
+
+  /**
+   * Get a list of extension tags.
+   *
+   * @return array
+   *   Ex: ['form-building' => ['org.civicrm.afform-gui', 'org.civicrm.afform-html']]
+   */
+  public function getAllTags() {
+    $tags = Civi::cache('short')->get('extension_tags', NULL);
+    if ($tags !== NULL) {
+      return $tags;
+    }
+
+    $tags = [];
+    $allInfos = $this->getAllInfos();
+    foreach ($allInfos as $key => $info) {
+      foreach ($info->tags as $tag) {
+        $tags[$tag][] = $key;
+      }
+    }
+    return $tags;
+  }
+
+  /**
    * @return array
    *   Ex: $result['org.civicrm.foobar'] = new CRM_Extension_Info(...).
    * @throws \CRM_Extension_Exception

--- a/tests/extensions/test.extension.manager.moduletest/info.xml
+++ b/tests/extensions/test.extension.manager.moduletest/info.xml
@@ -1,4 +1,7 @@
 <extension key='test.extension.manager.moduletest' type='module'>
   <file>moduletest</file>
   <name>test_extension_manager_moduletest</name>
+  <tags>
+    <tag>mock</tag>
+  </tags>
 </extension>

--- a/tests/extensions/test.extension.manager.paymenttest/info.xml
+++ b/tests/extensions/test.extension.manager.paymenttest/info.xml
@@ -19,4 +19,7 @@
     <isRecur>0</isRecur>
     <paymentType>1</paymentType>
   </typeInfo>
+  <tags>
+    <tag>mock</tag>
+  </tags>
 </extension>

--- a/tests/phpunit/CRM/Extension/MapperTest.php
+++ b/tests/phpunit/CRM/Extension/MapperTest.php
@@ -124,6 +124,11 @@ class CRM_Extension_MapperTest extends CiviUnitTestCase {
     }
   }
 
+  public function testGetKeysByTag() {
+    $this->assertEquals([], $this->mapper->getKeysByTag('big-rock-candy-mountain'));
+    $this->assertEquals(['test.foo.bar'], $this->mapper->getKeysByTag('wakka'));
+  }
+
   /**
    * @param CRM_Utils_Cache_Interface $cache
    * @param null $cacheKey
@@ -143,7 +148,7 @@ class CRM_Extension_MapperTest extends CiviUnitTestCase {
     $basedir = rtrim($this->createTempDir('ext-'), '/');
     mkdir("$basedir/weird");
     mkdir("$basedir/weird/foobar");
-    file_put_contents("$basedir/weird/foobar/info.xml", "<extension key='test.foo.bar' type='report'><file>oddball</file></extension>");
+    file_put_contents("$basedir/weird/foobar/info.xml", "<extension key='test.foo.bar' type='report'><file>oddball</file><tags><tag>wakka</tag></tags></extension>");
     // not needed for now // file_put_contents("$basedir/weird/bar/oddball.php", "<?php\n");
     $c = new CRM_Extension_Container_Basic($basedir . $appendPathGarbage, 'http://example/basedir' . $appendPathGarbage, $cache, $cacheKey);
     return [$basedir, $c];

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -72,7 +72,9 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
   public function testExtensionGet() {
     $result = $this->callAPISuccess('extension', 'get', ['options' => ['limit' => 0]]);
     $testExtensionResult = $this->callAPISuccess('extension', 'get', ['key' => 'test.extension.manager.paymenttest']);
-    $this->assertNotNull($result['values'][$testExtensionResult['id']]['typeInfo']);
+    $ext = $result['values'][$testExtensionResult['id']];
+    $this->assertNotNull($ext['typeInfo']);
+    $this->assertEquals(['mock'], $ext['tags']);
     $this->assertTrue($result['count'] >= 6);
   }
 


### PR DESCRIPTION
Overview
--------

This adopts a convention by which extensions may use `info.xml` to register tags, e.g.

```xml
<extension key="org.civicrm.foo" type="module">
  <tags>
    <tag>civicontribute</tag>
    <tag>payment-processor</tag>
    <tag>install-mandatory</tag>
  </tags>
</extension>
```

Before
------

To add *any* metadata to `info.xml` files, you must update the parser and provide filtering/indexing logic.

After
-----

If you need to add very simple metadata (tags), you can do that without extra parsing code.  The tag information can be accessed in the following ways:

* Using the extension mapper
    ```php
    $mapper = CRM_Extension_System::singleton()->getMapper();
    $allTags = $mapper->getAllTags();
    $mandatoryExts = $mapper->getKeysByTag('install-mandatory');
    ```
* The `Extension.get` API will return the list of tags for each ext
