### PR TITLE
Fix values passed to tokenValues hook

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -204,6 +204,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
     $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts, TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, $primaryLocationOnly);
     $messageToken = CRM_Utils_Token::getTokens($mailingFormat);
 
+    // $details[0] is an array of [ contactID => contactDetails ]
     // also get all token values
     CRM_Utils_Hook::tokenValues($details[0],
       $this->_contactIds,

--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -140,6 +140,7 @@ class CRM_Contact_Form_Task_LabelCommon {
     $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts);
 
     $messageToken = CRM_Utils_Token::getTokens($mailingFormat);
+    // $details[0] is an array of [ contactID => contactDetails ]
     $details = $details[0];
     $tokenFields = CRM_Contact_Form_Task_LabelCommon::getTokenData($details);
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1080,15 +1080,18 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     elseif ($contactId === 0) {
       //anonymous user
       $contact = [];
-      CRM_Utils_Hook::tokenValues($contact, $contactId, $job_id);
+      CRM_Utils_Hook::tokenValues($contact, [$contactId], $job_id);
     }
     else {
       $params = [['contact_id', '=', $contactId, 0, 0]];
       list($contact) = CRM_Contact_BAO_Query::apiQuery($params);
+      // $contact is an array of [ contactID => contactDetails ]
 
-      //CRM-4524
+      // also call the hook to get contact details
+      CRM_Utils_Hook::tokenValues($contact, [$contactId], $job_id);
+
+      // Don't send if contact doesn't exist
       $contact = reset($contact);
-
       if (!$contact || is_a($contact, 'CRM_Core_Error')) {
         CRM_Core_Error::debug_log_message(ts('CiviMail will not send email to a non-existent contact: %1',
           [1 => $contactId]
@@ -1098,9 +1101,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         $res = NULL;
         return $res;
       }
-
-      // also call the hook to get contact details
-      CRM_Utils_Hook::tokenValues($contact, $contactId, $job_id);
     }
 
     $pTemplates = $this->getPreparedTemplates();

--- a/CRM/Mailing/Page/Preview.php
+++ b/CRM/Mailing/Page/Preview.php
@@ -66,7 +66,7 @@ class CRM_Mailing_Page_Preview extends CRM_Core_Page {
       $mailing->getFlattenedTokens(),
       get_class($this)
     );
-
+    // $details[0] is an array of [ contactID => contactDetails ]
     $mime = &$mailing->compose(NULL, NULL, NULL, $session->get('userID'), $fromEmail, $fromEmail,
       TRUE, $details[0][$session->get('userID')], $attachments
     );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -884,7 +884,7 @@ abstract class CRM_Utils_Hook {
    * tokens returned by the 'tokens' hook
    *
    * @param array $details
-   *   The array to store the token values indexed by contactIDs (unless it a single).
+   *   The array to store the token values indexed by contactIDs.
    * @param array $contactIDs
    *   An array of contactIDs.
    * @param int $jobID

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1228,7 +1228,6 @@ class CRM_Utils_Token {
     }
 
     $details = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, count($contactIDs), TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, TRUE);
-
     $contactDetails = &$details[0];
 
     foreach ($contactIDs as $contactID) {
@@ -1263,8 +1262,9 @@ class CRM_Utils_Token {
       }
     }
 
+    // $contactDetails = &$details[0] = is an array of [ contactID => contactDetails ]
     // also call a hook and get token details
-    CRM_Utils_Hook::tokenValues($details[0],
+    CRM_Utils_Hook::tokenValues($contactDetails,
       $contactIDs,
       $jobID,
       $tokens,
@@ -1291,9 +1291,7 @@ class CRM_Utils_Token {
    * @return array
    *   contactDetails with hooks swapped out
    */
-  public static function getAnonymousTokenDetails($contactIDs = [
-    0,
-  ],
+  public static function getAnonymousTokenDetails($contactIDs = [0],
                                            $returnProperties = NULL,
                                            $skipOnHold = TRUE,
                                            $skipDeceased = TRUE,

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -89,12 +89,9 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $contact = array_merge($contact, $row->context['tmpTokenParams']);
       }
 
-      $contactArray = !is_array($contactId) ? [$contactId => $contact] : $contact;
-
-      // Note: This is a small contract change from the past; data should be missing
-      // less randomly.
+      $contactArray = [$contactId => $contact];
       \CRM_Utils_Hook::tokenValues($contactArray,
-        (array) $contactId,
+        [$contactId],
         empty($row->context['mailingJobId']) ? NULL : $row->context['mailingJobId'],
         $messageTokens,
         $row->context['controller']


### PR DESCRIPTION
Overview
----------------------------------------
Originally identified by @MegaphoneJon in the emailapi extension. Also ping @magnolia61 https://lab.civicrm.org/extensions/emailapi/-/merge_requests/6

There are places in CiviCRM core that are not calling this hook correctly (and not in accordance with the documentation). Depending on the "route" through core this leads to missing tokens or unexpected data.

It has been documented correctly for some time:
See: https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_tokenValues/

Before
----------------------------------------
Some calls from core not using correct parameters for `hook_civicrm_tokenValues`

After
----------------------------------------
All core calls using correct (documented) parameters for `hook_civicrm_tokenValues`.

Technical Details
----------------------------------------
Parameter 1 should be an array of keyed contactID => detail.
Parameter 2 should *always* be an array of contact IDs.

Comments
----------------------------------------
There is a chance that this will cause some breakage to custom integrations if they are using custom tokens and this hook. But they are likely already experiencing breakage when called via "other" routes.
