### PR TITLE
WIP dev/core#1605 State/province not copied on shared address 

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -821,6 +821,11 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
       if (!empty($masterAddress->county_id) && empty($values['county_id'])) {
         $values['county_id'] = $masterAddress->county_id;
       }
+
+      // dev/core#1605 ensure state/province is copied
+      if (!empty($masterAddress->state_province_id) && empty($values['state_province_id'])) {
+        $values['state_province_id'] = $masterAddress->state_province_id;
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Ensure the state/province is copied when sharing an address.

More details including screenshots in the gitlab issue: https://lab.civicrm.org/dev/core/issues/1605

Before
----------------------------------------
1. User goes to a contact's summary tab 
2. Clicks "Add Address"
3. Selects the "Use another contact's address" checkbox
4. Selects a contact with an address WITH a state 
5. Clicks Save

Result: All the address fields are copied over EXCEPT the state/province.

After
----------------------------------------
1. User goes to a contact's summary tab 
2. Clicks "Add Address"
3. Selects the "Use another contact's address" checkbox
4. Selects a contact with an address WITH a state 
5. Clicks Save

Result: All the address fields are copied over INCLUDING the state/province.

Comments
----------------------------------------
This fixes the bug described in https://lab.civicrm.org/dev/core/issues/1605, I intend to open another pr that addresses the code cleanup @agh1 lined out in https://lab.civicrm.org/dev/core/issues/1605.
