### PR TITLE
dev/financial#120 - Fix CiviCRM base URL on Joomla frontend

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -667,13 +667,9 @@ abstract class CRM_Utils_System_Base {
       $baseURL = str_replace('http://', 'https://', $baseURL);
     }
 
-    if ($config->userFramework == 'Joomla') {
-      $userFrameworkResourceURL = $baseURL . "components/com_civicrm/civicrm/";
-    }
-    elseif ($config->userFramework == 'WordPress') {
-      $userFrameworkResourceURL = CIVICRM_PLUGIN_URL . "civicrm/";
-    }
-    elseif ($this->is_drupal) {
+    // @todo this function is only called / code is only reached when is_drupal is true - move this to the drupal classes
+    // and don't implement here.
+    if ($this->is_drupal) {
       // Drupal setting
       // check and see if we are installed in sites/all (for D5 and above)
       // we dont use checkURL since drupal generates an error page and throws

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -879,4 +879,41 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     ];
   }
 
+  /**
+   * Determine the location of the CiviCRM source tree.
+   *
+   * FIXME:
+   *  1. This was pulled out from a bigger function. It should be split
+   *     into even smaller pieces and marked abstract.
+   *  2. This would be easier to compute by a calling a CMS API, but
+   *     for whatever reason we take the hard way.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/sites/all/modules/civicrm"
+   *   - path: string. ex: "/var/www/sites/all/modules/civicrm"
+   */
+  public function getCiviSourceStorage() {
+    global $civicrm_root;
+    if (!defined('CIVICRM_UF_BASEURL')) {
+      throw new RuntimeException('Undefined constant: CIVICRM_UF_BASEURL');
+    }
+    $baseURL = CRM_Utils_File::addTrailingSlash(CIVICRM_UF_BASEURL, '/');
+    if (CRM_Utils_System::isSSL()) {
+      $baseURL = str_replace('http://', 'https://', $baseURL);
+    }
+
+    // For Joomla CiviCRM Core files always live within the admistrator folder and $base_url is different on the frontend compared to the backend.
+    if (strpos($baseURL, 'administrator') === FALSE) {
+      $userFrameworkResourceURL = $baseURL . "administrator/components/com_civicrm/civicrm/";
+    }
+    else {
+      $userFrameworkResourceURL = $baseURL . "components/com_civicrm/civicrm/";
+    }
+
+    return [
+      'url' => CRM_Utils_File::addTrailingSlash($userFrameworkResourceURL, '/'),
+      'path' => CRM_Utils_File::addTrailingSlash($civicrm_root),
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

This fixes loading of several JS+CSS assets for front-end pages (such as the contribution page) on CiviCRM-Joomla.

See also: https://lab.civicrm.org/dev/financial/issues/120

(This PR is a revision/alternative to #16760 for which Seamus did the primary analysis. This variant iterates on code style.)

Background
-------------

* Joomla splits CiviCRM between two "components" -- a  backend `administrator` component and frontend/user component.
* Each component has a different `civicrm.settings.php` and a different `CIVICRM_UF_BASEURL`.
* CiviCRM's JS and CSS assets are physically stored under `administrator/components/com_civicrm/`. Regardless of whether the web-page is a frontend or backend screen, it should load JS/CSS assets from the `administrator` side.
* In Civi v5.23.alpha (1143a7815b1abbcb7cfc0cab6c754e499d11d064), the URL construction for certain folders (esp `civicrm/bower_components` and `civicrm/packages`) changed subtly.

Before
----------------------------------------
CiviCRM JS and CSS assets do not load on Joomla front end forms.

The asset URLs incorrectly point to (nonexistent) JS/CSS files in the user component.

The URL variable `[civicrm.root]` (and therefore `[civicrm.packages]`, `[civicrm.bower]`) does not truly point to the public URL of CiviCRM assets.

After
----------------------------------------
CiviCRM JS and CSS assets do load on front end forms. 

The asset URLs correctly point to (existent) JS/CSS files in the `administrator` component.

The URL variable `[civicrm.root]` (and therefore `[civicrm.packages]`, `[civicrm.bower]`) does point to the public URL of CiviCRM assets.


(Original description from seamus. Revised by totten.)