### PR TITLE
Fix enotice regression (unreleased)

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2205,9 +2205,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   protected function getParticipantValue($fieldName) {
     if (!$this->participantRecord) {
-      $this->participantRecord = civicrm_api3('Participant', 'get', ['id' => $this->_id]);
+      $this->participantRecord = civicrm_api3('Participant', 'getsingle', ['id' => $this->_id]);
     }
-    return $this->participantRecord[$fieldName];
+    return $this->participantRecord[$fieldName] ?? $this->participantRecord['participant_' . $fieldName];
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
This was merged to 5.23 but I made a booboo in it
https://github.com/civicrm/civicrm-core/commit/a3aed42a453009733e8feb2c56fde5750b37cd14

I think the params are actually not used so it's just the notice it causes but this fixes

Before
----------------------------------------
Notice

After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------

