### PR TITLE
[NFC] Improve cleanup on membershipStatus to cope with undeleted memberships

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -626,6 +626,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param string $name
    *
    * @return mixed
+   *
+   * @throws \CRM_Core_Exception
    */
   public function membershipStatusCreate($name = 'test member status') {
     $params['name'] = $name;
@@ -636,17 +638,19 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
     $result = $this->callAPISuccess('MembershipStatus', 'Create', $params);
     CRM_Member_PseudoConstant::flush('membershipStatus');
-    return $result['id'];
+    return (int) $result['id'];
   }
 
   /**
+   * Delete the given membership status, deleting any memberships of the status first.
+   *
    * @param int $membershipStatusID
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function membershipStatusDelete($membershipStatusID) {
-    if (!$membershipStatusID) {
-      return;
-    }
-    $result = $this->callAPISuccess('MembershipStatus', 'Delete', ['id' => $membershipStatusID]);
+  public function membershipStatusDelete(int $membershipStatusID) {
+    $this->callAPISuccess('Membership', 'get', ['status_id' => $membershipStatusID, 'api.Membership.delete' => 1]);
+    $this->callAPISuccess('MembershipStatus', 'Delete', ['id' => $membershipStatusID]);
   }
 
   public function membershipRenewalDate($durationUnit, $membershipEndDate) {

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -32,6 +32,11 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
     CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'name', TRUE);
   }
 
+  /**
+   * Cleanup after test.
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function tearDown() {
     $this->membershipStatusDelete($this->_membershipStatusID);
     $this->membershipTypeDelete(['id' => $this->_membershipTypeID]);


### PR DESCRIPTION
Overview
----------------------------------------
This makes the cleanup function more robust

Before
----------------------------------------
It will fail if not all memberships are deleted

After
----------------------------------------
Memberships  handled

Technical Details
----------------------------------------
This might fail on the first pass as it forces the type  to be int & gets rid of the silliness of calling it to do nothing

Comments
----------------------------------------

