### PR TITLE
[REF] Apply fix for CRM-607 for when building the select section of t…

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -198,6 +198,10 @@ SELECT f.id, f.label, f.data_type,
     }
 
     foreach (array_keys($this->_ids) as $id) {
+      // Ignore any custom field ids within the ids array that are not present in the fields array.
+      if (empty($this->_fields[$id])) {
+        continue;
+      }
       $field = $this->_fields[$id];
 
       if ($this->_contactSearch && $field['search_table'] === 'contact_a') {


### PR DESCRIPTION
…he query as well as in where

Overview
----------------------------------------
This aims to apply the fix for CRM-607 to the select function as well as in the Where clause. Australian Greens found a problem where by a smart group was referencing 3 fields  that were no longer existing in the database this caused problems because it would try and join but as NULL was being passed to joinCustomTableForField then it caused a syntax error

Before
----------------------------------------
Syntax error can be caused in  a specific way

After
----------------------------------------
No syntax error

ping @andrew-cormick-dockery @johntwyman @eileenmcnaughton 