### PR TITLE
Add deprecated warning to hook_civicrm_tabs since it has been depreca…

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -796,6 +796,7 @@ abstract class CRM_Utils_Hook {
    * @deprecated Use tabset() instead.
    */
   public static function tabs(&$tabs, $contactID) {
+    CRM_Core_Error::deprecatedFunctionWarning('hook_civicrm_tabset instead');
     return self::singleton()->invoke(['tabs', 'contactID'], $tabs, $contactID,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabs'
     );


### PR DESCRIPTION
…ted since 4.7!

Overview
----------------------------------------
It would be nice to remove this hook soon since it's been deprecated since 4.7

Before
----------------------------------------
No deprecated warning.

After
----------------------------------------
Deprecated warning.

Technical Details
----------------------------------------

Comments
----------------------------------------
