### PR TITLE
Use dbAlias to generate where clause for date field in activity report

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -540,7 +540,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
             $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
             $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
 
-            $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
+            $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
           }
           else {
             $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -368,7 +368,7 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
             $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
             $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
 
-            $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
+            $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
           }
           else {
             $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);


### PR DESCRIPTION
Overview
----------------------------------------
Use db alias when generating where clause for date field over field name else it will result in "Column 'activity_date_time' in where clause is ambiguous" error if we want to join activity table again to the report using hook.

Before
----------------------------------------
WHERE ( activity_date_time >= 20200301000000 ) AND ( activity_date_time <= 20200307235959 )

After
----------------------------------------
WHERE ( activity_civireport.activity_date_time >= 20200301000000 ) AND ( activity_civireport.activity_date_time <= 20200307235959 )