### PR TITLE
dev/core#1528 - Consolidate to single constant for minimum PHP version

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -32,15 +32,6 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   const MINIMUM_UPGRADABLE_VERSION = '4.2.9';
 
   /**
-   * Minimum php version required to run (equal to or lower than the minimum install version)
-   *
-   * As of Civi 5.16, using PHP 5.x will lead to a hard crash during bootstrap.
-   *
-   * Tip: Keep in sync with composer.json ("config => platform => php")
-   */
-  const MINIMUM_PHP_VERSION = '7.1.0';
-
-  /**
    * @var \CRM_Core_Config
    */
   protected $_config;
@@ -457,10 +448,10 @@ SET    version = '$version'
       );
     }
 
-    if (version_compare(phpversion(), self::MINIMUM_PHP_VERSION) < 0) {
+    if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) < 0) {
       $error = ts('CiviCRM %3 requires PHP version %1 (or newer), but the current system uses %2 ',
         [
-          1 => self::MINIMUM_PHP_VERSION,
+          1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER,
           2 => phpversion(),
           3 => $latestVer,
         ]);

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -24,20 +24,25 @@ class CRM_Upgrade_Incremental_General {
 
   /**
    * The recommended PHP version.
+   *
+   * The point release will be dropped in recommendations unless it's .1 or
+   * higher.
    */
-  const RECOMMENDED_PHP_VER = '7.3';
+  const RECOMMENDED_PHP_VER = '7.3.0';
 
   /**
-   * The previous recommended PHP version.
+   * The minimum recommended PHP version.
+   *
+   * A site running an earlier version will be told to upgrade.
    */
-  const MIN_RECOMMENDED_PHP_VER = '7.2';
+  const MIN_RECOMMENDED_PHP_VER = '7.2.0';
 
   /**
    * The minimum PHP version required to install Civi.
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '7.1';
+  const MIN_INSTALL_PHP_VER = '7.1.0';
 
   /**
    * Compute any messages which should be displayed before upgrade.
@@ -54,7 +59,7 @@ class CRM_Upgrade_Incremental_General {
       $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend PHP version %3.', [
         1 => $latestVer,
         2 => self::MIN_RECOMMENDED_PHP_VER,
-        3 => self::RECOMMENDED_PHP_VER,
+        3 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', self::RECOMMENDED_PHP_VER),
       ]);
       $preUpgradeMessage .= '</p>';
     }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -29,7 +29,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         ts('This system uses PHP version %1 which meets or exceeds the recommendation of %2.',
           [
             1 => $phpVersion,
-            2 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
+            2 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER),
           ]),
           ts('PHP Up-to-Date'),
           \Psr\Log\LogLevel::INFO,
@@ -56,7 +56,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
           [
             1 => $phpVersion,
             2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-            3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
+            3 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER),
           ]),
           ts('PHP Out-of-Date'),
           \Psr\Log\LogLevel::WARNING,
@@ -66,11 +66,11 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     else {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. To ensure the continued operation of CiviCRM, upgrade your server now. At least PHP version %2 is recommended; the preferrred version is %3.',
+        ts('This system uses PHP version %1. To ensure the continued operation of CiviCRM, upgrade your server now. At least PHP version %2 is recommended; the preferred version is %3.',
           [
             1 => $phpVersion,
             2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-            3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
+            3 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER),
           ]),
           ts('PHP Out-of-Date'),
           \Psr\Log\LogLevel::ERROR,

--- a/install/index.php
+++ b/install/index.php
@@ -904,7 +904,7 @@ class InstallRequirements {
         $testDetails[2] = ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk. The preferred version is %3.', array(
           1 => $phpVersion,
           2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-          3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
+          3 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER),
         ));
         $this->warning($testDetails);
       }

--- a/tests/phpunit/CRM/Upgrade/FormTest.php
+++ b/tests/phpunit/CRM/Upgrade/FormTest.php
@@ -17,7 +17,7 @@ class CRM_Upgrade_FormTest extends CiviUnitTestCase {
     $composerJson = json_decode(file_get_contents($composerJsonPath), 1);
     $composerJsonRequirePhp = preg_replace(';[~^];', '', $composerJson['require']['php']);
     $actualMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', $composerJsonRequirePhp);
-    $expectMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', \CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER);
+    $expectMajorMinor = preg_replace(';^(\d+\.\d+)\..*$;', '\1', \CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER);
     $this->assertEquals($expectMajorMinor, $actualMajorMinor, "The PHP version requirements in CRM_Upgrade_Form ($expectMajorMinor) and composer.json ($actualMajorMinor) should specify same major+minor versions.");
   }
 

--- a/tests/phpunit/CRM/Upgrade/FormTest.php
+++ b/tests/phpunit/CRM/Upgrade/FormTest.php
@@ -7,7 +7,8 @@
 class CRM_Upgrade_FormTest extends CiviUnitTestCase {
 
   /**
-   * "php" requirement (composer.json) should match MINIMUM_PHP_VERSION (CRM/Upgrade/Form.php).
+   * "php" requirement (composer.json) should match
+   * CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER.
    */
   public function testComposerRequirementMatch() {
     global $civicrm_root;
@@ -16,7 +17,7 @@ class CRM_Upgrade_FormTest extends CiviUnitTestCase {
     $composerJson = json_decode(file_get_contents($composerJsonPath), 1);
     $composerJsonRequirePhp = preg_replace(';[~^];', '', $composerJson['require']['php']);
     $actualMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', $composerJsonRequirePhp);
-    $expectMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', \CRM_Upgrade_Form::MINIMUM_PHP_VERSION);
+    $expectMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', \CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER);
     $this->assertEquals($expectMajorMinor, $actualMajorMinor, "The PHP version requirements in CRM_Upgrade_Form ($expectMajorMinor) and composer.json ($actualMajorMinor) should specify same major+minor versions.");
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
There have been two constants that handle the minimum PHP version: `CRM_Upgrade_Form::MINIMUM_PHP_VERSION` (for upgrades) and `CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER` (for new installs).  They were allowed to deviate in https://github.com/civicrm/civicrm-core/pull/14437 with the intention of making a softer transition to PHP 7.  However, [dev/drupal#79](https://lab.civicrm.org/dev/drupal/issues/79) illustrated a situation where sites with PHP 5.6 would be allowed to upgrade and immediately run into a fatal error.

Since then, tests have been added to enforce constants in civicrm-drupal, civicrm-wordpress, civicrm-backdrop, and `composer.json` being equal to `CRM_Upgrade_Form::MINIMUM_PHP_VERSION`.  In [discussion on dev/core#1528](https://lab.civicrm.org/dev/core/issues/1528#note_32978) @totten indicated that there's little need or desire for there to be different minimums for upgrades and new installs.

In that case, there's no reason for separate constants: all they'll do is confuse everyone.  This PR consolidates the two into `CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER` since it sits alongside the constants for the recommended PHP version and the minimum-recommended PHP version.

Before
----------------------------------------
Upgrades and tests in other repos look to one constant, while new installs and the system check look to another.

After
----------------------------------------
There is a single constant for the minimum allowable PHP version: `CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER`.  The minimum PHP version for upgrades may never deviate from the minimum PHP version for new installations.

Comments
----------------------------------------
PRs forthcoming for civicrm-drupal, civicrm-wordpress, and civicrm-backdrop since they look to `CRM_Upgrade_Form::MINIMUM_PHP_VERSION`.
