### PR TITLE
Make savedSearch bao sane

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -515,7 +515,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       if (isset($ssParams['saved_search_id'])) {
         $ssParams['id'] = $ssParams['saved_search_id'];
       }
-
+      $params['form_values'] = $params['formValues'];
       $savedSearch = CRM_Contact_BAO_SavedSearch::create($params);
 
       $params['saved_search_id'] = $savedSearch->id;

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -336,20 +336,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
    */
   public static function create(&$params) {
     $savedSearch = new CRM_Contact_DAO_SavedSearch();
-    if (isset($params['formValues']) &&
-      !empty($params['formValues'])
-    ) {
-      $savedSearch->form_values = serialize($params['formValues']);
-    }
-    else {
-      $savedSearch->form_values = NULL;
-    }
-
-    $savedSearch->is_active = CRM_Utils_Array::value('is_active', $params, 1);
-    $savedSearch->mapping_id = CRM_Utils_Array::value('mapping_id', $params, 'null');
-    $savedSearch->custom_search_id = CRM_Utils_Array::value('custom_search_id', $params, 'null');
-    $savedSearch->id = CRM_Utils_Array::value('id', $params, NULL);
-
+    $savedSearch->copyValues($params, TRUE);
     $savedSearch->save();
 
     return $savedSearch;

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -45,25 +45,17 @@
  */
 function civicrm_api3_saved_search_create($params) {
   civicrm_api3_verify_one_mandatory($params, NULL, ['form_values', 'where_clause']);
-  // The create function of the dao expects a 'formValues' that is
-  // not serialized. The get function returns form_values, that is
-  // serialized.
-  // So for the create API, I guess it should work for serialized and
-  // unserialized form_values.
-
-  if (isset($params["form_values"])) {
-    if (is_array($params["form_values"])) {
-      $params["formValues"] = $params["form_values"];
-    }
-    else {
-      // Assume that form_values is serialized.
-      $params["formValues"] = \CRM_Utils_String::unserialize($params["form_values"]);
-    }
-  }
 
   $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'SavedSearch');
   _civicrm_api3_saved_search_result_cleanup($result);
   return $result;
+}
+
+/**
+ * @param array $fields
+ */
+function _civicrm_api3_saved_search_create_spec(&$fields) {
+  $fields['form_values']['api.aliases'][] = 'formValues';
 }
 
 /**

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1178,7 +1178,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     ]);
 
     // create smart group which will contain all Male contacts
-    $smartGroupParams = ['formValues' => ['gender_id' => 1]];
+    $smartGroupParams = ['form_values' => ['gender_id' => 1]];
     $smartGroupID = $this->smartGroupCreate(
       $smartGroupParams,
       [

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -290,7 +290,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
       }
       else {
         $groupIDs[$i] = $this->smartGroupCreate([
-          'formValues' => ['last_name' => (($i == 6) ? 'smart5' : 'smart' . $i)],
+          'form_values' => ['last_name' => (($i == 6) ? 'smart5' : 'smart' . $i)],
         ], $params);
       }
     }
@@ -458,7 +458,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
 
     // Setup
     $smartGroupParams = [
-      'formValues' => ['contact_type' => ['IN' => ['Individual']]],
+      'form_values' => ['contact_type' => ['IN' => ['Individual']]],
     ];
     $group = $this->smartGroupCreate($smartGroupParams);
     $sms_provider = $this->callAPISuccess('SmsProvider', 'create', [

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1289,10 +1289,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @return int
    */
   public function smartGroupCreate($smartGroupParams = [], $groupParams = [], $contactType = 'Household') {
-    $smartGroupParams = array_merge([
-      'formValues' => ['contact_type' => ['IN' => [$contactType]]],
-    ],
-      $smartGroupParams);
+    $smartGroupParams = array_merge(['form_values' => ['contact_type' => ['IN' => [$contactType]]]], $smartGroupParams);
     $savedSearch = CRM_Contact_BAO_SavedSearch::create($smartGroupParams);
 
     $groupParams['saved_search_id'] = $savedSearch->id;

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -4415,14 +4415,14 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     ];
     $g1ID = $this->smartGroupCreate($ssParams, ['name' => uniqid(), 'title' => uniqid()]);
     $ssParams = [
-      'formValues' => [
+      'form_values' => [
         // Household Member of
         'display_relationship_type' => $rtype2['id'] . '_a_b',
       ],
     ];
     $g2ID = $this->smartGroupCreate($ssParams, ['name' => uniqid(), 'title' => uniqid()]);
     $ssParams = [
-      'formValues' => [
+      'form_values' => [
         // Household Member is
         'display_relationship_type' => $rtype2['id'] . '_b_a',
       ],
@@ -4430,12 +4430,9 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     // the reverse of g2 which adds another layer for overlap at related contact filter
     $g3ID = $this->smartGroupCreate($ssParams, ['name' => uniqid(), 'title' => uniqid()]);
     CRM_Contact_BAO_GroupContactCache::loadAll();
-    $g1Contacts = $this->callAPISuccess('contact', 'get', ['group' => $g1ID]);
-    $g2Contacts = $this->callAPISuccess('contact', 'get', ['group' => $g2ID]);
-    $g3Contacts = $this->callAPISuccess('contact', 'get', ['group' => $g3ID]);
-    $this->assertTrue($g1Contacts['count'] == 1);
-    $this->assertTrue($g2Contacts['count'] == 2);
-    $this->assertTrue($g3Contacts['count'] == 1);
+    $this->callAPISuccessGetCount('contact', ['group' => $g1ID], 1);
+    $this->callAPISuccessGetCount('contact', ['group' => $g2ID], 2);
+    $this->callAPISuccessGetCount('contact', ['group' => $g3ID], 1);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -4407,7 +4407,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     ]);
 
     $ssParams = [
-      'formValues' => [
+      'form_values' => [
         // Child of
         'display_relationship_type' => $rtype1['id'] . '_a_b',
         'sort_name' => 'Adams',

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -96,7 +96,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'Payment',
       'Order',
       //work fine in local
-      'SavedSearch',
       'Logging',
     ];
     $this->toBeImplemented['delete'] = [
@@ -723,15 +722,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'ReportInstance' => [
         // View mode is part of the navigation which is not retrieved by the api.
         'cant_return' => ['view_mode'],
-      ],
-      'SavedSearch' => [
-        // I think the fields below are generated based on form_values.
-        'cant_update' => [
-          'search_custom_id',
-          'where_clause',
-          'select_tables',
-          'where_tables',
-        ],
       ],
       'StatusPreference' => [
         'break_return' => [


### PR DESCRIPTION
Overview
----------------------------------------
Makes the savedSearch create function act in a more standard way so that tests pass and the APIv4 can use it.

Before
----------------------------------------
BAO create would overwrite values on update for no reason I can fathom. It also tries to save a non-existent field (`is_active` was removed in v1.5!) which doesn't give me much confidence that it was doing these things for a good reason.

After
----------------------------------------
Make it act like a normal bao create function.
