### PR TITLE
dev/financial#120 Fix CiviCRM base url for Joomla when loading on the…

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -668,7 +668,13 @@ abstract class CRM_Utils_System_Base {
     }
 
     if ($config->userFramework == 'Joomla') {
-      $userFrameworkResourceURL = $baseURL . "components/com_civicrm/civicrm/";
+      // For Joomla CiviCRM Core files always live within the admistrator folder and $base_url is different on the frontend compared to the backend.
+      if (strpos($baseURL, 'administrator') === FALSE) {
+        $userFrameworkResourceURL = $baseURL . "administrator/components/com_civicrm/civicrm/";
+      }
+      else {
+        $userFrameworkResourceURL = $baseURL . "components/com_civicrm/civicrm/";
+      }
     }
     elseif ($config->userFramework == 'WordPress') {
       $userFrameworkResourceURL = CIVICRM_PLUGIN_URL . "civicrm/";


### PR DESCRIPTION
… front end and using relative urls in settings

Overview
----------------------------------------
For Joomla there is a split codebase between what is for the Administative component and what is front end. This also leads to two sets of civicrm.settings.php files an 2 separate base urls one without administrator and one with. However all the assets are only found in one place on the server and that is under the administrator folder. This changes it so that if the notional base_url does not have administrator/ in the url for Joomla we add it in. This used to not be such an issue as a system admin could just hard code the resource url and be done with things. However https://github.com/civicrm/civicrm-core/commit/1143a7815b1abbcb7cfc0cab6c754e499d11d064 changed things as it made the packages and the bower_components folders relative for Drupal 8 support which then stopped things from working with just a resource url override

Before
----------------------------------------
CiviCRM javascript and CSS assets do not load on front end forms

After
----------------------------------------
CiviCRM javascript and CSS assets do load on front end forms. 

ping @lcdservices @kcristiano @totten @eileenmcnaughton 