### PR TITLE
bin/*, extern/* - Fix leak of "$config" in global namespace

### DIFF
--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -463,7 +463,7 @@ class CiviContributeProcessor {
 session_start();
 require_once '../civicrm.config.php';
 require_once 'CRM/Core/Config.php';
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 
 CRM_Utils_System::authenticateScript(TRUE);
 

--- a/bin/cron.php
+++ b/bin/cron.php
@@ -13,7 +13,7 @@
 require_once '../civicrm.config.php';
 require_once 'CRM/Core/Config.php';
 require_once 'CRM/Utils/Request.php';
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 
 CRM_Utils_System::authenticateScript(TRUE);
 

--- a/extern/authorizeIPN.php
+++ b/extern/authorizeIPN.php
@@ -21,7 +21,7 @@ if (defined('PANTHEON_ENVIRONMENT')) {
 session_start();
 
 require_once '../civicrm.config.php';
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
 $log->alert('payment_notification processor_name=AuthNet', $_REQUEST);
 

--- a/extern/cxn.php
+++ b/extern/cxn.php
@@ -10,7 +10,7 @@
  */
 
 require_once '../civicrm.config.php';
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 
 CRM_Utils_System::loadBootStrap(array(), FALSE);
 

--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -47,7 +47,7 @@ require_once '../civicrm.config.php';
 
 /* Cache the real UF, override it with the SOAP environment */
 
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
 if (empty($_GET)) {
   $log->alert('payment_notification processor_name=PayPal', $_REQUEST);

--- a/extern/open.php
+++ b/extern/open.php
@@ -6,7 +6,7 @@ require_once 'CRM/Utils/Type.php';
 require_once 'CRM/Utils/Rule.php';
 require_once 'CRM/Utils/Request.php';
 
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 $queue_id = CRM_Utils_Request::retrieveValue('q', 'Positive', NULL, FALSE, 'GET');
 if (!$queue_id) {
   echo "Missing input parameters\n";

--- a/extern/pxIPN.php
+++ b/extern/pxIPN.php
@@ -18,7 +18,7 @@ session_start();
 require_once '../civicrm.config.php';
 require_once 'CRM/Core/Config.php';
 
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
 $log->alert('payment_notification processor_name=Payment_Express', $_REQUEST);
 /*

--- a/extern/rest.php
+++ b/extern/rest.php
@@ -10,7 +10,7 @@
  */
 
 require_once '../civicrm.config.php';
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 
 if (defined('PANTHEON_ENVIRONMENT')) {
   ini_set('session.save_handler', 'files');

--- a/extern/soap.php
+++ b/extern/soap.php
@@ -30,9 +30,9 @@ $crm_soap = new CRM_Utils_SoapServer();
 
 /* Cache the real UF, override it with the SOAP environment */
 
-$config = CRM_Core_Config::singleton();
+$civicrmConfig = CRM_Core_Config::singleton();
 
-$server->setClass('CRM_Utils_SoapServer', $config->userFrameworkClass);
+$server->setClass('CRM_Utils_SoapServer', $civicrmConfig->userFrameworkClass);
 
 $server->setPersistence(SOAP_PERSISTENCE_SESSION);
 

--- a/extern/url.php
+++ b/extern/url.php
@@ -4,7 +4,7 @@ require_once 'CRM/Core/Config.php';
 require_once 'CRM/Core/Error.php';
 require_once 'CRM/Utils/Array.php';
 
-$config = CRM_Core_Config::singleton();
+CRM_Core_Config::singleton();
 
 // To keep backward compatibility for URLs generated
 // by CiviCRM < 1.7, we check for the q variable as well.


### PR DESCRIPTION
…th backdrop

Overview
----------------------------------------
This removes the $config variable from some pre CMS boot locations to avoid issues with backdrop comparability 

Before
----------------------------------------
When using a `bin/` or `extern/` script, the `$config` variable implicitly enters the global namespace.

Rest API tests fail on current Backdrop `1.x` builds because Backdrop specifies its own `global $config` of type `array`.

After
----------------------------------------
Rest API tests pass again on backdrop

Technical Details
----------------------------------------
Backdrop recently made $config a global variable and its probable that our use of $config in these files whilst not declared global maybe caused to populate when backdrop is booted

ping @totten @herbdool 
