### PR TITLE
Fix another instance of NULL being passed to CRM_Utils_Array::value

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -85,7 +85,7 @@ class CRM_Core_PseudoConstant {
    * RelationshipType
    * @var array
    */
-  private static $relationshipType;
+  private static $relationshipType = [];
 
   /**
    * Civicrm groups that are not smart groups
@@ -1006,9 +1006,9 @@ WHERE  id = %1";
    * @return array
    *   array reference of all relationship types.
    */
-  public static function &relationshipType($valueColumnName = 'label', $reset = FALSE, $isActive = 1) {
+  public static function relationshipType($valueColumnName = 'label', $reset = FALSE, $isActive = 1) {
     $cacheKey = $valueColumnName . '::' . $isActive;
-    if (!CRM_Utils_Array::value($cacheKey, self::$relationshipType) || $reset) {
+    if (!isset(self::$relationshipType[$cacheKey]) || $reset) {
       self::$relationshipType[$cacheKey] = [];
 
       //now we have name/label columns CRM-3336

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -8,6 +8,11 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
   private $allowedContactsACL = [];
 
+  /**
+   * Set up for test.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
   public function setUp() {
     parent::setUp();
     $this->prepareForACLs();
@@ -17,6 +22,9 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Clean up after tests.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function tearDown() {
     $tablesToTruncate = [
@@ -34,6 +42,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Test case for create() method.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreate() {
     $contactId = $this->individualCreate();
@@ -73,6 +83,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Test case for getContactActivity() method.
    *
    * getContactActivity() method get activities detail for given target contact id.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetContactActivity() {
     $contactId = $this->individualCreate();


### PR DESCRIPTION


Overview
----------------------------------------
Fixes another bad-coding instance where we do silly things rather than set the parameter up as an array from the start

Before
----------------------------------------
NULL being passed to CRM_Utils_Array::value

After
----------------------------------------
self::$relationshipType is always an array, isset used

Technical Details
----------------------------------------
Note that the test has only cosmetic changes picked up while running the test to identify the bug

Comments
----------------------------------------

