### PR TITLE
dev/core#1615 - Fix for recently migrated civicrm-setup

### DIFF
--- a/setup/civicrm-setup-autoload.php
+++ b/setup/civicrm-setup-autoload.php
@@ -1,0 +1,13 @@
+<?php
+
+// This file was provided in previous builds of `civicrm-setup`. It served two purposes:
+//
+// 1. Defining the classloader for `civicrm-setup/src/**.php`
+// 2. Defining a flag to help search for a copy of `civicrm-setup`.
+//    (To wit: If a folder has this file, then it must be a valid copy of `civicrm-setup`.
+//    Otherwise, move on and look for civicrm-setup in another location.)
+//
+// The extant consumers enable both the `civicrm-setup` and `civicrm-core` classloaders. But
+// now that civicrm-setup is in core, this classloader is redundant. Thus, an empty file.
+//
+// However, we still need the file to exist for the second purpose (as a flag).


### PR DESCRIPTION
Overview
--------

Fix a recent (intra-alpha) regression from https://github.com/civicrm/civicrm-core/pull/16618

The search for `civicrm-setup` goes slightly awry because the migrated copy of civicrm-setup uses the core's classloader rather than its own classloader.

Steps to Reproduce
------------------

* Create a site with WP and Civi(master).
* Ensure Civi is uninstalled. (ex: `cv core:uninstall -f`)
* In `wp-content/plugins/civicrm/civicrm`, touch the file `.use-civicrm-setup`.
  (*This is supposed to activate the new UI.*)
* Go to the WP admin console. In the left navbar, choose "CiviCRM Installer".

Before
------

It fails to load the new UI -- the search finds `.use-civicrm-setup` but does not find `civicrm-setup-autoload.php`. It falls back to the old UI.

After
-----

It opens the new UI.
