### PR TITLE
dev/core#547 Fix Event financial_type_id getOptions

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2351,7 +2351,7 @@ LEFT  JOIN  civicrm_price_field_value value ON ( value.id = lineItem.price_field
         // @fixme - this is going to ignore context, better to get conditions, add params, and call PseudoConstant::get
         // @fixme - https://lab.civicrm.org/dev/core/issues/547 if CiviContribute not enabled this causes an invalid query
         //   because $relationTypeId is not set in CRM_Financial_BAO_FinancialType::getIncomeFinancialType()
-        if (array_key_exists('CiviEvent', CRM_Core_Component::getEnabledComponents())) {
+        if (array_key_exists('CiviContribute', CRM_Core_Component::getEnabledComponents())) {
           return CRM_Financial_BAO_FinancialType::getIncomeFinancialType();
         }
         return [];


### PR DESCRIPTION
Overview
----------------------------------------

* https://dmaster.demo.civicrm.org/
* Disable the CiviPledge component, then disable the CiviContribute component
* Go to Events -> New Event
* Use the Paid Event template, fill in the title and start date
* Go to the Fee tab.

Result: fatal error.

Comments
----------------------------------------

This is a followup to #16365, which didn't fix the issue for me.

Seems odd to check if CiviEvent is enabled while in an Event BAO?

cc @mattwire 