### PR TITLE
dev/core#1366 - CRM_Case_XMLProcessor_Report::run() is never called anymore

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -28,25 +28,6 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
   public function __construct() {
   }
 
-  /**
-   * @param int $clientID
-   * @param int $caseID
-   * @param string $activitySetName
-   * @param array $params
-   *
-   * @return mixed
-   */
-  public function run($clientID, $caseID, $activitySetName, $params) {
-    $contents = self::getCaseReport($clientID,
-      $caseID,
-      $activitySetName,
-      $params,
-      $this
-    );
-
-    return CRM_Case_Audit_Audit::run($contents, $clientID, $caseID);
-  }
-
   public function getRedactionRules() {
     foreach (array(
       'redactionStringRules',


### PR DESCRIPTION
Overview
----------------------------------------
This function is no longer used. This is a further step towards removing unneeded case audit-related code.

Technical Details
----------------------------------------
To see that it's no longer used, start by grepping for CRM_Case_XMLProcessor_Report:
* CRM_Case_BAO_Case: All it does is call getActivityInfo.
* CRM_Case_Form_ActivityView: Ditto.
* Inside itself: It doesn't call its own run() anywhere.
* CRM/Case/xml/Menu/Case.xml: Points to a different function.

Then to understand why it's never used, it's because it was purposely bypassed in https://github.com/civicrm/civicrm-core/pull/15998/files#diff-fdb4ad333e7ba641428562199adc7dee. When you run the audit from manage case the options form you fill out no longer calls this when submitted.

Comments
----------------------------------------
There's more that can be removed but will be separate PRs.