### PR TITLE
dev/core#1593 and dev/core#1536 - Remove unused code causing E_WARNING

### DIFF
--- a/templates/CRM/Tag/Form/Edit.tpl
+++ b/templates/CRM/Tag/Form/Edit.tpl
@@ -57,15 +57,6 @@
           </tr>
         {/if}
     </table>
-        {if $parent_tags|@count > 0}
-        <table class="form-layout-compressed">
-            <tr><td><label>{ts}Remove Parent?{/ts}</label></td></tr>
-            {foreach from=$parent_tags item=ctag key=tag_id}
-                {assign var="element_name" value="remove_parent_tag_"|cat:$tag_id}
-                <tr><td>&nbsp;&nbsp;{$form.$element_name.html}&nbsp;{$form.$element_name.label}</td></tr>
-            {/foreach}
-        </table><br />
-        {/if}
     {else}
         <div class="status">{ts 1=$delName}Are you sure you want to delete <b>%1</b>?{/ts}<br />{ts}This tag will be removed from any currently tagged contacts, and users will no longer be able to assign contacts to this tag.{/ts}</div>
     {/if}

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Core_FormTest extends CiviUnitTestCase {
+
+  /**
+   * Simulate opening various forms. All we're looking to do here is
+   * see if any warnings or notices come up, the equivalent of red boxes
+   * on the screen, but which are hidden when using popup forms.
+   * So no assertions required.
+   *
+   * @param string $classname
+   * @dataProvider formClassList
+   */
+  public function testOpeningForms(string $classname) {
+    $form = $this->getFormObject($classname);
+    $form->preProcess();
+    $form->buildQuickForm();
+    $form->setDefaultValues();
+    $form->assign('action', CRM_Core_Action::UPDATE);
+    $form->getTemplate()->fetch($form->getTemplateFileName());
+  }
+
+  /**
+   * Dataprovider for testOpeningForms().
+   * TODO: Add more forms! Use a descriptive array key so when it fails
+   * it will make it clearer what form it is, although you'll see the class
+   * anyway.
+   */
+  public function formClassList() {
+    return [
+      'Add New Tag' => ['CRM_Tag_Form_Edit'],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
On the add new tag screen there's an E_WARNING about count() because it's referencing a variable that probably used to exist but doesn't anymore. The warning is hidden though when using popup forms.

Before
----------------------------------------
E_WARNING and added test fails.

After
----------------------------------------
No E_WARNING and test passes.

Technical Details
----------------------------------------
The variable $parent_tags doesn't exist anywhere. It probably used to but I couldn't find it anywhere.

Comments
----------------------------------------

