### PR TITLE
Fix bug where a % in a serialized array can lead to the data being broken

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -348,12 +348,12 @@ class CRM_Dedupe_Finder {
         'canMerge' => TRUE,
       ];
 
-      $data = CRM_Core_DAO::escapeString(serialize($row));
       CRM_Core_DAO::executeQuery("INSERT INTO civicrm_prevnext_cache (entity_table, entity_id1, entity_id2, cacheKey, data) VALUES
-        ('civicrm_contact', %1, %2, %3, '{$data}')", [
+        ('civicrm_contact', %1, %2, %3, %4)", [
           1 => [$dstID, 'Integer'],
           2 => [$srcID, 'Integer'],
           3 => [$cacheKeyString, 'String'],
+          4 => [serialize($row), 'String'],
         ]
       );
     }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -775,10 +775,9 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       'merged' => (int) $merged,
       'skipped' => (int) $skipped,
     ];
-    $data = serialize($data);
 
     CRM_Core_DAO::executeQuery("INSERT INTO civicrm_prevnext_cache (entity_table, entity_id1, entity_id2, cacheKey, data) VALUES
-        ('civicrm_contact', 0, 0, %1, '{$data}')", [1 => [$cacheKeyString . '_stats', 'String']]);
+        ('civicrm_contact', 0, 0, %1, %2)", [1 => [$cacheKeyString . '_stats', 'String'], 2 => [serialize($data), 'String']]);
   }
 
   /**

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -829,6 +829,22 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test weird characters don't mess with merge & cause a fatal.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testNoErrorOnOdd() {
+    $this->individualCreate();
+    $this->individualCreate(['first_name' => 'Gerrit%0a%2e%0a']);
+    $this->callAPISuccess('Job', 'process_batch_merge', []);
+
+    $this->individualCreate();
+    $this->individualCreate(['first_name' => '[foo\\bar\'baz']);
+    $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $this->callAPISuccessGetSingle('Contact', ['first_name' => '[foo\\bar\'baz']);
+  }
+
+  /**
    * Test the batch merge does not create duplicate emails.
    *
    * Test CRM-18546, a 4.7 regression whereby a merged contact gets duplicate emails.


### PR DESCRIPTION

Overview
----------------------------------------
Fixes obscure dedupe bug



Before
----------------------------------------
Dedupe will fail on a contact with '%2' in their name

After
----------------------------------------
Dedupe can cope

Technical Details
----------------------------------------
Basically we have a contact in our DB who had a weird string (carriage returns & a .) in his name.
The dedupe script fell over on him because it could not unserialize what it had serialised for
his display name. 

It turns out that is a field in a serialized array has a %2 (for example) this gets swapped in executeQuery for the
%2 value (in this case srcID - rendering the serialized array invalid. This proposes that we
explicitly handle arrays as a data type in compose query.

Some thoughts

we could make serialized arrays valid types in validate (not done here)
we could iterate through the array keys & values escaping them -
at this stage it's left in the calling function
there are whole bikeshed factories to keep in business on discussion of whether
'Array-1', 'Array-2' etc are the right format

---- notes below written before @pfigel pointed to where it was going awol-----

```
INSERT INTO civicrm_prevnext_cache (entity_table, entity_id1, entity_id2, cacheKey, data) VALUES
        ('civicrm_contact', 4, 5, 'merge_Individual_4_0_0_0_0', 'a:6:{s:5:"dstID";s:1:"4";s:7:"dstName";s:23:"Mr. Anthony Anderson II";s:5:"srcID";s:1:"5";s:7:"srcName";s:31:"Mr. Gerrit%0a4e%0a Anderson II";s:6:"weight";s:2:"10";s:8:"canMerge";b:1;}')
```

It then retrieves with this query

```

SELECT SQL_CALC_FOUND_ROWS pn.*
FROM   civicrm_prevnext_cache pn
       
      LEFT JOIN civicrm_dedupe_exception de
        ON (
          pn.entity_id1 = de.contact_id1
          AND pn.entity_id2 = de.contact_id2 )
       
        WHERE (pn.cachekey = 'merge_Individual_4_0_0_0_0') AND de.id IS NULL
       
 LIMIT 0, 1
```

And the value in data is
```
a:6:{s:5:"dstID";s:1:"4";s:7:"dstName";s:23:"Mr. Anthony Anderson II";s:5:"srcID";s:1:"5";s:7:"srcName";s:31:"Mr. Gerrit%0a4e%0a Anderson II";s:6:"weight";s:2:"10";s:8:"canMerge";b:1;}
```
which fails to unserialize here 
https://github.com/civicrm/civicrm-core/blob/bd4c91fa63ea1884bcb352aa2a27952f2a0862df/CRM/Core/BAO/PrevNextCache.php#L288


Comments
----------------------------------------
@pfigel @ejegg @seamuslee001 if anyone has thoughts - this IS pretty obscure & I'm comfortable it's not a security hole