### PR TITLE
[REF] Extract self-service eligibility code into its own function

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -164,23 +164,8 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     $this->_contact_email = $email;
 
     $details = CRM_Event_BAO_Participant::participantDetails($this->_from_participant_id);
-    $optionGroupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'participant_role', 'id', 'name');
-    $query = "
-      SELECT cpst.name as status, cov.name as role, cp.fee_level, cp.fee_amount, cp.register_date, civicrm_event.start_date
-      FROM civicrm_participant cp
-      LEFT JOIN civicrm_participant_status_type cpst ON cpst.id = cp.status_id
-      LEFT JOIN civicrm_option_value cov ON cov.value = cp.role_id and cov.option_group_id = {$optionGroupId}
-      LEFT JOIN civicrm_event ON civicrm_event.id = cp.event_id
-      WHERE cp.id = {$this->_from_participant_id}";
-    $dao = CRM_Core_DAO::executeQuery($query);
-    while ($dao->fetch()) {
-      $details['status']  = $dao->status;
-      $details['role'] = $dao->role;
-      $details['fee_level']   = $dao->fee_level;
-      $details['fee_amount'] = $dao->fee_amount;
-      $details['register_date'] = $dao->register_date;
-      $details['event_start_date'] = $dao->start_date;
-    }
+    $selfServiceDetails = CRM_Event_BAO_Participant::getSelfServiceEligibility($this->_from_participant_id, $url, $this->isBackoffice);
+    $details = array_merge($details, $selfServiceDetails);
     $this->assign('details', $details);
     //This participant row will be cancelled.  Get line item(s) to cancel
     $this->selfsvctransferUrl = CRM_Utils_System::url('civicrm/event/selfsvcupdate',

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -412,4 +412,74 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $this->eventDelete($eventId);
   }
 
+  /**
+   * Test various self-service eligibility scenarios.
+   *
+   * @dataProvider selfServiceScenarios
+   * @param $selfSvcEnabled
+   * @param $selfSvcHours
+   * @param $hoursToEvent
+   * @param $participantStatusId
+   * @param $isBackOffice
+   * @param $successExpected  A boolean that indicates whether this test should pass or fail.
+   */
+  public function testGetSelfServiceEligibility($selfSvcEnabled, $selfSvcHours, $hoursToEvent, $participantStatusId, $isBackOffice, $successExpected) {
+    $participantId = $this->participantCreate(['contact_id' => $this->_contactId, 'event_id' => $this->_eventId, 'status_id' => $participantStatusId]);
+    $now = new Datetime();
+    $startDate = $now->add(new DateInterval("PT{$hoursToEvent}H"))->format('Y-m-d H:i:s');
+    $this->callAPISuccess('Event', 'create', [
+      'id' => $this->_eventId,
+      'allow_selfcancelxfer' => $selfSvcEnabled,
+      'selfcancelxfer_time' => $selfSvcHours,
+      'start_date' => $startDate,
+    ]);
+    $url = CRM_Utils_System::url('civicrm/event/info', "reset=1&id={$this->_eventId}");
+    // If we return without an error, then success.  But we don't always expect success.
+    try {
+      CRM_Event_BAO_Participant::getSelfServiceEligibility($participantId, $url, $isBackOffice);
+    }
+    catch (\Exception $e) {
+      if ($successExpected === FALSE) {
+        return;
+      }
+      else {
+        $this->fail();
+      }
+    }
+    if ($successExpected === FALSE) {
+      $this->fail();
+    }
+  }
+
+  public function selfServiceScenarios() {
+    // Standard pass scenario
+    $scenarios[] = [
+      'selfSvcEnabled' => TRUE,
+      'selfSvcHours' => 12,
+      'hoursToEvent' => 16,
+      'participantStatusId' => 1,
+      'isBackOffice' => FALSE,
+      'successExpected' => TRUE,
+    ];
+    // Too late to self-service
+    $scenarios[] = [
+      'selfSvcEnabled' => TRUE,
+      'selfSvcHours' => 12,
+      'hoursToEvent' => 8,
+      'participantStatusId' => 1,
+      'isBackOffice' => FALSE,
+      'successExpected' => FALSE,
+    ];
+    // Participant status is other than "Registered".
+    $scenarios[] = [
+      'selfSvcEnabled' => TRUE,
+      'selfSvcHours' => 12,
+      'hoursToEvent' => 16,
+      'participantStatusId' => 2,
+      'isBackOffice' => FALSE,
+      'successExpected' => FALSE,
+    ];
+    return $scenarios;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
There are two pages that check for self-service eligibility - the "update" and "transfer" pages.  The code to check if an event is eligible for cancellation/transfer is a) out-of-sync, b) buggy.  This initial PR seeks to extract to a shared function with tests so further improvements can be made.

Before
----------------------------------------
* Copy/paste code
* No tests
* Self-service transfer doesn't respect the `Cancellation or transfer time limit (hours)` UI option.

After
----------------------------------------
* Copy/paste annihilated
* Tests
* Self-service transfer respects the same settings that self-service cancellation does.

Technical Details
----------------------------------------
If you're reviewing by replicating my extraction, work from  `CRM_Event_Form_SelfSvcUpdate`, since `CRM/Event/Form/SelfSvcTransfer` is missing validations that the first class doesn't.  Once you're comfortable with the extraction, it should be clear what the difference is.

Comments
----------------------------------------
There are further bugs to fix and improvements to make - [event#34](https://lab.civicrm.org/dev/event/issues/34) and [event#35](https://lab.civicrm.org/dev/event/issues/35) but this feels like an important prerequisite.

Additionally, once this is merged I intend to open a PR allowing users to cancel/transfer from their user dashboard.