### PR TITLE
Fix SettingTrait YesNo translation

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -224,7 +224,7 @@ trait CRM_Admin_Form_SettingTrait {
           $this->$add($setting, $props['title'], $props['entity_reference_options']);
         }
         elseif ($add === 'addYesNo' && ($props['type'] === 'Boolean')) {
-          $this->addRadio($setting, $props['title'], [1 => 'Yes', 0 => 'No'], CRM_Utils_Array::value('html_attributes', $props), '&nbsp;&nbsp;');
+          $this->addRadio($setting, $props['title'], [1 => ts('Yes'), 0 => ts('No')], CRM_Utils_Array::value('html_attributes', $props), '&nbsp;&nbsp;');
         }
         elseif ($add === 'add') {
           $this->add($props['html_type'], $setting, $props['title'], $options);


### PR DESCRIPTION
Overview
----------------------------------------

"Yes/no" radio admin settings are no longer correctly translated.

To reproduce:

* Change the CiviCRM language to French (Administer > Localization > Languages)
* Then go to an admin page, such as Administer > System Settings > Misc.

Before
----------------------------------------

![Capture d’écran de 2020-03-04 16-02-16](https://user-images.githubusercontent.com/254741/75922707-8cfcaf00-5e31-11ea-8780-9b407dff6fea.png)

After
----------------------------------------

![Capture d’écran de 2020-03-04 16-02-47](https://user-images.githubusercontent.com/254741/75922740-a00f7f00-5e31-11ea-98e7-3eba6d579b49.png)

Technical Details
----------------------------------------

This doesn't seem like a recent regression according to the git log, but their usage may be more recent. I didn't feel like it was justified to PR this against the RC (and it would introduce a conflict, if the RC changes get merged back to master).