### PR TITLE
Update recently-added PathUrlTest to be more representative

### DIFF
--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -18,7 +18,7 @@ class PathUrlTest extends \CiviEndToEndTestCase {
    */
   public function testSystemRouter() {
     $this->assertUrlContentRegex(';class="CRM_Mailing_Form_Subscribe";',
-      \CRM_Utils_System::url('civicrm/mailing/subscribe', 'reset=1', TRUE, NULL, FALSE));
+      \CRM_Utils_System::url('civicrm/mailing/subscribe', 'reset=1', TRUE, NULL, FALSE, TRUE));
   }
 
   /**


### PR DESCRIPTION
Before
------

The test generates the URL for an example page (`civicrm/mailing/subscribe`)
by calling `url()`. It does not explicitly set the `url(...$frontend...)` option,
so it defaults to `$frontend=FALSE`.

By contrast, the other places which make URLs for `civicrm/mailing/subscribe`
(eg `CRM/Mailing/BAO/Mailing.php` and `CRM/Utils/Token.php`) do pass `$frontend=TRUE`.

After
-----

The test behaves the same way as other code (i.e. passing `$frontend=TRUE`).

Comments
--------------

This issue was noticed while debugging this E2E test on WP (which has been failing). This plausibly would cause problems with the correctness of the test on WP/J, although (in my local testing so far) I don't think this actually fixes things. But it's still good to address.