### PR TITLE
dev/core#1613/Updated Misleading labels

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -479,7 +479,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (!($allAreBillingModeProcessors && !$this->_values['is_pay_later'])) {
       $submitButton = [
         'type' => 'upload',
-        'name' => !empty($this->_values['is_confirm_enabled']) ? ts('Confirm Contribution') : ts('Contribute'),
+        'name' => !empty($this->_values['is_confirm_enabled']) ? ts('Review your contribution') : ts('Contribute'),
         'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
         'isDefault' => TRUE,
       ];

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -475,7 +475,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $buttonLabel = ts('Register');
       }
       else {
-        $buttonLabel = ts('Continue');
+        $buttonLabel = ts('Review your registration');
       }
 
       $this->addButtons([


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

Overview
----------------------------------------
Update the misleading labels on public Contribution and Registration forms, as mentioned in dev/core#1613 . Changed 'confirm payment' to 'Review your contribution' on contribution form and 'continue' on registration page to 'Review your registration' .
