### PR TITLE
dev/financial#118 Move source & receive date to the top on contribution view page

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -65,6 +65,14 @@
     <td class="label">{ts}Financial Type{/ts}</td>
     <td>{$financial_type}{if $is_test} {ts}(test){/ts} {/if}</td>
   </tr>
+  <tr>
+    <td class="label">{ts}Source{/ts}</td>
+    <td>{$source}</td>
+  </tr>
+  <tr>
+    <td class="label">{ts}Received{/ts}</td>
+    <td>{if $receive_date}{$receive_date|crmDate}{else}({ts}not available{/ts}){/if}</td>
+  </tr>
   {if $displayLineItems}
     <tr>
       <td class="label">{ts}Contribution Amount{/ts}</td>
@@ -120,10 +128,6 @@
       <td>{$revenue_recognition_date|crmDate:"%B, %Y"}</td>
     </tr>
   {/if}
-  <tr>
-    <td class="label">{ts}Received{/ts}</td>
-    <td>{if $receive_date}{$receive_date|crmDate}{else}({ts}not available{/ts}){/if}</td>
-  </tr>
   {if $to_financial_account }
     <tr>
       <td class="label">{ts}Received Into{/ts}</td>
@@ -165,10 +169,6 @@
       <td>{$check_number}</td>
     </tr>
   {/if}
-  <tr>
-    <td class="label">{ts}Source{/ts}</td>
-    <td>{$source}</td>
-  </tr>
 
   {if $campaign}
     <tr>


### PR DESCRIPTION
Overview
----------------------------------------
Slight re-ordering of fields on contribution view - moves source & date to near the top

Before
----------------------------------------
<img width="930" alt="b4" src="https://lab.civicrm.org/dev/financial/uploads/14d9e729c34efe642d66bffa26568b68/Screen_Shot_2020-02-15_at_2.26.31_PM.png">

After
----------------------------------------
<img width="930" alt="Screen Shot 2020-02-17 at 7 27 28 PM" src="https://user-images.githubusercontent.com/336308/74628934-d2777600-51bb-11ea-9399-e21379c98d07.png">


Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/financial/issues/118 this doesn't seem to be controversial - although there is a desire
to take it further & once this is merged I'll look at that  - ie the moving the fees block up

<img width="930" alt="fees" src="https://lab.civicrm.org/dev/financial/uploads/8d5c9f99236ba679e7c550986dc764c1/Screen_Shot_2020-02-15_at_2.45.54_PM.png">

Comments
----------------------------------------
Double 'total amount' on before is unrelated
