### PR TITLE
Add deprecation notice

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1879,6 +1879,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $params['fee_level'] = $params['amount_level'] = $this->getParticipantValue('fee_level');
       $params['fee_amount'] = $this->getParticipantValue('fee_amount');
       if (isset($params['priceSetId'])) {
+        CRM_Core_Error::deprecatedFunctionWarning('It seems this line is never hit & can go.');
         $lineItem[0] = CRM_Price_BAO_LineItem::getLineItems($this->_id);
       }
       //also add additional participant's fee level/priceset


### PR DESCRIPTION


Overview
----------------------------------------
I've been trying to figure out when this line would be hit but I just can't find a way to trigger
it - removing it would help a lot with this code but let's deprecate for a bit.

Before
----------------------------------------
LIne not hit as far as I can tell - $params['priceSetId'] has no way of being populated

After
----------------------------------------
Notice it it were to be hit

Technical Details
----------------------------------------
This code hasn't been touched for a while & lots has changed without stuff being cleaned up + functions that used to be shared are no longer so there seems to be a lot of unused stuff

Comments
----------------------------------------
