### PR TITLE
Mark unused function as deprecated

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1859,6 +1859,7 @@ WHERE      activity.id IN ($activityIds)";
    *   $params  count of prior activities otherwise false.
    */
   public static function getPriorCount($activityID) {
+    CRM_Core_Error::deprecatedFunctionWarning('unused function to be removed');
     static $priorCounts = [];
 
     $activityID = CRM_Utils_Type::escape($activityID, 'Integer');


### PR DESCRIPTION
Overview
----------------------------------------
Mark unused function as deprecated

Before
----------------------------------------
CRM_Activity_BAO_Activity::getPriorCount unused 

After
----------------------------------------
CRM_Activity_BAO_Activity::getPriorCount unused AND deprecated

Technical Details
----------------------------------------
I searched for getPriorCount before deciding this

Comments

