### PR TITLE
Extensions - Change new tag "hidden" to "mgmt:hidden"

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -148,7 +148,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
     $localExtensionRows = [];
     $keys = array_keys($manager->getStatuses());
     sort($keys);
-    $hiddenExtensions = $mapper->getKeysByTag('hidden');
+    $hiddenExtensions = $mapper->getKeysByTag('mgmt:hidden');
     foreach ($keys as $key) {
       if (in_array($key, $hiddenExtensions)) {
         continue;

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -17,7 +17,7 @@
   <releaseDate>2020-01-28</releaseDate>
   <version>1.0</version>
   <tags>
-    <tag>hidden</tag>
+    <tag>mgmt:hidden</tag>
   </tags>
   <develStage>stable</develStage>
   <compatibility>


### PR DESCRIPTION
Overview
--------

This is follow-up from the discussion about how to name extension tags (https://github.com/civicrm/civicrm-dev-docs/pull/761).

It's a revision of #16531 (dev/financial#84) within the same 5.24.alpha1 dev cycle.

Before
------

The `sequentialcreditnotes` extension is tagged `hidden` and omitted from display in the web UI.

After
-----

The `sequentialcreditnotes` extension is tagged `mgmt:hidden` and omitted from display in the web UI.
