### PR TITLE
core#1623: My Case dashlet doesn't sort by name but contact_id instead

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -594,7 +594,7 @@ HERESQL;
       );
 
       $phone = empty($case['phone']) ? '' : '<br /><span class="description">' . $case['phone'] . '</span>';
-      $casesList[$key]['contact_id'] = sprintf('<a href="%s">%s</a>%s<br /><span class="description">%s: %d</span>',
+      $casesList[$key]['sort_name'] = sprintf('<a href="%s">%s</a>%s<br /><span class="description">%s: %d</span>',
         CRM_Utils_System::url('civicrm/contact/view', ['cid' => $case['contact_id']]),
         $case['sort_name'],
         $phone,

--- a/CRM/Utils/JSON.php
+++ b/CRM/Utils/JSON.php
@@ -25,6 +25,9 @@ class CRM_Utils_JSON {
    * @param mixed $input
    */
   public static function output($input) {
+    if (CIVICRM_UF === 'UnitTests') {
+      throw new CRM_Core_Exception_PrematureExitException('civiExit called', $input);
+    }
     CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
     echo json_encode($input);
     CRM_Utils_System::civiExit();

--- a/templates/CRM/Case/Page/DashboardSelector.tpl
+++ b/templates/CRM/Case/Page/DashboardSelector.tpl
@@ -13,7 +13,7 @@
 <thead>
   <tr>
     <th data-data="activity_list" data-orderable="false" class="crm-case-activity_list"></th>
-    <th data-data="contact_id" class="crm-case-contact">{ts}Contact{/ts}</th>
+    <th data-data="sort_name" class="crm-case-contact">{ts}Contact{/ts}</th>
     <th data-data="subject" cell-class="crmf-subject crm-editable" class="crm-case-subject">{ts}Subject{/ts}</th>
     <th data-data="case_status" class="crm-case-status">{ts}Status{/ts}</th>
     <th data-data="case_type" class="crm-case-type">{ts}Type{/ts}</th>

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -137,6 +137,115 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
   }
 
   /**
+   * core/issue-1623: My Case dashlet doesn't sort by name but contact_id instead
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSortByCaseContact() {
+    // delete any cases if present
+    $this->callAPISuccess('Case', 'get', ['api.Case.delete' => ['id' => '$value.id']]);
+
+    // create three contacts with different name, later used in respective cases
+    $contacts = [
+      $this->individualCreate(['first_name' => 'Antonia', 'last_name' => 'D`souza']),
+      $this->individualCreate(['first_name' => 'Darric', 'last_name' => 'Roy']),
+      $this->individualCreate(['first_name' => 'Adam', 'last_name' => 'Pitt']),
+    ];
+    $loggedInUser = $this->createLoggedInUser();
+    $relationshipType = $this->relationshipTypeCreate([
+      'contact_type_b' => 'Individual',
+    ]);
+
+    // create cases for each contact
+    $cases = [];
+    foreach ($contacts as $contactID) {
+      $cases[] = $caseID = $this->createCase($contactID)->id;
+      $this->callAPISuccess('Relationship', 'create', [
+        'contact_id_a'         => $contactID,
+        'contact_id_b'         => $loggedInUser,
+        'relationship_type_id' => $relationshipType,
+        'case_id'              => $caseID,
+        'is_active'            => TRUE,
+      ]);
+    }
+
+    // USECASE A: fetch all cases using the AJAX fn without any sorting criteria, and match the result
+    global $_GET;
+    $_GET = [
+      'start' => 0,
+      'length' => 10,
+      'type' => 'any',
+      'all' => 1,
+      'is_unittest' => 1,
+    ];
+
+    $cases = [];
+    try {
+      CRM_Case_Page_AJAX::getCases();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $cases = $e->errorData['data'];
+    }
+
+    // list of expected sorted names in order the respective cases were created
+    $unsortedExpectedContactNames = [
+      'D`souza, Antonia',
+      'Roy, Darric',
+      'Pitt, Adam',
+    ];
+    $unsortedActualContactNames = CRM_Utils_Array::collect('sort_name', $cases);
+    foreach ($unsortedExpectedContactNames as $key => $name) {
+      $this->assertContains($name, $unsortedActualContactNames[$key]);
+    }
+
+    // USECASE B: fetch all cases using the AJAX fn based any 'Contact' sorting criteria, and match the result against expected sequence of names
+    $_GET = [
+      'start' => 0,
+      'length' => 10,
+      'type' => 'any',
+      'all' => 1,
+      'is_unittest' => 1,
+      'columns' => [
+        1 => [
+          'data' => 'sort_name',
+          'name' => NULL,
+          'searchable' => TRUE,
+          'orderable' => TRUE,
+          'search' => [
+            'value' => NULL,
+            'regex' => FALSE,
+          ],
+        ],
+      ],
+      'order' => [
+        [
+          'column' => 1,
+          'dir' => 'asc',
+        ],
+      ],
+    ];
+
+    $cases = [];
+    try {
+      CRM_Case_Page_AJAX::getCases();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $cases = $e->errorData['data'];
+    }
+
+    // list of expected sorted names in ASC order
+    $sortedExpectedContactNames = [
+      'D`souza, Antonia',
+      'Pitt, Adam',
+      'Roy, Darric',
+    ];
+    $sortedActualContactNames = CRM_Utils_Array::collect('sort_name', $cases);
+    foreach ($sortedExpectedContactNames as $key => $name) {
+      $this->assertContains($name, $sortedActualContactNames[$key]);
+    }
+  }
+
+  /**
    * Test that Case count is exactly one for logged in user for user's active role.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
My Case dashlet doesn't sort by name but contact_id instead

Steps to replicate:
1. Enable CiviCase component
2. Create multiple case for different contact
3. Go to dashboard and add 'My Cases' dashlet.
4. Try to sort by 'Contact'

Before
----------------------------------------
![after](https://lab.civicrm.org/dev/core/uploads/e365f2ba1e39512e79ebffb165f54ade/after.gif)

After
----------------------------------------
_Expected behaviour_ : As you can sort by 'Contact' doesn't consider the name. Internally it is sorted by contact ID which is not correct, which should be by sort name.

![after](https://user-images.githubusercontent.com/3735621/75530504-cbf9c180-5a39-11ea-9762-28a6ada920bc.gif)


Technical Details
----------------------------------------
The fix is in core BAO fn and its been called in various places in codebase: 
```
Monishs-MacBook-Pro:civicrm-core monish$ grep -irn "CRM_Case_BAO_Case::getCases(" CRM/
CRM//Contact/BAO/Relationship.php:1459:              $userCases = CRM_Case_BAO_Case::getCases(FALSE);
CRM//Dashlet/Page/MyCases.php:49:    if (CRM_Case_BAO_Case::getCases(FALSE, ['type' => 'any'], $context, TRUE)) {
CRM//Dashlet/Page/AllCases.php:49:    if (CRM_Case_BAO_Case::getCases(TRUE, ['type' => 'any'], 'dashboard', TRUE)) {
CRM//Case/Page/DashBoard.php:71:    $upcoming = CRM_Case_BAO_Case::getCases($allCases, [], 'dashboard', TRUE);
CRM//Case/Page/DashBoard.php:72:    $recent = CRM_Case_BAO_Case::getCases($allCases, ['type' => 'recent'], 'dashboard', TRUE);
CRM//Case/Page/AJAX.php:188:    $cases = CRM_Case_BAO_Case::getCases($allCases, $params);
CRM//Case/Page/Tab.php:54:          $userCases = CRM_Case_BAO_Case::getCases(FALSE, ['type' => 'any']);
CRM//Case/Form/Activity.php:96:      $allCases = CRM_Case_BAO_Case::getCases(TRUE, $params);
CRM//Case/BAO/Case.php:1852:      $filterCases = CRM_Case_BAO_Case::getCases(FALSE);
```
Checked the impact of changing the key from contact_id to sort_name on each case and its safe. 

