### PR TITLE
Fix passing a non-array to CRM_Utils_Array::value

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -227,9 +227,10 @@ class CRM_Core_Menu {
 
       foreach ($fieldsToPropagate as $field) {
         if (!$fieldsPresent[$field]) {
-          if (CRM_Utils_Array::value($field, CRM_Utils_Array::value($parentPath, $menu)) !== NULL) {
+          $fieldInParentMenu = $menu[$parentPath][$field] ?? NULL;
+          if ($fieldInParentMenu !== NULL) {
             $fieldsPresent[$field] = TRUE;
-            $menu[$path][$field] = $menu[$parentPath][$field];
+            $menu[$path][$field] = $fieldInParentMenu;
           }
         }
       }


### PR DESCRIPTION


Overview
----------------------------------------
As surfaced in https://test.civicrm.org/job/CiviCRM-Core-PR/32543/console when we tested deprecating
passing in a non-array

Before
----------------------------------------
Passes in a non-array

After
----------------------------------------
Ensures it is an array

Technical Details
----------------------------------------
I didn't clean up the second instance - I thought about empty() but wasn't sure it if could be 0 - just wanted to keep scope minimal for this

Comments
----------------------------------------

