### PR TITLE
Use case id to get relationship for activity creation

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -650,6 +650,7 @@ AND        a.is_deleted = 0
       "contact_id_$b" => $targetContactId,
       'is_active' => 1,
       'case_id' => $caseId,
+      'options' => ['limit' => 1],
     ];
 
     if ($this->isBidirectionalRelationshipType($relTypeId)) {
@@ -657,10 +658,14 @@ AND        a.is_deleted = 0
       $params['options']['or'] = [['contact_id_a', 'contact_id_b']];
     }
 
-    $relationships = civicrm_api3('Relationship', 'get', $params);
+    $relationships = civicrm_api3('Relationship', 'get', $params)['values'];
+    if (empty($relationships)) {
+      unset($params['case_id']);
+      $relationships = civicrm_api3('Relationship', 'get', $params)['values'];
+    }
 
-    if ($relationships['count']) {
-      $relationship = CRM_Utils_Array::first($relationships['values']);
+    if (!empty($relationships)) {
+      $relationship = CRM_Utils_Array::first($relationships);
 
       // returns the contact id on the other side of the relationship:
       return (int) $relationship['contact_id_a'] === (int) $targetContactId

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -197,7 +197,6 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
    * @throws Exception
    */
   public function createRelationships($relationshipTypeXML, &$params) {
-
     // get the relationship
     list($relationshipType, $relationshipTypeName) = $this->locateNameOrLabel($relationshipTypeXML);
     if ($relationshipType === FALSE) {
@@ -470,7 +469,7 @@ AND        a.is_deleted = 0
       ];
     }
 
-    $activityParams['assignee_contact_id'] = $this->getDefaultAssigneeForActivity($activityParams, $activityTypeXML);
+    $activityParams['assignee_contact_id'] = $this->getDefaultAssigneeForActivity($activityParams, $activityTypeXML, $params['caseID']);
 
     //parsing date to default preference format
     $params['activity_date_time'] = CRM_Utils_Date::processDate($params['activity_date_time']);
@@ -571,10 +570,11 @@ AND        a.is_deleted = 0
    *
    * @param array $activityParams
    * @param object $activityTypeXML
+   * @param int $caseId
    *
    * @return int|null the ID of the default assignee contact or null if none.
    */
-  protected function getDefaultAssigneeForActivity($activityParams, $activityTypeXML) {
+  protected function getDefaultAssigneeForActivity($activityParams, $activityTypeXML, $caseId) {
     if (!isset($activityTypeXML->default_assignee_type)) {
       return NULL;
     }
@@ -583,7 +583,7 @@ AND        a.is_deleted = 0
 
     switch ($activityTypeXML->default_assignee_type) {
       case $defaultAssigneeOptionsValues['BY_RELATIONSHIP']:
-        return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML);
+        return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML, $caseId);
 
       break;
       case $defaultAssigneeOptionsValues['SPECIFIC_CONTACT']:
@@ -628,10 +628,11 @@ AND        a.is_deleted = 0
    *
    * @param array $activityParams
    * @param object $activityTypeXML
+   * @param int $caseId
    *
    * @return int|null the ID of the default assignee contact or null if none.
    */
-  protected function getDefaultAssigneeByRelationship($activityParams, $activityTypeXML) {
+  protected function getDefaultAssigneeByRelationship($activityParams, $activityTypeXML, $caseId) {
     $isDefaultRelationshipDefined = isset($activityTypeXML->default_assignee_relationship)
       && preg_match('/\d+_[ab]_[ab]/', $activityTypeXML->default_assignee_relationship);
 
@@ -648,6 +649,7 @@ AND        a.is_deleted = 0
       'relationship_type_id' => $relTypeId,
       "contact_id_$b" => $targetContactId,
       'is_active' => 1,
+      'case_id' => $caseId,
     ];
 
     if ($this->isBidirectionalRelationshipType($relTypeId)) {


### PR DESCRIPTION
Overview
----------------------------------------
When using a timeline which sets the activity assignee role by relationship, than the relationship contact is fetched those who doesn't belong to case. For example if a contact has 3 'Target is relationship' (Contact A, B, and C where is C belongs to case X)than when creating activity via time line for Case X than Contact A is assigned to an activity.

Before
----------------------------------------
No case id was used as filter to fetch relationship contact


After
----------------------------------------
Filtered using case id.