### PR TITLE
Fix two more php-finding regexes

### DIFF
--- a/Civi/Api4/Action/Entity/Get.php
+++ b/Civi/Api4/Action/Entity/Get.php
@@ -58,7 +58,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       if (is_dir($dir)) {
         foreach (glob("$dir/*.php") as $file) {
           $matches = [];
-          preg_match('/(\w*).php/', $file, $matches);
+          preg_match('/(\w*)\.php$/', $file, $matches);
           if (
             (!$toGet || in_array($matches[1], $toGet))
             && is_a('\Civi\Api4\\' . $matches[1], '\Civi\Api4\Generic\AbstractEntity', TRUE)

--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -67,7 +67,7 @@ class GetActions extends BasicGetAction {
     if (is_dir($dir)) {
       foreach (glob("$dir/*.php") as $file) {
         $matches = [];
-        preg_match('/(\w*).php/', $file, $matches);
+        preg_match('/(\w*)\.php$/', $file, $matches);
         $actionName = array_pop($matches);
         $actionClass = new \ReflectionClass('\\Civi\\Api4\\Action\\' . $this->_entityName . '\\' . $actionName);
         if ($actionClass->isInstantiable() && $actionClass->isSubclassOf('\\Civi\\Api4\\Generic\\AbstractAction')) {


### PR DESCRIPTION
Overview
----------------------------------------
Very similar to PR #16377

Before: Civi code living under a path containing the characters php
(such as ~/src/php/civicrm) will fail to load the API4 explorer with
a message like the following:
    ReflectionException: "Class \Civi\Api4\src does not exist"

After: API4 explorer loads no matter what the enclosing path
