### PR TITLE
dev/core#1366 - case audit printReport parameter is no longer used

### DIFF
--- a/CRM/Case/Audit/Audit.php
+++ b/CRM/Case/Audit/Audit.php
@@ -215,25 +215,20 @@ class CRM_Case_Audit_Audit {
    * @param string $xmlString
    * @param int $clientID
    * @param int $caseID
-   * @param bool $printReport
    *
    * @return mixed
    */
-  public static function run($xmlString, $clientID, $caseID, $printReport = FALSE) {
+  public static function run($xmlString, $clientID, $caseID) {
     $audit = new CRM_Case_Audit_Audit($xmlString, 'audit.conf.xml');
-    $activities = $audit->getActivities($printReport);
+    $activities = $audit->getActivities(TRUE);
 
     $template = CRM_Core_Smarty::singleton();
     $template->assign_by_ref('activities', $activities);
 
-    if ($printReport) {
-      $reportDate = CRM_Utils_Date::customFormat(date('Y-m-d H:i'));
-      $template->assign('reportDate', $reportDate);
-      $contents = $template->fetch('CRM/Case/Audit/Report.tpl');
-    }
-    else {
-      $contents = $template->fetch('CRM/Case/Audit/Audit.tpl');
-    }
+    $reportDate = CRM_Utils_Date::customFormat(date('Y-m-d H:i'));
+    $template->assign('reportDate', $reportDate);
+    $contents = $template->fetch('CRM/Case/Audit/Report.tpl');
+
     return $contents;
   }
 

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -963,7 +963,7 @@ LIMIT  1
       $params,
       $report
     );
-    $printReport = CRM_Case_Audit_Audit::run($contents, $clientID, $caseID, TRUE);
+    $printReport = CRM_Case_Audit_Audit::run($contents, $clientID, $caseID);
     echo $printReport;
     CRM_Utils_System::civiExit();
   }


### PR DESCRIPTION
Overview
----------------------------------------
The printReport parameter to run() is no longer used because it's now always TRUE.

If you look at the files changed tab with the ignore whitespace setting turned on it's a little cleaner.

Technical Details
----------------------------------------
To see that it's no longer used, start by grepping for CRM_Case_Audit_Audit (exclude AuditConfig: `grep -r CRM_Case_Audit_Audit * | grep -v CRM_Case_Audit_AuditConfig`)
* CRM/Case/XMLProcessor/Report.php: calls it with TRUE.
* Within its own run function: Instantiates itself but doesn't call run.

Then to understand why it's never used, it's because the feature it supported was purposely bypassed in https://github.com/civicrm/civicrm-core/pull/15998/files#diff-fdb4ad333e7ba641428562199adc7dee, and thru some intermediate cleanup all other references to it have also been removed.

Comments
----------------------------------------
It's now also easier to see why PR https://github.com/civicrm/civicrm-core/pull/16660 was able to remove the Audit.tpl file since there's no references to it. The order of these PRs was backwards but it's the same result.

There's still more that can be removed but will be separate PRs.