### PR TITLE
[NFC] Mark unused function deprecated, fix some comments & formatting

### DIFF
--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -35,8 +35,12 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
    * @return string
    *   the note text or NULL if note not found
    *
+   * @throws \CRM_Core_Exception
+   *
+   * @deprecated
    */
   public static function getNoteText($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('unused function');
     return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Note', $id, 'note');
   }
 
@@ -49,6 +53,7 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
    * @return string
    *   the note subject or NULL if note not found
    *
+   * @throws \CRM_Core_Exception
    */
   public static function getNoteSubject($id) {
     return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Note', $id, 'subject');
@@ -69,8 +74,8 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
       return FALSE;
     }
 
-    $noteValues = array();
-    if (is_object($note) && get_class($note) == 'CRM_Core_DAO_Note') {
+    $noteValues = [];
+    if (is_object($note) && get_class($note) === 'CRM_Core_DAO_Note') {
       CRM_Core_DAO::storeValues($note, $noteValues);
     }
     else {
@@ -174,7 +179,7 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
         }
       }
 
-      $recentOther = array();
+      $recentOther = [];
       if ($noteActions) {
         $recentOther = array(
           'editUrl' => CRM_Utils_System::url('civicrm/contact/view/note',
@@ -229,8 +234,7 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
    * @param int $numNotes
    *   The maximum number of notes to return (0 if all).
    *
-   * @return object
-   *   $notes  Object of CRM_Core_BAO_Note
+   * @return array
    */
   public static function &getValues(&$params, &$values, $numNotes = self::MAX_NOTES) {
     if (empty($params)) {
@@ -248,10 +252,10 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
     $note->limit($numNotes);
     $note->find();
 
-    $notes = array();
+    $notes = [];
     $count = 0;
     while ($note->fetch()) {
-      $values['note'][$note->id] = array();
+      $values['note'][$note->id] = [];
       CRM_Core_DAO::storeValues($note, $values['note'][$note->id]);
       $notes[] = $note;
 


### PR DESCRIPTION
Overview
----------------------------------------
Main change is marking unused getNoteText as deprecated

Before
----------------------------------------
getNoteText is unused 

After
----------------------------------------
getNoteText is unused and deprecated

Technical Details
----------------------------------------


Comments
----------------------------------------

