### PR TITLE
dev/core#1603 - Error in tax calculation when price option is stored …

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -234,7 +234,7 @@ class CRM_Financial_BAO_Order {
     foreach ($this->getPriceOptions() as $fieldID => $valueID) {
       $throwAwayArray = [];
       // @todo - still using getLine for now but better to bring it to this class & do a better job.
-      $lineItems[$valueID] = CRM_Price_BAO_PriceSet::getLine($params, $throwAwayArray, $this->getPriceSetID(), $this->getPriceFieldSpec($fieldID), $fieldID, 0)[1][$valueID];
+      $lineItems[$valueID] = CRM_Price_BAO_PriceSet::getLine($params, $throwAwayArray, $this->getPriceSetID(), $this->getPriceFieldSpec($fieldID), $fieldID, 0, 0)[1][$valueID];
     }
 
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();


### PR DESCRIPTION
…in 8 decimal points

Overview
----------------------------------------
Fix tax amount calculation when 8 decimal amount is stored in database.

Before
----------------------------------------
See details on gitlab - https://lab.civicrm.org/dev/core/issues/1603

![image](https://user-images.githubusercontent.com/5929648/74832968-8739a080-533e-11ea-8635-363740c6e26b.png)

It also fixes the partial tax amount calculation issue(which seems like a recent regression) as mentioned by @petednz on MM https://chat.civicrm.org/civicrm/pl/psu835jc6trctcbwu9ysrt5mdw

![image](https://user-images.githubusercontent.com/5929648/75845246-80129800-5dfe-11ea-8d9a-d3a2ef048ed6.png)

After
----------------------------------------
The display of tax and total amount is fixed.

![image](https://user-images.githubusercontent.com/5929648/74833079-c9fb7880-533e-11ea-800b-4d90d54b79da.png)


Technical Details
----------------------------------------
The amount is not rounded in the BAO layer. The templates already uses smarty `crmMoney` function to render the money variables which takes care of rounding the value to 2dp.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1603