### PR TITLE
(NFC) Remove `$Id$` from header

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 /**

--- a/header.txt
+++ b/header.txt
@@ -14,6 +14,4 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */


### PR DESCRIPTION


Overview
----------------------------------------
I was a bit surprised to see the old drupal svn  value pop back up - did if come from this header.txt file

Before
----------------------------------------
$ids added in header

After
----------------------------------------
$ids removed again

Technical Details
----------------------------------------


Comments
----------------------------------------
@totten @seamuslee001 @colemanw 