### PR TITLE
Fix display of administrator permissions in WordPress Multisite

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -37,8 +37,8 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
       $wp_roles = new WP_Roles();
     }
     foreach ($wp_roles->role_names as $role => $name) {
-      // Don't show the permissions options for administrator, as they have all permissions
-      if ($role !== 'administrator') {
+      // Unless it's Multisite, don't show the permissions options for administrator, as they have all permissions
+      if (is_multisite() or $role !== 'administrator') {
         $roleObj = $wp_roles->get_role($role);
         if (!empty($roleObj->capabilities)) {
           foreach ($roleObj->capabilities as $ckey => $cname) {


### PR DESCRIPTION
Overview
----------------------------------------
In WordPress Multisite, roles function somewhat differently to Single Site: in Multisite there is a "Network Administrator" with greater capabilities than a "Site Administrator". At present, the "WordPress Permissions" screen does not take this into account.

Before
----------------------------------------
A "Network Administrator" cannot limit the permissions for a "Site Administrator"

After
----------------------------------------
A "Network Administrator" is able to limit the permissions for a "Site Administrator"

Comments
----------------------------------------
Fixes [the issue on CiviCRM Lab](https://lab.civicrm.org/dev/core/issues/1628)