### PR TITLE
Activity Details report: fix filtering by is null/is not null

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -544,7 +544,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           }
           else {
             $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
-            if ($op && ($op != 'nnll' && $op != 'nll')) {
+            if ($op && !($fieldName == "contact_{$recordType}" && ($op != 'nnll' || $op != 'nll'))) {
               $clause = $this->whereClause($field,
                 $op,
                 CRM_Utils_Array::value("{$fieldName}_value", $this->_params),

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1201,6 +1201,31 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Activity Details report has some whack-a-mole to fix when filtering on null/not null.
+   */
+  public function testActivityDetailsNullFilters() {
+    $this->createContactsWithActivities();
+    $params = [
+      'report_id' => 'activity',
+      'location_op' => 'nll',
+      'location_value' => '',
+    ];
+    $rowsWithoutLocation = $this->callAPISuccess('report_template', 'getrows', $params)['values'];
+    $this->assertEmpty($rowsWithoutLocation);
+    $params['location_op'] = 'nnll';
+    $rowsWithLocation = $this->callAPISuccess('report_template', 'getrows', $params)['values'];
+    $this->assertCount(1, $rowsWithLocation);
+    // Test for CRM-18356 - activity shouldn't appear if target contact filter is null.
+    $params = [
+      'report_id' => 'activity',
+      'contact_target_op' => 'nll',
+      'contact_target_value' => '',
+    ];
+    $rowsWithNullTarget = $this->callAPISuccess('report_template', 'getrows', $params)['values'];
+    $this->assertEmpty($rowsWithNullTarget);
+  }
+
+  /**
    * Set up some activity data..... use some chars that challenge our utf handling.
    */
   public function createContactsWithActivities() {


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/1627

Overview
----------------------------------------
On the Activity Details report, any filter that allows selecting "Is Null" or "Is Not Null" is broken (with the possible exception of the Source/Target/Assignee Contact filters).

Reproduction steps
----------------------------------------
* Go to the Activity Details report.
* Remove the "Activity Date is this month" default filter.
* Run the report.  Observe the total number of activities in the database.
* Filter a field that allows null/not null (e.g. *Location*) to **Is Null**.
* Run the report again.  Observe that the total number of activities is the same (but that could be legitimate).
* Filter the same field to **Is Not Null**. 
* Run the report one more time.   Observe that the total number of activities is *still* the same.

Current behaviour
----------------------------------------
Filtering by "is null" or "is not null" is ignored.

Expected behaviour
----------------------------------------
Filtering by "is null" or "is not null" should work.

Comments
----------------------------------------
This was broken by the fix to [CRM-18356](https://issues.civicrm.org/jira/browse/CRM-18356).  Since my initial attempts at fixing this reintroduced the bug described there, I wrote tests for both scenarios to lock both fixes in.