### PR TITLE
Add contributor email address to cancelSubscription form so it is cle…

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -8,13 +8,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
  */
-use Civi\Payment\PropertyBag;
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
+use Civi\Payment\PropertyBag;
 
 /**
  * This class provides support for canceling recurring subscriptions.
@@ -24,6 +19,13 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
   protected $_userContext = NULL;
 
   protected $_mode = NULL;
+
+  /**
+   * The contributor email
+   *
+   * @var string
+   */
+  protected $_donorEmail = '';
 
   /**
    * Should custom data be suppressed on this form.
@@ -149,8 +151,8 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     }
     $this->assign('cancelSupported', $cancelSupported);
 
-    if ($this->_donorEmail) {
-      $this->add('checkbox', 'is_notify', ts('Notify Contributor?'));
+    if (!empty($this->_donorEmail)) {
+      $this->add('checkbox', 'is_notify', ts('Notify Contributor?') . " ({$this->_donorEmail})");
     }
     if ($this->_mid) {
       $cancelButton = ts('Cancel Automatic Membership Renewal');
@@ -205,7 +207,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         $params['send_cancel_request'] = 1;
       }
 
-      if ($this->_donorEmail) {
+      if (!empty($this->_donorEmail)) {
         $params['is_notify'] = 1;
       }
     }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -419,7 +419,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       unset($extra['option_context']);
     }
 
-    $element = $this->addElement($type, $name, $label, $attributes, $extra);
+    $element = $this->addElement($type, $name, CRM_Utils_String::purifyHTML($label), $attributes, $extra);
     if (HTML_QuickForm::isError($element)) {
       CRM_Core_Error::fatal(HTML_QuickForm::errorMessage($element));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Just adds the contributor email to the form so it is clear who will be notified.

Before
----------------------------------------
Not clear which email address will receive the cancellation notice.

After
----------------------------------------
Clear to the person cancelling the recur:
![image](https://user-images.githubusercontent.com/2052161/76214970-a8870180-6205-11ea-9139-a4f42b673207.png)

Technical Details
----------------------------------------
We already have the email - just adding to the label. It might have been nice to do this via description/help_text on the element but they are not passed through if defined via `$this->add`.

Comments
----------------------------------------
