### PR TITLE
Add some deprecation notices, stop calling PrevNext::cleanupCache

### DIFF
--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -387,7 +387,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
 
     if ($prevNext) {
       // delete all PrevNext caches
-      CRM_Core_BAO_PrevNextCache::cleanupCache();
+      Civi::service('prevnext')->cleanup();
     }
 
     if ($table) {

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -326,6 +326,7 @@ FROM   civicrm_prevnext_cache pn
    * @return array
    */
   public static function convertSetItemValues($sqlValues) {
+    CRM_Core_Error::deprecatedFunctionWarning('Deprecated function');
     $closingBrace = strpos($sqlValues, ')') - strlen($sqlValues);
     $valueArray = array_map('trim', explode(', ', substr($sqlValues, strpos($sqlValues, '(') + 1, $closingBrace - 1)));
     foreach ($valueArray as $key => &$value) {
@@ -462,7 +463,13 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
     }
   }
 
+  /**
+   * Old function to clean up he cache.
+   *
+   * @deprecated.
+   */
   public static function cleanupCache() {
+    CRM_Core_Error::deprecatedFunctionWarning('Deprecated function');
     Civi::service('prevnext')->cleanup();
   }
 
@@ -476,6 +483,7 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
    * @see CRM_Core_PrevNextCache_Sql::getSelection()
    */
   public static function getSelection($cacheKey, $action = 'get') {
+    CRM_Core_Error::deprecatedFunctionWarning('Deprecated function');
     return Civi::service('prevnext')->getSelection($cacheKey, $action);
   }
 
@@ -533,6 +541,8 @@ WHERE (pn.cachekey $op %1 OR pn.cachekey $op %2)
    * @param array $fieldDef
    * @param int $counter
    *   The globally-unique ID of the test object.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function assignTestValue($fieldName, &$fieldDef, $counter) {
     if ($fieldName === 'cachekey') {

--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -211,8 +211,7 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
   public function flush() {
     if ($this->group == CRM_Utils_Cache::cleanKey('CiviCRM Search PrevNextCache') &&
       Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
-      // Use the standard PrevNextCache cleanup function here not just delete from civicrm_cache
-      CRM_Core_BAO_PrevNextCache::cleanupCache();
+      Civi::service('prevnext')->cleanup();
     }
     else {
       CRM_Core_DAO::executeQuery("DELETE FROM {$this->table} WHERE {$this->where()}");


### PR DESCRIPTION
Overview
----------------------------------------
Marks some functions as deprecated that are unused by core, removes calls to PrevNext::cleanupCache

Before
----------------------------------------
Calling PrevNext::cleanupCache saves no code & adds no clarity 

After
----------------------------------------
Calls to PrevNext::cleanupCache replaced, function deprecated

Technical Details
----------------------------------------


Comments
----------------------------------------

