### PR TITLE
Move determination of year & month to formatCreditCardDetails

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -552,10 +552,6 @@ WHERE  contribution_id = {$id}
         $this->_params['payment_processor_id'],
         ($this->_mode == 'test')
       );
-      if (in_array('credit_card_exp_date', array_keys($this->_params))) {
-        $this->_params['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($this->_params);
-        $this->_params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($this->_params);
-      }
       $this->assign('credit_card_exp_date', CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format($this->_params['credit_card_exp_date'])));
       $this->assign('credit_card_number', CRM_Utils_System::mungeCreditCard($this->_params['credit_card_number']));
       $this->assign('credit_card_type', CRM_Utils_Array::value('credit_card_type', $this->_params));
@@ -590,6 +586,10 @@ WHERE  contribution_id = {$id}
     }
     if (!empty($params['credit_card_number']) && empty($params['pan_truncation'])) {
       $params['pan_truncation'] = substr($params['credit_card_number'], -4);
+    }
+    if (!empty($params['credit_card_exp_date'])) {
+      $params['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($params);
+      $params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($params);
     }
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Minor code re-org Per https://github.com/civicrm/civicrm-core/pull/16514 it makes sense as a better place for these

Before
----------------------------------------
allocation of  year & month are in a code chunk that concerns itself with assignments

After
----------------------------------------
allocation of  year & month are in a code chunk that concerns itself with building params

Technical Details
----------------------------------------


Comments
----------------------------------------

