### PR TITLE
[NFC] Test cleanup, remove duplicate test

### DIFF
--- a/tests/phpunit/api/v3/EntityTagTest.php
+++ b/tests/phpunit/api/v3/EntityTagTest.php
@@ -42,6 +42,8 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Set up for test.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function setUp() {
     parent::setUp();
@@ -50,7 +52,7 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
     $this->_individualID = $this->individualCreate();
     $this->_tag = $this->tagCreate(['name' => 'EntityTagTest']);
     $this->_tagID = $this->_tag['id'];
-    $this->_householdID = $this->houseHoldCreate();
+    $this->_householdID = $this->householdCreate();
     $this->_organizationID = $this->organizationCreate();
     $this->_params = [
       'entity_id' => $this->_individualID,
@@ -74,18 +76,23 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Test basic create.
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testContactEntityTagCreate($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPISuccess('entity_tag', 'create', $this->_params);
+    $this->callAPISuccess('entity_tag', 'create', $this->_params);
   }
 
   /**
    * Test multiple add functionality.
    *
    * This needs review for api v4 as it makes for a very non standard api.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testAddDouble() {
 
@@ -114,12 +121,15 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Basic get functionality test.
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testIndividualEntityTagGet($version) {
     $this->_apiversion = $version;
-    $individualEntity = $this->callAPISuccess('entity_tag', 'create', $this->_params);
+    $this->callAPISuccess('entity_tag', 'create', $this->_params);
 
     $paramsEntity = [
       'contact_id' => $this->_individualID,
@@ -131,6 +141,8 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Test memory usage does not escalate crazily.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testMemoryLeak() {
     $start = memory_get_usage();
@@ -157,8 +169,11 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Test tag can be added to an organization.
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testOrganizationEntityGet($version) {
     $this->_apiversion = $version;
@@ -177,6 +192,8 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
 
   /**
    * Civicrm_entity_tag_Delete methods.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testEntityTagDeleteNoTagId() {
     $entityTagParams = [
@@ -251,24 +268,6 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('entity_tag', 'delete', $params);
     $this->assertEquals($result['removed'], 1);
     $this->assertEquals($result['not_removed'], 1);
-  }
-
-  public function testEntityTagCommonDeleteINDHH() {
-    $entityTagParams = [
-      'contact_id_i' => $this->_individualID,
-      'contact_id_h' => $this->_householdID,
-      'tag_id' => $this->_tagID,
-    ];
-    $this->entityTagAdd($entityTagParams);
-
-    $params = [
-      'contact_id_i' => $this->_individualID,
-      'contact_id_h' => $this->_householdID,
-      'tag_id' => $this->_tagID,
-    ];
-
-    $result = $this->callAPISuccess('entity_tag', 'delete', $params);
-    $this->assertEquals($result['removed'], 2);
   }
 
   public function testEntityTagCommonDeleteHH() {


### PR DESCRIPTION


Overview
----------------------------------------
It turns out the removed test is identical to testEntityTagDeleteINDHH earlier in the class
- probably consolidation of the functions called led to this

Before
----------------------------------------
2  tests have exactly the same  code

After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------

