### PR TITLE
Add recurring contribution ID to doCancelRecurring

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -206,6 +206,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     if (CRM_Utils_Array::value('send_cancel_request', $params) == 1) {
       try {
         $propertyBag = new PropertyBag();
+        $propertyBag->setContributionRecurID($this->getSubscriptionDetails()->recur_id);
         $propertyBag->setRecurProcessorID($this->getSubscriptionDetails()->subscription_id);
         $message = $this->_paymentProcessorObj->doCancelRecurring($propertyBag)['message'];
       }


### PR DESCRIPTION
Overview
----------------------------------------
Add the most useful parameter to the propertybag - the ID of the recurring contribution.

Before
----------------------------------------
Only subscriptionID (processorID) available.

After
----------------------------------------
processorID + recurID available.

Technical Details
----------------------------------------
Just add to propertybag - the ID is always available on the form parameters.

Comments
----------------------------------------
@eileenmcnaughton @artfulrobot