### PR TITLE
Increase php min recommended version

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -30,7 +30,7 @@ class CRM_Upgrade_Incremental_General {
   /**
    * The previous recommended PHP version.
    */
-  const MIN_RECOMMENDED_PHP_VER = '7.1';
+  const MIN_RECOMMENDED_PHP_VER = '7.2';
 
   /**
    * The minimum PHP version required to install Civi.


### PR DESCRIPTION

Overview
----------------------------------------
Update minimum recommended php version from 7.1 to 7.2

Before
----------------------------------------
<img width="637" alt="Screen Shot 2020-03-02 at 5 02 36 PM" src="https://user-images.githubusercontent.com/336308/75644586-a376ff00-5ca7-11ea-87cf-682b882d8cf0.png">


After
----------------------------------------
The above will say php  7.2, sites on less than 7.2 will  get the 'still works but won't at some point' message

Technical Details
----------------------------------------
We seem to not be doing a good job of communicating about dropping php 7.0
but given php 7.1 is now out of support https://www.php.net/supported-versions.php
it seems pretty clear it meets no longer meets the criteria for 'minimum recommended'

https://www.php.net/supported-versions.php


Comments
----------------------------------------

