### PR TITLE
dev/core#1636 - In system status check avoid E_NOTICEs for smart groups that don't have form_values[0]

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -106,7 +106,7 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
         continue;
       }
       foreach ($group['form_values'] as $formValues) {
-        if (substr($formValues[0], 0, 7) == 'custom_') {
+        if (isset($formValues[0]) && (substr($formValues[0], 0, 7) == 'custom_')) {
           list(, $customFieldID) = explode('custom_', $formValues[0]);
           if (!in_array($customFieldID, $customFieldIds)) {
             $problematicSG[CRM_Contact_BAO_SavedSearch::getName($group['id'], 'id')] = [


### PR DESCRIPTION
Overview
----------------------------------------
In some installs where smart groups are defined differently, you get `Undefined index 0 line 109 in CRM/Utils/Check/Component/Schema.php` when first logging in. They also happen on the system status page but you don't see them there because they get snippet'd out, but they appear in drupal watchdog.

Related lab tickets:
* https://lab.civicrm.org/dev/core/issues/1636
* https://lab.civicrm.org/dev/core/issues/1471
* https://lab.civicrm.org/dev/core/issues/1555

Technical Details
----------------------------------------
In PR https://github.com/civicrm/civicrm-core/pull/16267 a check for deleted custom fields in smart groups was added. For whatever reason, as also addressed in https://github.com/civicrm/civicrm-core/pull/16417, some smart groups don't have a `form_values[0]`, so you get undefined index notices.

I've just applied the same fix/workaround as in #16417 

Comments
----------------------------------------
Started in 5.23 so have based against 5.24. It's just a system status check so not sure it needs to be backported, although you see the notices every time you log in.

FYI @jitendrapurohit @jmcclelland 