### PR TITLE
Allow adding datepicker to metadata based settings pages

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -227,7 +227,7 @@ trait CRM_Admin_Form_SettingTrait {
           $this->addRadio($setting, $props['title'], [1 => ts('Yes'), 0 => ts('No')], CRM_Utils_Array::value('html_attributes', $props), '&nbsp;&nbsp;');
         }
         elseif ($add === 'add') {
-          $this->add($props['html_type'], $setting, $props['title'], $options);
+          $this->add($props['html_type'], $setting, $props['title'], $options, FALSE, $props['html_extra'] ?? NULL);
         }
         else {
           $this->$add($setting, $props['title'], $options);
@@ -290,7 +290,7 @@ trait CRM_Admin_Form_SettingTrait {
       'advmultiselect' => 'Element',
     ];
     $mapping += array_fill_keys(CRM_Core_Form::$html5Types, '');
-    return $mapping[$htmlType];
+    return $mapping[$htmlType] ?? '';
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -387,6 +387,14 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
     // @see http://wiki.civicrm.org/confluence/display/CRMDOC/crmDatepicker
     if ($type == 'datepicker') {
+      // Support minDate/maxDate properties
+      if (isset($extra['minDate'])) {
+        $extra['minDate'] = date('Y-m-d', strtotime($extra['minDate']));
+      }
+      if (isset($extra['maxDate'])) {
+        $extra['maxDate'] = date('Y-m-d', strtotime($extra['maxDate']));
+      }
+
       $attributes = ($attributes ? $attributes : []);
       $attributes['data-crm-datepicker'] = json_encode((array) $extra);
       if (!empty($attributes['aria-label']) || $label) {


### PR DESCRIPTION
Overview
----------------------------------------
Allow adding datepicker to metadata based settings pages.

Before
----------------------------------------
Not possible to add datepicker.

After
----------------------------------------
`datepicker` can be added just by specifying `html_type='datepicker'` in settings metadata.

We also specifically handle the `minDate` parameter for datepicker and may want to handle more in future. This allows us to use a PHP style relative date in the metadata and convert it to the fixed date required by datepicker.

Technical Details
----------------------------------------
To test add a setting with a datepicker. For example
```
  'variablerecurpayments_fixedpaymentdate' => [
    'admin_group' => 'variablerecurpayments_date',
    'admin_grouptitle' => 'Payment Dates',
    'admin_groupdescription' => 'Settings that modify payment dates',
    'group_name' => 'Variablerecurpayments Settings',
    'group' => 'variablerecurpayments',
    'name' => 'variablerecurpayments_fixedpaymentdate',
    'type' => 'Date',
    'html_type' => 'datepicker',
    'default' => '',
    'add' => '4.7',
    'is_domain' => 1,
    'is_contact' => 0,
    'title' => E::ts('Fixed ANNUAL date for recurring payments'),
    'description' => E::ts('If this is set all (Smartdebit) recurring payments will be updated to match this date during the nightly sync job once the initial payment has been taken.
    Leave blank to disable. Note: The year is ignored, just specify a year in the future.'),
    'html_attributes' => [
      'formatType' => 'activityDate',
    ],
    'html_extra' => [
      'time' => FALSE,
      'minDate' => '+10 day'
    ],
    'settings_pages' => [
      'variablerecurpayments' => [
        'weight' => 10,
      ]
    ],
  ],
```

Comments
----------------------------------------
@eileenmcnaughton Be nice to see this in 5.24 if you have time to review? It allows me to convert some more of my extensions to use the settingstrait and should help progress some of the core settings pages.
