### PR TITLE
[REF] Hopefully fix regularly failing conformance test

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -335,7 +335,7 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
         }
       }
       $processors['values'][$processor['id']]['payment_processor_type'] = $processor['payment_processor_type'] = $processors['values'][$processor['id']]['api.payment_processor_type.getsingle']['name'];
-      $processors['values'][$processor['id']]['object'] = Civi\Payment\System::singleton()->getByProcessor($processor);
+      $processors['values'][$processor['id']]['object'] = Civi\Payment\System::singleton()->getByProcessor($processors['values'][$processor['id']]);
     }
 
     // Add the pay-later pseudo-processor.


### PR DESCRIPTION
There's still an unanswered question but here's my thinking:

The line I've changed is passing $processor to a function, however it is the UNMODIFIED version of the variable from the foreach iterator NOT the one that gets updated during the loop before being passed on, so it might not have `user_name` in it. But note for subsequent callers of the getAllPaymentProcessors function it will use the modified one from the cache and not even call the failing line.

Let's see what happens...