### PR TITLE
dev/core#1528: drop support for PHP 7.0

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -34,7 +34,9 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   /**
    * Minimum php version required to run (equal to or lower than the minimum install version)
    *
-   * As of Civi 5.16, using PHP 5.x will lead to a hard crash during bootstrap.
+   * As of CiviCRM 5.25, this is left as 7.0.0 for the time being in order to
+   * not block stragglers from upgrading.  As soon as this is found to cause a
+   * hard crash, or at the end of 2020 at the latest, this should be increased.
    *
    * Tip: Keep in sync with composer.json ("config => platform => php")
    */

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -37,7 +37,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '7.0';
+  const MIN_INSTALL_PHP_VER = '7.1';
 
   /**
    * Compute any messages which should be displayed before upgrade.

--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
   "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
-      "php": "7.0.10"
+      "php": "7.1.0"
     }
   },
   "require": {
-    "php": "~7.0",
+    "php": "~7.1",
     "cache/integration-tests": "~0.16.0",
     "dompdf/dompdf" : "0.8.*",
     "electrolinux/phpquery": "^0.9.6",


### PR DESCRIPTION
Overview
----------------------------------------
No longer allow installations with PHP < 7.1.

Before
----------------------------------------
Sites on PHP 7.0 can install and upgrade.

After
----------------------------------------
Sites on PHP 7.0 cannot install.  They can upgrade, however: see below.

Technical Details
----------------------------------------
This uses a parallel system to https://github.com/civicrm/civicrm-core/pull/14437 for PHP 5.6 where the minimum for installation is PHP 7.1 but the minimum for upgrades remains PHP 7.0.  The site will yell at you, but you can at least get through the upgrade.

When we did this last time, there was an issue that was raised a couple of months later ([dev/drupal#79](https://lab.civicrm.org/dev/drupal/issues/79)) where it turned out that there would be a hard crash using old PHP.  I expect that may happen again in a few months.  A comment in `CRM/Upgrade/Form.php` anticipates this.

Still, my sense is that this was a good approach that we should repeat: prevent new installs on PHP 7.0, yell at people if they upgrade while still on PHP 7.0, and when it starts to truly fail, tell them "I told you so" and add a change parallel to https://github.com/civicrm/civicrm-core/pull/15090.

The alternative would be to edit `CRM/Upgrade/Form.php` as part of this change and prevent upgrades now.

Comments
----------------------------------------
I have no idea how the testing infrastructure will react to this.  Let's see!
