### PR TITLE
dev/core#1637 - Multiple fixes for Civi/Core/Paths.php

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -282,7 +282,7 @@ class CRM_Core_I18n {
    * @return string
    */
   public static function getResourceDir() {
-    return \Civi::paths()->getPath('[civicrm.l10n]/.');
+    return CRM_Utils_File::addTrailingSlash(\Civi::paths()->getPath('[civicrm.l10n]/.'));
   }
 
   /**

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -210,18 +210,23 @@ class Paths {
    * @return mixed|string
    */
   public function getPath($value) {
+    if ($value === NULL || $value === FALSE || $value === '') {
+      return FALSE;
+    }
+
     $defaultContainer = self::DEFAULT_PATH;
     if ($value && $value{0} == '[' && preg_match(';^\[([a-zA-Z0-9\._]+)\]/(.*);', $value, $matches)) {
       $defaultContainer = $matches[1];
       $value = $matches[2];
     }
-    if (empty($value)) {
-      return FALSE;
-    }
-    if ($value === '.') {
+
+    $isDot = $value === '.';
+    if ($isDot) {
       $value = '';
     }
-    return \CRM_Utils_File::absoluteDirectory($value, $this->getVariable($defaultContainer, 'path'));
+
+    $result = \CRM_Utils_File::absoluteDirectory($value, $this->getVariable($defaultContainer, 'path'));
+    return $isDot ? rtrim($result, '/' . DIRECTORY_SEPARATOR) : $result;
   }
 
   /**
@@ -229,6 +234,14 @@ class Paths {
    *
    * @param string $value
    *   The file path. The path may begin with a variable, e.g. "[civicrm.files]/upload".
+   *
+   *   This function was designed for locating files under a given tree, and the
+   *   the result for a straight variable expressions ("[foo.bar]") was not
+   *   originally defined. You may wish to use one of these:
+   *
+   *   - getVariable('foo.bar', 'url') => Lookup variable by itself
+   *   - getUrl('[foo.bar]/') => Get the variable (normalized with a trailing "/").
+   *   - getUrl('[foo.bar]/.') => Get the variable (normalized without a trailing "/").
    * @param string $preferFormat
    *   The preferred format ('absolute', 'relative').
    *   The result data may not meet the preference -- if the setting
@@ -236,26 +249,26 @@ class Paths {
    *   absolute (regardless of preference).
    * @param bool|NULL $ssl
    *   NULL to autodetect. TRUE to force to SSL.
-   * @return mixed|string
+   * @return FALSE|string
+   *   The URL for $value (string), or FALSE if the $value is not specified.
    */
   public function getUrl($value, $preferFormat = 'relative', $ssl = NULL) {
+    if ($value === NULL || $value === FALSE || $value === '') {
+      return FALSE;
+    }
+
     $defaultContainer = self::DEFAULT_URL;
     if ($value && $value{0} == '[' && preg_match(';^\[([a-zA-Z0-9\._]+)\](/(.*))$;', $value, $matches)) {
       $defaultContainer = $matches[1];
-      $value = empty($matches[3]) ? '.' : $matches[3];
+      $value = $matches[3];
     }
 
-    if (empty($value)) {
-      return FALSE;
-    }
-    if ($value === '.') {
-      $value = '';
-    }
-    if (substr($value, 0, 4) == 'http') {
+    $isDot = $value === '.';
+    if (substr($value, 0, 5) === 'http:' || substr($value, 0, 6) === 'https:') {
       return $value;
     }
 
-    $value = rtrim($this->getVariable($defaultContainer, 'url'), '/') . '/' . $value;
+    $value = rtrim($this->getVariable($defaultContainer, 'url'), '/') . ($isDot ? '' : "/$value");
 
     if ($preferFormat === 'relative') {
       $parsed = parse_url($value);

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -255,7 +255,7 @@ class Paths {
       return $value;
     }
 
-    $value = $this->getVariable($defaultContainer, 'url') . $value;
+    $value = rtrim($this->getVariable($defaultContainer, 'url'), '/') . '/' . $value;
 
     if ($preferFormat === 'relative') {
       $parsed = parse_url($value);

--- a/tests/phpunit/Civi/Core/PathsTest.php
+++ b/tests/phpunit/Civi/Core/PathsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Civi\Core;
+
+/**
+ * Class PathsTest
+ * @package Civi\Core
+ * @group headless
+ */
+class PathsTest extends \CiviUnitTestCase {
+
+  public function getExamples() {
+    $exs = [];
+
+    // Ensure that various permutations of `$civicrm_paths`, `Civi::paths()->getPath()`
+    // and `Civi::paths()->getUrl()` work as expected.
+
+    // Trailing-slash configurations -- these all worked before current patch
+
+    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
+    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/', '/var/www/files/foo/'];
+    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo', '/var/www/files/foo'];
+    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/.', '/var/www/files/'];
+
+    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
+    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/', 'http://example.com/files/foo/'];
+    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo', 'http://example.com/files/foo'];
+    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/.', 'http://example.com/files/'];
+
+    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
+    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/', 'http://example.com:8080/foo/'];
+    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo', 'http://example.com:8080/foo'];
+    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/.', 'http://example.com:8080/'];
+
+    // Trimmed-slash configurations -- some of these worked before, and some misbehaved. Now fixed.
+
+    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
+    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/', '/var/www/files/foo/'];
+    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/foo', '/var/www/files/foo'];
+    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/.', '/var/www/files/'];
+
+    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
+    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/', 'http://example.com/files/foo/'];
+    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo', 'http://example.com/files/foo'];
+    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/.', 'http://example.com/files/'];
+
+    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
+    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/', 'http://example.com:8080/foo/'];
+    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo', 'http://example.com:8080/foo'];
+    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/.', 'http://example.com:8080/'];
+
+    return $exs;
+  }
+
+  /**
+   * @param $varName
+   * @param $varType
+   * @param $varValue
+   * @param $inputExpr
+   * @param $expectValue
+   * @dataProvider getExamples
+   */
+  public function testExamples($varName, $varType, $varValue, $inputExpr, $expectValue) {
+    global $civicrm_paths;
+    $civicrm_paths[$varName][$varType] = $varValue;
+    $func = ($varType === 'url') ? 'getUrl' : 'getPath';
+
+    $paths = new Paths();
+    $paths->register($varName, function() {
+      return ['path' => 'FIXME-PATH', 'url' => 'FIXME-URL'];
+    });
+
+    $actualValue = call_user_func([$paths, $func], $inputExpr);
+    $this->assertEquals($expectValue, $actualValue);
+
+    unset($civicrm_paths[$varName][$varType]);
+  }
+
+  public function testGetUrl_ImplicitBase() {
+    $p = \Civi::paths();
+    $cmsRoot = rtrim($p->getVariable('cms.root', 'url'), '/');
+
+    $this->assertEquals("$cmsRoot/foo/bar", $p->getUrl('foo/bar'));
+    $this->assertEquals("$cmsRoot/foo/", $p->getUrl('foo/'));
+    $this->assertEquals("$cmsRoot/foo", $p->getUrl('foo'));
+  }
+
+}

--- a/tests/phpunit/Civi/Core/PathsTest.php
+++ b/tests/phpunit/Civi/Core/PathsTest.php
@@ -20,34 +20,50 @@ class PathsTest extends \CiviUnitTestCase {
     $exs['ap1'] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
     $exs['ap2'] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/', '/var/www/files/foo/'];
     $exs['ap3'] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo', '/var/www/files/foo'];
-    $exs['ap4'] = ['te.st', 'path', '/var/www/files/', '[te.st]/.', '/var/www/files/'];
+    $exs['ap4'] = ['te.st', 'path', '/var/www/files/', '[te.st]/.', '/var/www/files'];
+    $exs['ap5'] = ['te.st', 'path', '/var/www/files/', '[te.st]/0', '/var/www/files/0'];
+    $exs['ap6'] = ['te.st', 'path', '/var/www/files/', '[te.st]/', '/var/www/files/'];
 
     $exs['au1'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
     $exs['au2'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/', 'http://example.com/files/foo/'];
     $exs['au3'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo', 'http://example.com/files/foo'];
-    $exs['au4'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/.', 'http://example.com/files/'];
+    $exs['au4'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/.', 'http://example.com/files'];
+    $exs['au5'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/0', 'http://example.com/files/0'];
+    $exs['au6'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/', 'http://example.com/files/'];
 
     $exs['au18'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
     $exs['au28'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/', 'http://example.com:8080/foo/'];
     $exs['au38'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo', 'http://example.com:8080/foo'];
-    $exs['au48'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/.', 'http://example.com:8080/'];
+    $exs['au48'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/.', 'http://example.com:8080'];
+    $exs['au58'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/0', 'http://example.com:8080/0'];
+    $exs['au68'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/', 'http://example.com:8080/'];
 
     // Trimmed-slash configurations
 
     $exs['bp1'] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
     $exs['bp2'] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/', '/var/www/files/foo/'];
     $exs['bp3'] = ['te.st', 'path', '/var/www/files', '[te.st]/foo', '/var/www/files/foo'];
-    $exs['bp4'] = ['te.st', 'path', '/var/www/files', '[te.st]/.', '/var/www/files/'];
+    $exs['bp4'] = ['te.st', 'path', '/var/www/files', '[te.st]/.', '/var/www/files'];
+    $exs['bp5'] = ['te.st', 'path', '/var/www/files', '[te.st]/0', '/var/www/files/0'];
+    $exs['bp6'] = ['te.st', 'path', '/var/www/files', '[te.st]/', '/var/www/files/'];
 
     $exs['bu1'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
     $exs['bu2'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/', 'http://example.com/files/foo/'];
     $exs['bu3'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo', 'http://example.com/files/foo'];
-    $exs['bu4'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/.', 'http://example.com/files/'];
+    $exs['bu4'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/.', 'http://example.com/files'];
+    $exs['bu5'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/0', 'http://example.com/files/0'];
+    $exs['bu6'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/', 'http://example.com/files/'];
 
     $exs['bu18'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
     $exs['bu28'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/', 'http://example.com:8080/foo/'];
     $exs['bu38'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo', 'http://example.com:8080/foo'];
-    $exs['bu48'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/.', 'http://example.com:8080/'];
+    $exs['bu48'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/.', 'http://example.com:8080'];
+    $exs['bu58'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/0', 'http://example.com:8080/0'];
+    $exs['bu68'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/', 'http://example.com:8080/'];
+
+    // Oddballs
+    $exs['wp1'] = ['wp.ex1', 'url', 'http://example.com/wp-admin/admin.php', '[wp.ex1]/.', 'http://example.com/wp-admin/admin.php'];
+    $exs['http'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/httpIsBetterThanGopher', 'http://example.com/files/httpIsBetterThanGopher'];
 
     return $exs;
   }

--- a/tests/phpunit/Civi/Core/PathsTest.php
+++ b/tests/phpunit/Civi/Core/PathsTest.php
@@ -15,39 +15,39 @@ class PathsTest extends \CiviUnitTestCase {
     // Ensure that various permutations of `$civicrm_paths`, `Civi::paths()->getPath()`
     // and `Civi::paths()->getUrl()` work as expected.
 
-    // Trailing-slash configurations -- these all worked before current patch
+    // Trailing-slash configurations
 
-    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
-    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/', '/var/www/files/foo/'];
-    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo', '/var/www/files/foo'];
-    $exs[] = ['te.st', 'path', '/var/www/files/', '[te.st]/.', '/var/www/files/'];
+    $exs['ap1'] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
+    $exs['ap2'] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo/', '/var/www/files/foo/'];
+    $exs['ap3'] = ['te.st', 'path', '/var/www/files/', '[te.st]/foo', '/var/www/files/foo'];
+    $exs['ap4'] = ['te.st', 'path', '/var/www/files/', '[te.st]/.', '/var/www/files/'];
 
-    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
-    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/', 'http://example.com/files/foo/'];
-    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo', 'http://example.com/files/foo'];
-    $exs[] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/.', 'http://example.com/files/'];
+    $exs['au1'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
+    $exs['au2'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo/', 'http://example.com/files/foo/'];
+    $exs['au3'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/foo', 'http://example.com/files/foo'];
+    $exs['au4'] = ['te.st', 'url', 'http://example.com/files/', '[te.st]/.', 'http://example.com/files/'];
 
-    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
-    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/', 'http://example.com:8080/foo/'];
-    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo', 'http://example.com:8080/foo'];
-    $exs[] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/.', 'http://example.com:8080/'];
+    $exs['au18'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
+    $exs['au28'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo/', 'http://example.com:8080/foo/'];
+    $exs['au38'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/foo', 'http://example.com:8080/foo'];
+    $exs['au48'] = ['te.st', 'url', 'http://example.com:8080/', '[te.st]/.', 'http://example.com:8080/'];
 
-    // Trimmed-slash configurations -- some of these worked before, and some misbehaved. Now fixed.
+    // Trimmed-slash configurations
 
-    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
-    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/', '/var/www/files/foo/'];
-    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/foo', '/var/www/files/foo'];
-    $exs[] = ['te.st', 'path', '/var/www/files', '[te.st]/.', '/var/www/files/'];
+    $exs['bp1'] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/bar', '/var/www/files/foo/bar'];
+    $exs['bp2'] = ['te.st', 'path', '/var/www/files', '[te.st]/foo/', '/var/www/files/foo/'];
+    $exs['bp3'] = ['te.st', 'path', '/var/www/files', '[te.st]/foo', '/var/www/files/foo'];
+    $exs['bp4'] = ['te.st', 'path', '/var/www/files', '[te.st]/.', '/var/www/files/'];
 
-    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
-    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/', 'http://example.com/files/foo/'];
-    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo', 'http://example.com/files/foo'];
-    $exs[] = ['te.st', 'url', 'http://example.com/files', '[te.st]/.', 'http://example.com/files/'];
+    $exs['bu1'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/bar', 'http://example.com/files/foo/bar'];
+    $exs['bu2'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo/', 'http://example.com/files/foo/'];
+    $exs['bu3'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/foo', 'http://example.com/files/foo'];
+    $exs['bu4'] = ['te.st', 'url', 'http://example.com/files', '[te.st]/.', 'http://example.com/files/'];
 
-    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
-    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/', 'http://example.com:8080/foo/'];
-    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo', 'http://example.com:8080/foo'];
-    $exs[] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/.', 'http://example.com:8080/'];
+    $exs['bu18'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/bar', 'http://example.com:8080/foo/bar'];
+    $exs['bu28'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo/', 'http://example.com:8080/foo/'];
+    $exs['bu38'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/foo', 'http://example.com:8080/foo'];
+    $exs['bu48'] = ['te.st', 'url', 'http://example.com:8080', '[te.st]/.', 'http://example.com:8080/'];
 
     return $exs;
   }
@@ -71,7 +71,7 @@ class PathsTest extends \CiviUnitTestCase {
     });
 
     $actualValue = call_user_func([$paths, $func], $inputExpr);
-    $this->assertEquals($expectValue, $actualValue);
+    $this->assertEquals($expectValue, $actualValue, "Evaluate $func(\"$inputExpr\") given ([$varName] = \"$varValue\")");
 
     unset($civicrm_paths[$varName][$varType]);
   }

--- a/tests/phpunit/E2E/Extern/CliRunnerTest.php
+++ b/tests/phpunit/E2E/Extern/CliRunnerTest.php
@@ -101,7 +101,7 @@ class E2E_Extern_CliRunnerTest extends CiviEndToEndTestCase {
 
     $ufrUrl = $this->callRunnerJson($r, 'CRM_Core_Config::singleton()->userFrameworkResourceURL');
     $crmUrl = $this->callRunnerJson($r, 'Civi::paths()->getUrl("[civicrm.root]/.")');
-    $this->assertEquals($crmUrl, $ufrUrl);
+    $this->assertEquals(rtrim($crmUrl, '/'), rtrim($ufrUrl, '/'));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

This fixes multiple edge-case issues in the evaluation of `Civi::paths()->getUrl($expr)` and `Civi::paths()->getPath($expr)`.

Before + After
----------------------------------------

Describing the before+after is a bit daunting because we're in bouncy-bug territory - i.e. 5.22.x had an issue fixed in 5.23.0, but 5.23.0 caused a regression/new issue, so there's a pending revert in the unreleased HEADs of 5.24.beta1/5.23.1 which fixes the latter, but it rebreaks the former. Thus, we have multiple issues and multiple revisions to consider in "Before"+"After".

Instead of a simple Before+After, think of this as a grid. The columns of the grid are different git-branches/git-tags, and the rows are the use-cases for `Civi::paths()`. Each row has an example of an `$expr` that you could pass to `Civi::paths()->getUrl($expr)` and `Civi::paths()->getPath($expr)`.

| Row | Expression | 5.22.1 | 5.23.0 | 5.24 (HEAD) | 5.24 (This PR) |
| --- | -- | -- | -- | -- | -- |
| A   | `[myvar]/myfile` | BAD: Sometimes ignores `/` from `/myfile` | GOOD: Keeps `/` from `/myfile` | BAD: Sometimes ignores `/` from `/myfile` | GOOD: Keeps `/` from `/myfile` |
| B   | `[myvar]/.` | BAD: Ending varies | BAD: Ending always has trailing `/` | BAD: Ending varies | GOOD: Ending never has trailing `/` |
| C   | `[wp.backend]/.` | GOOD: Ends with `admin.php` | BAD: Ends with `admin.php/` | GOOD: Ends with `admin.php` | GOOD: Ends with `admin.php` |
| D   | `[myvar]/0` | BAD: Returns false | BAD: Returns false | BAD: Returns false | GOOD: Returns configured value of `[myvar]` plus `/0` |
| E   | `[myvar]/`  | BAD: Returns false | BAD: Returns false | BAD: Returns false | GOOD: Returns the value of `[myvar]` with one trailing slash |
| F   | `[myvar]/http-1.1-rfc2616.txt` | BAD: Returns malformed URL (`http-1.1-rfc2616.txt`) | BAD: Returns malformed URL (`http-1.1-rfc2616.txt`) | BAD: Returns malformed URL (`http-1.1-rfc2616.txt`) | GOOD: Returns configured value of `[myvar]` plus `/http-1.1-rfc2616.txt` |

This patch generally un-reverts #16404/#16713 to provide a less bouncy patch - i.e. the revert fixed (C) but rebroke (A) - and this patch fixes both (A) and (C). Strictly speaking, I can see the argument that buggy (A) is preferable over buggy (C) (*because (A) bug is older*), but I think it's preferrable to fix both.

Technical Details
----------------------------------------

(1) IMHO, the best way to think about this functionality is to work through the list of examples in `Civi\Core\PathsTest`. I can give prose to discuss specific situations if needed, but using prose for all of these edge-cases would be laborious for both reader and writer, so let's first try the table+code and then raise comments as needed.

(2) It may help to note some history of `Civi::paths()->getUrl($expr)` and `getPath($expr)`. Originally, an `$expr` was simply the name of a file (e.g. `getPath('README')`), and you had the *option* to use a *prefix* or *variable* (e.g. `getPath('[civicrm.root]/README')`). That means each `$expr` would have two parts (a *prefix-part* and a *file-part*). But over time, more prefixes/variables/use-cases arose, and now we have cases where there is only a *prefix-part* (e.g. `[wp.backend]/.` or `[civicrm.l10n]/.`) and no substantive *file-part*. There's been an undocumented trick to coerce it to use a trivial file-part (i.e. `.`, the dot-file, an alias for the self-path).

(3) My general feeling is that the behavior of `getUrl()` when there's no substantive *file-part* has been inappropriate for a long time.

* For 16404, I took a lazy route and tried to just lock-in the existing behavior of dot-file trick on the most plausible use-case I saw (assuming that all other active users were similar) - but the WP regression shows the problem was harder. The dot-file behavior was previously *inconsistent*. Witness:`WordPress.php` expected that `[wp.backend]/.` would not return a trailing slash, and `I18n.php` expected that `[civicrm.l10n]/.` would return a slash. Witness: `tutorial.php` and `Resources.php` were already defensive/mistrusting.

* With inconsistent behavior, it's not enough to just read the output from an example and lock it into a test. So this fix pulls out heavier guns. Paragraph `#4`  asks "What behavior makes more sense as user of `getUrl`/`getPath`?", and `#5`  demonstrates *by exhaustion* that the chosen behavior is compatible with various use-cases..

(4) If you call `getUrl($expr)` and `getPath($expr)` with a non-substantive file-part, what would the caller expect as the result?

* `[myvar]/` => You would expect this to yield `myvar` with one trailing slash (so that you can append subdirs/files). The patch makes these varying examples behave interchangeably as you would intuit.
  ```php
  // Similar/interchangeable definitions of $myDir
  $myDir = '/var/www/foo/';
  $myDir = "{$wwwVar}/foo/";
  $myDir = Civi::paths()->getUrl('[myvar]/');

  // Similar/interchangeable definitions of $readmeFile
  $readmeFile = $myDir . 'README';
  $readmeFile = "{$myDir}README";
  ```
* `[myvar]/.` => You would expect this to yield `myvar` in a form that needs another `/`. The patch makes these varying examples  behave interchangeably as you would intuit.
  ```php
  // Similar/interchangeable definitions of $myDir
  $myDir = '/var/www/foo';
  $myDir = '/var/www/foo/.';
  $myDir = "{$wwwVar}/foo";
  $myDir = "{$wwwVar}/foo/.";
  $myDir = Civi::paths()->getUrl('[myvar]/.');

  // Similar/interchangeable definitions of $readmeFile
  $readmeFile = $myDir . '/README';
  $readmeFile = "{$myDir}/README";
  ```
* `[myvar]` => This still does not behave as you'd expect, and arguably is unreasonable, but it does behave exactly as it has in previous releases. Not on critical path of current bugs.

(5) IMHO, the most substantive change/flipflop is in the handling of the `.` dotfile.
* In 5.22, `[myvar]/.` was already wishywashy - it may or may not produce a trailing `/` - depending on the specific variable/configuration.
* For #16404, I didn't really care if `[myvar]/.` ended with `/` -- I just wanted it to be consistent / defined / unit-tested.
* In [dev/core#1637](https://lab.civicrm.org/dev/core/issues/1637), it does matter if it ends in `/` (and, specifically, it's better *without* the trailing `/`).
* Since we're really looking at this now, I did some grepping on `universe` to find all code which relied on the `[myvar]/.` notation. These are the things which came up:
  ```
  org.civicrm.tutorial/tutorial.php                       <== already defensive; conditionally appends trailing "/"
  civicrm-wordpress/civicrm.php                           <== part of the issue under investigation; prefers no trailing "/"; not defensively written
  civicrm-core/CRM/Utils/System/WordPress.php             <== part of the issue under investigation; prefers no trailing "/"; not defensively written
  civicrm-core/CRM/Core/Resources.php                     <== already defensive; conditionally appends trailing "/"
  civicrm-core/CRM/Core/I18n.php                          <== new use-case in 5.23; updated in this PR to be more defensive
  civicrm-core/tests/phpunit/Civi/Core/PathsTest.php      <== new unit-test in 5.23; updated in PR
  civicrm-core/tests/phpunit/E2E/Extern/CliRunnerTest.php <== unit-test; updated to be more defensive
  ```
* With the list, we can demonstrate (by exhaustion) that all use-cases are either defensively written (`tutorial.php`, `Resources.php`, `I18n.php`, `CliRunnerTest.php`) or compliant with the newer contract (`WordPress.php`, `civicrm.php`, `PathsTest.php`).

