### PR TITLE
Cleanup copyValues DAO function

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -401,7 +401,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
     }
     $group = new CRM_Contact_BAO_Group();
-    $group->copyValues($params, TRUE);
+    $group->copyValues($params);
 
     if (empty($params['id']) &&
       !$nameParam

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -336,7 +336,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
    */
   public static function create(&$params) {
     $savedSearch = new CRM_Contact_DAO_SavedSearch();
-    $savedSearch->copyValues($params, TRUE);
+    $savedSearch->copyValues($params);
     $savedSearch->save();
 
     return $savedSearch;

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -132,7 +132,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'Domain', CRM_Utils_Array::value('id', $params), $params);
     $domain = new CRM_Core_DAO_Domain();
-    $domain->copyValues($params, TRUE);
+    $domain->copyValues($params);
     $domain->save();
     CRM_Utils_Hook::post($hook, 'Domain', $domain->id, $domain);
     return $domain;

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -1194,7 +1194,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
             'column_number' => $colCnt,
           ], $v);
           $saveMappingField = new CRM_Core_DAO_MappingField();
-          $saveMappingField->copyValues($saveMappingParams, TRUE);
+          $saveMappingField->copyValues($saveMappingParams);
           $saveMappingField->save();
           $colCnt++;
         }

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -38,7 +38,7 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
     }
 
     $dao = new CRM_Core_DAO_UFJoin();
-    $dao->copyValues($params, TRUE);
+    $dao->copyValues($params);
     if ($params['uf_group_id']) {
       $dao->save();
     }

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -54,7 +54,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     CRM_Utils_Hook::pre($op, 'MailingJob', CRM_Utils_Array::value('id', $params), $params);
 
     $jobDAO = new CRM_Mailing_BAO_MailingJob();
-    $jobDAO->copyValues($params, TRUE);
+    $jobDAO->copyValues($params);
     $jobDAO->save();
     if (!empty($params['mailing_id']) && empty('is_calling_function_updated_to_reflect_deprecation')) {
       CRM_Mailing_BAO_Mailing::getRecipients($params['mailing_id']);

--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -38,7 +38,7 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'MembershipBlock', CRM_Utils_Array::value('id', $params), $params);
     $dao = new CRM_Member_DAO_MembershipBlock();
-    $dao->copyValues($params, TRUE);
+    $dao->copyValues($params);
     $dao->id = CRM_Utils_Array::value('id', $params);
     $dao->save();
     CRM_Utils_Hook::post($hook, 'MembershipBlock', $dao->id, $dao);

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -61,7 +61,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
     }
 
     $instance = new CRM_Report_DAO_ReportInstance();
-    $instance->copyValues($params, TRUE);
+    $instance->copyValues($params);
 
     if (CRM_Core_Config::singleton()->userFramework == 'Joomla') {
       $instance->permission = 'null';

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -186,7 +186,7 @@ trait DAOActionTrait {
     \CRM_Utils_Hook::pre($hook, $this->getEntityName(), $params['id'] ?? NULL, $params);
     /** @var \CRM_Core_DAO $instance */
     $instance = new $baoName();
-    $instance->copyValues($params, TRUE);
+    $instance->copyValues($params);
     $instance->save();
     \CRM_Utils_Hook::post($hook, $this->getEntityName(), $instance->id, $instance);
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1357,7 +1357,7 @@ function _civicrm_api3_basic_create_fallback($bao_name, &$params) {
 
   CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
   $instance = new $dao_name();
-  $instance->copyValues($params, TRUE);
+  $instance->copyValues($params);
   $instance->save();
   CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up function variables and removes a transitional parameter.

Before
----------------------------------------

- The $serializeArrays parameter was transitional, but would trigger a test failure if it was incorrectly omitted. So at this point if all the tests are passing, it can be removed.
- Unnecessary passing $params by reference.

After
----------------------------------------

- The $serializeArrays parameter is gone as serialization is now always enabled.
- Passing $params by reference was unnecessary and has been removed.
- Renamed a few variables for readability.
