### PR TITLE
Fix theoretical regression

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -970,6 +970,21 @@ WHERE  civicrm_participant.id = {$participantId}
   }
 
   /**
+   * Get the ID of the default (first) participant role
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getDefaultRoleID() {
+    return (int) civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'participant_role',
+      'is_active' => 1,
+      'options' => ['limit' => 1, 'sort' => 'is_default DESC'],
+    ]);
+  }
+
+  /**
    * Get the additional participant ids.
    *
    * @param int $primaryParticipantId

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2102,6 +2102,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    *
    * @return \CRM_Event_BAO_Participant
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   protected function addParticipant(&$form, $params, $contactID) {
     $transaction = new CRM_Core_Transaction();
@@ -2114,7 +2115,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'status_id' => CRM_Utils_Array::value('participant_status',
         $params, 1
       ),
-      'role_id' => CRM_Utils_Array::value('participant_role_id', $params) ?: self::getDefaultRoleID(),
+      'role_id' => CRM_Utils_Array::value('participant_role_id', $params) ?: CRM_Event_BAO_Participant::getDefaultRoleID(),
       'register_date' => $params['register_date'],
       'source' => CRM_Utils_String::ellipsify(
         isset($params['participant_source']) ? CRM_Utils_Array::value('participant_source', $params) : CRM_Utils_Array::value('description', $params),

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -806,7 +806,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       'status_id' => CRM_Utils_Array::value('participant_status',
         $params, 1
       ),
-      'role_id' => CRM_Utils_Array::value('participant_role_id', $params) ?: self::getDefaultRoleID(),
+      'role_id' => CRM_Utils_Array::value('participant_role_id', $params) ?: CRM_Event_BAO_Participant::getDefaultRoleID(),
       'register_date' => ($registerDate) ? $registerDate : date('YmdHis'),
       'source' => CRM_Utils_String::ellipsify(
         isset($params['participant_source']) ? CRM_Utils_Array::value('participant_source', $params) : CRM_Utils_Array::value('description', $params),
@@ -856,21 +856,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $transaction->commit();
 
     return $participant;
-  }
-
-  /**
-   * Get the ID of the default (first) participant role
-   *
-   * @return int
-   * @throws \CiviCRM_API3_Exception
-   */
-  private static function getDefaultRoleID() {
-    return (int) civicrm_api3('OptionValue', 'getvalue', [
-      'return' => "value",
-      'option_group_id' => "participant_role",
-      'is_active' => 1,
-      'options' => ['limit' => 1, 'sort' => "is_default DESC"],
-    ]);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Fixes an instance where an invalid function is called - in a place I believe to be unreachable

Before
----------------------------------------
self::getDefaultRoleID() called

After
----------------------------------------
CRM_Event_BAO_Participant::getDefaultRoleID()

Technical Details
----------------------------------------
This PR https://github.com/civicrm/civicrm-core/pull/16363/commits/44237a295dc5eab4f6110fb0556b1af742364f6e
(merged to 5.23) calls self::::getDefaultRoleID() in a way that was always flawed (because it was private) but definitely would
not work now. I think it is never reached but better to put this fix into 5.23 & maybe reemove the line in master
later since it assumes participant_status_id is optional - which is not true of the backoffice form

Comments
----------------------------------------
