### PR TITLE
Alternate to #16650 - On Case Audit/Print Report richtext details field is getting escaped when system is non-english

### DIFF
--- a/CRM/Case/Audit/Audit.php
+++ b/CRM/Case/Audit/Audit.php
@@ -58,6 +58,9 @@ class CRM_Case_Audit_Audit {
           $datatype_elements = $field->getElementsByTagName("Type");
           $datatype = $datatype_elements->item(0)->nodeValue;
 
+          $name_elements = $field->getElementsByTagName("Name");
+          $name = $name_elements->item(0)->nodeValue;
+
           $label_elements = $field->getElementsByTagName("Label");
           $label = $label_elements->item(0)->nodeValue;
 
@@ -89,6 +92,7 @@ class CRM_Case_Audit_Audit {
 
             if ($this->auditConfig->includeInRegion($label, $region)) {
               $retval[$activityindex][$region][$fieldindex] = [];
+              $retval[$activityindex][$region][$fieldindex]['name'] = $name;
               $retval[$activityindex][$region][$fieldindex]['label'] = $label;
               $retval[$activityindex][$region][$fieldindex]['datatype'] = $datatype;
               $retval[$activityindex][$region][$fieldindex]['value'] = $value;
@@ -104,12 +108,14 @@ class CRM_Case_Audit_Audit {
                 ])
                 ) {
                   $caseActivities[$activityindex][$fieldindex] = [];
+                  $caseActivities[$activityindex][$fieldindex]['name'] = $name;
                   $caseActivities[$activityindex][$fieldindex]['label'] = $label;
                   $caseActivities[$activityindex][$fieldindex]['datatype'] = $datatype;
                   $caseActivities[$activityindex][$fieldindex]['value'] = $value;
                 }
                 else {
                   $activityStatusType[$activityindex][$fieldindex] = [];
+                  $activityStatusType[$activityindex][$fieldindex]['name'] = $name;
                   $activityStatusType[$activityindex][$fieldindex]['label'] = $label;
                   $activityStatusType[$activityindex][$fieldindex]['datatype'] = $datatype;
                   $activityStatusType[$activityindex][$fieldindex]['value'] = $value;

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -313,7 +313,8 @@ WHERE      a.id = %1
       }
 
       $activity['fields'][] = array(
-        'label' => 'Client',
+        'name' => 'Client',
+        'label' => ts('Client'),
         'value' => $this->redact($client),
         'type' => 'String',
       );
@@ -327,9 +328,11 @@ WHERE      a.id = %1
       // Maybe not the best solution.
       $targetNames = CRM_Activity_BAO_ActivityContact::getNames($activityDAO->id, $targetID);
       $processTarget = FALSE;
+      $name = 'With Contact(s)';
       $label = ts('With Contact(s)');
       if (in_array($activityTypeInfo['name'], array('Email', 'Inbound Email'))) {
         $processTarget = TRUE;
+        $name = 'Recipient';
         $label = ts('Recipient');
       }
       if (!$processTarget) {
@@ -359,6 +362,7 @@ WHERE      a.id = %1
         }
 
         $activity['fields'][] = array(
+          'name' => $name,
           'label' => $label,
           'value' => implode('; ', $targetRedacted),
           'type' => 'String',
@@ -368,13 +372,20 @@ WHERE      a.id = %1
 
     // Activity Type info is a special field
     $activity['fields'][] = array(
+      'name' => 'Activity Type',
       'label' => ts('Activity Type'),
       'value' => $activityTypeInfo['label'],
       'type' => 'String',
     );
 
     $activity['fields'][] = array(
+      'name' => 'Subject',
       'label' => ts('Subject'),
+      // TODO: Why is this being escaped at this point in the flow? Should
+      // this just be done in the tpl where all the other fields get escaped?
+      // Is anything depending on this currently or is it just a result of
+      // the see-sawing and some double-escaping that went back and forth
+      // for a few years?
       'value' => htmlspecialchars($this->redact($activityDAO->subject)),
       'type' => 'Memo',
     );
@@ -387,6 +398,7 @@ WHERE      a.id = %1
       );
     }
     $activity['fields'][] = array(
+      'name' => 'Created By',
       'label' => ts('Created By'),
       'value' => $this->redact($creator),
       'type' => 'String',
@@ -416,6 +428,7 @@ WHERE      a.id = %1
     }
 
     $activity['fields'][] = array(
+      'name' => 'Reported By',
       'label' => ts('Reported By'),
       'value' => $this->redact($reporter),
       'type' => 'String',
@@ -434,6 +447,7 @@ WHERE      a.id = %1
       }
       $assigneeContacts = implode(', ', $assignee_contact_names);
       $activity['fields'][] = array(
+        'name' => 'Assigned to',
         'label' => ts('Assigned to'),
         'value' => $assigneeContacts,
         'type' => 'String',
@@ -442,6 +456,7 @@ WHERE      a.id = %1
 
     if ($activityDAO->medium_id) {
       $activity['fields'][] = array(
+        'name' => 'Medium',
         'label' => ts('Medium'),
         'value' => CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'medium_id', $activityDAO->medium_id),
         'type' => 'String',
@@ -449,18 +464,21 @@ WHERE      a.id = %1
     }
 
     $activity['fields'][] = array(
+      'name' => 'Location',
       'label' => ts('Location'),
       'value' => $activityDAO->location,
       'type' => 'String',
     );
 
     $activity['fields'][] = array(
+      'name' => 'Date and Time',
       'label' => ts('Date and Time'),
       'value' => $activityDAO->activity_date_time,
       'type' => 'Date',
     );
 
     $activity['fields'][] = array(
+      'name' => 'Details',
       'label' => ts('Details'),
       'value' => $this->redact(CRM_Utils_String::stripAlternatives($activityDAO->details)),
       'type' => 'Memo',
@@ -469,12 +487,14 @@ WHERE      a.id = %1
     // Skip Duration field if empty (to avoid " minutes" output). Might want to do this for all fields at some point. dgg
     if ($activityDAO->duration) {
       $activity['fields'][] = array(
+        'name' => 'Duration',
         'label' => ts('Duration'),
         'value' => $activityDAO->duration . ' ' . ts('minutes'),
         'type' => 'Int',
       );
     }
     $activity['fields'][] = array(
+      'name' => 'Status',
       'label' => ts('Status'),
       'value' => CRM_Core_PseudoConstant::getLabel('CRM_Activity_DAO_Activity', 'activity_status_id',
         $activityDAO->status_id
@@ -483,6 +503,7 @@ WHERE      a.id = %1
     );
 
     $activity['fields'][] = array(
+      'name' => 'Priority',
       'label' => ts('Priority'),
       'value' => CRM_Core_PseudoConstant::getLabel('CRM_Activity_DAO_Activity', 'priority_id',
         $activityDAO->priority_id

--- a/templates/CRM/Case/Audit/Report.tpl
+++ b/templates/CRM/Case/Audit/Report.tpl
@@ -132,12 +132,14 @@
   <h2>{ts}Case Activities{/ts}</h2>
   {foreach from=$activities item=activity key=key}
     <table  class ="report-layout">
-      {foreach from=$activity item=field name=fieldloop}
-        <tr class="crm-case-report-activity-{$field.label}">
+      {foreach from=$activity item=field}
+        {* TODO: Using an unmunged field in the css class would have always been problematic? Since it sometimes has spaces. *}
+        <tr class="crm-case-report-activity-{$field.name}">
           <th scope="row" class="label">{$field.label|escape}</th>
-          {if $field.label eq 'Activity Type' or $field.label eq 'Status'}
+          {if $field.name eq 'Activity Type' or $field.name eq 'Status'}
             <td class="bold">{$field.value|escape}</td>
-          {elseif $field.label eq 'Details' or $field.label eq 'Subject'}
+          {* TODO: See note in CRM/Case/XMLProcessor/Report.php: Subject is already escaped in the php file so that's why it's not escaped here, but should that be reversed? *}
+          {elseif $field.name eq 'Details' or $field.name eq 'Subject'}
             <td>{$field.value}</td>
           {else}
             <td>{$field.value|escape}</td>

--- a/templates/CRM/Case/XMLProcessor/Report.tpl
+++ b/templates/CRM/Case/XMLProcessor/Report.tpl
@@ -25,6 +25,7 @@
        <Fields>
 {foreach from=$activity.fields item=field}
           <Field>
+            <Name>{$field.name|escape}</Name>
             <Label>{$field.label|escape}</Label>
 {if $field.category}
             <Category>{$field.category|escape}</Category>
@@ -40,6 +41,7 @@
                <GroupName>{$customGroupName|escape}</GroupName>
 {foreach from=$customGroup item=field}
                   <Field>
+                    <Name>{*TODO*}</Name>
                     <Label>{$field.label|escape}</Label>
                     <Value>{$field.value|escape}</Value>
                     <Type>{$field.type}</Type>

--- a/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
@@ -151,58 +151,69 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
             0 => [
               'fields' => [
                 0 => [
+                  'name' => 'Client',
                   'label' => 'Client',
                   'value' => 'Casey Reportee',
                   'type' => 'String',
                 ],
                 1 => [
+                  'name' => 'Activity Type',
                   'label' => 'Activity Type',
                   'value' => 'Open Case',
                   'type' => 'String',
                 ],
                 2 => [
+                  'name' => 'Subject',
                   'label' => 'Subject',
                   'value' => 'Case Subject',
                   'type' => 'Memo',
                 ],
                 3 => [
+                  'name' => 'Created By',
                   'label' => 'Created By',
                   // data providers run before everything, so update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 4 => [
+                  'name' => 'Reported By',
                   'label' => 'Reported By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 5 => [
+                  'name' => 'Medium',
                   'label' => 'Medium',
                   'value' => 'Phone',
                   'type' => 'String',
                 ],
                 6 => [
+                  'name' => 'Location',
                   'label' => 'Location',
                   'value' => NULL,
                   'type' => 'String',
                 ],
                 7 => [
+                  'name' => 'Date and Time',
                   'label' => 'Date and Time',
                   'value' => '2019-11-14 00:00:00',
                   'type' => 'Date',
                 ],
                 8 => [
+                  'name' => 'Details',
                   'label' => 'Details',
                   'value' => NULL,
                   'type' => 'Memo',
                 ],
                 9 => [
+                  'name' => 'Status',
                   'label' => 'Status',
                   'value' => 'Completed',
                   'type' => 'String',
                 ],
                 10 => [
+                  'name' => 'Priority',
                   'label' => 'Priority',
                   'value' => 'Normal',
                   'type' => 'String',
@@ -214,53 +225,63 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
             1 => [
               'fields' => [
                 0 => [
+                  'name' => 'Client',
                   'label' => 'Client',
                   'value' => 'Casey Reportee',
                   'type' => 'String',
                 ],
                 1 => [
+                  'name' => 'Activity Type',
                   'label' => 'Activity Type',
                   'value' => 'Medical evaluation',
                   'type' => 'String',
                 ],
                 2 => [
+                  'name' => 'Subject',
                   'label' => 'Subject',
                   'value' => '',
                   'type' => 'Memo',
                 ],
                 3 => [
+                  'name' => 'Created By',
                   'label' => 'Created By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 4 => [
+                  'name' => 'Reported By',
                   'label' => 'Reported By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 5 => [
+                  'name' => 'Location',
                   'label' => 'Location',
                   'value' => NULL,
                   'type' => 'String',
                 ],
                 6 => [
+                  'name' => 'Date and Time',
                   'label' => 'Date and Time',
                   'value' => '2019-11-15 00:00:00',
                   'type' => 'Date',
                 ],
                 7 => [
+                  'name' => 'Details',
                   'label' => 'Details',
                   'value' => NULL,
                   'type' => 'Memo',
                 ],
                 8 => [
+                  'name' => 'Status',
                   'label' => 'Status',
                   'value' => 'Scheduled',
                   'type' => 'String',
                 ],
                 9 => [
+                  'name' => 'Priority',
                   'label' => 'Priority',
                   'value' => 'Normal',
                   'type' => 'String',
@@ -291,58 +312,69 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
             0 => [
               'fields' => [
                 0 => [
+                  'name' => 'Client',
                   'label' => 'Client',
                   'value' => 'Casey Reportee',
                   'type' => 'String',
                 ],
                 1 => [
+                  'name' => 'Activity Type',
                   'label' => 'Activity Type',
                   'value' => 'Open Case',
                   'type' => 'String',
                 ],
                 2 => [
+                  'name' => 'Subject',
                   'label' => 'Subject',
                   'value' => 'Case Subject',
                   'type' => 'Memo',
                 ],
                 3 => [
+                  'name' => 'Created By',
                   'label' => 'Created By',
                   // data providers run before everything, so update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 4 => [
+                  'name' => 'Reported By',
                   'label' => 'Reported By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 5 => [
+                  'name' => 'Medium',
                   'label' => 'Medium',
                   'value' => 'Phone',
                   'type' => 'String',
                 ],
                 6 => [
+                  'name' => 'Location',
                   'label' => 'Location',
                   'value' => NULL,
                   'type' => 'String',
                 ],
                 7 => [
+                  'name' => 'Date and Time',
                   'label' => 'Date and Time',
                   'value' => '2019-11-14 00:00:00',
                   'type' => 'Date',
                 ],
                 8 => [
+                  'name' => 'Details',
                   'label' => 'Details',
                   'value' => NULL,
                   'type' => 'Memo',
                 ],
                 9 => [
+                  'name' => 'Status',
                   'label' => 'Status',
                   'value' => 'Completed',
                   'type' => 'String',
                 ],
                 10 => [
+                  'name' => 'Priority',
                   'label' => 'Priority',
                   'value' => 'Normal',
                   'type' => 'String',
@@ -354,53 +386,63 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
             1 => [
               'fields' => [
                 0 => [
+                  'name' => 'Client',
                   'label' => 'Client',
                   'value' => 'Casey Reportee',
                   'type' => 'String',
                 ],
                 1 => [
+                  'name' => 'Activity Type',
                   'label' => 'Activity Type',
                   'value' => 'Medical evaluation',
                   'type' => 'String',
                 ],
                 2 => [
+                  'name' => 'Subject',
                   'label' => 'Subject',
                   'value' => '',
                   'type' => 'Memo',
                 ],
                 3 => [
+                  'name' => 'Created By',
                   'label' => 'Created By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 4 => [
+                  'name' => 'Reported By',
                   'label' => 'Reported By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 5 => [
+                  'name' => 'Location',
                   'label' => 'Location',
                   'value' => NULL,
                   'type' => 'String',
                 ],
                 6 => [
+                  'name' => 'Date and Time',
                   'label' => 'Date and Time',
                   'value' => '2019-11-15 00:00:00',
                   'type' => 'Date',
                 ],
                 7 => [
+                  'name' => 'Details',
                   'label' => 'Details',
                   'value' => NULL,
                   'type' => 'Memo',
                 ],
                 8 => [
+                  'name' => 'Status',
                   'label' => 'Status',
                   'value' => 'Scheduled',
                   'type' => 'String',
                 ],
                 9 => [
+                  'name' => 'Priority',
                   'label' => 'Priority',
                   'value' => 'Normal',
                   'type' => 'String',
@@ -412,53 +454,63 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
             2 => [
               'fields' => [
                 0 => [
+                  'name' => 'Client',
                   'label' => 'Client',
                   'value' => 'Casey Reportee',
                   'type' => 'String',
                 ],
                 1 => [
+                  'name' => 'Activity Type',
                   'label' => 'Activity Type',
                   'value' => 'Meeting',
                   'type' => 'String',
                 ],
                 2 => [
+                  'name' => 'Subject',
                   'label' => 'Subject',
                   'value' => 'Test Meeting',
                   'type' => 'Memo',
                 ],
                 3 => [
+                  'name' => 'Created By',
                   'label' => 'Created By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 4 => [
+                  'name' => 'Reported By',
                   'label' => 'Reported By',
                   // see above - need to update this later
                   'value' => 'placeholder',
                   'type' => 'String',
                 ],
                 5 => [
+                  'name' => 'Location',
                   'label' => 'Location',
                   'value' => NULL,
                   'type' => 'String',
                 ],
                 6 => [
+                  'name' => 'Date and Time',
                   'label' => 'Date and Time',
                   'value' => '2019-11-14 12:34:56',
                   'type' => 'Date',
                 ],
                 7 => [
+                  'name' => 'Details',
                   'label' => 'Details',
                   'value' => NULL,
                   'type' => 'Memo',
                 ],
                 8 => [
+                  'name' => 'Status',
                   'label' => 'Status',
                   'value' => 'Completed',
                   'type' => 'String',
                 ],
                 9 => [
+                  'name' => 'Priority',
                   'label' => 'Priority',
                   'value' => 'Normal',
                   'type' => 'String',


### PR DESCRIPTION
Overview
----------------------------------------
When the system isn't english the case audit/print report has visible html tags in the output for the Details field.

Alternative to PR https://github.com/civicrm/civicrm-core/pull/16650 which is shorter but compares against possibly future-changing text.

Technical Details
----------------------------------------
The field labels it was comparing against are translated field labels so they don't match up.

It looks like a lot of code, but most of it is clerical where it is just adding in a non-changing `name` counterpart to the label whereever it shows up. The only functional change is in templates/CRM/Case/Audit/Report.tpl.

I'm struggling writing a new test for this because
  * When the system isn't english, then even before the part the patch addresses the audit/print report throws a whole bunch of E_WARNING's related to sorting so I would need to fix those first, and
  * When I try anyway, there's some undefined indexes which may or may not be related to the sorting and I didn't get into tracking that down.

Comments
----------------------------------------
Also noting the original use of the label as a css class in the tpl would always have been problematic because of spaces, but I resisted trying to also fix that, and a few other things, here.

I've left out addressing custom fields pending https://github.com/civicrm/civicrm-core/pull/16654

@mlutfy 