### PR TITLE
Bump Minimum Install version to be 7.1 (Do not merge until 5.24 RC is cut)

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -38,7 +38,7 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
    *
    * Tip: Keep in sync with composer.json ("config => platform => php")
    */
-  const MINIMUM_PHP_VERSION = '7.0.0';
+  const MINIMUM_PHP_VERSION = '7.1.0';
 
   /**
    * @var \CRM_Core_Config

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -37,7 +37,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '7.0';
+  const MIN_INSTALL_PHP_VER = '7.1';
 
   /**
    * Compute any messages which should be displayed before upgrade.

--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
   "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
-      "php": "7.0.10"
+      "php": "7.1"
     }
   },
   "require": {
-    "php": "~7.0",
+    "php": "~7.1",
     "cache/integration-tests": "~0.16.0",
     "dompdf/dompdf" : "0.8.*",
     "electrolinux/phpquery": "^0.9.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3e774ecb53f47ad1c02f3c570d4aabb",
+    "content-hash": "4461b6a9f42757ed76cbca218261acc3",
     "packages": [
         {
             "name": "cache/integration-tests",
@@ -2665,10 +2665,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.0"
+        "php": "~7.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.10"
+        "php": "7.1"
     }
 }


### PR DESCRIPTION
Overview
----------------------------------------
This bumps the minimum PHP needed to install CiviCRM to be 7.1 

Before
----------------------------------------
Min PHP version is 7.0

After
----------------------------------------
Min PHP version is 7.1

ping @eileenmcnaughton @totten 