### PR TITLE
Contribution Summary Report: Taking the currency filtered in the "gen…

### DIFF
--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -136,7 +136,11 @@
                 {foreach from=$columnHeaders item=header key=field}
                     <td class="report-label">
                         {if $header.type eq 1024}
-                            {$grandStat.$field|crmMoney}
+                            {if $currencyColumn}
+                                {$grandStat.$field|crmMoney:$row.$currencyColumn}
+                            {else}
+                                {$grandStat.$field|crmMoney}
+                            {/if}
                         {else}
                             {$grandStat.$field}
                         {/if}


### PR DESCRIPTION
…eral total" row. Implements dev/report#27

Overview
----------------------------------------
Contribution Summary Report: Taking the currency filtered in the "general total" row

Before
----------------------------------------
When the contribution summary report is used by filtering for a currency other than the site's default currency, the "grand total" row shows the sign of the default currency instead of the filtered currency.
![image](https://user-images.githubusercontent.com/56721994/76309538-babb7b00-62ab-11ea-9c1d-56aee61dc64f.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/56721994/76309996-b2b00b00-62ac-11ea-8a6b-a74114ae6abb.png)

Technical Details
----------------------------------------

Comments
----------------------------------------

