### PR TITLE
xml/GenCode.php - Fix execution in default locale (without l10n data)

### DIFF
--- a/xml/GenCode.php
+++ b/xml/GenCode.php
@@ -29,6 +29,7 @@ date_default_timezone_set('UTC');
 define('CIVICRM_UF', 'Drupal');
 define('CIVICRM_UF_BASEURL', '/');
 define('CIVICRM_L10N_BASEDIR', getenv('CIVICRM_L10N_BASEDIR') ? getenv('CIVICRM_L10N_BASEDIR') : __DIR__ . '/../l10n');
+$GLOBALS['civicrm_paths']['cms.root']['url'] = 'http://gencode.example.com/do-not-use';
 
 require_once 'CRM/Core/ClassLoader.php';
 CRM_Core_ClassLoader::singleton()->register();


### PR DESCRIPTION
Overview
--------

This fixes a recent regression in which `xml/GenCode.php` fails to execute in certain configurations.

Initial report: https://github.com/civicrm/civicrm-buildkit/issues/503

This most likely stems from https://lab.civicrm.org/dev/translation/issues/30 aka #15408 which was first merged into 5.23.

Before
------

* If the folder `l10n` exists in its traditional location, and if you run `./bin/setup.sh -g`, then it correctly executes.
* If the folder `l10n` does not exist in its traditional location, and if you run `./bin/setup.sh -g`, then it fails with an error like this:
  ```
  + php -d mysql.default_host=127.0.0.1:3306 -d mysql.default_user=dmasterciv_abcde -d mysql.default_password=abcd1234 GenCode.php schema/Schema.xml '' Drupal

  civicrm_domain.version := 5.23.beta1

  Parsing schema description schema/Schema.xml
  Extracting database information
  Extracting table information
  PHP Fatal error:  Uncaught RuntimeException: Invalid configuration: the [cms.root] path must be an absolute URL in /home/me/.../Civi/Core/Paths.php:174
  Stack trace:
  #0 /home/me/.../Civi/Core/Paths.php(151): Civi\Core\Paths->toAbsoluteUrl('/', 'cms.root')
  #1 /home/me/.../Civi/Core/Paths.php(176): Civi\Core\Paths->getVariable('cms.root', 'url')
  #2 /home/me/.../Civi/Core/Paths.php(151): Civi\Core\Paths->toAbsoluteUrl('/', 'civicrm.root')
  #3 /home/me/.../Civi/Core/Paths.php(224): Civi\Core\Paths->getVariable('civicrm.root', 'path')
  #4 /home/me/.../Civi/Core/Paths.php(84): Civi\Core\Paths->getPath('l10n')
  #5 [internal function]: Civi\Core\Paths->Civi\Core\{closure}()
  #6 /home/jo in /home/me/.../Civi/Core/Paths.php on line 174
  ```

After
-----

You can run `./bin/setup.sh -g` with or without the `l10n` folder.

When running `GenCode`, the CMS URL is set to a fake value `http://gencode.example.com/do-not-use`.

Comments
--------

There's an argument to be made that this shouldn't be necessary: when running `GenCode`, it should only create PHP files, and none of the output should depend on the CMS URL - because that's liable to change when you deploy the PHP code. If someone did try to generate URL at such an early stage, it's arguably good to generate an error.  In point of fact, `GenCode` is not actually using the CMS URL.

The oddity stems from the contract of `CRM_Utils_System_*` (specifically, `getCiviSourceStorage()` and `getDefaultFileStorage()`) which do double-duty providing both path and URL.  To avoid duplicate work, `Civi\Core\Paths` uses the same grain of information - it tracks the pairs of path+URL. And because it works at the same grain, we get into logic like:

* If you want the `civicrm.root` path, then you need to also get the `civicrm.root` URL.
* If you want the `civicrm.root` URL, then you need to get the `cms.root` URL.

A more aggressive fix might be to split `getCiviSourceStorage()` and `getDefaultFileStorage()` so that it's possible to get the path and URL separately; then revise `Civi\Core\Paths` to take advantage of the finer-grained contract.  However, splitting those things would be a more invasive patch, and we're currently in RC.

