### PR TITLE
Support PropertyBag in CRM_Utils_Array

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -21,12 +21,12 @@ class CRM_Utils_Array {
    * Returns $list[$key] if such element exists, or a default value otherwise.
    *
    * If $list is not actually an array at all, then the default value is
-   * returned.
+   * returned. We hope to deprecate this behaviour.
    *
    *
    * @param string $key
    *   Key value to look up in the array.
-   * @param array $list
+   * @param array|ArrayAccess $list
    *   Array from which to look up a value.
    * @param mixed $default
    *   (optional) Value to return $list[$key] does not exist.
@@ -38,6 +38,11 @@ class CRM_Utils_Array {
     if (is_array($list)) {
       return array_key_exists($key, $list) ? $list[$key] : $default;
     }
+    if ($list instanceof ArrayAccess) {
+      return $list[$key] ?? $default;
+    }
+    // @todo - eliminate these from core & uncomment this line.
+    // CRM_Core_Error::deprecatedFunctionWarning('You have passed an invalid parameter for the "list"');
     return $default;
   }
 

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -192,6 +192,15 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   /**
+   * Test retrieves using CRM_Utils_Array::value still work.
+   */
+  public function testUtilsArray() {
+    $propertyBag = new PropertyBag();
+    $propertyBag->setContactID(123);
+    $this->assertEquals(123, \CRM_Utils_Array::value('contact_id', $propertyBag));
+  }
+
+  /**
    *
    * Data provider for testOtherParams
    *


### PR DESCRIPTION

Overview
----------------------------------------
We now use the PropertyBag in payment processors - but as @mattwire discovered the CRM_Utils_Array::value
function is commonly used to access values now potentially 'in the bag' and the 'is_array'
filtering here means it is not being returned

Before
----------------------------------------
Support PropertyBag in CRM_Utils_Array::value does not return values from the PropertyBag

After
----------------------------------------
Values returned - note we will encourage devs to move to direct access

Technical Details
----------------------------------------


Comments
----------------------------------------

discussion https://chat.civicrm.org/civicrm/pl/aygaho49jff5tqgar9erow7dew