### PR TITLE
[REF] dev/core#1116 - Remove unused misnamed activityTypeName variable

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -54,12 +54,8 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     $params = ['id' => $activityId];
     CRM_Activity_BAO_Activity::retrieve($params, $defaults);
 
-    // Set activity type name and description to template.
-    list($activityTypeName, $activityTypeDescription) = CRM_Core_BAO_OptionValue::getActivityTypeDetails($defaults['activity_type_id']);
-
-    // activityTypeName - dev/core#1116-unknown-if-ok
-    // It seems like activityTypeName is no longer used? Description is still used though. See PR notes for more details.
-    $this->assign('activityTypeName', $activityTypeName);
+    // Send activity type description to template.
+    list(, $activityTypeDescription) = CRM_Core_BAO_OptionValue::getActivityTypeDetails($defaults['activity_type_id']);
     $this->assign('activityTypeDescription', $activityTypeDescription);
 
     if (!empty($defaults['mailingId'])) {


### PR DESCRIPTION
Overview
----------------------------------------
"Fixes" another reference to activityTypeName where Name means Label, but this time by removing it since it's not used.

Technical Details
----------------------------------------
The variable activityTypeName (which is label - see https://github.com/civicrm/civicrm-core/blob/5.23.0/CRM/Core/BAO/OptionValue.php#L288) used to be used in ActivityView.tpl but was removed in

https://github.com/civicrm/civicrm-core/commit/c27ebe4e95bc8984b06a4ca783bfcf2fad63277e#diff-82708b475d546c52a906d4e34ff6dbbc

(and then that temporary placeholder was removed in https://github.com/civicrm/civicrm-core/commit/b0a72b3b28baf264d37a47984ae229657ea9359f#diff-82708b475d546c52a906d4e34ff6dbbc)

The only files ActivityView.tpl further `{include}`'s is formButtons, so it isn't used in an `{include}`.

It's possible some local customization on a site is using it in their smarty template, but I don't think you can deprecate smarty variables.

The local php variable in ActivityView.php isn't used anywhere else in the file.

Comments
----------------------------------------
The diff seems easier to read in github if you use split view instead of unified.
