### PR TITLE
dev/core#1602 fix join_date filter in search builder

### DIFF
--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -154,6 +154,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
     $fields = self::getFields();
 
     switch ($name) {
+      case 'membership_join_date':
       case 'member_join_date_low':
       case 'member_join_date_high':
         Civi::log()->warning(


### PR DESCRIPTION
Overview
----------------------------------------
In search builder, the Member Since field is ignored.

Before
----------------------------------------
1. visit Search > Search Builder
2. select: Members > Member Since > = > (enter a date)
3. returns all records

After
----------------------------------------
Filtered by member since (join_date) field. Search result qil should also show that the filter is applied.

Technical Details
----------------------------------------
join_date needs to be handled in the same way as start_date and end_date in the membership query BAO.