### PR TITLE
dev/core#1595 fix issue when using dedupe rule with custom field

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -62,14 +62,16 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
     $where = [];
     $on = ["SUBSTR(t1.{$this->rule_field}, 1, {$this->rule_length}) = SUBSTR(t2.{$this->rule_field}, 1, {$this->rule_length})"];
     $entity = CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($this->rule_table));
-    $fields = civicrm_api3($entity, 'getfields', ['action' => 'create'])['values'];
+    if (isset($entity)) {
+      $fields = civicrm_api3($entity, 'getfields', ['action' => 'create'])['values'];
+    }
 
     $innerJoinClauses = [
       "t1.{$this->rule_field} IS NOT NULL",
       "t2.{$this->rule_field} IS NOT NULL",
       "t1.{$this->rule_field} = t2.{$this->rule_field}",
     ];
-    if ($fields[$this->rule_field]['type'] === CRM_Utils_Type::T_DATE) {
+    if (isset($fields[$this->rule_field]['type']) && ($fields[$this->rule_field]['type'] === CRM_Utils_Type::T_DATE)) {
       $innerJoinClauses[] = "t1.{$this->rule_field} > '1000-01-01'";
       $innerJoinClauses[] = "t2.{$this->rule_field} > '1000-01-01'";
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes using dedupe rule when it includes custom field. It used to work until this strict `civicrm_api3(string $entity, ..)` definition was introduced in API v3 definition

Before
----------------------------------------
Execution of dedupe rule with custom field throws exception:
```
TypeError: Argument 1 passed to civicrm_api3() must be of the type string, null given, called in civicrm/CRM/Dedupe/BAO/Rule.php on line 62 in civicrm_api3() (line 84 of civicrm/api/api.php).
```

After
----------------------------------------
Execution dedupe rule with custom field works

Technical Details
----------------------------------------
Gitlab issue here 
https://lab.civicrm.org/dev/core/issues/1595

Comments
----------------------------------------
This is a workaround to get this code block working, probably a deeper code refactor is needed here
