### PR TITLE
dev/translation#36 Ensure that we are only passing integers to the ng…

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -448,7 +448,7 @@ class CRM_Core_I18n {
       if (isset($count) && isset($plural)) {
 
         if ($this->_phpgettext) {
-          $text = $this->_phpgettext->ngettext($text, $plural, $count);
+          $text = $this->_phpgettext->ngettext($text, $plural, (int) $count);
         }
         else {
           // if the locale's not set, we do ngettext work by hand


### PR DESCRIPTION
…ettext function for plurals

Overview
----------------------------------------
Error is thrown when trying to perform a search using after setting language to say English UK

Before
----------------------------------------
An error "Resulting fatal: Select_string only accepts integers: 1" when trying to do a basic advanced search after changing the site language to something other than English US

After
----------------------------------------
No error

further steps are on the issue https://lab.civicrm.org/dev/translation/issues/36

ping @mlutfy @demeritcowboy 
