### PR TITLE
Introduce "civi.dao.preUpdate" and "civi.dao.preInsert" events

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -543,19 +543,29 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function save($hook = TRUE) {
     if (!empty($this->id)) {
-      $this->update();
+      if ($hook) {
+        $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);
+        \Civi::service('dispatcher')->dispatch("civi.dao.preUpdate", $preEvent);
+      }
+
+      $result = $this->update();
 
       if ($hook) {
-        $event = new \Civi\Core\DAO\Event\PostUpdate($this);
+        $event = new \Civi\Core\DAO\Event\PostUpdate($this, $result);
         \Civi::service('dispatcher')->dispatch("civi.dao.postUpdate", $event);
       }
       $this->clearDbColumnValueCache();
     }
     else {
-      $this->insert();
+      if ($hook) {
+        $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);
+        \Civi::service('dispatcher')->dispatch("civi.dao.preInsert", $preEvent);
+      }
+
+      $result = $this->insert();
 
       if ($hook) {
-        $event = new \Civi\Core\DAO\Event\PostUpdate($this);
+        $event = new \Civi\Core\DAO\Event\PostUpdate($this, $result);
         \Civi::service('dispatcher')->dispatch("civi.dao.postInsert", $event);
       }
     }

--- a/Civi/Core/DAO/Event/PreUpdate.php
+++ b/Civi/Core/DAO/Event/PreUpdate.php
@@ -12,10 +12,10 @@
 namespace Civi\Core\DAO\Event;
 
 /**
- * Class PostUpdate
+ * Class PreDelete
  * @package Civi\Core\DAO\Event
  */
-class PostUpdate extends \Symfony\Component\EventDispatcher\Event {
+class PreUpdate extends \Symfony\Component\EventDispatcher\Event {
 
   /**
    * @var \CRM_Core_DAO
@@ -23,17 +23,10 @@ class PostUpdate extends \Symfony\Component\EventDispatcher\Event {
   public $object;
 
   /**
-   * @var mixed
-   */
-  public $result;
-
-  /**
    * @param $object
-   * @param $result
    */
-  public function __construct($object, $result) {
+  public function __construct($object) {
     $this->object = $object;
-    $this->result = $result;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR is for [this issue on GitLab](https://lab.civicrm.org/dev/core/issues/1638) and mirrors the pattern of `hook_civicrm_pre` + `hook_civicrm_post` and `hook_civicrm_preProcess` +  `hook_civicrm_postProcess` and the existing pattern of `civi.dao.preDelete` + `civi.dao.postDelete` to complete the set with:

* `civi.dao.preInsert` + `civi.dao.postInsert`
* `civi.dao.preUpdate` + `civi.dao.postUpdate`

Before
----------------------------------------
There isn't a hook available to inspect (for example) the data of an Option Value prior to it being created or updated programatically.

After
----------------------------------------
It is possible to inspect the data of an Option Value prior to it being created or updated programatically.

Technical Details
----------------------------------------
With this PR, the following comparison between Option Value data before and after it is updated becomes possible:

```php
class CiviCRM_Pre_Update_Demo {

  /**
   * Register hooks.
   */
  public function __construct() {
    add_action( 'civicrm_config', [ $this, 'config_callback' ], 10 );
  }

  /**
   * Callback for "hook_civicrm_config".
   *
   * @param object $config The CiviCRM config object.
   */
  public function config_callback( &$config ) {

    // Add callback for CiviCRM "preUpdate" hook.
    Civi::service('dispatcher')->addListener(
      'civi.dao.preUpdate',
      [ $this, 'event_type_pre_update' ],
      -100 // Default priority.
    );

    // Add callback for CiviCRM "postUpdate" hook.
    Civi::service('dispatcher')->addListener(
      'civi.dao.postUpdate',
      [ $this, 'event_type_updated' ],
      -100 // Default priority.
    );

  }

  /**
   * Callback for the CiviCRM 'civi.dao.preUpdate' hook.
   *
   * @param object $event The event object.
   * @param string $hook The hook name.
   */
  public function event_type_pre_update( $event, $hook ) {

    // Extract Event Type for this hook.
    $event_type =& $event->object;

    // Bail if this isn't the type of object we're after.
    if ( ! ( $event_type instanceof CRM_Core_DAO_OptionValue ) ) {
      return;
    }
    
    // Get the full data for the Event Type about to be updated.
    $this->event_type_pre = $this->get_event_type_by_id( $event_type->id );
  
    // Maybe do something with the existing data.

  }

  /**
   * Callback for the CiviCRM 'civi.dao.postUpdate' hook.
   *
   * @param object $event The event object.
   * @param string $hook The hook name.
   */
  public function event_type_updated( $event, $hook ) {

    // Extract Event Type for this hook.
    $event_type =& $event->object;

    // Bail if this isn't the type of object we're after.
    if ( ! ( $event_type instanceof CRM_Core_DAO_OptionValue ) ) {
      return;
    }

    // Get the actual Event Type being updated.
    $event_type_full = $this->get_event_type_by_id( $event_type->id );
  
    // Maybe compare new data with the existing data.
    if ( $this->event_type_pre['is_default'] != $event_type_full['is_default'] ) {
      // Do something.
    }

  }

  /**
   * Grab the full data for the Event Type via the CiviCRM API.
   *
   * @param int $event_type_id The ID of the Event Type.
   * @return array $event_type The array of data from the API.
   */
  public function get_event_type_by_id( $event_type_id ) {
    
    // Code to get the data for the Event Type.
  
  }

}

new CiviCRM_Pre_Update_Demo();
```