### PR TITLE
Fix synchronisation of Users to Contacts in WordPress Multisite

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -838,11 +838,13 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $contactCreated = 0;
     $contactMatching = 0;
 
-    global $wpdb;
-    $wpUserIds = $wpdb->get_col("SELECT $wpdb->users.ID FROM $wpdb->users");
+    // Previously used the $wpdb global - which means WordPress *must* be bootstrapped.
+    $wpUsers = get_users(array(
+      'blog_id' => get_current_blog_id(),
+      'number' => -1,
+    ));
 
-    foreach ($wpUserIds as $wpUserId) {
-      $wpUserData = get_userdata($wpUserId);
+    foreach ($wpUsers as $wpUserData) {
       $contactCount++;
       if ($match = CRM_Core_BAO_UFMatch::synchronizeUFMatch($wpUserData,
         $wpUserData->$id,
@@ -857,6 +859,9 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       }
       else {
         $contactMatching++;
+      }
+      if (is_object($match)) {
+        $match->free();
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
In WordPress Multisite, only Users present on a particular Site should be synced to CiviCRM. At present, all WordPress Users are synced to CiviCRM regardless of their Site membership.

Before
----------------------------------------
All WordPress Users from all Sites are synced to CiviCRM.

After
----------------------------------------
Only WordPress Users that are members of that Sub-site are synced to CiviCRM.

Comments
----------------------------------------
Fixes [this issue on CiviCRM Lab](https://lab.civicrm.org/dev/core/issues/1629)