### PR TITLE
Validate email address per recommendation (ie. require a . after the @)

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -853,6 +853,10 @@ if (!CRM.vars) CRM.vars = {};
       var that = this,
         settings = $.extend({}, CRM.validate._defaults, CRM.validate.params);
       $(this).validate(settings);
+      // Default email validator accepts test@example but on test@example.org is valid (https://jqueryvalidation.org/jQuery.validator.methods/)
+      $.validator.methods.email = function( value, element ) {
+        return this.optional(element) || /[a-z]+@[a-z]+\.[a-z]+/.test(value);
+      };
       // Call any post-initialization callbacks
       if (CRM.validate.functions && CRM.validate.functions.length) {
         $.each(CRM.validate.functions, function(i, func) {


### PR DESCRIPTION
Overview
----------------------------------------
When using jquery Validate the default validation only checks for an @. But that's not valid as we need a . after the @ sign too. This adds a custom validator per recommendation at https://jqueryvalidation.org/jQuery.validator.methods/ to verify that email has an @ and a . .

Before
----------------------------------------
admin@exampleorg is ok

After
----------------------------------------
admin@exampleorg is not valid, but admin@example.org is valid.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
Follows on from https://github.com/civicrm/civicrm-core/pull/16495