### PR TITLE
Remove helper function now that contribution settings is not weirdly stored

### DIFF
--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -54,7 +54,7 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
           'label' => ts('Pay Now'),
           'url' => CRM_Utils_System::url('civicrm/contribute/transact', [
             'reset' => 1,
-            'id' => CRM_Invoicing_Utils::getDefaultPaymentPage(),
+            'id' => Civi::settings()->get('default_invoice_page'),
             'ccid' => $row['contribution_id'],
             'cs' => $this->getUserChecksum(),
             'cid' => $row['contact_id'],

--- a/CRM/Invoicing/Utils.php
+++ b/CRM/Invoicing/Utils.php
@@ -63,24 +63,6 @@ class CRM_Invoicing_Utils {
   }
 
   /**
-   * Function to call to determine default invoice page.
-   *
-   * Historically the invoicing was declared as a setting but actually
-   * set within contribution_invoice_settings (which stores multiple settings
-   * as an array in a non-standard way).
-   *
-   * We check both here. But will deprecate the latter in time.
-   */
-  public static function getDefaultPaymentPage() {
-    $value = Civi::settings()->get('default_invoice_page');
-    if (is_numeric($value)) {
-      return $value;
-    }
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    return CRM_Utils_Array::value('default_invoice_page', $invoiceSettings);
-  }
-
-  /**
    * Function to get the tax term.
    *
    * The value is nested in the contribution_invoice_settings setting - which


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup - now the setting is stored properly we just need setting::get to retrieve it

Before
----------------------------------------
Helper function to get the setting from a non-std array

After
----------------------------------------
Since the setting is no longer non-std we can just use setting.get

Technical Details
----------------------------------------
This is the only place that accesses this function / setting - it's as if it were defined properly all along
now - it was all just a dream.

Comments
----------------------------------------

