### PR TITLE
[REF] Minor code simplification

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -211,15 +211,15 @@ class CRM_Core_PseudoConstant {
     $dao = new $daoName();
     $fieldSpec = $dao->getFieldSpec($fieldName);
 
-    // Ensure we have the canonical name for this field
-    $fieldName = CRM_Utils_Array::value('name', $fieldSpec, $fieldName);
-
     // Return false if field doesn't exist.
     if (empty($fieldSpec)) {
       return FALSE;
     }
 
-    elseif (!empty($fieldSpec['pseudoconstant'])) {
+    // Ensure we have the canonical name for this field
+    $fieldName = $fieldSpec['name'] ?? $fieldName;
+
+    if (!empty($fieldSpec['pseudoconstant'])) {
       $pseudoconstant = $fieldSpec['pseudoconstant'];
 
       // if callback is specified..


### PR DESCRIPTION

Overview
----------------------------------------
Move the return earlier, simplify the IF


Before
----------------------------------------
'delay' between retrieving fieldSpec & early return if empty

After
----------------------------------------
Lines follows on

Technical Details
----------------------------------------
This came up in the attempt to deprecate the passing of non-arrays to the array fn

Comments
----------------------------------------

