### PR TITLE
skip smart groups that don't have a form_values[0]

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -106,7 +106,7 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
         continue;
       }
       foreach ($group['form_values'] as $formValues) {
-        if (substr($formValues[0], 0, 7) == 'custom_') {
+        if (isset($formValues[0]) && (substr($formValues[0], 0, 7) == 'custom_')) {
           list(, $customFieldID) = explode('custom_', $formValues[0]);
           if (!in_array($customFieldID, $customFieldIds)) {
             $problematicSG[CRM_Contact_BAO_SavedSearch::getName($group['id'], 'id')] = [


### PR DESCRIPTION
Back port from #16707 

@eileenmcnaughton given the likelyhood of a 5.23 drop i figure this should go in as well