### PR TITLE
[REF] simplify references to civicrm_acl

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -160,11 +160,10 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
 
     $rule = new CRM_ACL_BAO_ACL();
 
-    $acl = self::getTableName();
     $contact = CRM_Contact_BAO_Contact::getTableName();
 
     $query = " SELECT acl.*
-      FROM $acl acl
+      FROM civicrm_acl acl
       WHERE   acl.entity_table   = '$contact'
       AND acl.entity_id      = $contact_id";
 
@@ -232,7 +231,6 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
 
     $rule = new CRM_ACL_BAO_ACL();
 
-    $acl = self::getTableName();
     $c2g = CRM_Contact_BAO_GroupContact::getTableName();
     $group = CRM_Contact_BAO_Group::getTableName();
     $results = [];
@@ -240,7 +238,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
     if ($contact_id) {
       $query = "
 SELECT      acl.*
-  FROM      $acl acl
+  FROM      civicrm_acl acl
  INNER JOIN  $c2g group_contact
         ON  acl.entity_id      = group_contact.group_id
      WHERE  acl.entity_table   = '$group'
@@ -277,14 +275,13 @@ SELECT      acl.*
 
     $rule = new CRM_ACL_BAO_ACL();
 
-    $acl = self::getTableName();
     $aclRole = 'civicrm_acl_role';
 
     $aclER = CRM_ACL_DAO_EntityRole::getTableName();
     $c2g = CRM_Contact_BAO_GroupContact::getTableName();
 
     $query = "   SELECT          acl.*
-                        FROM            $acl acl
+                        FROM            civicrm_acl acl
                         INNER JOIN      civicrm_option_group og
                                 ON      og.name = 'acl_role'
                         INNER JOIN      civicrm_option_value ov
@@ -321,7 +318,7 @@ SELECT      acl.*
 
     $query = "
 SELECT acl.*
-  FROM $acl acl
+  FROM civicrm_acl acl
  WHERE acl.entity_id      IN ( $roles )
    AND acl.entity_table   = 'civicrm_acl_role'
 ";


### PR DESCRIPTION

Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
A variable used in mysql to stand in for civicrm_acl

After
----------------------------------------
civicrm_acl is used - no change in functionality - ACLS still work (& we have test cover on that)

Technical Details
----------------------------------------
We can see looking at ACL.xml that civicm_acl can't be localised so we gain nothing
by using a varible.

Also note that we want to switch to CRM_Core_Execute::query in these functions so
that table translation is handled by that function - this is old code done the old way.

However, the thing I'm trying to unravel is if & where the values for the fields
entity_table & object_table are localised. We have been switching AWAY from
saving localised table names & TBH I think we maybe don't & it's a lot of cruft
for some ideas that never eventuated but I'm still digging

Comments
----------------------------------------

