### PR TITLE
dev/core#1619 - Fatal error when grouping Activity Summary report by activity date

### DIFF
--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -457,7 +457,9 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
     $insertCols = '';
     $insertQuery = "INSERT INTO {$this->_tempTableName} ( " . implode(',', array_merge(array_keys($this->_columnHeaders), array_keys($unselectedColumns))) . " )
 {$sql}";
+    CRM_Core_DAO::disableFullGroupByMode();
     CRM_Core_DAO::executeQuery($insertQuery);
+    CRM_Core_DAO::reenableFullGroupByMode();
 
     // now build the query for duration sum
     $this->activityDurationFrom();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1619
Run an activity summary civireport and on the grouping tab pick activity date. Pick any frequency. Gives a fatal error.

Before
----------------------------------------
Invalid query. Fatal error.

After
----------------------------------------
Query still invalid, but worked around by disabling ONLY_FULL_GROUP_BY.

Technical Details
----------------------------------------
ONLY_FULL_GROUP_BY

Comments
----------------------------------------
Adds a test.
