### PR TITLE
Pending #17146 Always use cancelSubscription form if recur has a payment processor

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -135,16 +135,20 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     // Determine if we can cancel recurring contribution via API with this processor
     $cancelSupported = $this->_paymentProcessorObj->supports('CancelRecurring');
     if ($cancelSupported) {
-      $searchRange = [];
-      $searchRange[] = $this->createElement('radio', NULL, NULL, ts('Yes'), '1');
-      $searchRange[] = $this->createElement('radio', NULL, NULL, ts('No'), '0');
+      // We check if we are using the manual processor as that does not support cancellation requests.
+      // It would be nice to improve the way this is handled instead of hardcoding the ID here.
+      if ($this->_paymentProcessorObj->getPaymentProcessor()['id'] !== 0) {
+        $searchRange = [];
+        $searchRange[] = $this->createElement('radio', NULL, NULL, ts('Yes'), '1');
+        $searchRange[] = $this->createElement('radio', NULL, NULL, ts('No'), '0');
 
-      $this->addGroup(
-        $searchRange,
-        'send_cancel_request',
-        ts('Send cancellation request to %1 ?',
-          [1 => $this->_paymentProcessorObj->getTitle()])
-      );
+        $this->addGroup(
+          $searchRange,
+          'send_cancel_request',
+          ts('Send cancellation request to %1 ?',
+            [1 => $this->_paymentProcessorObj->getTitle()])
+        );
+      }
     }
     else {
       $this->assign('cancelRecurNotSupportedText', $this->_paymentProcessorObj->getText('cancelRecurNotSupportedText', []));

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -42,12 +42,12 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
    * - Edit
    * - Cancel
    *
-   * @param bool $recurID
+   * @param int $recurID
    * @param string $context
    *
    * @return array
    */
-  public static function recurLinks($recurID = FALSE, $context = 'contribution') {
+  public static function recurLinks($recurID, $context = 'contribution') {
     $links = [
       CRM_Core_Action::VIEW => [
         'name' => ts('View'),
@@ -68,30 +68,22 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
       ],
     ];
 
-    if ($recurID) {
-      $paymentProcessorObj = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorObject($recurID);
-      if ($paymentProcessorObj) {
-        if ($paymentProcessorObj->supports('cancelRecurring')) {
-          unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
-          $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
-          $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
-        }
+    $paymentProcessorObj = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorObject($recurID);
+    if ($paymentProcessorObj) {
+      unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
+      $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
+      $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
 
-        if ($paymentProcessorObj->supports('UpdateSubscriptionBillingInfo')) {
-          $links[CRM_Core_Action::RENEW] = [
-            'name' => ts('Change Billing Details'),
-            'title' => ts('Change Billing Details'),
-            'url' => 'civicrm/contribute/updatebilling',
-            'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
-          ];
-        }
-
-        if (!$paymentProcessorObj->supports('ChangeSubscriptionAmount') && !$paymentProcessorObj->supports('EditRecurringContribution')) {
-          unset($links[CRM_Core_Action::UPDATE]);
-        }
+      if ($paymentProcessorObj->supports('UpdateSubscriptionBillingInfo')) {
+        $links[CRM_Core_Action::RENEW] = [
+          'name' => ts('Change Billing Details'),
+          'title' => ts('Change Billing Details'),
+          'url' => 'civicrm/contribute/updatebilling',
+          'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
+        ];
       }
-      else {
-        unset($links[CRM_Core_Action::DISABLE]);
+
+      if (!$paymentProcessorObj->supports('ChangeSubscriptionAmount') && !$paymentProcessorObj->supports('EditRecurringContribution')) {
         unset($links[CRM_Core_Action::UPDATE]);
       }
     }

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -19,6 +19,18 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
   protected $result;
 
   /**
+   * Constructor.
+   *
+   * @param string $mode
+   *   The mode of operation: live or test (deprecated)
+   * @param array $paymentProcessor
+   */
+  public function __construct($mode, &$paymentProcessor) {
+    $this->_mode = $mode;
+    $this->_paymentProcessor = $paymentProcessor;
+  }
+
+  /**
    * This function checks to see if we have the right config values.
    */
   public function checkConfig() {}
@@ -263,7 +275,19 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
         }
         return ts('To complete your contribution, click the <strong>Continue</strong> button below.');
 
+      default:
+        return parent::getText($context, $params);
+
     }
+  }
+
+  /**
+   * Does this processor support cancelling recurring contributions through code.
+   *
+   * @return bool
+   */
+  protected function supportsCancelRecurring() {
+    return TRUE;
   }
 
 }

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -308,6 +308,24 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
     }
 
     $processors = civicrm_api3('payment_processor', 'get', $retrievalParameters);
+    // Add the pay-later pseudo-processor.
+    $processors['values'][0] = [
+      'id' => 0,
+      'payment_processor_type_id' => 0,
+      // This shouldn't be required but there are still some processors hacked into core with nasty 'if's.
+      'api.payment_processor_type.getsingle' => ['name' => 'Manual'],
+      'class_name' => 'Payment_Manual',
+      'name' => 'pay_later',
+      'billing_mode' => '',
+      'is_default' => 0,
+      'payment_instrument_id' => key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1')),
+      // Making this optionally recur would give lots of options -but it should
+      // be a row in the payment processor table before we do that.
+      'is_recur' => FALSE,
+      'is_test' => FALSE,
+      'domain_id' => CRM_Core_Config::domainID(),
+      'is_active' => 1,
+    ];
     foreach ($processors['values'] as $processor) {
       $fieldsToProvide = [
         'id',
@@ -337,24 +355,6 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
       $processors['values'][$processor['id']]['payment_processor_type'] = $processor['payment_processor_type'] = $processors['values'][$processor['id']]['api.payment_processor_type.getsingle']['name'];
       $processors['values'][$processor['id']]['object'] = Civi\Payment\System::singleton()->getByProcessor($processors['values'][$processor['id']]);
     }
-
-    // Add the pay-later pseudo-processor.
-    $processors['values'][0] = [
-      'object' => new CRM_Core_Payment_Manual(),
-      'id' => 0,
-      'payment_processor_type_id' => 0,
-      // This shouldn't be required but there are still some processors hacked into core with nasty 'if's.
-      'payment_processor_type' => 'Manual',
-      'class_name' => 'Payment_Manual',
-      'name' => 'pay_later',
-      'billing_mode' => '',
-      'is_default' => 0,
-      'payment_instrument_id' => key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1')),
-      // Making this optionally recur would give lots of options -but it should
-      // be a row in the payment processor table before we do that.
-      'is_recur' => FALSE,
-      'is_test' => FALSE,
-    ];
 
     CRM_Utils_Cache::singleton()->set($cacheKey, $processors['values']);
 


### PR DESCRIPTION
Overview
----------------------------------------
There was existing code to handle cancellation if the processor does not support cancellation.

You may still want to record cancellation reason, see instructions to manually cancel with your provider and send a notification email to the contributor.

But if the processor reports that it does not `supportCancelRecurring` the form is never displayed and the built in entity enable/disable via javascript is used. This only really makes sense if there is no payment processor.

Before
----------------------------------------
enable/disable javascript used if processor does not support cancelling recur (cancel link still available in list of recurs!).

After
----------------------------------------
If recurring contribution has a payment processor, always display the cancellation form. Eg.
![image](https://user-images.githubusercontent.com/2052161/76215359-8477f000-6206-11ea-93ca-09500b5dfddc.png)

![image](https://user-images.githubusercontent.com/2052161/76215434-a8d3cc80-6206-11ea-8e97-51fbfc0aec9c.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
This cleans up another inconsistency in the way civi handles things. Most of the work leading up to this was yours @eileenmcnaughton so comments would be appreciated.
