### PR TITLE
Fix Case Audit Report formatting for non-English

### DIFF
--- a/templates/CRM/Case/Audit/Report.tpl
+++ b/templates/CRM/Case/Audit/Report.tpl
@@ -135,9 +135,9 @@
       {foreach from=$activity item=field name=fieldloop}
         <tr class="crm-case-report-activity-{$field.label}">
           <th scope="row" class="label">{$field.label|escape}</th>
-          {if $field.label eq 'Activity Type' or $field.label eq 'Status'}
+          {if $field.label eq ts('Activity Type') or $field.label eq ts('Status')}
             <td class="bold">{$field.value|escape}</td>
-          {elseif $field.label eq 'Details' or $field.label eq 'Subject'}
+          {elseif $field.label eq ts('Details') or $field.label eq ts('Subject')}
             <td>{$field.value}</td>
           {else}
             <td>{$field.value|escape}</td>


### PR DESCRIPTION
Overview
----------------------------------------

When using CiviCase in another language than English (ex: French), the Case Activity Audit Report displays HTML for the Activity Details field:

![Capture d’écran de 2020-02-28 15-33-52](https://user-images.githubusercontent.com/254741/75585344-db7c0900-5a3f-11ea-83cc-1041a9969bd4.png)

To reproduce:

* Switch the CiviCRM language to French (make sure you have i18n files)
* Enable CiviCase
* Create a Case, add an activity to that case (with a few newlines and throw in a bit of bold formatting).
* Then go back to the Case, and click "Print Report" (Imprimer le rapport)

Before
----------------------------------------

Case Activity Audit Report displays HTML.

After
----------------------------------------

Displays correctly.

Technical Details
----------------------------------------

I don't like the fix, because we should avoid relying on translations this way, but doing a better fix would be a bit tedious.

Also,

- I'm not sure the "subject" field should be printed unescaped?
- I was hesitating to use "datatype == Memo", but I gues custom fields might be a Memo, but not necessarily have the WYSIWYG?

ping @demeritcowboy 