### PR TITLE
If using a prefix to get export fields we need to append to labelName…

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -286,7 +286,7 @@ class CRM_Core_DAO_AllCoreTables {
       foreach ($fields as $name => $field) {
         if (!empty($field['export'])) {
           if ($prefix) {
-            $exports[$labelName] = & $fields[$name];
+            $exports["{$labelName}_{$name}"] = & $fields[$name];
           }
           else {
             $exports[$name] = & $fields[$name];


### PR DESCRIPTION
… otherwise we only get one field!

Overview
----------------------------------------
This seems to have changed 4 years ago(!) when refactored by @totten. However I'm not sure it worked then either... This seems to be used by a couple of extensions including CiviBooking.

Before
----------------------------------------
Only one field returned if you set $prefix = TRUE.

After
----------------------------------------
All fields returned with a prefix!

Technical Details
----------------------------------------
I found this while tracing why enabling CiviBooking causes all contributions to appear with 0 amount on the contribution tab. It turns out that because it implements the query object and has it's own total_amount field it was overwriting the contribution.total_amount field.
So changing https://github.com/compucorp/civibooking/blob/develop/CRM/Booking/BAO/Query.php#L51 to set `prefix=TRUE` in export is the obvious solution but it doesn't work because it only returns a single field!

Comments
----------------------------------------
