### PR TITLE
Fix parameter format for upgrade call to install/enable sequentialcreditnotes

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyFour.php
@@ -75,7 +75,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyFour extends CRM_Upgrade_Incremental
    * @throws \CiviCRM_API3_Exception
    */
   public static function installCreditNotes(CRM_Queue_TaskContext $ctx) {
-    civicrm_api3('Extension', 'install', ['sequentialcreditnotes']);
+    civicrm_api3('Extension', 'install', ['keys' => 'sequentialcreditnotes']);
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The third parameter doesn't have the expected format, so it silently doesn't do anything.
