### PR TITLE
CiviCase: fix case custom data values in Case Audit Report

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -956,26 +956,14 @@ LIMIT  1
 
     // Retrieve custom values for cases.
     $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($caseID, 'Case');
-    $extends = array('case');
-    $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
-    $caseCustomFields = array();
-    foreach ($groupTree as $gid => $group_values) {
-      foreach ($group_values['fields'] as $id => $field_values) {
-        if (array_key_exists($id, $customValues)) {
-          $caseCustomFields[$gid]['title'] = $group_values['title'];
-          $caseCustomFields[$gid]['values'][$id] = array(
-            'label' => $field_values['label'],
-            'value' => $customValues[$id],
-          );
-        }
-      }
-    }
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Case', NULL, $caseID);
+    CRM_Core_BAO_CustomGroup::buildCustomDataView($template, $groupTree, FALSE, NULL, NULL, NULL, $caseID);
+
     $template->assign('caseRelationships', $caseRelationships);
     $template->assign('caseRoles', $caseRoles);
     $template->assign('otherRelationships', $otherRelationships);
     $template->assign('globalRelationships', $relGlobal);
     $template->assign('globalGroupInfo', $globalGroupInfo);
-    $template->assign('caseCustomFields', $caseCustomFields);
     $contents = self::getCaseReport($clientID,
       $caseID,
       $activitySetName,

--- a/templates/CRM/Case/Audit/Report.tpl
+++ b/templates/CRM/Case/Audit/Report.tpl
@@ -114,17 +114,19 @@
     </table>
 {/if}
 
-{if $caseCustomFields}
-  {foreach from=$caseCustomFields item=group}
-    <h2>{$group.title}</h2>
-      <table class ="report-layout">
-        {foreach from=$group.values item=row}
-          <tr>
-            <th class="label">{$row.label}</td>
-            <td class="crm-case-report-custom-field">{$row.value}</td>
-          </tr>
-        {/foreach}
-    </table>
+{if $viewCustomData}
+  {foreach from=$viewCustomData item=cd}
+    {foreach from=$cd item=group}
+      <h2>{$group.title}</h2>
+        <table class="report-layout">
+          {foreach from=$group.fields item=row}
+            <tr>
+              <th class="label">{$row.field_title}</td>
+              <td class="crm-case-report-custom-field">{$row.field_value}</td>
+            </tr>
+          {/foreach}
+      </table>
+    {/foreach}
   {/foreach}
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

* Create a new Case Custom Field of type "alphanumeric" and widget "checkbox", with a few options that use a numeric value, string label (ex: Case Type, "1 = Blue, 2 = Green").
* Create a new Case
* Print the Case Report

The custom field will be printed in numeric form, instead of string.

Before
----------------------------------------

![Capture d’écran de 2020-02-28 16-53-26](https://user-images.githubusercontent.com/254741/75590305-0fa8f700-5a4b-11ea-9e63-4b58b4eea906.png)

After
----------------------------------------

![Capture d’écran de 2020-02-28 16-55-43](https://user-images.githubusercontent.com/254741/75590368-2e0ef280-5a4b-11ea-8351-75aa8d6851f8.png)

Technical Details
----------------------------------------

To be perfectly honest, these CustomData BAOs are pretty scary and I'm not sure I am using them correctly. :man_shrugging: 

cc @demeritcowboy 