### PR TITLE
Fix PayPal Express on events

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -929,7 +929,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   protected function handlePreApproval(&$params) {
     try {
       $payment = Civi\Payment\System::singleton()->getByProcessor($this->_paymentProcessor);
-      $params['component'] = 'contribute';
+      $params['component'] = $params['component'] ?? 'contribute';
       $result = $payment->doPreApproval($params);
       if (empty($result)) {
         // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.


### PR DESCRIPTION
https://lab.civicrm.org/dev/financial/issues/119

Overview
--------------------------------
PayPal Express fails on events.


To replicate:
* Set up PayPal Pro.
* Create a paid event using PayPal Pro as the payment processor.
* Attempt to pay via PayPal.

Expected result:
* Payment goes through.

Actual result:
`Your browser session has expired and we are unable to complete your form submission. We have returned you to the initial step so you can complete and resubmit the form. If you experience continued difficulties, please contact us for assistance.`

Why:
`CRM_Event_Form_Registration_Register->postProcess()` has these lines:
```php
        $params['component'] = 'event';
        // This code is duplicated multiple places and should be consolidated.
        $params = $this->prepareParamsForPaymentProcessor($params);
        $this->handlePreApproval($params);
```

But `CRM_Core_Form::handlePreApproval()` has [this line](https://github.com/civicrm/civicrm-core/blob/f1c78d29e7ec9b59b2ca286efaec6b33af2c8af3/CRM/Core/Form.php#L935):
```
      $params['component'] = 'contribute';
```

As a result, the `$params['component']` is ALWAYS treated as `contribute`, which causes Civi to send the wrong URL to PayPal as the "success URL".  so you're redirected back to `civicrm/contribute/transact` instead of `civicrm/event/register`.

I have a solution, but I don't have any idea how one tests this.  You would need to mock up the PayPal API.  Also, this amazingly seems to have been a problem [back to 4.7alpha1](https://github.com/civicrm/civicrm-core/commit/ec022878580e581215e845f418797dddf416a325).