### PR TITLE
[REF] Only call getACLs when contact_id is present, remove handling

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -155,14 +155,8 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
    *
    * @throws \CRM_Core_Exception
    */
-  protected static function getACLs($contact_id = NULL) {
+  protected static function getACLs(int $contact_id) {
     $results = [];
-
-    if (empty($contact_id)) {
-      return $results;
-    }
-
-    $contact_id = CRM_Utils_Type::escape($contact_id, 'Integer');
 
     $rule = new CRM_ACL_BAO_ACL();
 
@@ -170,12 +164,9 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
     $contact = CRM_Contact_BAO_Contact::getTableName();
 
     $query = " SELECT acl.*
-     FROM $acl acl";
-
-    if (!empty($contact_id)) {
-      $query .= " WHERE   acl.entity_table   = '$contact'
-       AND acl.entity_id      = $contact_id";
-    }
+      FROM $acl acl
+      WHERE   acl.entity_table   = '$contact'
+      AND acl.entity_id      = $contact_id";
 
     $rule->query($query);
 
@@ -358,7 +349,9 @@ SELECT acl.*
     $result = [];
 
     /* First, the contact-specific ACLs, including ACL Roles */
-    $result += self::getACLs($contact_id);
+    if ($contact_id) {
+      $result += self::getACLs((int) $contact_id);
+    }
 
     /* Then, all ACLs granted through group membership */
     $result += self::getGroupACLs($contact_id, TRUE);


### PR DESCRIPTION


Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
getACLs called regardless if $contact_id is NULL, handling in the function for it being null or not an integer

After
----------------------------------------
getACLs only called if contact_id is not null, cast to an int

Technical Details
----------------------------------------
getACLs is called from one place in the code. Within the function there are 2 places that
handle the possibility it might be null - this moves it to the calling function
& requires contact id to be an int

Comments

