### PR TITLE
dev/core#1599/Deceased Contact's Membership Marked to Deceased via Inline

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -426,6 +426,14 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       self::unsetProtectedFields($contacts);
     }
 
+    // Edit Membership Status
+    $deceasedParams = [
+      'contact_id' => CRM_Utils_Array::value('contact_id', $params),
+      'is_deceased' => CRM_Utils_Array::value('is_deceased', $params, FALSE),
+      'deceased_date' => CRM_Utils_Array::value('deceased_date', $params, NULL),
+    ];
+    CRM_Member_BAO_Membership::updateMembershipStatus($deceasedParams, $params['contact_type']);
+
     return $contact;
   }
 

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -137,6 +137,25 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that after checking the person as 'Deceased', the Membership is also 'Deceased' both through inline and normal edit.
+   */
+  public function testDeceasedMembershipInline() {
+    $contactID = $this->individualCreate();
+    $params = [
+      'contact_id' => $contactID,
+      'membership_type_id' => $this->_membershipTypeID,
+      'join_date' => '2006-01-21',
+      'start_date' => '2006-01-21',
+      'end_date' => '2006-12-21',
+      'status_id' => $this->_membershipStatusID,
+    ];
+    $this->callApiSuccess('membership', 'create', $params);
+    $this->callApiSuccess('contact', 'create', ['id' => $contactID, 'is_deceased' => 1]);
+    $membership = $this->callApiSuccessGetSingle('membership', ['contact_id' => $contactID]);
+    $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Deceased'), $membership['status_id']);
+  }
+
+  /**
    * Test that trying to delete membership status while membership still exists creates error.
    */
   public function testDeleteWithMembershipError() {


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

Overview
The Deceased Contact's Membership will also be Deceased, if you mark a contact as deceased even via Inline. The BAO Contact Create function will call the updateMemberhship function and change the Contact's Membership Status. Added Test as well for the same. 