### PR TITLE
Fix another instance of silly use of CRM_Utils_Array::value

### DIFF
--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -54,7 +54,7 @@ class ChainSubscriber implements EventSubscriberInterface {
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] < 4) {
       $result = $event->getResponse();
-      if (\CRM_Utils_Array::value('is_error', $result, 0) == 0) {
+      if (!is_array($result) || ($result['is_error'] ?? 0) == 0) {
         $this->callNestedApi($event->getApiKernel(), $apiRequest['params'], $result, $apiRequest['action'], $apiRequest['entity'], $apiRequest['version']);
         $event->setResponse($result);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Removes another place where a non array is sometimes passed to CRM_Utils_Array::value

Before
----------------------------------------
Values passed to include CRM_Utils_Array::value as the array include strings & integers

After
----------------------------------------
It the value is a string CRM_Utils_Array::value would return the  default - of 0 - so !is_array($result) is equivalent to $result['is_error'] = 0. It could also be a getsingle result so the absence of is_error as a  key also indicates success

Technical Details
----------------------------------------


Comments
----------------------------------------

