### PR TITLE
[REF] Migrate fpdi library to be deployed using composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
     "civicrm/composer-downloads-plugin": "^2.0",
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",
-    "xkerman/restricted-unserialize": "~1.1"
+    "xkerman/restricted-unserialize": "~1.1",
+    "setasign/fpdi":"1.5.*"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "582096c249c04484659162a3e90f7fbd",
+    "content-hash": "3004d65cd6105c0810730e2cf82ed2ce",
     "packages": [
         {
             "name": "cache/integration-tests",
@@ -1799,6 +1799,55 @@
             "time": "2019-02-22T07:42:52+00:00"
         },
         {
+            "name": "setasign/fpdi",
+            "version": "1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI.git",
+                "reference": "911d44f3e58fc956b79a9cc2567f74a6ec86741f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/911d44f3e58fc956b79a9cc2567f74a6ec86741f",
+                "reference": "911d44f3e58fc956b79a9cc2567f74a6ec86741f",
+                "shasum": ""
+            },
+            "suggest": {
+                "setasign/fpdf": "FPDI will extend this class but as it is also possible to use \"tecnick.com/tcpdf\" as an alternative there's no fixed dependency configured.",
+                "setasign/fpdi-fpdf": "Use this package to automatically evaluate dependencies to FPDF.",
+                "setasign/fpdi-tcpdf": "Use this package to automatically evaluate dependencies to TCPDF."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "filters/",
+                    "fpdi.php",
+                    "fpdf_tpl.php",
+                    "fpdi_pdf_parser.php",
+                    "pdf_context.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ],
+            "description": "FPDI is a collection of PHP classes facilitating developers to read pages from existing PDF documents and use them as templates in FPDF. Because it is also possible to use FPDI with TCPDF, there are no fixed dependencies defined. Please see suggestions for packages which evaluates the dependencies automatically.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "time": "2015-05-18T11:02:31+00:00"
+        },
+        {
             "name": "symfony/config",
             "version": "v2.8.50",
             "source": {
@@ -2380,7 +2429,9 @@
             "version": "3.0.0+php53",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip"
+                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "php": ">=5.3.0"


### PR DESCRIPTION
Overview
----------------------------------------
This migrates the installation of the FPDI library from the packages folder to being via composer and upgrades from v1.5.0 to v1.5.4 A diff is here https://gist.github.com/5939e12f232f96a3c0b52c527e96f40b

Before
----------------------------------------
FPDI library deployed via packages folder

After
----------------------------------------
FPDI library deployed using composer

ping @totten @demeritcowboy 