### PR TITLE
(NFC) Fix typo - no hyphen in 'override'

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -121,7 +121,7 @@
           <td id="end-date-readonly">
               {$endDate|crmDate}
               <a href="#" class="crm-hover-button action-item override-date" id="show-end-date">
-                {ts}Over-ride end date{/ts}
+                {ts}Override end date{/ts}
               </a>
               {help id="override_end_date"}
           </td>


### PR DESCRIPTION
Overview
----------------------------------------
Very minor change to fix a typo. There is no hyphen in the word 'override'.

Before
----------------------------------------
Incorrect spelling: 'over-ride'

![image](https://user-images.githubusercontent.com/13518928/74677532-7f4bf600-51b0-11ea-8916-b14302e85299.png)

After
----------------------------------------
Correct spelling: 'override'.

![image](https://user-images.githubusercontent.com/13518928/74677567-94288980-51b0-11ea-99c0-8531e467e3b2.png)


Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.
