### PR TITLE
dev/1640 New feature - adds a  checkbox to the  update contribution  status  form  to determine  if  a receipt  is  sent

### DIFF
--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -83,6 +83,8 @@ AND    {$this->_componentClause}";
       $status,
       TRUE
     );
+    $this->add('checkbox', 'is_email_receipt', ts('Send e-mail receipt'));
+    $this->setDefaults(['is_email_receipt' => 1]);
 
     $contribIDs = implode(',', $this->_contributionIds);
     $query = "
@@ -278,6 +280,7 @@ AND    co.id IN ( $contribIDs )";
         $input['trxn_id'] = $contribution->invoice_id;
       }
       $input['trxn_date'] = $params["trxn_date_{$row['contribution_id']}"] . ' ' . date('H:i:s');
+      $input['is_email_receipt'] = !empty($params['is_email_receipt']);
 
       // @todo calling baseIPN like this is a pattern in it's last gasps. Call contribute.completetransaction api.
       $baseIPN->completeTransaction($input, $ids, $objects, $transaction, FALSE);

--- a/templates/CRM/Contribute/Form/Task/Status.tpl
+++ b/templates/CRM/Contribute/Form/Task/Status.tpl
@@ -16,6 +16,11 @@
      <table class="form-layout-compressed">
      <tr class="crm-contribution-form-block-contribution_status_id"><td class="label">{$form.contribution_status_id.label}</td><td class="html-adjust">{$form.contribution_status_id.html}<br />
             <span class="description">{ts}Assign the selected status to all contributions listed below.{/ts}</td></tr>
+       <tr class="crm-contribution-form-block-is_email_receipt"><td class="label">{$form.is_email_receipt.label}</td>
+         <td class="html-adjust">{$form.is_email_receipt.html}<br />
+           <span class="description">{ts}When checked CiviCRM will send an e-mail receipt to the donor. Leave unchecked when you don't want to send an e-mail.{/ts}
+         </td>
+       </tr>
      </table>
 <table>
 <tr class="columnheader">

--- a/tests/phpunit/CRM/Contribute/Form/Task/StatusTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/StatusTest.php
@@ -25,11 +25,14 @@ class CRM_Contribute_Form_Task_StatusTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test update pending contribution
+   * Test update pending contribution with sending a confirmation mail.
    */
-  public function testUpdatePendingContribution() {
+  public function testUpdatePendingContributionWithSendingEmail() {
     $this->_individualId = $this->individualCreate();
     $form = new CRM_Contribute_Form_Task_Status();
+
+    $mut = new CiviMailUtils($this, TRUE);
+    $mut->clearMessages();
 
     // create a pending contribution
     $contributionParams = [
@@ -45,6 +48,7 @@ class CRM_Contribute_Form_Task_StatusTest extends CiviUnitTestCase {
     $form->buildQuickForm();
 
     $params = [
+      "is_email_receipt" => '1',
       "contribution_status_id" => 1,
       "trxn_id_{$contributionId}" => NULL,
       "check_number_{$contributionId}" => NULL,
@@ -62,6 +66,57 @@ class CRM_Contribute_Form_Task_StatusTest extends CiviUnitTestCase {
     $this->assertEquals(date("Y-m-d"), date("Y-m-d", strtotime($updatedContribution['receive_date'])));
     $this->assertNotEquals("00:00:00", date("H:i:s", strtotime($updatedContribution['receive_date'])));
     $this->assertEquals('Completed', $updatedContribution['contribution_status']);
+
+    $msg = $mut->getMostRecentEmail();
+    $this->assertNotEmpty($msg);
+    $mut->stop();
+  }
+
+  /**
+   * Test update pending contribution without sending a confirmation mail.
+   */
+  public function testUpdatePendingContributionWithoutSendingEmail() {
+    $this->_individualId = $this->individualCreate();
+    $form = new CRM_Contribute_Form_Task_Status();
+
+    $mut = new CiviMailUtils($this, TRUE);
+    $mut->clearMessages();
+
+    // create a pending contribution
+    $contributionParams = [
+      'contact_id' => $this->_individualId,
+      'total_amount' => 100,
+      'financial_type_id' => 'Donation',
+      'contribution_status_id' => 2,
+    ];
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $contributionId = $contribution['id'];
+    $form->setContributionIds([$contributionId]);
+
+    $form->buildQuickForm();
+
+    $params = [
+      "is_email_receipt" => '0',
+      "contribution_status_id" => 1,
+      "trxn_id_{$contributionId}" => NULL,
+      "check_number_{$contributionId}" => NULL,
+      "fee_amount_{$contributionId}" => 0,
+      "trxn_date_{$contributionId}" => date('m/d/Y'),
+      "payment_instrument_id_{$contributionId}" => 4,
+    ];
+
+    CRM_Contribute_Form_Task_Status::processForm($form, $params);
+
+    $contribution = $this->callAPISuccess('Contribution', 'get', ['id' => $contributionId]);
+    $updatedContribution = $contribution['values'][1];
+
+    $this->assertEquals('', $updatedContribution['contribution_source']);
+    $this->assertEquals(date("Y-m-d"), date("Y-m-d", strtotime($updatedContribution['receive_date'])));
+    $this->assertNotEquals("00:00:00", date("H:i:s", strtotime($updatedContribution['receive_date'])));
+    $this->assertEquals('Completed', $updatedContribution['contribution_status']);
+
+    $mut->assertMailLogEmpty();
+    $mut->stop();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add an option to the update contribution status to send an e-mail receipt or not.

See: https://lab.civicrm.org/dev/core/issues/1640

Before
----------------------------------------
![Screenshot from 2020-03-10 22-39-20](https://user-images.githubusercontent.com/4126292/76363372-2856be00-6323-11ea-8d3e-2eaff5a83909.png)


After
----------------------------------------

![Screenshot from 2020-03-10 22-58-49](https://user-images.githubusercontent.com/4126292/76363385-31e02600-6323-11ea-96c1-f3fd254aae1d.png)

Comments
----------------------------------------

The code in this bit of PR contains a comment to move to the order api. 
I thought about change that but I was unsure because it might affect more than this simple change. 
