### PR TITLE
Fixed DB Error: syntax error if line item refers to civicrm_case

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -186,8 +186,8 @@ WHERE li.contribution_id = %1";
    */
   public static function getLineItems($entityId, $entity = 'participant', $isQuick = FALSE, $isQtyZero = TRUE, $relatedEntity = FALSE) {
     $whereClause = $fromClause = NULL;
-    $selectClause = "
-      SELECT    li.id,
+    $selectClause = '
+      SELECT li.id,
       li.label,
       li.contribution_id,
       li.qty,
@@ -205,19 +205,19 @@ WHERE li.contribution_id = %1";
       li.price_field_value_id,
       li.financial_type_id,
       li.tax_amount,
-      pfv.description";
+      pfv.description';
 
-    $condition = "li.entity_id = %2.id AND li.entity_table = 'civicrm_%2'";
+    $condition = "li.entity_id = civicrm_%2.id AND li.entity_table = 'civicrm_%2'";
     if ($relatedEntity) {
-      $condition = "li.contribution_id = %2.id ";
+      $condition = 'li.contribution_id = civicrm_%2.id ';
     }
 
     $fromClause = "
-      FROM      civicrm_%2 as %2
+      FROM civicrm_%2
       LEFT JOIN civicrm_line_item li ON ({$condition})
-      LEFT JOIN civicrm_price_field_value pfv ON ( pfv.id = li.price_field_value_id )
+      LEFT JOIN civicrm_price_field_value pfv ON (pfv.id = li.price_field_value_id)
       LEFT JOIN civicrm_price_field pf ON (pf.id = li.price_field_id )";
-    $whereClause = " WHERE     %2.id = %1";
+    $whereClause = " WHERE civicrm_%2.id = %1";
     $orderByClause = " ORDER BY pf.weight, pfv.weight";
 
     if ($isQuick) {


### PR DESCRIPTION
Overview
----------------------------------------
This is unusual case and won't be replicated without having custom extension. CiviCRM line item table allows to specify entity tables to refer to any table. If we store line item for case via custom extension than getLineItems throws DB Error: syntax error.  The reason for using getLineItems() function in an extension is it provides additional details about the line items which are missing in lineitem get api method.

Before
----------------------------------------
```
[message] => DB Error: syntax error
    [mode] => 16
    [debug_info] => 
      SELECT    li.id,
      li.label,
      li.contribution_id,
      li.qty,
      li.unit_price,
      li.line_total,
      li.entity_table,
      li.entity_id,
      pf.label as field_title,
      pf.html_type,
      pf.price_set_id,
      pfv.membership_type_id,
      pfv.membership_num_terms,
      li.price_field_id,
      li.participant_count,
      li.price_field_value_id,
      li.financial_type_id,
      li.tax_amount,
      pfv.description 
      FROM      civicrm_case as case
      LEFT JOIN civicrm_line_item li ON (li.entity_id = case.id AND li.entity_table = 'civicrm_case')
      LEFT JOIN civicrm_price_field_value pfv ON ( pfv.id = li.price_field_value_id )
      LEFT JOIN civicrm_price_field pf ON (pf.id = li.price_field_id ) 
      WHERE     case.id = 14  ORDER BY pf.weight, pfv.weight [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'case
      LEFT JOIN civicrm_line_item li ON (li.entity_id = case.id AND li.enti' at line 20]
```

After
----------------------------------------
No error