### PR TITLE
CRM_Utils_Array::values follow up from #16699

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -39,7 +39,8 @@ class CRM_Utils_Array {
       return array_key_exists($key, $list) ? $list[$key] : $default;
     }
     if ($list instanceof ArrayAccess) {
-      return $list[$key] ?? $default;
+      // ArrayAccess requires offsetExists is implemented for the equivalent to array_key_exists.
+      return $list->offsetExists($key) ? $list[$key] : $default;
     }
     // @todo - eliminate these from core & uncomment this line.
     // CRM_Core_Error::deprecatedFunctionWarning('You have passed an invalid parameter for the "list"');

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -106,8 +106,8 @@ class PropertyBag implements \ArrayAccess {
    * @return bool TRUE if we have that value (on our default store)
    */
   public function offsetExists ($offset): bool {
-    $prop = $this->handleLegacyPropNames($offset);
-    return isset($this->props['default'][$prop]);
+    $prop = $this->handleLegacyPropNames($offset, TRUE);
+    return $prop && isset($this->props['default'][$prop]);
   }
 
   /**
@@ -199,16 +199,21 @@ class PropertyBag implements \ArrayAccess {
 
   /**
    * @param string $prop
+   * @param bool $silent if TRUE return NULL instead of throwing an exception. This is because offsetExists should be safe and not throw exceptions.
    * @return string canonical name.
    * @throws \InvalidArgumentException if prop name not known.
    */
-  protected function handleLegacyPropNames($prop) {
+  protected function handleLegacyPropNames($prop, $silent = FALSE) {
     $newName = static::$propMap[$prop] ?? NULL;
     if ($newName === TRUE) {
       // Good, modern name.
       return $prop;
     }
     if ($newName === NULL) {
+      if ($silent) {
+        // Only for use by offsetExists
+        return;
+      }
       throw new \InvalidArgumentException("Unknown property '$prop'.");
     }
     // Remaining case is legacy name that's been translated.

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -198,6 +198,9 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $propertyBag = new PropertyBag();
     $propertyBag->setContactID(123);
     $this->assertEquals(123, \CRM_Utils_Array::value('contact_id', $propertyBag));
+
+    // Test that using utils array value to get a nonexistent property returns the default.
+    $this->assertEquals(456, \CRM_Utils_Array::value('ISawAManWhoWasntThere', $propertyBag, 456));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This:  https://github.com/civicrm/civicrm-core/pull/16699
introduces handling objects passed into `CRM_Utils_Array::values` but it just used null coalesce to pick the default value, which failed if the calling code was requesting an item that does not exist on the object.

Before
----------------------------------------

Calling for a non-existant property would return either cause an exception unless the object has soft handling of accessing non existing properties (e.g. __get that returns NULL if prop unknown), in which case the default (expected), value would be returned.

After
----------------------------------------

- added test as proof, using Payment\PropertyBag which will throw an exception if a property does not exist.
- use [ArrayAccess::offsetExists](https://www.php.net/manual/en/arrayaccess.offsetexists.php) which is the object equiv to `array_key_exists`.
- update PropertyBag's internals (offsetExists should safely return and not throw exception, even if property does not exist)

