### PR TITLE
Skip expensive smarty Processing when nothing to see here

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -1117,7 +1117,10 @@ WHERE id IN (" . implode(',', $contactIds) . ")";
    */
   public static function processGreetingTemplate(&$templateString, $contactDetails, $contactID, $className) {
     CRM_Utils_Token::replaceGreetingTokens($templateString, $contactDetails, $contactID, $className, TRUE);
-
+    if (!CRM_Utils_String::stringContainsTokens($templateString)) {
+      // Skip expensive smarty processing.
+      return;
+    }
     $smarty = CRM_Core_Smarty::singleton();
     $templateString = $smarty->fetch("string:$templateString");
   }

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -971,4 +971,18 @@ class CRM_Utils_String {
     }
   }
 
+  /**
+   * Generic check as to whether any tokens are in the given string.
+   *
+   * It might be a smarty token OR a CiviCRM token. In both cases the
+   * absence of a '{' indicates no token is present.
+   *
+   * @param string $string
+   *
+   * @return bool
+   */
+  public static function stringContainsTokens(string $string) {
+    return strpos($string, '{') !== FALSE;
+  }
+
 }

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -399,6 +399,14 @@ trait Api3TestTrait {
           unset($options['return'][$name]);
         }
       }
+
+      if ($name === 'option_group_id' && isset($v3Params[$name]) && !is_numeric($v3Params[$name])) {
+        // This is a per field hack (bad) but we can't solve everything at once
+        // & a cleverer way turned out to be too much for this round.
+        // Being in the test class it's tested....
+        $v3Params['option_group.name'] = $v3Params['option_group_id'];
+        unset($v3Params['option_group_id']);
+      }
     }
 
     switch ($v3Action) {


### PR DESCRIPTION
Overview
----------------------------------------
This addresses a speed & disk use issue by not calling smarty in greeting processing when there are no tokens to process. It is a performance fix and a disk usage fix

The call to Smarty occurs AFTER civi tokens are processed - so in addition to parsing the tokens that will be present on most sites there are a small number of sites that implement actual smarty tokens like {if} in their address greetings. This is a feature that was implemented back in 4.2 https://github.com/civicrm/civicrm-core/commit/73d64eb695adbf17d25e1714226e519b4a6e155b
to support German greetings.

Before
----------------------------------------
Smarty called on every contact create, edit, ?delete? to get tokens. 



After
----------------------------------------
Smarty only called when there is a '{' present - otherwise we can assume it has nothing to do

No change in results

Technical Details
----------------------------------------
On digging into speed & disk use issues I find that significant disk space is being
used on smartyProcessing of greetings. The same also seems to be true of display names. This is
a first shot across the bows but I'm  also investigating
1) also doing an early return before replaceGreetingTemplate
2) changing  the   smarty ->fetch call to pass 'eval' rather than  string.
Despite the gut-reaction the docs identify this  as correct
https://www.smarty.net/docs/en/resources.string.tpl and eval is not eval

From my local profiling this  code also kicks in  on delete & it's likely we will actually
see a decrease in overall test time on this

Comments
----------------------------------------

