### PR TITLE
Api4 - Display sql errors in explorer

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -84,13 +84,23 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
     }
     catch (Exception $e) {
       http_response_code(500);
-      $response = [
-        'error_code' => $e->getCode(),
-      ];
+      $response = [];
       if (CRM_Core_Permission::check('view debug output')) {
+        $response['error_code'] = $e->getCode();
         $response['error_message'] = $e->getMessage();
-        if (!empty($params['debug']) && \Civi::settings()->get('backtrace')) {
-          $response['debug']['backtrace'] = $e->getTrace();
+        if (!empty($params['debug'])) {
+          if (method_exists($e, 'getUserInfo')) {
+            $response['debug']['info'] = $e->getUserInfo();
+          }
+          $cause = method_exists($e, 'getCause') ? $e->getCause() : $e;
+          if ($cause instanceof \DB_Error) {
+            $response['debug']['db_error'] = \DB::errorMessage($cause->getCode());
+            $response['debug']['sql'][] = $cause->getDebugInfo();
+          }
+          if (\Civi::settings()->get('backtrace')) {
+            // Would prefer getTrace() but that causes json_encode to bomb
+            $response['debug']['backtrace'] = $e->getTraceAsString();
+          }
         }
       }
     }

--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -34,7 +34,7 @@ class Request {
     switch ($params['version'] ?? NULL) {
       case 3:
         return [
-          'id' => self::$nextId++,
+          'id' => self::getNextId(),
           'version' => 3,
           'params' => $params,
           'fields' => NULL,

--- a/api/api.php
+++ b/api/api.php
@@ -15,12 +15,11 @@
  *   create, get, delete or some special action name.
  * @param array $params
  *   array to be passed to function
- * @param null $extra
  *
  * @return array|int
  */
-function civicrm_api(string $entity, string $action, array $params, $extra = NULL) {
-  return \Civi::service('civi_api_kernel')->runSafe($entity, $action, $params, $extra);
+function civicrm_api(string $entity, string $action, array $params) {
+  return \Civi::service('civi_api_kernel')->runSafe($entity, $action, $params);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes display of debug info in Api4 Explorer.

Before
----------------------------------------
No sql shown for db_errors. And due to a json_encode problem, sometimes would show nothing at all.

After
----------------------------------------
Correctly shows backtrace & full sql for db_errors.

![image](https://user-images.githubusercontent.com/2874912/75465987-764ce880-5957-11ea-941b-35523d12eaa2.png)

