### PR TITLE
dev/core#1630 Partial fix on renew membership missing

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1225,7 +1225,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
             if ($allowAutoRenewOpt) {
               $javascriptMethod = ['onclick' => "return showHideAutoRenew( this.value );"];
-              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = (int) $memType['auto_renew'] * CRM_Utils_Array::value($value, CRM_Utils_Array::value('auto_renew', $this->_membershipBlock));
+              $isAvailableAutoRenew = $this->_membershipBlock['auto_renew'][$value] ?? 1;
+              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = (int) $memType['auto_renew'] * $isAvailableAutoRenew;
               $allowAutoRenewMembership = TRUE;
             }
             else {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug which looks like a year-old-regression where price-set auto-renew memberships do not show the auto-renew flag



Before
----------------------------------------
Repro steps:
Configure a membership type with "auto-renew option" = "Give option, but not required", e.g., "General type A"
Create a membership price set with a "membership type" field (radio) including at least the "General type A" membership type.
Create a contribution page using this price set;
Just in case, ensure the contribution page uses a payment processor that supports recurring contributions (not sure if this step is necessary for repro, but it would be in the real world)
Open the contribution page in "live" mode
Below the "Membership type" price field, observe the message "Membership will renew automatically."; also observe there is no checkbox labeled "Please renew my membership automatically." (which would be expected for optional auto-renewal).

After
----------------------------------------
The checkbox now shows when the above steps are followed.

Note however  this is partial - if the price set was created  using the version routine  then the civicrm_membership_block.membership_type field will be populated & that will be respected. I've left worrying about that out of scope

Technical Details
----------------------------------------
I'm pretty comfortable that this regressed at least  a year ago - possibly much longer - so it's not
a recent regression. However, the issue is that when a price set is configured it is still 'listening to'
the  presence or otherwise of auto_renew in civicrm_membership_block.membership_types. This makes it
ignore that if not present (which is the case when creating a new price set from scratch).
When converting a price set the membership_types field is still populated and still kicks in
- I think we should really empty that out when a block is converted but I've left it out of scope as this
seems like an edge case bug & it was only the possibity it was a regression that caused me to dig into it

Comments
----------------------------------------
@twomice 