### PR TITLE
Remove an instance of passing non-arraay to CRM_Utils_Array::value(

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -502,6 +502,8 @@ class CRM_Core_Menu {
   /**
    * @param $menu
    * @param $path
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function fillComponentIds(&$menu, $path) {
     static $cache = array();
@@ -525,7 +527,7 @@ class CRM_Core_Menu {
       $menu[$path]['component_id'] = $cache[$compPath];
     }
     else {
-      if (CRM_Utils_Array::value('component', CRM_Utils_Array::value($compPath, $menu))) {
+      if (!empty($menu[$compPath]['component'])) {
         $componentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Component',
           $menu[$compPath]['component'],
           'id', 'name'


### PR DESCRIPTION
Overview
----------------------------------------
Removes one instance where a non-array is being passing int CRM_Utils_Array::value

Before
----------------------------------------
non-array passed in

After
----------------------------------------
Trying to fix once instance here - https://github.com/civicrm/civicrm-core/pull/16699 this will fail tests if not OK

Comments
----------------------------------------

