### PR TITLE
[NFC] Use insert ignore for inserts into civicrm_extension to stop warnings on duplicate entry for sequential credit notes extension

### DIFF
--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1780,4 +1780,4 @@ VALUES
 -- Note this is a limited interim technique for installing core extensions -  the goal is that core extensions would be installed
 -- in the setup routine based on their tags & using the standard extension install api.
 -- do not try this at home folks.
-INSERT INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'sequentialcreditnotes', 'Sequential credit notes', 'Sequential credit notes', 'sequentialcreditnotes', 1);
+INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'sequentialcreditnotes', 'Sequential credit notes', 'Sequential credit notes', 'sequentialcreditnotes', 1);


### PR DESCRIPTION
Overview
----------------------------------------
This resolved notices such as 

```
/home/jenkins/bknix-dfl/build/core-16642-770zv/web/sites/all/modules/civicrm/Civi/Test.php:205:
bool(false)
/home/jenkins/bknix-dfl/build/core-16642-770zv/web/sites/all/modules/civicrm/Civi/Test.php:206:
array(3) {
  [0] =>
  string(5) "23000"
  [1] =>
  int(1062)
  [2] =>
  string(72) "Duplicate entry 'sequentialcreditnotes' for key 'UI_extension_full_name'"
}
```
occurring when running tests 

Before
----------------------------------------
Notices show

After
----------------------------------------
No notices

Technical Details
----------------------------------------
The issue is that civicrm_extension table is not 'cleaned' out between test runs unlike other tables to ensure that we don't remove information on enabled extensions. This adds in some logic specific to the sequential credit notes extension as it is added via the civicrm_data.mysql file

ping @demeritcowboy @eileenmcnaughton @totten 
