### PR TITLE
TokenProcessor - fix greetings tokens

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -120,12 +120,11 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $e->string = \CRM_Utils_Token::replaceDomainTokens($e->string, $domain, $isHtml, $e->message['tokens'], $useSmarty);
 
     if (!empty($e->context['contact'])) {
+      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, $useSmarty);
       $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], TRUE, $useSmarty);
 
       // FIXME: This may depend on $contact being merged with hook values.
       $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
-
-      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, $useSmarty);
     }
 
     if ($useSmarty) {

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -147,4 +147,52 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * This is a basic test of the token processor (currently testing TokenCompatSubscriber)
+   *   and makes sure that greeting + contact tokens are replaced.
+   * This is a good example to copy/expand when creating additional tests for token processor
+   *   in "real" situations.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testTokenProcessor() {
+    $params['contact_id'] = $this->individualCreate();
+
+    // Prepare the processor and general context.
+    $tokenProc = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), [
+      // Unique(ish) identifier for our controller/use-case.
+      'controller' => 'civicrm_tokentest',
+
+      // Provide hints about what data will be available for each row.
+      // Ex: 'schema' => ['contactId', 'activityId', 'caseId'],
+      'schema' => ['contactId'],
+
+      // Whether to enable Smarty evaluation.
+      'smarty' => (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY),
+    ]);
+
+    // Define message templates.
+    $tokenProc->addMessage('body_html', 'Good morning, <p>{contact.email_greeting} {contact.display_name}</p>. {custom.foobar} Bye!', 'text/html');
+    $tokenProc->addMessage('body_text', 'Good morning, {contact.email_greeting} {contact.display_name} Bye!', 'text/plain');
+
+    $expect[$params['contact_id']]['html'] = 'Good morning, <p>Dear Anthony Mr. Anthony Anderson II</p>.  Bye!';
+    $expect[$params['contact_id']]['text'] = 'Good morning, Dear Anthony Mr. Anthony Anderson II Bye!';
+
+    // Define row data.
+    foreach (explode(',', $params['contact_id']) as $contactId) {
+      $context = ['contactId' => $contactId];
+      $tokenProc->addRow()->context($context);
+    }
+
+    $tokenProc->evaluate();
+
+    foreach ($tokenProc->getRows() as $tokenRow) {
+      /** @var \Civi\Token\TokenRow $tokenRow */
+      $html = $tokenRow->render('body_html');
+      $text = $tokenRow->render('body_text');
+      $this->assertEquals($expect[$params['contact_id']]['html'], $html);
+      $this->assertEquals($expect[$params['contact_id']]['text'], $text);
+    }
+  }
+
 }

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -186,6 +186,7 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
 
     $tokenProc->evaluate();
 
+    $this->assertNotEmpty($tokenProc->getRows());
     foreach ($tokenProc->getRows() as $tokenRow) {
       /** @var \Civi\Token\TokenRow $tokenRow */
       $html = $tokenRow->render('body_html');


### PR DESCRIPTION
Overview
----------------------------------------
replaceGreetingsTokens must be called before replaceContactTokens because replaceContactTokens removes all 'invalid' tokens (including the `{contact.email_greeting}` etc. so they don't get replaced.

Found while working on emailapi extension and tokenprocessor.

Before
----------------------------------------
Greetings tokens not replaced.

After
----------------------------------------
Greetings tokens replaced.

Technical Details
----------------------------------------
TokenCompatSubscriber is a compatibility layer between contact tokens and the new token processor. So this change *only* affects code that uses the tokenProcessor (which is just scheduled reminders).

Also see CRM/Core/BAO/MessageTemplate.php where it is called in the same order as this PR.

Aside, I don't understand why we have separate functions for contact greetings and contact tokens - and why replaceContactTokens can't just call replaceGreetingTokens or similar (currently it's the other way around and replaceGreetingTokens calls replaceContactTokens internally! Ugh!

Comments
----------------------------------------
@aydun any chance of a quick review so we can get this into 5.24 with all the other tokenProcessor improvements that have already gone in. @eileenmcnaughton 