### PR TITLE
dev/core#1622 Fix unsubscribe when loading the unsubscribe form on a …

### DIFF
--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -128,10 +128,8 @@ WHERE  email = %2
     $mailing_type = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $mailing_id, 'mailing_type', 'id');
 
     $groupObject = new CRM_Contact_BAO_Group();
-    $groupTableName = $groupObject->getTableName();
 
     $mailingObject = new CRM_Mailing_BAO_Mailing();
-    $mailingTableName = $mailingObject->getTableName();
 
     // We need a mailing id that points to the mailing that defined the recipients.
     // This is usually just the passed-in mailing_id, however in the case of AB
@@ -175,7 +173,8 @@ WHERE  email = %2
     $mailings = [];
 
     while ($do->fetch()) {
-      if ($do->entity_table === $groupTableName) {
+      // @todo this is should be a temporary measure until we stop storing the translated table name in the database
+      if (substr($do->entity_table, 0, 13) === 'civicrm_group') {
         if ($do->group_type == 'Base') {
           $base_groups[$do->entity_id] = NULL;
         }
@@ -183,7 +182,8 @@ WHERE  email = %2
           $groups[$do->entity_id] = NULL;
         }
       }
-      elseif ($do->entity_table === $mailingTableName) {
+      elseif (substr($do->entity_table, 0, 15) === 'civicrm_mailing') {
+        // @todo this is should be a temporary measure until we stop storing the translated table name in the database
         $mailings[] = $do->entity_id;
       }
     }
@@ -202,10 +202,12 @@ WHERE  email = %2
       $mailings = [];
 
       while ($do->fetch()) {
-        if ($do->entity_table === $groupTableName) {
+        // @todo this is should be a temporary measure until we stop storing the translated table name in the database
+        if (substr($do->entity_table, 0, 13) === 'civicrm_group') {
           $groups[$do->entity_id] = TRUE;
         }
-        elseif ($do->entity_table === $mailing) {
+        elseif (substr($do->entity_table, 0, 15) === 'civicrm_mailing') {
+          // @todo this is should be a temporary measure until we stop storing the translated table name in the database
           $mailings[] = $do->entity_id;
         }
       }

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -160,6 +160,7 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
     // (If this behaviour ever changes we throw an exception.)
     if ($isMultiLingual) {
       $this->enableMultilingual();
+      CRM_Core_I18n_Schema::addLocale('fr_FR', 'en_US');
     }
     $max_group_id = CRM_Core_DAO::singleValueQuery("SELECT MAX(id) FROM civicrm_group");
     $max_mailing_id = 0;
@@ -295,6 +296,31 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
     $this->assertNotEmpty($groups, "We should have received an array.");
     $this->assertEquals([$group_1], array_keys($groups),
       "We should have received an array with our group 1 in it.");
+
+    if ($isMultiLingual) {
+      global $dbLocale;
+      $dbLocale = '_fr_FR';
+      // Now test unsubscribe groups.
+      $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing(
+        $matches[1],
+        $matches[2],
+        $matches[3],
+        TRUE
+      );
+
+      // We expect that our group_1 was found.
+      $this->assertEquals(['groups' => [$group_1], 'baseGroups' => []], $found);
+
+      // We *should* get an array with just our $group_1 since this is the only group
+      // that we have included.
+      // $group_2 was only used to exclude people.
+      // $group_3 has nothing to do with this mailing and should not be there.
+      $this->assertNotEmpty($groups, "We should have received an array.");
+      $this->assertEquals([$group_1], array_keys($groups),
+        "We should have received an array with our group 1 in it.");
+      global $dbLocale;
+      $dbLocale = '_en_US';
+    }
   }
 
 }


### PR DESCRIPTION
…different locale to the one the mailing was sent from

Overview
----------------------------------------
This aims to fix a bug where by if you create and send mailing on locale 1 e.g. en_US but then load the unsubscribe form on locale 2 e.g. fr_FR the unsubscribe form does not show the correct list of groups. 

Before
----------------------------------------
Incorrect list of groups shown if loading unsubscribe form on locale other than the locale used to send the mailing

After
----------------------------------------
Correct list of groups shown on unsubscribe form no matter the locale

Technical Details
----------------------------------------
The long and short of is we store the full translated table name in the entity_table and getTableName() will use the current locale to set the table name so if your on a different locale to the one the mailing was sent from then it breaks. 

ping @eileenmcnaughton @artfulrobot @mlutfy 