### PR TITLE
dev/translation#37 - Remove hardcoded translations from 13 years ago that no longer do anything

### DIFF
--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -394,31 +394,6 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
     foreach ($rows as $k => $row) {
       $row = &$rows[$k];
 
-      // DRAFTING: provide a facility for db-stored strings
-      // localize the built-in activity names for display
-      // (these are not enums, so we can't use any automagic here)
-      switch ($row['activity_type']) {
-        case 'Meeting':
-          $row['activity_type'] = ts('Meeting');
-          break;
-
-        case 'Phone Call':
-          $row['activity_type'] = ts('Phone Call');
-          break;
-
-        case 'Email':
-          $row['activity_type'] = ts('Email');
-          break;
-
-        case 'SMS':
-          $row['activity_type'] = ts('SMS');
-          break;
-
-        case 'Event':
-          $row['activity_type'] = ts('Event');
-          break;
-      }
-
       // add class to this row if overdue
       if (CRM_Utils_Date::overdue(CRM_Utils_Array::value('activity_date_time', $row))
         && CRM_Utils_Array::value('status_id', $row) == 1


### PR DESCRIPTION
Overview
----------------------------------------
These lines, they do nothing.

Full details at https://lab.civicrm.org/dev/translation/issues/37, which even includes a table(!)

Technical Details
----------------------------------------
Other than the interesting history, the main thing to note is that `$row['activity_type']` is the option value LABEL, so if you follow the table thru it never has any effect.