### PR TITLE
Generate text for cancelSubscription form in payment class

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -45,12 +45,17 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
    */
   public function preProcess() {
     parent::preProcess();
-    if ($this->_crid) {
-      $this->assign('frequency_unit', $this->getSubscriptionDetails()->frequency_unit);
-      $this->assign('frequency_interval', $this->getSubscriptionDetails()->frequency_interval);
-      $this->assign('amount', $this->getSubscriptionDetails()->amount);
-      $this->assign('installments', $this->getSubscriptionDetails()->installments);
 
+    $cancelRecurTextParams = [
+      'mode' => $this->_mode,
+      'amount' => $this->getSubscriptionDetails()->amount,
+      'currency' => $this->getSubscriptionDetails()->currency,
+      'frequency_interval' => $this->getSubscriptionDetails()->frequency_interval,
+      'frequency_unit' => $this->getSubscriptionDetails()->frequency_unit,
+      'installments' => $this->getSubscriptionDetails()->installments,
+    ];
+
+    if ($this->_crid) {
       // Are we cancelling a recurring contribution that is linked to an auto-renew membership?
       if ($this->getSubscriptionDetails()->membership_id) {
         $this->_mid = $this->getSubscriptionDetails()->membership_id;
@@ -64,7 +69,9 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
 
       $membershipTypes = CRM_Member_PseudoConstant::membershipType();
       $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_mid, 'membership_type_id');
-      $this->assign('membershipType', CRM_Utils_Array::value($membershipTypeId, $membershipTypes));
+      $membershipType = $membershipTypes[$membershipTypeId] ?? '';
+      $this->assign('membershipType', $membershipType);
+      $cancelRecurTextParams['membershipType'] = $membershipType;
     }
 
     if ($this->_coid) {
@@ -72,11 +79,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         CRM_Core_Error::statusBounce(ts('The recurring contribution looks to have been cancelled already.'));
       }
       $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'obj');
-
-      $this->assign('frequency_unit', $this->getSubscriptionDetails()->frequency_unit);
-      $this->assign('frequency_interval', $this->getSubscriptionDetails()->frequency_interval);
-      $this->assign('amount', $this->getSubscriptionDetails()->amount);
-      $this->assign('installments', $this->getSubscriptionDetails()->installments);
     }
 
     if (
@@ -85,6 +87,8 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     ) {
       CRM_Core_Error::statusBounce('Required information missing.');
     }
+
+    $this->assign('cancelRecurDetailText', $this->_paymentProcessorObj->getText('cancelRecurDetailText', $cancelRecurTextParams));
 
     // handle context redirection
     CRM_Contribute_BAO_ContributionRecur::setSubscriptionContext();
@@ -139,6 +143,9 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         ts('Send cancellation request to %1 ?',
           [1 => $this->_paymentProcessorObj->_processorName])
       );
+    }
+    else {
+      $this->assign('cancelRecurNotSupportedText', $this->_paymentProcessorObj->getText('cancelRecurNotSupportedText', []));
     }
     $this->assign('cancelSupported', $cancelSupported);
 
@@ -239,13 +246,13 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         else {
           $tplParams['recur_frequency_interval'] = $this->getSubscriptionDetails()->frequency_interval;
           $tplParams['recur_frequency_unit'] = $this->getSubscriptionDetails()->frequency_unit;
-          $tplParams['amount'] = $this->getSubscriptionDetails()->amount;
+          $tplParams['amount'] = CRM_Utils_Money::format($this->getSubscriptionDetails()->amount, $this->getSubscriptionDetails()->currency);
           $tplParams['contact'] = ['display_name' => $this->_donorDisplayName];
           $status = ts('The recurring contribution of %1, every %2 %3 has been cancelled.',
             [
-              1 => $this->getSubscriptionDetails()->amount,
-              2 => $this->getSubscriptionDetails()->frequency_interval,
-              3 => $this->getSubscriptionDetails()->frequency_unit,
+              1 => $tplParams['amount'],
+              2 => $tplParams['recur_frequency_interval'],
+              3 => $tplParams['recur_frequency_unit'],
             ]
           );
           $msgTitle = 'Contribution Cancelled';

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -551,6 +551,9 @@ abstract class CRM_Core_Payment {
    *   Only explicitly supported contexts are handled without error.
    *   Currently supported:
    *   - contributionPageRecurringHelp (params: is_recur_installments, is_email_receipt)
+   *   - contributionPageContinueText (params: amount, is_payment_to_existing)
+   *   - cancelRecurDetailText (params: mode, amount, currency, frequency_interval, frequency_unit, installments, {membershipType|only if mode=auto_renew})
+   *   - cancelRecurNotSupportedText
    *
    * @param array $params
    *   Parameters for the field, context specific.
@@ -589,6 +592,30 @@ abstract class CRM_Core_Payment {
           return ts('To complete this transaction, click the <strong>Make Payment</strong> button below.');
         }
         return ts('To complete your contribution, click the <strong>Continue</strong> button below.');
+
+      case 'cancelRecurDetailText':
+        if ($params['mode'] === 'auto_renew') {
+          return ts('Click the button below if you want to cancel the auto-renewal option for your %1 membership. This will not cancel your membership. However you will need to arrange payment for renewal when your membership expires.',
+            [1 => $params['membershipType']]
+          );
+        }
+        else {
+          $text = ts('Recurring Contribution Details: %1 every %2 %3', [
+            1 => CRM_Utils_Money::format($params['amount'], $params['currency']),
+            2 => $params['frequency_interval'],
+            3 => $params['frequency_unit'],
+          ]);
+          if (!empty($params['installments'])) {
+            $text .= ' ' . ts('for %1 installments', [1 => $params['installments']]) . '.';
+          }
+          $text = "<strong>{$text}</strong><div class='content'>";
+          $text .= ts('Click the button below to cancel this commitment and stop future transactions. This does not affect contributions which have already been completed.');
+          $text .= '</div>';
+          return $text;
+        }
+
+      case 'cancelRecurNotSupportedText':
+        return ts('Automatic cancellation is not supported for this payment processor. You or the contributor will need to manually cancel this recurring contribution using the payment processor website.');
 
     }
     CRM_Core_Error::deprecatedFunctionWarning('Calls to getText must use a supported method');

--- a/templates/CRM/Contribute/Form/CancelSubscription.tpl
+++ b/templates/CRM/Contribute/Form/CancelSubscription.tpl
@@ -11,19 +11,9 @@
 <div class="crm-block crm-form-block crm-auto-renew-membership-cancellation">
 <div class="help">
   <div class="icon inform-icon"></div>&nbsp;
-  {if $mode eq 'auto_renew'}
-      {ts}Click the button below if you want to cancel the auto-renewal option for your {$membershipType} membership. This will not cancel your membership. However you will need to arrange payment for renewal when your membership expires.{/ts}
-  {else}
-      <strong>{ts 1=$amount|crmMoney 2=$frequency_interval 3=$frequency_unit}Recurring Contribution Details: %1 every %2 %3{/ts}
-      {if $installments}
-        {ts 1=$installments}for %1 installments{/ts}.
-      {/if}</strong>
-      <div class="content">{ts}Click the button below to cancel this commitment and stop future transactions. This does not affect contributions which have already been completed.{/ts}</div>
-  {/if}
+  {$cancelRecurDetailText}
   {if !$cancelSupported}
-    <div class="status-warning">
-      {ts}Automatic cancellation is not supported for this payment processor. You or the contributor will need to manually cancel this recurring contribution using the payment processor website.{/ts}
-    </div>
+    <div class="status-warning">{$cancelRecurNotSupportedText}</div>
   {/if}
 </div>
   {include file="CRM/Core/Form/EntityForm.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Following on from previous work that @eileenmcnaughton has done in this area. This allows a payment processor to override the text displayed on the cancel subscription form if it wants to.

Before
----------------------------------------
Text built in tpl file.

After
----------------------------------------
Text built in class and can be changed by individual payment processors.

Technical Details
----------------------------------------
Uses the CRM_Core_Payment::getText function.

Comments
----------------------------------------
We could go a step further and stop assigning most params to the form because they are no longer required.