### PR TITLE
CommunicationPreferences 'loclize' -> 'localize'

### DIFF
--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -51,7 +51,7 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
     $form->addGroup($privacy, 'privacy', ts('Privacy'), '&nbsp;<br/>');
 
     // preferred communication method
-    $comm = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method', ['loclize' => TRUE]);
+    $comm = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method', ['localize' => TRUE]);
     foreach ($comm as $value => $title) {
       $commPreff[] = $form->createElement('advcheckbox', $value, NULL, $title);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Localize option for getting communication preferences on edit form has a typo.


Technical Details
----------------------------------------

```php
CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method', ['localize' => TRUE]);
```

```php
class CRM_Core_PseudoConstant {
  [...]
  public static function get($daoName, $fieldName, $params = [], $context = NULL) {
    [...]
    // Historically this was 'false' but according to the notes in
    // CRM_Core_DAO::buildOptionsContext it should be context dependent.
    // timidly changing for 'search' only to fix world_region in search options.
    $localizeDefault = in_array($context, ['search']) ? TRUE : FALSE;
    // Merge params with defaults
    $params += [
      'localize' => $localizeDefault,
    [...]

```