### PR TITLE
[Feature] Add in new hook alterUFFields to allow extensions to modify…

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -1031,6 +1031,7 @@ SELECT  id
       unset($fields[$value['field_type']][$key]);
     }
 
+    // Allow extensions to alter the array of entity => fields permissible in a CiviCRM Profile.
     CRM_Utils_Hook::alterUFFields($fields);
     return $fields;
   }

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -1031,6 +1031,7 @@ SELECT  id
       unset($fields[$value['field_type']][$key]);
     }
 
+    CRM_Utils_Hook::alterUFFields($fields);
     return $fields;
   }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2634,6 +2634,7 @@ abstract class CRM_Utils_Hook {
   /**
    * Allow extensions to modify the array of acceptable fields to be included on profiles
    * @param array $fields
+   *   format is [Entity => array of DAO fields]
    * @return mixed
    */
   public static function alterUFFields(&$fields) {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2631,4 +2631,17 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * Allow extensions to modify the array of acceptable fields to be included on profiles
+   * @param array $fields
+   * @return mixed
+   */
+  public static function alterUFFields(&$fields) {
+    return self::singleton()->invoke(['fields'],
+      $fields, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_alterUFFields'
+    );
+  }
+
 }

--- a/tests/phpunit/CRM/Core/BAO/UFFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/UFFieldTest.php
@@ -218,4 +218,20 @@ class CRM_Core_BAO_UFFieldTest extends CiviUnitTestCase {
     return $ufGroup->id;
   }
 
+  /**
+   * Test ability to modify the acceptable fields for use in a profile via hook
+   */
+  public function testGetFieldsFlatModifiedByHook() {
+    unset(Civi::$statics['UFFieldsFlat']);
+    $this->hookClass->setHook('civicrm_alterUFFields', [$this, 'modifyUFFields']);
+    $fields = CRM_Core_BAO_UFField::getAvailableFieldsFlat();
+
+    $this->assertEquals('Grant', $fields['grant_id']['field_type']);
+    $this->assertEquals('contact_id', $fields['grant_contact_id']['name']);
+  }
+
+  public function modifyUFFields(&$fields) {
+    $fields['Grant'] = CRM_Grant_DAO_Grant::export();
+  }
+
 }


### PR DESCRIPTION
… which fields can be added to a profile

Overview
----------------------------------------
This adds in a new hook to allow extensions to modify which fields can be included within a profile

Before
----------------------------------------
No ability for extensions to modify fields permitted for a profile / ufField

After
----------------------------------------
Hook added for extensions to be able to modify the array of fields

ping @eileenmcnaughton @colemanw @monishdeb 