### PR TITLE
[REF] Use ?? operator instead of CRM_Utils_Array::value() in return statements

### DIFF
--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -886,7 +886,7 @@ INNER JOIN  civicrm_contact contact_a ON ( activityTarget.contact_id = contact_a
       }
     }
 
-    return CRM_Utils_Array::value($surveyId, $ufIds);
+    return $ufIds[$surveyId] ?? NULL;
   }
 
   /**

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3620,7 +3620,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
   public static function isFieldHasLocationType($fieldTitle) {
     foreach (CRM_Contact_BAO_Contact::importableFields() as $key => $field) {
       if ($field['title'] === $fieldTitle) {
-        return CRM_Utils_Array::value('hasLocationType', $field);
+        return $field['hasLocationType'] ?? NULL;
       }
     }
     return FALSE;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5008,7 +5008,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public static function checkContributeSettings($name) {
     $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
-    return CRM_Utils_Array::value($name, $contributeSettings);
+    return $contributeSettings[$name] ?? NULL;
   }
 
   /**

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -63,7 +63,7 @@ class CRM_Core_Component {
   public static function get($name, $attribute = NULL) {
     $comp = CRM_Utils_Array::value($name, self::_info());
     if ($attribute) {
-      return CRM_Utils_Array::value($attribute, $comp->info);
+      return $comp->info[$attribute] ?? NULL;
     }
     return $comp;
   }

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -464,7 +464,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    */
   public function getButtonName() {
     $data = &$this->container();
-    return CRM_Utils_Array::value('_qf_button_name', $data);
+    return $data['_qf_button_name'] ?? NULL;
   }
 
   /**

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -375,7 +375,7 @@ class CRM_Core_Payment_Form {
       return $month;
     }
 
-    return CRM_Utils_Array::value('m', $src['credit_card_exp_date']);
+    return $src['credit_card_exp_date']['m'] ?? NULL;
   }
 
   /**
@@ -388,7 +388,7 @@ class CRM_Core_Payment_Form {
    * @return int
    */
   public static function getCreditCardExpirationYear($src) {
-    return CRM_Utils_Array::value('Y', $src['credit_card_exp_date']);
+    return $src['credit_card_exp_date']['Y'] ?? NULL;
   }
 
   /**

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -76,7 +76,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       throw new CRM_Core_Exception("Failure: Missing Parameter $name");
     }
     else {
-      return CRM_Utils_Array::value($name, $this->_invoiceData);
+      return $this->_invoiceData[$name] ?? NULL;
     }
   }
 

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -397,7 +397,7 @@ class CRM_Core_PseudoConstant {
     if ($values === FALSE) {
       return FALSE;
     }
-    return CRM_Utils_Array::value($key, $values);
+    return $values[$key] ?? NULL;
   }
 
   /**
@@ -417,7 +417,7 @@ class CRM_Core_PseudoConstant {
     if ($values === FALSE) {
       return FALSE;
     }
-    return CRM_Utils_Array::value($key, $values);
+    return $values[$key] ?? NULL;
   }
 
   /**
@@ -1478,7 +1478,7 @@ WHERE  id = %1
       self::$accountOptionValues[$cacheKey] = CRM_Core_OptionGroup::values($optionGroupName, FALSE, FALSE, FALSE, $condition);
     }
     if ($id) {
-      return CRM_Utils_Array::value($id, self::$accountOptionValues[$cacheKey]);
+      return self::$accountOptionValues[$cacheKey][$id] ?? NULL;
     }
 
     return self::$accountOptionValues[$cacheKey];

--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -250,7 +250,7 @@ class CRM_Core_Session {
       $session =& $this->_session[$this->_key][$prefix];
     }
 
-    return CRM_Utils_Array::value($name, $session);
+    return $session[$name] ?? NULL;
   }
 
   /**

--- a/CRM/Event/Cart/BAO/Cart.php
+++ b/CRM/Event/Cart/BAO/Cart.php
@@ -238,7 +238,7 @@ class CRM_Event_Cart_BAO_Cart extends CRM_Event_Cart_DAO_Cart {
    * @return mixed
    */
   public function get_event_in_cart_by_event_id($event_id) {
-    return CRM_Utils_Array::value($event_id, $this->events_in_carts);
+    return $this->events_in_carts[$event_id] ?? NULL;
   }
 
   /**

--- a/CRM/Event/PseudoConstant.php
+++ b/CRM/Event/PseudoConstant.php
@@ -298,7 +298,7 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
       );
     }
     if ($id) {
-      return CRM_Utils_Array::value($id, self::$pcPage);
+      return self::$pcPage[$id] ?? NULL;
     }
     return self::$pcPage;
   }

--- a/CRM/Financial/Form/SalesTaxTrait.php
+++ b/CRM/Financial/Form/SalesTaxTrait.php
@@ -41,7 +41,7 @@ trait CRM_Financial_Form_SalesTaxTrait {
     if (!$invoicing) {
       return '';
     }
-    return CRM_Utils_Array::value('tax_term', $invoiceSettings);
+    return $invoiceSettings['tax_term'] ?? NULL;
   }
 
   /**

--- a/CRM/Invoicing/Utils.php
+++ b/CRM/Invoicing/Utils.php
@@ -59,7 +59,7 @@ class CRM_Invoicing_Utils {
       return TRUE;
     }
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    return CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    return $invoiceSettings['invoicing'] ?? NULL;
   }
 
   /**
@@ -70,7 +70,7 @@ class CRM_Invoicing_Utils {
    */
   public static function getTaxTerm() {
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    return CRM_Utils_Array::value('tax_term', $invoiceSettings);
+    return $invoiceSettings['tax_term'] ?? NULL;
   }
 
 }

--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -280,7 +280,7 @@ WHERE  log_date <= %1 AND id = %2 ORDER BY log_date DESC LIMIT 1";
         if (array_key_exists('options', $this->_logTables[$entity]['bracket_info']) &&
           $entityID
         ) {
-          return CRM_Utils_Array::value($entityID, $this->_logTables[$entity]['bracket_info']['options']);
+          return $this->_logTables[$entity]['bracket_info']['options'][$entityID] ?? NULL;
         }
       }
     }

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -792,7 +792,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
     if (!$lookup) {
       $lookup = CRM_Contact_BAO_Relationship::buildOptions("is_permission_a_b");
     };
-    return CRM_Utils_Array::value($key, $lookup);
+    return $lookup[$key] ?? NULL;
   }
 
   /**

--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -99,7 +99,7 @@ WHERE  TRIM(BOTH '/' FROM CONCAT(report_id, '/', name)) = %1";
       $params = [1 => [$path, 'String']];
       $valId[$path] = CRM_Core_DAO::singleValueQuery($sql, $params);
     }
-    return CRM_Utils_Array::value($path, $valId);
+    return $valId[$path] ?? NULL;
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1278,7 +1278,7 @@ class CRM_Utils_System {
    *   The previous page URL
    */
   public static function refererPath() {
-    return CRM_Utils_Array::value('HTTP_REFERER', $_SERVER);
+    return $_SERVER['HTTP_REFERER'] ?? NULL;
   }
 
   /**

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -501,7 +501,7 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
 
     $result = [];
     CRM_Financial_BAO_FinancialTypeAccount::retrieve($searchParams, $result);
-    return CRM_Utils_Array::value('financial_account_id', $result);
+    return $result['financial_account_id'] ?? NULL;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is part of a series of PRs to update an old code pattern. `CRM_Utils_Array::value()` can in many cases be swapped for the new PHP7 `??` operator.

Comments
----------------------------------------
This PR was generated from a single regex which replaces all return statements that use `CRM_Utils_Array::value()` with only 2 arguments. Before/after are functionally identical because the default is `null`.