### PR TITLE
[REF] CRM_Utils_Array::value() -> empty()

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -132,7 +132,7 @@ class CRM_Activity_BAO_Query {
       $query->_tables['civicrm_activity'] = $query->_whereTables['civicrm_activity'] = 1;
     }
 
-    if (CRM_Utils_Array::value('parent_id', $query->_returnProperties)) {
+    if (!empty($query->_returnProperties['parent_id'])) {
       $query->_tables['parent_id'] = 1;
       $query->_whereTables['parent_id'] = 1;
       $query->_element['parent_id'] = 1;

--- a/CRM/Admin/Form/Preferences/Address.php
+++ b/CRM/Admin/Form/Preferences/Address.php
@@ -80,7 +80,7 @@ class CRM_Admin_Form_Preferences_Address extends CRM_Admin_Form_Preferences {
     $addressOptions = CRM_Core_OptionGroup::values('address_options', TRUE);
 
     // check if county option has been set
-    if (CRM_Utils_Array::value($addressOptions['County'], $this->_params['address_options'])) {
+    if (!empty($this->_params['address_options'][$addressOptions['County']])) {
       $countyCount = CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_county");
       if ($countyCount < 10) {
         CRM_Core_Session::setStatus(ts('You have enabled the County option. Please ensure you populate the county table in your CiviCRM Database. You can find extensions to populate counties in the <a %1>CiviCRM Extensions Directory</a>.', [1 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', ['reset' => 1], TRUE, 'extensions-addnew') . '"']),

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -94,7 +94,7 @@ class CRM_Case_XMLRepository {
     //  throw new CRM_Core_Exception("Cannot load caseType with malformed name [$caseType]");
     //}
 
-    if (!CRM_Utils_Array::value($caseType, $this->xml)) {
+    if (empty($this->xml[$caseType])) {
       $fileXml = $this->retrieveFile($caseType);
       if ($fileXml) {
         $this->xml[$caseType] = $fileXml;

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -788,7 +788,7 @@ class CRM_Contact_BAO_Query {
         elseif (isset($field['where'])) {
           list($tableName, $fieldName) = explode('.', $field['where'], 2);
           if (isset($tableName)) {
-            if (CRM_Utils_Array::value($tableName, self::$_dependencies)) {
+            if (!empty(self::$_dependencies[$tableName])) {
               $this->_tables['civicrm_address'] = 1;
               $this->_select['address_id'] = 'civicrm_address.id as address_id';
               $this->_element['address_id'] = 1;
@@ -4727,7 +4727,7 @@ civicrm_relationship.start_date > {$today}
       list($from, $to) = CRM_Utils_Date::getFromTo($values, NULL, NULL);
     }
     else {
-      if ($fieldName == $customFieldName . '_to' && CRM_Utils_Array::value($customFieldName . '_from', $formValues)) {
+      if ($fieldName == $customFieldName . '_to' && !empty($formValues[$customFieldName . '_from'])) {
         // Both to & from are set. We only need to acton one, choosing from.
         return;
       }
@@ -6554,15 +6554,15 @@ AND   displayRelType.is_active = 1
       return FALSE;
     }
 
-    if (!empty($pseudoConstant['optionGroupName']) && CRM_Utils_Array::value($pseudoConstant['optionGroupName'], $this->_returnProperties)) {
+    if (!empty($pseudoConstant['optionGroupName']) && !empty($this->_returnProperties[$pseudoConstant['optionGroupName']])) {
       return TRUE;
     }
-    if (CRM_Utils_Array::value($fieldName, $this->_returnProperties)) {
+    if (!empty($this->_returnProperties[$fieldName])) {
       return TRUE;
     }
     // Is this still required - the above goes off the unique name. Test with things like
     // communication_preferences & prefix_id.
-    if (CRM_Utils_Array::value($field['name'], $this->_returnProperties)) {
+    if (!empty($this->_returnProperties[$field['name']])) {
       return TRUE;
     }
     return FALSE;

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -215,7 +215,7 @@ UPDATE civicrm_dedupe_rule_group
     }
 
     // lets skip updating of fields for reserved dedupe group
-    if (CRM_Utils_Array::value('is_reserved', $this->_defaults)) {
+    if (!empty($this->_defaults['is_reserved'])) {
       CRM_Core_Session::setStatus(ts("The rule '%1' has been saved.", [1 => $rgDao->title]), ts('Saved'), 'success');
       return;
     }

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -546,7 +546,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
     // assign context to drive the template display, make sure context is valid
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'search');
-    if (!CRM_Utils_Array::value($this->_context, self::validContext())) {
+    if (!array_key_exists($this->_context, self::validContext())) {
       $this->_context = 'search';
     }
     $this->set('context', $this->_context);

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -311,7 +311,7 @@ class CRM_Contact_Task extends CRM_Core_Task {
   public static function getTask($value) {
     self::tasks();
 
-    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+    if (empty(self::$_tasks[$value])) {
       // make it the print task by default
       $value = self::TASK_PRINT;
     }

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -146,7 +146,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
         $paymentParams['source'] = $paymentParams['contribution_source'];
       }
 
-      if (CRM_Utils_Array::value('is_recur', $form->_params) && $contribution->contribution_recur_id) {
+      if (!empty($form->_params['is_recur']) && $contribution->contribution_recur_id) {
         $paymentParams['contributionRecurID'] = $contribution->contribution_recur_id;
       }
       if (isset($paymentParams['contribution_source'])) {

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -168,7 +168,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
         'soft_credit_type_id' => $params['soft_credit_type_id'],
       ];
 
-      if (CRM_Utils_Array::value('is_email_receipt', $form->_values)) {
+      if (!empty($form->_values['is_email_receipt'])) {
         $form->_values['honor'] = [
           'soft_credit_type' => CRM_Utils_Array::value(
             $params['soft_credit_type_id'],

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1366,7 +1366,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $financialTypeID = CRM_Utils_Array::value('financial_type_id', $membershipType, CRM_Utils_Array::value('financial_type_id', $membershipParams));
     }
 
-    if (CRM_Utils_Array::value('membership_source', $this->_params)) {
+    if (!empty($this->_params['membership_source'])) {
       $membershipParams['contribution_source'] = $this->_params['membership_source'];
     }
 
@@ -2054,7 +2054,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($this->_params);
 
     // CRM-18854
-    if (CRM_Utils_Array::value('is_pledge', $this->_params) && !CRM_Utils_Array::value('pledge_id', $this->_values) && CRM_Utils_Array::value('adjust_recur_start_date', $this->_values)) {
+    if (!empty($this->_params['is_pledge']) && empty($this->_values['pledge_id']) && !empty($this->_values['adjust_recur_start_date'])) {
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($this->_id);
       if (CRM_Utils_Array::value('start_date', $this->_params) || !CRM_Utils_Array::value('is_pledge_start_date_visible', $pledgeBlock)
           || !CRM_Utils_Array::value('is_pledge_start_date_editable', $pledgeBlock)) {
@@ -2066,7 +2066,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     //carry payment processor id.
-    if (CRM_Utils_Array::value('id', $this->_paymentProcessor)) {
+    if (!empty($this->_paymentProcessor['id'])) {
       $this->_params['payment_processor_id'] = $this->_paymentProcessor['id'];
     }
 

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -675,7 +675,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         );
 
         foreach ($self->_values['fee'] as $fieldKey => $fieldValue) {
-          if ($fieldValue['html_type'] != 'Text' && CRM_Utils_Array::value('price_' . $fieldKey, $fields)) {
+          if ($fieldValue['html_type'] != 'Text' && !empty($fields['price_' . $fieldKey])) {
             if (!is_array($fields['price_' . $fieldKey]) && isset($fieldValue['options'][$fields['price_' . $fieldKey]])) {
               if (array_key_exists('membership_type_id', $fieldValue['options'][$fields['price_' . $fieldKey]])
                 && in_array($fieldValue['options'][$fields['price_' . $fieldKey]]['membership_type_id'], $currentMemberships)

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -481,7 +481,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
 
     // check if billing block is required for pay later
-    if (CRM_Utils_Array::value('is_pay_later', $this->_values)) {
+    if (!empty($this->_values['is_pay_later'])) {
       $this->_isBillingAddressRequiredForPayLater = CRM_Utils_Array::value('is_billing_required', $this->_values);
       $this->assign('isBillingAddressRequiredForPayLater', $this->_isBillingAddressRequiredForPayLater);
     }
@@ -951,7 +951,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
         $form->assign('fieldSetTitle', CRM_Core_BAO_UFGroup::getTitle($form->_values['onbehalf_profile_id']));
 
-        if (CRM_Utils_Array::value('is_for_organization', $form->_values)) {
+        if (!empty($form->_values['is_for_organization'])) {
           if ($form->_values['is_for_organization'] == 2) {
             $form->assign('onBehalfRequired', TRUE);
           }

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -1146,7 +1146,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
   public static function updateModeLinkedEntity($entityId, $linkedEntityTable, $mainEntityTable) {
     $result = [];
     if ($entityId && $linkedEntityTable && $mainEntityTable) {
-      if (CRM_Utils_Array::value($linkedEntityTable, self::$_tableDAOMapper)) {
+      if (!empty(self::$_tableDAOMapper[$linkedEntityTable])) {
         $dao = self::$_tableDAOMapper[$linkedEntityTable];
       }
       else {

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -400,8 +400,8 @@ class CRM_Core_Form_RecurringEntity {
         //Delete relations if any from recurring entity tables before inserting new relations for this entity id
         if ($params['entity_id']) {
           //If entity has any pre delete function, consider that first
-          if (CRM_Utils_Array::value('pre_delete_func', CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]) &&
-            CRM_Utils_Array::value('helper_class', CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']])
+          if (!empty(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['pre_delete_func']) &&
+            !empty(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['helper_class'])
           ) {
             $preDeleteResult = call_user_func_array(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['pre_delete_func'], [$params['entity_id']]);
             if (!empty($preDeleteResult)) {
@@ -409,8 +409,8 @@ class CRM_Core_Form_RecurringEntity {
             }
           }
           //Ready to execute delete on entities if it has delete function set
-          if (CRM_Utils_Array::value('delete_func', CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]) &&
-            CRM_Utils_Array::value('helper_class', CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']])
+          if (!empty(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['delete_func']) &&
+            !empty(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['helper_class'])
           ) {
             //Check if pre delete function has some ids to be deleted
             if (!empty(CRM_Core_BAO_RecurringEntity::$_entitiesToBeDeleted)) {

--- a/CRM/Core/Page/RecurringEntityPreview.php
+++ b/CRM/Core/Page/RecurringEntityPreview.php
@@ -28,14 +28,14 @@ class CRM_Core_Page_RecurringEntityPreview extends CRM_Core_Page {
       $endDateColumnName = CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['intervalDateColumns'][0];
 
       $recursion = new CRM_Core_BAO_RecurringEntity();
-      if (CRM_Utils_Array::value('dateColumns', CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']])) {
+      if (!empty(CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['dateColumns'])) {
         $recursion->dateColumns = CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['dateColumns'];
       }
       $recursion->scheduleFormValues = $formValues;
       if (!empty($formValues['exclude_date_list'])) {
         $recursion->excludeDates = explode(',', $formValues['exclude_date_list']);
       }
-      if (CRM_Utils_Array::value('excludeDateRangeColumns', CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']])) {
+      if (!empty(CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['excludeDateRangeColumns'])) {
         $recursion->excludeDateRangeColumns = CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['excludeDateRangeColumns'];
       }
 
@@ -52,7 +52,7 @@ class CRM_Core_Page_RecurringEntityPreview extends CRM_Core_Page {
       }
 
       //Check if there is any enddate column defined to find out the interval between the two range
-      if (CRM_Utils_Array::value('intervalDateColumns', CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']])) {
+      if (!empty(CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['intervalDateColumns'])) {
         if ($endDate) {
           $interval = $recursion->getInterval($startDate, $endDate);
           $recursion->intervalDateColumns = [$endDateColumnName => $interval];

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -654,7 +654,7 @@ class CRM_Core_PseudoConstant {
    *   array reference of all State/Provinces.
    */
   public static function &stateProvince($id = FALSE, $limit = TRUE) {
-    if (($id && !CRM_Utils_Array::value($id, self::$stateProvince)) || !self::$stateProvince || !$id) {
+    if (($id && empty(self::$stateProvince[$id])) || !self::$stateProvince || !$id) {
       $whereClause = FALSE;
       if ($limit) {
         $countryIsoCodes = self::countryIsoCode();
@@ -791,7 +791,7 @@ WHERE  id = %1";
    *   array reference of all countries.
    */
   public static function country($id = FALSE, $applyLimit = TRUE) {
-    if (($id && !CRM_Utils_Array::value($id, self::$country)) || !self::$country || !$id) {
+    if (($id && empty(self::$country[$id])) || !self::$country || !$id) {
 
       $config = CRM_Core_Config::singleton();
       $limitCodes = [];
@@ -1151,7 +1151,7 @@ WHERE  id = %1";
     if (empty(self::$paymentProcessorType[$cacheKey])) {
       self::populate(self::$paymentProcessorType[$cacheKey], 'CRM_Financial_DAO_PaymentProcessorType', $all, $return, 'is_active', NULL, "is_default, $return", 'id');
     }
-    if ($id && CRM_Utils_Array::value($id, self::$paymentProcessorType[$cacheKey])) {
+    if ($id && !empty(self::$paymentProcessorType[$cacheKey][$id])) {
       return self::$paymentProcessorType[$cacheKey][$id];
     }
     return self::$paymentProcessorType[$cacheKey];
@@ -1398,7 +1398,7 @@ WHERE  id = %1
       $index .= '_' . $contactType;
     }
 
-    if (!CRM_Utils_Array::value($index, Civi::$statics[__CLASS__]['greeting'])) {
+    if (empty(Civi::$statics[__CLASS__]['greeting'][$index])) {
       $filterCondition = NULL;
       if ($contactType) {
         $filterVal = 'v.filter =';

--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -155,7 +155,7 @@ abstract class CRM_Core_Task {
   public static function getTask($value) {
     static::tasks();
 
-    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+    if (empty(self::$_tasks[$value])) {
       // Children can specify a default task (eg. print), pick another if it is not valid.
       $value = key(self::$_tasks);
     }

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1645,7 +1645,7 @@ UPDATE  civicrm_participant
       $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     }
 
-    if (CRM_Utils_Array::value($participantStatuses[$oldStatusId], self::$_statusTransitionsRules) &&
+    if (!empty(self::$_statusTransitionsRules[$participantStatuses[$oldStatusId]]) &&
       in_array($participantStatuses[$newStatusId], self::$_statusTransitionsRules[$participantStatuses[$oldStatusId]])
     ) {
       $additionalParticipantIds = self::getAdditionalParticipantIds($participantId, TRUE, $oldStatusId);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1384,7 +1384,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           }
         }
 
-        if (CRM_Utils_Array::value('tax_amount', $this->_params)) {
+        if (!empty($this->_params['tax_amount'])) {
           $contributionParams['tax_amount'] = $this->_params['tax_amount'];
         }
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -410,7 +410,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     // note that I have started removing the use of isBillingAddressRequiredForPayLater in favour of letting
     // the CRM_Core_Payment_Manual class handle it - but there are ~300 references to it in the code base so only
     // removing in very limited cases.
-    if (CRM_Utils_Array::value('is_pay_later', $this->_values['event'])) {
+    if (!empty($this->_values['event']['is_pay_later'])) {
       $this->_isBillingAddressRequiredForPayLater = CRM_Utils_Array::value('is_billing_required', $this->_values['event']);
       $this->assign('isBillingAddressRequiredForPayLater', $this->_isBillingAddressRequiredForPayLater);
     }

--- a/CRM/Event/PseudoConstant.php
+++ b/CRM/Event/PseudoConstant.php
@@ -125,7 +125,7 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
 
     $index = $cond ? $cond : 'No Condition';
     $index = "{$index}_{$retColumn}";
-    if (!CRM_Utils_Array::value($index, self::$participantStatus)) {
+    if (empty(self::$participantStatus[$index])) {
       self::$participantStatus[$index] = [];
       CRM_Core_PseudoConstant::populate(self::$participantStatus[$index],
         'CRM_Event_DAO_ParticipantStatusType',
@@ -182,7 +182,7 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    */
   public static function &participantRole($id = NULL, $cond = NULL) {
     $index = $cond ? $cond : 'No Condition';
-    if (!CRM_Utils_Array::value($index, self::$participantRole)) {
+    if (empty(self::$participantRole[$index])) {
       self::$participantRole[$index] = [];
 
       $condition = NULL;

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -120,7 +120,7 @@ class CRM_Grant_Task extends CRM_Core_Task {
   public static function getTask($value) {
     self::tasks();
 
-    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+    if (empty(self::$_tasks[$value])) {
       // make it the print task by default
       $value = self::TASK_PRINT;
     }

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -106,7 +106,7 @@ class CRM_Mailing_BAO_Query {
       }
     }
 
-    if (CRM_Utils_Array::value('mailing_campaign_id', $query->_returnProperties)) {
+    if (!empty($query->_returnProperties['mailing_campaign_id'])) {
       $query->_select['mailing_campaign_id'] = 'civicrm_mailing.campaign_id as mailing_campaign_id';
       $query->_element['mailing_campaign_id'] = 1;
       $query->_tables['civicrm_campaign'] = 1;

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -670,7 +670,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
           break;
 
         case 'membership_type_id':
-          if (!CRM_Utils_Array::value($value, CRM_Member_PseudoConstant::membershipType())) {
+          if (!array_key_exists($value, CRM_Member_PseudoConstant::membershipType())) {
             throw new Exception('Invalid Membership Type Id');
           }
           $values[$key] = $value;

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -475,7 +475,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     $isCancelSupported = FALSE,
     $isUpdateBilling = FALSE
   ) {
-    if (!CRM_Utils_Array::value('view', self::$_links)) {
+    if (empty(self::$_links['view'])) {
       self::$_links['view'] = [
         CRM_Core_Action::VIEW => [
           'name' => ts('View'),
@@ -486,7 +486,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
       ];
     }
 
-    if (!CRM_Utils_Array::value('all', self::$_links)) {
+    if (empty(self::$_links['all'])) {
       $extraLinks = [
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -105,7 +105,7 @@ class CRM_Pledge_Task extends CRM_Core_Task {
   public static function getTask($value) {
     self::tasks();
 
-    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+    if (empty(self::$_tasks[$value])) {
       // make it the print task by default
       $value = self::TASK_PRINT;
     }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -357,7 +357,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $this->_ufGroup = (array) $dao;
       }
 
-      if (!CRM_Utils_Array::value('is_active', $this->_ufGroup)) {
+      if (empty($this->_ufGroup['is_active'])) {
         CRM_Core_Error::fatal(ts('The requested profile (gid=%1) is inactive or does not exist.', [
           1 => $this->_gid,
         ]));


### PR DESCRIPTION
Overview
----------------------------------------
Replaces `CRM_Utils_Array::value()` with `empty()` when the value is immediately cast to boolean.
The two statements have identical meaning but the latter is faster & easier to read.

Technical Details
----------------
Before/after should be functionally identical.

Comments
----------------------------------------
This was done via regex with some spot-checking.
