### PR TITLE
Fix <select> element styling for Wordpress 5.3

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -257,7 +257,8 @@ input.crm-form-entityref {
 /* Style civi form inputs to match select2 */
 .crm-container select.crm-form-select,
 .crm-container select.crm-form-date {
-  background: #fff no-repeat;
+  background-repeat: repeat;
+  background-color: transparent;
   border: 1px solid #aaa;
   color: #444;
   height: 2.2em;
@@ -268,7 +269,6 @@ input.crm-form-entityref {
   background-image: -moz-linear-gradient(center bottom, #eee 0%, #fff 50%);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr = '#ffffff', endColorstr = '#eeeeee', GradientType = 0);
   background-image: linear-gradient(top, #fff 0%, #eee 50%);
-  line-height: 0;
   -webkit-appearance: listbox;
   background-size: auto;
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -258,7 +258,7 @@ input.crm-form-entityref {
 .crm-container select.crm-form-select,
 .crm-container select.crm-form-date {
   background-repeat: repeat;
-  background-color: transparent;
+  background-color: #fff;
   border: 1px solid #aaa;
   color: #444;
   height: 2.2em;

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -257,17 +257,20 @@ input.crm-form-entityref {
 /* Style civi form inputs to match select2 */
 .crm-container select.crm-form-select,
 .crm-container select.crm-form-date {
+  background: #fff no-repeat;
   border: 1px solid #aaa;
   color: #444;
   height: 2.2em;
   padding: 4px;
   border-radius: 4px;
-  background-color: #fff;
   background-image: -webkit-gradient(linear, left bottom, left top, color-stop(0, #eee), color-stop(0.5, #fff));
   background-image: -webkit-linear-gradient(center bottom, #eee 0%, #fff 50%);
   background-image: -moz-linear-gradient(center bottom, #eee 0%, #fff 50%);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr = '#ffffff', endColorstr = '#eeeeee', GradientType = 0);
   background-image: linear-gradient(top, #fff 0%, #eee 50%);
+  line-height: 0;
+  -webkit-appearance: listbox;
+  background-size: auto;
 }
 .crm-container input.crm-form-text.ng-invalid.ng-dirty {
     border: 1px solid #FF0000;


### PR DESCRIPTION
First PR done by myself so apologies if this isn't the correct process!

As per https://lab.civicrm.org/dev/wordpress/issues/46 the changes proposed above will override the new Wordpress styling changes that happened in version 5.3.

I have attached before and after screenshots of the select element.

On a side note, I checked that it didn't interfere with any Drupal styling as well. :)

![before](https://user-images.githubusercontent.com/44573518/76313003-0847e000-62cc-11ea-959c-6f96f19a5c1b.png)

![after](https://user-images.githubusercontent.com/44573518/76313014-0bdb6700-62cc-11ea-8125-03df8ee85d44.png)
