### PR TITLE
dev/core#1331 Don't freeze fields for auto-renew memberships

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -552,9 +552,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     );
 
     $sel->setOptions([$selMemTypeOrg, $selOrgMemType]);
-    if ($isUpdateToExistingRecurringMembership) {
-      $sel->freeze();
-    }
 
     if ($this->_action & CRM_Core_Action::ADD) {
       $this->add('number', 'num_terms', ts('Number of Terms'), ['size' => 6]);
@@ -579,9 +576,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $statusOverride = $this->addElement('select', 'is_override', ts('Status Override?'),
         CRM_Member_StatusOverrideTypes::getSelectOptions()
       );
-      if ($statusOverride && $isUpdateToExistingRecurringMembership) {
-        $statusOverride->freeze();
-      }
 
       $this->add('datepicker', 'status_override_end_date', ts('Status Override End Date'), '', FALSE, ['minDate' => time(), 'time' => FALSE]);
 

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -76,7 +76,16 @@
         </tr>
         <tr class="crm-membership-form-block-membership_type_id">
           <td class="label">{$form.membership_type_id.label}</td>
-          <td><span id='mem_type_id'>{$form.membership_type_id.html}</span>
+          <td id="mem_type_id-readonly">
+            <span id="membership_type_id_0-readonly"></span> : <span id="membership_type_id_1-readonly"></span>
+            <span id="mem-type-override">
+              <a href="#" class="crm-hover-button action-item override-mem-type" id="show-mem-type">
+                {ts}Override organization and type{/ts}
+              </a>
+              {help id="override_membership_type"}
+            </span>
+          </td>
+          <td id="mem_type_id-editable"><span id='mem_type_id'>{$form.membership_type_id.html}</span>
             {if $hasPriceSets}
               <span id='totalAmountORPriceSet'> {ts}OR{/ts}</span>
               <span id='selectPriceSet'>{$form.price_set_id.html}</span>
@@ -350,6 +359,25 @@
       setDifferentContactBlock();
       cj('#is_different_contribution_contact').change( function() {
         setDifferentContactBlock();
+      });
+
+      // give option to override membership type for auto-renew memberships - dev/core#1331
+      {/literal}
+      {if $isRecur}
+        cj('#membership_type_id_0-readonly').text(cj('#membership_type_id_0 option:selected').text());
+        cj('#membership_type_id_1-readonly').text(cj('#membership_type_id_1 option:selected').text());
+        cj('#mem_type_id-readonly').show();
+        cj('#mem_type_id-editable').hide();
+      {else}
+        cj('#mem_type_id-readonly').hide();
+        cj('#mem_type_id-editable').show();
+      {/if}
+      {literal}
+
+      cj('#show-mem-type').click( function( e ) {
+        e.preventDefault();
+        cj('#mem_type_id-readonly').hide();
+        cj('#mem_type_id-editable').show();
       });
 
       // give option to override end-date for auto-renew memberships

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -8,10 +8,13 @@
  +--------------------------------------------------------------------+
 *}
 {* this template is used for adding/editing/deleting memberships for a contact  *}
-{if $cancelAutoRenew}
+{if $isRecur}
   <div class="messages status no-popup">
     <div class="icon inform-icon"></div>
-    <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type or Membership Status: <a href="%1">Cancel auto-renew</a>{/ts}</p>
+    <p>{ts}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. Please be aware that any changes that you make here may not be reflected in the payment processor. Please ensure that you alter the related subscription at the payment processor.{/ts}</p>
+    {if $cancelAutoRenew}<p>{ts}To stop the automatic renewal:
+      <a href="%1">Cancel auto-renew</a>
+    {/ts}</p>{/if}
   </div>
 {/if}
 <div class="spacer"></div>

--- a/templates/CRM/Member/Page/Tab.hlp
+++ b/templates/CRM/Member/Page/Tab.hlp
@@ -28,3 +28,10 @@
 {htxt id="override_end_date"}
   <p>{ts}If CiviCRM's membership end-date is different from when the payment processor will next collect a payment, various problems can occur. Members may experience a gap in their membership, and the renewal date may get changed from what is manually entered. Use care when modifying the End Date value, and check the associated recurring payment in your payment processor system so they always match.{/ts}</p>
 {/htxt}
+
+{htxt id="override_membership_type-title"}
+{ts}Override Membership Type for Auto-renew Memberships{/ts}
+{/htxt}
+{htxt id="override_membership_type"}
+  <p>{ts}This membership is set to renew automatically. Take care when you change the membership type. Make sure that you also change the related payment at the payment processor. Otherwise future payments may be for the wrong amount.{/ts}</p>
+{/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
If a membership is set to auto-renew some of the fields are frozen, which means that a user is unable to edit them when they visit the edit membership screen.

This PR changes this behaviour so that these fields are NOT frozen. The membership organisation/type field is initially disabled but with the option to enable this field and edit it. The membership status field has the option to override as per non auto-renew memberships.

Warning messages have been added to alert the user to the consequence of changing these membership details.

See https://lab.civicrm.org/dev/core/issues/1331 for more details and discussion.

Before
----------------------------------------
If the membership is set to auto-renew, the following fields are frozen:

-  Membership organisation / Membership type
-  Membership status

![image](https://user-images.githubusercontent.com/13518928/75034004-21672900-54a4-11ea-8e9d-fd54d6f5f3a6.png)

If the payment processor supports cancelling automatic renewal there is a text alert with the option to cancel:

![image](https://user-images.githubusercontent.com/13518928/75033971-07c5e180-54a4-11ea-80a6-b21b29774c83.png)

(If the payment processor doesn't support cancelling automatic renewal this alert doesn't show.)

After
----------------------------------------
If the membership is set to auto-renew the fields are not frozen and the user has the ability to override them if required. Help text with an appropriate warning is displayed.

![image](https://user-images.githubusercontent.com/13518928/76120905-62a22180-5fea-11ea-8f51-5e2d0a6371cc.png)

If the payment processor supports cancelling automatic renewal there is an option to do so (within the alert):

![image](https://user-images.githubusercontent.com/13518928/75033823-a6057780-54a3-11ea-85ca-c9847b934616.png)


Technical Details
----------------------------------------
None.

Comments
----------------------------------------
This replaces a previous PR #16322

I have created an extension that restores the current functionality for sites that need it: https://lab.civicrm.org/extensions/freeze-membership-fields

The end date field was unfrozen in #15540. See https://lab.civicrm.org/dev/core/issues/1126 for details.
