### PR TITLE
Api4 AJAX endpoint: change required permission to access AJAX API.

### DIFF
--- a/CRM/Core/xml/Menu/Api4.xml
+++ b/CRM/Core/xml/Menu/Api4.xml
@@ -3,7 +3,7 @@
   <item>
     <path>civicrm/ajax/api4</path>
     <page_callback>CRM_Api4_Page_AJAX</page_callback>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access AJAX API</access_arguments>
   </item>
   <item>
     <path>civicrm/api4</path>


### PR DESCRIPTION
Overview
----------------------------------------

As an anonymous user, it's not possible to use the API4 AJAX endpoint.

(I'm working on an extension which implements its own API4 entity that is accessible to anonymous users.)

Before
----------------------------------------

HTTP request to the ajax api4 endpoint return an Authorization Denied.

After
----------------------------------------

HTTP request to the ajax api4 endpoint respects the permissions of the entity.

cc @colemanw 