### PR TITLE
[REF] Replace CRM_Utils_Array::value with ?? in variable assignments

### DIFF
--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -135,7 +135,7 @@ ORDER BY entity_id
       $acl[$dao->id]['is_active'] = $dao->is_active;
 
       if ($acl[$dao->id]['entity_id']) {
-        $acl[$dao->id]['entity'] = CRM_Utils_Array::value($acl[$dao->id]['entity_id'], $roles);
+        $acl[$dao->id]['entity'] = $roles[$acl[$dao->id]['entity_id']] ?? NULL;
       }
       else {
         $acl[$dao->id]['entity'] = ts('Everyone');
@@ -143,22 +143,22 @@ ORDER BY entity_id
 
       switch ($acl[$dao->id]['object_table']) {
         case 'civicrm_saved_search':
-          $acl[$dao->id]['object'] = CRM_Utils_Array::value($acl[$dao->id]['object_id'], $group);
+          $acl[$dao->id]['object'] = $group[$acl[$dao->id]['object_id']] ?? NULL;
           $acl[$dao->id]['object_name'] = ts('Group');
           break;
 
         case 'civicrm_uf_group':
-          $acl[$dao->id]['object'] = CRM_Utils_Array::value($acl[$dao->id]['object_id'], $ufGroup);
+          $acl[$dao->id]['object'] = $ufGroup[$acl[$dao->id]['object_id']] ?? NULL;
           $acl[$dao->id]['object_name'] = ts('Profile');
           break;
 
         case 'civicrm_custom_group':
-          $acl[$dao->id]['object'] = CRM_Utils_Array::value($acl[$dao->id]['object_id'], $customGroup);
+          $acl[$dao->id]['object'] = $customGroup[$acl[$dao->id]['object_id']] ?? NULL;
           $acl[$dao->id]['object_name'] = ts('Custom Group');
           break;
 
         case 'civicrm_event':
-          $acl[$dao->id]['object'] = CRM_Utils_Array::value($acl[$dao->id]['object_id'], $event);
+          $acl[$dao->id]['object'] = $event[$acl[$dao->id]['object_id']] ?? NULL;
           $acl[$dao->id]['object_name'] = ts('Event');
           break;
       }

--- a/CRM/ACL/Page/ACLBasic.php
+++ b/CRM/ACL/Page/ACLBasic.php
@@ -114,7 +114,7 @@ ORDER BY entity_id
         $acl[$dao->entity_id]['name'] = $dao->name;
         $acl[$dao->entity_id]['entity_id'] = $dao->entity_id;
         $acl[$dao->entity_id]['entity_table'] = $dao->entity_table;
-        $acl[$dao->entity_id]['object_table'] = CRM_Utils_Array::value($dao->object_table, $permissions);
+        $acl[$dao->entity_id]['object_table'] = $permissions[$dao->object_table] ?? NULL;
         $acl[$dao->entity_id]['is_active'] = 1;
 
         if ($acl[$dao->entity_id]['entity_id']) {

--- a/CRM/ACL/Page/EntityRole.php
+++ b/CRM/ACL/Page/EntityRole.php
@@ -127,7 +127,7 @@ class CRM_ACL_Page_EntityRole extends CRM_Core_Page_Basic {
       $entityRoles[$dao->id] = [];
       CRM_Core_DAO::storeValues($dao, $entityRoles[$dao->id]);
 
-      $entityRoles[$dao->id]['acl_role'] = CRM_Utils_Array::value($dao->acl_role_id, $aclRoles);
+      $entityRoles[$dao->id]['acl_role'] = $aclRoles[$dao->acl_role_id] ?? NULL;
       $entityRoles[$dao->id]['entity'] = $groups[$dao->entity_id];
 
       // form all action links

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -153,7 +153,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $sourceRecordIds = implode(',', $params['source_record_id']);
     }
     else {
-      $sourceRecordIds = CRM_Utils_Array::value('source_record_id', $params);
+      $sourceRecordIds = $params['source_record_id'] ?? NULL;
     }
 
     $result = NULL;
@@ -490,7 +490,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
     else {
       // at worst, take source for recently viewed display
-      $recentContactId = CRM_Utils_Array::value('source_contact_id', $params);
+      $recentContactId = $params['source_contact_id'] ?? NULL;
     }
 
     if (isset($params['assignee_contact_id'])) {
@@ -582,7 +582,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     // if the subject contains a ‘[case #…]’ string, file that activity on the related case (CRM-5916)
     $matches = [];
-    $subjectToMatch = CRM_Utils_Array::value('subject', $params);
+    $subjectToMatch = $params['subject'] ?? NULL;
     if (preg_match('/\[case #([0-9a-h]{7})\]/', $subjectToMatch, $matches)) {
       $key = CRM_Core_DAO::escapeString(CIVICRM_SITE_KEY);
       $hash = $matches[1];
@@ -804,7 +804,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         }
         // case related fields
         elseif ($apiKey == 'case_id' && !$isBulkActivity) {
-          $activities[$id][$expectedName] = CRM_Utils_Array::value($apiKey, $activity);
+          $activities[$id][$expectedName] = $activity[$apiKey] ?? NULL;
 
           // fetch case subject for case ID found
           if (!empty($activity['case_id'])) {
@@ -815,9 +815,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         }
         else {
           // @todo this generic assign could just be handled in array declaration earlier.
-          $activities[$id][$expectedName] = CRM_Utils_Array::value($apiKey, $activity);
+          $activities[$id][$expectedName] = $activity[$apiKey] ?? NULL;
           if ($apiKey == 'campaign_id') {
-            $activities[$id]['campaign'] = CRM_Utils_Array::value($activities[$id][$expectedName], $allCampaigns);
+            $activities[$id]['campaign'] = $allCampaigns[$activities[$id][$expectedName]] ?? NULL;
           }
         }
       }
@@ -1427,7 +1427,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       // To get primary mobile phonenumber, if not get the first mobile phonenumber
       if (!empty($toPhoneNumbers)) {
         $toPhoneNumberDetails = reset($toPhoneNumbers);
-        $toPhoneNumber = CRM_Utils_Array::value('phone', $toPhoneNumberDetails);
+        $toPhoneNumber = $toPhoneNumberDetails['phone'] ?? NULL;
         // Contact allows to send sms
       }
     }
@@ -2002,8 +2002,8 @@ AND cl.modified_id  = c.id
 
     $followupParams['activity_type_id'] = $params['followup_activity_type_id'];
     // Get Subject of Follow-up Activiity, CRM-4491
-    $followupParams['subject'] = CRM_Utils_Array::value('followup_activity_subject', $params);
-    $followupParams['assignee_contact_id'] = CRM_Utils_Array::value('followup_assignee_contact_id', $params);
+    $followupParams['subject'] = $params['followup_activity_subject'] ?? NULL;
+    $followupParams['assignee_contact_id'] = $params['followup_assignee_contact_id'] ?? NULL;
 
     // Create target contact for followup.
     if (!empty($params['target_contact_id'])) {
@@ -2523,9 +2523,9 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
     // Format the params.
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['rowCount'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
     $params['caseId'] = NULL;
-    $context = CRM_Utils_Array::value('context', $params);
+    $context = $params['context'] ?? NULL;
     $showContactOverlay = !CRM_Utils_String::startsWith($context, "dashlet");
     $activityTypeInfo = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => "activity_type",
@@ -2897,8 +2897,8 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
    */
   public static function sendToAssignee($activity, $mailToContacts, $params = []) {
     if (!CRM_Utils_Array::crmIsEmptyArray($mailToContacts)) {
-      $clientID = CRM_Utils_Array::value('client_id', $params);
-      $caseID = CRM_Utils_Array::value('case_id', $params);
+      $clientID = $params['client_id'] ?? NULL;
+      $caseID = $params['case_id'] ?? NULL;
 
       $ics = new CRM_Activity_BAO_ICalendar($activity);
       $attachments = CRM_Core_BAO_File::getEntityFile('civicrm_activity', $activity->id);

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -230,7 +230,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    */
   public function preProcess() {
     CRM_Core_Form_RecurringEntity::preProcess('civicrm_activity');
-    $this->_atypefile = CRM_Utils_Array::value('atypefile', $_GET);
+    $this->_atypefile = $_GET['atypefile'] ?? NULL;
     $this->assign('atypefile', FALSE);
     if ($this->_atypefile) {
       $this->assign('atypefile', TRUE);
@@ -444,7 +444,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     // hack to retrieve activity type id from post variables
     if (!$this->_activityTypeId) {
-      $this->_activityTypeId = CRM_Utils_Array::value('activity_type_id', $_POST);
+      $this->_activityTypeId = $_POST['activity_type_id'] ?? NULL;
     }
 
     // when custom data is included in this page
@@ -540,8 +540,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       }
 
       // Fixme: why are we getting the wrong keys from upstream?
-      $defaults['target_contact_id'] = CRM_Utils_Array::value('target_contact', $defaults);
-      $defaults['assignee_contact_id'] = CRM_Utils_Array::value('assignee_contact', $defaults);
+      $defaults['target_contact_id'] = $defaults['target_contact'] ?? NULL;
+      $defaults['assignee_contact_id'] = $defaults['assignee_contact'] ?? NULL;
 
       // set default tags if exists
       $defaults['tag'] = implode(',', CRM_Core_BAO_EntityTag::getTag($this->_activityId, 'civicrm_activity'));
@@ -649,7 +649,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     foreach ($this->_fields as $field => $values) {
       if (!empty($this->_fields[$field])) {
-        $attribute = CRM_Utils_Array::value('attributes', $values);
+        $attribute = $values['attributes'] ?? NULL;
         $required = !empty($values['required']);
 
         if ($values['type'] == 'select' && empty($attribute)) {
@@ -831,8 +831,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $errors['activity_type_id'] = ts('Activity Type is a required field');
     }
 
-    $activity_type_id = CRM_Utils_Array::value('activity_type_id', $fields);
-    $activity_status_id = CRM_Utils_Array::value('status_id', $fields);
+    $activity_type_id = $fields['activity_type_id'] ?? NULL;
+    $activity_status_id = $fields['status_id'] ?? NULL;
     $scheduled_status_id = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled');
 
     if ($activity_type_id && $activity_status_id == $scheduled_status_id) {
@@ -1237,7 +1237,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       // Set title.
       if (isset($activityTypeDisplayLabels)) {
         // FIXME - it's not clear why the if line just above is needed here and why we can't just set this once above and re-use. What is interesting, but can't possibly be the reason, is that the first if block will fail if the label is the string '0', whereas this one won't. But who would have an activity type called '0'?
-        $activityTypeDisplayLabel = CRM_Utils_Array::value($this->_activityTypeId, $activityTypeDisplayLabels);
+        $activityTypeDisplayLabel = $activityTypeDisplayLabels[$this->_activityTypeId] ?? NULL;
 
         if ($this->_currentlyViewedContactId) {
           $displayName = CRM_Contact_BAO_Contact::displayName($this->_currentlyViewedContactId);

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -59,7 +59,7 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     $this->assign('activityTypeDescription', $activityTypeDescription);
 
     if (!empty($defaults['mailingId'])) {
-      $this->_mailing_id = CRM_Utils_Array::value('source_record_id', $defaults);
+      $this->_mailing_id = $defaults['source_record_id'] ?? NULL;
       $mailingReport = CRM_Mailing_BAO_Mailing::report($this->_mailing_id, TRUE);
       CRM_Mailing_BAO_Mailing::getMailingContent($mailingReport, $this);
       $this->assign('mailingReport', $mailingReport);

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -251,7 +251,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
 
     if ($survey) {
       $this->_formValues['activity_survey_id'] = $this->_defaults['activity_survey_id'] = $survey;
-      $sid = CRM_Utils_Array::value('activity_survey_id', $this->_formValues);
+      $sid = $this->_formValues['activity_survey_id'] ?? NULL;
       $activity_type_id = CRM_Core_DAO::getFieldValue('CRM_Campaign_DAO_Survey', $sid, 'activity_type_id');
 
       // since checkbox are replaced by multiple select option

--- a/CRM/Activity/Form/Task/Batch.php
+++ b/CRM/Activity/Form/Task/Batch.php
@@ -146,7 +146,7 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
       $typeId = CRM_Core_DAO::getFieldValue("CRM_Activity_DAO_Activity", $activityId, 'activity_type_id');
       foreach ($this->_fields as $name => $field) {
         if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($name)) {
-          $customValue = CRM_Utils_Array::value($customFieldID, $customFields);
+          $customValue = $customFields[$customFieldID] ?? NULL;
           if (!empty($customValue['extends_entity_column_value'])) {
             $entityColumnValue = explode(CRM_Core_DAO::VALUE_SEPARATOR,
               $customValue['extends_entity_column_value']

--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -309,7 +309,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     if (!empty($fields['saveMapping'])) {
-      $nameField = CRM_Utils_Array::value('saveMappingName', $fields);
+      $nameField = $fields['saveMappingName'] ?? NULL;
       if (empty($nameField)) {
         $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
       }

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -249,7 +249,7 @@ class CRM_Activity_Page_AJAX {
     $params = ['caseID', 'activityID', 'contactID', 'newSubject', 'targetContactIds', 'mode'];
     $vals = [];
     foreach ($params as $param) {
-      $vals[$param] = CRM_Utils_Array::value($param, $_POST);
+      $vals[$param] = $_POST[$param] ?? NULL;
     }
 
     CRM_Utils_JSON::output(self::_convertToCaseActivity($vals));

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -282,9 +282,9 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
         }
       }
 
-      $contactId = CRM_Utils_Array::value('contact_id', $row);
+      $contactId = $row['contact_id'] ?? NULL;
       if (!$contactId) {
-        $contactId = CRM_Utils_Array::value('source_contact_id', $row);
+        $contactId = $row['source_contact_id'] ?? NULL;
       }
 
       $row['target_contact_name'] = CRM_Activity_BAO_ActivityContact::getNames($row['activity_id'], $targetID);
@@ -339,7 +339,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
       );
 
       // Carry campaign to selector.
-      $row['campaign'] = CRM_Utils_Array::value($result->activity_campaign_id, $allCampaigns);
+      $row['campaign'] = $allCampaigns[$result->activity_campaign_id] ?? NULL;
       $row['campaign_id'] = $result->activity_campaign_id;
 
       if ($engagementLevel = CRM_Utils_Array::value('activity_engagement_level', $row)) {

--- a/CRM/Activity/StateMachine/Search.php
+++ b/CRM/Activity/StateMachine/Search.php
@@ -65,7 +65,7 @@ class CRM_Activity_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -157,7 +157,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
         $params[$f] = CRM_Utils_Array::value($f, $formValues, FALSE);
       }
       else {
-        $params[$f] = CRM_Utils_Array::value($f, $formValues);
+        $params[$f] = $formValues[$f] ?? NULL;
       }
     }
 

--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -94,7 +94,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
       ]);
     }
     else {
-      $this->_workflow_id = CRM_Utils_Array::value('workflow_id', $this->_values);
+      $this->_workflow_id = $this->_values['workflow_id'] ?? NULL;
       $this->checkUserPermission($this->_workflow_id);
       $this->assign('workflow_id', $this->_workflow_id);
 
@@ -289,7 +289,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
         }
       }
 
-      $this->_workflow_id = CRM_Utils_Array::value('workflow_id', $this->_values);
+      $this->_workflow_id = $this->_values['workflow_id'] ?? NULL;
       if ($this->_workflow_id) {
         $params['workflow_id'] = $this->_workflow_id;
         $params['is_active'] = TRUE;

--- a/CRM/Admin/Form/Navigation.php
+++ b/CRM/Admin/Form/Navigation.php
@@ -98,7 +98,7 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
     if (isset($this->_id)) {
       //Take parent id in object variable to calculate the menu
       //weight if menu parent id changed
-      $this->_currentParentID = CRM_Utils_Array::value('parent_id', $this->_defaults);
+      $this->_currentParentID = $this->_defaults['parent_id'] ?? NULL;
     }
     else {
       $defaults['permission'] = "access CiviCRM";

--- a/CRM/Admin/Form/ParticipantStatusType.php
+++ b/CRM/Admin/Form/ParticipantStatusType.php
@@ -65,7 +65,7 @@ class CRM_Admin_Form_ParticipantStatusType extends CRM_Admin_Form {
     if (empty($defaults['weight'])) {
       $defaults['weight'] = CRM_Utils_Weight::getDefaultWeight('CRM_Event_DAO_ParticipantStatusType');
     }
-    $this->_isReserved = CRM_Utils_Array::value('is_reserved', $defaults);
+    $this->_isReserved = $defaults['is_reserved'] ?? NULL;
     if ($this->_isReserved) {
       $this->freeze(['name', 'class', 'is_active']);
     }

--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -138,12 +138,12 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       $params = ['id' => $this->_id];
       $baoName = $this->_BAOName;
       $baoName::retrieve($params, $defaults);
-      $defaults['contact_types_a'] = CRM_Utils_Array::value('contact_type_a', $defaults);
+      $defaults['contact_types_a'] = $defaults['contact_type_a'] ?? NULL;
       if (!empty($defaults['contact_sub_type_a'])) {
         $defaults['contact_types_a'] .= '__' . $defaults['contact_sub_type_a'];
       }
 
-      $defaults['contact_types_b'] = CRM_Utils_Array::value('contact_type_b', $defaults);
+      $defaults['contact_types_b'] = $defaults['contact_type_b'] ?? NULL;
       if (!empty($defaults['contact_sub_type_b'])) {
         $defaults['contact_types_b'] .= '__' . $defaults['contact_sub_type_b'];
       }
@@ -187,7 +187,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       $params['contact_sub_type_b'] = $cTypeB[1] ? $cTypeB[1] : 'null';
 
       if (!strlen(trim(CRM_Utils_Array::value('label_b_a', $params)))) {
-        $params['label_b_a'] = CRM_Utils_Array::value('label_a_b', $params);
+        $params['label_b_a'] = $params['label_a_b'] ?? NULL;
       }
 
       if (empty($params['id'])) {

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -387,7 +387,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $entityValue = explode(CRM_Core_DAO::VALUE_SEPARATOR, CRM_Utils_Array::value('entity_value', $defaults));
       $entityStatus = explode(CRM_Core_DAO::VALUE_SEPARATOR, CRM_Utils_Array::value('entity_status', $defaults));
       if (empty($this->getContext())) {
-        $defaults['entity'][0] = CRM_Utils_Array::value('mapping_id', $defaults);
+        $defaults['entity'][0] = $defaults['mapping_id'] ?? NULL;
         $defaults['entity'][1] = $entityValue;
         $defaults['entity'][2] = $entityStatus;
       }
@@ -400,11 +400,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
           $recipientListing
         );
       }
-      $defaults['text_message'] = CRM_Utils_Array::value('body_text', $defaults);
-      $defaults['html_message'] = CRM_Utils_Array::value('body_html', $defaults);
-      $defaults['sms_text_message'] = CRM_Utils_Array::value('sms_body_text', $defaults);
-      $defaults['template'] = CRM_Utils_Array::value('msg_template_id', $defaults);
-      $defaults['SMStemplate'] = CRM_Utils_Array::value('sms_template_id', $defaults);
+      $defaults['text_message'] = $defaults['body_text'] ?? NULL;
+      $defaults['html_message'] = $defaults['body_html'] ?? NULL;
+      $defaults['sms_text_message'] = $defaults['sms_body_text'] ?? NULL;
+      $defaults['template'] = $defaults['msg_template_id'] ?? NULL;
+      $defaults['SMStemplate'] = $defaults['sms_template_id'] ?? NULL;
       if (!empty($defaults['group_id'])) {
         $defaults['recipient'] = 'group';
       }
@@ -489,7 +489,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       'from_email',
     ];
     foreach ($keys as $key) {
-      $params[$key] = CRM_Utils_Array::value($key, $values);
+      $params[$key] = $values[$key] ?? NULL;
     }
 
     $params['is_repeat'] = CRM_Utils_Array::value('is_repeat', $values, 0);
@@ -515,15 +515,15 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
         $params[$mkey] = 'null';
         continue;
       }
-      $params[$mkey] = CRM_Utils_Array::value($mkey, $values);
+      $params[$mkey] = $values[$mkey] ?? NULL;
     }
 
-    $params['body_text'] = CRM_Utils_Array::value('text_message', $values);
-    $params['sms_body_text'] = CRM_Utils_Array::value('sms_text_message', $values);
-    $params['body_html'] = CRM_Utils_Array::value('html_message', $values);
+    $params['body_text'] = $values['text_message'] ?? NULL;
+    $params['sms_body_text'] = $values['sms_text_message'] ?? NULL;
+    $params['body_html'] = $values['html_message'] ?? NULL;
 
     if (CRM_Utils_Array::value('recipient', $values) == 'manual') {
-      $params['recipient_manual'] = CRM_Utils_Array::value('recipient_manual_id', $values);
+      $params['recipient_manual'] = $values['recipient_manual_id'] ?? NULL;
       $params['group_id'] = $params['recipient'] = $params['recipient_listing'] = 'null';
     }
     elseif (CRM_Utils_Array::value('recipient', $values) == 'group') {
@@ -531,14 +531,14 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $params['recipient_manual'] = $params['recipient'] = $params['recipient_listing'] = 'null';
     }
     elseif (isset($values['recipient_listing']) && isset($values['limit_to']) && !CRM_Utils_System::isNull($values['recipient_listing']) && !CRM_Utils_System::isNull($values['limit_to'])) {
-      $params['recipient'] = CRM_Utils_Array::value('recipient', $values);
+      $params['recipient'] = $values['recipient'] ?? NULL;
       $params['recipient_listing'] = implode(CRM_Core_DAO::VALUE_SEPARATOR,
         CRM_Utils_Array::value('recipient_listing', $values)
       );
       $params['group_id'] = $params['recipient_manual'] = 'null';
     }
     else {
-      $params['recipient'] = CRM_Utils_Array::value('recipient', $values);
+      $params['recipient'] = $values['recipient'] ?? NULL;
       $params['group_id'] = $params['recipient_manual'] = $params['recipient_listing'] = 'null';
     }
 
@@ -573,7 +573,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     // multilingual options
     $params['filter_contact_language'] = CRM_Utils_Array::value('filter_contact_language', $values, []);
     $params['filter_contact_language'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['filter_contact_language']);
-    $params['communication_language'] = CRM_Utils_Array::value('communication_language', $values, NULL);
+    $params['communication_language'] = $values['communication_language'] ?? NULL;
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;
@@ -657,7 +657,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
           $params['sms_template_id'] = $msgTemplate->id;
         }
         else {
-          $params['sms_template_id'] = CRM_Utils_Array::value('SMStemplate', $values);
+          $params['sms_template_id'] = $values['SMStemplate'] ?? NULL;
         }
       }
       else {
@@ -665,7 +665,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
           $params['msg_template_id'] = $msgTemplate->id;
         }
         else {
-          $params['msg_template_id'] = CRM_Utils_Array::value('template', $values);
+          $params['msg_template_id'] = $values['template'] ?? NULL;
         }
       }
     }

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -162,7 +162,7 @@ trait CRM_Admin_Form_SettingTrait {
     foreach ($settingMetaData as $setting => $props) {
       $quickFormType = $this->getQuickFormType($props);
       if (isset($quickFormType)) {
-        $options = CRM_Utils_Array::value('options', $props);
+        $options = $props['options'] ?? NULL;
         if ($options) {
           if ($props['html_type'] === 'Select' && isset($props['is_required']) && $props['is_required'] === FALSE && !isset($options[''])) {
             // If the spec specifies the field is not required add a null option.
@@ -233,7 +233,7 @@ trait CRM_Admin_Form_SettingTrait {
           $this->$add($setting, $props['title'], $options);
         }
         // Migrate to using an array as easier in smart...
-        $description = CRM_Utils_Array::value('description', $props);
+        $description = $props['description'] ?? NULL;
         $descriptions[$setting] = $description;
         $this->assign("{$setting}_description", $description);
         if ($setting === 'max_attachments') {

--- a/CRM/Admin/Form/WordReplacements.php
+++ b/CRM/Admin/Form/WordReplacements.php
@@ -31,7 +31,7 @@ class CRM_Admin_Form_WordReplacements extends CRM_Core_Form {
     // should rewrite this UI.
     CRM_Core_BAO_WordReplacement::rebuild(FALSE);
 
-    $this->_soInstance = CRM_Utils_Array::value('instance', $_GET);
+    $this->_soInstance = $_GET['instance'] ?? NULL;
     $this->assign('soInstance', $this->_soInstance);
   }
 
@@ -148,10 +148,10 @@ class CRM_Admin_Form_WordReplacements extends CRM_Core_Form {
   public static function formRule($values) {
     $errors = [];
 
-    $oldValues = CRM_Utils_Array::value('old', $values);
-    $newValues = CRM_Utils_Array::value('new', $values);
-    $enabled = CRM_Utils_Array::value('enabled', $values);
-    $exactMatch = CRM_Utils_Array::value('cb', $values);
+    $oldValues = $values['old'] ?? NULL;
+    $newValues = $values['new'] ?? NULL;
+    $enabled = $values['enabled'] ?? NULL;
+    $exactMatch = $values['cb'] ?? NULL;
 
     foreach ($oldValues as $k => $v) {
       if ($v && !$newValues[$k]) {

--- a/CRM/Admin/Page/APIExplorer.php
+++ b/CRM/Admin/Page/APIExplorer.php
@@ -131,9 +131,9 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
   public static function getDoc() {
     // Verify the API handler we're talking to is valid.
     $entities = civicrm_api3('Entity', 'get');
-    $entity = CRM_Utils_Array::value('entity', $_GET);
+    $entity = $_GET['entity'] ?? NULL;
     if (!empty($entity) && in_array($entity, $entities['values']) && strpos($entity, '.') === FALSE) {
-      $action = CRM_Utils_Array::value('action', $_GET);
+      $action = $_GET['action'] ?? NULL;
       $doc = self::getDocblock($entity, $action);
       $result = [
         'doc' => $doc ? self::formatDocBlock($doc[0]) : 'Not found.',

--- a/CRM/Admin/Page/MailSettings.php
+++ b/CRM/Admin/Page/MailSettings.php
@@ -84,7 +84,7 @@ class CRM_Admin_Page_MailSettings extends CRM_Core_Page_Basic {
     $mailSetting->find();
     while ($mailSetting->fetch()) {
       //replace protocol value with name
-      $mailSetting->protocol = CRM_Utils_Array::value($mailSetting->protocol, $allProtocols);
+      $mailSetting->protocol = $allProtocols[$mailSetting->protocol] ?? NULL;
       CRM_Core_DAO::storeValues($mailSetting, $allMailSettings[$mailSetting->id]);
 
       //form all action links

--- a/CRM/Badge/BAO/Badge.php
+++ b/CRM/Badge/BAO/Badge.php
@@ -204,10 +204,10 @@ class CRM_Badge_BAO_Badge {
     if ((CRM_Utils_Array::value('height_image_1', $formattedRow) >
         CRM_Utils_Array::value('height_image_2', $formattedRow)) && !empty($formattedRow['height_image_1'])
     ) {
-      $startOffset = CRM_Utils_Array::value('height_image_1', $formattedRow);
+      $startOffset = $formattedRow['height_image_1'] ?? NULL;
     }
     elseif (!empty($formattedRow['height_image_2'])) {
-      $startOffset = CRM_Utils_Array::value('height_image_2', $formattedRow);
+      $startOffset = $formattedRow['height_image_2'] ?? NULL;
     }
 
     if (!empty($formattedRow['participant_image'])) {

--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -43,7 +43,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
    */
   public static function create(&$params) {
     $op = 'edit';
-    $batchId = CRM_Utils_Array::value('id', $params);
+    $batchId = $params['id'] ?? NULL;
     if (!$batchId) {
       $op = 'create';
       $params['name'] = CRM_Utils_String::titleToVar($params['title']);
@@ -150,7 +150,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
     // format the params
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['rowCount'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
 
     // get batches
     $batches = self::getBatchList($params);
@@ -185,8 +185,8 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
       $batch['batch_name'] = $value['title'];
       $batch['total'] = '';
       $batch['payment_instrument'] = $value['payment_instrument'];
-      $batch['item_count'] = CRM_Utils_Array::value('item_count', $value);
-      $batch['type'] = CRM_Utils_Array::value('batch_type', $value);
+      $batch['item_count'] = $value['item_count'] ?? NULL;
+      $batch['type'] = $value['batch_type'] ?? NULL;
       if (!empty($value['total'])) {
         // CRM-21205
         $batch['total'] = CRM_Utils_Money::format($value['total'], $value['currency']);

--- a/CRM/Batch/BAO/EntityBatch.php
+++ b/CRM/Batch/BAO/EntityBatch.php
@@ -24,7 +24,7 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
    */
   public static function create(&$params) {
     $op = 'edit';
-    $entityId = CRM_Utils_Array::value('id', $params);
+    $entityId = $params['id'] ?? NULL;
     if (!$entityId) {
       $op = 'create';
     }
@@ -46,7 +46,7 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
       $params = ['id' => $params];
     }
     $entityBatch = new CRM_Batch_DAO_EntityBatch();
-    $entityId = CRM_Utils_Array::value('id', $params);
+    $entityId = $params['id'] ?? NULL;
     CRM_Utils_Hook::pre('delete', 'EntityBatch', $entityId, $params);
     $entityBatch->copyValues($params);
     $entityBatch->delete();

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -463,7 +463,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           continue;
         }
 
-        $value['contact_id'] = CRM_Utils_Array::value($key, $params['primary_contact_id']);
+        $value['contact_id'] = $params['primary_contact_id'][$key] ?? NULL;
 
         // update contact information
         $this->updateContactInfo($value);
@@ -647,7 +647,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           continue;
         }
 
-        $value['contact_id'] = CRM_Utils_Array::value($key, $params['primary_contact_id']);
+        $value['contact_id'] = $params['primary_contact_id'][$key] ?? NULL;
 
         // update contact information
         $this->updateContactInfo($value);
@@ -779,12 +779,12 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           // The following parameter setting may be obsolete.
           $this->_params = $params;
           $value['is_renew'] = TRUE;
-          $isPayLater = CRM_Utils_Array::value('is_pay_later', $params);
+          $isPayLater = $params['is_pay_later'] ?? NULL;
           $campaignId = NULL;
           if (isset($this->_values) && is_array($this->_values) && !empty($this->_values)) {
-            $campaignId = CRM_Utils_Array::value('campaign_id', $this->_params);
+            $campaignId = $this->_params['campaign_id'] ?? NULL;
             if (!array_key_exists('campaign_id', $this->_params)) {
-              $campaignId = CRM_Utils_Array::value('campaign_id', $this->_values);
+              $campaignId = $this->_values['campaign_id'] ?? NULL;
             }
           }
 
@@ -792,7 +792,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
             'end_date' => $value['membership_end_date'] ?? NULL,
             'start_date' => $value['membership_start_date'] ?? NULL,
           ];
-          $membershipSource = CRM_Utils_Array::value('source', $value);
+          $membershipSource = $value['source'] ?? NULL;
           list($membership) = CRM_Member_BAO_Membership::processMembership(
             $value['contact_id'], $value['membership_type_id'], FALSE,
             //$numTerms should be default to 1.
@@ -822,7 +822,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           ];
           foreach ($dateTypes as $dateField => $dateVariable) {
             $$dateVariable = CRM_Utils_Date::processDate($value[$dateField]);
-            $fDate[$dateField] = CRM_Utils_Array::value($dateField, $value);
+            $fDate[$dateField] = $value[$dateField] ?? NULL;
           }
 
           $calcDates = [];
@@ -833,9 +833,9 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           foreach ($calcDates as $memType => $calcDate) {
             foreach ($dates as $d) {
               //first give priority to form values then calDates.
-              $date = CRM_Utils_Array::value($d, $value);
+              $date = $value[$d] ?? NULL;
               if (!$date) {
-                $date = CRM_Utils_Array::value($d, $calcDate);
+                $date = $calcDate[$d] ?? NULL;
               }
 
               $value[$d] = CRM_Utils_Date::processDate($date);

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -577,7 +577,7 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
     $campaignDetails = self::getPermissionedCampaigns($connectedCampaignId, NULL, TRUE, TRUE, $appendDates);
     $fields = ['campaigns', 'hasAccessCampaign', 'isCampaignEnabled'];
     foreach ($fields as $fld) {
-      $$fld = CRM_Utils_Array::value($fld, $campaignDetails);
+      $$fld = $campaignDetails[$fld] ?? NULL;
     }
 
     $showAddCampaign = FALSE;
@@ -618,7 +618,7 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
     $campaignDetails = self::getPermissionedCampaigns(NULL, NULL, FALSE, FALSE, FALSE, TRUE);
     $fields = ['campaigns', 'hasAccessCampaign', 'isCampaignEnabled'];
     foreach ($fields as $fld) {
-      $$fld = CRM_Utils_Array::value($fld, $campaignDetails);
+      $$fld = $campaignDetails[$fld] ?? NULL;
     }
     $showCampaignInSearch = FALSE;
     if ($isCampaignEnabled && $hasAccessCampaign && !empty($campaigns)) {

--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -440,8 +440,8 @@ INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
     if (!is_array($params) || empty($params)) {
       return $voterClause;
     }
-    $surveyId = CRM_Utils_Array::value('campaign_survey_id', $params);
-    $searchVoterFor = CRM_Utils_Array::value('campaign_search_voter_for', $params);
+    $surveyId = $params['campaign_survey_id'] ?? NULL;
+    $searchVoterFor = $params['campaign_search_voter_for'] ?? NULL;
 
     //get the survey activities.
     $activityStatus = CRM_Core_PseudoConstant::activityStatus('name');
@@ -478,7 +478,7 @@ INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
         ) {
           $voterIds = [];
           foreach ($voterActValues as $values) {
-            $numOfDays = CRM_Utils_Array::value($values['result'], $recontactInterval);
+            $numOfDays = $recontactInterval[$values['result']] ?? NULL;
             if ($numOfDays &&
               $values['status_id'] == $completedStatusId
             ) {

--- a/CRM/Campaign/Form/Gotv.php
+++ b/CRM/Campaign/Form/Gotv.php
@@ -35,7 +35,7 @@ class CRM_Campaign_Form_Gotv extends CRM_Core_Form {
    * Processing needed for buildForm and later.
    */
   public function preProcess() {
-    $this->_search = CRM_Utils_Array::value('search', $_GET);
+    $this->_search = $_GET['search'] ?? NULL;
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_surveyId = CRM_Utils_Request::retrieve('sid', 'Positive', $this);
     $this->_interviewerId = CRM_Utils_Request::retrieve('cid', 'Positive', $this);

--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -487,7 +487,7 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
 
     // create the signature activity record
     $params['contactId'] = $this->_contactId;
-    $params['activity_campaign_id'] = CRM_Utils_Array::value('campaign_id', $this->petition);
+    $params['activity_campaign_id'] = $this->petition['campaign_id'] ?? NULL;
     $result = $this->bao->createSignature($params);
 
     // send thank you or email verification emails

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -186,7 +186,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
         'release' => CRM_Campaign_Task::RELEASE,
       );
 
-      $currentTaskValue = CRM_Utils_Array::value($this->_operation, $taskMapping);
+      $currentTaskValue = $taskMapping[$this->_operation] ?? NULL;
       $taskValue = array($currentTaskValue => $allTasks[$currentTaskValue]);
       if ($this->_operation == 'interview' && !empty($this->_formValues['campaign_survey_id'])) {
         $activityTypes = CRM_Core_PseudoConstant::activityType(FALSE, TRUE, FALSE, 'label', TRUE);
@@ -288,7 +288,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
   }
 
   public function formatParams() {
-    $interviewerId = CRM_Utils_Array::value('survey_interviewer_id', $this->_formValues);
+    $interviewerId = $this->_formValues['survey_interviewer_id'] ?? NULL;
     if ($interviewerId) {
       $this->set('interviewerId', $interviewerId);
     }
@@ -298,7 +298,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
       if ($this->_force) {
         continue;
       }
-      $paramValue = CRM_Utils_Array::value($param, $this->_formValues);
+      $paramValue = $this->_formValues[$param] ?? NULL;
       if ($paramValue && is_array($paramValue)) {
         unset($this->_formValues[$param]);
         foreach ($paramValue as $key => $value) {
@@ -323,7 +323,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
         //allow voter search in sub-part of given constituents,
         //but make sure in case user does not select any group.
         //get all associated campaign groups in where filter, CRM-7406
-        $groups = CRM_Utils_Array::value('group', $this->_formValues);
+        $groups = $this->_formValues['group'] ?? NULL;
         if ($campaignId && CRM_Utils_System::isNull($groups)) {
           $campGroups = CRM_Campaign_BAO_Campaign::getCampaignGroups($campaignId);
           foreach ($campGroups as $id => $title) {
@@ -410,7 +410,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     );
 
     foreach ($clauseFields as $param => $key) {
-      $params[$key] = CRM_Utils_Array::value($key, $this->_formValues);
+      $params[$key] = $this->_formValues[$key] ?? NULL;
       if (!$params[$key]) {
         $params[$key] = $this->get($param);
       }

--- a/CRM/Campaign/Form/Search/Campaign.php
+++ b/CRM/Campaign/Form/Search/Campaign.php
@@ -40,7 +40,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
    * Processing needed for buildForm and later.
    */
   public function preProcess() {
-    $this->_search = CRM_Utils_Array::value('search', $_GET);
+    $this->_search = $_GET['search'] ?? NULL;
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE, FALSE);
     $this->_searchTab = CRM_Utils_Request::retrieve('type', 'String', $this, FALSE, 'campaign');
 

--- a/CRM/Campaign/Form/Search/Petition.php
+++ b/CRM/Campaign/Form/Search/Petition.php
@@ -31,7 +31,7 @@ class CRM_Campaign_Form_Search_Petition extends CRM_Core_Form {
    * Processing needed for buildForm and later.
    */
   public function preProcess() {
-    $this->_search = CRM_Utils_Array::value('search', $_GET);
+    $this->_search = $_GET['search'] ?? NULL;
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE, FALSE);
     $this->_searchTab = CRM_Utils_Request::retrieve('type', 'String', $this, FALSE, 'petition');
 

--- a/CRM/Campaign/Form/Search/Survey.php
+++ b/CRM/Campaign/Form/Search/Survey.php
@@ -31,7 +31,7 @@ class CRM_Campaign_Form_Search_Survey extends CRM_Core_Form {
    * Processing needed for buildForm and later.
    */
   public function preProcess() {
-    $this->_search = CRM_Utils_Array::value('search', $_GET);
+    $this->_search = $_GET['search'] ?? NULL;
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE, FALSE);
     $this->_searchTab = CRM_Utils_Request::retrieve('type', 'String', $this, FALSE, 'survey');
 

--- a/CRM/Campaign/Form/Task.php
+++ b/CRM/Campaign/Form/Task.php
@@ -35,7 +35,7 @@ class CRM_Campaign_Form_Task extends CRM_Core_Form_Task {
 
     $this->_task = $values['task'];
     $campaignTasks = CRM_Campaign_Task::tasks();
-    $taskName = CRM_Utils_Array::value($this->_task, $campaignTasks);
+    $taskName = $campaignTasks[$this->_task] ?? NULL;
     $this->assign('taskName', $taskName);
 
     $ids = [];

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -87,7 +87,7 @@ class CRM_Campaign_Form_Task_Interview extends CRM_Campaign_Form_Task {
     $buttonName = $this->controller->getButtonName();
     $walkListActivityId = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'WalkList');
     if ($buttonName == '_qf_Interview_submit_orderBy' && !empty($_POST['order_bys'])) {
-      $orderByParams = CRM_Utils_Array::value('order_bys', $_POST);
+      $orderByParams = $_POST['order_bys'] ?? NULL;
     }
     elseif ($walkListActivityId == $this->_surveyDetails['activity_type_id']) {
       $orderByParams
@@ -160,9 +160,9 @@ WHERE {$clause}
 
     $activityIds = [];
     foreach ($this->_contactIds as $key => $voterId) {
-      $actVals = CRM_Utils_Array::value($voterId, $this->_surveyActivityIds);
-      $statusId = CRM_Utils_Array::value('status_id', $actVals);
-      $activityId = CRM_Utils_Array::value('activity_id', $actVals);
+      $actVals = $this->_surveyActivityIds[$voterId] ?? NULL;
+      $statusId = $actVals['status_id'] ?? NULL;
+      $activityId = $actVals['activity_id'] ?? NULL;
       if ($activityId &&
         $statusId &&
         $scheduledStatusId == $statusId
@@ -233,7 +233,7 @@ WHERE {$clause}
     }
 
     //set the title.
-    $this->_surveyTypeId = CRM_Utils_Array::value('activity_type_id', $this->_surveyValues);
+    $this->_surveyTypeId = $this->_surveyValues['activity_type_id'] ?? NULL;
     $surveyTypeLabel = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $this->_surveyTypeId);
     CRM_Utils_System::setTitle(ts('Record %1 Responses', [1 => $surveyTypeLabel]));
   }
@@ -446,8 +446,8 @@ WHERE {$clause}
    * @return mixed
    */
   public static function registerInterview($params) {
-    $activityId = CRM_Utils_Array::value('activity_id', $params);
-    $surveyTypeId = CRM_Utils_Array::value('activity_type_id', $params);
+    $activityId = $params['activity_id'] ?? NULL;
+    $surveyTypeId = $params['activity_type_id'] ?? NULL;
     if (!is_array($params) || !$surveyTypeId || !$activityId) {
       return FALSE;
     }
@@ -496,7 +496,7 @@ WHERE {$clause}
       }
     }
 
-    $contactId = CRM_Utils_Array::value('voter_id', $params);
+    $contactId = $params['voter_id'] ?? NULL;
     if ($contactId && !empty($contactParams)) {
       CRM_Contact_BAO_Contact::createProfileContact($contactParams, $fields, $contactId);
     }
@@ -516,7 +516,7 @@ WHERE {$clause}
     }
 
     $subject = '';
-    $surveyTitle = CRM_Utils_Array::value('surveyTitle', $params);
+    $surveyTitle = $params['surveyTitle'] ?? NULL;
     if ($surveyTitle) {
       $subject = $surveyTitle . ' - ';
     }

--- a/CRM/Campaign/Form/Task/Reserve.php
+++ b/CRM/Campaign/Form/Task/Reserve.php
@@ -104,7 +104,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
 
   public function validateSurvey() {
     $errorMsg = NULL;
-    $maxVoters = CRM_Utils_Array::value('max_number_of_contacts', $this->_surveyDetails);
+    $maxVoters = $this->_surveyDetails['max_number_of_contacts'] ?? NULL;
     if ($maxVoters) {
       if ($maxVoters <= $this->_numVoters) {
         $errorMsg = ts('The maximum number of contacts is already reserved for this interviewer.');
@@ -119,7 +119,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
       }
     }
 
-    $defaultNum = CRM_Utils_Array::value('default_number_of_contacts', $this->_surveyDetails);
+    $defaultNum = $this->_surveyDetails['default_number_of_contacts'] ?? NULL;
     if (!$errorMsg && $defaultNum && (count($this->_contactIds) > $defaultNum)) {
       $errorMsg = ts('You can reserve a maximum of %count contact at a time for this survey.',
         [
@@ -219,7 +219,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
   public function postProcess() {
     //add reservation.
     $countVoters = 0;
-    $maxVoters = CRM_Utils_Array::value('max_number_of_contacts', $this->_surveyDetails);
+    $maxVoters = $this->_surveyDetails['max_number_of_contacts'] ?? NULL;
     $activityStatus = CRM_Core_PseudoConstant::activityStatus('name');
     $statusHeld = array_search('Scheduled', $activityStatus);
 
@@ -297,8 +297,8 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
 
     $params = $this->controller->exportValues($this->_name);
     $groups = CRM_Utils_Array::value('groups', $params, []);
-    $newGroupName = CRM_Utils_Array::value('newGroupName', $params);
-    $newGroupDesc = CRM_Utils_Array::value('newGroupDesc', $params);
+    $newGroupName = $params['newGroupName'] ?? NULL;
+    $newGroupDesc = $params['newGroupDesc'] ?? NULL;
 
     $newGroupId = NULL;
     //create new group.
@@ -317,7 +317,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
       $existingGroups = CRM_Core_PseudoConstant::group();
       foreach ($groups as $groupId) {
         $addCount = CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIds, $groupId);
-        $totalCount = CRM_Utils_Array::value(1, $addCount);
+        $totalCount = $addCount[1] ?? NULL;
         if ($groupId == $newGroupId) {
           $name = $newGroupName;
           $new = TRUE;

--- a/CRM/Campaign/Page/AJAX.php
+++ b/CRM/Campaign/Page/AJAX.php
@@ -34,9 +34,9 @@ class CRM_Campaign_Page_AJAX {
 
     $params = [];
     foreach ($fields as $fld) {
-      $params[$fld] = CRM_Utils_Array::value($fld, $_POST);
+      $params[$fld] = $_POST[$fld] ?? NULL;
     }
-    $params['details'] = CRM_Utils_Array::value('note', $_POST);
+    $params['details'] = $_POST['note'] ?? NULL;
     $voterId = $params['voter_id'];
     $activityId = $params['activity_id'];
 
@@ -145,7 +145,7 @@ class CRM_Campaign_Page_AJAX {
       'group',
       'contact_type',
     ] as $param) {
-      $paramValue = CRM_Utils_Array::value($param, $params);
+      $paramValue = $params[$param] ?? NULL;
       if ($paramValue) {
         unset($params[$param]);
         $paramValue = explode(',', $paramValue);
@@ -161,7 +161,7 @@ class CRM_Campaign_Page_AJAX {
       'survey_interviewer_id',
       'campaign_search_voter_for',
     ] as $fld) {
-      $voterClauseParams[$fld] = CRM_Utils_Array::value($fld, $params);
+      $voterClauseParams[$fld] = $params[$fld] ?? NULL;
     }
 
     $interviewerId = $surveyTypeId = $surveyId = NULL;
@@ -178,7 +178,7 @@ class CRM_Campaign_Page_AJAX {
         //allow voter search in sub-part of given constituents,
         //but make sure in case user does not select any group.
         //get all associated campaign groups in where filter, CRM-7406
-        $groups = CRM_Utils_Array::value('group', $params);
+        $groups = $params['group'] ?? NULL;
         if ($campaignId && CRM_Utils_System::isNull($groups)) {
           $campaignGroups = CRM_Campaign_BAO_Campaign::getCampaignGroups($campaignId);
           foreach ($campaignGroups as $id => $group) {
@@ -392,7 +392,7 @@ class CRM_Campaign_Page_AJAX {
         ];
         $activityParams = [];
         foreach ($ids as $id) {
-          $val = CRM_Utils_Array::value($id, $_POST);
+          $val = $_POST[$id] ?? NULL;
           if (!$val) {
             $createActivity = FALSE;
             break;
@@ -415,7 +415,7 @@ class CRM_Campaign_Page_AJAX {
 
           $activityTypeId = $surveyValues['activity_type_id'];
 
-          $surveytitle = CRM_Utils_Array::value('surveyTitle', $_POST);
+          $surveytitle = $_POST['surveyTitle'] ?? NULL;
           if (!$surveytitle) {
             $surveytitle = $surveyValues['title'];
           }
@@ -442,7 +442,7 @@ class CRM_Campaign_Page_AJAX {
             [$scheduledStatusId]
           );
           foreach ($activities as $voterId => $values) {
-            $activityId = CRM_Utils_Array::value('activity_id', $values);
+            $activityId = $values['activity_id'] ?? NULL;
             if ($activityId && ($values['status_id'] == $scheduledStatusId)) {
               CRM_Core_DAO::setFieldValue('CRM_Activity_DAO_Activity',
                 $activityId,
@@ -604,7 +604,7 @@ class CRM_Campaign_Page_AJAX {
       }
       foreach ($campaigns as $campaignID => $values) {
         foreach ($selectorCols as $col) {
-          $searchRows[$campaignID][$col] = CRM_Utils_Array::value($col, $values);
+          $searchRows[$campaignID][$col] = $values[$col] ?? NULL;
         }
       }
     }
@@ -709,7 +709,7 @@ class CRM_Campaign_Page_AJAX {
       }
       foreach ($surveys as $surveyID => $values) {
         foreach ($selectorCols as $col) {
-          $searchRows[$surveyID][$col] = CRM_Utils_Array::value($col, $values);
+          $searchRows[$surveyID][$col] = $values[$col] ?? NULL;
         }
       }
     }
@@ -809,7 +809,7 @@ class CRM_Campaign_Page_AJAX {
       }
       foreach ($petitions as $petitionID => $values) {
         foreach ($selectorCols as $col) {
-          $searchRows[$petitionID][$col] = CRM_Utils_Array::value($col, $values);
+          $searchRows[$petitionID][$col] = $values[$col] ?? NULL;
         }
       }
     }

--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -202,10 +202,10 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
       ];
       foreach ($campaigns as $cmpid => $campaign) {
         foreach ($properties as $prop) {
-          $campaignsData[$cmpid][$prop] = CRM_Utils_Array::value($prop, $campaign);
+          $campaignsData[$cmpid][$prop] = $campaign[$prop] ?? NULL;
         }
-        $statusId = CRM_Utils_Array::value('status_id', $campaign);
-        $campaignsData[$cmpid]['status'] = CRM_Utils_Array::value($statusId, $campaignStatus);
+        $statusId = $campaign['status_id'] ?? NULL;
+        $campaignsData[$cmpid]['status'] = $campaignStatus[$statusId] ?? NULL;
         $campaignsData[$cmpid]['campaign_id'] = $campaign['id'];
         $campaignsData[$cmpid]['campaign_type'] = $campaignType[$campaign['campaign_type_id']];
 
@@ -291,8 +291,8 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
       $surveyType = CRM_Campaign_BAO_Survey::getSurveyActivityType();
       foreach ($surveys as $sid => $survey) {
         $surveysData[$sid] = $survey;
-        $campaignId = CRM_Utils_Array::value('campaign_id', $survey);
-        $surveysData[$sid]['campaign'] = CRM_Utils_Array::value($campaignId, $campaigns);
+        $campaignId = $survey['campaign_id'] ?? NULL;
+        $surveysData[$sid]['campaign'] = $campaigns[$campaignId] ?? NULL;
         $surveysData[$sid]['activity_type'] = $surveyType[$survey['activity_type_id']];
         if (!empty($survey['release_frequency'])) {
           $surveysData[$sid]['release_frequency'] = ts('1 Day', ['plural' => '%count Days', 'count' => $survey['release_frequency']]);
@@ -397,8 +397,8 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
       $petitionType = CRM_Campaign_BAO_Survey::getSurveyActivityType('label', TRUE);
       foreach ($petitions as $pid => $petition) {
         $petitionsData[$pid] = $petition;
-        $camapignId = CRM_Utils_Array::value('campaign_id', $petition);
-        $petitionsData[$pid]['campaign'] = CRM_Utils_Array::value($camapignId, $campaigns);
+        $camapignId = $petition['campaign_id'] ?? NULL;
+        $petitionsData[$pid]['campaign'] = $campaigns[$camapignId] ?? NULL;
         $petitionsData[$pid]['activity_type'] = $petitionType[$petition['activity_type_id']];
 
         $action = array_sum(array_keys(self::petitionActionLinks()));

--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -140,8 +140,8 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
     $this->_context = $context;
 
     $this->_campaignClause = $surveyClause;
-    $this->_campaignFromClause = CRM_Utils_Array::value('fromClause', $surveyClause);
-    $this->_campaignWhereClause = CRM_Utils_Array::value('whereClause', $surveyClause);
+    $this->_campaignFromClause = $surveyClause['fromClause'] ?? NULL;
+    $this->_campaignWhereClause = $surveyClause['whereClause'] ?? NULL;
 
     // type of selector
     $this->_action = $action;

--- a/CRM/Campaign/StateMachine/Search.php
+++ b/CRM/Campaign/StateMachine/Search.php
@@ -67,7 +67,7 @@ class CRM_Campaign_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -602,15 +602,15 @@ HERESQL;
         $case['case_id']
       );
       $casesList[$key]['subject'] = $case['case_subject'];
-      $casesList[$key]['case_status'] = CRM_Utils_Array::value($case['case_status_id'], $caseStatuses);
+      $casesList[$key]['case_status'] = $caseStatuses[$case['case_status_id']] ?? NULL;
       if ($case['case_status_id'] == CRM_Case_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Urgent')) {
         $casesList[$key]['case_status'] = sprintf('<strong>%s</strong>', strtoupper($casesList[$key]['case_status']));
       }
-      $casesList[$key]['case_type'] = CRM_Utils_Array::value($case['case_type_id'], $caseTypeTitles);
+      $casesList[$key]['case_type'] = $caseTypeTitles[$case['case_type_id']] ?? NULL;
       $casesList[$key]['case_role'] = CRM_Utils_Array::value('case_role', $case, '---');
       $casesList[$key]['manager'] = self::getCaseManagerContact($caseTypes[$case['case_type_id']], $case['case_id']);
 
-      $casesList[$key]['date'] = CRM_Utils_Array::value($case['activity_type_id'], $activityTypeLabels);
+      $casesList[$key]['date'] = $activityTypeLabels[$case['activity_type_id']] ?? NULL;
       if ($actId = CRM_Utils_Array::value('activity_id', $case)) {
         if (self::checkPermission($actId, 'view', $case['activity_type_id'], $userID)) {
           if ($type == 'recent') {
@@ -951,7 +951,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
     $groupBy = "
          GROUP BY ca.id, tcc.id, scc.id, acc.id, ov.value";
 
-    $sortBy = CRM_Utils_Array::value('sortBy', $params);
+    $sortBy = $params['sortBy'] ?? NULL;
     if (!$sortBy) {
       // CRM-5081 - added id to act like creation date
       $orderBy = "
@@ -962,8 +962,8 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
       $orderBy = " ORDER BY $sortBy ";
     }
 
-    $page = CRM_Utils_Array::value('page', $params);
-    $rp = CRM_Utils_Array::value('rp', $params);
+    $page = $params['page'] ?? NULL;
+    $rp = $params['rp'] ?? NULL;
 
     if (!$page) {
       $page = 1;
@@ -1198,7 +1198,7 @@ HERESQL;
         ];
         // Add more info about the role (creator, manager)
         // The XML historically has the reverse direction, so look up reverse.
-        $role = CRM_Utils_Array::value($dao->role_name_reverse, $caseRoles);
+        $role = $caseRoles[$dao->role_name_reverse] ?? NULL;
         if ($role) {
           unset($role['name']);
           $details += $role;
@@ -1300,7 +1300,7 @@ HERESQL;
       $tplParams['contact'] = $info;
       self::buildPermissionLinks($tplParams, $activityParams);
 
-      $displayName = CRM_Utils_Array::value('display_name', $info);
+      $displayName = $info['display_name'] ?? NULL;
 
       list($result[CRM_Utils_Array::value('contact_id', $info)], $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
@@ -1417,11 +1417,11 @@ HERESQL;
     while ($res->fetch()) {
       if ($type == 'upcoming') {
         $activityInfo[$res->case_id]['date'] = $res->activity_date_time;
-        $activityInfo[$res->case_id]['type'] = CRM_Utils_Array::value($res->activity_type_id, $activityTypes);
+        $activityInfo[$res->case_id]['type'] = $activityTypes[$res->activity_type_id] ?? NULL;
       }
       else {
         $activityInfo[$res->case_id]['date'] = $res->activity_date_time;
-        $activityInfo[$res->case_id]['type'] = CRM_Utils_Array::value($res->activity_type_id, $activityTypes);
+        $activityInfo[$res->case_id]['type'] = $activityTypes[$res->activity_type_id] ?? NULL;
       }
     }
 
@@ -2022,7 +2022,7 @@ HERESQL;
       //for duplicate cases do not process singleton activities.
       $otherActivityIds = $singletonActivityIds = [];
       foreach ($otherCaseActivities as $caseActivityId => $otherIds) {
-        $otherActId = CRM_Utils_Array::value('activity_id', $otherIds);
+        $otherActId = $otherIds['activity_id'] ?? NULL;
         if (!$otherActId || in_array($otherActId, $otherActivityIds)) {
           continue;
         }
@@ -2425,7 +2425,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
 
         //check for core permission.
         $hasPermissions = [];
-        $checkPermissions = CRM_Utils_Array::value($operation, $permissions);
+        $checkPermissions = $permissions[$operation] ?? NULL;
         if (is_array($checkPermissions)) {
           foreach ($checkPermissions as $per) {
             if (CRM_Core_Permission::check($per)) {

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -45,7 +45,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     $caseTypeDAO = new CRM_Case_DAO_CaseType();
 
     // form the name only if missing: CRM-627
-    $nameParam = CRM_Utils_Array::value('name', $params, NULL);
+    $nameParam = $params['name'] ?? NULL;
     if (!$nameParam && empty($params['id'])) {
       $params['name'] = CRM_Utils_String::titleToVar($params['title']);
     }

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -621,7 +621,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
             if (isset($id) && array_key_exists($id, $this->_relatedContacts) && isset($this->_relatedContacts[$id]['email'])) {
               //if email already exists in array then append with ', ' another role only otherwise add it to array.
               if ($contactDetails = CRM_Utils_Array::value($this->_relatedContacts[$id]['email'], $mailToContacts)) {
-                $caseRole = CRM_Utils_Array::value('role', $this->_relatedContacts[$id]);
+                $caseRole = $this->_relatedContacts[$id]['role'] ?? NULL;
                 $mailToContacts[$this->_relatedContacts[$id]['email']]['role'] = $contactDetails['role'] . ', ' . $caseRole;
               }
               else {

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -127,7 +127,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
    * @param array $params
    */
   public static function beginPostProcess(&$form, &$params) {
-    $params['id'] = CRM_Utils_Array::value('case_id', $params);
+    $params['id'] = $params['case_id'] ?? NULL;
 
     if (CRM_Utils_Array::value('updateLinkedCases', $params) === '1') {
       $caseID = CRM_Utils_Array::first($form->_caseId);

--- a/CRM/Case/Form/Activity/LinkCases.php
+++ b/CRM/Case/Form/Activity/LinkCases.php
@@ -98,7 +98,7 @@ class CRM_Case_Form_Activity_LinkCases {
   public static function formRule($values, $files, $form) {
     $errors = [];
 
-    $linkCaseId = CRM_Utils_Array::value('link_to_case_id', $values);
+    $linkCaseId = $values['link_to_case_id'] ?? NULL;
     assert('is_numeric($linkCaseId)');
     if ($linkCaseId == CRM_Utils_Array::first($form->_caseId)) {
       $errors['link_to_case'] = ts('Please select some other case to link.');
@@ -133,7 +133,7 @@ class CRM_Case_Form_Activity_LinkCases {
    */
   public static function endPostProcess(&$form, &$params, &$activity) {
     $activityId = $activity->id;
-    $linkCaseID = CRM_Utils_Array::value('link_to_case_id', $params);
+    $linkCaseID = $params['link_to_case_id'] ?? NULL;
 
     //create a link between two cases.
     if ($activityId && $linkCaseID) {

--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -212,7 +212,7 @@ class CRM_Case_Form_Activity_OpenCase {
     }
 
     // rename activity_location param to the correct column name for activity DAO
-    $params['location'] = CRM_Utils_Array::value('activity_location', $params);
+    $params['location'] = $params['activity_location'] ?? NULL;
 
     // Add attachments
     CRM_Core_BAO_File::formatAttachment(

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -29,7 +29,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $this->_showRelatedCases = CRM_Utils_Array::value('relatedCases', $_GET);
+    $this->_showRelatedCases = $_GET['relatedCases'] ?? NULL;
 
     $xmlProcessorProcess = new CRM_Case_XMLProcessor_Process();
     $isMultiClient = $xmlProcessorProcess->getAllowMultipleCaseClients();
@@ -470,7 +470,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $allCaseActTypes = CRM_Case_PseudoConstant::caseActivityType();
     foreach ($allCaseActTypes as $typeDetails) {
       if (!in_array($typeDetails['name'], ['Open Case'])) {
-        $aTypesFilter[$typeDetails['id']] = CRM_Utils_Array::value('label', $typeDetails);
+        $aTypesFilter[$typeDetails['id']] = $typeDetails['label'] ?? NULL;
       }
     }
     $aTypesFilter = $aTypesFilter + $aTypes;

--- a/CRM/Case/Form/Task/Batch.php
+++ b/CRM/Case/Form/Task/Batch.php
@@ -60,7 +60,7 @@ class CRM_Case_Form_Task_Batch extends CRM_Core_Form_Task_Batch {
 
       // Get the case status
       $daoClass = 'CRM_Case_DAO_Case';
-      $caseStatus = CRM_Utils_Array::value('case_status', $value);
+      $caseStatus = $value['case_status'] ?? NULL;
       if (!$caseStatus) {
         // default to existing status ID
         $caseStatus = CRM_Core_DAO::getFieldValue($daoClass, $key, 'status_id');

--- a/CRM/Case/StateMachine/Search.php
+++ b/CRM/Case/StateMachine/Search.php
@@ -69,7 +69,7 @@ class CRM_Case_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -81,8 +81,8 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
    * @throws Exception
    */
   public function process($xml, &$params) {
-    $standardTimeline = CRM_Utils_Array::value('standardTimeline', $params);
-    $activitySetName = CRM_Utils_Array::value('activitySetName', $params);
+    $standardTimeline = $params['standardTimeline'] ?? NULL;
+    $activitySetName = $params['activitySetName'] ?? NULL;
 
     if ('Open Case' == CRM_Utils_Array::value('activityTypeName', $params)) {
       // create relationships for the ones that are required
@@ -269,7 +269,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
       foreach ($activityTypeXML as $recordXML) {
         $activityTypeName = (string ) $recordXML->name;
         $maxInstances = (string ) $recordXML->max_instances;
-        $activityTypeInfo = CRM_Utils_Array::value($activityTypeName, $activityTypes);
+        $activityTypeInfo = $activityTypes[$activityTypeName] ?? NULL;
 
         if ($activityTypeInfo['id']) {
           if ($maskAction) {
@@ -415,7 +415,7 @@ AND        a.is_deleted = 0
   public function createActivity($activityTypeXML, &$params) {
     $activityTypeName = (string) $activityTypeXML->name;
     $activityTypes = &$this->allActivityTypes(TRUE, TRUE);
-    $activityTypeInfo = CRM_Utils_Array::value($activityTypeName, $activityTypes);
+    $activityTypeInfo = $activityTypes[$activityTypeName] ?? NULL;
 
     if (!$activityTypeInfo) {
       $docLink = CRM_Utils_System::docURL2("user/case-management/set-up");
@@ -503,7 +503,7 @@ AND        a.is_deleted = 0
           $activityDate = $params['activity_date_time'];
         }
         else {
-          $referenceActivityInfo = CRM_Utils_Array::value($referenceActivityName, $activityTypes);
+          $referenceActivityInfo = $activityTypes[$referenceActivityName] ?? NULL;
           if ($referenceActivityInfo['id']) {
             $caseActivityParams = ['activity_type_id' => $referenceActivityInfo['id']];
 
@@ -516,7 +516,7 @@ AND        a.is_deleted = 0
 
             if (is_array($referenceActivity)) {
               foreach ($referenceActivity as $aId => $details) {
-                $activityDate = CRM_Utils_Array::value('activity_date', $details);
+                $activityDate = $details['activity_date'] ?? NULL;
                 break;
               }
             }

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -116,7 +116,7 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
           foreach ($activitySetXML->ActivityTypes as $activityTypesXML) {
             foreach ($activityTypesXML as $activityTypeXML) {
               $activityTypeName = (string ) $activityTypeXML->name;
-              $activityTypeInfo = CRM_Utils_Array::value($activityTypeName, $allActivityTypes);
+              $activityTypeInfo = $allActivityTypes[$activityTypeName] ?? NULL;
               if ($activityTypeInfo) {
                 $activityTypes[$activityTypeInfo['id']] = $activityTypeInfo;
               }
@@ -743,7 +743,7 @@ LIMIT  1
     $xml = $form->retrieve($case['caseTypeName']);
 
     $activitySetNames = CRM_Case_XMLProcessor_Process::activitySets($xml->ActivitySets);
-    $pageTitle = CRM_Utils_Array::value($activitySetName, $activitySetNames);
+    $pageTitle = $activitySetNames[$activitySetName] ?? NULL;
     $template->assign('pageTitle', $pageTitle);
 
     if ($activitySetName) {

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -63,7 +63,7 @@ class CRM_Contact_BAO_Contact_Utils {
           $type = CRM_Contact_BAO_ContactType::getBasicType($typeInfo['name']) . '-subtype';
         }
         else {
-          $type = CRM_Utils_Array::value('name', $typeInfo);
+          $type = $typeInfo['name'] ?? NULL;
         }
 
         // do not add title since it hides contact name
@@ -209,9 +209,9 @@ WHERE  id IN ( $idString )
 
     $input = CRM_Utils_System::explode('_', $inputCheck, 3);
 
-    $inputCS = CRM_Utils_Array::value(0, $input);
-    $inputTS = CRM_Utils_Array::value(1, $input);
-    $inputLF = CRM_Utils_Array::value(2, $input);
+    $inputCS = $input[0] ?? NULL;
+    $inputTS = $input[1] ?? NULL;
+    $inputLF = $input[2] ?? NULL;
 
     $check = self::generateChecksum($contactID, $inputTS, $inputLF);
     // Joomla_11 - If $inputcheck is null without explicitly casting to a string
@@ -584,7 +584,7 @@ LEFT JOIN  civicrm_email ce ON ( ce.contact_id=c.id AND ce.is_primary = 1 )
       $contactLinks['rows'][$i]['primary_email'] = $dao->email;
 
       // get the permission for current contact id.
-      $hasPermissions = CRM_Utils_Array::value($dao->id, $permissionedContactIds);
+      $hasPermissions = $permissionedContactIds[$dao->id] ?? NULL;
       if (!is_array($hasPermissions) || empty($hasPermissions)) {
         $i++;
         continue;
@@ -799,7 +799,7 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
 
       // 3. get the address details for master_id
       $masterAddress = new CRM_Core_BAO_Address();
-      $masterAddress->id = CRM_Utils_Array::value('master_id', $values);
+      $masterAddress->id = $values['master_id'] ?? NULL;
       $masterAddress->find(TRUE);
 
       // 4. CRM-10336: Empty all fields (execept the fields to skip)
@@ -893,9 +893,9 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
   public static function updateGreeting($params) {
     $contactType = $params['ct'];
     $greeting = $params['gt'];
-    $valueID = $id = CRM_Utils_Array::value('id', $params);
-    $force = CRM_Utils_Array::value('force', $params);
-    $limit = CRM_Utils_Array::value('limit', $params);
+    $valueID = $id = $params['id'] ?? NULL;
+    $force = $params['force'] ?? NULL;
+    $limit = $params['limit'] ?? NULL;
 
     // if valueID is not passed use default value
     if (!$valueID) {
@@ -908,14 +908,14 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
     ];
 
     $allGreetings = CRM_Core_PseudoConstant::greeting($filter);
-    $originalGreetingString = $greetingString = CRM_Utils_Array::value($valueID, $allGreetings);
+    $originalGreetingString = $greetingString = $allGreetings[$valueID] ?? NULL;
     if (!$greetingString) {
       throw new CRM_Core_Exception(ts('Incorrect greeting value id %1, or no default greeting for this contact type and greeting type.', [1 => $valueID]));
     }
 
     // build return properties based on tokens
     $greetingTokens = CRM_Utils_Token::getTokens($greetingString);
-    $tokens = CRM_Utils_Array::value('contact', $greetingTokens);
+    $tokens = $greetingTokens['contact'] ?? NULL;
     $greetingsReturnProperties = [];
     if (is_array($tokens)) {
       $greetingsReturnProperties = array_fill_keys(array_values($tokens), 1);

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -515,7 +515,7 @@ WHERE  subtype.name IN ('" . implode("','", $subType) . "' )";
     foreach ($contactTypes as $key => $value) {
       if ($key) {
         $typeValue = explode(CRM_Core_DAO::VALUE_SEPARATOR, $key);
-        $cType = CRM_Utils_Array::value('0', $typeValue);
+        $cType = $typeValue['0'] ?? NULL;
         $typeUrl = 'ct=' . $cType;
         if ($csType = CRM_Utils_Array::value('1', $typeValue)) {
           $typeUrl .= "&cst=$csType";
@@ -612,7 +612,7 @@ WHERE name = %1";
 
     $contactType = new CRM_Contact_DAO_ContactType();
     $contactType->copyValues($params);
-    $contactType->id = CRM_Utils_Array::value('id', $params);
+    $contactType->id = $params['id'] ?? NULL;
     $contactType->is_active = CRM_Utils_Array::value('is_active', $params, 0);
 
     $contactType->save();

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -364,7 +364,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
     }
     // form the name only if missing: CRM-627
-    $nameParam = CRM_Utils_Array::value('name', $params, NULL);
+    $nameParam = $params['name'] ?? NULL;
     if (!$nameParam && empty($params['id'])) {
       $params['name'] = CRM_Utils_String::titleToVar($params['title']);
     }
@@ -645,7 +645,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
    *   ( smartGroupId, ssId ) smart group id and saved search id
    */
   public static function createHiddenSmartGroup($params) {
-    $ssId = CRM_Utils_Array::value('saved_search_id', $params);
+    $ssId = $params['saved_search_id'] ?? NULL;
 
     //add mapping record only for search builder saved search
     $mappingId = NULL;
@@ -677,7 +677,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $formValues = $params['search_context'] === 'builder' ? $params['form_values'] : CRM_Contact_BAO_Query::convertFormValues($params['form_values']);
     $savedSearch->form_values = serialize($formValues);
     $savedSearch->mapping_id = $mappingId;
-    $savedSearch->search_custom_id = CRM_Utils_Array::value('search_custom_id', $params);
+    $savedSearch->search_custom_id = $params['search_custom_id'] ?? NULL;
     $savedSearch->save();
 
     $ssId = $savedSearch->id;
@@ -735,7 +735,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     // format the params
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['rowCount'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
 
     // get groups
     $groups = CRM_Contact_BAO_Group::getGroupList($params);
@@ -781,7 +781,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       $group['DT_RowAttr']['data-id'] = $value['id'];
       $group['DT_RowAttr']['data-entity'] = 'group';
 
-      $group['description'] = CRM_Utils_Array::value('description', $value);
+      $group['description'] = $value['description'] ?? NULL;
 
       if (!empty($value['group_type'])) {
         $group['group_type'] = $value['group_type'];
@@ -792,8 +792,8 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
 
       $group['visibility'] = $value['visibility'];
       $group['links'] = $value['action'];
-      $group['org_info'] = CRM_Utils_Array::value('org_info', $value);
-      $group['created_by'] = CRM_Utils_Array::value('created_by', $value);
+      $group['org_info'] = $value['org_info'] ?? NULL;
+      $group['created_by'] = $value['created_by'] ?? NULL;
 
       $group['is_parent'] = $value['is_parent'];
 
@@ -942,7 +942,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
         );
         $types = [];
         foreach ($groupTypes as $type) {
-          $types[] = CRM_Utils_Array::value($type, $allTypes);
+          $types[] = $allTypes[$type] ?? NULL;
         }
         $values[$object->id]['group_type'] = implode(', ', $types);
       }
@@ -1167,7 +1167,7 @@ WHERE {$whereClause}";
    */
   public static function whereClause(&$params, $sortBy = TRUE, $excludeHidden = TRUE) {
     $values = [];
-    $title = CRM_Utils_Array::value('title', $params);
+    $title = $params['title'] ?? NULL;
     if ($title) {
       $clauses[] = "`groups`.title LIKE %1";
       if (strpos($title, '%') !== FALSE) {
@@ -1178,7 +1178,7 @@ WHERE {$whereClause}";
       }
     }
 
-    $groupType = CRM_Utils_Array::value('group_type', $params);
+    $groupType = $params['group_type'] ?? NULL;
     if ($groupType) {
       $types = explode(',', $groupType);
       if (!empty($types)) {
@@ -1188,13 +1188,13 @@ WHERE {$whereClause}";
       }
     }
 
-    $visibility = CRM_Utils_Array::value('visibility', $params);
+    $visibility = $params['visibility'] ?? NULL;
     if ($visibility) {
       $clauses[] = '`groups`.visibility = %3';
       $params[3] = [$visibility, 'String'];
     }
 
-    $groupStatus = CRM_Utils_Array::value('status', $params);
+    $groupStatus = $params['status'] ?? NULL;
     if ($groupStatus) {
       switch ($groupStatus) {
         case 1:
@@ -1213,13 +1213,13 @@ WHERE {$whereClause}";
       }
     }
 
-    $parentsOnly = CRM_Utils_Array::value('parentsOnly', $params);
+    $parentsOnly = $params['parentsOnly'] ?? NULL;
     if ($parentsOnly) {
       $clauses[] = '`groups`.parents IS NULL';
     }
 
     // only show child groups of a specific parent group
-    $parent_id = CRM_Utils_Array::value('parent_id', $params);
+    $parent_id = $params['parent_id'] ?? NULL;
     if ($parent_id) {
       $clauses[] = '`groups`.id IN (SELECT child_group_id FROM civicrm_group_nesting WHERE parent_group_id = %5)';
       $params[5] = [$parent_id, 'Integer'];

--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -225,7 +225,7 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
           }
         }
       }
-      $uniqId = CRM_Utils_Array::value('user_unique_id', $params);
+      $uniqId = $params['user_unique_id'] ?? NULL;
       if (!$email && $contact->id) {
         $email = CRM_Contact_BAO_Contact::getPrimaryEmail($contact->id);
       }

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1118,7 +1118,7 @@ class CRM_Contact_BAO_Query {
           $elementType = '-' . $elementType;
         }
 
-        $field = CRM_Utils_Array::value($elementName, $this->_fields);
+        $field = $this->_fields[$elementName] ?? NULL;
 
         // hack for profile, add location id
         if (!$field) {
@@ -1127,28 +1127,28 @@ class CRM_Contact_BAO_Query {
             !is_numeric($elementType)
           ) {
             if (is_numeric($name)) {
-              $field = CRM_Utils_Array::value($elementName . "-Primary$elementType", $this->_fields);
+              $field = $this->_fields[$elementName . "-Primary$elementType"] ?? NULL;
             }
             else {
-              $field = CRM_Utils_Array::value($elementName . "-$locationTypeId$elementType", $this->_fields);
+              $field = $this->_fields[$elementName . "-$locationTypeId$elementType"] ?? NULL;
             }
           }
           elseif (is_numeric($name)) {
             //this for phone type to work
             if (in_array($elementName, ['phone', 'phone_ext'])) {
-              $field = CRM_Utils_Array::value($elementName . "-Primary" . $elementType, $this->_fields);
+              $field = $this->_fields[$elementName . "-Primary" . $elementType] ?? NULL;
             }
             else {
-              $field = CRM_Utils_Array::value($elementName . "-Primary", $this->_fields);
+              $field = $this->_fields[$elementName . "-Primary"] ?? NULL;
             }
           }
           else {
             //this is for phone type to work for profile edit
             if (in_array($elementName, ['phone', 'phone_ext'])) {
-              $field = CRM_Utils_Array::value($elementName . "-$locationTypeId$elementType", $this->_fields);
+              $field = $this->_fields[$elementName . "-$locationTypeId$elementType"] ?? NULL;
             }
             else {
-              $field = CRM_Utils_Array::value($elementName . "-$locationTypeId", $this->_fields);
+              $field = $this->_fields[$elementName . "-$locationTypeId"] ?? NULL;
             }
           }
         }
@@ -2040,7 +2040,7 @@ class CRM_Contact_BAO_Query {
         // check for both id and contact_id
         if ($this->_params[$id][0] == 'id' || $this->_params[$id][0] == 'contact_id') {
           $this->_where[0][] = self::buildClause("contact_a.id", $this->_params[$id][1], $this->_params[$id][2]);
-          $field = CRM_Utils_Array::value('id', $this->_fields);
+          $field = $this->_fields['id'] ?? NULL;
           list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(
             'CRM_Contact_BAO_Contact',
             "contact_a.id",
@@ -2108,11 +2108,11 @@ class CRM_Contact_BAO_Query {
    * @throws Exception
    */
   public function restWhere(&$values) {
-    $name = CRM_Utils_Array::value(0, $values);
-    $op = CRM_Utils_Array::value(1, $values);
-    $value = CRM_Utils_Array::value(2, $values);
-    $grouping = CRM_Utils_Array::value(3, $values);
-    $wildcard = CRM_Utils_Array::value(4, $values);
+    $name = $values[0] ?? NULL;
+    $op = $values[1] ?? NULL;
+    $value = $values[2] ?? NULL;
+    $grouping = $values[3] ?? NULL;
+    $wildcard = $values[4] ?? NULL;
 
     if (isset($grouping) && empty($this->_where[$grouping])) {
       $this->_where[$grouping] = [];
@@ -2131,10 +2131,10 @@ class CRM_Contact_BAO_Query {
       }
     }
 
-    $field = CRM_Utils_Array::value($name, $this->_fields);
+    $field = $this->_fields[$name] ?? NULL;
 
     if (!$field) {
-      $field = CRM_Utils_Array::value($locType[0], $this->_fields);
+      $field = $this->_fields[$locType[0]] ?? NULL;
 
       if (!$field) {
         // Strip any trailing _high & _low that might be appended.
@@ -2893,7 +2893,7 @@ class CRM_Contact_BAO_Query {
     else {
       $contactTypeANDSubType = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value, 2);
       $contactType = $contactTypeANDSubType[0];
-      $subType = CRM_Utils_Array::value(1, $contactTypeANDSubType);
+      $subType = $contactTypeANDSubType[1] ?? NULL;
       if (!empty($subType)) {
         $subTypes[$subType] = 1;
       }
@@ -3903,7 +3903,7 @@ WHERE  $smartGroupClause
 
       $county = CRM_Core_PseudoConstant::county();
       foreach ($value as $id) {
-        $names[] = CRM_Utils_Array::value($id, $county);
+        $names[] = $county[$id] ?? NULL;
       }
     }
     else {
@@ -4059,7 +4059,7 @@ WHERE  $smartGroupClause
     else {
       $this->_where[$grouping][] = "contact_a.{$name} $op $value";
     }
-    $field = CRM_Utils_Array::value($name, $this->_fields);
+    $field = $this->_fields[$name] ?? NULL;
     $op = CRM_Utils_Array::value($op, CRM_Core_SelectValues::getSearchBuilderOperators(), $op);
     $title = $field ? $field['title'] : $name;
     $this->_qill[$grouping][] = "$title $op $value";
@@ -4097,7 +4097,7 @@ WHERE  $smartGroupClause
     $qill = [];
     foreach ($value as $dontCare => $pOption) {
       $clauses[] = " ( contact_a.{$pOption} = 1 ) ";
-      $field = CRM_Utils_Array::value($pOption, $this->_fields);
+      $field = $this->_fields[$pOption] ?? NULL;
       $title = $field ? $field['title'] : $pOption;
       $qill[] = " $title = 1 ";
     }
@@ -4733,8 +4733,8 @@ civicrm_relationship.start_date > {$today}
         return;
       }
 
-      $from = CRM_Utils_Array::value($customFieldName . '_from', $formValues, NULL);
-      $to = CRM_Utils_Array::value($customFieldName . '_to', $formValues, NULL);
+      $from = $formValues[$customFieldName . '_from'] ?? NULL;
+      $to = $formValues[$customFieldName . '_to'] ?? NULL;
 
       if (self::isCustomDateField($customFieldName)) {
         list($from, $to) = CRM_Utils_Date::getFromTo(NULL, $from, $to);
@@ -6025,7 +6025,7 @@ AND   displayRelType.is_active = 1
             }
 
             $dao->$key = ($usedForAPI) ? $convertedValues : implode(', ', $convertedValues);
-            $realFieldName = CRM_Utils_Array::value('field_name', $this->_pseudoConstantsSelect[$key]);
+            $realFieldName = $this->_pseudoConstantsSelect[$key]['field_name'] ?? NULL;
             if ($usedForAPI && $realFieldName) {
               // normally we would see 2 fields returned for pseudoConstants. An exception is
               // preferred_communication_method where there is no id-variant.
@@ -6317,7 +6317,7 @@ AND   displayRelType.is_active = 1
     $nullableFields = ['contribution_batch_id'];
 
     foreach ($specialFields as $element) {
-      $value = CRM_Utils_Array::value($element, $formValues);
+      $value = $formValues[$element] ?? NULL;
       if ($value) {
         if (is_array($value)) {
           if (in_array($element, array_keys($changeNames))) {
@@ -6810,9 +6810,9 @@ AND   displayRelType.is_active = 1
     // if we’re explicitly looking for a certain contact’s contribs, events, etc.
     // and that contact happens to be deleted, set $onlyDeleted to true
     foreach ($this->_params as $values) {
-      $name = CRM_Utils_Array::value(0, $values);
-      $op = CRM_Utils_Array::value(1, $values);
-      $value = CRM_Utils_Array::value(2, $values);
+      $name = $values[0] ?? NULL;
+      $op = $values[1] ?? NULL;
+      $value = $values[2] ?? NULL;
       if ($name == 'contact_id' and $op == '=') {
         if (CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $value, 'is_deleted')) {
           $onlyDeleted = TRUE;
@@ -6954,7 +6954,7 @@ AND   displayRelType.is_active = 1
   protected function addPseudoconstantFieldToSelect($name) {
     $field = $this->getMetadataForRealField($name);
     $realFieldName = $field['name'];
-    $pseudoFieldName = CRM_Utils_Array::value('pseudofield_name', $field);
+    $pseudoFieldName = $field['pseudofield_name'] ?? NULL;
     if ($pseudoFieldName) {
       // @todo - we don't really need to build this array now we have metadata more available with getMetadataForField fn.
       $this->_pseudoConstantsSelect[$pseudoFieldName] = [
@@ -7055,7 +7055,7 @@ AND   displayRelType.is_active = 1
    * @param $values
    */
   protected function buildRelativeDateQuery(&$values) {
-    $value = CRM_Utils_Array::value(2, $values);
+    $value = $values[2] ?? NULL;
     if (empty($value)) {
       return;
     }
@@ -7063,7 +7063,7 @@ AND   displayRelType.is_active = 1
     $fieldSpec = $this->_fields[$fieldName];
     $tableName = $fieldSpec['table_name'];
     $filters = CRM_Core_OptionGroup::values('relative_date_filters');
-    $grouping = CRM_Utils_Array::value(3, $values);
+    $grouping = $values[3] ?? NULL;
     // If the table value is already set for a custom field it will be more nuanced than just '1'.
     $this->_tables[$tableName] = $this->_tables[$tableName] ?? 1;
     $this->_whereTables[$tableName] = $this->_whereTables[$tableName] ?? 1;

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -288,7 +288,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     }
     CRM_Utils_Hook::pre($hook, 'Relationship', $params['id'], $params);
 
-    $relationshipTypes = CRM_Utils_Array::value('relationship_type_id', $params);
+    $relationshipTypes = $params['relationship_type_id'] ?? NULL;
     // explode the string with _ to get the relationship type id
     // and to know which contact has to be inserted in
     // contact_id_a and which one in contact_id_b
@@ -475,14 +475,14 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       throw new CRM_Core_Exception('Cannot create relationship, insufficient contact IDs provided');
     }
     if (isset($params['relationship_type_id']) && !is_numeric($params['relationship_type_id'])) {
-      $relationshipTypes = CRM_Utils_Array::value('relationship_type_id', $params);
+      $relationshipTypes = $params['relationship_type_id'] ?? NULL;
       list($relationshipTypeID, $first) = explode('_', $relationshipTypes);
       $returnFields['relationship_type_id'] = $relationshipTypeID;
 
       foreach (['a', 'b'] as $contactLetter) {
         if (empty($params['contact_' . $contactLetter])) {
           if ($first == $contactLetter) {
-            $returnFields['contact_id_' . $contactLetter] = CRM_Utils_Array::value('contact', $ids);
+            $returnFields['contact_id_' . $contactLetter] = $ids['contact'] ?? NULL;
           }
           else {
             $returnFields['contact_id_' . $contactLetter] = $contactID;
@@ -931,7 +931,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    *   true if record exists else false
    */
   public static function checkDuplicateRelationship(&$params, $id, $contactId = 0, $relationshipId = 0) {
-    $relationshipTypeId = CRM_Utils_Array::value('relationship_type_id', $params);
+    $relationshipTypeId = $params['relationship_type_id'] ?? NULL;
     list($type) = explode('_', $relationshipTypeId);
 
     $queryString = "
@@ -1728,7 +1728,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
             $relIds = [$params['id']];
           }
           else {
-            $relIds = CRM_Utils_Array::value('relationship_ids', $params);
+            $relIds = $params['relationship_ids'] ?? NULL;
           }
           if (self::isRelatedMembershipExpired($relTypeIds, $contactId, $mainRelatedContactId, $relTypeId,
               $relIds) && !empty($membershipValues['owner_membership_id']
@@ -2009,7 +2009,7 @@ AND cc.sort_name LIKE '%$name%'";
   public static function getContactRelationshipSelector(&$params) {
     // format the params
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
 
     if ($params['context'] == 'past') {
       $relationshipStatus = CRM_Contact_BAO_Relationship::INACTIVE;
@@ -2226,11 +2226,11 @@ AND cc.sort_name LIKE '%$name%'";
    * @return array
    */
   public static function buildRelationshipTypeOptions($params = []) {
-    $contactId = CRM_Utils_Array::value('contact_id', $params);
+    $contactId = $params['contact_id'] ?? NULL;
     $direction = CRM_Utils_Array::value('relationship_direction', $params, 'a_b');
-    $relationshipId = CRM_Utils_Array::value('relationship_id', $params);
-    $contactType = CRM_Utils_Array::value('contact_type', $params);
-    $isForm = CRM_Utils_Array::value('is_form', $params);
+    $relationshipId = $params['relationship_id'] ?? NULL;
+    $contactType = $params['contact_type'] ?? NULL;
+    $isForm = $params['is_form'] ?? NULL;
     $showAll = FALSE;
 
     // getContactRelationshipType will return an empty set if these are not set

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -94,11 +94,11 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
     $specialFields = ['contact_type', 'group', 'contact_tags', 'member_membership_type_id', 'member_status_id'];
     foreach ($result as $element => $value) {
       if (CRM_Contact_BAO_Query::isAlreadyProcessedForQueryFormat($value)) {
-        $id = CRM_Utils_Array::value(0, $value);
-        $value = CRM_Utils_Array::value(2, $value);
+        $id = $value[0] ?? NULL;
+        $value = $value[2] ?? NULL;
         if (is_array($value) && in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
           $op = key($value);
-          $value = CRM_Utils_Array::value($op, $value);
+          $value = $value[$op] ?? NULL;
           if (in_array($op, ['BETWEEN', '>=', '<='])) {
             self::decodeRelativeFields($result, $id, $op, $value);
             unset($result[$element]);
@@ -150,7 +150,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
         // As per the OK (Operator as Key) value format, value array may contain key
         // as an operator so to ensure the default is always set actual value
         elseif (in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
-          $result[$element] = CRM_Utils_Array::value(key($value), $value);
+          $result[$element] = $value[key($value)] ?? NULL;
           if (is_string($result[$element])) {
             $result[$element] = str_replace("%", '', $result[$element]);
           }

--- a/CRM/Contact/DAO/Factory.php
+++ b/CRM/Contact/DAO/Factory.php
@@ -30,7 +30,7 @@ class CRM_Contact_DAO_Factory {
    * @return mixed
    */
   public static function create($className) {
-    $type = CRM_Utils_Array::value($className, self::$_classes);
+    $type = self::$_classes[$className] ?? NULL;
     if (!$type) {
       return CRM_Core_DAO_Factory::create($className);
     }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -200,8 +200,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           CRM_Core_Error::statusBounce(ts('A Contact with that ID does not exist: %1', [1 => $this->_contactId]));
         }
 
-        $this->_contactType = CRM_Utils_Array::value('contact_type', $defaults);
-        $this->_contactSubType = CRM_Utils_Array::value('contact_sub_type', $defaults);
+        $this->_contactType = $defaults['contact_type'] ?? NULL;
+        $this->_contactSubType = $defaults['contact_sub_type'] ?? NULL;
 
         // check for permissions
         $session = CRM_Core_Session::singleton();
@@ -321,7 +321,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     // retain the multiple count custom fields value
     if (!empty($_POST['hidden_custom'])) {
-      $customGroupCount = CRM_Utils_Array::value('hidden_custom_group_count', $_POST);
+      $customGroupCount = $_POST['hidden_custom_group_count'] ?? NULL;
 
       if ($contactSubType = CRM_Utils_Array::value('contact_sub_type', $_POST)) {
         $paramSubType = implode(',', $contactSubType);
@@ -614,7 +614,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           $dataExists = self::blockDataExists($blockValues);
 
           if (!$dataExists && $name == 'address') {
-            $dataExists = CRM_Utils_Array::value('use_shared_address', $fields['address'][$instance]);
+            $dataExists = $fields['address'][$instance]['use_shared_address'] ?? NULL;
           }
 
           if ($dataExists) {
@@ -652,7 +652,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
           if ($name == 'openid' && !empty($blockValues[$name])) {
             $oid = new CRM_Core_DAO_OpenID();
-            $oid->openid = $openIds[$instance] = CRM_Utils_Array::value($name, $blockValues);
+            $oid->openid = $openIds[$instance] = $blockValues[$name];
             $cid = $contactId ?? 0;
             if ($oid->find(TRUE) && ($oid->contact_id != $cid)) {
               $errors["{$name}[$instance][openid]"] = ts('%1 already exist.', [1 => $blocks['OpenID']]);
@@ -869,7 +869,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $params['preferred_communication_method'] = 'null';
     }
 
-    $group = CRM_Utils_Array::value('group', $params);
+    $group = $params['group'] ?? NULL;
     if (!empty($group) && is_array($group)) {
       unset($params['group']);
       foreach ($group as $key => $value) {
@@ -1256,7 +1256,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       }
 
       // main parse string.
-      $parseString = CRM_Utils_Array::value($parseFieldName, $address);
+      $parseString = $address[$parseFieldName] ?? NULL;
 
       // parse address field.
       $parsedFields = CRM_Core_BAO_Address::parseStreetAddress($parseString);
@@ -1288,7 +1288,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
             $streetAddress .= ' ';
           }
           // CRM-17619 - if the street number suffix begins with a number, add a space
-          $thesuffix = CRM_Utils_Array::value('street_number_suffix', $address);
+          $thesuffix = $address['street_number_suffix'] ?? NULL;
           if ($fld === 'street_number_suffix' && $thesuffix) {
             if (ctype_digit(substr($thesuffix, 0, 1))) {
               $streetAddress .= ' ';

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -90,7 +90,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
    * Gets session variables for table name, id of entity in table, type of entity and stores them.
    */
   public function preProcess() {
-    $this->_cdType = CRM_Utils_Array::value('type', $_GET);
+    $this->_cdType = $_GET['type'] ?? NULL;
     $this->assign('cdType', FALSE);
     $this->_multiRecordDisplay = CRM_Utils_Request::retrieve('multiRecordDisplay', 'String', $this);
     if ($this->_cdType || $this->_multiRecordDisplay == 'single') {

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -287,7 +287,7 @@ class CRM_Contact_Form_Edit_Address {
               $streetAddress .= ' ';
             }
             // CRM-17619 - if the street number suffix begins with a number, add a space
-            $numsuffix = CRM_Utils_Array::value($fld, $address);
+            $numsuffix = $address[$fld] ?? NULL;
             if ($fld === 'street_number_suffix' && !empty($numsuffix)) {
               if (ctype_digit(substr($numsuffix, 0, 1))) {
                 $streetAddress .= ' ';
@@ -301,7 +301,7 @@ class CRM_Contact_Form_Edit_Address {
           }
           if (isset($address['street_number'])) {
             // CRM-17619 - if the street number suffix begins with a number, add a space
-            $thesuffix = CRM_Utils_Array::value('street_number_suffix', $address);
+            $thesuffix = $address['street_number_suffix'] ?? NULL;
             if ($thesuffix) {
               if (ctype_digit(substr($thesuffix, 0, 1))) {
                 $address['street_number'] .= " ";
@@ -311,7 +311,7 @@ class CRM_Contact_Form_Edit_Address {
           }
           // build array for set default.
           foreach ($parseFields as $field) {
-            $addressValues["{$field}_{$cnt}"] = CRM_Utils_Array::value($field, $address);
+            $addressValues["{$field}_{$cnt}"] = $address[$field] ?? NULL;
           }
           // don't load fields, use js to populate.
           foreach (['street_number', 'street_name', 'street_unit'] as $f) {

--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -71,7 +71,7 @@ class CRM_Contact_Form_Edit_CustomData {
       $contactSubType = $_POST['contact_sub_type'];
     }
     else {
-      $contactSubType = CRM_Utils_Array::value('contact_sub_type', $form->_values);
+      $contactSubType = $form->_values['contact_sub_type'] ?? NULL;
     }
     $form->assign('contactType', $form->_contactType);
     $form->assign('contactSubType', $contactSubType);

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -207,14 +207,14 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     if ($this->_action & CRM_Core_Action::UPDATE) {
       if (!empty($this->_values)) {
         $defaults['relationship_type_id'] = $this->_rtypeId;
-        $defaults['start_date'] = CRM_Utils_Array::value('start_date', $this->_values);
-        $defaults['end_date'] = CRM_Utils_Array::value('end_date', $this->_values);
-        $defaults['description'] = CRM_Utils_Array::value('description', $this->_values);
-        $defaults['is_active'] = CRM_Utils_Array::value('is_active', $this->_values);
+        $defaults['start_date'] = $this->_values['start_date'] ?? NULL;
+        $defaults['end_date'] = $this->_values['end_date'] ?? NULL;
+        $defaults['description'] = $this->_values['description'] ?? NULL;
+        $defaults['is_active'] = $this->_values['is_active'] ?? NULL;
 
         // The postprocess function will swap these fields if it is a b_a relationship, so we compensate here
-        $defaults['is_permission_a_b'] = CRM_Utils_Array::value('is_permission_' . $this->_rtype, $this->_values);
-        $defaults['is_permission_b_a'] = CRM_Utils_Array::value('is_permission_' . strrev($this->_rtype), $this->_values);
+        $defaults['is_permission_a_b'] = $this->_values['is_permission_' . $this->_rtype] ?? NULL;
+        $defaults['is_permission_b_a'] = $this->_values['is_permission_' . strrev($this->_rtype)] ?? NULL;
 
         $defaults['is_current_employer'] = $this->_isCurrentEmployer;
 
@@ -239,7 +239,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
           'version' => 3,
         ];
         $note = civicrm_api('Note', 'getsingle', $noteParams);
-        $defaults['note'] = CRM_Utils_Array::value('note', $note);
+        $defaults['note'] = $note['note'] ?? NULL;
       }
     }
     else {

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -364,7 +364,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     if ($this->_context !== 'amtg') {
       $taskParams['deletedContacts'] = FALSE;
       if ($this->_componentMode == CRM_Contact_BAO_Query::MODE_CONTACTS || $this->_componentMode == CRM_Contact_BAO_Query::MODE_CONTACTSRELATED) {
-        $taskParams['deletedContacts'] = CRM_Utils_Array::value('deleted_contacts', $this->_formValues);
+        $taskParams['deletedContacts'] = $this->_formValues['deleted_contacts'] ?? NULL;
       }
       $className = $this->_modeValue['taskClassName'];
       $taskParams['ssID'] = $this->_ssID ?? NULL;
@@ -398,9 +398,9 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
     if ($this->_context === 'smog') {
       // CRM-11788, we might want to do this for all of search where force=1
-      $formQFKey = CRM_Utils_Array::value('qfKey', $this->_formValues);
-      $getQFKey = CRM_Utils_Array::value('qfKey', $_GET);
-      $postQFKey = CRM_Utils_Array::value('qfKey', $_POST);
+      $formQFKey = $this->_formValues['qfKey'] ?? NULL;
+      $getQFKey = $_GET['qfKey'] ?? NULL;
+      $postQFKey = $_POST['qfKey'] ?? NULL;
       if ($formQFKey && empty($getQFKey) && empty($postQFKey)) {
         $url = CRM_Utils_System::makeURL('qfKey') . $formQFKey;
         CRM_Utils_System::redirect($url);
@@ -481,7 +481,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     }
 
     $selectedContactIds = [];
-    $qfKeyParam = CRM_Utils_Array::value('qfKey', $this->_formValues);
+    $qfKeyParam = $this->_formValues['qfKey'] ?? NULL;
     // We use ajax to handle selections only if the search results component_mode is set to "contacts"
     if ($qfKeyParam && ($this->get('component_mode') <= CRM_Contact_BAO_Query::MODE_CONTACTS || $this->get('component_mode') == CRM_Contact_BAO_Query::MODE_CONTACTSRELATED)) {
       $this->addClass('crm-ajax-selection-form');

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -38,7 +38,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
   public function buildQuickForm() {
     $this->set('context', 'advanced');
 
-    $this->_searchPane = CRM_Utils_Array::value('searchPane', $_GET);
+    $this->_searchPane = $_GET['searchPane'] ?? NULL;
 
     $this->_searchOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
       'advanced_search_options'
@@ -303,7 +303,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
    * multiple purposes (queries, save/edit etc)
    */
   public function normalizeFormValues() {
-    $contactType = CRM_Utils_Array::value('contact_type', $this->_formValues);
+    $contactType = $this->_formValues['contact_type'] ?? NULL;
 
     if ($contactType && is_array($contactType)) {
       unset($this->_formValues['contact_type']);
@@ -334,7 +334,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
     ];
     CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);
 
-    $taglist = CRM_Utils_Array::value('contact_taglist', $this->_formValues);
+    $taglist = $this->_formValues['contact_taglist'] ?? NULL;
 
     if ($taglist && is_array($taglist)) {
       unset($this->_formValues['contact_taglist']);

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -83,7 +83,7 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
   public function setDefaultValues() {
     $defaults = [];
 
-    $defaults['sort_name'] = CRM_Utils_Array::value('sort_name', $this->_formValues);
+    $defaults['sort_name'] = $this->_formValues['sort_name'] ?? NULL;
     foreach (self::$csv as $v) {
       if (!empty($this->_formValues[$v]) && is_array($this->_formValues[$v])) {
         $tmpArray = array_keys($this->_formValues[$v]);

--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -190,8 +190,8 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
               $fldName = substr($v[0], 13);
             }
 
-            $fldValue = CRM_Utils_Array::value($fldName, $fields);
-            $fldType = CRM_Utils_Array::value('type', $fldValue);
+            $fldValue = $fields[$fldName] ?? NULL;
+            $fldType = $fldValue['type'] ?? NULL;
             $type = CRM_Utils_Type::typeToString($fldType);
 
             if (strstr($v[1], 'IN')) {
@@ -328,7 +328,7 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
         return;
       }
       // Add another field
-      $addMore = CRM_Utils_Array::value('addMore', $params);
+      $addMore = $params['addMore'] ?? NULL;
       for ($x = 1; $x <= $this->_blockCount; $x++) {
         if (!empty($addMore[$x])) {
           $this->set('newBlock', $x);

--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -58,7 +58,7 @@ class CRM_Contact_Form_Search_Custom_ContribSYBNT extends CRM_Contact_Form_Searc
     $this->_checkboxes = ['is_first_amount' => ts('First Donation?')];
 
     foreach ($this->_amounts as $name => $title) {
-      $this->{$name} = CRM_Utils_Array::value($name, $this->_formValues);
+      $this->{$name} = $this->_formValues[$name] ?? NULL;
     }
 
     foreach ($this->_checkboxes as $name => $title) {
@@ -329,12 +329,12 @@ AND      c.receive_date < {$this->start_date_1}
    */
   public function having($includeContactIDs = FALSE) {
     $clauses = [];
-    $min = CRM_Utils_Array::value('min_amount', $this->_formValues);
+    $min = $this->_formValues['min_amount'] ?? NULL;
     if ($min) {
       $clauses[] = "sum(contrib_1.total_amount) >= $min";
     }
 
-    $max = CRM_Utils_Array::value('max_amount', $this->_formValues);
+    $max = $this->_formValues['max_amount'] ?? NULL;
     if ($max) {
       $clauses[] = "sum(contrib_1.total_amount) <= $max";
     }

--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -269,13 +269,13 @@ civicrm_contact AS contact_a {$this->_aclFrom}
    */
   public function having($includeContactIDs = FALSE) {
     $clauses = [];
-    $min = CRM_Utils_Array::value('min_amount', $this->_formValues);
+    $min = $this->_formValues['min_amount'] ?? NULL;
     if ($min) {
       $min = CRM_Utils_Rule::cleanMoney($min);
       $clauses[] = "sum(contrib.total_amount) >= $min";
     }
 
-    $max = CRM_Utils_Array::value('max_amount', $this->_formValues);
+    $max = $this->_formValues['max_amount'] ?? NULL;
     if ($max) {
       $max = CRM_Utils_Rule::cleanMoney($max);
       $clauses[] = "sum(contrib.total_amount) <= $max";

--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -126,7 +126,7 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
    * @return mixed|null
    */
   public function getFieldValue($formValues, $field, $type, $default = NULL) {
-    $value = CRM_Utils_Array::value($field, $formValues);
+    $value = $formValues[$field] ?? NULL;
     if (!$value) {
       return CRM_Utils_Request::retrieve($field, $type, CRM_Core_DAO::$_nullObject, FALSE, $default);
     }
@@ -384,7 +384,7 @@ WHERE      t.table_name = 'Activity' AND
           $row[$name] = $dao->$name;
         }
         else {
-          $row['activity_type'] = CRM_Utils_Array::value($dao->$name, $activityTypes);
+          $row['activity_type'] = $activityTypes[$dao->$name] ?? NULL;
         }
       }
       if (isset($row['participant_role'])) {
@@ -411,7 +411,7 @@ WHERE      t.table_name = 'Activity' AND
 
     $summary['Count'] = [];
     foreach (array_keys($summary) as $table) {
-      $summary['Count'][$table] = CRM_Utils_Array::value($table, $this->_foundRows);
+      $summary['Count'][$table] = $this->_foundRows[$table] ?? NULL;
       if ($summary['Count'][$table] >= self::LIMIT) {
         $summary['addShowAllLink'][$table] = TRUE;
       }

--- a/CRM/Contact/Form/Search/Custom/Group.php
+++ b/CRM/Contact/Form/Search/Custom/Group.php
@@ -91,7 +91,7 @@ class CRM_Contact_Form_Search_Custom_Group extends CRM_Contact_Form_Search_Custo
     $this->_allSearch = FALSE;
     $this->_groups = FALSE;
     $this->_tags = FALSE;
-    $this->_andOr = CRM_Utils_Array::value('andOr', $this->_formValues);
+    $this->_andOr = $this->_formValues['andOr'] ?? NULL;
     //make easy to check conditions for groups and tags are
     //selected or it is empty search
     if (empty($this->_includeGroups) && empty($this->_excludeGroups) &&

--- a/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -33,9 +33,9 @@ class CRM_Contact_Form_Search_Custom_MultipleValues extends CRM_Contact_Form_Sea
 
     $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree("'Contact', 'Individual', 'Organization', 'Household'", NULL, NULL, -1);
 
-    $this->_group = CRM_Utils_Array::value('group', $this->_formValues);
+    $this->_group = $this->_formValues['group'] ?? NULL;
 
-    $this->_tag = CRM_Utils_Array::value('tag', $this->_formValues);
+    $this->_tag = $this->_formValues['tag'] ?? NULL;
 
     $this->_columns = [
       ts('Contact ID') => 'contact_id',
@@ -43,7 +43,7 @@ class CRM_Contact_Form_Search_Custom_MultipleValues extends CRM_Contact_Form_Sea
       ts('Name') => 'sort_name',
     ];
 
-    $this->_customGroupIDs = CRM_Utils_Array::value('custom_group', $formValues);
+    $this->_customGroupIDs = $formValues['custom_group'] ?? NULL;
 
     if (!empty($this->_customGroupIDs)) {
       $this->addColumns();

--- a/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -229,7 +229,7 @@ AND    p.entity_id    = e.id
       foreach ($priceSet[$dao->price_set_id]['fields'] as $key => $value) {
         if (is_array($value['options'])) {
           foreach ($value['options'] as $oKey => $oValue) {
-            $columnHeader = CRM_Utils_Array::value('label', $value);
+            $columnHeader = $value['label'] ?? NULL;
             if (CRM_Utils_Array::value('html_type', $value) != 'Text') {
               $columnHeader .= ' - ' . $oValue['label'];
             }

--- a/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -54,9 +54,9 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
       }
       $this->_distance = $this->_formValues['distance'] * $conversionFactor;
     }
-    $this->_group = CRM_Utils_Array::value('group', $this->_formValues);
+    $this->_group = $this->_formValues['group'] ?? NULL;
 
-    $this->_tag = CRM_Utils_Array::value('tag', $this->_formValues);
+    $this->_tag = $this->_formValues['tag'] ?? NULL;
 
     $this->_columns = [
       ts('Name') => 'sort_name',

--- a/CRM/Contact/Form/Search/Custom/RandomSegment.php
+++ b/CRM/Contact/Form/Search/Custom/RandomSegment.php
@@ -39,11 +39,11 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
   }
 
   public function initialize() {
-    $this->_segmentSize = CRM_Utils_Array::value('segmentSize', $this->_formValues);
+    $this->_segmentSize = $this->_formValues['segmentSize'] ?? NULL;
 
-    $this->_includeGroups = CRM_Utils_Array::value('includeGroups', $this->_formValues);
+    $this->_includeGroups = $this->_formValues['includeGroups'] ?? NULL;
 
-    $this->_excludeGroups = CRM_Utils_Array::value('excludeGroups', $this->_formValues);
+    $this->_excludeGroups = $this->_formValues['excludeGroups'] ?? NULL;
 
     $this->_allSearch = FALSE;
     $this->_groups = FALSE;

--- a/CRM/Contact/Form/Search/Custom/TagContributions.php
+++ b/CRM/Contact/Form/Search/Custom/TagContributions.php
@@ -173,7 +173,7 @@ WHERE  $where
       $clauses[] = "civicrm_contribution.receive_date <= '{$this->_formValues['end_date']} 23:59:59'";
     }
 
-    $tag = CRM_Utils_Array::value('tag', $this->_formValues);
+    $tag = $this->_formValues['tag'] ?? NULL;
     if ($tag) {
       $clauses[] = "civicrm_entity_tag.tag_id = $tag";
       $clauses[] = "civicrm_tag.id = civicrm_entity_tag.tag_id";

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -133,7 +133,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext($url);
 
-    $form->_task = CRM_Utils_Array::value('task', self::$_searchFormValues);
+    $form->_task = self::$_searchFormValues['task'] ?? NULL;
     $crmContactTaskTasks = CRM_Contact_Task::taskTitles();
     $form->assign('taskName', CRM_Utils_Array::value($form->_task, $crmContactTaskTasks));
 
@@ -251,7 +251,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     if (CRM_Utils_Array::value('radio_ts', self::$_searchFormValues) == 'ts_sel'
       && ($form->_action != CRM_Core_Action::COPY)
     ) {
-      $sel = CRM_Utils_Array::value('radio_ts', self::$_searchFormValues);
+      $sel = self::$_searchFormValues['radio_ts'] ?? NULL;
       $form->assign('searchtype', $sel);
       $result = self::getSelectedContactNames();
       $form->assign("value", $result);

--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -175,7 +175,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
    */
   public function postProcess() {
     $params = $this->controller->exportValues();
-    $groupOption = CRM_Utils_Array::value('group_option', $params, NULL);
+    $groupOption = $params['group_option'] ?? NULL;
     if ($groupOption) {
       $groupParams = [];
       $groupParams['title'] = $params['title'];

--- a/CRM/Contact/Form/Task/AlterPreferences.php
+++ b/CRM/Contact/Form/Task/AlterPreferences.php
@@ -79,7 +79,7 @@ class CRM_Contact_Form_Task_AlterPreferences extends CRM_Contact_Form_Task {
     //get the submitted values in an array
     $params = $this->controller->exportValues($this->_name);
 
-    $actionTypeOption = CRM_Utils_Array::value('actionTypeOption', $params, NULL);
+    $actionTypeOption = $params['actionTypeOption'] ?? NULL;
     // If remove option has been selected set new privacy value to "false"
     $privacyValueNew = empty($actionTypeOption);
 

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -304,7 +304,7 @@ class CRM_Contact_Form_Task_EmailCommon {
 
     foreach ($fields as $field => $values) {
       if (!empty($fields[$field])) {
-        $attribute = CRM_Utils_Array::value('attributes', $values);
+        $attribute = $values['attributes'] ?? NULL;
         $required = !empty($values['required']);
 
         if ($values['type'] == 'select' && empty($attribute)) {
@@ -380,7 +380,7 @@ class CRM_Contact_Form_Task_EmailCommon {
   public static function submit(&$form, $formValues) {
     self::saveMessageTemplate($formValues);
 
-    $from = CRM_Utils_Array::value('from_email_address', $formValues);
+    $from = $formValues['from_email_address'] ?? NULL;
     // dev/core#357 User Emails are keyed by their id so that the Signature is able to be added
     // If we have had a contact email used here the value returned from the line above will be the
     // numerical key where as $from for use in the sendEmail in Activity needs to be of format of "To Name" <toemailaddress>

--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -83,7 +83,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
   public function setDefaultValues() {
     $defaults = [];
     $format = CRM_Core_BAO_LabelFormat::getDefaultValues();
-    $defaults['label_name'] = CRM_Utils_Array::value('name', $format);
+    $defaults['label_name'] = $format['name'] ?? NULL;
     $defaults['do_not_mail'] = 1;
 
     return $defaults;
@@ -227,7 +227,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
           $details[0][$value]["custom_{$cfID}"] = CRM_Core_BAO_CustomField::displayValue($details[0][$value]["custom_{$cfID}"], $cfID);
         }
       }
-      $contact = CRM_Utils_Array::value($value, $details['0']);
+      $contact = $details['0'][$value] ?? NULL;
 
       if (is_a($contact, 'CRM_Core_Error')) {
         return NULL;

--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -149,7 +149,7 @@ class CRM_Contact_Form_Task_LabelCommon {
           $details[$value]["custom_{$cfID}"] = CRM_Core_BAO_CustomField::displayValue($details[$value]["custom_{$cfID}"], $cfID);
         }
       }
-      $contact = CRM_Utils_Array::value($value, $details);
+      $contact = $details[$value] ?? NULL;
 
       if (is_a($contact, 'CRM_Core_Error')) {
         return NULL;

--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -76,7 +76,7 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
     if (isset($this->_activityId)) {
       $params = ['id' => $this->_activityId];
       CRM_Activity_BAO_Activity::retrieve($params, $defaults);
-      $defaults['html_message'] = CRM_Utils_Array::value('details', $defaults);
+      $defaults['html_message'] = $defaults['details'] ?? NULL;
     }
     $defaults = $defaults + CRM_Contact_Form_Task_PDFLetterCommon::setDefaultValues();
     return $defaults;

--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -204,7 +204,7 @@ class CRM_Contact_Form_Task_SMSCommon {
               $mobilePhone = CRM_Utils_Array::retrieveValueRecursive($contactPhones, 'phone');
               $form->_contactDetails[$contactId]['phone_id'] = CRM_Utils_Array::retrieveValueRecursive($contactPhones, 'id');
               $form->_contactDetails[$contactId]['phone'] = $mobilePhone;
-              $form->_contactDetails[$contactId]['phone_type_id'] = CRM_Utils_Array::value('Mobile', $phoneTypes);
+              $form->_contactDetails[$contactId]['phone_type_id'] = $phoneTypes['Mobile'] ?? NULL;
             }
             else {
               $suppressedSms++;
@@ -226,7 +226,7 @@ class CRM_Contact_Form_Task_SMSCommon {
           $phone = $value['phone'];
         }
         else {
-          $phone = CRM_Utils_Array::value($key, $form->_toContactPhone);
+          $phone = $form->_toContactPhone[$key] ?? NULL;
         }
 
         if ($phone) {
@@ -302,7 +302,7 @@ class CRM_Contact_Form_Task_SMSCommon {
     }
     else {
       if (!empty($fields['sms_text_message'])) {
-        $messageCheck = CRM_Utils_Array::value('sms_text_message', $fields);
+        $messageCheck = $fields['sms_text_message'] ?? NULL;
         $messageCheck = str_replace("\r\n", "\n", $messageCheck);
         if ($messageCheck && (strlen($messageCheck) > CRM_SMS_Provider::MAX_SMS_CHAR)) {
           $errors['sms_text_message'] = ts("You can configure the SMS message body up to %1 characters", [1 => CRM_SMS_Provider::MAX_SMS_CHAR]);

--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -54,7 +54,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     $modeValue = CRM_Contact_Form_Search::getModeValue(CRM_Utils_Array::value('component_mode', $values, CRM_Contact_BAO_Query::MODE_CONTACTS));
     $className = $modeValue['taskClassName'];
     $taskList = $className::taskTitles();
-    $this->_task = CRM_Utils_Array::value('task', $values);
+    $this->_task = $values['task'] ?? NULL;
     $this->assign('taskName', CRM_Utils_Array::value($this->_task, $taskList));
   }
 

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -429,7 +429,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   public static function formRule($fields) {
     $errors = [];
     if (!empty($fields['saveMapping'])) {
-      $nameField = CRM_Utils_Array::value('saveMappingName', $fields);
+      $nameField = $fields['saveMappingName'] ?? NULL;
       if (empty($nameField)) {
         $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
       }
@@ -532,10 +532,10 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     for ($i = 0; $i < $this->_columnCount; $i++) {
 
-      $fldName = CRM_Utils_Array::value(0, $mapperKeys[$i]);
-      $selOne = CRM_Utils_Array::value(1, $mapperKeys[$i]);
-      $selTwo = CRM_Utils_Array::value(2, $mapperKeys[$i]);
-      $selThree = CRM_Utils_Array::value(3, $mapperKeys[$i]);
+      $fldName = $mapperKeys[$i][0] ?? NULL;
+      $selOne = $mapperKeys[$i][1] ?? NULL;
+      $selTwo = $mapperKeys[$i][2] ?? NULL;
+      $selThree = $mapperKeys[$i][3] ?? NULL;
       $mapper[$i] = $this->_mapperFields[$mapperKeys[$i][0]];
       $mapperKeysMain[$i] = $fldName;
 
@@ -569,7 +569,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
             $parserParameters['relatedContactWebsiteType'][$i] = $websiteTypes[$selTwo];
           }
           else {
-            $parserParameters['relatedContactLocType'][$i] = CRM_Utils_Array::value($selTwo, $locationTypes);
+            $parserParameters['relatedContactLocType'][$i] = $locationTypes[$selTwo] ?? NULL;
             if ($selThree) {
               if ($selOne === 'phone') {
                 $parserParameters['relatedContactPhoneType'][$i] = $phoneTypes[$selThree];
@@ -623,7 +623,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       for ($i = 0; $i < $this->_columnCount; $i++) {
         $updateMappingFields = new CRM_Core_DAO_MappingField();
-        $updateMappingFields->id = CRM_Utils_Array::value($i, $mappingFieldsId);
+        $updateMappingFields->id = $mappingFieldsId[$i] ?? NULL;
         $updateMappingFields->mapping_id = $params['mappingId'];
         $updateMappingFields->column_number = $i;
 

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -133,11 +133,11 @@ class CRM_Contact_Import_ImportJob {
 
     foreach ($mapper as $key => $value) {
 
-      $fldName = CRM_Utils_Array::value(0, $mapper[$key]);
+      $fldName = $mapper[$key][0] ?? NULL;
       $header = array($this->_mapFields[$fldName]);
-      $selOne = CRM_Utils_Array::value(1, $mapper[$key]);
-      $selTwo = CRM_Utils_Array::value(2, $mapper[$key]);
-      $selThree = CRM_Utils_Array::value(3, $mapper[$key]);
+      $selOne = $mapper[$key][1] ?? NULL;
+      $selTwo = $mapper[$key][2] ?? NULL;
+      $selThree = $mapper[$key][3] ?? NULL;
       $this->_mapperKeys[$key] = $fldName;
 
       //need to differentiate non location elements.

--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -865,8 +865,8 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
         !array_key_exists($customFieldID, $addressCustomFields)
       ) {
 
-        $extends = CRM_Utils_Array::value('extends', $customFields[$customFieldID]);
-        $htmlType = CRM_Utils_Array::value('html_type', $customFields[$customFieldID]);
+        $extends = $customFields[$customFieldID]['extends'] ?? NULL;
+        $htmlType = $customFields[$customFieldID]['html_type'] ?? NULL;
         switch ($htmlType) {
           case 'Select':
           case 'Radio':
@@ -874,8 +874,8 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
             if ($customFields[$customFieldID]['data_type'] == 'String' || $customFields[$customFieldID]['data_type'] == 'Int') {
               $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
               foreach ($customOption as $customValue) {
-                $val = CRM_Utils_Array::value('value', $customValue);
-                $label = CRM_Utils_Array::value('label', $customValue);
+                $val = $customValue['value'] ?? NULL;
+                $label = $customValue['label'] ?? NULL;
                 $label = strtolower($label);
                 $value = strtolower(trim($formatted[$key]));
                 if (($value == $label) || ($value == strtolower($val))) {
@@ -926,7 +926,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
         if (empty($formatted['custom'][$customKey][-1]['is_required'])) {
           $formatted['custom'][$customKey][-1]['is_required'] = $customFields[$customKey]['is_required'];
         }
-        $emptyValue = CRM_Utils_Array::value('value', $customvalue[-1]);
+        $emptyValue = $customvalue[-1]['value'] ?? NULL;
         if (!isset($emptyValue)) {
           unset($formatted['custom'][$customKey]);
         }
@@ -937,7 +937,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
     if ($this->_parseStreetAddress) {
       if (array_key_exists('address', $formatted) && is_array($formatted['address'])) {
         foreach ($formatted['address'] as $instance => & $address) {
-          $streetAddress = CRM_Utils_Array::value('street_address', $address);
+          $streetAddress = $address['street_address'] ?? NULL;
           if (empty($streetAddress)) {
             continue;
           }
@@ -1237,7 +1237,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
         $customFieldID = CRM_Core_BAO_CustomField::getKeyID($key);
         if ($customFieldID && array_key_exists($customFieldID, $customFields)) {
 
-          $htmlType = CRM_Utils_Array::value('html_type', $customFields[$customFieldID]);
+          $htmlType = $customFields[$customFieldID]['html_type'] ?? NULL;
           switch ($htmlType) {
             case 'CheckBox':
             case 'Multi-Select':

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -301,7 +301,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         }
       }
 
-      $email = CRM_Utils_Array::value($this->_emailIndex, $values);
+      $email = $values[$this->_emailIndex] ?? NULL;
       if ($email) {
         /* If the email address isn't valid, bail */
 
@@ -339,7 +339,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     }
 
     //check for duplicate external Identifier
-    $externalID = CRM_Utils_Array::value($this->_externalIdentifierIndex, $values);
+    $externalID = $values[$this->_externalIdentifierIndex] ?? NULL;
     if ($externalID) {
       /* If it's a dupe,external Identifier  */
 
@@ -1121,7 +1121,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     $dateType = CRM_Core_Session::singleton()->get("dateTypes");
 
     if (!empty($params['contact_sub_type'])) {
-      $csType = CRM_Utils_Array::value('contact_sub_type', $params);
+      $csType = $params['contact_sub_type'] ?? NULL;
     }
 
     if (empty($params['contact_type'])) {
@@ -1908,7 +1908,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         if (!empty($relatedContactFields[$name]) && !is_array($relatedContactFields[$name])) {
           $relatedContactFields[$name] = [];
         }
-        $fldName = CRM_Utils_Array::value($key, $this->_mapperRelatedContactDetails);
+        $fldName = $this->_mapperRelatedContactDetails[$key] ?? NULL;
         if ($fldName == 'url') {
           $fldName = 'website';
         }

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -37,7 +37,7 @@ class CRM_Contact_Page_AJAX {
    * Todo: Migrate contact reference fields to use EntityRef
    */
   public static function contactReference() {
-    $name = CRM_Utils_Array::value('term', $_GET);
+    $name = $_GET['term'] ?? NULL;
     $name = CRM_Utils_Type::escape($name, 'String');
     $cfID = CRM_Utils_Type::escape($_GET['id'], 'Positive');
 
@@ -54,7 +54,7 @@ class CRM_Contact_Page_AJAX {
       $filterParams = [];
       parse_str($cf['filter'], $filterParams);
 
-      $action = CRM_Utils_Array::value('action', $filterParams);
+      $action = $filterParams['action'] ?? NULL;
       if (!empty($action) && !in_array($action, ['get', 'lookup'])) {
         CRM_Utils_System::civiExit(1);
       }
@@ -146,7 +146,7 @@ class CRM_Contact_Page_AJAX {
    * Fetch PCP ID by PCP Supporter sort_name, also displays PCP title and associated Contribution Page title
    */
   public static function getPCPList() {
-    $name = CRM_Utils_Array::value('term', $_GET);
+    $name = $_GET['term'] ?? NULL;
     $name = CRM_Utils_Type::escape($name, 'String');
     $limit = $max = Civi::settings()->get('search_autocomplete_count');
 
@@ -347,7 +347,7 @@ class CRM_Contact_Page_AJAX {
    */
   public static function getContactEmail() {
     $queryStrings = [];
-    $name = CRM_Utils_Array::value('name', $_GET);
+    $name = $_GET['name'] ?? NULL;
     if ($name) {
       $name = CRM_Utils_Type::escape($name, 'String');
       $wildCard = Civi::settings()->get('includeWildCardInName') ? '%' : '';
@@ -401,7 +401,7 @@ LIMIT {$rowCount}
     $sqlParmas = [];
     //check for mobile type
     $phoneTypes = CRM_Core_OptionGroup::values('phone_type', TRUE, FALSE, FALSE, NULL, 'name');
-    $mobileType = CRM_Utils_Array::value('Mobile', $phoneTypes);
+    $mobileType = $phoneTypes['Mobile'] ?? NULL;
 
     $name = CRM_Utils_Request::retrieveValue('name', 'String', NULL, FALSE, 'GET');
     if ($name) {
@@ -651,7 +651,7 @@ LIMIT {$offset}, {$rowCount}
           $dir = CRM_Utils_Type::escape($orderInfo['dir'], 'MysqlOrderByDirection', FALSE);
         }
       }
-      $columnDetails = CRM_Utils_Array::value($orderColumnNumber, $_REQUEST['columns']);
+      $columnDetails = $_REQUEST['columns'][$orderColumnNumber] ?? NULL;
     }
     if (!empty($columnDetails)) {
       switch ($columnDetails['data']) {
@@ -699,8 +699,8 @@ LIMIT {$offset}, {$rowCount}
     $count = 0;
     foreach ($dupePairs as $key => $pairInfo) {
       $pair = $pairInfo['data'];
-      $srcContactSubType  = CRM_Utils_Array::value('src_contact_sub_type', $pairInfo);
-      $dstContactSubType  = CRM_Utils_Array::value('dst_contact_sub_type', $pairInfo);
+      $srcContactSubType  = $pairInfo['src_contact_sub_type'] ?? NULL;
+      $dstContactSubType  = $pairInfo['dst_contact_sub_type'] ?? NULL;
       $srcTypeImage = CRM_Contact_BAO_Contact_Utils::getImage($srcContactSubType ?
         $srcContactSubType : $pairInfo['src_contact_type'],
         FALSE,
@@ -716,16 +716,16 @@ LIMIT {$offset}, {$rowCount}
       $searchRows[$count]['is_selected_input'] = "<input type='checkbox' class='crm-dedupe-select' name='pnid_{$pairInfo['prevnext_id']}' value='{$pairInfo['is_selected']}' onclick='toggleDedupeSelect(this)'>";
       $searchRows[$count]['src_image'] = $srcTypeImage;
       $searchRows[$count]['src'] = CRM_Utils_System::href($pair['srcName'], 'civicrm/contact/view', "reset=1&cid={$pairInfo['entity_id2']}");
-      $searchRows[$count]['src_email'] = CRM_Utils_Array::value('src_email', $pairInfo);
-      $searchRows[$count]['src_street'] = CRM_Utils_Array::value('src_street', $pairInfo);
-      $searchRows[$count]['src_postcode'] = CRM_Utils_Array::value('src_postcode', $pairInfo);
+      $searchRows[$count]['src_email'] = $pairInfo['src_email'] ?? NULL;
+      $searchRows[$count]['src_street'] = $pairInfo['src_street'] ?? NULL;
+      $searchRows[$count]['src_postcode'] = $pairInfo['src_postcode'] ?? NULL;
       $searchRows[$count]['dst_image'] = $dstTypeImage;
       $searchRows[$count]['dst'] = CRM_Utils_System::href($pair['dstName'], 'civicrm/contact/view', "reset=1&cid={$pairInfo['entity_id1']}");
-      $searchRows[$count]['dst_email'] = CRM_Utils_Array::value('dst_email', $pairInfo);
-      $searchRows[$count]['dst_street'] = CRM_Utils_Array::value('dst_street', $pairInfo);
-      $searchRows[$count]['dst_postcode'] = CRM_Utils_Array::value('dst_postcode', $pairInfo);
+      $searchRows[$count]['dst_email'] = $pairInfo['dst_email'] ?? NULL;
+      $searchRows[$count]['dst_street'] = $pairInfo['dst_street'] ?? NULL;
+      $searchRows[$count]['dst_postcode'] = $pairInfo['dst_postcode'] ?? NULL;
       $searchRows[$count]['conflicts'] = str_replace("',", "',<br/>", CRM_Utils_Array::value('conflicts', $pair));
-      $searchRows[$count]['weight'] = CRM_Utils_Array::value('weight', $pair);
+      $searchRows[$count]['weight'] = $pair['weight'] ?? NULL;
 
       if (!empty($pairInfo['data']['canMerge'])) {
         $mergeParams = [
@@ -769,7 +769,7 @@ LIMIT {$offset}, {$rowCount}
    */
   public static function getSearchOptionsFromRequest() {
     $searchParams = [];
-    $searchData = CRM_Utils_Array::value('search', $_REQUEST);
+    $searchData = $_REQUEST['search'] ?? NULL;
     $searchData['value'] = CRM_Utils_Type::escape($searchData['value'], 'String');
     $selectorElements = [
       'is_selected',
@@ -814,7 +814,7 @@ LIMIT {$offset}, {$rowCount}
    * @return bool
    */
   public static function isOrQuery() {
-    $searchData = CRM_Utils_Array::value('search', $_REQUEST);
+    $searchData = $_REQUEST['search'] ?? NULL;
     return !empty($searchData['value']);
   }
 
@@ -909,8 +909,8 @@ LIMIT {$offset}, {$rowCount}
    * Used to store selected contacts across multiple pages in advanced search.
    */
   public static function selectUnselectContacts() {
-    $name = CRM_Utils_Array::value('name', $_REQUEST);
-    $cacheKey = CRM_Utils_Array::value('qfKey', $_REQUEST);
+    $name = $_REQUEST['name'] ?? NULL;
+    $cacheKey = $_REQUEST['qfKey'] ?? NULL;
     $state = CRM_Utils_Array::value('state', $_REQUEST, 'checked');
     $variableType = CRM_Utils_Array::value('variableType', $_REQUEST, 'single');
 

--- a/CRM/Contact/Page/Inline/CustomData.php
+++ b/CRM/Contact/Page/Inline/CustomData.php
@@ -44,7 +44,7 @@ class CRM_Contact_Page_Inline_CustomData extends CRM_Core_Page {
       $fields = reset($details[$cgId]);
     }
     else {
-      $fields = CRM_Utils_Array::value($customRecId, $details[$cgId]);
+      $fields = $details[$cgId][$customRecId] ?? NULL;
     }
     $this->assign('cgcount', $cgcount);
     $this->assign('customRecId', $customRecId);

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -119,7 +119,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
         $found = TRUE;
       }
 
-      $context = CRM_Utils_Array::value('context', $_GET);
+      $context = $_GET['context'] ?? NULL;
       if (!$found) {
         // seems like we did not find any contacts
         // maybe due to bug CRM-9096

--- a/CRM/Contact/Page/View/Vcard.php
+++ b/CRM/Contact/Page/View/Vcard.php
@@ -50,7 +50,7 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
         CRM_Utils_Array::value('prefix', $defaults),
         CRM_Utils_Array::value('suffix', $defaults)
       );
-      $organizationName = CRM_Utils_Array::value('organization_name', $defaults);
+      $organizationName = $defaults['organization_name'] ?? NULL;
       if ($organizationName !== NULL) {
         $vcard->addOrganization($organizationName);
       }
@@ -87,15 +87,15 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
       foreach ($defaults['address'] as $location) {
         // we don't keep PO boxes in separate fields
         $pob = '';
-        $extend = CRM_Utils_Array::value('supplemental_address_1', $location);
+        $extend = $location['supplemental_address_1'] ?? NULL;
         if (!empty($location['supplemental_address_2'])) {
           $extend .= ', ' . $location['supplemental_address_2'];
         }
         if (!empty($location['supplemental_address_3'])) {
           $extend .= ', ' . $location['supplemental_address_3'];
         }
-        $street = CRM_Utils_Array::value('street_address', $location);
-        $locality = CRM_Utils_Array::value('city', $location);
+        $street = $location['street_address'] ?? NULL;
+        $locality = $location['city'] ?? NULL;
         $region = NULL;
         if (!empty($location['state_province_id'])) {
           $region = $stateProvices[CRM_Utils_Array::value('state_province_id', $location)];
@@ -105,7 +105,7 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
           $country = $countries[CRM_Utils_Array::value('country_id', $location)];
         }
 
-        $postcode = CRM_Utils_Array::value('postal_code', $location);
+        $postcode = $location['postal_code'] ?? NULL;
         if (!empty($location['postal_code_suffix'])) {
           $postcode .= '-' . $location['postal_code_suffix'];
         }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -179,7 +179,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     $this->_searchContext = $searchContext;
 
-    $this->_ufGroupID = CRM_Utils_Array::value('uf_group_id', $this->_formValues);
+    $this->_ufGroupID = $this->_formValues['uf_group_id'] ?? NULL;
 
     if ($this->_ufGroupID) {
       $this->_fields = CRM_Core_BAO_UFGroup::getListingFields(CRM_Core_Action::VIEW,
@@ -204,7 +204,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       }
     }
 
-    $displayRelationshipType = CRM_Utils_Array::value('display_relationship_type', $this->_formValues);
+    $displayRelationshipType = $this->_formValues['display_relationship_type'] ?? NULL;
     $operator = CRM_Utils_Array::value('operator', $this->_formValues, 'AND');
 
     // rectify params to what proximity search expects if there is a value for prox_distance
@@ -612,7 +612,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
               $locationTypeName = "website-{$id}";
             }
             else {
-              $locationTypeName = CRM_Utils_Array::value($id, $locationTypes);
+              $locationTypeName = $locationTypes[$id] ?? NULL;
               if (!$locationTypeName) {
                 continue;
               }
@@ -653,7 +653,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $links = self::links($this->_context, $this->_contextMenu, $this->_key);
 
     //check explicitly added contact to a Smart Group.
-    $groupID = CRM_Utils_Array::value('group', $this->_formValues);
+    $groupID = $this->_formValues['group'] ?? NULL;
 
     $pseudoconstants = [];
     // for CRM-3157 purposes

--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -81,7 +81,7 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -215,8 +215,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     $result = $contribution->save();
 
     // Add financial_trxn details as part of fix for CRM-4724
-    $contribution->trxn_result_code = CRM_Utils_Array::value('trxn_result_code', $params);
-    $contribution->payment_processor = CRM_Utils_Array::value('payment_processor', $params);
+    $contribution->trxn_result_code = $params['trxn_result_code'] ?? NULL;
+    $contribution->payment_processor = $params['payment_processor'] ?? NULL;
 
     //add Account details
     $params['contribution'] = $contribution;
@@ -417,13 +417,13 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     $addressParams['location_type_id'] = $billingLocationTypeID;
     $addressParams['is_billing'] = 1;
 
-    $billingFirstName = CRM_Utils_Array::value('billing_first_name', $params);
-    $billingMiddleName = CRM_Utils_Array::value('billing_middle_name', $params);
-    $billingLastName = CRM_Utils_Array::value('billing_last_name', $params);
+    $billingFirstName = $params['billing_first_name'] ?? NULL;
+    $billingMiddleName = $params['billing_middle_name'] ?? NULL;
+    $billingLastName = $params['billing_last_name'] ?? NULL;
     $addressParams['address_name'] = "{$billingFirstName}" . CRM_Core_DAO::VALUE_SEPARATOR . "{$billingMiddleName}" . CRM_Core_DAO::VALUE_SEPARATOR . "{$billingLastName}";
 
     foreach ($billingFields as $value) {
-      $addressParams[$value] = CRM_Utils_Array::value("billing_{$value}-{$billingLocationTypeID}", $params);
+      $addressParams[$value] = $params["billing_{$value}-{$billingLocationTypeID}"] ?? NULL;
       if (!empty($addressParams[$value])) {
         $hasBillingField = TRUE;
       }
@@ -1587,10 +1587,10 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = c.contact_id )
    */
   public static function checkDuplicate($input, &$duplicates, $id = NULL) {
     if (!$id) {
-      $id = CRM_Utils_Array::value('id', $input);
+      $id = $input['id'] ?? NULL;
     }
-    $trxn_id = CRM_Utils_Array::value('trxn_id', $input);
-    $invoice_id = CRM_Utils_Array::value('invoice_id', $input);
+    $trxn_id = $input['trxn_id'] ?? NULL;
+    $invoice_id = $input['invoice_id'] ?? NULL;
 
     $clause = [];
     $input = [];
@@ -2088,14 +2088,14 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
    */
   public static function transitionComponents($params, $processContributionObject = FALSE) {
     // get minimum required values.
-    $contactId = CRM_Utils_Array::value('contact_id', $params);
-    $componentId = CRM_Utils_Array::value('component_id', $params);
-    $componentName = CRM_Utils_Array::value('componentName', $params);
-    $contributionId = CRM_Utils_Array::value('contribution_id', $params);
-    $contributionStatusId = CRM_Utils_Array::value('contribution_status_id', $params);
+    $contactId = $params['contact_id'] ?? NULL;
+    $componentId = $params['component_id'] ?? NULL;
+    $componentName = $params['componentName'] ?? NULL;
+    $contributionId = $params['contribution_id'] ?? NULL;
+    $contributionStatusId = $params['contribution_status_id'] ?? NULL;
 
     // if we already processed contribution object pass previous status id.
-    $previousContriStatusId = CRM_Utils_Array::value('previous_contribution_status_id', $params);
+    $previousContriStatusId = $params['previous_contribution_status_id'] ?? NULL;
 
     $updateResult = [];
 
@@ -2146,13 +2146,13 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
 
     $input = $ids = $objects = [];
 
-    $input['component'] = CRM_Utils_Array::value('component', $componentDetails);
+    $input['component'] = $componentDetails['component'] ?? NULL;
     $ids['contribution'] = $contributionId;
-    $ids['contact'] = CRM_Utils_Array::value('contact_id', $componentDetails);
-    $ids['membership'] = CRM_Utils_Array::value('membership', $componentDetails);
-    $ids['participant'] = CRM_Utils_Array::value('participant', $componentDetails);
-    $ids['event'] = CRM_Utils_Array::value('event', $componentDetails);
-    $ids['pledge_payment'] = CRM_Utils_Array::value('pledge_payment', $componentDetails);
+    $ids['contact'] = $componentDetails['contact_id'] ?? NULL;
+    $ids['membership'] = $componentDetails['membership'] ?? NULL;
+    $ids['participant'] = $componentDetails['participant'] ?? NULL;
+    $ids['event'] = $componentDetails['event'] ?? NULL;
+    $ids['pledge_payment'] = $componentDetails['pledge_payment'] ?? NULL;
     $ids['contributionRecur'] = NULL;
     $ids['contributionPage'] = NULL;
 
@@ -2290,7 +2290,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             $lineitems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contributionId);
             foreach ($lineitems as $lineitem) {
               if ($membership->membership_type_id == CRM_Utils_Array::value('membership_type_id', $lineitem)) {
-                $numterms = CRM_Utils_Array::value('membership_num_terms', $lineitem);
+                $numterms = $lineitem['membership_num_terms'] ?? NULL;
 
                 // in case membership_num_terms comes through as null or zero
                 $numterms = $numterms >= 1 ? $numterms : 1;
@@ -2948,7 +2948,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $this->loadRelatedObjects($input, $ids);
 
     if (empty($this->_component)) {
-      $this->_component = CRM_Utils_Array::value('component', $input);
+      $this->_component = $input['component'] ?? NULL;
     }
 
     //not really sure what params might be passed in but lets merge em into values
@@ -3208,7 +3208,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $groupLabel = $group['title'];
         if (!empty($customField['customValue'])) {
           foreach ($customField['customValue'] as $customFieldValues) {
-            $customGroup[$groupLabel][$customField['label']] = CRM_Utils_Array::value('data', $customFieldValues);
+            $customGroup[$groupLabel][$customField['label']] = $customFieldValues['data'] ?? NULL;
           }
         }
       }
@@ -3579,15 +3579,15 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $balanceTrxnParams['to_financial_account_id'] = $toFinancialAccount;
         $balanceTrxnParams['contribution_id'] = $params['contribution']->id;
         $balanceTrxnParams['trxn_date'] = !empty($params['contribution']->receive_date) ? $params['contribution']->receive_date : date('YmdHis');
-        $balanceTrxnParams['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
-        $balanceTrxnParams['net_amount'] = CRM_Utils_Array::value('net_amount', $params);
+        $balanceTrxnParams['fee_amount'] = $params['fee_amount'] ?? NULL;
+        $balanceTrxnParams['net_amount'] = $params['net_amount'] ?? NULL;
         $balanceTrxnParams['currency'] = $params['contribution']->currency;
         $balanceTrxnParams['trxn_id'] = $params['contribution']->trxn_id;
         $balanceTrxnParams['status_id'] = $statusId;
         $balanceTrxnParams['payment_instrument_id'] = $params['contribution']->payment_instrument_id;
-        $balanceTrxnParams['check_number'] = CRM_Utils_Array::value('check_number', $params);
-        $balanceTrxnParams['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $params);
-        $balanceTrxnParams['card_type_id'] = CRM_Utils_Array::value('card_type_id', $params);
+        $balanceTrxnParams['check_number'] = $params['check_number'] ?? NULL;
+        $balanceTrxnParams['pan_truncation'] = $params['pan_truncation'] ?? NULL;
+        $balanceTrxnParams['card_type_id'] = $params['card_type_id'] ?? NULL;
         if (!empty($balanceTrxnParams['from_financial_account_id']) &&
           ($statusId == array_search('Completed', $contributionStatuses) || $statusId == array_search('Partially paid', $contributionStatuses))
         ) {
@@ -3635,7 +3635,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $params['to_financial_account_id'] = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_financial_account WHERE is_default = 1 AND financial_account_type_id = %1", $queryParams);
       }
 
-      $totalAmount = CRM_Utils_Array::value('total_amount', $params);
+      $totalAmount = $params['total_amount'] ?? NULL;
       if (!isset($totalAmount) && !empty($params['prevContribution'])) {
         $totalAmount = $params['total_amount'] = $params['prevContribution']->total_amount;
       }
@@ -3777,15 +3777,15 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $params['contribution']->find(TRUE);
         }
         $params['trxnParams']['payment_instrument_id'] = $params['contribution']->payment_instrument_id;
-        $params['trxnParams']['check_number'] = CRM_Utils_Array::value('check_number', $params);
+        $params['trxnParams']['check_number'] = $params['check_number'] ?? NULL;
 
         if (self::isPaymentInstrumentChange($params, $pendingStatus)) {
           $updated = CRM_Core_BAO_FinancialTrxn::updateFinancialAccountsOnPaymentInstrumentChange($params);
         }
 
         //if Change contribution amount
-        $params['trxnParams']['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
-        $params['trxnParams']['net_amount'] = CRM_Utils_Array::value('net_amount', $params);
+        $params['trxnParams']['fee_amount'] = $params['fee_amount'] ?? NULL;
+        $params['trxnParams']['net_amount'] = $params['net_amount'] ?? NULL;
         $params['trxnParams']['total_amount'] = $trxnParams['total_amount'] = $params['total_amount'] = $totalAmount;
         $params['trxnParams']['trxn_id'] = $params['contribution']->trxn_id;
         if (isset($totalAmount) &&
@@ -3814,8 +3814,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
               ]);
             }
           }
-          $cardType = CRM_Utils_Array::value('card_type_id', $params);
-          $panTruncation = CRM_Utils_Array::value('pan_truncation', $params);
+          $cardType = $params['card_type_id'] ?? NULL;
+          $panTruncation = $params['pan_truncation'] ?? NULL;
           CRM_Core_BAO_FinancialTrxn::updateCreditCardDetails($params['contribution']->id, $panTruncation, $cardType);
         }
       }
@@ -3824,8 +3824,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         // records finanical trxn and entity financial trxn
         // also make it available as return value
         self::recordAlwaysAccountsReceivable($trxnParams, $params);
-        $trxnParams['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $params);
-        $trxnParams['card_type_id'] = CRM_Utils_Array::value('card_type_id', $params);
+        $trxnParams['pan_truncation'] = $params['pan_truncation'] ?? NULL;
+        $trxnParams['card_type_id'] = $params['card_type_id'] ?? NULL;
         $return = $financialTxn = CRM_Core_BAO_FinancialTrxn::create($trxnParams);
         $params['entity_id'] = $financialTxn->id;
         if (empty($params['partial_payment_total']) && empty($params['partial_amount_to_pay'])) {
@@ -4461,10 +4461,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $inputContributionWhiteList[] = 'financial_type_id';
     }
 
-    $participant = CRM_Utils_Array::value('participant', $objects);
-    $recurContrib = CRM_Utils_Array::value('contributionRecur', $objects);
+    $participant = $objects['participant'] ?? NULL;
+    $recurContrib = $objects['contributionRecur'] ?? NULL;
     $recurringContributionID = (empty($recurContrib->id)) ? NULL : $recurContrib->id;
-    $event = CRM_Utils_Array::value('event', $objects);
+    $event = $objects['event'] ?? NULL;
 
     $paymentProcessorId = '';
     if (isset($objects['paymentProcessor'])) {
@@ -4577,7 +4577,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       // @fixme Can we remove this if altogether? - we removed the participant if / else and left relatedObjects['participant'] to ensure behaviour didn't change but it is probably not required.
       // @todo - use getRelatedMemberships instead
       $contribution->contribution_status_id = $contributionParams['contribution_status_id'];
-      $contribution->trxn_id = CRM_Utils_Array::value('trxn_id', $input);
+      $contribution->trxn_id = $input['trxn_id'] ?? NULL;
       $contribution->receive_date = CRM_Utils_Date::isoToMysql($contribution->receive_date);
     }
 
@@ -4762,13 +4762,13 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $balanceTrxnParams['total_amount'] = $params['total_amount'];
     $balanceTrxnParams['contribution_id'] = $params['contribution_id'];
     $balanceTrxnParams['trxn_date'] = CRM_Utils_Array::value('trxn_date', $params, CRM_Utils_Array::value('contribution_receive_date', $params, date('YmdHis')));
-    $balanceTrxnParams['fee_amount'] = CRM_Utils_Array::value('fee_amount', $params);
-    $balanceTrxnParams['net_amount'] = CRM_Utils_Array::value('total_amount', $params);
+    $balanceTrxnParams['fee_amount'] = $params['fee_amount'] ?? NULL;
+    $balanceTrxnParams['net_amount'] = $params['total_amount'] ?? NULL;
     $balanceTrxnParams['currency'] = $contribution['currency'];
-    $balanceTrxnParams['trxn_id'] = CRM_Utils_Array::value('contribution_trxn_id', $params, NULL);
+    $balanceTrxnParams['trxn_id'] = $params['contribution_trxn_id'] ?? NULL;
     $balanceTrxnParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'status_id', 'Completed');
     $balanceTrxnParams['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $params, $contribution['payment_instrument_id']);
-    $balanceTrxnParams['check_number'] = CRM_Utils_Array::value('check_number', $params);
+    $balanceTrxnParams['check_number'] = $params['check_number'] ?? NULL;
     $balanceTrxnParams['is_payment'] = 1;
 
     if (!empty($params['payment_processor'])) {
@@ -4844,7 +4844,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \API_Exception
    */
   public static function checkLineItems(&$params) {
-    $totalAmount = CRM_Utils_Array::value('total_amount', $params);
+    $totalAmount = $params['total_amount'] ?? NULL;
     $lineItemAmount = 0;
 
     foreach ($params['line_items'] as &$lineItems) {
@@ -5859,7 +5859,7 @@ LIMIT 1;";
         $groupLabel = $group['title'];
         if (!empty($customField['customValue'])) {
           foreach ($customField['customValue'] as $customFieldValues) {
-            $eventCustomGroup[$groupLabel][$customField['label']] = CRM_Utils_Array::value('data', $customFieldValues);
+            $eventCustomGroup[$groupLabel][$customField['label']] = $customFieldValues['data'] ?? NULL;
           }
         }
       }
@@ -5886,7 +5886,7 @@ LIMIT 1;";
         $groupLabel = $group['title'];
         if (!empty($customField['customValue'])) {
           foreach ($customField['customValue'] as $customFieldValues) {
-            $participantCustomGroup[$groupLabel][$customField['label']] = CRM_Utils_Array::value('data', $customFieldValues);
+            $participantCustomGroup[$groupLabel][$customField['label']] = $customFieldValues['data'] ?? NULL;
           }
         }
       }

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -574,7 +574,7 @@ LIMIT 1
     }
     else {
       $contributionStatus = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $id, 'contribution_status_id');
-      $name = CRM_Utils_Array::value($contributionStatus, $statusNames);
+      $name = $statusNames[$contributionStatus] ?? NULL;
       switch ($name) {
         case 'Completed':
           // [CRM-17498] Removing unsupported status change options.

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -314,7 +314,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
           $preProfileTypes = CRM_Core_BAO_UFGroup::profileGroups($preID);
           if (in_array('Individual', $preProfileTypes) || in_array('Contact', $preProfileTypes)) {
             //Take Individual contact ID
-            $userID = CRM_Utils_Array::value('related_contact', $values);
+            $userID = $values['related_contact'] ?? NULL;
           }
         }
         list($values['customPre_grouptitle'], $values['customPre']) = self::getProfileNameAndFields($preID, $userID, $params['custom_pre_id']);
@@ -325,7 +325,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
           $postProfileTypes = CRM_Core_BAO_UFGroup::profileGroups($postID);
           if (in_array('Individual', $postProfileTypes) || in_array('Contact', $postProfileTypes)) {
             //Take Individual contact ID
-            $userID = CRM_Utils_Array::value('related_contact', $values);
+            $userID = $values['related_contact'] ?? NULL;
           }
         }
         list($values['customPost_grouptitle'], $values['customPost']) = self::getProfileNameAndFields($postID, $userID, $params['custom_post_id']);
@@ -391,7 +391,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       }
 
       // CRM-6976
-      $originalCCReceipt = CRM_Utils_Array::value('cc_receipt', $values);
+      $originalCCReceipt = $values['cc_receipt'] ?? NULL;
 
       // cc to related contacts of contributor OR the one who
       // signs up. Is used for cases like - on behalf of
@@ -442,13 +442,13 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $sendTemplateParams['from'] = CRM_Utils_Array::value('receipt_from_name', $values) . ' <' . $values['receipt_from_email'] . '>';
         $sendTemplateParams['toName'] = $displayName;
         $sendTemplateParams['toEmail'] = $email;
-        $sendTemplateParams['cc'] = CRM_Utils_Array::value('cc_receipt', $values);
-        $sendTemplateParams['bcc'] = CRM_Utils_Array::value('bcc_receipt', $values);
+        $sendTemplateParams['cc'] = $values['cc_receipt'] ?? NULL;
+        $sendTemplateParams['bcc'] = $values['bcc_receipt'] ?? NULL;
         //send email with pdf invoice
         $template = CRM_Core_Smarty::singleton();
         $taxAmt = $template->get_template_vars('dataArray');
         $prefixValue = Civi::settings()->get('contribution_invoice_settings');
-        $invoicing = CRM_Utils_Array::value('invoicing', $prefixValue);
+        $invoicing = $prefixValue['invoicing'] ?? NULL;
         if (isset($invoicing) && isset($prefixValue['is_email_pdf'])) {
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $values['contribution_id'];
@@ -461,8 +461,8 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $sendTemplateParams['groupName'] = 'msg_tpl_workflow_contribution';
         $sendTemplateParams['valueName'] = 'contribution_dupalert';
         $sendTemplateParams['from'] = ts('Automatically Generated') . " <{$values['receipt_from_email']}>";
-        $sendTemplateParams['toName'] = CRM_Utils_Array::value('receipt_from_name', $values);
-        $sendTemplateParams['toEmail'] = CRM_Utils_Array::value('receipt_from_email', $values);
+        $sendTemplateParams['toName'] = $values['receipt_from_name'] ?? NULL;
+        $sendTemplateParams['toEmail'] = $values['receipt_from_email'] ?? NULL;
         $sendTemplateParams['tplParams']['onBehalfID'] = $contactID;
         $sendTemplateParams['tplParams']['receiptMessage'] = $message;
 
@@ -539,7 +539,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'cc_receipt',
         'bcc_receipt',
       ]);
-      $isEmailReceipt = CRM_Utils_Array::value('is_email_receipt', $value[$pageID]);
+      $isEmailReceipt = $value[$pageID]['is_email_receipt'] ?? NULL;
     }
     elseif ($recur->id) {
       // This means we are coming from back-office - ie. no page ID, but recurring.
@@ -585,8 +585,8 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       ];
       //CRM-13811
       if ($pageID) {
-        $templatesParams['cc'] = CRM_Utils_Array::value('cc_receipt', $value[$pageID]);
-        $templatesParams['bcc'] = CRM_Utils_Array::value('bcc_receipt', $value[$pageID]);
+        $templatesParams['cc'] = $value[$pageID]['cc_receipt'] ?? NULL;
+        $templatesParams['bcc'] = $value[$pageID]['bcc_receipt'] ?? NULL;
       }
       if ($recur->id) {
         // in some cases its just recurringNotify() thats called for the first time and these urls don't get set.

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -66,7 +66,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
 
     $recurring = new CRM_Contribute_BAO_ContributionRecur();
     $recurring->copyValues($params);
-    $recurring->id = CRM_Utils_Array::value('id', $params);
+    $recurring->id = $params['id'] ?? NULL;
 
     // set currency for CRM-1496
     if (empty($params['id']) && !isset($recurring->currency)) {
@@ -103,9 +103,9 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *   true if duplicate, false otherwise
    */
   public static function checkDuplicate($params, &$duplicates) {
-    $id = CRM_Utils_Array::value('id', $params);
-    $trxn_id = CRM_Utils_Array::value('trxn_id', $params);
-    $invoice_id = CRM_Utils_Array::value('invoice_id', $params);
+    $id = $params['id'] ?? NULL;
+    $trxn_id = $params['trxn_id'] ?? NULL;
+    $invoice_id = $params['invoice_id'] ?? NULL;
 
     $clause = [];
     $params = [];
@@ -264,19 +264,19 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $recur->start_date = CRM_Utils_Date::isoToMysql($recur->start_date);
       $recur->create_date = CRM_Utils_Date::isoToMysql($recur->create_date);
       $recur->modified_date = CRM_Utils_Date::isoToMysql($recur->modified_date);
-      $recur->cancel_reason = CRM_Utils_Array::value('cancel_reason', $params);
+      $recur->cancel_reason = $params['cancel_reason'] ?? NULL;
       $recur->cancel_date = date('YmdHis');
       $recur->save();
 
       // @fixme https://lab.civicrm.org/dev/core/issues/927 Cancelling membership etc is not desirable for all use-cases and we should be able to disable it
       $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurId);
       if ($dao && $dao->recur_id) {
-        $details = CRM_Utils_Array::value('details', $activityParams);
+        $details = $activityParams['details'] ?? NULL;
         if ($dao->auto_renew && $dao->membership_id) {
           // its auto-renewal membership mode
           $membershipTypes = CRM_Member_PseudoConstant::membershipType();
           $membershipType = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $dao->membership_id, 'membership_type_id');
-          $membershipType = CRM_Utils_Array::value($membershipType, $membershipTypes);
+          $membershipType = $membershipTypes[$membershipType] ?? NULL;
           $details .= '
 <br/>' . ts('Automatic renewal of %1 membership cancelled.', [1 => $membershipType]);
         }

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -71,9 +71,9 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       );
       $softParams['currency'] = $contribution->currency;
       $softParams['amount'] = $contribution->total_amount;
-      $softParams['pcp_display_in_roll'] = CRM_Utils_Array::value('pcp_display_in_roll', $pcp);
-      $softParams['pcp_roll_nickname'] = CRM_Utils_Array::value('pcp_roll_nickname', $pcp);
-      $softParams['pcp_personal_note'] = CRM_Utils_Array::value('pcp_personal_note', $pcp);
+      $softParams['pcp_display_in_roll'] = $pcp['pcp_display_in_roll'] ?? NULL;
+      $softParams['pcp_roll_nickname'] = $pcp['pcp_roll_nickname'] ?? NULL;
+      $softParams['pcp_personal_note'] = $pcp['pcp_personal_note'] ?? NULL;
       $softParams['soft_credit_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'pcp');
       $contributionSoft = self::add($softParams);
       //Send notification to owner for PCP
@@ -130,7 +130,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
         'pcp_personal_note',
       ];
       foreach ($fields as $f) {
-        $pcp[$f] = CRM_Utils_Array::value($f, $params);
+        $pcp[$f] = $params[$f] ?? NULL;
       }
     }
 
@@ -154,7 +154,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
         FALSE
       );
       if (count($ids)) {
-        $honorId = CRM_Utils_Array::value(0, $ids);
+        $honorId = $ids[0] ?? NULL;
       }
 
       $null = [];
@@ -399,7 +399,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     // Format the params.
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['rowCount'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
     $contactId = $params['cid'];
 
     $filter = NULL;

--- a/CRM/Contribute/BAO/Product.php
+++ b/CRM/Contribute/BAO/Product.php
@@ -78,7 +78,7 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
    * @return CRM_Contribute_DAO_Product
    */
   public static function create($params) {
-    $id = CRM_Utils_Array::value('id', $params);
+    $id = $params['id'] ?? NULL;
     if (empty($id)) {
       $defaultParams = [
         'id' => $id,

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -276,7 +276,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
 
     // Also don't allow user to update some fields for recurring contributions.
     if (!$this->_online) {
-      $this->_online = CRM_Utils_Array::value('contribution_recur_id', $values);
+      $this->_online = $values['contribution_recur_id'] ?? NULL;
     }
 
     $this->assign('isOnline', $this->_online ? TRUE : FALSE);
@@ -415,9 +415,9 @@ WHERE  contribution_id = {$id}
       $payParams = ['id' => $this->_ppID];
 
       CRM_Pledge_BAO_PledgePayment::retrieve($payParams, $this->_pledgeValues['pledgePayment']);
-      $this->_pledgeID = CRM_Utils_Array::value('pledge_id', $this->_pledgeValues['pledgePayment']);
-      $paymentStatusID = CRM_Utils_Array::value('status_id', $this->_pledgeValues['pledgePayment']);
-      $this->_id = CRM_Utils_Array::value('contribution_id', $this->_pledgeValues['pledgePayment']);
+      $this->_pledgeID = $this->_pledgeValues['pledgePayment']['pledge_id'] ?? NULL;
+      $paymentStatusID = $this->_pledgeValues['pledgePayment']['status_id'] ?? NULL;
+      $this->_id = $this->_pledgeValues['pledgePayment']['contribution_id'] ?? NULL;
 
       //get all status
       $allStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -171,7 +171,7 @@ class CRM_Contribute_Form_AdditionalInfo {
    */
   public static function processPremium($params, $contributionID, $premiumID = NULL, $options = []) {
     $selectedProductID = $params['product_name'][0];
-    $selectedProductOptionID = CRM_Utils_Array::value(1, $params['product_name']);
+    $selectedProductOptionID = $params['product_name'][1] ?? NULL;
 
     $dao = new CRM_Contribute_DAO_ContributionProduct();
     $dao->contribution_id = $contributionID;
@@ -186,7 +186,7 @@ class CRM_Contribute_Form_AdditionalInfo {
 
     $productDetails = [];
     CRM_Contribute_BAO_Product::retrieve($premiumParams, $productDetails);
-    $dao->financial_type_id = CRM_Utils_Array::value('financial_type_id', $productDetails);
+    $dao->financial_type_id = $productDetails['financial_type_id'] ?? NULL;
     if (!empty($options[$selectedProductID])) {
       $dao->product_option = $options[$selectedProductID][$selectedProductOptionID];
     }
@@ -268,7 +268,7 @@ class CRM_Contribute_Form_AdditionalInfo {
       'contribution_page_id',
     ];
     foreach ($fields as $f) {
-      $formatted[$f] = CRM_Utils_Array::value($f, $params);
+      $formatted[$f] = $params[$f] ?? NULL;
     }
 
     if (!empty($params['thankyou_date']) && !CRM_Utils_System::isNull($params['thankyou_date'])) {
@@ -437,7 +437,7 @@ class CRM_Contribute_Form_AdditionalInfo {
     $taxAmt = $template->get_template_vars('dataArray');
     $eventTaxAmt = $template->get_template_vars('totalTaxAmount');
     $prefixValue = Civi::settings()->get('contribution_invoice_settings');
-    $invoicing = CRM_Utils_Array::value('invoicing', $prefixValue);
+    $invoicing = $prefixValue['invoicing'] ?? NULL;
     if ((!empty($taxAmt) || isset($eventTaxAmt)) && (isset($invoicing) && isset($prefixValue['is_email_pdf']))) {
       $isEmailPdf = TRUE;
     }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -223,10 +223,10 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     parent::preProcess();
 
-    $this->_formType = CRM_Utils_Array::value('formType', $_GET);
+    $this->_formType = $_GET['formType'] ?? NULL;
 
     // Get price set id.
-    $this->_priceSetId = CRM_Utils_Array::value('priceSetId', $_GET);
+    $this->_priceSetId = $_GET['priceSetId'] ?? NULL;
     $this->set('priceSetId', $this->_priceSetId);
     $this->assign('priceSetId', $this->_priceSetId);
 
@@ -321,9 +321,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     // Set defaults for pledge payment.
     if ($this->_ppID) {
-      $defaults['total_amount'] = CRM_Utils_Array::value('scheduled_amount', $this->_pledgeValues['pledgePayment']);
-      $defaults['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $this->_pledgeValues);
-      $defaults['currency'] = CRM_Utils_Array::value('currency', $this->_pledgeValues);
+      $defaults['total_amount'] = $this->_pledgeValues['pledgePayment']['scheduled_amount'] ?? NULL;
+      $defaults['financial_type_id'] = $this->_pledgeValues['financial_type_id'] ?? NULL;
+      $defaults['currency'] = $this->_pledgeValues['currency'] ?? NULL;
       $defaults['option_type'] = 1;
     }
 
@@ -437,7 +437,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $defaults['receive_date'] = date('Y-m-d H:i:s');
     }
 
-    $currency = CRM_Utils_Array::value('currency', $defaults);
+    $currency = $defaults['currency'] ?? NULL;
     $this->assign('currency', $currency);
     // Hack to get currency info to the js layer. CRM-11440.
     CRM_Utils_Money::format(1);
@@ -1069,9 +1069,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       CRM_Core_Config::singleton()->defaultCurrency
     );
 
-    $this->_params['pcp_display_in_roll'] = CRM_Utils_Array::value('pcp_display_in_roll', $params);
-    $this->_params['pcp_roll_nickname'] = CRM_Utils_Array::value('pcp_roll_nickname', $params);
-    $this->_params['pcp_personal_note'] = CRM_Utils_Array::value('pcp_personal_note', $params);
+    $this->_params['pcp_display_in_roll'] = $params['pcp_display_in_roll'] ?? NULL;
+    $this->_params['pcp_roll_nickname'] = $params['pcp_roll_nickname'] ?? NULL;
+    $this->_params['pcp_personal_note'] = $params['pcp_personal_note'] ?? NULL;
 
     //Add common data to formatted params
     CRM_Contribute_Form_AdditionalInfo::postProcessCommon($params, $this->_params, $this);
@@ -1205,7 +1205,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // Send receipt mail.
     array_unshift($this->statusMessage, ts('The contribution record has been saved.'));
     if ($contribution->id && !empty($this->_params['is_email_receipt'])) {
-      $this->_params['trxn_id'] = CRM_Utils_Array::value('trxn_id', $result);
+      $this->_params['trxn_id'] = $result['trxn_id'] ?? NULL;
       $this->_params['contact_id'] = $contactID;
       $this->_params['contribution_id'] = $contribution->id;
       if (CRM_Contribute_Form_AdditionalInfo::emailReceipt($this, $this->_params, TRUE)) {
@@ -1372,7 +1372,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     // Process price set and get total amount and line items.
     $lineItem = [];
-    $priceSetId = CRM_Utils_Array::value('price_set_id', $submittedValues);
+    $priceSetId = $submittedValues['price_set_id'] ?? NULL;
     if (empty($priceSetId) && !$this->_id) {
       $this->_priceSetId = $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', 'default_contribution_amount', 'id', 'name');
       $this->_priceSet = current(CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
@@ -1396,7 +1396,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       ) {
         unset($submittedValues['tax_amount']);
       }
-      $submittedValues['total_amount'] = CRM_Utils_Array::value('amount', $submittedValues);
+      $submittedValues['total_amount'] = $submittedValues['amount'] ?? NULL;
     }
 
     if ($this->_id) {
@@ -1507,7 +1507,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     if (!isset($submittedValues['total_amount'])) {
-      $submittedValues['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_values);
+      $submittedValues['total_amount'] = $this->_values['total_amount'] ?? NULL;
       // Avoid tax amount deduction on edit form and keep it original, because this will lead to error described in CRM-20676
       if (!$this->_id) {
         $submittedValues['total_amount'] -= CRM_Utils_Array::value('tax_amount', $this->_values, 0);
@@ -1574,7 +1574,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         'pan_truncation',
       ];
       foreach ($fields as $f) {
-        $params[$f] = CRM_Utils_Array::value($f, $formValues);
+        $params[$f] = $formValues[$f] ?? NULL;
       }
 
       $params['revenue_recognition_date'] = NULL;
@@ -1620,7 +1620,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $params['contribution_mode'] = 'membership';
       }
       $params['line_item'] = $lineItem;
-      $params['payment_processor_id'] = $params['payment_processor'] = CRM_Utils_Array::value('id', $this->_paymentProcessor);
+      $params['payment_processor_id'] = $params['payment_processor'] = $this->_paymentProcessor['id'] ?? NULL;
       $params['tax_amount'] = CRM_Utils_Array::value('tax_amount', $submittedValues, CRM_Utils_Array::value('tax_amount', $this->_values));
       //create contribution.
       if ($isQuickConfig) {
@@ -1657,7 +1657,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $formValues += CRM_Contribute_BAO_ContributionSoft::getSoftContribution($contribution->id);
 
         // to get 'from email id' for send receipt
-        $this->fromEmailId = CRM_Utils_Array::value('from_email_address', $formValues);
+        $this->fromEmailId = $formValues['from_email_address'] ?? NULL;
         if (CRM_Contribute_Form_AdditionalInfo::emailReceipt($this, $formValues)) {
           $this->statusMessage[] = ts('A receipt has been emailed to the contributor.');
         }
@@ -1715,7 +1715,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         }
         else {
           if (isset($v['tax_rate'])) {
-            $taxRate[(string) $v['tax_rate']] = CRM_Utils_Array::value('tax_amount', $v);
+            $taxRate[(string) $v['tax_rate']] = $v['tax_amount'] ?? NULL;
             $getTaxDetails = TRUE;
           }
         }
@@ -1763,7 +1763,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       return $params['non_deductible_amount'];
     }
 
-    $priceSetId = CRM_Utils_Array::value('price_set_id', $params);
+    $priceSetId = $params['price_set_id'] ?? NULL;
     // return non-deductible amount if it is set at the price field option level
     if ($priceSetId && !empty($params['line_item'])) {
       $nonDeductibleAmount = CRM_Price_BAO_PriceSet::getNonDeductibleAmountFromPriceSet($priceSetId, $params['line_item']);

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -113,7 +113,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $pledgeParams['original_installment_amount'] = $pledgeParams['installment_amount'];
 
       //inherit campaign from contirb page.
-      $pledgeParams['campaign_id'] = CRM_Utils_Array::value('campaign_id', $contributionParams);
+      $pledgeParams['campaign_id'] = $contributionParams['campaign_id'] ?? NULL;
 
       $pledge = CRM_Pledge_BAO_Pledge::create($pledgeParams);
 
@@ -171,7 +171,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     ];
 
     if ($paymentProcessorOutcome) {
-      $contributionParams['payment_processor'] = CRM_Utils_Array::value('payment_processor', $paymentProcessorOutcome);
+      $contributionParams['payment_processor'] = $paymentProcessorOutcome['payment_processor'] ?? NULL;
     }
     if (!empty($params["is_email_receipt"])) {
       $contributionParams += [
@@ -216,7 +216,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if (isset($params['non_deductible_amount']) && (!empty($params['non_deductible_amount']))) {
       return $params['non_deductible_amount'];
     }
-    $priceSetId = CRM_Utils_Array::value('priceSetId', $params);
+    $priceSetId = $params['priceSetId'] ?? NULL;
     // return non-deductible amount if it is set at the price field option level
     if ($priceSetId && !empty($form->_lineItem)) {
       $nonDeductibleAmount = CRM_Price_BAO_PriceSet::getNonDeductibleAmountFromPriceSet($priceSetId, $form->_lineItem);
@@ -228,7 +228,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     else {
       if ($financialType->is_deductible) {
         if ($online && isset($params['selectProduct'])) {
-          $selectProduct = CRM_Utils_Array::value('selectProduct', $params);
+          $selectProduct = $params['selectProduct'] ?? NULL;
         }
         if (!$online && isset($params['product_name'][0])) {
           $selectProduct = $params['product_name'][0];
@@ -309,7 +309,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // if onbehalf-of-organization
     if (!empty($this->_values['onbehalf_profile_id']) && !empty($this->_params['onbehalf']['organization_name'])) {
       if (empty($this->_params['org_option']) && empty($this->_params['organization_id'])) {
-        $this->_params['organization_id'] = CRM_Utils_Array::value('onbehalfof_id', $this->_params);
+        $this->_params['organization_id'] = $this->_params['onbehalfof_id'] ?? NULL;
       }
       $this->_params['organization_name'] = $this->_params['onbehalf']['organization_name'];
       $addressBlocks = [
@@ -514,7 +514,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     if (!empty($params['selectProduct']) && $params['selectProduct'] != 'no_thanks') {
-      $option = CRM_Utils_Array::value('options_' . $params['selectProduct'], $params);
+      $option = $params['options_' . $params['selectProduct']] ?? NULL;
       $productID = $params['selectProduct'];
       CRM_Contribute_BAO_Premium::buildPremiumBlock($this, $this->_id, FALSE,
         $productID, $option
@@ -733,7 +733,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   protected function postProcessPremium($premiumParams, $contribution) {
     $hour = $minute = $second = 0;
     // assigning Premium information to receipt tpl
-    $selectProduct = CRM_Utils_Array::value('selectProduct', $premiumParams);
+    $selectProduct = $premiumParams['selectProduct'] ?? NULL;
     if ($selectProduct &&
       $selectProduct != 'no_thanks'
     ) {
@@ -918,11 +918,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $params['is_email_receipt'] = $isEmailReceipt;
     }
     $params['is_recur'] = $isRecur;
-    $params['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $contributionParams);
+    $params['payment_instrument_id'] = $contributionParams['payment_instrument_id'] ?? NULL;
     $recurringContributionID = self::processRecurringContribution($form, $params, $contactID, $financialType);
 
     $now = date('YmdHis');
-    $receiptDate = CRM_Utils_Array::value('receipt_date', $params);
+    $receiptDate = $params['receipt_date'] ?? NULL;
     if ($isEmailReceipt) {
       $receiptDate = $now;
     }
@@ -942,7 +942,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
 
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
       if ($invoicing) {
         $dataArray = [];
         // @todo - interrogate the line items passed in on the params array.
@@ -954,7 +954,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
                 $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + CRM_Utils_Array::value('tax_amount', $value);
               }
               else {
-                $dataArray[$value['tax_rate']] = CRM_Utils_Array::value('tax_amount', $value);
+                $dataArray[$value['tax_rate']] = $value['tax_amount'] ?? NULL;
               }
             }
           }
@@ -1053,13 +1053,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     $recurParams = ['contact_id' => $contactID];
-    $recurParams['amount'] = CRM_Utils_Array::value('amount', $params);
-    $recurParams['auto_renew'] = CRM_Utils_Array::value('auto_renew', $params);
-    $recurParams['frequency_unit'] = CRM_Utils_Array::value('frequency_unit', $params);
-    $recurParams['frequency_interval'] = CRM_Utils_Array::value('frequency_interval', $params);
-    $recurParams['installments'] = CRM_Utils_Array::value('installments', $params);
-    $recurParams['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $params);
-    $recurParams['currency'] = CRM_Utils_Array::value('currency', $params);
+    $recurParams['amount'] = $params['amount'] ?? NULL;
+    $recurParams['auto_renew'] = $params['auto_renew'] ?? NULL;
+    $recurParams['frequency_unit'] = $params['frequency_unit'] ?? NULL;
+    $recurParams['frequency_interval'] = $params['frequency_interval'] ?? NULL;
+    $recurParams['installments'] = $params['installments'] ?? NULL;
+    $recurParams['financial_type_id'] = $params['financial_type_id'] ?? NULL;
+    $recurParams['currency'] = $params['currency'] ?? NULL;
     $recurParams['payment_instrument_id'] = $params['payment_instrument_id'];
 
     // CRM-14354: For an auto-renewing membership with an additional contribution,
@@ -1086,10 +1086,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if (!empty($params['receive_date'])) {
       $recurParams['start_date'] = date('YmdHis', strtotime($params['receive_date']));
     }
-    $recurParams['invoice_id'] = CRM_Utils_Array::value('invoiceID', $params);
+    $recurParams['invoice_id'] = $params['invoiceID'] ?? NULL;
     $recurParams['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
-    $recurParams['payment_processor_id'] = CRM_Utils_Array::value('payment_processor_id', $params);
-    $recurParams['is_email_receipt'] = CRM_Utils_Array::value('is_email_receipt', $params);
+    $recurParams['payment_processor_id'] = $params['payment_processor_id'] ?? NULL;
+    $recurParams['is_email_receipt'] = $params['is_email_receipt'] ?? NULL;
     // we need to add a unique trxn_id to avoid a unique key error
     // in paypal IPN we reset this when paypal sends us the real trxn id, CRM-2991
     $recurParams['trxn_id'] = CRM_Utils_Array::value('trxn_id', $params, $params['invoiceID']);
@@ -1347,7 +1347,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $membershipType = empty($membershipTypes) ? [] : reset($membershipTypes);
 
     $this->assign('membership_name', CRM_Utils_Array::value('name', $membershipType));
-    $this->_values['membership_name'] = CRM_Utils_Array::value('name', $membershipType);
+    $this->_values['membership_name'] = $membershipType['name'] ?? NULL;
 
     $isPaidMembership = FALSE;
     if ($this->_amount >= 0.0 && isset($membershipParams['amount'])) {
@@ -1525,13 +1525,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
         $isPayLater = NULL;
         if (isset($form->_params)) {
-          $isPayLater = CRM_Utils_Array::value('is_pay_later', $form->_params);
+          $isPayLater = $form->_params['is_pay_later'] ?? NULL;
         }
         $campaignId = NULL;
         if (isset($form->_values) && is_array($form->_values) && !empty($form->_values)) {
-          $campaignId = CRM_Utils_Array::value('campaign_id', $form->_params);
+          $campaignId = $form->_params['campaign_id'] ?? NULL;
           if (!array_key_exists('campaign_id', $form->_params)) {
-            $campaignId = CRM_Utils_Array::value('campaign_id', $form->_values);
+            $campaignId = $form->_values['campaign_id'] ?? NULL;
           }
         }
 
@@ -1706,7 +1706,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $financialType->find(TRUE);
     $tempParams['amount'] = $minimumFee;
     $tempParams['invoiceID'] = md5(uniqid(rand(), TRUE));
-    $isRecur = CRM_Utils_Array::value('is_recur', $tempParams);
+    $isRecur = $tempParams['is_recur'] ?? NULL;
 
     //assign receive date when separate membership payment
     //and contribution amount not selected.
@@ -1926,7 +1926,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $form->_fields['billing_last_name'] = 1;
     // CRM-18854 - Set form values to allow pledge to be created for api test.
     if (!empty($params['pledge_block_id'])) {
-      $form->_values['pledge_id'] = CRM_Utils_Array::value('pledge_id', $params, NULL);
+      $form->_values['pledge_id'] = $params['pledge_id'] ?? NULL;
       $form->_values['pledge_block_id'] = $params['pledge_block_id'];
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($params['id']);
       $form->_values['max_reminders'] = $pledgeBlock['max_reminders'];
@@ -2046,7 +2046,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $title = !empty($this->_values['frontend_title']) ? $this->_values['frontend_title'] : $this->_values['title'];
     $this->_params['description'] = ts('Online Contribution') . ': ' . (!empty($this->_pcpInfo['title']) ? $this->_pcpInfo['title'] : $title);
 
-    $this->_params['accountingCode'] = CRM_Utils_Array::value('accountingCode', $this->_values);
+    $this->_params['accountingCode'] = $this->_values['accountingCode'] ?? NULL;
 
     // fix currency ID
     $this->_params['currencyID'] = CRM_Core_Config::singleton()->defaultCurrency;
@@ -2058,7 +2058,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($this->_id);
       if (CRM_Utils_Array::value('start_date', $this->_params) || !CRM_Utils_Array::value('is_pledge_start_date_visible', $pledgeBlock)
           || !CRM_Utils_Array::value('is_pledge_start_date_editable', $pledgeBlock)) {
-        $pledgeStartDate = CRM_Utils_Array::value('start_date', $this->_params, NULL);
+        $pledgeStartDate = $this->_params['start_date'] ?? NULL;
         $this->_params['receive_date'] = CRM_Pledge_BAO_Pledge::getPledgeStartDate($pledgeStartDate, $pledgeBlock);
         $recurParams = CRM_Pledge_BAO_Pledge::buildRecurParams($this->_params);
         $this->_params = array_merge($this->_params, $recurParams);
@@ -2213,7 +2213,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     //get email primary first if exist
     $subscriptionEmail = ['email' => CRM_Utils_Array::value('email-Primary', $params)];
     if (!$subscriptionEmail['email']) {
-      $subscriptionEmail['email'] = CRM_Utils_Array::value("email-{$this->_bltID}", $params);
+      $subscriptionEmail['email'] = $params["email-{$this->_bltID}"] ?? NULL;
     }
     // subscribing contact to groups
     if (!empty($subscribeGroupIds) && $subscriptionEmail['email']) {
@@ -2276,7 +2276,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
       //inherit campaign from contribution page.
       if (!array_key_exists('campaign_id', $membershipParams)) {
-        $membershipParams['campaign_id'] = CRM_Utils_Array::value('campaign_id', $this->_values);
+        $membershipParams['campaign_id'] = $this->_values['campaign_id'] ?? NULL;
       }
 
       $this->_params = CRM_Core_Payment_Form::mapParams($this->_bltID, $this->_params, $membershipParams, TRUE);

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -205,7 +205,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $selectedCurrentMemTypes = [];
         foreach ($this->_priceSet['fields'] as $key => $val) {
           foreach ($val['options'] as $keys => $values) {
-            $opMemTypeId = CRM_Utils_Array::value('membership_type_id', $values);
+            $opMemTypeId = $values['membership_type_id'] ?? NULL;
             $priceFieldName = 'price_' . $values['price_field_id'];
             $priceFieldValue = CRM_Price_BAO_PriceSet::getPriceFieldValueFromURL($this, $priceFieldName);
             if (!empty($priceFieldValue)) {
@@ -241,7 +241,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (!empty($this->_fields)) {
       //load default campaign from page.
       if (array_key_exists('contribution_campaign_id', $this->_fields)) {
-        $this->_defaults['contribution_campaign_id'] = CRM_Utils_Array::value('campaign_id', $this->_values);
+        $this->_defaults['contribution_campaign_id'] = $this->_values['campaign_id'] ?? NULL;
       }
 
       //set custom field defaults
@@ -528,7 +528,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $form->add('hidden', 'frequency_interval', 1);
     }
 
-    $frUnits = CRM_Utils_Array::value('recur_frequency_unit', $form->_values);
+    $frUnits = $form->_values['recur_frequency_unit'] ?? NULL;
     if (empty($frUnits) &&
       $className == 'CRM_Contribute_Form_Contribution'
     ) {
@@ -639,8 +639,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           }
           elseif (!empty($fields["price_{$priceField->id}"])) {
             $otherAmountVal = CRM_Utils_Rule::cleanMoney($fields["price_{$priceField->id}"]);
-            $min = CRM_Utils_Array::value('min_amount', $self->_values);
-            $max = CRM_Utils_Array::value('max_amount', $self->_values);
+            $min = $self->_values['min_amount'] ?? NULL;
+            $max = $self->_values['max_amount'] ?? NULL;
             if ($min && $otherAmountVal < $min) {
               $errors["price_{$priceField->id}"] = ts('Contribution amount must be at least %1',
                 [1 => $min]
@@ -954,15 +954,15 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
     else {
       if (!empty($formValues['amount'])) {
-        $amountID = CRM_Utils_Array::value('amount', $params);
+        $amountID = $params['amount'] ?? NULL;
 
         if ($amountID) {
           // @todo - stop setting amount level in this function & call the CRM_Price_BAO_PriceSet::getAmountLevel
           // function to get correct amount level consistently. Remove setting of the amount level in
           // CRM_Price_BAO_PriceSet::processAmount. Extend the unit tests in CRM_Price_BAO_PriceSetTest
           // to cover all variants.
-          $params['amount_level'] = CRM_Utils_Array::value('label', $formValues[$amountID]);
-          $amount = CRM_Utils_Array::value('value', $formValues[$amountID]);
+          $params['amount_level'] = $formValues[$amountID]['label'] ?? NULL;
+          $amount = $formValues[$amountID]['value'] ?? NULL;
         }
       }
     }
@@ -1019,7 +1019,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           if (($selectedPriceOptionID = CRM_Utils_Array::value("price_{$priceField->id}", $params)) != FALSE && $selectedPriceOptionID > 0) {
             switch ($priceField->name) {
               case 'membership_amount':
-                $this->_params['selectMembership'] = $params['selectMembership'] = CRM_Utils_Array::value('membership_type_id', $priceOptions[$selectedPriceOptionID]);
+                $this->_params['selectMembership'] = $params['selectMembership'] = $priceOptions[$selectedPriceOptionID]['membership_type_id'] ?? NULL;
                 $this->set('selectMembership', $params['selectMembership']);
 
               case 'contribution_amount':
@@ -1028,12 +1028,12 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
                     ($priceField->name == 'membership_amount' &&
                       CRM_Utils_Array::value('is_separate_payment', $this->_membershipBlock) == 0)
                 ) {
-                  $this->_values['amount'] = CRM_Utils_Array::value('amount', $priceOptions[$selectedPriceOptionID]);
+                  $this->_values['amount'] = $priceOptions[$selectedPriceOptionID]['amount'] ?? NULL;
                 }
-                $this->_values[$selectedPriceOptionID]['value'] = CRM_Utils_Array::value('amount', $priceOptions[$selectedPriceOptionID]);
-                $this->_values[$selectedPriceOptionID]['label'] = CRM_Utils_Array::value('label', $priceOptions[$selectedPriceOptionID]);
-                $this->_values[$selectedPriceOptionID]['amount_id'] = CRM_Utils_Array::value('id', $priceOptions[$selectedPriceOptionID]);
-                $this->_values[$selectedPriceOptionID]['weight'] = CRM_Utils_Array::value('weight', $priceOptions[$selectedPriceOptionID]);
+                $this->_values[$selectedPriceOptionID]['value'] = $priceOptions[$selectedPriceOptionID]['amount'] ?? NULL;
+                $this->_values[$selectedPriceOptionID]['label'] = $priceOptions[$selectedPriceOptionID]['label'] ?? NULL;
+                $this->_values[$selectedPriceOptionID]['amount_id'] = $priceOptions[$selectedPriceOptionID]['id'] ?? NULL;
+                $this->_values[$selectedPriceOptionID]['weight'] = $priceOptions[$selectedPriceOptionID]['weight'] ?? NULL;
                 break;
 
               case 'other_amount':
@@ -1104,7 +1104,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
             $params['price_' . $key] = CRM_Utils_Rule::cleanMoney($params['price_' . $key]);
             if ($params['price_' . $key] != 0) {
               foreach ($val['options'] as $optionKey => & $options) {
-                $options['amount'] = CRM_Utils_Array::value('price_' . $key, $params);
+                $options['amount'] = $params['price_' . $key] ?? NULL;
                 break;
               }
             }

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -204,7 +204,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
       $this->buildCustom($this->_values['onbehalf_profile_id'], 'onbehalfProfile', TRUE, 'onbehalf', $fieldTypes);
     }
 
-    $this->_trxnId = CRM_Utils_Array::value('trxn_id', $this->_params);
+    $this->_trxnId = $this->_params['trxn_id'] ?? NULL;
 
     $this->assign('trxn_id', $this->_trxnId);
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -316,8 +316,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->assignBillingType();
 
       // check for is_monetary status
-      $isMonetary = CRM_Utils_Array::value('is_monetary', $this->_values);
-      $isPayLater = CRM_Utils_Array::value('is_pay_later', $this->_values);
+      $isMonetary = $this->_values['is_monetary'] ?? NULL;
+      $isPayLater = $this->_values['is_pay_later'] ?? NULL;
       if (!empty($this->_ccid)) {
         $this->_values['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',
           $this->_ccid,
@@ -382,10 +382,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($this->_id);
 
       if ($pledgeBlock) {
-        $this->_values['pledge_block_id'] = CRM_Utils_Array::value('id', $pledgeBlock);
-        $this->_values['max_reminders'] = CRM_Utils_Array::value('max_reminders', $pledgeBlock);
-        $this->_values['initial_reminder_day'] = CRM_Utils_Array::value('initial_reminder_day', $pledgeBlock);
-        $this->_values['additional_reminder_day'] = CRM_Utils_Array::value('additional_reminder_day', $pledgeBlock);
+        $this->_values['pledge_block_id'] = $pledgeBlock['id'] ?? NULL;
+        $this->_values['max_reminders'] = $pledgeBlock['max_reminders'] ?? NULL;
+        $this->_values['initial_reminder_day'] = $pledgeBlock['initial_reminder_day'] ?? NULL;
+        $this->_values['additional_reminder_day'] = $pledgeBlock['additional_reminder_day'] ?? NULL;
 
         //set pledge id in values
         $pledgeId = CRM_Utils_Request::retrieve('pledgeId', 'Positive', $this);
@@ -482,7 +482,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // check if billing block is required for pay later
     if (!empty($this->_values['is_pay_later'])) {
-      $this->_isBillingAddressRequiredForPayLater = CRM_Utils_Array::value('is_billing_required', $this->_values);
+      $this->_isBillingAddressRequiredForPayLater = $this->_values['is_billing_required'] ?? NULL;
       $this->assign('isBillingAddressRequiredForPayLater', $this->_isBillingAddressRequiredForPayLater);
     }
   }
@@ -656,14 +656,14 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             $field['data_type'] == 'File' || ($viewOnly && $field['name'] == 'image_URL')
           ) {
             //retrieve file value from submitted values on basis of $profileContactType
-            $fileValue = CRM_Utils_Array::value($key, $this->_params);
+            $fileValue = $this->_params[$key] ?? NULL;
             if (!empty($profileContactType) && !empty($this->_params[$profileContactType])) {
-              $fileValue = CRM_Utils_Array::value($key, $this->_params[$profileContactType]);
+              $fileValue = $this->_params[$profileContactType][$key] ?? NULL;
             }
 
             if ($fileValue) {
-              $path = CRM_Utils_Array::value('name', $fileValue);
-              $fileType = CRM_Utils_Array::value('type', $fileValue);
+              $path = $fileValue['name'] ?? NULL;
+              $fileType = $fileValue['type'] ?? NULL;
               $fileValue = CRM_Utils_File::getFileURL($path, $fileType);
             }
 
@@ -1154,7 +1154,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $allowAutoRenewMembership = $autoRenewOption = FALSE;
       $autoRenewMembershipTypeOptions = [];
 
-      $separateMembershipPayment = CRM_Utils_Array::value('is_separate_payment', $this->_membershipBlock);
+      $separateMembershipPayment = $this->_membershipBlock['is_separate_payment'] ?? NULL;
 
       if ($membershipPriceset) {
         foreach ($this->_priceSet['fields'] as $pField) {
@@ -1346,7 +1346,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * Arguably the form should start to build $this->_params in the pre-process main page & use that array consistently throughout.
    */
   protected function setRecurringMembershipParams() {
-    $selectedMembershipTypeID = CRM_Utils_Array::value('selectMembership', $this->_params);
+    $selectedMembershipTypeID = $this->_params['selectMembership'] ?? NULL;
     if ($selectedMembershipTypeID) {
       // @todo the price_x fields will ALWAYS allow us to determine the membership - so we should ignore
       // 'selectMembership' and calculate from the price_x fields so we have one method that always works

--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -139,7 +139,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
     $monthlyChart = $yearlyChart = FALSE;
 
     foreach ($chartData as $chartKey => & $values) {
-      $chartValues = CRM_Utils_Array::value('values', $values);
+      $chartValues = $values['values'] ?? NULL;
 
       if (!is_array($chartValues) || empty($chartValues)) {
         continue;

--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -156,7 +156,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     $this->applyFilter('__ALL__', 'trim');
 
     $session = CRM_Core_Session::singleton();
-    $this->_cancelURL = CRM_Utils_Array::value('cancelURL', $_POST);
+    $this->_cancelURL = $_POST['cancelURL'] ?? NULL;
 
     if (!$this->_cancelURL) {
       $this->_cancelURL = CRM_Utils_System::url('civicrm/admin/contribute', 'reset=1');
@@ -289,7 +289,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
         'is_pledge_start_date_editable',
       ];
       foreach ($pledgeBlock as $key) {
-        $defaults[$key] = CRM_Utils_Array::value($key, $pledgeBlockDefaults);
+        $defaults[$key] = $pledgeBlockDefaults[$key] ?? NULL;
         if ($key == 'pledge_start_date' && !empty($pledgeBlockDefaults[$key])) {
           $defaultPledgeDate = (array) json_decode($pledgeBlockDefaults['pledge_start_date']);
           $pledgeDateFields = [

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -226,8 +226,8 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
               foreach ($options as $optionId => $optionValue) {
                 $countRow++;
                 $defaults['value'][$countRow] = $optionValue['amount'];
-                $defaults['label'][$countRow] = CRM_Utils_Array::value('label', $optionValue);
-                $defaults['name'][$countRow] = CRM_Utils_Array::value('name', $optionValue);
+                $defaults['label'][$countRow] = $optionValue['label'] ?? NULL;
+                $defaults['name'][$countRow] = $optionValue['name'] ?? NULL;
                 $defaults['weight'][$countRow] = $optionValue['weight'];
 
                 $defaults["price_field_value"][$countRow] = $optionValue['id'];
@@ -339,8 +339,8 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     if (!empty($fields['amount_block_is_active']) && empty($fields['price_set_id']) && empty($fields['amount_label'])) {
       $errors['amount_label'] = ts('Please enter the contribution amount label.');
     }
-    $minAmount = CRM_Utils_Array::value('min_amount', $fields);
-    $maxAmount = CRM_Utils_Array::value('max_amount', $fields);
+    $minAmount = $fields['min_amount'] ?? NULL;
+    $maxAmount = $fields['max_amount'] ?? NULL;
     if (!empty($minAmount) && !empty($maxAmount)) {
       $minAmount = CRM_Utils_Rule::cleanMoney($minAmount);
       $maxAmount = CRM_Utils_Rule::cleanMoney($maxAmount);
@@ -395,7 +395,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
           !$priceSetId
         ) {
           //get the values of amount block
-          $values = CRM_Utils_Array::value('value', $fields);
+          $values = $fields['value'] ?? NULL;
           $isSetRow = FALSE;
           for ($i = 1; $i < self::NUM_OPTION; $i++) {
             if ((isset($values[$i]) && (strlen(trim($values[$i])) > 0))) {
@@ -439,7 +439,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     }
 
     // check for price set.
-    $priceSetID = CRM_Utils_Array::value('price_set_id', $params);
+    $priceSetID = $params['price_set_id'] ?? NULL;
 
     // get required fields.
     $fields = [
@@ -565,9 +565,9 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
           // process contribution amount block
           $deleteAmountBlk = FALSE;
 
-          $labels = CRM_Utils_Array::value('label', $params);
-          $values = CRM_Utils_Array::value('value', $params);
-          $default = CRM_Utils_Array::value('default', $params);
+          $labels = $params['label'] ?? NULL;
+          $values = $params['value'] ?? NULL;
+          $default = $params['default'] ?? NULL;
 
           $options = [];
           for ($i = 1; $i < self::NUM_OPTION; $i++) {
@@ -603,7 +603,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
                 $setParams['name'] = $pageTitle . '_' . date('is', $timeSec[0]) . $timeSec[1];
               }
               $setParams['is_quick_config'] = 1;
-              $setParams['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $this->_values);
+              $setParams['financial_type_id'] = $this->_values['financial_type_id'] ?? NULL;
               $setParams['extends'] = CRM_Core_Component::getComponentID('CiviContribute');
               $priceSet = CRM_Price_BAO_PriceSet::create($setParams);
               $priceSetId = $priceSet->id;
@@ -620,7 +620,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
                   }
                 }
                 if (implode('', $params['price_field_value'])) {
-                  $fieldParams['id'] = CRM_Utils_Array::value('price_field_id', $params);
+                  $fieldParams['id'] = $params['price_field_id'] ?? NULL;
                   $fieldParams['option_id'] = $params['price_field_value'];
                 }
                 else {
@@ -629,7 +629,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
                 }
               }
               else {
-                $priceFieldId = CRM_Utils_Array::value('price_field_other', $params);
+                $priceFieldId = $params['price_field_other'] ?? NULL;
               }
               $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', $priceFieldId, 'price_set_id');
             }
@@ -646,7 +646,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
                 $fieldParams['name'] = strtolower(CRM_Utils_String::munge("Contribution Amount", '_', 245));
               }
               else {
-                $fieldParams['id'] = CRM_Utils_Array::value('id', $editedResults);
+                $fieldParams['id'] = $editedResults['id'] ?? NULL;
               }
 
               $fieldParams['price_set_id'] = $priceSetId;
@@ -663,7 +663,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
               $fieldParams['html_type'] = 'Radio';
               $fieldParams['option_label'] = $params['label'];
               $fieldParams['option_amount'] = $params['value'];
-              $fieldParams['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $this->_values);
+              $fieldParams['financial_type_id'] = $this->_values['financial_type_id'] ?? NULL;
               foreach ($options as $value) {
                 $fieldParams['option_weight'][$value['weight']] = $value['weight'];
               }
@@ -759,7 +759,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
               'is_pledge_start_date_editable',
             ];
             foreach ($pledgeBlock as $key) {
-              $pledgeBlockParams[$key] = CRM_Utils_Array::value($key, $params);
+              $pledgeBlockParams[$key] = $params[$key] ?? NULL;
             }
             $pledgeBlockParams['is_pledge_interval'] = CRM_Utils_Array::value('is_pledge_interval',
               $params, FALSE

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -276,7 +276,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams);
 
       // @todo - stop changing formValues - respect submitted form values, change a working array.
-      $tags = CRM_Utils_Array::value('contact_tags', $this->_formValues);
+      $tags = $this->_formValues['contact_tags'] ?? NULL;
       if ($tags && !is_array($tags)) {
         // @todo - stop changing formValues - respect submitted form values, change a working array.
         unset($this->_formValues['contact_tags']);
@@ -291,7 +291,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
         }
       }
 
-      $group = CRM_Utils_Array::value('group', $this->_formValues);
+      $group = $this->_formValues['group'] ?? NULL;
       if ($group && !is_array($group)) {
         // @todo - stop changing formValues - respect submitted form values, change a working array.
         unset($this->_formValues['group']);

--- a/CRM/Contribute/Form/SoftCredit.php
+++ b/CRM/Contribute/Form/SoftCredit.php
@@ -148,14 +148,14 @@ class CRM_Contribute_Form_SoftCredit {
     if (!empty($form->_softCreditInfo['pcp_id'])) {
       $noPCP = FALSE;
       $pcpInfo = $form->_softCreditInfo;
-      $pcpId = CRM_Utils_Array::value('pcp_id', $pcpInfo);
+      $pcpId = $pcpInfo['pcp_id'] ?? NULL;
       $pcpTitle = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP', $pcpId, 'title');
       $contributionPageTitle = CRM_PCP_BAO_PCP::getPcpPageTitle($pcpId, 'contribute');
       $defaults['pcp_made_through'] = CRM_Utils_Array::value('sort_name', $pcpInfo) . " :: " . $pcpTitle . " :: " . $contributionPageTitle;
-      $defaults['pcp_made_through_id'] = CRM_Utils_Array::value('pcp_id', $pcpInfo);
-      $defaults['pcp_display_in_roll'] = CRM_Utils_Array::value('pcp_display_in_roll', $pcpInfo);
-      $defaults['pcp_roll_nickname'] = CRM_Utils_Array::value('pcp_roll_nickname', $pcpInfo);
-      $defaults['pcp_personal_note'] = CRM_Utils_Array::value('pcp_personal_note', $pcpInfo);
+      $defaults['pcp_made_through_id'] = $pcpInfo['pcp_id'] ?? NULL;
+      $defaults['pcp_display_in_roll'] = $pcpInfo['pcp_display_in_roll'] ?? NULL;
+      $defaults['pcp_roll_nickname'] = $pcpInfo['pcp_roll_nickname'] ?? NULL;
+      $defaults['pcp_personal_note'] = $pcpInfo['pcp_personal_note'] ?? NULL;
     }
 
     $form->assign('noSoftCredit', $noSoftCredit);

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -57,7 +57,7 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
 
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
-    $form->_task = CRM_Utils_Array::value('task', $values);
+    $form->_task = $values['task'] ?? NULL;
     $contributeTasks = CRM_Contribute_Task::tasks();
     $form->assign('taskName', CRM_Utils_Array::value($form->_task, $contributeTasks));
 

--- a/CRM/Contribute/Form/Task/Batch.php
+++ b/CRM/Contribute/Form/Task/Batch.php
@@ -135,7 +135,7 @@ class CRM_Contribute_Form_Task_Batch extends CRM_Contribute_Form_Task {
       foreach ($this->_fields as $name => $field) {
         $entityColumnValue = [];
         if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($name)) {
-          $customValue = CRM_Utils_Array::value($customFieldID, $customFields);
+          $customValue = $customFields[$customFieldID] ?? NULL;
           if (!empty($customValue['extends_entity_column_value'])) {
             $entityColumnValue = explode(CRM_Core_DAO::VALUE_SEPARATOR,
               $customValue['extends_entity_column_value']

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -227,9 +227,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       $ids['contribution'] = $contribID;
       $ids['contributionRecur'] = NULL;
       $ids['contributionPage'] = NULL;
-      $ids['membership'] = CRM_Utils_Array::value('membership', $detail);
-      $ids['participant'] = CRM_Utils_Array::value('participant', $detail);
-      $ids['event'] = CRM_Utils_Array::value('event', $detail);
+      $ids['membership'] = $detail['membership'] ?? NULL;
+      $ids['participant'] = $detail['participant'] ?? NULL;
+      $ids['event'] = $detail['event'] ?? NULL;
 
       if (!$invoiceElements['baseIPN']->validateData($input, $ids, $objects, FALSE)) {
         CRM_Core_Error::fatal();
@@ -282,7 +282,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
           $dataArray[(string) $taxRate['tax_rate']] = $dataArray[(string) $taxRate['tax_rate']] + CRM_Utils_Array::value('tax_amount', $taxRate);
         }
         else {
-          $dataArray[(string) $taxRate['tax_rate']] = CRM_Utils_Array::value('tax_amount', $taxRate);
+          $dataArray[(string) $taxRate['tax_rate']] = $taxRate['tax_amount'] ?? NULL;
         }
         $subTotal += CRM_Utils_Array::value('subTotal', $taxRate);
       }
@@ -299,11 +299,11 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
           'confirm_from_email',
         ];
         CRM_Core_DAO::commonRetrieveAll($daoName, 'id', $pageId, $mailDetails, $mailElements);
-        $values['title'] = CRM_Utils_Array::value('title', $mailDetails[$contribution->_relatedObjects['event']->id]);
-        $values['confirm_from_name'] = CRM_Utils_Array::value('confirm_from_name', $mailDetails[$contribution->_relatedObjects['event']->id]);
-        $values['confirm_from_email'] = CRM_Utils_Array::value('confirm_from_email', $mailDetails[$contribution->_relatedObjects['event']->id]);
+        $values['title'] = $mailDetails[$contribution->_relatedObjects['event']->id]['title'] ?? NULL;
+        $values['confirm_from_name'] = $mailDetails[$contribution->_relatedObjects['event']->id]['confirm_from_name'] ?? NULL;
+        $values['confirm_from_email'] = $mailDetails[$contribution->_relatedObjects['event']->id]['confirm_from_email'] ?? NULL;
 
-        $title = CRM_Utils_Array::value('title', $mailDetails[$contribution->_relatedObjects['event']->id]);
+        $title = $mailDetails[$contribution->_relatedObjects['event']->id]['title'] ?? NULL;
       }
       elseif ($contribution->_component == 'contribute') {
         $daoName = 'CRM_Contribute_DAO_ContributionPage';
@@ -414,7 +414,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       ];
 
       // from email address
-      $fromEmailAddress = CRM_Utils_Array::value('from_email_address', $params);
+      $fromEmailAddress = $params['from_email_address'] ?? NULL;
 
       // condition to check for download PDF Invoice or email Invoice
       if ($invoiceElements['createPdf']) {
@@ -442,8 +442,8 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         $sendTemplateParams['tplParams'] = array_merge($tplParams, ['email_comment' => $invoiceElements['params']['email_comment']]);
         $sendTemplateParams['from'] = $fromEmailAddress;
         $sendTemplateParams['toEmail'] = $email;
-        $sendTemplateParams['cc'] = CRM_Utils_Array::value('cc_receipt', $values);
-        $sendTemplateParams['bcc'] = CRM_Utils_Array::value('bcc_receipt', $values);
+        $sendTemplateParams['cc'] = $values['cc_receipt'] ?? NULL;
+        $sendTemplateParams['bcc'] = $values['bcc_receipt'] ?? NULL;
 
         list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         // functions call for adding activity with attachment
@@ -456,8 +456,8 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         $sendTemplateParams['tplParams'] = array_merge($tplParams, ['email_comment' => $invoiceElements['params']['email_comment']]);
         $sendTemplateParams['from'] = $fromEmailAddress;
         $sendTemplateParams['toEmail'] = $email;
-        $sendTemplateParams['cc'] = CRM_Utils_Array::value('cc_confirm', $values);
-        $sendTemplateParams['bcc'] = CRM_Utils_Array::value('bcc_confirm', $values);
+        $sendTemplateParams['cc'] = $values['cc_confirm'] ?? NULL;
+        $sendTemplateParams['bcc'] = $values['bcc_confirm'] ?? NULL;
 
         list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         // functions call for adding activity with attachment

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -154,9 +154,9 @@ AND    {$this->_componentClause}";
       $ids['contribution'] = $contribID;
       $ids['contributionRecur'] = NULL;
       $ids['contributionPage'] = NULL;
-      $ids['membership'] = CRM_Utils_Array::value('membership', $detail);
-      $ids['participant'] = CRM_Utils_Array::value('participant', $detail);
-      $ids['event'] = CRM_Utils_Array::value('event', $detail);
+      $ids['membership'] = $detail['membership'] ?? NULL;
+      $ids['participant'] = $detail['participant'] ?? NULL;
+      $ids['event'] = $detail['event'] ?? NULL;
 
       if (!$elements['baseIPN']->validateData($input, $ids, $objects, FALSE)) {
         throw new CRM_Core_Exception('invalid data');

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -77,7 +77,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     if (isset($this->_activityId)) {
       $params = ['id' => $this->_activityId];
       CRM_Activity_BAO_Activity::retrieve($params, $defaults);
-      $defaults['html_message'] = CRM_Utils_Array::value('details', $defaults);
+      $defaults['html_message'] = $defaults['details'] ?? NULL;
     }
     else {
       $defaults['thankyou_update'] = 1;

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -258,7 +258,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     $contributions = $contacts = [];
     foreach ($contributionIDs as $item => $contributionId) {
       $contribution = CRM_Contribute_BAO_Contribution::getContributionTokenValues($contributionId, $messageToken)['values'][$contributionId];
-      $contribution['campaign'] = CRM_Utils_Array::value('contribution_campaign_title', $contribution);
+      $contribution['campaign'] = $contribution['contribution_campaign_title'] ?? NULL;
       $contributions[$contributionId] = $contribution;
 
       if ($isIncludeSoftCredits) {

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -210,7 +210,7 @@ AND    co.id IN ( $contribIDs )";
    * @throws \Exception
    */
   public static function processForm($form, $params) {
-    $statusID = CRM_Utils_Array::value('contribution_status_id', $params);
+    $statusID = $params['contribution_status_id'] ?? NULL;
     $baseIPN = new CRM_Core_Payment_BaseIPN();
 
     $transaction = new CRM_Core_Transaction();
@@ -229,9 +229,9 @@ AND    co.id IN ( $contribIDs )";
       $ids['contribution'] = $row['contribution_id'];
       $ids['contributionRecur'] = NULL;
       $ids['contributionPage'] = NULL;
-      $ids['membership'] = CRM_Utils_Array::value('membership', $details[$row['contribution_id']]);
-      $ids['participant'] = CRM_Utils_Array::value('participant', $details[$row['contribution_id']]);
-      $ids['event'] = CRM_Utils_Array::value('event', $details[$row['contribution_id']]);
+      $ids['membership'] = $details[$row['contribution_id']]['membership'] ?? NULL;
+      $ids['participant'] = $details[$row['contribution_id']]['participant'] ?? NULL;
+      $ids['event'] = $details[$row['contribution_id']]['event'] ?? NULL;
 
       if (!$baseIPN->validateData($input, $ids, $objects, FALSE)) {
         CRM_Core_Error::fatal();

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -252,7 +252,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
       // format new address for display
       $addressParts = array("street_address", "city", "postal_code", "state_province", "country");
       foreach ($addressParts as $part) {
-        $addressParts[$part] = CRM_Utils_Array::value($part, $processorParams);
+        $addressParts[$part] = $processorParams[$part] ?? NULL;
       }
       $tplParams['address'] = CRM_Utils_Address::format($addressParts);
 
@@ -262,7 +262,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
       $addressParts = array("street_address", "city", "postal_code", "state_province", "country");
       foreach ($addressParts as $part) {
         $key = "{$part}-{$this->_bltID}";
-        $addressParts[$part] = CRM_Utils_Array::value($key, $this->_defaults);
+        $addressParts[$part] = $this->_defaults[$key] ?? NULL;
       }
       $this->_defaults['address'] = CRM_Utils_Address::format($addressParts);
 

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -384,7 +384,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     if (!empty($fields['saveMapping'])) {
-      $nameField = CRM_Utils_Array::value('saveMappingName', $fields);
+      $nameField = $fields['saveMappingName'] ?? NULL;
       if (empty($nameField)) {
         $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
       }

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -679,8 +679,8 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
         ) {
           $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
           foreach ($customOption as $customFldID => $customValue) {
-            $val = CRM_Utils_Array::value('value', $customValue);
-            $label = CRM_Utils_Array::value('label', $customValue);
+            $val = $customValue['value'] ?? NULL;
+            $label = $customValue['label'] ?? NULL;
             $label = strtolower($label);
             $value = strtolower(trim($value));
             if (($value == $label) || ($value == strtolower($val))) {
@@ -715,9 +715,9 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
           // import contribution record according to select contact type
           require_once 'CRM/Contact/DAO/Contact.php';
           $contactType = new CRM_Contact_DAO_Contact();
-          $contactId = CRM_Utils_Array::value('contribution_contact_id', $params);
-          $externalId = CRM_Utils_Array::value('external_identifier', $params);
-          $email = CRM_Utils_Array::value('email', $params);
+          $contactId = $params['contribution_contact_id'] ?? NULL;
+          $externalId = $params['external_identifier'] ?? NULL;
+          $email = $params['email'] ?? NULL;
           //when insert mode check contact id or external identifier
           if ($contactId || $externalId) {
             $contactType->id = $contactId;
@@ -825,9 +825,9 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
           $value[$key] = $mismatchContactType = $softCreditContactIds = '';
           if (isset($params[$key]) && is_array($params[$key])) {
             foreach ($params[$key] as $softKey => $softParam) {
-              $contactId = CRM_Utils_Array::value('contact_id', $softParam);
-              $externalId = CRM_Utils_Array::value('external_identifier', $softParam);
-              $email = CRM_Utils_Array::value('email', $softParam);
+              $contactId = $softParam['contact_id'] ?? NULL;
+              $externalId = $softParam['external_identifier'] ?? NULL;
+              $email = $softParam['email'] ?? NULL;
               if ($contactId || $externalId) {
                 require_once 'CRM/Contact/DAO/Contact.php';
                 $contact = new CRM_Contact_DAO_Contact();
@@ -885,9 +885,9 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
           }
 
           // get total amount of from import fields
-          $totalAmount = CRM_Utils_Array::value('total_amount', $params);
+          $totalAmount = $params['total_amount'] ?? NULL;
 
-          $onDuplicate = CRM_Utils_Array::value('onDuplicate', $params);
+          $onDuplicate = $params['onDuplicate'] ?? NULL;
 
           // we need to get contact id $contributionContactID to
           // retrieve pledge details as well as to validate pledge ID

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -530,7 +530,7 @@ ORDER BY is_active desc, title asc
       );
 
       //show campaigns on selector.
-      $contribution[$dao->id]['campaign'] = CRM_Utils_Array::value($dao->campaign_id, $allCampaigns);
+      $contribution[$dao->id]['campaign'] = $allCampaigns[$dao->campaign_id] ?? NULL;
     }
 
     if (isset($contribution)) {
@@ -689,7 +689,7 @@ ORDER BY UPPER(LEFT(title, 1))
     // build the formatted configure links.
     $formattedConfLinks = self::configureActionLinks();
     foreach ($formattedConfLinks as $act => & $link) {
-      $sectionName = CRM_Utils_Array::value('uniqueName', $link);
+      $sectionName = $link['uniqueName'] ?? NULL;
       if (!$sectionName) {
         continue;
       }

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -194,7 +194,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'contribution_status_id' => ['NOT IN' => CRM_Contribute_BAO_ContributionRecur::getInactiveStatuses()],
         'options' => ['limit' => 0, 'sort' => 'is_test, start_date DESC'],
       ]);
-      $recurContributions = CRM_Utils_Array::value('values', $contributionRecurResult);
+      $recurContributions = $contributionRecurResult['values'] ?? NULL;
     }
     catch (Exception $e) {
       $recurContributions = [];
@@ -216,7 +216,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'contribution_status_id' => ['IN' => CRM_Contribute_BAO_ContributionRecur::getInactiveStatuses()],
         'options' => ['limit' => 0, 'sort' => 'is_test, start_date DESC'],
       ]);
-      $recurContributions = CRM_Utils_Array::value('values', $contributionRecurResult);
+      $recurContributions = $contributionRecurResult['values'] ?? NULL;
     }
     catch (Exception $e) {
       $recurContributions = NULL;

--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -108,7 +108,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
     }
 
     if ($id) {
-      $result = CRM_Utils_Array::value($id, self::$financialType);
+      $result = self::$financialType[$id] ?? NULL;
       return $result;
     }
     return self::$financialType;
@@ -149,7 +149,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
 
     }
     if ($id) {
-      $result = CRM_Utils_Array::value($id, self::$financialAccount[$cacheKey]);
+      $result = self::$financialAccount[$cacheKey][$id] ?? NULL;
       return $result;
     }
     return self::$financialAccount[$cacheKey];
@@ -197,7 +197,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
       );
     }
     if ($id) {
-      $pageTitle = CRM_Utils_Array::value($id, $cacheVarToUse);
+      $pageTitle = $cacheVarToUse[$id] ?? NULL;
       return $pageTitle;
     }
     return $cacheVarToUse;
@@ -300,7 +300,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
     }
     $result = self::$contributionStatus[$cacheKey];
     if ($id) {
-      $result = CRM_Utils_Array::value($id, $result);
+      $result = $result[$id] ?? NULL;
     }
 
     return $result;
@@ -331,7 +331,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
     }
     $result = self::$pcPage[$pageType];
     if ($id) {
-      return $result = CRM_Utils_Array::value($id, $result);
+      return $result = $result[$id] ?? NULL;
     }
 
     return $result;
@@ -412,7 +412,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
     }
 
     if ($id) {
-      $result = CRM_Utils_Array::value($id, self::$batch);
+      $result = self::$batch[$id] ?? NULL;
       return $result;
     }
     return self::$batch;

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -390,7 +390,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
       //carry campaign on selectors.
       // @todo - I can't find any evidence that 'carrying' the campaign on selectors actually
       // results in it being displayed anywhere so why do we do this???
-      $row['campaign'] = CRM_Utils_Array::value($result->contribution_campaign_id, $allCampaigns);
+      $row['campaign'] = $allCampaigns[$result->contribution_campaign_id] ?? NULL;
       $row['campaign_id'] = $result->contribution_campaign_id;
 
       // add contribution status name

--- a/CRM/Contribute/StateMachine/Search.php
+++ b/CRM/Contribute/StateMachine/Search.php
@@ -68,7 +68,7 @@ class CRM_Contribute_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -113,7 +113,7 @@ class CRM_Contribute_Task extends CRM_Core_Task {
 
       // remove action "Invoices - print or email"
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
       if (!$invoicing) {
         unset(self::$_tasks[self::PDF_INVOICE]);
       }

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -140,7 +140,7 @@ class CRM_Core_Action {
    *   the action mask corresponding to the input string
    */
   public static function mapItem($item) {
-    $mask = CRM_Utils_Array::value(trim($item), self::$_names);
+    $mask = self::$_names[trim($item)] ?? NULL;
     return $mask ? $mask : 0;
   }
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -673,7 +673,7 @@ FROM civicrm_action_schedule cas
     //to get primary mobile ph,if not get a first mobile phONE
     if (!empty($toPhoneNumbers)) {
       $toPhoneNumberDetails = reset($toPhoneNumbers);
-      $toPhoneNumber = CRM_Utils_Array::value('phone', $toPhoneNumberDetails);
+      $toPhoneNumber = $toPhoneNumberDetails['phone'] ?? NULL;
       return $toPhoneNumber;
     }
     return NULL;

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -353,7 +353,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
         unset($params[$fld]);
       }
       // main parse string.
-      $parseString = CRM_Utils_Array::value('street_address', $params);
+      $parseString = $params['street_address'] ?? NULL;
       $parsedFields = CRM_Core_BAO_Address::parseStreetAddress($parseString);
 
       // merge parse address in to main address block.
@@ -450,7 +450,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
     $address = new CRM_Core_BAO_Address();
 
     if (empty($entityBlock['entity_table'])) {
-      $address->$fieldName = CRM_Utils_Array::value($fieldName, $entityBlock);
+      $address->$fieldName = $entityBlock[$fieldName] ?? NULL;
     }
     else {
       $addressIds = [];
@@ -490,7 +490,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
 
       // add state and country information: CRM-369
       if (!empty($address->location_type_id)) {
-        $values['location_type'] = CRM_Utils_Array::value($address->location_type_id, $locationTypes);
+        $values['location_type'] = $locationTypes[$address->location_type_id] ?? NULL;
       }
       if (!empty($address->state_province_id)) {
         $address->state = CRM_Core_PseudoConstant::stateProvinceAbbreviation($address->state_province_id, FALSE);
@@ -978,8 +978,8 @@ SELECT is_primary,
       }
 
       $nameVal = explode('-', $values['name']);
-      $fldName = CRM_Utils_Array::value(0, $nameVal);
-      $locType = CRM_Utils_Array::value(1, $nameVal);
+      $fldName = $nameVal[0] ?? NULL;
+      $locType = $nameVal[1] ?? NULL;
       if (!empty($values['location_type_id'])) {
         $locType = $values['location_type_id'];
       }

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -231,7 +231,7 @@ class CRM_Core_BAO_Block {
     //get existing block ids.
     $blockIds = self::getBlockIds($blockName, $contactId, $entityElements);
     foreach ($params[$blockName] as $count => $value) {
-      $blockId = CRM_Utils_Array::value('id', $value);
+      $blockId = $value['id'] ?? NULL;
       if ($blockId) {
         if (is_array($blockIds) && array_key_exists($blockId, $blockIds)) {
           unset($blockIds[$blockId]);
@@ -275,13 +275,13 @@ class CRM_Core_BAO_Block {
         if (empty($value['id']) && $blockValue['locationTypeId'] == CRM_Utils_Array::value('location_type_id', $value) && !$isIdSet) {
           $valueId = FALSE;
           if ($blockName == 'phone') {
-            $phoneTypeBlockValue = CRM_Utils_Array::value('phoneTypeId', $blockValue);
+            $phoneTypeBlockValue = $blockValue['phoneTypeId'] ?? NULL;
             if ($phoneTypeBlockValue == CRM_Utils_Array::value('phone_type_id', $value)) {
               $valueId = TRUE;
             }
           }
           elseif ($blockName == 'im') {
-            $providerBlockValue = CRM_Utils_Array::value('providerId', $blockValue);
+            $providerBlockValue = $blockValue['providerId'] ?? NULL;
             if (!empty($value['provider_id']) && $providerBlockValue == $value['provider_id']) {
               $valueId = TRUE;
             }
@@ -474,8 +474,8 @@ class CRM_Core_BAO_Block {
    * @return int
    */
   public static function primaryComparison($location1, $location2) {
-    $l1 = CRM_Utils_Array::value('is_primary', $location1);
-    $l2 = CRM_Utils_Array::value('is_primary', $location2);
+    $l1 = $location1['is_primary'] ?? NULL;
+    $l2 = $location2['is_primary'] ?? NULL;
     if ($l1 == $l2) {
       return 0;
     }

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1113,7 +1113,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         elseif (is_array($value)) {
           $v = [];
           foreach ($value as $key => $val) {
-            $v[] = CRM_Utils_Array::value($val, $field['options']);
+            $v[] = $field['options'][$val] ?? NULL;
           }
           $display = implode(', ', $v);
         }
@@ -1130,7 +1130,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         $value = is_array($value) ? CRM_Utils_Array::first($value) : $value;
 
         $actualPHPFormats = CRM_Utils_Date::datePluginToPHPFormats();
-        $format = CRM_Utils_Array::value('date_format', $field);
+        $format = $field['date_format'] ?? NULL;
 
         if ($format) {
           if (array_key_exists($format, $actualPHPFormats)) {
@@ -1966,8 +1966,8 @@ WHERE  id IN ( %1, %2 )
         break;
     }
 
-    $htmlType = CRM_Utils_Array::value('html_type', $params);
-    $dataType = CRM_Utils_Array::value('data_type', $params);
+    $htmlType = $params['html_type'] ?? NULL;
+    $dataType = $params['data_type'] ?? NULL;
     $allowedOptionTypes = ['String', 'Int', 'Float', 'Money'];
 
     // create any option group & values if required
@@ -2450,7 +2450,7 @@ WHERE      f.id IN ($ids)";
 
     //pick up profile fields.
     $profileFields = [];
-    $ufGroupId = CRM_Utils_Array::value('ufGroupId', $params);
+    $ufGroupId = $params['ufGroupId'] ?? NULL;
     if ($ufGroupId) {
       $profileFields = CRM_Core_BAO_UFGroup::getFields($ufGroupId,
         FALSE,
@@ -2474,8 +2474,8 @@ WHERE      f.id IN ($ids)";
       $dataType = $field->data_type;
 
       $profileField = CRM_Utils_Array::value($key, $profileFields, []);
-      $fieldTitle = CRM_Utils_Array::value('title', $profileField);
-      $isRequired = CRM_Utils_Array::value('is_required', $profileField);
+      $fieldTitle = $profileField['title'] ?? NULL;
+      $isRequired = $profileField['is_required'] ?? NULL;
       if (!$fieldTitle) {
         $fieldTitle = $field->label;
       }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -46,7 +46,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     }
 
     $extends = CRM_Utils_Array::value('extends', $params, []);
-    $extendsEntity = CRM_Utils_Array::value(0, $extends);
+    $extendsEntity = $extends[0] ?? NULL;
 
     $participantEntities = [
       'ParticipantRole',
@@ -68,7 +68,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     }
 
     // this is format when form get submit.
-    $extendsChildType = CRM_Utils_Array::value(1, $extends);
+    $extendsChildType = $extends[1] ?? NULL;
     // lets allow user to pass direct child type value, CRM-6893
     if (!empty($params['extends_entity_column_value'])) {
       $extendsChildType = $params['extends_entity_column_value'];
@@ -144,8 +144,8 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
       }
     }
     else {
-      $group->created_id = CRM_Utils_Array::value('created_id', $params);
-      $group->created_date = CRM_Utils_Array::value('created_date', $params);
+      $group->created_id = $params['created_id'] ?? NULL;
+      $group->created_date = $params['created_date'] ?? NULL;
 
       // we do this only once, so name never changes
       if (isset($params['name'])) {
@@ -1556,7 +1556,7 @@ ORDER BY civicrm_custom_group.weight,
     foreach ($groupTree as $id => $group) {
       CRM_Core_ShowHideBlocks::links($form, $group['title'], '', '');
       foreach ($group['fields'] as $field) {
-        $required = CRM_Utils_Array::value('is_required', $field);
+        $required = $field['is_required'] ?? NULL;
         //fix for CRM-1620
         if ($field['data_type'] == 'File') {
           if (!empty($field['element_value']['data'])) {
@@ -1815,21 +1815,21 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
       }
 
       // add group information
-      $formattedGroupTree[$key]['name'] = CRM_Utils_Array::value('name', $value);
-      $formattedGroupTree[$key]['title'] = CRM_Utils_Array::value('title', $value);
-      $formattedGroupTree[$key]['help_pre'] = CRM_Utils_Array::value('help_pre', $value);
-      $formattedGroupTree[$key]['help_post'] = CRM_Utils_Array::value('help_post', $value);
-      $formattedGroupTree[$key]['collapse_display'] = CRM_Utils_Array::value('collapse_display', $value);
-      $formattedGroupTree[$key]['collapse_adv_display'] = CRM_Utils_Array::value('collapse_adv_display', $value);
-      $formattedGroupTree[$key]['style'] = CRM_Utils_Array::value('style', $value);
+      $formattedGroupTree[$key]['name'] = $value['name'] ?? NULL;
+      $formattedGroupTree[$key]['title'] = $value['title'] ?? NULL;
+      $formattedGroupTree[$key]['help_pre'] = $value['help_pre'] ?? NULL;
+      $formattedGroupTree[$key]['help_post'] = $value['help_post'] ?? NULL;
+      $formattedGroupTree[$key]['collapse_display'] = $value['collapse_display'] ?? NULL;
+      $formattedGroupTree[$key]['collapse_adv_display'] = $value['collapse_adv_display'] ?? NULL;
+      $formattedGroupTree[$key]['style'] = $value['style'] ?? NULL;
 
       // this params needed of bulding multiple values
-      $formattedGroupTree[$key]['is_multiple'] = CRM_Utils_Array::value('is_multiple', $value);
-      $formattedGroupTree[$key]['extends'] = CRM_Utils_Array::value('extends', $value);
-      $formattedGroupTree[$key]['extends_entity_column_id'] = CRM_Utils_Array::value('extends_entity_column_id', $value);
-      $formattedGroupTree[$key]['extends_entity_column_value'] = CRM_Utils_Array::value('extends_entity_column_value', $value);
-      $formattedGroupTree[$key]['subtype'] = CRM_Utils_Array::value('subtype', $value);
-      $formattedGroupTree[$key]['max_multiple'] = CRM_Utils_Array::value('max_multiple', $value);
+      $formattedGroupTree[$key]['is_multiple'] = $value['is_multiple'] ?? NULL;
+      $formattedGroupTree[$key]['extends'] = $value['extends'] ?? NULL;
+      $formattedGroupTree[$key]['extends_entity_column_id'] = $value['extends_entity_column_id'] ?? NULL;
+      $formattedGroupTree[$key]['extends_entity_column_value'] = $value['extends_entity_column_value'] ?? NULL;
+      $formattedGroupTree[$key]['subtype'] = $value['subtype'] ?? NULL;
+      $formattedGroupTree[$key]['max_multiple'] = $value['max_multiple'] ?? NULL;
 
       // add field information
       foreach ($value['fields'] as $k => $properties) {
@@ -1910,13 +1910,13 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
             if (!empty($customValueId) && $customValueId != $values['id']) {
               continue;
             }
-            $details[$groupID][$values['id']]['title'] = CRM_Utils_Array::value('title', $group);
-            $details[$groupID][$values['id']]['name'] = CRM_Utils_Array::value('name', $group);
-            $details[$groupID][$values['id']]['help_pre'] = CRM_Utils_Array::value('help_pre', $group);
-            $details[$groupID][$values['id']]['help_post'] = CRM_Utils_Array::value('help_post', $group);
-            $details[$groupID][$values['id']]['collapse_display'] = CRM_Utils_Array::value('collapse_display', $group);
-            $details[$groupID][$values['id']]['collapse_adv_display'] = CRM_Utils_Array::value('collapse_adv_display', $group);
-            $details[$groupID][$values['id']]['style'] = CRM_Utils_Array::value('style', $group);
+            $details[$groupID][$values['id']]['title'] = $group['title'] ?? NULL;
+            $details[$groupID][$values['id']]['name'] = $group['name'] ?? NULL;
+            $details[$groupID][$values['id']]['help_pre'] = $group['help_pre'] ?? NULL;
+            $details[$groupID][$values['id']]['help_post'] = $group['help_post'] ?? NULL;
+            $details[$groupID][$values['id']]['collapse_display'] = $group['collapse_display'] ?? NULL;
+            $details[$groupID][$values['id']]['collapse_adv_display'] = $group['collapse_adv_display'] ?? NULL;
+            $details[$groupID][$values['id']]['style'] = $group['style'] ?? NULL;
             $details[$groupID][$values['id']]['fields'][$k] = [
               'field_title' => $properties['label'] ?? NULL,
               'field_type' => $properties['html_type'] ?? NULL,
@@ -1938,18 +1938,18 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
               $details[$groupID][$values['id']]['fields'][$k]['field_data_type'] ==
               'ContactReference'
             ) {
-              $details[$groupID][$values['id']]['fields'][$k]['contact_ref_id'] = CRM_Utils_Array::value('data', $values);
+              $details[$groupID][$values['id']]['fields'][$k]['contact_ref_id'] = $values['data'] ?? NULL;
             }
           }
         }
         else {
-          $details[$groupID][0]['title'] = CRM_Utils_Array::value('title', $group);
-          $details[$groupID][0]['name'] = CRM_Utils_Array::value('name', $group);
-          $details[$groupID][0]['help_pre'] = CRM_Utils_Array::value('help_pre', $group);
-          $details[$groupID][0]['help_post'] = CRM_Utils_Array::value('help_post', $group);
-          $details[$groupID][0]['collapse_display'] = CRM_Utils_Array::value('collapse_display', $group);
-          $details[$groupID][0]['collapse_adv_display'] = CRM_Utils_Array::value('collapse_adv_display', $group);
-          $details[$groupID][0]['style'] = CRM_Utils_Array::value('style', $group);
+          $details[$groupID][0]['title'] = $group['title'] ?? NULL;
+          $details[$groupID][0]['name'] = $group['name'] ?? NULL;
+          $details[$groupID][0]['help_pre'] = $group['help_pre'] ?? NULL;
+          $details[$groupID][0]['help_post'] = $group['help_post'] ?? NULL;
+          $details[$groupID][0]['collapse_display'] = $group['collapse_display'] ?? NULL;
+          $details[$groupID][0]['collapse_adv_display'] = $group['collapse_adv_display'] ?? NULL;
+          $details[$groupID][0]['style'] = $group['style'] ?? NULL;
           $details[$groupID][0]['fields'][$k] = ['field_title' => CRM_Utils_Array::value('label', $properties)];
         }
       }

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -92,7 +92,7 @@ class CRM_Core_BAO_CustomValueTable {
                       CRM_Core_PseudoConstant::stateProvinceAbbreviation(), TRUE
                     );
                   }
-                  $validStates[] = CRM_Utils_Array::value('state_province_id', $states);
+                  $validStates[] = $states['state_province_id'] ?? NULL;
                 }
                 $value = implode(CRM_Core_DAO::VALUE_SEPARATOR,
                   $validStates
@@ -132,7 +132,7 @@ class CRM_Core_BAO_CustomValueTable {
                       CRM_Core_PseudoConstant::countryIsoCode(), TRUE
                     );
                   }
-                  $validCountries[] = CRM_Utils_Array::value('country_id', $countries);
+                  $validCountries[] = $countries['country_id'] ?? NULL;
                 }
                 $value = implode(CRM_Core_DAO::VALUE_SEPARATOR,
                   $validCountries
@@ -217,7 +217,7 @@ class CRM_Core_BAO_CustomValueTable {
             $count++;
           }
 
-          $fieldExtends = CRM_Utils_Array::value('extends', $field);
+          $fieldExtends = $field['extends'] ?? NULL;
           if (
             CRM_Utils_Array::value('entity_table', $field) == 'civicrm_contact'
             || $fieldExtends == 'Contact'
@@ -225,7 +225,7 @@ class CRM_Core_BAO_CustomValueTable {
             || $fieldExtends == 'Organization'
             || $fieldExtends == 'Household'
           ) {
-            $paramFieldsExtendContactForEntities[$entityID]['custom_' . CRM_Utils_Array::value('custom_field_id', $field)] = CRM_Utils_Array::value('custom_field_id', $field);
+            $paramFieldsExtendContactForEntities[$entityID]['custom_' . CRM_Utils_Array::value('custom_field_id', $field)] = $field['custom_field_id'] ?? NULL;
           }
         }
 

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -387,7 +387,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
   public static function addDashlet(&$params) {
 
     // special case to handle duplicate entries for report instances
-    $dashboardID = CRM_Utils_Array::value('id', $params);
+    $dashboardID = $params['id'] ?? NULL;
 
     if (!empty($params['instanceURL'])) {
       $query = "SELECT id
@@ -405,16 +405,16 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
         $dashlet->domain_id = CRM_Core_Config::domainID();
       }
       else {
-        $dashlet->domain_id = CRM_Utils_Array::value('domain_id', $params);
+        $dashlet->domain_id = $params['domain_id'] ?? NULL;
       }
 
       // Try and find an existing dashlet - it will be updated if found.
       if (!empty($params['name'])) {
-        $dashlet->name = CRM_Utils_Array::value('name', $params);
+        $dashlet->name = $params['name'] ?? NULL;
         $dashlet->find(TRUE);
       }
       else {
-        $dashlet->url = CRM_Utils_Array::value('url', $params);
+        $dashlet->url = $params['url'] ?? NULL;
         $dashlet->find(TRUE);
       }
 
@@ -494,8 +494,8 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     $valuesString = NULL;
     $columns = [];
     foreach ($params as $dashboardIDs) {
-      $contactID = CRM_Utils_Array::value('contact_id', $dashboardIDs);
-      $dashboardID = CRM_Utils_Array::value('dashboard_id', $dashboardIDs);
+      $contactID = $dashboardIDs['contact_id'] ?? NULL;
+      $dashboardID = $dashboardIDs['dashboard_id'] ?? NULL;
       $column = $dashboardIDs['column_no'] ?? 0;
       $columns[$column][$dashboardID] = 0;
     }

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -170,7 +170,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
       foreach ($fromEmailAddress as $key => $value) {
         $email = CRM_Utils_Mail::pluckEmailFromHeader($value);
         $fromArray = explode('"', $value);
-        $fromName = CRM_Utils_Array::value(1, $fromArray);
+        $fromName = $fromArray[1] ?? NULL;
         break;
       }
       return [$fromName, $email];

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -805,8 +805,8 @@ AND       CEF.entity_id    = %2";
    */
   public static function validateFileHash($hash, $entityId, $fileId) {
     $input = CRM_Utils_System::explode('_', $hash, 3);
-    $inputTs = CRM_Utils_Array::value(1, $input);
-    $inputLF = CRM_Utils_Array::value(2, $input);
+    $inputTs = $input[1] ?? NULL;
+    $inputLF = $input[2] ?? NULL;
     $testHash = CRM_Core_BAO_File::generateFileHash($entityId, $fileId, $inputTs, $inputLF);
     if (hash_equals($testHash, $hash)) {
       $now = time();

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -667,7 +667,7 @@ WHERE ceft.entity_id = %1";
     }
 
     $financialTrxn = $financialTrxn['values'][$financialTrxn['id']];
-    $paymentProcessorID = CRM_Utils_Array::value('financial_trxn_id.payment_processor_id', $financialTrxn);
+    $paymentProcessorID = $financialTrxn['financial_trxn_id.payment_processor_id'] ?? NULL;
 
     if ($paymentProcessorID) {
       return NULL;
@@ -696,7 +696,7 @@ WHERE ceft.entity_id = %1";
     // ensure that there are all the information in updated contribution object identified by $currentContribution
     $currentContribution->find(TRUE);
 
-    $deferredFinancialAccount = CRM_Utils_Array::value('deferred_financial_account_id', $inputParams);
+    $deferredFinancialAccount = $inputParams['deferred_financial_account_id'] ?? NULL;
     if (empty($deferredFinancialAccount)) {
       $deferredFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($prevContribution->financial_type_id, 'Deferred Revenue Account is');
     }

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -795,16 +795,16 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
     $locationTypeId = NULL;
     $saveMappingFields = $defaults;
 
-    $saveMappingFields['name'] = CRM_Utils_Array::value('1', $v);
-    $saveMappingFields['contact_type'] = CRM_Utils_Array::value('0', $v);
-    $locationId = CRM_Utils_Array::value('2', $v);
+    $saveMappingFields['name'] = $v['1'] ?? NULL;
+    $saveMappingFields['contact_type'] = $v['0'] ?? NULL;
+    $locationId = $v['2'] ?? NULL;
     $saveMappingFields['location_type_id'] = is_numeric($locationId) ? $locationId : NULL;
 
     if ($v[1] == 'phone') {
-      $saveMappingFields['phone_type_id'] = CRM_Utils_Array::value('3', $v);
+      $saveMappingFields['phone_type_id'] = $v['3'] ?? NULL;
     }
     elseif ($v[1] == 'im') {
-      $saveMappingFields['im_provider_id'] = CRM_Utils_Array::value('3', $v);
+      $saveMappingFields['im_provider_id'] = $v['3'] ?? NULL;
     }
 
     // Handle mapping for 'related contact' fields
@@ -813,17 +813,17 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
       if (($first == 'a' && $second == 'b') || ($first == 'b' && $second == 'a')) {
 
         if (!empty($v['2'])) {
-          $saveMappingFields['name'] = CRM_Utils_Array::value('2', $v);
+          $saveMappingFields['name'] = $v['2'] ?? NULL;
         }
         elseif (!empty($v['4'])) {
-          $saveMappingFields['name'] = CRM_Utils_Array::value('4', $v);
+          $saveMappingFields['name'] = $v['4'] ?? NULL;
         }
 
         if (is_numeric(CRM_Utils_Array::value('3', $v))) {
-          $locationTypeId = CRM_Utils_Array::value('3', $v);
+          $locationTypeId = $v['3'] ?? NULL;
         }
         elseif (is_numeric(CRM_Utils_Array::value('5', $v))) {
-          $locationTypeId = CRM_Utils_Array::value('5', $v);
+          $locationTypeId = $v['5'] ?? NULL;
         }
 
         if (is_numeric(CRM_Utils_Array::value('4', $v))) {
@@ -831,11 +831,11 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
             $saveMappingFields['im_provider_id'] = $v[4];
           }
           else {
-            $saveMappingFields['phone_type_id'] = CRM_Utils_Array::value('4', $v);
+            $saveMappingFields['phone_type_id'] = $v['4'] ?? NULL;
           }
         }
         elseif (is_numeric(CRM_Utils_Array::value('6', $v))) {
-          $saveMappingFields['phone_type_id'] = CRM_Utils_Array::value('6', $v);
+          $saveMappingFields['phone_type_id'] = $v['6'] ?? NULL;
         }
 
         $saveMappingFields['location_type_id'] = is_numeric($locationTypeId) ? $locationTypeId : NULL;
@@ -940,11 +940,11 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
         $jsSet = TRUE;
 
         if (CRM_Utils_Array::value($i, CRM_Utils_Array::value($x, $mappingOperator))) {
-          $defaults["operator[$x][$i]"] = CRM_Utils_Array::value($i, $mappingOperator[$x]);
+          $defaults["operator[$x][$i]"] = $mappingOperator[$x][$i] ?? NULL;
         }
 
         if (CRM_Utils_Array::value($i, CRM_Utils_Array::value($x, $mappingValue))) {
-          $defaults["value[$x][$i]"] = CRM_Utils_Array::value($i, $mappingValue[$x]);
+          $defaults["value[$x][$i]"] = $mappingValue[$x][$i] ?? NULL;
         }
       }
     }
@@ -1024,12 +1024,12 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
         }
         if (!empty($v['1'])) {
           $fldName = $v[1];
-          $v2 = CRM_Utils_Array::value('2', $v);
+          $v2 = $v['2'] ?? NULL;
           if ($v2 && trim($v2)) {
             $fldName .= "-{$v[2]}";
           }
 
-          $v3 = CRM_Utils_Array::value('3', $v);
+          $v3 = $v['3'] ?? NULL;
           if ($v3 && trim($v3)) {
             $fldName .= "-{$v[3]}";
           }

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -461,7 +461,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     CRM_Utils_Hook::tokens($hookTokens);
     $categories = array_keys($hookTokens);
 
-    $contactID = CRM_Utils_Array::value('contactId', $params);
+    $contactID = $params['contactId'] ?? NULL;
 
     if ($contactID) {
       $contactParams = ['contact_id' => $contactID];

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -366,7 +366,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
   public static function checkPermission($item) {
     if (!empty($item['permission'])) {
       $permissions = explode(',', $item['permission']);
-      $operator = CRM_Utils_Array::value('operator', $item);
+      $operator = $item['operator'] ?? NULL;
       $hasPermission = FALSE;
       foreach ($permissions as $key) {
         $key = trim($key);
@@ -486,7 +486,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
     $referenceID = (int) str_replace("node_", "", $params['ref_id']);
     $position = $params['ps'];
     $type = $params['type'];
-    $label = CRM_Utils_Array::value('data', $params);
+    $label = $params['data'] ?? NULL;
 
     switch ($type) {
       case "move":

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -319,7 +319,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
 
     $recursionDates = [];
     if (is_a($this->recursion, 'When\When')) {
-      $initialCount = CRM_Utils_Array::value('start_action_offset', $this->schedule);
+      $initialCount = $this->schedule['start_action_offset'] ?? NULL;
 
       $exRangeStart = $exRangeEnd = NULL;
       if (!empty($this->excludeDateRangeColumns)) {
@@ -894,7 +894,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
     //For Repeats on:(weekly case)
     if ($formParams['repetition_frequency_unit'] == 'week') {
       if (!empty($formParams['start_action_condition'])) {
-        $repeats_on = CRM_Utils_Array::value('start_action_condition', $formParams);
+        $repeats_on = $formParams['start_action_condition'] ?? NULL;
         $dbParams['start_action_condition'] = implode(",", array_keys($repeats_on));
       }
     }

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -110,7 +110,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     foreach ($domains as $domainID) {
       $result[$domainID] = [];
       foreach ($fieldsToGet as $name => $value) {
-        $contactID = CRM_Utils_Array::value('contact_id', $params);
+        $contactID = $params['contact_id'] ?? NULL;
         $setting = CRM_Core_BAO_Setting::getItem(NULL, $name, NULL, NULL, $contactID, $domainID);
         if (!is_null($setting)) {
           // we won't return if not set - helps in return all scenario - otherwise we can't indentify the missing ones

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -37,7 +37,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
    * @throws \API_Exception
    */
   public static function create($params) {
-    $id = CRM_Utils_Array::value('id', $params);
+    $id = $params['id'] ?? NULL;
 
     $op = empty($id) ? 'create' : 'edit';
     CRM_Utils_Hook::pre('UFField', $op, $id, $params);
@@ -180,18 +180,18 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
    */
   public static function duplicateField($params) {
     $ufField = new CRM_Core_DAO_UFField();
-    $ufField->uf_group_id = CRM_Utils_Array::value('uf_group_id', $params);
-    $ufField->field_type = CRM_Utils_Array::value('field_type', $params);
-    $ufField->field_name = CRM_Utils_Array::value('field_name', $params);
-    $ufField->website_type_id = CRM_Utils_Array::value('website_type_id', $params);
+    $ufField->uf_group_id = $params['uf_group_id'] ?? NULL;
+    $ufField->field_type = $params['field_type'] ?? NULL;
+    $ufField->field_name = $params['field_name'] ?? NULL;
+    $ufField->website_type_id = $params['website_type_id'] ?? NULL;
     if (is_null(CRM_Utils_Array::value('location_type_id', $params, ''))) {
       // primary location type have NULL value in DB
       $ufField->whereAdd("location_type_id IS NULL");
     }
     else {
-      $ufField->location_type_id = CRM_Utils_Array::value('location_type_id', $params);
+      $ufField->location_type_id = $params['location_type_id'] ?? NULL;
     }
-    $ufField->phone_type_id = CRM_Utils_Array::value('phone_type_id', $params);
+    $ufField->phone_type_id = $params['phone_type_id'] ?? NULL;
 
     if (!empty($params['id'])) {
       $ufField->whereAdd("id <> " . $params['id']);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -69,7 +69,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         $cType = $type;
       }
       elseif (array_key_exists($type, $validSubTypes)) {
-        $cType = CRM_Utils_Array::value('parent', $validSubTypes[$type]);
+        $cType = $validSubTypes[$type]['parent'] ?? NULL;
       }
       if ($cType) {
         break;
@@ -932,7 +932,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         if (!empty($_POST)) {
           // get the new email
           $config = CRM_Core_Config::singleton();
-          $email = CRM_Utils_Array::value('mail', $_POST);
+          $email = $_POST['mail'] ?? NULL;
 
           if (CRM_Utils_Rule::email($email) && ($email != $userEmail[1])) {
             CRM_Core_BAO_UFMatch::updateContactEmail($userID, $email);
@@ -1115,7 +1115,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
               // field_type is only set when we are retrieving profile values
               // when sending email, we call the same function to get custom field
               // values etc, i.e. emulating a profile
-              $fieldType = CRM_Utils_Array::value('field_type', $field);
+              $fieldType = $field['field_type'] ?? NULL;
 
               if ($htmlType == 'File') {
                 $entityId = $cid;
@@ -1218,7 +1218,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
             $locationTypeName = 1;
           }
           else {
-            $locationTypeName = CRM_Utils_Array::value($id, $locationTypes);
+            $locationTypeName = $locationTypes[$id] ?? NULL;
           }
 
           if (!$locationTypeName) {
@@ -1448,8 +1448,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       $params[$field] = CRM_Utils_Array::value($field, $params, FALSE);
     }
 
-    $params['limit_listings_group_id'] = CRM_Utils_Array::value('group', $params);
-    $params['add_to_group_id'] = CRM_Utils_Array::value('add_contact_to_group', $params);
+    $params['limit_listings_group_id'] = $params['group'] ?? NULL;
+    $params['add_to_group_id'] = $params['add_contact_to_group'] ?? NULL;
 
     //CRM-15427
     if (!empty($params['group_type']) && is_array($params['group_type'])) {
@@ -2288,7 +2288,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     if (!$componentId) {
       //get the contact details
       $contactDetails = CRM_Contact_BAO_Contact::getHierContactDetails($contactId, $fields);
-      $details = CRM_Utils_Array::value($contactId, $contactDetails);
+      $details = $contactDetails[$contactId] ?? NULL;
       $multipleFields = ['website' => 'url'];
 
       //start of code to set the default values
@@ -2397,7 +2397,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                           }
                         }
                         else {
-                          $phoneDefault = CRM_Utils_Array::value('phone', $value);
+                          $phoneDefault = $value['phone'] ?? NULL;
                           // CRM-9216
                           if (!is_array($phoneDefault)) {
                             $defaults[$fldName] = $phoneDefault;
@@ -2440,7 +2440,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                 && !empty($details['website'])
                 && !empty($details['website'][$locTypeId])
               ) {
-                $defaults[$fldName] = CRM_Utils_Array::value('url', $details['website'][$locTypeId]);
+                $defaults[$fldName] = $details['website'][$locTypeId]['url'] ?? NULL;
               }
             }
           }

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -53,9 +53,9 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
    * @param array $params
    */
   public static function deleteAll(&$params) {
-    $module = CRM_Utils_Array::value('module', $params);
-    $entityTable = CRM_Utils_Array::value('entity_table', $params);
-    $entityID = CRM_Utils_Array::value('entity_id', $params);
+    $module = $params['module'] ?? NULL;
+    $entityTable = $params['entity_table'] ?? NULL;
+    $entityID = $params['entity_id'] ?? NULL;
 
     if (empty($entityTable) ||
       empty($entityID) ||
@@ -90,10 +90,10 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
 
     // CRM-4377 (ab)uses the module column
     if (isset($params['module'])) {
-      $dao->module = CRM_Utils_Array::value('module', $params);
+      $dao->module = $params['module'] ?? NULL;
     }
-    $dao->entity_table = CRM_Utils_Array::value('entity_table', $params);
-    $dao->entity_id = CRM_Utils_Array::value('entity_id', $params);
+    $dao->entity_table = $params['entity_table'] ?? NULL;
+    $dao->entity_id = $params['entity_id'] ?? NULL;
     // user reg / my account can have multiple entries, so we return if thats
     // the case. (since entity_table/id is empty in those cases
     if (!$dao->entity_table ||
@@ -101,7 +101,7 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
     ) {
       return NULL;
     }
-    $dao->weight = CRM_Utils_Array::value('weight', $params);
+    $dao->weight = $params['weight'] ?? NULL;
     if ($dao->find(TRUE)) {
       return $dao->id;
     }
@@ -122,10 +122,10 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
 
     $dao = new CRM_Core_DAO_UFJoin();
 
-    $dao->entity_table = CRM_Utils_Array::value('entity_table', $params);
-    $dao->entity_id = CRM_Utils_Array::value('entity_id', $params);
-    $dao->weight = CRM_Utils_Array::value('weight', $params);
-    $dao->module = CRM_Utils_Array::value('module', $params);
+    $dao->entity_table = $params['entity_table'] ?? NULL;
+    $dao->entity_id = $params['entity_id'] ?? NULL;
+    $dao->weight = $params['weight'] ?? NULL;
+    $dao->module = $params['module'] ?? NULL;
     if ($dao->find(TRUE)) {
       return $dao->uf_group_id;
     }
@@ -143,10 +143,10 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
 
     // CRM-4377 (ab)uses the module column
     if (isset($params['module'])) {
-      $dao->module = CRM_Utils_Array::value('module', $params);
+      $dao->module = $params['module'] ?? NULL;
     }
-    $dao->entity_table = CRM_Utils_Array::value('entity_table', $params);
-    $dao->entity_id = CRM_Utils_Array::value('entity_id', $params);
+    $dao->entity_table = $params['entity_table'] ?? NULL;
+    $dao->entity_id = $params['entity_id'] ?? NULL;
     $dao->orderBy('weight asc');
     $dao->find();
     $first = $firstActive = NULL;

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -83,7 +83,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
 
     $ids = self::allWebsites($contactID);
     foreach ($params as $key => $values) {
-      $id = CRM_Utils_Array::value('id', $values);
+      $id = $values['id'] ?? NULL;
       if (array_key_exists($id, $ids)) {
         unset($ids[$id]);
       }

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -477,7 +477,7 @@ class CRM_Core_Block {
         $value['url'] = CRM_Utils_System::url($dash['path'], $dash['query'], FALSE);
       }
       $value['title'] = $dash['title'];
-      $value['key'] = CRM_Utils_Array::value('key', $dash);
+      $value['key'] = $dash['key'] ?? NULL;
       $values[] = $value;
     }
     self::setProperty(self::DASHBOARD, 'templateValues', array('dashboardLinks' => $values));

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -421,7 +421,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
         $urlVar = 'task';
       }
 
-      $path = CRM_Utils_Array::value($urlVar, $_GET);
+      $path = $_GET[$urlVar] ?? NULL;
     }
 
     if ($path && preg_match('/^civicrm\/upgrade(\/.*)?$/', $path)) {

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -208,7 +208,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
 
     parent::__construct($name, $modal);
 
-    $snippet = CRM_Utils_Array::value('snippet', $_REQUEST);
+    $snippet = $_REQUEST['snippet'] ?? NULL;
     if ($snippet) {
       if ($snippet == 3) {
         $this->_print = CRM_Core_Smarty::PRINT_PDF;
@@ -284,7 +284,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       return NULL;
     }
 
-    $key = CRM_Utils_Array::value('qfKey', $_REQUEST, NULL);
+    $key = $_REQUEST['qfKey'] ?? NULL;
     if (!$key && $_SERVER['REQUEST_METHOD'] === 'GET') {
       $key = CRM_Core_Key::get($name, $addSequence);
     }
@@ -417,8 +417,8 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
     $pages = $stateMachine->getPages();
     foreach ($pages as $name => $value) {
       $className = CRM_Utils_Array::value('className', $value, $name);
-      $title = CRM_Utils_Array::value('title', $value);
-      $options = CRM_Utils_Array::value('options', $value);
+      $title = $value['title'] ?? NULL;
+      $options = $value['options'] ?? NULL;
       $stateName = CRM_Utils_String::getClassName($className);
       if (!empty($value['className'])) {
         $formName = $name;

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -202,8 +202,8 @@ class CRM_Core_DAO extends DB_DataObject {
    * @param array $params
    */
   protected function assignTestFK($fieldName, $fieldDef, $params) {
-    $required = CRM_Utils_Array::value('required', $fieldDef);
-    $FKClassName = CRM_Utils_Array::value('FKClassName', $fieldDef);
+    $required = $fieldDef['required'] ?? NULL;
+    $FKClassName = $fieldDef['FKClassName'] ?? NULL;
     $dbName = $fieldDef['name'];
     $daoName = str_replace('_BAO_', '_DAO_', get_class($this));
 
@@ -343,7 +343,7 @@ class CRM_Core_DAO extends DB_DataObject {
           }
           else {
             $this->$dbName = $dbName . '_' . $counter;
-            $maxlength = CRM_Utils_Array::value('maxlength', $fieldDef);
+            $maxlength = $fieldDef['maxlength'] ?? NULL;
             if ($maxlength > 0 && strlen($this->$dbName) > $maxlength) {
               $this->$dbName = substr($this->$dbName, 0, $fieldDef['maxlength']);
             }
@@ -672,7 +672,7 @@ class CRM_Core_DAO extends DB_DataObject {
           $allNull = FALSE;
         }
         else {
-          $maxLength = CRM_Utils_Array::value('maxlength', $field);
+          $maxLength = $field['maxlength'] ?? NULL;
           if (!is_array($value) && $maxLength && mb_strlen($value) > $maxLength && empty($field['pseudoconstant'])) {
             Civi::log()->warning(ts('A string for field $dbName has been truncated. The original string was %1', [CRM_Utils_Type::escape($value, 'String')]));
             // The string is too long - what to do what to do? Well losing data is generally bad so lets' truncate
@@ -721,8 +721,8 @@ class CRM_Core_DAO extends DB_DataObject {
   public static function makeAttribute($field) {
     if ($field) {
       if (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_STRING) {
-        $maxLength = CRM_Utils_Array::value('maxlength', $field);
-        $size = CRM_Utils_Array::value('size', $field);
+        $maxLength = $field['maxlength'] ?? NULL;
+        $size = $field['size'] ?? NULL;
         if ($maxLength || $size) {
           $attributes = [];
           if ($maxLength) {
@@ -735,11 +735,11 @@ class CRM_Core_DAO extends DB_DataObject {
         }
       }
       elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_TEXT) {
-        $rows = CRM_Utils_Array::value('rows', $field);
+        $rows = $field['rows'] ?? NULL;
         if (!isset($rows)) {
           $rows = 2;
         }
-        $cols = CRM_Utils_Array::value('cols', $field);
+        $cols = $field['cols'] ?? NULL;
         if (!isset($cols)) {
           $cols = 80;
         }
@@ -775,7 +775,7 @@ class CRM_Core_DAO extends DB_DataObject {
     $object = new $class();
     $fields = $object->fields();
     if ($fieldName != NULL) {
-      $field = CRM_Utils_Array::value($fieldName, $fields);
+      $field = $fields[$fieldName] ?? NULL;
       return self::makeAttribute($field);
     }
     else {
@@ -1993,8 +1993,8 @@ SELECT contact_id
       $fields = $object->fields();
       foreach ($fields as $fieldName => $fieldDef) {
         $dbName = $fieldDef['name'];
-        $FKClassName = CRM_Utils_Array::value('FKClassName', $fieldDef);
-        $required = CRM_Utils_Array::value('required', $fieldDef);
+        $FKClassName = $fieldDef['FKClassName'] ?? NULL;
+        $required = $fieldDef['required'] ?? NULL;
 
         if (CRM_Utils_Array::value($dbName, $params) !== NULL && !is_array($params[$dbName])) {
           $object->$dbName = $params[$dbName];
@@ -2046,7 +2046,7 @@ SELECT contact_id
     $config->backtrace = TRUE;
 
     $object = new $daoName();
-    $object->id = CRM_Utils_Array::value('id', $params);
+    $object->id = $params['id'] ?? NULL;
 
     // array(array(0 => $daoName, 1 => $daoParams))
     $deletions = [];
@@ -2057,8 +2057,8 @@ SELECT contact_id
 
         $dbName = $value['name'];
 
-        $FKClassName = CRM_Utils_Array::value('FKClassName', $value);
-        $required = CRM_Utils_Array::value('required', $value);
+        $FKClassName = $value['FKClassName'] ?? NULL;
+        $required = $value['required'] ?? NULL;
         if ($FKClassName != NULL
           && $object->$dbName
           && !in_array($FKClassName, CRM_Core_DAO::$_testEntitiesToSkip)
@@ -2526,7 +2526,7 @@ SELECT contact_id
       throw new Exception('Cannot call getOptionLabels on CRM_Core_DAO');
     }
     foreach ($fields as $field) {
-      $name = CRM_Utils_Array::value('name', $field);
+      $name = $field['name'] ?? NULL;
       if ($name && isset($this->$name)) {
         $label = CRM_Core_PseudoConstant::getLabel(get_class($this), $name, $this->$name);
         if ($label !== FALSE) {
@@ -2573,7 +2573,7 @@ SELECT contact_id
     // Support "unique names" as well as sql names
     $fieldKey = $fieldName;
     if (empty($fields[$fieldKey])) {
-      $fieldKey = CRM_Utils_Array::value($fieldName, $fieldKeys);
+      $fieldKey = $fieldKeys[$fieldName] ?? NULL;
     }
     // If neither worked then this field doesn't exist. Return false.
     if (empty($fields[$fieldKey])) {

--- a/CRM/Core/DAO/Factory.php
+++ b/CRM/Core/DAO/Factory.php
@@ -27,7 +27,7 @@ class CRM_Core_DAO_Factory {
    * @throws Exception
    */
   public static function create($className) {
-    $type = CRM_Utils_Array::value($className, self::$_classes);
+    $type = self::$_classes[$className] ?? NULL;
     if (!$type) {
       CRM_Core_Error::fatal("class $className not found");
     }

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -726,7 +726,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $ret = [];
     foreach ($backTrace as $trace) {
       $args = [];
-      $fnName = CRM_Utils_Array::value('function', $trace);
+      $fnName = $trace['function'] ?? NULL;
       $className = isset($trace['class']) ? ($trace['class'] . $trace['type']) : '';
 
       // Do not show args for a few password related functions

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -878,8 +878,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->_paymentProcessorID = NULL;
     if ($this->_paymentProcessors) {
       if (!empty($this->_submitValues)) {
-        $this->_paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $this->_submitValues);
-        $this->_paymentProcessor = CRM_Utils_Array::value($this->_paymentProcessorID, $this->_paymentProcessors);
+        $this->_paymentProcessorID = $this->_submitValues['payment_processor_id'] ?? NULL;
+        $this->_paymentProcessor = $this->_paymentProcessors[$this->_paymentProcessorID] ?? NULL;
         $this->set('type', $this->_paymentProcessorID);
         $this->set('mode', $this->_mode);
         $this->set('paymentProcessor', $this->_paymentProcessor);
@@ -2522,7 +2522,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return string
    */
   public function getCurrency($submittedValues = []) {
-    $currency = CRM_Utils_Array::value('currency', $this->_values);
+    $currency = $this->_values['currency'] ?? NULL;
     // For event forms, currency is in a different spot
     if (empty($currency)) {
       $currency = CRM_Utils_Array::value('currency', CRM_Utils_Array::value('event', $this->_values));

--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -172,7 +172,7 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
       if ($type == 'text' || $type == 'password') {
         $size = $element->getAttribute('size');
         if (!empty($size)) {
-          $class = CRM_Utils_Array::value($size, self::$_sizeMapper);
+          $class = self::$_sizeMapper[$size] ?? NULL;
         }
       }
     }

--- a/CRM/Core/Form/Task/Batch.php
+++ b/CRM/Core/Form/Task/Batch.php
@@ -134,7 +134,7 @@ class CRM_Core_Form_Task_Batch extends CRM_Core_Form_Task {
       $typeId = CRM_Core_DAO::getFieldValue('CRM_' . ucfirst($this::$entityShortname) . '_DAO_' . ucfirst($this::$entityShortname), $entityId, $this::$entityShortname . '_type_id');
       foreach ($this->_fields as $name => $field) {
         if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($name)) {
-          $customValue = CRM_Utils_Array::value($customFieldID, $customFields);
+          $customValue = $customFields[$customFieldID] ?? NULL;
           $entityColumnValue = [];
           if (!empty($customValue['extends_entity_column_value'])) {
             $entityColumnValue = explode(CRM_Core_DAO::VALUE_SEPARATOR,

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -225,7 +225,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    * @return string $html_message
    */
   public static function processTemplate(&$formValues) {
-    $html_message = CRM_Utils_Array::value('html_message', $formValues);
+    $html_message = $formValues['html_message'] ?? NULL;
 
     // process message template
     if (!empty($formValues['saveTemplate']) || !empty($formValues['updateTemplate'])) {

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -248,7 +248,7 @@ class CRM_Core_Invoke {
           $mode = $pageArgs['mode'];
           unset($pageArgs['mode']);
         }
-        $title = CRM_Utils_Array::value('title', $item);
+        $title = $item['title'] ?? NULL;
         if (strstr($item['page_callback'], '_Page') || strstr($item['page_callback'], '\\Page\\')) {
           $object = new $item['page_callback']($title, $mode);
           $object->urlPath = explode('/', $_GET[$config->userFrameworkURLVar]);

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -246,7 +246,7 @@ class CRM_Core_ManagedEntities {
     $dao->name = $todo['name'];
     $dao->entity_type = $todo['entity'];
     $dao->entity_id = $result['id'];
-    $dao->cleanup = CRM_Utils_Array::value('cleanup', $todo);
+    $dao->cleanup = $todo['cleanup'] ?? NULL;
     $dao->save();
   }
 

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -478,11 +478,11 @@ WHERE  v.option_group_id = g.id
         $value->option_group_id = $group->id;
         $value->label = $v['label'];
         $value->value = $v['value'];
-        $value->name = CRM_Utils_Array::value('name', $v);
-        $value->description = CRM_Utils_Array::value('description', $v);
-        $value->weight = CRM_Utils_Array::value('weight', $v);
-        $value->is_default = CRM_Utils_Array::value('is_default', $v);
-        $value->is_active = CRM_Utils_Array::value('is_active', $v);
+        $value->name = $v['name'] ?? NULL;
+        $value->description = $v['description'] ?? NULL;
+        $value->weight = $v['weight'] ?? NULL;
+        $value->is_default = $v['is_default'] ?? NULL;
+        $value->is_active = $v['is_active'] ?? NULL;
         $value->save();
 
         if ($value->is_default) {

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -70,7 +70,7 @@ class CRM_Core_OptionValue {
       $optionGroupID = $groupParams['id'];
     }
 
-    $groupName = CRM_Utils_Array::value('name', $groupParams);
+    $groupName = $groupParams['name'] ?? NULL;
     if (!$groupName && $optionGroupID) {
       $groupName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup',
         $optionGroupID, 'name', 'id'
@@ -418,8 +418,8 @@ FROM
 
     $order = " ORDER BY " . $orderBy;
 
-    $groupId = CRM_Utils_Array::value('id', $groupParams);
-    $groupName = CRM_Utils_Array::value('name', $groupParams);
+    $groupId = $groupParams['id'] ?? NULL;
+    $groupName = $groupParams['name'] ?? NULL;
 
     if ($groupId) {
       $where .= " AND option_group.id = %1";

--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -145,7 +145,7 @@ class CRM_Core_Page_AJAX_Location {
     if (!empty($defaults)) {
       foreach ($profileFields as $key => $val) {
         if (array_key_exists($key, $defaults)) {
-          $htmlType = CRM_Utils_Array::value('html_type', $val);
+          $htmlType = $val['html_type'] ?? NULL;
           if ($htmlType == 'Radio') {
             $elements["onbehalf_{$key}"]['type'] = $htmlType;
             $elements["onbehalf_{$key}"]['value'] = $defaults[$key];
@@ -226,7 +226,7 @@ class CRM_Core_Page_AJAX_Location {
           $element = 'name';
         }
         $fld = "address[1][{$element}]";
-        $value = CRM_Utils_Array::value($element, $location['address'][1]);
+        $value = $location['address'][1][$element] ?? NULL;
         $value = $value ? $value : "";
         $result[str_replace([
           '][',
@@ -244,7 +244,7 @@ class CRM_Core_Page_AJAX_Location {
       $block = ($element == 'phone_type_id') ? 'phone' : $element;
       for ($i = 1; $i < 3; $i++) {
         $fld = "{$block}[{$i}][{$element}]";
-        $value = CRM_Utils_Array::value($element, $location[$block][$i]);
+        $value = $location[$block][$i][$element] ?? NULL;
         $value = $value ? $value : "";
         $result[str_replace([
           '][',

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -175,7 +175,7 @@ class CRM_Core_Payment_BaseIPN {
     else {
       //legacy support - functions are 'used' to be able to pass in a DAO
       $contribution = new CRM_Contribute_BAO_Contribution();
-      $contribution->id = CRM_Utils_Array::value('contribution', $ids);
+      $contribution->id = $ids['contribution'] ?? NULL;
       $contribution->find(TRUE);
       $objects['contribution'] = &$contribution;
     }
@@ -322,7 +322,7 @@ class CRM_Core_Payment_BaseIPN {
     $contribution->receipt_date = CRM_Utils_Date::isoToMysql($contribution->receipt_date);
     $contribution->thankyou_date = CRM_Utils_Date::isoToMysql($contribution->thankyou_date);
     $contribution->cancel_date = self::$_now;
-    $contribution->cancel_reason = CRM_Utils_Array::value('reasonCode', $input);
+    $contribution->cancel_reason = $input['reasonCode'] ?? NULL;
     $contribution->save();
 
     // Add line items for recurring payments.

--- a/CRM/Core/Payment/Elavon.php
+++ b/CRM/Core/Payment/Elavon.php
@@ -133,8 +133,8 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
 
     // define variables for connecting with the gateway
     $requestFields['ssl_merchant_id'] = $this->_paymentProcessor['user_name'];
-    $requestFields['ssl_user_id'] = CRM_Utils_Array::value('password', $this->_paymentProcessor);
-    $requestFields['ssl_pin'] = CRM_Utils_Array::value('signature', $this->_paymentProcessor);
+    $requestFields['ssl_user_id'] = $this->_paymentProcessor['password'] ?? NULL;
+    $requestFields['ssl_pin'] = $this->_paymentProcessor['signature'] ?? NULL;
     $host = $this->_paymentProcessor['url_site'];
 
     if ($this->_mode == "test") {

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -236,7 +236,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['paymentAction'] = 'Sale';
     $args['amt'] = $params['amount'];
     $args['currencyCode'] = $params['currencyID'];
-    $args['desc'] = CRM_Utils_Array::value('description', $params);
+    $args['desc'] = $params['description'] ?? NULL;
     $args['invnum'] = $params['invoiceID'];
     $args['returnURL'] = $this->getReturnSuccessUrl($params['qfKey']);
     $args['cancelURL'] = $this->getCancelUrl($params['qfKey'], NULL);
@@ -354,7 +354,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $params['trxn_id'] = $result['transactionid'];
     $params['gross_amount'] = $result['amt'];
     $params['fee_amount'] = $result['feeamt'];
-    $params['net_amount'] = CRM_Utils_Array::value('settleamt', $result);
+    $params['net_amount'] = $result['settleamt'] ?? NULL;
     if ($params['net_amount'] == 0 && $params['fee_amount'] != 0) {
       $params['net_amount'] = number_format(($params['gross_amount'] - $params['fee_amount']), 2);
     }
@@ -399,7 +399,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['billingfrequency'] = $params['frequency_interval'];
     $args['billingperiod'] = ucwords($params['frequency_unit']);
     $args['desc'] = $params['amount'] . " Per " . $params['frequency_interval'] . " " . $params['frequency_unit'];
-    $args['totalbillingcycles'] = CRM_Utils_Array::value('installments', $params);
+    $args['totalbillingcycles'] = $params['installments'] ?? NULL;
     $args['version'] = '56.0';
     $args['profilereference'] = "i={$params['invoiceID']}" .
       "&m=" .
@@ -440,7 +440,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['pwd'] = $this->_paymentProcessor['password'];
     $args['version'] = 3.0;
     $args['signature'] = $this->_paymentProcessor['signature'];
-    $args['subject'] = CRM_Utils_Array::value('subject', $this->_paymentProcessor);
+    $args['subject'] = $this->_paymentProcessor['subject'] ?? NULL;
     $args['method'] = $method;
   }
 
@@ -506,14 +506,14 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['cvv2'] = $params['cvv2'];
     $args['firstName'] = $params['first_name'];
     $args['lastName'] = $params['last_name'];
-    $args['email'] = CRM_Utils_Array::value('email', $params);
+    $args['email'] = $params['email'] ?? NULL;
     $args['street'] = $params['street_address'];
     $args['city'] = $params['city'];
     $args['state'] = $params['state_province'];
     $args['countryCode'] = $params['country'];
     $args['zip'] = $params['postal_code'];
     $args['desc'] = substr(CRM_Utils_Array::value('description', $params), 0, 127);
-    $args['custom'] = CRM_Utils_Array::value('accountingCode', $params);
+    $args['custom'] = $params['accountingCode'] ?? NULL;
 
     // add CiviCRM BN code
     $args['BUTTONSOURCE'] = 'CiviCRM_SP';
@@ -533,7 +533,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
         $params['frequency_interval'] . " " .
         $params['frequency_unit'];
       $args['amt'] = $this->getAmount($params);
-      $args['totalbillingcycles'] = CRM_Utils_Array::value('installments', $params);
+      $args['totalbillingcycles'] = $params['installments'] ?? NULL;
       $args['version'] = 56.0;
       $args['PROFILEREFERENCE'] = "" .
         "i=" . $params['invoiceID'] . "&m=" . $component .
@@ -554,8 +554,8 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
     /* Success */
 
-    $params['trxn_id'] = CRM_Utils_Array::value('transactionid', $result);
-    $params['gross_amount'] = CRM_Utils_Array::value('amt', $result);
+    $params['trxn_id'] = $result['transactionid'] ?? NULL;
+    $params['gross_amount'] = $result['amt'] ?? NULL;
     $params = array_merge($params, $this->doQuery($params));
     return $params;
   }
@@ -685,9 +685,9 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       $args = [];
       $this->initialize($args, 'ManageRecurringPaymentsProfileStatus');
 
-      $args['PROFILEID'] = CRM_Utils_Array::value('subscriptionId', $params);
+      $args['PROFILEID'] = $params['subscriptionId'] ?? NULL;
       $args['ACTION'] = 'Cancel';
-      $args['NOTE'] = CRM_Utils_Array::value('reason', $params);
+      $args['NOTE'] = $params['reason'] ?? NULL;
 
       $result = $this->invokeAPI($args);
 
@@ -719,7 +719,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       throw new CRM_Core_Exception("Could not find a processor with the given processor_id value '{$params['processor_id']}'.");
     }
 
-    $paymentProcessorType = CRM_Utils_Array::value('api.PaymentProcessorType.getvalue', $result['values'][0]);
+    $paymentProcessorType = $result['values'][0]['api.PaymentProcessorType.getvalue'] ?? NULL;
     switch ($paymentProcessorType) {
       case 'PayPal':
         // "PayPal - Website Payments Pro"

--- a/CRM/Core/Payment/PaymentExpress.php
+++ b/CRM/Core/Payment/PaymentExpress.php
@@ -151,7 +151,7 @@ class CRM_Core_Payment_PaymentExpress extends CRM_Core_Payment {
       $privateData .= ",f={$params['participantID']},g={$params['eventID']}";
     }
     elseif ($component == 'contribute') {
-      $membershipID = CRM_Utils_Array::value('membershipID', $params);
+      $membershipID = $params['membershipID'] ?? NULL;
       if ($membershipID) {
         $privateData .= ",e=$membershipID";
       }

--- a/CRM/Core/Payment/PaymentExpressIPN.php
+++ b/CRM/Core/Payment/PaymentExpressIPN.php
@@ -62,7 +62,7 @@ class CRM_Core_Payment_PaymentExpressIPN extends CRM_Core_Payment_BaseIPN {
    * @return mixed
    */
   public static function retrieve($name, $type, $object, $abort = TRUE) {
-    $value = CRM_Utils_Array::value($name, $object);
+    $value = $object[$name] ?? NULL;
     if ($abort && $value === NULL) {
       CRM_Core_Error::debug_log_message("Could not find an entry for $name");
       echo "Failure: Missing Parameter - " . $name . "<p>";

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -465,7 +465,7 @@ class CRM_Core_Permission {
         'CiviMail' => 'access CiviMail',
         'CiviAuction' => 'add auction items',
       ];
-      $permissionName = CRM_Utils_Array::value($module, $editPermissions);
+      $permissionName = $editPermissions[$module] ?? NULL;
     }
 
     if ($module == 'CiviCase' && !$permissionName) {

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -824,7 +824,7 @@ WHERE  id = %1";
         $countryIsoCodes = self::countryIsoCode();
         $defaultID = array_search(CRM_Core_BAO_Country::defaultContactCountry(), $countryIsoCodes);
         if ($defaultID !== FALSE) {
-          $default[$defaultID] = CRM_Utils_Array::value($defaultID, self::$country);
+          $default[$defaultID] = self::$country[$defaultID] ?? NULL;
           self::$country = $default + self::$country;
         }
       }
@@ -1393,7 +1393,7 @@ WHERE  id = %1
     $index = $filter['greeting_type'] . '_' . $columnName;
 
     // also add contactType to the array
-    $contactType = CRM_Utils_Array::value('contact_type', $filter);
+    $contactType = $filter['contact_type'] ?? NULL;
     if ($contactType) {
       $index .= '_' . $contactType;
     }

--- a/CRM/Core/Smarty/plugins/function.crmAPI.php
+++ b/CRM/Core/Smarty/plugins/function.crmAPI.php
@@ -31,7 +31,7 @@ function smarty_function_crmAPI($params, &$smarty) {
   $entity = $params['entity'];
   $action = CRM_Utils_Array::value('action', $params, 'get');
   $params['sequential'] = CRM_Utils_Array::value('sequential', $params, 1);
-  $var = CRM_Utils_Array::value('var', $params);
+  $var = $params['var'] ?? NULL;
   CRM_Utils_Array::remove($params, 'entity', 'action', 'var');
   $params['version'] = 3;
   require_once 'api/api.php';

--- a/CRM/Custom/Form/DeleteField.php
+++ b/CRM/Custom/Form/DeleteField.php
@@ -49,7 +49,7 @@ class CRM_Custom_Form_DeleteField extends CRM_Core_Form {
     $params = ['id' => $this->_id];
     CRM_Core_BAO_CustomField::retrieve($params, $defaults);
 
-    $this->_title = CRM_Utils_Array::value('label', $defaults);
+    $this->_title = $defaults['label'] ?? NULL;
     $this->assign('title', $this->_title);
     CRM_Utils_System::setTitle(ts('Delete %1', [1 => $this->_title]));
   }

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -90,7 +90,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $params = ['id' => $this->_id];
       CRM_Core_BAO_CustomField::retrieve($params, $this->_values);
       // note_length is an alias for the text_length field
-      $this->_values['note_length'] = CRM_Utils_Array::value('text_length', $this->_values);
+      $this->_values['note_length'] = $this->_values['text_length'] ?? NULL;
       // custom group id
       $this->_gid = $this->_values['custom_group_id'];
     }
@@ -571,7 +571,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
    *                  true otherwise
    */
   public static function formRule($fields, $files, $self) {
-    $default = CRM_Utils_Array::value('default_value', $fields);
+    $default = $fields['default_value'] ?? NULL;
 
     $errors = [];
 

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -73,7 +73,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
       $params = ['id' => $this->_id];
       CRM_Core_BAO_CustomGroup::retrieve($params, $this->_defaults);
 
-      $subExtends = CRM_Utils_Array::value('extends_entity_column_value', $this->_defaults);
+      $subExtends = $this->_defaults['extends_entity_column_value'] ?? NULL;
       if (!empty($subExtends)) {
         $this->_subtypes = explode(CRM_Core_DAO::VALUE_SEPARATOR, substr($subExtends, 1, -1));
       }
@@ -255,7 +255,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
       $sel->_elements[1]->setSize(5);
     }
     if ($this->_action == CRM_Core_Action::UPDATE) {
-      $subName = CRM_Utils_Array::value('extends_entity_column_id', $this->_defaults);
+      $subName = $this->_defaults['extends_entity_column_id'] ?? NULL;
       if ($this->_defaults['extends'] == 'Participant') {
         if ($subName == 1) {
           $this->_defaults['extends'] = 'ParticipantRole';

--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -83,7 +83,7 @@ class CRM_Custom_Import_Form_MapField extends CRM_Contact_Import_Form_MapField {
     }
 
     if (!empty($fields['saveMapping'])) {
-      $nameField = CRM_Utils_Array::value('saveMappingName', $fields);
+      $nameField = $fields['saveMappingName'] ?? NULL;
       if (empty($nameField)) {
         $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
       }
@@ -96,7 +96,7 @@ class CRM_Custom_Import_Form_MapField extends CRM_Contact_Import_Form_MapField {
 
     //display Error if loaded mapping is not selected
     if (array_key_exists('loadMapping', $fields)) {
-      $getMapName = CRM_Utils_Array::value('savedMapping', $fields);
+      $getMapName = $fields['savedMapping'] ?? NULL;
       if (empty($getMapName)) {
         $errors['savedMapping'] = ts('Select saved mapping');
       }
@@ -172,9 +172,9 @@ class CRM_Custom_Import_Form_MapField extends CRM_Contact_Import_Form_MapField {
         $updateMappingFields->column_number = $i;
 
         $explodedValues = explode('_', $mapperKeys[$i][0]);
-        $id = CRM_Utils_Array::value(0, $explodedValues);
-        $first = CRM_Utils_Array::value(1, $explodedValues);
-        $second = CRM_Utils_Array::value(2, $explodedValues);
+        $id = $explodedValues[0] ?? NULL;
+        $first = $explodedValues[1] ?? NULL;
+        $second = $explodedValues[2] ?? NULL;
 
         $updateMappingFields->name = $mapper[$i];
         $updateMappingFields->save();
@@ -196,9 +196,9 @@ class CRM_Custom_Import_Form_MapField extends CRM_Contact_Import_Form_MapField {
         $saveMappingFields->column_number = $i;
 
         $explodedValues = explode('_', $mapperKeys[$i][0]);
-        $id = CRM_Utils_Array::value(0, $explodedValues);
-        $first = CRM_Utils_Array::value(1, $explodedValues);
-        $second = CRM_Utils_Array::value(2, $explodedValues);
+        $id = $explodedValues[0] ?? NULL;
+        $first = $explodedValues[1] ?? NULL;
+        $second = $explodedValues[2] ?? NULL;
 
         $saveMappingFields->name = $mapper[$i];
         $saveMappingFields->save();

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -242,7 +242,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Custom_Import_Parser {
     $allFields = civicrm_api3('custom_field', 'get', $params);
     $fields = $allFields['values'];
     foreach ($fields as $id => $values) {
-      $datatype = CRM_Utils_Array::value('data_type', $values);
+      $datatype = $values['data_type'] ?? NULL;
       if ($datatype == 'File') {
         continue;
       }
@@ -261,8 +261,8 @@ class CRM_Custom_Import_Parser_Api extends CRM_Custom_Import_Parser {
         'is_search_range' => $values['is_search_range'] ?? NULL,
       ];
       if (CRM_Utils_Array::value('html_type', $values) == 'Select Date') {
-        $importableFields[$key]['date_format'] = CRM_Utils_Array::value('date_format', $values);
-        $importableFields[$key]['time_format'] = CRM_Utils_Array::value('time_format', $values);
+        $importableFields[$key]['date_format'] = $values['date_format'] ?? NULL;
+        $importableFields[$key]['time_format'] = $values['time_format'] ?? NULL;
         $this->_dateFields[] = $key;
       }
     }

--- a/CRM/Custom/Page/Group.php
+++ b/CRM/Custom/Page/Group.php
@@ -268,9 +268,9 @@ class CRM_Custom_Page_Group extends CRM_Core_Page {
     CRM_Core_BAO_CustomGroup::getExtendedObjectTypes($subTypes);
 
     foreach ($customGroup as $key => $values) {
-      $subValue = CRM_Utils_Array::value('extends_entity_column_value', $customGroup[$key]);
-      $subName = CRM_Utils_Array::value('extends_entity_column_id', $customGroup[$key]);
-      $type = CRM_Utils_Array::value('extends', $customGroup[$key]);
+      $subValue = $customGroup[$key]['extends_entity_column_value'] ?? NULL;
+      $subName = $customGroup[$key]['extends_entity_column_id'] ?? NULL;
+      $type = $customGroup[$key]['extends'] ?? NULL;
       if ($subValue) {
         $subValue = explode(CRM_Core_DAO::VALUE_SEPARATOR,
           substr($subValue, 1, -1)

--- a/CRM/Dedupe/BAO/Exception.php
+++ b/CRM/Dedupe/BAO/Exception.php
@@ -30,13 +30,13 @@ class CRM_Dedupe_BAO_Exception extends CRM_Dedupe_DAO_Exception {
   public static function create($params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'Exception', CRM_Utils_Array::value('id', $params), $params);
-    $contact1 = CRM_Utils_Array::value('contact_id1', $params);
-    $contact2 = CRM_Utils_Array::value('contact_id2', $params);
+    $contact1 = $params['contact_id1'] ?? NULL;
+    $contact2 = $params['contact_id2'] ?? NULL;
     $dao = new CRM_Dedupe_BAO_Exception();
     $dao->copyValues($params);
     if ($contact1 && $contact2) {
       CRM_Core_DAO::singleValueQuery("
-        DELETE FROM civicrm_prevnext_cache 
+        DELETE FROM civicrm_prevnext_cache
         WHERE (entity_id1 = %1 AND entity_id2 = %2)
         OR (entity_id1 = %2 AND entity_id2 = %2)",
         [1 => [$contact1, 'Integer'], 2 => [$contact2, 'Integer']]

--- a/CRM/Dedupe/BAO/QueryBuilder/IndividualGeneral.php
+++ b/CRM/Dedupe/BAO/QueryBuilder/IndividualGeneral.php
@@ -12,8 +12,8 @@ class CRM_Dedupe_BAO_QueryBuilder_IndividualGeneral extends CRM_Dedupe_BAO_Query
    * @return array
    */
   public static function record($rg) {
-    $civicrm_contact = CRM_Utils_Array::value('civicrm_contact', $rg->params);
-    $civicrm_address = CRM_Utils_Array::value('civicrm_address', $rg->params);
+    $civicrm_contact = $rg->params['civicrm_contact'] ?? NULL;
+    $civicrm_address = $rg->params['civicrm_address'] ?? NULL;
 
     // Since definitely have first and last name, escape them upfront.
     $first_name = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('first_name', $civicrm_contact, ''));

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -230,7 +230,7 @@ class CRM_Dedupe_Finder {
         continue;
       }
       foreach ($cg['fields'] as $cf) {
-        $flat[$cf['column_name']] = CRM_Utils_Array::value('data', $cf['customValue']);
+        $flat[$cf['column_name']] = $cf['customValue']['data'] ?? NULL;
       }
     }
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -637,8 +637,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       if (strpos($key, '_')) {
         continue;
       }
-      $key1 = CRM_Utils_Array::value($key, $mainEvs);
-      $key2 = CRM_Utils_Array::value($key, $otherEvs);
+      $key1 = $mainEvs[$key] ?? NULL;
+      $key2 = $otherEvs[$key] ?? NULL;
       // We wish to retain '0' as it has a different meaning than NULL on a checkbox.
       // However I can't think of a case where an empty string is more meaningful than null
       // or where it would be FALSE or something else nullish.
@@ -859,7 +859,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   public static function merge($dupePairs = [], $cacheParams = [], $mode = 'safe',
                                $redirectForPerformance = FALSE, $checkPermissions = TRUE
   ) {
-    $cacheKeyString = CRM_Utils_Array::value('cache_key_string', $cacheParams);
+    $cacheKeyString = $cacheParams['cache_key_string'] ?? NULL;
     $resultStats = ['merged' => [], 'skipped' => []];
 
     // we don't want dupe caching to get reset after every-merge, and therefore set the
@@ -1716,7 +1716,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       // @todo Tidy this up
       $operation = 0;
       if ($fieldName != 'website') {
-        $operation = CRM_Utils_Array::value('operation', $migrationInfo['location_blocks'][$fieldName][$fieldCount]);
+        $operation = $migrationInfo['location_blocks'][$fieldName][$fieldCount]['operation'] ?? NULL;
       }
       // default operation is overwrite.
       if (!$operation) {
@@ -1744,7 +1744,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         $billingDAOId = (array_key_exists($name, $billingBlockIds)) ? array_pop($billingBlockIds[$name]) : NULL;
 
         foreach ($block as $blkCount => $values) {
-          $otherBlockId = CRM_Utils_Array::value('id', $migrationInfo['other_details']['location_blocks'][$name][$blkCount]);
+          $otherBlockId = $migrationInfo['other_details']['location_blocks'][$name][$blkCount]['id'] ?? NULL;
           $mainBlockId = CRM_Utils_Array::value('mainContactBlockId', $migrationInfo['location_blocks'][$name][$blkCount], 0);
           if (!$otherBlockId) {
             continue;
@@ -1759,18 +1759,18 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
           // Add/update location and type information from the form, if applicable
           if ($locationBlocks[$name]['hasLocation']) {
-            $locTypeId = CRM_Utils_Array::value('locTypeId', $migrationInfo['location_blocks'][$name][$blkCount]);
+            $locTypeId = $migrationInfo['location_blocks'][$name][$blkCount]['locTypeId'] ?? NULL;
             $otherBlockDAO->location_type_id = $locTypeId;
           }
           if ($locationBlocks[$name]['hasType']) {
-            $typeTypeId = CRM_Utils_Array::value('typeTypeId', $migrationInfo['location_blocks'][$name][$blkCount]);
+            $typeTypeId = $migrationInfo['location_blocks'][$name][$blkCount]['typeTypeId'] ?? NULL;
             $otherBlockDAO->{$locationBlocks[$name]['hasType']} = $typeTypeId;
           }
 
           // If we're deliberately setting this as primary then add the flag
           // and remove it from the current primary location (if there is one).
           // But only once for each entity.
-          $set_primary = CRM_Utils_Array::value('set_other_primary', $migrationInfo['location_blocks'][$name][$blkCount]);
+          $set_primary = $migrationInfo['location_blocks'][$name][$blkCount]['set_other_primary'] ?? NULL;
           if (!$changePrimary && $set_primary == "1") {
             $otherBlockDAO->is_primary = 1;
             if ($primaryDAOId) {
@@ -2125,7 +2125,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
           // Load the address we're inspecting from the 'other' contact
           $addressRecord = $migrationInfo['other_details']['location_blocks'][$fieldName][$fieldCount];
-          $addressRecordLocTypeId = CRM_Utils_Array::value('location_type_id', $addressRecord);
+          $addressRecordLocTypeId = $addressRecord['location_type_id'] ?? NULL;
 
           // If it exists on the 'main' contact already, skip it. Otherwise
           // if the location type exists already, log a conflict.
@@ -2217,7 +2217,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           if (in_array($fieldName, self::ignoredFields())) {
             continue;
           }
-          $toRemoveValue = CRM_Utils_Array::value($fieldName, $toRemoveContactLocationBlocks[$entity][$blockIndex]);
+          $toRemoveValue = $toRemoveContactLocationBlocks[$entity][$blockIndex][$fieldName] ?? NULL;
           if ($fieldValue !== $toRemoveValue) {
             $entityConflicts[$fieldName] = [
               $toKeepID => $fieldValue,
@@ -2296,7 +2296,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   private static function getFieldValueAndLabel($field, $contact): array {
     $fields = self::getMergeFieldsMetadata();
-    $value = $label = CRM_Utils_Array::value($field, $contact);
+    $value = $label = $contact[$field] ?? NULL;
     $fieldSpec = $fields[$field];
     if (!empty($fieldSpec['serialize']) && is_array($value)) {
       // In practice this only applies to preferred_communication_method as the sub types are skipped above
@@ -2475,7 +2475,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
         $lookupType = FALSE;
         if ($blockInfo['hasType']) {
-          $lookupType = CRM_Utils_Array::value($blockInfo['hasType'], $value);
+          $lookupType = $value[$blockInfo['hasType']] ?? NULL;
         }
 
         // Hold ID of main contact's matching block
@@ -2571,7 +2571,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           // Load the type options for this entity
           $typeOptions = civicrm_api3($blockName, 'getoptions', ['field' => $blockInfo['hasType']]);
 
-          $thisTypeId = CRM_Utils_Array::value($blockInfo['hasType'], $value);
+          $thisTypeId = $value[$blockInfo['hasType']] ?? NULL;
 
           // Put this field's location type at the top of the list
           $tmpIdList = $typeOptions['values'];

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -134,7 +134,7 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event {
 
     $contactId = CRM_Core_Session::getLoggedInContactID();
     if (!$contactId) {
-      $contactId = CRM_Utils_Array::value('contact_id', $params);
+      $contactId = $params['contact_id'] ?? NULL;
     }
 
     // Log the information on successful add/edit of Event
@@ -1104,8 +1104,8 @@ WHERE civicrm_event.is_active = 1
 
       //send email only when email is present
       if (isset($email) || $returnMessageText) {
-        $preProfileID = CRM_Utils_Array::value('custom_pre_id', $values);
-        $postProfileID = CRM_Utils_Array::value('custom_post_id', $values);
+        $preProfileID = $values['custom_pre_id'] ?? NULL;
+        $postProfileID = $values['custom_post_id'] ?? NULL;
 
         if (!empty($values['params']['additionalParticipant'])) {
           $preProfileID = CRM_Utils_Array::value('additional_custom_pre_id', $values, $preProfileID);
@@ -1233,7 +1233,7 @@ WHERE civicrm_event.is_active = 1
           );
           // append invoice pdf to email
           $prefixValue = Civi::settings()->get('contribution_invoice_settings');
-          $invoicing = CRM_Utils_Array::value('invoicing', $prefixValue);
+          $invoicing = $prefixValue['invoicing'] ?? NULL;
           if (isset($invoicing) && isset($prefixValue['is_email_pdf']) && !empty($values['contributionId'])) {
             $sendTemplateParams['isEmailPdf'] = TRUE;
             $sendTemplateParams['contributionId'] = $values['contributionId'];
@@ -1581,7 +1581,7 @@ WHERE civicrm_event.is_active = 1
         }
         elseif (substr($name, -11) == 'campaign_id') {
           $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($params[$name]);
-          $values[$index] = CRM_Utils_Array::value($params[$name], $campaigns);
+          $values[$index] = $campaigns[$params[$name]] ?? NULL;
         }
         elseif (strpos($name, '-') !== FALSE) {
           list($fieldName, $id) = CRM_Utils_System::explode('-', $name, 2);
@@ -1598,7 +1598,7 @@ WHERE civicrm_event.is_active = 1
           elseif ($fieldName == 'im') {
             $providerName = NULL;
             if ($providerId = $detailName . '-provider_id') {
-              $providerName = CRM_Utils_Array::value($params[$providerId], $imProviders);
+              $providerName = $imProviders[$params[$providerId]] ?? NULL;
             }
             if ($providerName) {
               $values[$index] = $params[$detailName] . " (" . $providerName . ")";
@@ -1638,8 +1638,8 @@ WHERE  id = $cfID
               $htmlType = $dao->html_type;
 
               if ($htmlType == 'File') {
-                $path = CRM_Utils_Array::value('name', $params[$name]);
-                $fileType = CRM_Utils_Array::value('type', $params[$name]);
+                $path = $params[$name]['name'] ?? NULL;
+                $fileType = $params[$name]['type'] ?? NULL;
                 $values[$index] = CRM_Utils_File::getFileURL($path, $fileType);
               }
               else {
@@ -1710,7 +1710,7 @@ WHERE  id = $cfID
               $values[$index] = CRM_Utils_Date::customFormat(CRM_Utils_Date::format($params[$name]));
             }
             else {
-              $values[$index] = CRM_Utils_Array::value($name, $params);
+              $values[$index] = $params[$name] ?? NULL;
             }
           }
         }
@@ -1780,8 +1780,8 @@ WHERE  id = $cfID
       return $additionalIDs;
     }
 
-    $preProfileID = CRM_Utils_Array::value('additional_custom_pre_id', $values);
-    $postProfileID = CRM_Utils_Array::value('additional_custom_post_id', $values);
+    $preProfileID = $values['additional_custom_pre_id'] ?? NULL;
+    $postProfileID = $values['additional_custom_post_id'] ?? NULL;
     //else build array of Additional participant's information.
     if (count($additionalIDs)) {
       if ($preProfileID || $postProfileID) {

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -97,7 +97,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
 
     $participantBAO = new CRM_Event_BAO_Participant();
     if (!empty($params['id'])) {
-      $participantBAO->id = CRM_Utils_Array::value('id', $params);
+      $participantBAO->id = $params['id'] ?? NULL;
       $participantBAO->find(TRUE);
       $participantBAO->register_date = CRM_Utils_Date::isoToMysql($participantBAO->register_date);
     }
@@ -203,7 +203,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
     $session = CRM_Core_Session::singleton();
     $id = $session->get('userID');
     if (!$id) {
-      $id = CRM_Utils_Array::value('contact_id', $params);
+      $id = $params['contact_id'] ?? NULL;
     }
 
     // add custom field values
@@ -666,7 +666,7 @@ INNER JOIN  civicrm_price_field field       ON ( value.price_field_id = field.id
               'column_name'
             );
             $value = $customFieldId ? 'custom_' . $customFieldId : $value;
-            $tmpContactField[trim($value)] = CRM_Utils_Array::value(trim($value), $contactFields);
+            $tmpContactField[trim($value)] = $contactFields[trim($value)] ?? NULL;
             if (!$status) {
               $title = $tmpContactField[trim($value)]['title'] . ' (match to contact)';
             }
@@ -678,7 +678,7 @@ INNER JOIN  civicrm_price_field field       ON ( value.price_field_id = field.id
           }
         }
       }
-      $extIdentifier = CRM_Utils_Array::value('external_identifier', $contactFields);
+      $extIdentifier = $contactFields['external_identifier'] ?? NULL;
       if ($extIdentifier) {
         $tmpContactField['external_identifier'] = $extIdentifier;
         $tmpContactField['external_identifier']['title'] = CRM_Utils_Array::value('title', $extIdentifier) . ' (match to contact)';
@@ -904,8 +904,8 @@ WHERE  civicrm_participant.id = {$participantId}
    * @return CRM_Contribute_BAO_Contribution
    */
   public static function checkDuplicate($input, &$duplicates) {
-    $eventId = CRM_Utils_Array::value('event_id', $input);
-    $contactId = CRM_Utils_Array::value('contact_id', $input);
+    $eventId = $input['event_id'] ?? NULL;
+    $contactId = $input['contact_id'] ?? NULL;
 
     $clause = [];
     $input = [];
@@ -1283,7 +1283,7 @@ UPDATE  civicrm_participant
         CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails[$eventId]);
 
         //get default participant role.
-        $eventDetails[$eventId]['participant_role'] = CRM_Utils_Array::value($eventDetails[$eventId]['default_role_id'], $participantRoles);
+        $eventDetails[$eventId]['participant_role'] = $participantRoles[$eventDetails[$eventId]['default_role_id']] ?? NULL;
 
         //get the location info
         $locParams = ['entity_id' => $eventId, 'entity_table' => 'civicrm_event'];
@@ -1296,7 +1296,7 @@ UPDATE  civicrm_participant
 
     $emailType = NULL;
     $toStatus = $statusTypes[$toStatusId];
-    $fromStatus = CRM_Utils_Array::value($fromStatusId, $statusTypes);
+    $fromStatus = $statusTypes[$fromStatusId] ?? NULL;
 
     switch ($toStatus) {
       case 'Pending from waitlist':
@@ -1432,7 +1432,7 @@ UPDATE  civicrm_participant
     ) {
       return $mailSent;
     }
-    $toEmail = CRM_Utils_Array::value('email', $contactDetails);
+    $toEmail = $contactDetails['email'] ?? NULL;
     if ($toEmail) {
 
       $contactId = $participantValues['contact_id'];
@@ -1442,7 +1442,7 @@ UPDATE  civicrm_participant
       $checksumValue = NULL;
       if ($mailType == 'Confirm' && !$participantValues['registered_by_id']) {
         $checksumLife = 'inf';
-        $endDate = CRM_Utils_Array::value('end_date', $eventDetails);
+        $endDate = $eventDetails['end_date'] ?? NULL;
         if ($endDate) {
           $checksumLife = (CRM_Utils_Date::unixTime($endDate) - time()) / (60 * 60);
         }

--- a/CRM/Event/BAO/ParticipantStatusType.php
+++ b/CRM/Event/BAO/ParticipantStatusType.php
@@ -168,7 +168,7 @@ LEFT JOIN  civicrm_event event ON ( event.id = participant.event_id )
           continue;
         }
 
-        $expirationTime = CRM_Utils_Array::value('expiration_time', $values);
+        $expirationTime = $values['expiration_time'] ?? NULL;
         if ($expirationTime && array_key_exists($values['status_id'], $pendingStatuses)) {
 
           //get the expiration and registration pending time.

--- a/CRM/Event/Cart/BAO/MerParticipant.php
+++ b/CRM/Event/Cart/BAO/MerParticipant.php
@@ -38,7 +38,7 @@ class CRM_Event_Cart_BAO_MerParticipant extends CRM_Event_BAO_Participant {
     $a = (array) $participant;
     $this->copyValues($a);
 
-    $this->email = CRM_Utils_Array::value('email', $participant);
+    $this->email = $participant['email'] ?? NULL;
   }
 
   /**

--- a/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
+++ b/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
@@ -128,7 +128,7 @@ EOS;
     foreach ($this->events_by_slot as $slot_name => $events) {
       $slot_index++;
       $field_name = "slot_$slot_index";
-      $session_event_id = CRM_Utils_Array::value($field_name, $params, NULL);
+      $session_event_id = $params[$field_name] ?? NULL;
       if (!$session_event_id) {
         continue;
       }

--- a/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
+++ b/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
@@ -220,7 +220,7 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
           $price_sets = CRM_Price_BAO_PriceSet::getSetDetail($price_set_id, TRUE, TRUE);
           $price_set  = $price_sets[$price_set_id];
           foreach ($price_set['fields'] as $field) {
-            $options = CRM_Utils_Array::value('options', $field);
+            $options = $field['options'] ?? NULL;
             if (!is_array($options)) {
               continue;
             }

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -712,7 +712,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     $stat = FALSE;
     foreach ($discounts as $key => $discountValue) {
       if ($key == $discountCode) {
-        $events = CRM_Utils_Array::value('events', $discountValue);
+        $events = $discountValue['events'] ?? NULL;
         $evt_ids = implode(",", $events);
         if ($evt_ids == "0" || strpos($evt_ids, $event_id)) {
           $event_match = TRUE;

--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -254,8 +254,8 @@ class CRM_Event_Form_EventFees {
 
       $priceFields = $htmlTypes = $optionValues = [];
       foreach ($lineItems[$participantID] as $lineId => $items) {
-        $priceFieldId = CRM_Utils_Array::value('price_field_id', $items);
-        $priceOptionId = CRM_Utils_Array::value('price_field_value_id', $items);
+        $priceFieldId = $items['price_field_id'] ?? NULL;
+        $priceOptionId = $items['price_field_value_id'] ?? NULL;
         if ($priceFieldId && $priceOptionId) {
           $priceFields[$priceFieldId][] = $priceOptionId;
         }
@@ -277,7 +277,7 @@ SELECT  id, html_type
 
       foreach ($lineItems[$participantID] as $lineId => $items) {
         $fieldId = $items['price_field_id'];
-        $htmlType = CRM_Utils_Array::value($fieldId, $htmlTypes);
+        $htmlType = $htmlTypes[$fieldId] ?? NULL;
         if (!$htmlType) {
           continue;
         }
@@ -286,7 +286,7 @@ SELECT  id, html_type
           $defaults["price_{$fieldId}"] = $items['qty'];
         }
         else {
-          $fieldOptValues = CRM_Utils_Array::value($fieldId, $priceFields);
+          $fieldOptValues = $priceFields[$fieldId] ?? NULL;
           if (!is_array($fieldOptValues)) {
             continue;
           }

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -130,7 +130,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
         CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
       }
 
-      $participantListingID = CRM_Utils_Array::value('participant_listing_id', $eventInfo);
+      $participantListingID = $eventInfo['participant_listing_id'] ?? NULL;
       //CRM_Core_DAO::getFieldValue( 'CRM_Event_DAO_Event', $this->_id, 'participant_listing_id' );
       if ($participantListingID) {
         $participantListingURL = CRM_Utils_System::url('civicrm/event/participant',
@@ -147,7 +147,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
 
     // figure out whether we’re handling an event or an event template
     if ($this->_id) {
-      $this->_isTemplate = CRM_Utils_Array::value('is_template', $eventInfo);
+      $this->_isTemplate = $eventInfo['is_template'] ?? NULL;
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {
       $this->_isTemplate = CRM_Utils_Request::retrieve('is_template', 'Boolean', $this);
@@ -250,7 +250,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       $params = ['id' => $this->_id];
       CRM_Event_BAO_Event::retrieve($params, $defaults);
 
-      $this->_campaignID = CRM_Utils_Array::value('campaign_id', $defaults);
+      $this->_campaignID = $defaults['campaign_id'] ?? NULL;
     }
     elseif ($this->_templateId) {
       $params = ['id' => $this->_templateId];
@@ -275,7 +275,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
   public function buildQuickForm() {
     $session = CRM_Core_Session::singleton();
 
-    $this->_cancelURL = CRM_Utils_Array::value('cancelURL', $_POST);
+    $this->_cancelURL = $_POST['cancelURL'] ?? NULL;
 
     if (!$this->_cancelURL) {
       if ($this->_isTemplate) {
@@ -372,8 +372,8 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       $config = CRM_Core_Config::singleton();
       if (in_array('CiviCampaign', $config->enableComponents)) {
         $values = $this->controller->exportValues($this->_name);
-        $newCampaignID = CRM_Utils_Array::value('campaign_id', $values);
-        $eventID = CRM_Utils_Array::value('id', $values);
+        $newCampaignID = $values['campaign_id'] ?? NULL;
+        $eventID = $values['id'] ?? NULL;
         if ($eventID && $this->_campaignID != $newCampaignID) {
           CRM_Event_BAO_Event::updateParticipantCampaignID($eventID, $newCampaignID);
         }

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -215,8 +215,8 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $params = array_merge($this->controller->exportValues($this->_name), $this->_submitValues);
 
     //format params
-    $params['start_date'] = CRM_Utils_Array::value('start_date', $params);
-    $params['end_date'] = CRM_Utils_Array::value('end_date', $params);
+    $params['start_date'] = $params['start_date'] ?? NULL;
+    $params['end_date'] = $params['end_date'] ?? NULL;
     $params['has_waitlist'] = CRM_Utils_Array::value('has_waitlist', $params, FALSE);
     $params['is_map'] = CRM_Utils_Array::value('is_map', $params, FALSE);
     $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -476,7 +476,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
           }
         }
 
-        $default = CRM_Utils_Array::value('default', $values);
+        $default = $values['default'] ?? NULL;
         if ($default && !in_array($default, $optionKeys)) {
           $errors['default'] = ts('Please select an appropriate option as default.');
         }
@@ -577,9 +577,9 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       }
       else {
         // if there are label / values, create custom options for them
-        $labels = CRM_Utils_Array::value('label', $params);
-        $values = CRM_Utils_Array::value('value', $params);
-        $default = CRM_Utils_Array::value('default', $params);
+        $labels = $params['label'] ?? NULL;
+        $values = $params['value'] ?? NULL;
+        $default = $params['default'] ?? NULL;
         $options = [];
         if (!CRM_Utils_System::isNull($labels) && !CRM_Utils_System::isNull($values)) {
           for ($i = 1; $i < self::NUM_OPTION; $i++) {
@@ -624,7 +624,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
                     unset($params['price_field_value'][$arrayID]);
                   }
                 }
-                $fieldParams['id'] = CRM_Utils_Array::value('price_field_id', $params);
+                $fieldParams['id'] = $params['price_field_id'] ?? NULL;
                 $fieldParams['option_id'] = $params['price_field_value'];
 
                 $priceSet = new CRM_Price_BAO_PriceSet();
@@ -654,9 +654,9 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
         if (CRM_Utils_Array::value('is_discount', $params) == 1) {
           // if there are discounted set of label / values,
           // create custom options for them
-          $labels = CRM_Utils_Array::value('discounted_label', $params);
-          $values = CRM_Utils_Array::value('discounted_value', $params);
-          $default = CRM_Utils_Array::value('discounted_default', $params);
+          $labels = $params['discounted_label'] ?? NULL;
+          $values = $params['discounted_value'] ?? NULL;
+          $default = $params['discounted_default'] ?? NULL;
 
           if (!CRM_Utils_System::isNull($labels) && !CRM_Utils_System::isNull($values)) {
             for ($j = 1; $j <= self::NUM_DISCOUNT; $j++) {

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -102,7 +102,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
       // Set event registration as the default profile if none selected
       if (!$defaults['custom_pre_id'] && count($defaults['custom_post']) == 0) {
-        $defaults['custom_pre_id'] = CRM_Utils_Array::value('id', $eventRegistrationIdDefaults);
+        $defaults['custom_pre_id'] = $eventRegistrationIdDefaults['id'] ?? NULL;
       }
       if (isset($defaults['custom_post']) && is_numeric($defaults['custom_post'])) {
         $defaults['custom_post_id'] = $defaults['custom_post'];
@@ -499,7 +499,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
         $profiles = CRM_Core_BAO_UFGroup::getProfiles($types);
 
         //check for additional custom pre profile
-        $additionalCustomPreId = CRM_Utils_Array::value('additional_custom_pre_id', $values);
+        $additionalCustomPreId = $values['additional_custom_pre_id'] ?? NULL;
         if (!empty($additionalCustomPreId)) {
           if (!($additionalCustomPreId == 'none')) {
             $customPreId = $additionalCustomPreId;
@@ -527,7 +527,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
         // We don't have required Individual fields in the pre-custom profile, so now check the post-custom profile
         if ($isPreError) {
-          $additionalCustomPostId = CRM_Utils_Array::value('additional_custom_post_id', $values);
+          $additionalCustomPostId = $values['additional_custom_post_id'] ?? NULL;
           if (!empty($additionalCustomPostId)) {
             if (!($additionalCustomPostId == 'none')) {
               $customPostId = $additionalCustomPostId;

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -266,7 +266,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   public function preProcess() {
     parent::preProcess();
-    $this->_showFeeBlock = CRM_Utils_Array::value('eventId', $_GET);
+    $this->_showFeeBlock = $_GET['eventId'] ?? NULL;
     $this->assign('showFeeBlock', FALSE);
     $this->assign('feeBlockPaid', FALSE);
 
@@ -522,7 +522,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     //setting default register date
     if ($this->_action == CRM_Core_Action::ADD) {
       $statuses = array_flip(CRM_Event_PseudoConstant::participantStatus());
-      $defaults[$this->_id]['status_id'] = CRM_Utils_Array::value('Registered', $statuses);
+      $defaults[$this->_id]['status_id'] = $statuses['Registered'] ?? NULL;
       if (!empty($defaults[$this->_id]['event_id'])) {
         $contributionTypeId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event',
           $defaults[$this->_id]['event_id'],
@@ -893,13 +893,13 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     // for this event.
     if ($self->_single && ($self->_action & CRM_Core_Action::ADD)) {
       if ($self->_context == 'standalone') {
-        $contactId = CRM_Utils_Array::value('contact_id', $values);
+        $contactId = $values['contact_id'] ?? NULL;
       }
       else {
         $contactId = $self->_contactId;
       }
 
-      $eventId = CRM_Utils_Array::value('event_id', $values);
+      $eventId = $values['event_id'] ?? NULL;
 
       $event = new CRM_Event_DAO_Event();
       $event->id = $eventId;
@@ -1061,7 +1061,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     // overwrite actual payment amount if entered
     if (!empty($params['total_amount'])) {
-      $contributionParams['total_amount'] = CRM_Utils_Array::value('total_amount', $params);
+      $contributionParams['total_amount'] = $params['total_amount'] ?? NULL;
     }
 
     // Retrieve the name and email of the current user - this will be the FROM for the receipt email
@@ -1337,7 +1337,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         ];
 
         foreach ($recordContribution as $f) {
-          $contributionParams[$f] = CRM_Utils_Array::value($f, $this->_params);
+          $contributionParams[$f] = $this->_params[$f] ?? NULL;
           if ($f == 'trxn_id') {
             $this->assign('trxn_id', $contributionParams[$f]);
           }
@@ -1548,7 +1548,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           // fix amount for each of participants ( for bulk mode )
           $eventAmount = [];
           $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-          $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+          $invoicing = $invoiceSettings['invoicing'] ?? NULL;
           $totalTaxAmount = 0;
 
           //add dataArray in the receipts in ADD and UPDATE condition
@@ -1567,7 +1567,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
                   $dataArray[(string) $value['tax_rate']] = $dataArray[(string) $value['tax_rate']] + CRM_Utils_Array::value('tax_amount', $value);
                 }
                 else {
-                  $dataArray[(string) $value['tax_rate']] = CRM_Utils_Array::value('tax_amount', $value);
+                  $dataArray[(string) $value['tax_rate']] = $value['tax_amount'] ?? NULL;
                 }
               }
             }
@@ -1606,8 +1606,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $sendTemplateParams['from'] = $receiptFrom;
           $sendTemplateParams['toName'] = $this->_contributorDisplayName;
           $sendTemplateParams['toEmail'] = $this->_contributorEmail;
-          $sendTemplateParams['cc'] = CRM_Utils_Array::value('cc', $this->_fromEmails);
-          $sendTemplateParams['bcc'] = CRM_Utils_Array::value('bcc', $this->_fromEmails);
+          $sendTemplateParams['cc'] = $this->_fromEmails['cc'] ?? NULL;
+          $sendTemplateParams['bcc'] = $this->_fromEmails['bcc'] ?? NULL;
         }
 
         //send email with pdf invoice
@@ -1617,7 +1617,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $this->_id, 'contribution_id', 'participant_id'
         );
         $prefixValue = Civi::settings()->get('contribution_invoice_settings');
-        $invoicing = CRM_Utils_Array::value('invoicing', $prefixValue);
+        $invoicing = $prefixValue['invoicing'] ?? NULL;
         if (!empty($taxAmt) && (isset($invoicing) && isset($prefixValue['is_email_pdf']))) {
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $contributionId;
@@ -1627,7 +1627,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $sent[] = $contactID;
           foreach ($participants as $ids => $values) {
             if ($values->contact_id == $contactID) {
-              $values->details = CRM_Utils_Array::value('receipt_text', $params);
+              $values->details = $params['receipt_text'] ?? NULL;
               CRM_Activity_BAO_Activity::addActivity($values, 'Email');
               break;
             }
@@ -1732,7 +1732,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->_discountId);
       $lineItem = [];
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
       $totalTaxAmount = 0;
       if (!CRM_Utils_System::isNull(CRM_Utils_Array::value('line_items', $form->_values))) {
         $lineItem[] = $form->_values['line_items'];
@@ -1907,8 +1907,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       //CRM-11529 for quick config backoffice transactions
       //when financial_type_id is passed in form, update the
       //lineitems with the financial type selected in form
-      $submittedFinancialType = CRM_Utils_Array::value('financial_type_id', $params);
-      $isPaymentRecorded = CRM_Utils_Array::value('record_contribution', $params);
+      $submittedFinancialType = $params['financial_type_id'] ?? NULL;
+      $isPaymentRecorded = $params['record_contribution'] ?? NULL;
       if ($isPaymentRecorded && $this->_quickConfig && $submittedFinancialType) {
         foreach ($lineItem[0] as &$values) {
           $values['financial_type_id'] = $submittedFinancialType;
@@ -1984,7 +1984,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $event['participant_role'] = implode(', ', $selectedRoles);
     }
     else {
-      $event['participant_role'] = CRM_Utils_Array::value($participantRoles, $role);
+      $event['participant_role'] = $role[$participantRoles] ?? NULL;
     }
     $event['is_monetary'] = $isPaidEvent;
 

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -296,7 +296,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     unset($event['end_date']);
 
     $role = CRM_Event_PseudoConstant::participantRole();
-    $participantRoles = CRM_Utils_Array::value('role_id', $params);
+    $participantRoles = $params['role_id'] ?? NULL;
     if (is_array($participantRoles)) {
       $selectedRoles = [];
       foreach (array_keys($participantRoles) as $roleId) {
@@ -305,7 +305,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       $event['participant_role'] = implode(', ', $selectedRoles);
     }
     else {
-      $event['participant_role'] = CRM_Utils_Array::value($participantRoles, $role);
+      $event['participant_role'] = $role[$participantRoles] ?? NULL;
     }
     $event['is_monetary'] = $this->_isPaidEvent;
 
@@ -374,8 +374,8 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       $sendTemplateParams['from'] = $receiptFrom;
       $sendTemplateParams['toName'] = $this->_contributorDisplayName;
       $sendTemplateParams['toEmail'] = $this->_contributorEmail;
-      $sendTemplateParams['cc'] = CRM_Utils_Array::value('cc', $this->_fromEmails);
-      $sendTemplateParams['bcc'] = CRM_Utils_Array::value('bcc', $this->_fromEmails);
+      $sendTemplateParams['cc'] = $this->_fromEmails['cc'] ?? NULL;
+      $sendTemplateParams['bcc'] = $this->_fromEmails['bcc'] ?? NULL;
     }
 
     list($mailSent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -117,7 +117,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
       $values[$participantID]['lineItem'][] = $lineItem;
     }
 
-    $values[$participantID]['totalAmount'] = CRM_Utils_Array::value('fee_amount', $values[$participantID]);
+    $values[$participantID]['totalAmount'] = $values[$participantID]['fee_amount'] ?? NULL;
 
     // Get registered_by contact ID and display_name if participant was registered by someone else (CRM-4859)
     if (!empty($values[$participantID]['participant_registered_by_id'])) {
@@ -193,7 +193,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
 
     $participantCount = [];
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $invoicing = $invoiceSettings['invoicing'] ?? NULL;
     $totalTaxAmount = 0;
     foreach ($lineItem as $k => $v) {
       if (CRM_Utils_Array::value('participant_count', $lineItem[$k]) > 0) {
@@ -211,7 +211,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container
     CRM_Utils_System::setTitle(ts('View Event Registration for') . ' ' . $displayName);
 
-    $roleId = CRM_Utils_Array::value('role_id', $values[$participantID]);
+    $roleId = $values[$participantID]['role_id'] ?? NULL;
     $title = $displayName . ' (' . CRM_Utils_Array::value($roleId, $participantRoles) . ' - ' . $eventTitle . ')';
 
     $sep = CRM_Core_DAO::VALUE_SEPARATOR;

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -238,7 +238,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $params = array('id' => $this->_eventId);
       CRM_Event_BAO_Event::retrieve($params, $this->_values['event']);
       // check for is_monetary status
-      $isMonetary = CRM_Utils_Array::value('is_monetary', $this->_values['event']);
+      $isMonetary = $this->_values['event']['is_monetary'] ?? NULL;
       // check for ability to add contributions of type
       if ($isMonetary
         && CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
@@ -272,7 +272,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       if ($eventFull && !$this->_allowConfirmation) {
         $this->_isEventFull = TRUE;
         //lets redirecting to info only when to waiting list.
-        $this->_allowWaitlist = CRM_Utils_Array::value('has_waitlist', $this->_values['event']);
+        $this->_allowWaitlist = $this->_values['event']['has_waitlist'] ?? NULL;
         if (!$this->_allowWaitlist) {
           CRM_Utils_System::redirect($infoUrl);
         }
@@ -380,21 +380,21 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     // we do not want to display recently viewed items on Registration pages
     $this->assign('displayRecent', FALSE);
 
-    $isShowLocation = CRM_Utils_Array::value('is_show_location', $this->_values['event']);
+    $isShowLocation = $this->_values['event']['is_show_location'] ?? NULL;
     $this->assign('isShowLocation', $isShowLocation);
     // Handle PCP
     $pcpId = CRM_Utils_Request::retrieve('pcpId', 'Positive', $this);
     if ($pcpId) {
       $pcp = CRM_PCP_BAO_PCP::handlePcp($pcpId, 'event', $this->_values['event']);
       $this->_pcpId = $pcp['pcpId'];
-      $this->_values['event']['intro_text'] = CRM_Utils_Array::value('intro_text', $pcp['pcpInfo']);
+      $this->_values['event']['intro_text'] = $pcp['pcpInfo']['intro_text'] ?? NULL;
     }
 
     // assign all event properties so wizard templates can display event info.
     $this->assign('event', $this->_values['event']);
     $this->assign('location', $this->_values['location']);
     $this->assign('bltID', $this->_bltID);
-    $isShowLocation = CRM_Utils_Array::value('is_show_location', $this->_values['event']);
+    $isShowLocation = $this->_values['event']['is_show_location'] ?? NULL;
     $this->assign('isShowLocation', $isShowLocation);
     CRM_Contribute_BAO_Contribution_Utils::overrideDefaultCurrency($this->_values['event']);
 
@@ -405,13 +405,13 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
 
     // Set the same value for is_billing_required as contribution page so code can be shared.
-    $this->_values['is_billing_required'] = CRM_Utils_Array::value('is_billing_required', $this->_values['event']);
+    $this->_values['is_billing_required'] = $this->_values['event']['is_billing_required'] ?? NULL;
     // check if billing block is required for pay later
     // note that I have started removing the use of isBillingAddressRequiredForPayLater in favour of letting
     // the CRM_Core_Payment_Manual class handle it - but there are ~300 references to it in the code base so only
     // removing in very limited cases.
     if (!empty($this->_values['event']['is_pay_later'])) {
-      $this->_isBillingAddressRequiredForPayLater = CRM_Utils_Array::value('is_billing_required', $this->_values['event']);
+      $this->_isBillingAddressRequiredForPayLater = $this->_values['event']['is_billing_required'] ?? NULL;
       $this->assign('isBillingAddressRequiredForPayLater', $this->_isBillingAddressRequiredForPayLater);
     }
   }
@@ -630,8 +630,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       if (is_array($discountedEvent)) {
         foreach ($discountedEvent as $key => $priceSetId) {
           $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId);
-          $priceSet = CRM_Utils_Array::value($priceSetId, $priceSet);
-          $form->_values['discount'][$key] = CRM_Utils_Array::value('fields', $priceSet);
+          $priceSet = $priceSet[$priceSetId] ?? NULL;
+          $form->_values['discount'][$key] = $priceSet['fields'] ?? NULL;
           $fieldID = key($form->_values['discount'][$key]);
           $form->_values['discount'][$key][$fieldID]['name'] = CRM_Core_DAO::getFieldValue(
             'CRM_Price_DAO_PriceSet',
@@ -641,7 +641,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         }
       }
     }
-    $eventFee = CRM_Utils_Array::value('fee', $form->_values);
+    $eventFee = $form->_values['fee'] ?? NULL;
     if (!is_array($eventFee) || empty($eventFee)) {
       $form->_values['fee'] = array();
     }
@@ -651,7 +651,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $isPaidEvent = $form->_isPaidEvent;
     }
     else {
-      $isPaidEvent = CRM_Utils_Array::value('is_monetary', $form->_values['event']);
+      $isPaidEvent = $form->_values['event']['is_monetary'] ?? NULL;
     }
     if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
       && !empty($form->_values['fee'])
@@ -912,7 +912,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $count = 1;
 
       $usedCache = FALSE;
-      $cacheCount = CRM_Utils_Array::value($key, $form->_lineItemParticipantsCount);
+      $cacheCount = $form->_lineItemParticipantsCount[$key] ?? NULL;
       if ($cacheCount && is_numeric($cacheCount)) {
         $count = $cacheCount;
         $usedCache = TRUE;
@@ -1212,7 +1212,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       if (!is_array($values) || empty($values)) {
         continue;
       }
-      $eleVal = CRM_Utils_Array::value($elementName, $values);
+      $eleVal = $values[$elementName] ?? NULL;
       if (empty($eleVal)) {
         continue;
       }
@@ -1567,7 +1567,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
         //lets get additional participant id to cancel.
         if ($this->_allowConfirmation && is_array($cancelledIds)) {
-          $additonalId = CRM_Utils_Array::value('participant_id', $value);
+          $additonalId = $value['participant_id'] ?? NULL;
           if ($additonalId && $key = array_search($additonalId, $cancelledIds)) {
             unset($cancelledIds[$key]);
           }

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -39,7 +39,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     //lets process in-queue participants.
     if ($this->_participantId && $this->_additionalParticipantIds) {
-      $this->_additionalParticipantId = CRM_Utils_Array::value($participantNo, $this->_additionalParticipantIds);
+      $this->_additionalParticipantId = $this->_additionalParticipantIds[$participantNo] ?? NULL;
     }
 
     $participantCnt = $participantNo + 1;
@@ -130,7 +130,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     //load default campaign from page.
     if (array_key_exists('participant_campaign_id', $this->_fields)) {
-      $defaults['participant_campaign_id'] = CRM_Utils_Array::value('campaign_id', $this->_values['event']);
+      $defaults['participant_campaign_id'] = $this->_values['event']['campaign_id'] ?? NULL;
     }
 
     //CRM-17865 set custom field defaults
@@ -215,7 +215,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       //lets allow to become a part of runtime waiting list, if primary selected pay later.
       $realPayLater = FALSE;
       if (!empty($this->_values['event']['is_monetary']) && !empty($this->_values['event']['is_pay_later'])) {
-        $realPayLater = CRM_Utils_Array::value('is_pay_later', $this->_params[0]);
+        $realPayLater = $this->_params[0]['is_pay_later'] ?? NULL;
       }
 
       //truly spaces are greater than required.
@@ -360,7 +360,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     $realPayLater = FALSE;
     if (!empty($self->_values['event']['is_monetary']) && !empty($self->_values['event']['is_pay_later'])) {
-      $realPayLater = CRM_Utils_Array::value('is_pay_later', $self->_params[0]);
+      $realPayLater = $self->_params[0]['is_pay_later'] ?? NULL;
     }
 
     if ($button != 'skip') {
@@ -579,7 +579,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       $params['campaign_id'] = $params['participant_campaign_id'];
     }
     else {
-      $params['campaign_id'] = CRM_Utils_Array::value('campaign_id', $this->_values['event']);
+      $params['campaign_id'] = $this->_values['event']['campaign_id'] ?? NULL;
     }
 
     // if waiting is enabled

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -426,7 +426,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       }
       //lets get additional participant id to cancel.
       if ($this->_allowConfirmation && is_array($cancelledIds)) {
-        $additonalId = CRM_Utils_Array::value('participant_id', $record);
+        $additonalId = $record['participant_id'] ?? NULL;
         if ($additonalId && $key = array_search($additonalId, $cancelledIds)) {
           unset($cancelledIds[$key]);
         }
@@ -473,7 +473,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
       //Unset ContactID for additional participants and set RegisterBy Id.
       if (empty($value['is_primary'])) {
-        $contactID = CRM_Utils_Array::value('contact_id', $value);
+        $contactID = $value['contact_id'] ?? NULL;
         $registerByID = $this->get('registerByID');
         if ($registerByID) {
           $value['registered_by_id'] = $registerByID;
@@ -600,7 +600,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
       //CRM-4453.
       if (!empty($value['is_primary'])) {
-        $primaryCurrencyID = CRM_Utils_Array::value('currencyID', $value);
+        $primaryCurrencyID = $value['currencyID'] ?? NULL;
       }
       if (empty($value['currencyID'])) {
         $value['currencyID'] = $primaryCurrencyID;
@@ -619,12 +619,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         }
       }
 
-      $value['fee_amount'] = CRM_Utils_Array::value('amount', $value);
+      $value['fee_amount'] = $value['amount'] ?? NULL;
       $this->set('value', $value);
 
       // handle register date CRM-4320
       if ($this->_allowConfirmation) {
-        $registerDate = CRM_Utils_Array::value('participant_register_date', $params);
+        $registerDate = $params['participant_register_date'] ?? NULL;
       }
       elseif (!empty($params['participant_register_date']) &&
         is_array($params['participant_register_date'])
@@ -683,7 +683,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
                 $dataArray[$line['tax_rate']] = $dataArray[$line['tax_rate']] + CRM_Utils_Array::value('tax_amount', $line);
               }
               else {
-                $dataArray[$line['tax_rate']] = CRM_Utils_Array::value('tax_amount', $line);
+                $dataArray[$line['tax_rate']] = $line['tax_amount'] ?? NULL;
               }
             }
           }
@@ -1156,7 +1156,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     //get email primary first if exist
     $subscriptionEmail = ['email' => CRM_Utils_Array::value('email-Primary', $params)];
     if (!$subscriptionEmail['email']) {
-      $subscriptionEmail['email'] = CRM_Utils_Array::value("email-{$form->_bltID}", $params);
+      $subscriptionEmail['email'] = $params["email-{$form->_bltID}"] ?? NULL;
     }
     // subscribing contact to groups
     if (!empty($subscribeGroupIds) && $subscriptionEmail['email']) {
@@ -1200,7 +1200,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           if (count($values)) {
             $formattedValues[$count][$prefix1 . 'CustomPre'] = $values;
           }
-          $formattedValues[$count][$prefix1 . 'CustomPreGroupTitle'] = CRM_Utils_Array::value('groupTitle', $groupName);
+          $formattedValues[$count][$prefix1 . 'CustomPreGroupTitle'] = $groupName['groupTitle'] ?? NULL;
         }
         //get the customPost profile info
         if (!empty($form->_values[$prefix2 . 'custom_post_id'])) {
@@ -1259,9 +1259,9 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     // This happens in buildQuickForm so emulate here.
     $form->_amount = $form->_totalAmount = CRM_Utils_Rule::cleanMoney(CRM_Utils_Array::value('totalAmount', $params));
     $form->set('params', $params['params']);
-    $form->_values['custom_pre_id'] = CRM_Utils_Array::value('custom_pre_id', $params);
-    $form->_values['custom_post_id'] = CRM_Utils_Array::value('custom_post_id', $params);
-    $form->_values['event'] = CRM_Utils_Array::value('event', $params);
+    $form->_values['custom_pre_id'] = $params['custom_pre_id'] ?? NULL;
+    $form->_values['custom_post_id'] = $params['custom_post_id'] ?? NULL;
+    $form->_values['event'] = $params['event'] ?? NULL;
     $form->_contributeMode = $params['contributeMode'];
     $eventParams = ['id' => $params['id']];
     CRM_Event_BAO_Event::retrieve($eventParams, $form->_values['event']);

--- a/CRM/Event/Form/Registration/ParticipantConfirm.php
+++ b/CRM/Event/Form/Registration/ParticipantConfirm.php
@@ -50,9 +50,9 @@ class CRM_Event_Form_Registration_ParticipantConfirm extends CRM_Event_Form_Regi
       );
     }
 
-    $this->_participantStatusId = CRM_Utils_Array::value('status_id', $values);
-    $this->_eventId = CRM_Utils_Array::value('event_id', $values);
-    $csContactId = CRM_Utils_Array::value('contact_id', $values);
+    $this->_participantStatusId = $values['status_id'] ?? NULL;
+    $this->_eventId = $values['event_id'] ?? NULL;
+    $csContactId = $values['contact_id'] ?? NULL;
 
     // make sure we have right permission to edit this user
     $this->_csContactID = NULL;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -152,7 +152,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $this->_allowWaitlist = FALSE;
     if ($eventFull && !$this->_allowConfirmation && !empty($this->_values['event']['has_waitlist'])) {
       $this->_allowWaitlist = TRUE;
-      $this->_waitlistMsg = CRM_Utils_Array::value('waitlist_text', $this->_values['event']);
+      $this->_waitlistMsg = $this->_values['event']['waitlist_text'] ?? NULL;
       if (!$this->_waitlistMsg) {
         $this->_waitlistMsg = ts('This event is currently full. However you can register now and get added to a waiting list. You will be notified if spaces become available.');
       }
@@ -523,14 +523,14 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       return;
     }
 
-    $feeFields = CRM_Utils_Array::value('fee', $form->_values);
+    $feeFields = $form->_values['fee'] ?? NULL;
 
     if (is_array($feeFields)) {
       $form->_feeBlock = &$form->_values['fee'];
     }
 
     //check for discount.
-    $discountedFee = CRM_Utils_Array::value('discount', $form->_values);
+    $discountedFee = $form->_values['discount'] ?? NULL;
     if (is_array($discountedFee) && !empty($discountedFee)) {
       if (!$discountId) {
         $form->_discountId = $discountId = CRM_Core_BAO_Discount::findSet($form->_eventId, 'civicrm_event');
@@ -586,13 +586,13 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           $fieldId = $field['id'];
           $elementName = 'price_' . $fieldId;
 
-          $isRequire = CRM_Utils_Array::value('is_required', $field);
+          $isRequire = $field['is_required'] ?? NULL;
           if ($button == 'skip') {
             $isRequire = FALSE;
           }
 
           //user might modified w/ hook.
-          $options = CRM_Utils_Array::value('options', $field);
+          $options = $field['options'] ?? NULL;
           $formClasses = ['CRM_Event_Form_Participant', 'CRM_Event_Form_ParticipantFeeSelection'];
 
           if (!is_array($options)) {
@@ -654,7 +654,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       }
       $form->assign('eventFeeBlockValues', json_encode($eventFeeBlockValues));
 
-      $form->_defaults['amount'] = CRM_Utils_Array::value('default_fee_id', $form->_values['event']);
+      $form->_defaults['amount'] = $form->_values['event']['default_fee_id'] ?? NULL;
       $element = &$form->addGroup($elements, 'amount', ts('Event Fee(s)'), '<br />');
       if (isset($form->_online) && $form->_online) {
         $element->freeze();
@@ -967,7 +967,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $params['campaign_id'] = $params['participant_campaign_id'];
     }
     else {
-      $params['campaign_id'] = CRM_Utils_Array::value('campaign_id', $this->_values['event']);
+      $params['campaign_id'] = $this->_values['event']['campaign_id'] ?? NULL;
     }
 
     //hack to allow group to register w/ waiting

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -432,14 +432,14 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     $eventParams = ['id' => $participant->event_id];
     CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails);
     //get default participant role.
-    $eventDetails['participant_role'] = CRM_Utils_Array::value($eventDetails['default_role_id'], $participantRoles);
+    $eventDetails['participant_role'] = $participantRoles[$eventDetails['default_role_id']] ?? NULL;
     //get the location info
     $locParams = [
       'entity_id' => $participant->event_id,
       'entity_table' => 'civicrm_event',
     ];
     $eventDetails['location'] = CRM_Core_BAO_Location::getValues($locParams, TRUE);
-    $toEmail = CRM_Utils_Array::value('email', $contactDetails[$participant->contact_id]);
+    $toEmail = $contactDetails[$participant->contact_id]['email'] ?? NULL;
     if ($toEmail) {
       //take a receipt from as event else domain.
       $receiptFrom = $domainValues['name'] . ' <' . $domainValues['email'] . '>';
@@ -512,7 +512,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     $eventParams = ['id' => $this->_event_id];
     CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails[$this->_event_id]);
     //get default participant role.
-    $eventDetails[$this->_event_id]['participant_role'] = CRM_Utils_Array::value($eventDetails[$this->_event_id]['default_role_id'], $participantRoles);
+    $eventDetails[$this->_event_id]['participant_role'] = $participantRoles[$eventDetails[$this->_event_id]['default_role_id']] ?? NULL;
     //get the location info
     $locParams = ['entity_id' => $this->_event_id, 'entity_table' => 'civicrm_event'];
     $eventDetails[$this->_event_id]['location'] = CRM_Core_BAO_Location::getValues($locParams, TRUE);

--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -289,7 +289,7 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
     $eventParams = ['id' => $this->_event_id];
     CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails[$this->_event_id]);
     //get default participant role.
-    $eventDetails[$this->_event_id]['participant_role'] = CRM_Utils_Array::value($eventDetails[$this->_event_id]['default_role_id'], $participantRoles);
+    $eventDetails[$this->_event_id]['participant_role'] = $participantRoles[$eventDetails[$this->_event_id]['default_role_id']] ?? NULL;
     //get the location info
     $locParams = ['entity_id' => $this->_event_id, 'entity_table' => 'civicrm_event'];
     $eventDetails[$this->_event_id]['location'] = CRM_Core_BAO_Location::getValues($locParams, TRUE);

--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -189,7 +189,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
    */
   public function postProcess() {
     $params = $this->controller->exportValues();
-    $groupOption = CRM_Utils_Array::value('group_option', $params, NULL);
+    $groupOption = $params['group_option'] ?? NULL;
     if ($groupOption) {
       $groupParams = [];
       $groupParams['title'] = $params['title'];

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -165,14 +165,14 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       $eventTypeId = CRM_Core_DAO::getFieldValue("CRM_Event_DAO_Event", $eventId, 'event_type_id');
       foreach ($this->_fields as $name => $field) {
         if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($name)) {
-          $customValue = CRM_Utils_Array::value($customFieldID, $this->_customFields);
+          $customValue = $this->_customFields[$customFieldID] ?? NULL;
           $entityColumnValue = [];
           if (!empty($customValue['extends_entity_column_value'])) {
             $entityColumnValue = explode(CRM_Core_DAO::VALUE_SEPARATOR,
               $customValue['extends_entity_column_value']
             );
           }
-          $entityColumnValueRole = CRM_Utils_Array::value($roleId, $entityColumnValue);
+          $entityColumnValueRole = $entityColumnValue[$roleId] ?? NULL;
           $entityColumnValueEventType = in_array($eventTypeId, $entityColumnValue) ? $eventTypeId : NULL;
           if (($this->_roleCustomDataTypeID == $customValue['extends_entity_column_id']) &&
             ($entityColumnValueRole)
@@ -235,7 +235,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
 
       //get the from status ids, CRM-4323
       if (array_key_exists('participant_status', $this->_fields)) {
-        $this->_fromStatusIds[$participantId] = CRM_Utils_Array::value("field[$participantId][participant_status]", $defaults);
+        $this->_fromStatusIds[$participantId] = $defaults["field[$participantId][participant_status]"] ?? NULL;
       }
       if (array_key_exists('participant_role', $this->_fields)) {
         if ($defaults["field[{$participantId}][participant_role]"]) {
@@ -325,10 +325,10 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
    */
   public static function updateContributionStatus($params) {
     // get minimum required values.
-    $statusId = CRM_Utils_Array::value('contribution_status_id', $params);
-    $componentId = CRM_Utils_Array::value('component_id', $params);
-    $componentName = CRM_Utils_Array::value('componentName', $params);
-    $contributionId = CRM_Utils_Array::value('contribution_id', $params);
+    $statusId = $params['contribution_status_id'] ?? NULL;
+    $componentId = $params['component_id'] ?? NULL;
+    $componentName = $params['componentName'] ?? NULL;
+    $contributionId = $params['contribution_id'] ?? NULL;
 
     if (!$contributionId || !$componentId || !$componentName || !$statusId) {
       return NULL;
@@ -383,7 +383,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       'labelColumn' => 'name',
       'flip' => 1,
     ]);
-    $input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] = CRM_Utils_Array::value('IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved', $params);
+    $input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] = $params['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] ?? NULL;
     if ($statusId == $contributionStatuses['Cancelled']) {
       $baseIPN->cancelled($objects, $transaction, $input);
       $transaction->commit();
@@ -487,7 +487,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
         $relatedStatusChange = FALSE;
         if (!empty($value['participant_status'])) {
           $value['status_id'] = $value['participant_status'];
-          $fromStatusId = CRM_Utils_Array::value($key, $this->_fromStatusIds);
+          $fromStatusId = $this->_fromStatusIds[$key] ?? NULL;
           if (!$fromStatusId) {
             $fromStatusId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $key, 'status_id');
           }

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -100,9 +100,9 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       $mappingName = $mappingName[1];
       $mappingContactType = $mappingContactType[1];
-      $mappingLocation = CRM_Utils_Array::value('1', $mappingLocation);
-      $mappingPhoneType = CRM_Utils_Array::value('1', $mappingPhoneType);
-      $mappingRelation = CRM_Utils_Array::value('1', $mappingRelation);
+      $mappingLocation = $mappingLocation['1'] ?? NULL;
+      $mappingPhoneType = $mappingPhoneType['1'] ?? NULL;
+      $mappingRelation = $mappingRelation['1'] ?? NULL;
 
       //mapping is to be loaded from database
 
@@ -339,7 +339,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     if (!empty($fields['saveMapping'])) {
-      $nameField = CRM_Utils_Array::value('saveMappingName', $fields);
+      $nameField = $fields['saveMappingName'] ?? NULL;
       if (empty($nameField)) {
         $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
       }
@@ -352,7 +352,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     //display Error if loaded mapping is not selected
     if (array_key_exists('loadMapping', $fields)) {
-      $getMapName = CRM_Utils_Array::value('savedMapping', $fields);
+      $getMapName = $fields['savedMapping'] ?? NULL;
       if (empty($getMapName)) {
         $errors['savedMapping'] = ts('Select saved mapping');
       }
@@ -428,9 +428,9 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
         $updateMappingFields->column_number = $i;
 
         $explodedValues = explode('_', $mapperKeys[$i][0]);
-        $id = CRM_Utils_Array::value(0, $explodedValues);
-        $first = CRM_Utils_Array::value(1, $explodedValues);
-        $second = CRM_Utils_Array::value(2, $explodedValues);
+        $id = $explodedValues[0] ?? NULL;
+        $first = $explodedValues[1] ?? NULL;
+        $second = $explodedValues[2] ?? NULL;
 
         $updateMappingFields->name = $mapper[$i];
         $updateMappingFields->save();
@@ -452,9 +452,9 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
         $saveMappingFields->column_number = $i;
 
         $explodedValues = explode('_', $mapperKeys[$i][0]);
-        $id = CRM_Utils_Array::value(0, $explodedValues);
-        $first = CRM_Utils_Array::value(1, $explodedValues);
-        $second = CRM_Utils_Array::value(2, $explodedValues);
+        $id = $explodedValues[0] ?? NULL;
+        $first = $explodedValues[1] ?? NULL;
+        $second = $explodedValues[2] ?? NULL;
 
         $saveMappingFields->name = $mapper[$i];
         $saveMappingFields->save();

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -443,8 +443,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
     if (is_array($newParticipant) && civicrm_error($newParticipant)) {
       if ($onDuplicate == CRM_Import_Parser::DUPLICATE_SKIP) {
 
-        $contactID = CRM_Utils_Array::value('contactID', $newParticipant);
-        $participantID = CRM_Utils_Array::value('participantID', $newParticipant);
+        $contactID = $newParticipant['contactID'] ?? NULL;
+        $participantID = $newParticipant['participantID'] ?? NULL;
         $url = CRM_Utils_System::url('civicrm/contact/view/participant',
           "reset=1&id={$participantID}&cid={$contactID}&action=view", TRUE
         );
@@ -463,7 +463,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
     }
 
     if (!(is_array($newParticipant) && civicrm_error($newParticipant))) {
-      $this->_newParticipants[] = CRM_Utils_Array::value('id', $newParticipant);
+      $this->_newParticipants[] = $newParticipant['id'] ?? NULL;
     }
 
     return CRM_Import_Parser::VALID;
@@ -535,8 +535,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
         elseif ($type == 'Select' || $type == 'Radio') {
           $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
           foreach ($customOption as $customFldID => $customValue) {
-            $val = CRM_Utils_Array::value('value', $customValue);
-            $label = CRM_Utils_Array::value('label', $customValue);
+            $val = $customValue['value'] ?? NULL;
+            $label = $customValue['label'] ?? NULL;
             $label = strtolower($label);
             $value = strtolower(trim($value));
             if (($value == $label) || ($value == strtolower($val))) {

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -117,7 +117,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
               $values['feeBlock']['value'][$fieldCnt] = '';
               $values['feeBlock']['label'][$fieldCnt] = $fieldValues['label'];
               $values['feeBlock']['lClass'][$fieldCnt] = 'price_set_option_group-label';
-              $values['feeBlock']['isDisplayAmount'][$fieldCnt] = CRM_Utils_Array::value('is_display_amounts', $fieldValues);
+              $values['feeBlock']['isDisplayAmount'][$fieldCnt] = $fieldValues['is_display_amounts'] ?? NULL;
               $fieldCnt++;
               $labelClass = 'price_set_option-label';
             }
@@ -126,9 +126,9 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
             }
             // show tax rate with amount
             $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-            $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
-            $displayOpt = CRM_Utils_Array::value('tax_display_settings', $invoiceSettings);
-            $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+            $taxTerm = $invoiceSettings['tax_term'] ?? NULL;
+            $displayOpt = $invoiceSettings['tax_display_settings'] ?? NULL;
+            $invoicing = $invoiceSettings['invoicing'] ?? NULL;
             foreach ($fieldValues['options'] as $optionId => $optionVal) {
               if (CRM_Utils_Array::value('visibility_id', $optionVal) != array_search('public', $visibility) &&
                 $adminFieldVisible == FALSE
@@ -136,7 +136,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
                 continue;
               }
 
-              $values['feeBlock']['isDisplayAmount'][$fieldCnt] = CRM_Utils_Array::value('is_display_amounts', $fieldValues);
+              $values['feeBlock']['isDisplayAmount'][$fieldCnt] = $fieldValues['is_display_amounts'] ?? NULL;
               if ($invoicing && isset($optionVal['tax_amount'])) {
                 $values['feeBlock']['value'][$fieldCnt] = CRM_Price_BAO_PriceField::getTaxLabel($optionVal, 'amount', $displayOpt, $taxTerm);
                 $values['feeBlock']['tax_amount'][$fieldCnt] = $optionVal['tax_amount'];
@@ -238,7 +238,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       $this->assign('findParticipants', $findParticipants);
     }
 
-    $participantListingID = CRM_Utils_Array::value('participant_listing_id', $values['event']);
+    $participantListingID = $values['event']['participant_listing_id'] ?? NULL;
     if ($participantListingID) {
       $participantListingURL = CRM_Utils_System::url('civicrm/event/participant',
         "reset=1&id={$this->_id}",
@@ -247,7 +247,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       $this->assign('participantListingURL', $participantListingURL);
     }
 
-    $hasWaitingList = CRM_Utils_Array::value('has_waitlist', $values['event']);
+    $hasWaitingList = $values['event']['has_waitlist'] ?? NULL;
     $eventFullMessage = CRM_Event_BAO_Participant::eventFull($this->_id,
       FALSE,
       $hasWaitingList
@@ -317,7 +317,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
         }
       }
       elseif ($hasWaitingList) {
-        $statusMessage = CRM_Utils_Array::value('waitlist_text', $values['event']);
+        $statusMessage = $values['event']['waitlist_text'] ?? NULL;
         if (!$statusMessage) {
           $statusMessage = ts('Event is currently full, but you can register and be a part of waiting list.');
         }

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -416,10 +416,10 @@ ORDER BY start_date desc
         }
 
         //show campaigns on selector.
-        $manageEvent[$dao->id]['campaign'] = CRM_Utils_Array::value($dao->campaign_id, $allCampaigns);
+        $manageEvent[$dao->id]['campaign'] = $allCampaigns[$dao->campaign_id] ?? NULL;
         $manageEvent[$dao->id]['reminder'] = CRM_Core_BAO_ActionSchedule::isConfigured($dao->id, $mapping->getId());
-        $manageEvent[$dao->id]['is_pcp_enabled'] = CRM_Utils_Array::value($dao->id, $eventPCPS);
-        $manageEvent[$dao->id]['event_type'] = CRM_Utils_Array::value($manageEvent[$dao->id]['event_type_id'], $eventType);
+        $manageEvent[$dao->id]['is_pcp_enabled'] = $eventPCPS[$dao->id] ?? NULL;
+        $manageEvent[$dao->id]['event_type'] = $eventType[$manageEvent[$dao->id]['event_type_id']] ?? NULL;
         $manageEvent[$dao->id]['is_repeating_event'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_RecurringEntity', $dao->id, 'parent_id', 'entity_id');
         // allow hooks to set 'field' value which allows configuration pop-up to show a tab as enabled/disabled
         CRM_Utils_Hook::tabset('civicrm/event/manage/rows', $manageEvent, ['event_id' => $dao->id]);

--- a/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
+++ b/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
@@ -86,7 +86,7 @@ LIMIT    $offset, $rowCount";
     $object = CRM_Core_DAO::executeQuery($query, $params);
     $statusLookup = CRM_Event_PseudoConstant::participantStatus(NULL, NULL, 'label');
     while ($object->fetch()) {
-      $status = CRM_Utils_Array::value($object->status_id, $statusLookup);
+      $status = $statusLookup[$object->status_id] ?? NULL;
       $row = [
         'id' => $object->contact_id,
         'participantID' => $object->participant_id,

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -333,7 +333,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
       }
 
       //carry campaign on selectors.
-      $row['campaign'] = CRM_Utils_Array::value($result->participant_campaign_id, $allCampaigns);
+      $row['campaign'] = $allCampaigns[$result->participant_campaign_id] ?? NULL;
       $row['campaign_id'] = $result->participant_campaign_id;
 
       // gross hack to show extra information for pending status

--- a/CRM/Event/StateMachine/Search.php
+++ b/CRM/Event/StateMachine/Search.php
@@ -71,7 +71,7 @@ class CRM_Event_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1006,7 +1006,7 @@ class CRM_Export_BAO_ExportProcessor {
           $fieldValue = $phoneTypes[$fieldValue];
         }
         elseif ($field == 'provider_id' || $field == 'im_provider') {
-          $fieldValue = CRM_Utils_Array::value($fieldValue, $imProviders);
+          $fieldValue = $imProviders[$fieldValue] ?? NULL;
         }
         elseif (strstr($field, 'master_id')) {
           // @todo - why not just $field === 'master_id'  - what else would it be?
@@ -1031,7 +1031,7 @@ class CRM_Export_BAO_ExportProcessor {
       if (!$this->isExportSpecifiedPaymentFields()) {
         $nullContributionDetails = array_fill_keys(array_keys($this->getPaymentHeaders()), NULL);
         if ($this->isExportPaymentFields()) {
-          $paymentData = CRM_Utils_Array::value($row[$paymentTableId], $paymentDetails);
+          $paymentData = $paymentDetails[$row[$paymentTableId]] ?? NULL;
           if (!is_array($paymentData) || empty($paymentData)) {
             $paymentData = $nullContributionDetails;
           }
@@ -1170,7 +1170,7 @@ class CRM_Export_BAO_ExportProcessor {
     }
     elseif ($this->isExportSpecifiedPaymentFields() && array_key_exists($field, $this->getcomponentPaymentFields())) {
       $paymentTableId = $this->getPaymentTableID();
-      $paymentData = CRM_Utils_Array::value($iterationDAO->$paymentTableId, $paymentDetails);
+      $paymentData = $paymentDetails[$iterationDAO->$paymentTableId] ?? NULL;
       $payFieldMapper = [
         'componentPaymentField_total_amount' => 'total_amount',
         'componentPaymentField_contribution_status' => 'contribution_status',
@@ -1357,7 +1357,7 @@ class CRM_Export_BAO_ExportProcessor {
   public function setRelationshipReturnProperties($value, $relationshipKey) {
     $relationField = $value['name'];
     $relIMProviderId = NULL;
-    $relLocTypeId = CRM_Utils_Array::value('location_type_id', $value);
+    $relLocTypeId = $value['location_type_id'] ?? NULL;
     $locationName = CRM_Core_PseudoConstant::getName('CRM_Core_BAO_Address', 'location_type_id', $relLocTypeId);
     $relPhoneTypeId = CRM_Utils_Array::value('phone_type_id', $value, ($locationName ? 'Primary' : NULL));
     $relIMProviderId = CRM_Utils_Array::value('im_provider_id', $value, ($locationName ? 'Primary' : NULL));
@@ -2104,7 +2104,7 @@ WHERE  id IN ( $deleteIDString )
     if (!empty($greetingOptions)) {
       // Greeting options is keyed by 'postal_greeting' or 'addressee'.
       foreach ($greetingOptions as $key => $value) {
-        $option = CRM_Utils_Array::value($key, $formValues);
+        $option = $formValues[$key] ?? NULL;
         if ($option) {
           if ($greetingOptions[$key][$option] == ts('Other')) {
             $formValues[$key] = $formValues["{$key}_other"];
@@ -2185,7 +2185,7 @@ WHERE  id IN ( $deleteIDString )
           $fieldValue = $phoneTypes[$relationValue];
         }
         elseif ($relationField == 'provider_id') {
-          $fieldValue = CRM_Utils_Array::value($relationValue, $imProviders);
+          $fieldValue = $imProviders[$relationValue] ?? NULL;
         }
         // CRM-13995
         elseif (is_object($relDAO) && in_array($relationField, [

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -340,7 +340,7 @@ FROM   {$this->_componentTable}
       ];
 
       foreach ($greetings as $key => $value) {
-        $otherOption = CRM_Utils_Array::value($key, $params);
+        $otherOption = $params[$key] ?? NULL;
 
         if ((CRM_Utils_Array::value($otherOption, $self->_greetingOptions[$key]) == ts('Other')) && empty($params[$value])) {
 
@@ -372,7 +372,7 @@ FROM   {$this->_componentTable}
     // all submitted options or any other argument
     $exportParams = $params;
 
-    $mappingId = CRM_Utils_Array::value('mapping', $params);
+    $mappingId = $params['mapping'] ?? NULL;
     if ($mappingId) {
       $this->set('mappingId', $mappingId);
     }

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -379,7 +379,7 @@ LIMIT 1";
     if (!Civi::settings()->get('deferred_revenue_enabled')) {
       return FALSE;
     }
-    $recognitionDate = CRM_Utils_Array::value('revenue_recognition_date', $params);
+    $recognitionDate = $params['revenue_recognition_date'] ?? NULL;
     if (!(!CRM_Utils_System::isNull($recognitionDate)
       || ($contributionID && isset($params['prevContribution'])
         && !CRM_Utils_System::isNull($params['prevContribution']->revenue_recognition_date)))
@@ -387,8 +387,8 @@ LIMIT 1";
       return FALSE;
     }
 
-    $lineItems = CRM_Utils_Array::value('line_item', $params);
-    $financialTypeID = CRM_Utils_Array::value('financial_type_id', $params);
+    $lineItems = $params['line_item'] ?? NULL;
+    $financialTypeID = $params['financial_type_id'] ?? NULL;
     if (!$financialTypeID) {
       $financialTypeID = $params['prevContribution']->financial_type_id;
     }

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -86,7 +86,7 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
 
     if ($taxTrxnID) {
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
+      $taxTerm = $invoiceSettings['tax_term'] ?? NULL;
       $params['amount'] = $lineItem->tax_amount;
       $params['description'] = $taxTerm;
       $accountRelName = 'Sales Tax Account is';
@@ -142,7 +142,7 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
     }
 
     $financialItem->save();
-    $financialtrxnIDS = CRM_Utils_Array::value('id', $trxnIds);
+    $financialtrxnIDS = $trxnIds['id'] ?? NULL;
     if (!empty($financialtrxnIDS)) {
       if (!is_array($financialtrxnIDS)) {
         $financialtrxnIDS = [$financialtrxnIDS];

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -90,7 +90,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
     $financialType = new CRM_Financial_DAO_FinancialType();
     $financialType->copyValues($params);
     if (!empty($ids['financialType'])) {
-      $financialType->id = CRM_Utils_Array::value('financialType', $ids);
+      $financialType->id = $ids['financialType'] ?? NULL;
       if (self::isACLFinancialTypeStatus()) {
         $prevName = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $financialType->id, 'name');
         if ($prevName != $params['name']) {

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -450,7 +450,7 @@ class CRM_Financial_BAO_Payment {
       $lineItems[$lineItemID]['balance'] = $lineItem['subTotal'] - $lineItems[$lineItemID]['paid'];
 
       if (!empty($lineItemOverrides)) {
-        $lineItems[$lineItemID]['allocation'] = CRM_Utils_Array::value($lineItemID, $lineItemOverrides);
+        $lineItems[$lineItemID]['allocation'] = $lineItemOverrides[$lineItemID] ?? NULL;
       }
       else {
         $lineItems[$lineItemID]['allocation'] = $lineItems[$lineItemID]['balance'] * $ratio;

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -262,8 +262,8 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    * @return int
    */
   public static function defaultComparison($processor1, $processor2) {
-    $p1 = CRM_Utils_Array::value('is_default', $processor1);
-    $p2 = CRM_Utils_Array::value('is_default', $processor2);
+    $p1 = $processor1['is_default'] ?? NULL;
+    $p2 = $processor2['is_default'] ?? NULL;
     if ($p1 == $p2) {
       return 0;
     }

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -165,7 +165,7 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
     if ($this->_action == CRM_Core_Action::ADD) {
       if (!empty($this->_submitValues['account_relationship']) || !empty($this->_submitValues['financial_account_id'])) {
         $financialAccountType = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations();
-        $financialAccountType = CRM_Utils_Array::value($this->_submitValues['account_relationship'], $financialAccountType);
+        $financialAccountType = $financialAccountType[$this->_submitValues['account_relationship']] ?? NULL;
         $result = CRM_Contribute_PseudoConstant::financialAccount(NULL, $financialAccountType);
 
         $financialAccountSelect = ['' => ts('- select -')] + $result;

--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -156,11 +156,11 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
 
     $paymentInstrumentName = CRM_Core_PseudoConstant::getName('CRM_Financial_DAO_FinancialTrxn', 'payment_instrument_id', $params['payment_instrument_id']);
     if ($paymentInstrumentName == 'Credit Card') {
-      $params['card_type_id'] = CRM_Utils_Array::value('card_type_id', $this->_submitValues);
-      $params['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $this->_submitValues);
+      $params['card_type_id'] = $this->_submitValues['card_type_id'] ?? NULL;
+      $params['pan_truncation'] = $this->_submitValues['pan_truncation'] ?? NULL;
     }
     elseif ($paymentInstrumentName == 'Check') {
-      $params['check_number'] = CRM_Utils_Array::value('check_number', $this->_submitValues);
+      $params['check_number'] = $this->_submitValues['check_number'] ?? NULL;
     }
 
     $this->submit($params);

--- a/CRM/Financial/Form/SalesTaxTrait.php
+++ b/CRM/Financial/Form/SalesTaxTrait.php
@@ -37,7 +37,7 @@ trait CRM_Financial_Form_SalesTaxTrait {
    */
   public function getSalesTaxTerm() {
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $invoicing = $invoiceSettings['invoicing'] ?? NULL;
     if (!$invoicing) {
       return '';
     }

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -38,7 +38,7 @@ class CRM_Financial_Page_AJAX {
     }
     else {
       $financialAccountType = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations();
-      $financialAccountType = CRM_Utils_Array::value($_GET['_value'], $financialAccountType);
+      $financialAccountType = $financialAccountType[$_GET['_value']] ?? NULL;
       $result = CRM_Contribute_PseudoConstant::financialAccount(NULL, $financialAccountType);
       if ($financialAccountType) {
         $defaultId = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_financial_account WHERE is_default = 1 AND financial_account_type_id = $financialAccountType");
@@ -303,7 +303,7 @@ class CRM_Financial_Page_AJAX {
     $params['context'] = $context;
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['rowCount'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
     $params['total'] = 0;
 
     // get batch list

--- a/CRM/Financial/Page/FinancialType.php
+++ b/CRM/Financial/Page/FinancialType.php
@@ -110,8 +110,7 @@ class CRM_Financial_Page_FinancialType extends CRM_Core_Page_Basic {
 
       foreach ($financialAccountIds as $key => $values) {
         if (!empty($financialAccounts[$values['financial_account_id']])) {
-          $financialAccountId[$values['financial_account_id']] = CRM_Utils_Array::value(
-            $values['financial_account_id'], $financialAccounts);
+          $financialAccountId[$values['financial_account_id']] = $financialAccounts[$values['financial_account_id']] ?? NULL;
         }
       }
 

--- a/CRM/Financial/Page/FinancialTypeAccount.php
+++ b/CRM/Financial/Page/FinancialTypeAccount.php
@@ -133,12 +133,12 @@ class CRM_Financial_Page_FinancialTypeAccount extends CRM_Core_Page {
           }
           if (!empty($financialAccount->financial_account_type_id)) {
             $optionGroupName = 'financial_account_type';
-            $financialType[$dao->id]['financial_account_type'] = CRM_Utils_Array::value($financialAccount->financial_account_type_id, $financialAccountType);
+            $financialType[$dao->id]['financial_account_type'] = $financialAccountType[$financialAccount->financial_account_type_id] ?? NULL;
 
           }
           if (!empty($dao->account_relationship)) {
             $optionGroupName = 'account_relationship';
-            $financialType[$dao->id]['account_relationship'] = CRM_Utils_Array::value($dao->account_relationship, $accountRelationship);
+            $financialType[$dao->id]['account_relationship'] = $accountRelationship[$dao->account_relationship] ?? NULL;
           }
         }
         // form all action links

--- a/CRM/Friend/BAO/Friend.php
+++ b/CRM/Friend/BAO/Friend.php
@@ -157,9 +157,9 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
     $transaction->commit();
 
     // Process sending of mails
-    $mailParams['title'] = CRM_Utils_Array::value('title', $params);
-    $mailParams['general_link'] = CRM_Utils_Array::value('general_link', $friendParams);
-    $mailParams['message'] = CRM_Utils_Array::value('suggested_message', $params);
+    $mailParams['title'] = $params['title'] ?? NULL;
+    $mailParams['general_link'] = $friendParams['general_link'] ?? NULL;
+    $mailParams['message'] = $params['suggested_message'] ?? NULL;
 
     // Default "from email address" is default domain address.
     list($_, $mailParams['email_from']) = CRM_Core_BAO_Domain::getNameAndEmail();

--- a/CRM/Friend/Form.php
+++ b/CRM/Friend/Form.php
@@ -73,8 +73,8 @@ class CRM_Friend_Form extends CRM_Core_Form {
       CRM_Core_DAO::commonRetrieve('CRM_Contribute_DAO_ContributionPage',
         $params, $values, ['title', 'campaign_id', 'is_share']
       );
-      $this->_title = CRM_Utils_Array::value('title', $values);
-      $this->_campaignId = CRM_Utils_Array::value('campaign_id', $values);
+      $this->_title = $values['title'] ?? NULL;
+      $this->_campaignId = $values['campaign_id'] ?? NULL;
       $this->_entityTable = 'civicrm_contribution_page';
       if ($pcomponent == 'event') {
         $this->_entityTable = 'civicrm_event';
@@ -82,7 +82,7 @@ class CRM_Friend_Form extends CRM_Core_Form {
         $this->_title = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_entityId, 'title');
       }
       else {
-        $isShare = CRM_Utils_Array::value('is_share', $values);
+        $isShare = $values['is_share'] ?? NULL;
       }
       // Tell Form.tpl whether to include SocialNetwork.tpl for social media sharing
       $this->assign('isShare', $isShare);

--- a/CRM/Friend/Form/Contribute.php
+++ b/CRM/Friend/Form/Contribute.php
@@ -48,11 +48,11 @@ class CRM_Friend_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
       $defaults['entity_table'] = 'civicrm_contribution_page';
       $defaults['entity_id'] = $this->_id;
       CRM_Friend_BAO_Friend::getValues($defaults);
-      $this->_friendId = CRM_Utils_Array::value('id', $defaults);
-      $defaults['tf_title'] = CRM_Utils_Array::value('title', $defaults);
-      $defaults['tf_is_active'] = CRM_Utils_Array::value('is_active', $defaults);
-      $defaults['tf_thankyou_title'] = CRM_Utils_Array::value('thankyou_title', $defaults);
-      $defaults['tf_thankyou_text'] = CRM_Utils_Array::value('thankyou_text', $defaults);
+      $this->_friendId = $defaults['id'] ?? NULL;
+      $defaults['tf_title'] = $defaults['title'] ?? NULL;
+      $defaults['tf_is_active'] = $defaults['is_active'] ?? NULL;
+      $defaults['tf_thankyou_title'] = $defaults['thankyou_title'] ?? NULL;
+      $defaults['tf_thankyou_text'] = $defaults['thankyou_text'] ?? NULL;
     }
 
     if (!$this->_friendId) {
@@ -76,7 +76,7 @@ class CRM_Friend_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
       $defaults['entity_table'] = 'civicrm_contribution_page';
       $defaults['entity_id'] = $this->_id;
       CRM_Friend_BAO_Friend::getValues($defaults);
-      $this->_friendId = CRM_Utils_Array::value('id', $defaults);
+      $this->_friendId = $defaults['id'] ?? NULL;
     }
 
     CRM_Friend_BAO_Friend::buildFriendForm($this);
@@ -97,8 +97,8 @@ class CRM_Friend_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
     $formValues['entity_id'] = $this->_id;
     $formValues['title'] = $formValues['tf_title'];
     $formValues['is_active'] = CRM_Utils_Array::value('tf_is_active', $formValues, FALSE);
-    $formValues['thankyou_title'] = CRM_Utils_Array::value('tf_thankyou_title', $formValues);
-    $formValues['thankyou_text'] = CRM_Utils_Array::value('tf_thankyou_text', $formValues);
+    $formValues['thankyou_title'] = $formValues['tf_thankyou_title'] ?? NULL;
+    $formValues['thankyou_text'] = $formValues['tf_thankyou_text'] ?? NULL;
 
     if (($this->_action & CRM_Core_Action::UPDATE) && $this->_friendId) {
       $formValues['id'] = $this->_friendId;

--- a/CRM/Friend/Form/Event.php
+++ b/CRM/Friend/Form/Event.php
@@ -49,16 +49,16 @@ class CRM_Friend_Form_Event extends CRM_Event_Form_ManageEvent {
       $defaults['entity_id'] = $this->_id;
       CRM_Friend_BAO_Friend::getValues($defaults);
       if (!empty($defaults['id'])) {
-        $defaults['tf_id'] = CRM_Utils_Array::value('id', $defaults);
+        $defaults['tf_id'] = $defaults['id'] ?? NULL;
         $this->_friendId = $defaults['tf_id'];
         // lets unset the 'id' since it conflicts with eventID (or contribID)
         // CRM-12667
         unset($defaults['id']);
       }
-      $defaults['tf_title'] = CRM_Utils_Array::value('title', $defaults);
-      $defaults['tf_is_active'] = CRM_Utils_Array::value('is_active', $defaults);
-      $defaults['tf_thankyou_title'] = CRM_Utils_Array::value('thankyou_title', $defaults);
-      $defaults['tf_thankyou_text'] = CRM_Utils_Array::value('thankyou_text', $defaults);
+      $defaults['tf_title'] = $defaults['title'] ?? NULL;
+      $defaults['tf_is_active'] = $defaults['is_active'] ?? NULL;
+      $defaults['tf_thankyou_title'] = $defaults['thankyou_title'] ?? NULL;
+      $defaults['tf_thankyou_text'] = $defaults['thankyou_text'] ?? NULL;
     }
 
     if (!$this->_friendId) {
@@ -82,7 +82,7 @@ class CRM_Friend_Form_Event extends CRM_Event_Form_ManageEvent {
       $defaults['entity_table'] = 'civicrm_event';
       $defaults['entity_id'] = $this->_id;
       CRM_Friend_BAO_Friend::getValues($defaults);
-      $this->_friendId = CRM_Utils_Array::value('id', $defaults);
+      $this->_friendId = $defaults['id'] ?? NULL;
     }
 
     CRM_Friend_BAO_Friend::buildFriendForm($this);
@@ -106,8 +106,8 @@ class CRM_Friend_Form_Event extends CRM_Event_Form_ManageEvent {
     $formValues['entity_id'] = $this->_id;
     $formValues['title'] = $formValues['tf_title'];
     $formValues['is_active'] = CRM_Utils_Array::value('tf_is_active', $formValues, FALSE);
-    $formValues['thankyou_title'] = CRM_Utils_Array::value('tf_thankyou_title', $formValues);
-    $formValues['thankyou_text'] = CRM_Utils_Array::value('tf_thankyou_text', $formValues);
+    $formValues['thankyou_title'] = $formValues['tf_thankyou_title'] ?? NULL;
+    $formValues['thankyou_text'] = $formValues['tf_thankyou_text'] ?? NULL;
 
     if (($this->_action & CRM_Core_Action::UPDATE) && $this->_friendId) {
       $formValues['id'] = $this->_friendId;

--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -154,7 +154,7 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
       }
     }
     $grant = new CRM_Grant_DAO_Grant();
-    $grant->id = CRM_Utils_Array::value('grant_id', $ids);
+    $grant->id = $ids['grant_id'] ?? NULL;
 
     $grant->copyValues($params);
 
@@ -233,7 +233,7 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
     $session = CRM_Core_Session::singleton();
     $id = $session->get('userID');
     if (!$id) {
-      $id = CRM_Utils_Array::value('contact_id', $params);
+      $id = $params['contact_id'] ?? NULL;
     }
     if (!empty($params['note']) || CRM_Utils_Array::value('id', CRM_Utils_Array::value('note', $ids))) {
       $noteParams = [

--- a/CRM/Grant/StateMachine/Search.php
+++ b/CRM/Grant/StateMachine/Search.php
@@ -71,7 +71,7 @@ class CRM_Grant_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -55,7 +55,7 @@ class CRM_Group_Page_AJAX {
       // go ahead with flat hierarchy, CRM-12225
       if (empty($groups)) {
         $groupsAccessible = CRM_Core_PseudoConstant::group();
-        $parentsOnly = CRM_Utils_Array::value('parentsOnly', $params);
+        $parentsOnly = $params['parentsOnly'] ?? NULL;
         if (!empty($groupsAccessible) && $parentsOnly) {
           // recompute group list with flat hierarchy
           $params['parentsOnly'] = 0;

--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -231,7 +231,7 @@ WHERE lt.log_conn_id = %1
             if (!empty(${$var[$diff]})) {
               $holder =& $$var;
               $val = explode(CRM_Case_BAO_Case::VALUE_SEPARATOR, $holder[$diff]);
-              $holder[$diff] = CRM_Utils_Array::value(1, $val);
+              $holder[$diff] = $val[1] ?? NULL;
             }
           }
         }
@@ -306,7 +306,7 @@ WHERE lt.log_conn_id = %1
 
         $dao = new $tableDAO();
         foreach ($dao->fields() as $field) {
-          $titles[$table][$field['name']] = CRM_Utils_Array::value('title', $field);
+          $titles[$table][$field['name']] = $field['title'] ?? NULL;
 
           if ($field['type'] == CRM_Utils_Type::T_BOOLEAN) {
             $values[$table][$field['name']] = ['0' => ts('false'), '1' => ts('true')];

--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -203,10 +203,10 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
         ) {
           $froms = $tos = [];
           foreach (explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($from, CRM_Core_DAO::VALUE_SEPARATOR)) as $val) {
-            $froms[] = CRM_Utils_Array::value($val, $values[$field]);
+            $froms[] = $values[$field][$val] ?? NULL;
           }
           foreach (explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($to, CRM_Core_DAO::VALUE_SEPARATOR)) as $val) {
-            $tos[] = CRM_Utils_Array::value($val, $values[$field]);
+            $tos[] = $values[$field][$val] ?? NULL;
           }
           $from = implode(', ', array_filter($froms));
           $to = implode(', ', array_filter($tos));

--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -342,7 +342,7 @@ WHERE  log_date <= %1 AND id = %2 ORDER BY log_date DESC LIMIT 1";
     $this->addToDeveloperTab($this->temporaryTable->getCreateSql());
     $this->temporaryTableName = $this->temporaryTable->getName();
 
-    $logTypes = CRM_Utils_Array::value('log_type_value', $this->_params);
+    $logTypes = $this->_params['log_type_value'] ?? NULL;
     unset($this->_params['log_type_value']);
     if (empty($logTypes)) {
       foreach (array_keys($this->_logTables) as $table) {

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1191,7 +1191,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $mailParams['attachments'] = $attachments;
 
-    $mailParams['Subject'] = CRM_Utils_Array::value('subject', $pEmails);
+    $mailParams['Subject'] = $pEmails['subject'] ?? NULL;
     if (is_array($mailParams['Subject'])) {
       $mailParams['Subject'] = implode('', $mailParams['Subject']);
     }
@@ -1396,7 +1396,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       }
     }
     else {
-      $data = CRM_Utils_Array::value("{$type}.{$token}", $contact);
+      $data = $contact["{$type}.{$token}"] ?? NULL;
     }
     return $data;
   }
@@ -2858,7 +2858,7 @@ ORDER BY civicrm_mailing.name";
     // format the params
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['rowCount'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
     $params['caseId'] = NULL;
 
     // get contact mailings
@@ -2951,7 +2951,7 @@ ORDER BY civicrm_mailing.name";
     $params['version'] = 3;
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['limit'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
 
     $result = civicrm_api('MailingContact', 'get', $params);
     return $result['values'];

--- a/CRM/Mailing/Form/Task.php
+++ b/CRM/Mailing/Form/Task.php
@@ -34,7 +34,7 @@ class CRM_Mailing_Form_Task extends CRM_Core_Form_Task {
   public static function preProcessCommon(&$form) {
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
-    $form->_task = CRM_Utils_Array::value('task', $values);
+    $form->_task = $values['task'] ?? NULL;
     $mailingTasks = CRM_Mailing_Task::tasks();
     $form->assign('taskName', CRM_Utils_Array::value('task', $values));
 

--- a/CRM/Mailing/Page/Preview.php
+++ b/CRM/Mailing/Page/Preview.php
@@ -44,7 +44,7 @@ class CRM_Mailing_Page_Preview extends CRM_Core_Page {
     $mailing = new CRM_Mailing_BAO_Mailing();
     if (!empty($options)) {
       $mailing->id = $options['mailing_id'];
-      $fromEmail = CRM_Utils_Array::value('from_email', $options);
+      $fromEmail = $options['from_email'] ?? NULL;
     }
 
     $mailing->find(TRUE);

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -89,7 +89,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     //get the log start date.
     //it is set during renewal of membership.
-    $logStartDate = CRM_Utils_Array::value('log_start_date', $params);
+    $logStartDate = $params['log_start_date'] ?? NULL;
     $logStartDate = ($logStartDate) ? CRM_Utils_Date::isoToMysql($logStartDate) : CRM_Utils_Date::isoToMysql($membership->start_date);
     $values = self::getStatusANDTypeValues($membership->id);
 
@@ -131,7 +131,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     $targetContactID = $membership->contact_id;
     if (!empty($params['is_for_organization'])) {
       // @todo - deprecate is_for_organization, require modified_id
-      $targetContactID = CRM_Utils_Array::value('modified_id', $params);
+      $targetContactID = $params['modified_id'] ?? NULL;
     }
 
     // add custom field values
@@ -293,7 +293,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       if (!array_key_exists('max_related', $params) && !empty($params['membership_type_id'])) {
         $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($params['membership_type_id']);
         if (isset($membershipType['relationship_type_id'])) {
-          $params['max_related'] = CRM_Utils_Array::value('max_related', $membershipType);
+          $params['max_related'] = $membershipType['max_related'] ?? NULL;
         }
       }
     }
@@ -365,7 +365,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
       foreach ($params['line_item'] as $priceSetId => $lineItems) {
         foreach ($lineItems as $lineIndex => $lineItem) {
-          $lineMembershipType = CRM_Utils_Array::value('membership_type_id', $lineItem);
+          $lineMembershipType = $lineItem['membership_type_id'] ?? NULL;
           if (!empty($params['contribution'])) {
             $params['line_item'][$priceSetId][$lineIndex]['contribution_id'] = $params['contribution']->id;
           }
@@ -520,7 +520,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       //get the membership status and type values.
       $statusANDType = self::getStatusANDTypeValues($membership->id);
       foreach (['status', 'membership_type'] as $fld) {
-        $defaults[$fld] = CRM_Utils_Array::value($fld, $statusANDType[$membership->id]);
+        $defaults[$fld] = $statusANDType[$membership->id][$fld] ?? NULL;
       }
       if (!empty($statusANDType[$membership->id]['is_current_member'])) {
         $defaults['active'] = TRUE;
@@ -929,7 +929,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
             'column_name'
           );
           $value = $customFieldId ? 'custom_' . $customFieldId : $value;
-          $tmpContactField[trim($value)] = CRM_Utils_Array::value(trim($value), $contactFields);
+          $tmpContactField[trim($value)] = $contactFields[trim($value)] ?? NULL;
           if (!$status) {
             $title = $tmpContactField[trim($value)]['title'] . " " . ts('(match to contact)');
           }
@@ -1849,9 +1849,9 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
 
         $currentMembership['join_date'] = CRM_Utils_Date::customFormat($currentMembership['join_date'], $format);
         foreach (['start_date', 'end_date'] as $dateType) {
-          $currentMembership[$dateType] = CRM_Utils_Array::value($dateType, $formDates);
+          $currentMembership[$dateType] = $formDates[$dateType] ?? NULL;
           if (empty($currentMembership[$dateType])) {
-            $currentMembership[$dateType] = CRM_Utils_Array::value($dateType, $dates);
+            $currentMembership[$dateType] = $dates[$dateType] ?? NULL;
           }
         }
         $currentMembership['is_test'] = $is_test;
@@ -1892,9 +1892,9 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
         $memParams = [];
         $memParams['join_date'] = CRM_Utils_Date::isoToMysql($membership->join_date);
         $memParams['start_date'] = CRM_Utils_Array::value('start_date', $formDates, CRM_Utils_Date::isoToMysql($membership->start_date));
-        $memParams['end_date'] = CRM_Utils_Array::value('end_date', $formDates);
+        $memParams['end_date'] = $formDates['end_date'] ?? NULL;
         if (empty($memParams['end_date'])) {
-          $memParams['end_date'] = CRM_Utils_Array::value('end_date', $dates);
+          $memParams['end_date'] = $dates['end_date'] ?? NULL;
         }
         $memParams['membership_type_id'] = $membershipTypeID;
 
@@ -1933,9 +1933,9 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
         $dates = CRM_Member_BAO_MembershipType::getDatesForMembershipType($membershipTypeID, NULL, NULL, NULL, $numRenewTerms);
 
         foreach (['join_date', 'start_date', 'end_date'] as $dateType) {
-          $memParams[$dateType] = CRM_Utils_Array::value($dateType, $formDates);
+          $memParams[$dateType] = $formDates[$dateType] ?? NULL;
           if (empty($memParams[$dateType])) {
-            $memParams[$dateType] = CRM_Utils_Array::value($dateType, $dates);
+            $memParams[$dateType] = $dates[$dateType] ?? NULL;
           }
         }
 
@@ -1953,7 +1953,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
           $membershipTypeID,
           $memParams
         );
-        $updateStatusId = CRM_Utils_Array::value('id', $status);
+        $updateStatusId = $status['id'] ?? NULL;
       }
       else {
         // if IPN/Pay-Later set status to: PENDING
@@ -2268,7 +2268,7 @@ WHERE      civicrm_membership.is_test = 0
           'ignore_admin_only' => TRUE,
         ], TRUE
       );
-      $statusId = CRM_Utils_Array::value('id', $newStatus);
+      $statusId = $newStatus['id'] ?? NULL;
 
       //process only when status change.
       if ($statusId &&
@@ -2400,11 +2400,11 @@ WHERE      civicrm_membership.is_test = 0
     $config = CRM_Core_Config::singleton();
     $contributionParams['currency'] = $config->defaultCurrency;
     $contributionParams['receipt_date'] = (CRM_Utils_Array::value('receipt_date', $params)) ? $params['receipt_date'] : 'null';
-    $contributionParams['source'] = CRM_Utils_Array::value('contribution_source', $params);
+    $contributionParams['source'] = $params['contribution_source'] ?? NULL;
     $contributionParams['non_deductible_amount'] = 'null';
     $contributionParams['skipCleanMoney'] = TRUE;
-    $contributionParams['payment_processor'] = CRM_Utils_Array::value('payment_processor_id', $params);
-    $contributionSoftParams = CRM_Utils_Array::value('soft_credit', $params);
+    $contributionParams['payment_processor'] = $params['payment_processor_id'] ?? NULL;
+    $contributionSoftParams = $params['soft_credit'] ?? NULL;
     $recordContribution = [
       'contact_id',
       'fee_amount',
@@ -2427,7 +2427,7 @@ WHERE      civicrm_membership.is_test = 0
       'card_type_id',
     ];
     foreach ($recordContribution as $f) {
-      $contributionParams[$f] = CRM_Utils_Array::value($f, $params);
+      $contributionParams[$f] = $params[$f] ?? NULL;
     }
 
     if (!empty($params['contribution_id'])) {
@@ -2446,7 +2446,7 @@ WHERE      civicrm_membership.is_test = 0
     if (!empty($params['processPriceSet']) &&
       !empty($params['lineItems'])
     ) {
-      $contributionParams['line_item'] = CRM_Utils_Array::value('lineItems', $params, NULL);
+      $contributionParams['line_item'] = $params['lineItems'] ?? NULL;
     }
 
     $contribution = CRM_Contribute_BAO_Contribution::create($contributionParams);
@@ -2680,8 +2680,8 @@ WHERE      civicrm_membership.is_test = 0
    */
   public static function updateMembershipStatus($deceasedParams, $contactType) {
     $updateMembershipMsg = NULL;
-    $contactId = CRM_Utils_Array::value('contact_id', $deceasedParams);
-    $deceasedDate = CRM_Utils_Array::value('deceased_date', $deceasedParams);
+    $contactId = $deceasedParams['contact_id'] ?? NULL;
+    $deceasedDate = $deceasedParams['deceased_date'] ?? NULL;
 
     // process to set membership status to deceased for both active/inactive membership
     if ($contactId &&

--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -39,7 +39,7 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
     CRM_Utils_Hook::pre($hook, 'MembershipBlock', CRM_Utils_Array::value('id', $params), $params);
     $dao = new CRM_Member_DAO_MembershipBlock();
     $dao->copyValues($params);
-    $dao->id = CRM_Utils_Array::value('id', $params);
+    $dao->id = $params['id'] ?? NULL;
     $dao->save();
     CRM_Utils_Hook::post($hook, 'MembershipBlock', $dao->id, $dao);
     return $dao;

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -85,13 +85,13 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       if (isset($ids['membershipType'])) {
         Civi::log()->warning('Deprecated: Passing membershipType by $ids array in CRM_Member_BAO_MembershipType::add');
       }
-      $params['id'] = CRM_Utils_Array::value('membershipType', $ids);
+      $params['id'] = $ids['membershipType'] ?? NULL;
     }
 
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'MembershipType', CRM_Utils_Array::value('id', $params), $params);
 
-    $membershipTypeId = CRM_Utils_Array::value('id', $params);
+    $membershipTypeId = $params['id'] ?? NULL;
 
     if (!$membershipTypeId) {
       if (!isset($params['is_active'])) {
@@ -717,15 +717,15 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       $fieldParams['is_display_amounts'] = $fieldParams['is_required'] = 0;
       $fieldParams['weight'] = $fieldParams['option_weight'][1] = 1;
       $fieldParams['option_label'][1] = $params['name'];
-      $fieldParams['option_description'][1] = CRM_Utils_Array::value('description', $params);
+      $fieldParams['option_description'][1] = $params['description'] ?? NULL;
 
       $fieldParams['membership_type_id'][1] = $membershipTypeId;
       $fieldParams['option_amount'][1] = empty($params['minimum_fee']) ? 0 : $params['minimum_fee'];
-      $fieldParams['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $params);
+      $fieldParams['financial_type_id'] = $params['financial_type_id'] ?? NULL;
 
       if ($previousID) {
         CRM_Member_Form_MembershipType::checkPreviousPriceField($previousID, $priceSetId, $membershipTypeId, $optionsIds);
-        $fieldParams['option_id'] = CRM_Utils_Array::value('option_id', $optionsIds);
+        $fieldParams['option_id'] = $optionsIds['option_id'] ?? NULL;
       }
       CRM_Price_BAO_PriceField::create($fieldParams);
     }
@@ -759,8 +759,8 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
           $optionsIds['id'] = current(CRM_Utils_Array::value('option_id', $optionsIds));
         }
       }
-      $results['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $params);
-      $results['description'] = CRM_Utils_Array::value('description', $params);
+      $results['financial_type_id'] = $params['financial_type_id'] ?? NULL;
+      $results['description'] = $params['description'] ?? NULL;
       CRM_Price_BAO_PriceFieldValue::add($results, $optionsIds);
     }
   }
@@ -801,7 +801,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
             $updateParams['visibility_id'] = CRM_Price_BAO_PriceField::getVisibilityOptionID(strtolower($params['visibility']));
           }
           else {
-            $updateParams[$value] = CRM_Utils_Array::value($key, $params);
+            $updateParams[$value] = $params[$key] ?? NULL;
           }
         }
         CRM_Price_BAO_PriceFieldValue::add($updateParams);

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -430,7 +430,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @return array
    */
   protected static function getPriceSetDetails($params) {
-    $priceSetID = CRM_Utils_Array::value('price_set_id', $params);
+    $priceSetID = $params['price_set_id'] ?? NULL;
     if ($priceSetID) {
       return CRM_Price_BAO_PriceSet::getSetDetail($priceSetID);
     }
@@ -450,7 +450,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @return int
    */
   protected static function getPriceSetID($params) {
-    $priceSetID = CRM_Utils_Array::value('price_set_id', $params);
+    $priceSetID = $params['price_set_id'] ?? NULL;
     if (!$priceSetID) {
       $priceSetDetails = self::getPriceSetDetails($params);
       return key($priceSetDetails);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -201,7 +201,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     parent::preProcess();
 
     // get price set id.
-    $this->_priceSetId = CRM_Utils_Array::value('priceSetId', $_GET);
+    $this->_priceSetId = $_GET['priceSetId'] ?? NULL;
     $this->set('priceSetId', $this->_priceSetId);
     $this->assign('priceSetId', $this->_priceSetId);
 
@@ -227,7 +227,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           $memberorgs = CRM_Member_BAO_MembershipType::getMemberOfContactByMemTypes($cMemTypes);
           $mems_by_org = [];
           foreach ($contactMemberships as $mem) {
-            $mem['member_of_contact_id'] = CRM_Utils_Array::value($mem['membership_type_id'], $memberorgs);
+            $mem['member_of_contact_id'] = $memberorgs[$mem['membership_type_id']] ?? NULL;
             if (!empty($mem['membership_end_date'])) {
               $mem['membership_end_date'] = CRM_Utils_Date::customFormat($mem['membership_end_date']);
             }
@@ -487,7 +487,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         continue;
       }
       else {
-        $memberOfContactId = CRM_Utils_Array::value('member_of_contact_id', $values);
+        $memberOfContactId = $values['member_of_contact_id'] ?? NULL;
         if (empty($selMemTypeOrg[$memberOfContactId])) {
           $selMemTypeOrg[$memberOfContactId] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
             $memberOfContactId,
@@ -498,10 +498,10 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           $selOrgMemType[$memberOfContactId][0] = ts('- select -');
         }
         if (empty($selOrgMemType[$memberOfContactId][$key])) {
-          $selOrgMemType[$memberOfContactId][$key] = CRM_Utils_Array::value('name', $values);
+          $selOrgMemType[$memberOfContactId][$key] = $values['name'] ?? NULL;
         }
       }
-      $totalAmount = CRM_Utils_Array::value('minimum_fee', $values);
+      $totalAmount = $values['minimum_fee'] ?? NULL;
       //CRM-18827 - override the default value if total_amount is submitted
       if (!empty($this->_submitValues['total_amount'])) {
         $totalAmount = $this->_submitValues['total_amount'];
@@ -710,7 +710,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       if (empty($params['membership_type_id'][1])) {
         $errors['membership_type_id'] = ts('Please select a membership type.');
       }
-      $numterms = CRM_Utils_Array::value('num_terms', $params);
+      $numterms = $params['num_terms'] ?? NULL;
       if ($numterms && intval($numterms) != $numterms) {
         $errors['num_terms'] = ts('Please enter an integer for the number of terms.');
       }
@@ -947,7 +947,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    */
   public static function emailReceipt(&$form, &$formValues, &$membership, $customValues = NULL) {
     // retrieve 'from email id' for acknowledgement
-    $receiptFrom = CRM_Utils_Array::value('from_email_address', $formValues);
+    $receiptFrom = $formValues['from_email_address'] ?? NULL;
 
     // @todo figure out how much of the stuff below is genuinely shared with the batch form & a logical shared place.
     if (!empty($formValues['payment_instrument_id'])) {
@@ -1030,7 +1030,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $taxAmt = $template->get_template_vars('dataArray');
     $eventTaxAmt = $template->get_template_vars('totalTaxAmount');
     $prefixValue = Civi::settings()->get('contribution_invoice_settings');
-    $invoicing = CRM_Utils_Array::value('invoicing', $prefixValue);
+    $invoicing = $prefixValue['invoicing'] ?? NULL;
     if ((!empty($taxAmt) || isset($eventTaxAmt)) && (isset($invoicing) && isset($prefixValue['is_email_pdf']))) {
       $isEmailPdf = TRUE;
     }
@@ -1149,7 +1149,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     if (!empty($formValues['tax_amount'])) {
       $params['tax_amount'] = $formValues['tax_amount'];
     }
-    $params['total_amount'] = CRM_Utils_Array::value('amount', $formValues);
+    $params['total_amount'] = $formValues['amount'] ?? NULL;
     if (!empty($lineItem[$this->_priceSetId])) {
       foreach ($lineItem[$this->_priceSetId] as &$li) {
         if (!empty($li['membership_type_id'])) {
@@ -1161,7 +1161,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         ///CRM-11529 for quick config backoffice transactions
         //when financial_type_id is passed in form, update the
         //lineitems with the financial type selected in form
-        $submittedFinancialType = CRM_Utils_Array::value('financial_type_id', $formValues);
+        $submittedFinancialType = $formValues['financial_type_id'] ?? NULL;
         if ($isQuickConfig && $submittedFinancialType) {
           $li['financial_type_id'] = $submittedFinancialType;
         }
@@ -1179,7 +1179,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     ];
 
     foreach ($fields as $f) {
-      $params[$f] = CRM_Utils_Array::value($f, $formValues);
+      $params[$f] = $formValues[$f] ?? NULL;
     }
 
     // fix for CRM-3724
@@ -1214,9 +1214,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     foreach ($calcDates as $memType => $calcDate) {
       foreach (array_keys($dateTypes) as $d) {
         //first give priority to form values then calDates.
-        $date = CRM_Utils_Array::value($d, $formValues);
+        $date = $formValues[$d] ?? NULL;
         if (!$date) {
-          $date = CRM_Utils_Array::value($d, $calcDate);
+          $date = $calcDate[$d] ?? NULL;
         }
 
         $membershipTypeValues[$memType][$d] = CRM_Utils_Date::processDate($date);
@@ -1226,7 +1226,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     foreach ($this->_memTypeSelected as $memType) {
       if (array_key_exists('max_related', $formValues)) {
         // max related memberships - take from form or inherit from membership type
-        $membershipTypeValues[$memType]['max_related'] = CRM_Utils_Array::value('max_related', $formValues);
+        $membershipTypeValues[$memType]['max_related'] = $formValues['max_related'] ?? NULL;
       }
       $membershipTypeValues[$memType]['custom'] = CRM_Core_BAO_CustomField::postProcess($formValues,
         $this->_id,
@@ -1268,7 +1268,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       ];
 
       foreach ($recordContribution as $f) {
-        $params[$f] = CRM_Utils_Array::value($f, $formValues);
+        $params[$f] = $formValues[$f] ?? NULL;
       }
 
       if (!$this->_onlinePendingContributionId) {
@@ -1294,7 +1294,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       }
 
       if (!empty($formValues['send_receipt'])) {
-        $params['receipt_date'] = CRM_Utils_Array::value('receive_date', $formValues);
+        $params['receipt_date'] = $formValues['receive_date'] ?? NULL;
       }
 
       //insert financial type name in receipt.
@@ -1313,8 +1313,8 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $params['total_amount'] = CRM_Utils_Array::value('total_amount', $formValues, 0);
 
       //CRM-20264 : Store CC type and number (last 4 digit) during backoffice or online payment
-      $params['card_type_id'] = CRM_Utils_Array::value('card_type_id', $this->_params);
-      $params['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $this->_params);
+      $params['card_type_id'] = $this->_params['card_type_id'] ?? NULL;
+      $params['pan_truncation'] = $this->_params['pan_truncation'] ?? NULL;
 
       if (!$isQuickConfig) {
         $params['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet',
@@ -1323,7 +1323,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         );
       }
       else {
-        $params['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $formValues);
+        $params['financial_type_id'] = $formValues['financial_type_id'] ?? NULL;
       }
 
       //get the payment processor id as per mode. Try removing in favour of beginPostProcess.
@@ -1455,7 +1455,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         [1 => $membershipType, 2 => $userName]
       );
       $params['source'] = $formValues['source'] ? $formValues['source'] : $params['contribution_source'];
-      $params['trxn_id'] = CRM_Utils_Array::value('trxn_id', $result);
+      $params['trxn_id'] = $result['trxn_id'] ?? NULL;
       $params['is_test'] = ($this->_mode === 'live') ? 0 : 1;
       if (!empty($formValues['send_receipt'])) {
         $params['receipt_date'] = $now;
@@ -1496,7 +1496,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         // appropriate as part of our 2-step always create the pending contribution & then finally add the payment
         // process -
         // @see http://wiki.civicrm.org/confluence/pages/viewpage.action?pageId=261062657#Payments&AccountsRoadmap-Movetowardsalwaysusinga2-steppaymentprocess
-        $membershipParams['contribution_status_id'] = CRM_Utils_Array::value('payment_status_id', $result);
+        $membershipParams['contribution_status_id'] = $result['payment_status_id'] ?? NULL;
         if (!empty($paymentParams['is_recur'])) {
           // The earlier process created the line items (although we want to get rid of the earlier one in favour
           // of a single path!
@@ -1505,7 +1505,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         $membershipParams['payment_instrument_id'] = $paymentInstrumentID;
         // @todo stop passing $ids (membership and userId only are set above)
         $membership = CRM_Member_BAO_Membership::create($membershipParams, $ids);
-        $params['contribution'] = CRM_Utils_Array::value('contribution', $membershipParams);
+        $params['contribution'] = $membershipParams['contribution'] ?? NULL;
         unset($params['lineItems']);
         $this->_membershipIDs[] = $membership->id;
         $createdMemberships[$memType] = $membership;
@@ -1602,7 +1602,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           }
           // @todo stop passing $ids (membership and userId only are set above)
           $membership = CRM_Member_BAO_Membership::create($membershipParams, $ids);
-          $params['contribution'] = CRM_Utils_Array::value('contribution', $membershipParams);
+          $params['contribution'] = $membershipParams['contribution'] ?? NULL;
           unset($params['lineItems']);
           // skip line item creation for next interation since line item(s) are already created.
           $params['skipLineItem'] = TRUE;
@@ -1613,7 +1613,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         }
       }
     }
-    $isRecur = CRM_Utils_Array::value('is_recur', $params);
+    $isRecur = $params['is_recur'] ?? NULL;
     if (($this->_action & CRM_Core_Action::UPDATE)) {
       $this->addStatusMessage($this->getStatusMessageForUpdate($membership, $endDate));
     }
@@ -1624,7 +1624,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
     if (!empty($lineItem[$this->_priceSetId])) {
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
       $taxAmount = FALSE;
       $totalTaxAmount = 0;
       foreach ($lineItem[$this->_priceSetId] as & $priceFieldOp) {
@@ -1648,7 +1648,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
               $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + CRM_Utils_Array::value('tax_amount', $value);
             }
             else {
-              $dataArray[$value['tax_rate']] = CRM_Utils_Array::value('tax_amount', $value);
+              $dataArray[$value['tax_rate']] = $value['tax_amount'] ?? NULL;
             }
           }
         }
@@ -1857,7 +1857,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
       //get the end date from calculated dates.
       if (!$memEndDate && !$isRecur) {
-        $memEndDate = CRM_Utils_Array::value('end_date', $calcDates[$memType]);
+        $memEndDate = $calcDates[$memType]['end_date'] ?? NULL;
       }
 
       if ($memEndDate && $memEndDate !== 'null') {

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -337,7 +337,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       if (is_array($params['membership_type'])) {
         foreach ($params['membership_type'] as $k => $v) {
           if ($v) {
-            $membershipTypes[$k] = CRM_Utils_Array::value("auto_renew_$k", $params);
+            $membershipTypes[$k] = $params["auto_renew_$k"] ?? NULL;
           }
         }
       }
@@ -347,7 +347,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       }
 
       // check for price set.
-      $priceSetID = CRM_Utils_Array::value('member_price_set_id', $params);
+      $priceSetID = $params['member_price_set_id'] ?? NULL;
       if (!empty($params['member_is_active']) && is_array($membershipTypes) && !$priceSetID) {
         $usedPriceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id, 2);
         if (empty($params['mem_price_field_id']) && !$usedPriceSetId) {
@@ -365,21 +365,21 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
           }
           $setParams['is_quick_config'] = 1;
           $setParams['extends'] = CRM_Core_Component::getComponentID('CiviMember');
-          $setParams['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $this->_values);
+          $setParams['financial_type_id'] = $this->_values['financial_type_id'] ?? NULL;
           $priceSet = CRM_Price_BAO_PriceSet::create($setParams);
           $priceSetID = $priceSet->id;
           $fieldParams['price_set_id'] = $priceSet->id;
         }
         elseif ($usedPriceSetId) {
           $setParams['extends'] = CRM_Core_Component::getComponentID('CiviMember');
-          $setParams['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $this->_values);
+          $setParams['financial_type_id'] = $this->_values['financial_type_id'] ?? NULL;
           $setParams['id'] = $usedPriceSetId;
           $priceSet = CRM_Price_BAO_PriceSet::create($setParams);
           $priceSetID = $priceSet->id;
           $fieldParams['price_set_id'] = $priceSet->id;
         }
         else {
-          $fieldParams['id'] = CRM_Utils_Array::value('mem_price_field_id', $params);
+          $fieldParams['id'] = $params['mem_price_field_id'] ?? NULL;
           $priceSetID = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', CRM_Utils_Array::value('mem_price_field_id', $params), 'price_set_id');
         }
         $editedFieldParams = [
@@ -396,7 +396,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
           $fieldParams['weight'] = 1;
         }
         else {
-          $fieldParams['id'] = CRM_Utils_Array::value('id', $editedResults);
+          $fieldParams['id'] = $editedResults['id'] ?? NULL;
         }
 
         $fieldParams['label'] = !empty($params['membership_type_label']) ? $params['membership_type_label'] : ts('Membership');
@@ -416,12 +416,12 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
             unset($options[$priceFieldID]);
           }
           $membetype = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($memType);
-          $fieldParams['option_label'][$rowCount] = CRM_Utils_Array::value('name', $membetype);
+          $fieldParams['option_label'][$rowCount] = $membetype['name'] ?? NULL;
           $fieldParams['option_amount'][$rowCount] = CRM_Utils_Array::value('minimum_fee', $membetype, 0);
-          $fieldParams['option_weight'][$rowCount] = CRM_Utils_Array::value('weight', $membetype);
-          $fieldParams['option_description'][$rowCount] = CRM_Utils_Array::value('description', $membetype);
-          $fieldParams['default_option'] = CRM_Utils_Array::value('membership_type_default', $params);
-          $fieldParams['option_financial_type_id'][$rowCount] = CRM_Utils_Array::value('financial_type_id', $membetype);
+          $fieldParams['option_weight'][$rowCount] = $membetype['weight'] ?? NULL;
+          $fieldParams['option_description'][$rowCount] = $membetype['description'] ?? NULL;
+          $fieldParams['default_option'] = $params['membership_type_default'] ?? NULL;
+          $fieldParams['option_financial_type_id'][$rowCount] = $membetype['financial_type_id'] ?? NULL;
 
           $fieldParams['membership_type_id'][$rowCount] = $memType;
           // [$rowCount] = $membetype[''];

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -214,7 +214,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $scTypes = CRM_Core_OptionGroup::values("soft_credit_type");
     $defaults['soft_credit_type_id'] = CRM_Utils_Array::value(ts('Gift'), array_flip($scTypes));
 
-    $renewalDate = CRM_Utils_Array::value('renewal_date', $defaults);
+    $renewalDate = $defaults['renewal_date'] ?? NULL;
     $this->assign('renewalDate', $renewalDate);
     $this->assign('member_is_test', CRM_Utils_Array::value('member_is_test', $defaults));
 
@@ -259,7 +259,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
           continue;
         }
         else {
-          $memberOfContactId = CRM_Utils_Array::value('member_of_contact_id', $values);
+          $memberOfContactId = $values['member_of_contact_id'] ?? NULL;
           if (empty($selMemTypeOrg[$memberOfContactId])) {
             $selMemTypeOrg[$memberOfContactId] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
               $memberOfContactId,
@@ -270,13 +270,13 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
             $selOrgMemType[$memberOfContactId][0] = ts('- select -');
           }
           if (empty($selOrgMemType[$memberOfContactId][$key])) {
-            $selOrgMemType[$memberOfContactId][$key] = CRM_Utils_Array::value('name', $values);
+            $selOrgMemType[$memberOfContactId][$key] = $values['name'] ?? NULL;
           }
         }
 
         //CRM-16950
         $taxAmount = NULL;
-        $totalAmount = CRM_Utils_Array::value('minimum_fee', $values);
+        $totalAmount = $values['minimum_fee'] ?? NULL;
         // @todo - feels a bug - we use taxRate from the form default rather than from the specified type?!?
         if ($this->getTaxRateForFinancialType($values['financial_type_id'])) {
           $taxAmount = ($taxRate / 100) * CRM_Utils_Array::value('minimum_fee', $values);

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -502,7 +502,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
         ];
         $editedResults = [];
         CRM_Price_BAO_PriceFieldValue::retrieve($editedFieldParams, $editedResults);
-        $optionsIds['option_id'][1] = CRM_Utils_Array::value('id', $editedResults);
+        $optionsIds['option_id'][1] = $editedResults['id'] ?? NULL;
       }
     }
   }

--- a/CRM/Member/Form/Task/Batch.php
+++ b/CRM/Member/Form/Task/Batch.php
@@ -133,7 +133,7 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
       $typeId = CRM_Core_DAO::getFieldValue("CRM_Member_DAO_Membership", $memberId, 'membership_type_id');
       foreach ($this->_fields as $name => $field) {
         if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($name)) {
-          $customValue = CRM_Utils_Array::value($customFieldID, $customFields);
+          $customValue = $customFields[$customFieldID] ?? NULL;
           $entityColumnValue = [];
           if (!empty($customValue['extends_entity_column_value'])) {
             $entityColumnValue = explode(CRM_Core_DAO::VALUE_SEPARATOR,

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -54,7 +54,7 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
   public function setDefaultValues() {
     $defaults = [];
     $format = CRM_Core_BAO_LabelFormat::getDefaultValues();
-    $defaults['label_name'] = CRM_Utils_Array::value('name', $format);
+    $defaults['label_name'] = $format['name'] ?? NULL;
     $defaults['merge_same_address'] = 0;
     $defaults['merge_same_household'] = 0;
     $defaults['do_not_mail'] = 1;
@@ -70,11 +70,11 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
   public function postProcess() {
     $formValues = $this->controller->exportValues($this->_name);
     $locationTypeID = $formValues['location_type_id'];
-    $respectDoNotMail = CRM_Utils_Array::value('do_not_mail', $formValues);
+    $respectDoNotMail = $formValues['do_not_mail'] ?? NULL;
     $labelName = $formValues['label_name'];
-    $mergeSameAddress = CRM_Utils_Array::value('merge_same_address', $formValues);
-    $mergeSameHousehold = CRM_Utils_Array::value('merge_same_household', $formValues);
-    $isPerMembership = CRM_Utils_Array::value('per_membership', $formValues);
+    $mergeSameAddress = $formValues['merge_same_address'] ?? NULL;
+    $mergeSameHousehold = $formValues['merge_same_household'] ?? NULL;
+    $isPerMembership = $formValues['per_membership'] ?? NULL;
     if ($isPerMembership && ($mergeSameAddress || $mergeSameHousehold)) {
       // this shouldn't happen  - perhaps is could if JS is disabled
       CRM_Core_Session::setStatus(ts('As you are printing one label per membership your merge settings are being ignored'));

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -113,9 +113,9 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       $mappingName = $mappingName[1];
       $mappingContactType = $mappingContactType[1];
-      $mappingLocation = CRM_Utils_Array::value('1', $mappingLocation);
-      $mappingPhoneType = CRM_Utils_Array::value('1', $mappingPhoneType);
-      $mappingRelation = CRM_Utils_Array::value('1', $mappingRelation);
+      $mappingLocation = $mappingLocation['1'] ?? NULL;
+      $mappingPhoneType = $mappingPhoneType['1'] ?? NULL;
+      $mappingRelation = $mappingRelation['1'] ?? NULL;
 
       //mapping is to be loaded from database
 
@@ -361,7 +361,7 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     if (!empty($fields['saveMapping'])) {
-      $nameField = CRM_Utils_Array::value('saveMappingName', $fields);
+      $nameField = $fields['saveMappingName'] ?? NULL;
       if (empty($nameField)) {
         $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
       }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -524,7 +524,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
           $formatted
         );
         if (empty($formatted['status_id'])) {
-          $formatted['status_id'] = CRM_Utils_Array::value('id', $calcStatus);
+          $formatted['status_id'] = $calcStatus['id'] ?? NULL;
         }
         elseif (empty($formatted['member_is_override'])) {
           if (empty($calcStatus)) {

--- a/CRM/Member/Page/AJAX.php
+++ b/CRM/Member/Page/AJAX.php
@@ -50,7 +50,7 @@ WHERE   id = %1";
     // fix the display of the monetary value, CRM-4038
     $details['total_amount'] = CRM_Utils_Money::format($details['total_amount'], NULL, '%a');
     $options = CRM_Core_SelectValues::memberAutoRenew();
-    $details['auto_renew'] = CRM_Utils_Array::value('auto_renew', $options[$details]);
+    $details['auto_renew'] = $options[$details]['auto_renew'] ?? NULL;
     CRM_Utils_JSON::output($details);
   }
 

--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -51,7 +51,7 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     $isCurrentMonth = 0;
 
     // You can force the dashboard to display based upon a certain date
-    $ym = CRM_Utils_Array::value('date', $_GET);
+    $ym = $_GET['date'] ?? NULL;
 
     if ($ym) {
       if (preg_match('/^\d{6}$/', $ym) == 0 ||

--- a/CRM/Member/Page/MembershipType.php
+++ b/CRM/Member/Page/MembershipType.php
@@ -125,7 +125,7 @@ class CRM_Member_Page_MembershipType extends CRM_Core_Page {
             $value, $relationshipName
           );
         }
-        $membershipType[$dao->id]['maxRelated'] = CRM_Utils_Array::value('max_related', $membershipType[$dao->id]);
+        $membershipType[$dao->id]['maxRelated'] = $membershipType[$dao->id]['max_related'] ?? NULL;
       }
       if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !CRM_Core_Permission::check('edit contributions of type ' . CRM_Contribute_PseudoConstant::financialType($dao->financial_type_id))) {
         unset($links[CRM_Core_Action::UPDATE], $links[CRM_Core_Action::ENABLE], $links[CRM_Core_Action::DISABLE]);

--- a/CRM/Member/Page/RecurringContributions.php
+++ b/CRM/Member/Page/RecurringContributions.php
@@ -96,7 +96,7 @@ class CRM_Member_Page_RecurringContributions extends CRM_Core_Page {
 
       $recurringContributions[$recurringContributionID]['id'] = $recurringContributionID;
       $recurringContributions[$recurringContributionID]['contactId'] = $contactID;
-      $recurringContributions[$recurringContributionID]['contribution_status'] = CRM_Utils_Array::value($contributionStatusID, $contributionStatuses);
+      $recurringContributions[$recurringContributionID]['contribution_status'] = $contributionStatuses[$contributionStatusID] ?? NULL;
 
       $this->setActionsForRecurringContribution($recurringContributionID, $recurringContributions[$recurringContributionID]);
     }

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -69,12 +69,12 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
       CRM_Core_DAO::storeValues($dao, $membership[$dao->id]);
 
       //carry campaign.
-      $membership[$dao->id]['campaign'] = CRM_Utils_Array::value($dao->campaign_id, $allCampaigns);
+      $membership[$dao->id]['campaign'] = $allCampaigns[$dao->campaign_id] ?? NULL;
 
       //get the membership status and type values.
       $statusANDType = CRM_Member_BAO_Membership::getStatusANDTypeValues($dao->id);
       foreach (['status', 'membership_type'] as $fld) {
-        $membership[$dao->id][$fld] = CRM_Utils_Array::value($fld, $statusANDType[$dao->id]);
+        $membership[$dao->id][$fld] = $statusANDType[$dao->id][$fld] ?? NULL;
       }
       if (!empty($statusANDType[$dao->id]['is_current_member'])) {
         $membership[$dao->id]['active'] = TRUE;
@@ -162,7 +162,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
      LEFT JOIN civicrm_contact ct ON ct.id = m.contact_id
   WHERE m.owner_membership_id = {$dao->id} AND m.is_test = 0 AND ms.is_current_member = 1 AND ct.is_deleted = 0";
         $num_related = CRM_Core_DAO::singleValueQuery($query);
-        $max_related = CRM_Utils_Array::value('max_related', $membership[$dao->id]);
+        $max_related = $membership[$dao->id]['max_related'] ?? NULL;
         $membership[$dao->id]['related_count'] = ($max_related == '' ? ts('%1 created', [1 => $num_related]) : ts('%1 out of %2', [
           1 => $num_related,
           2 => $max_related,
@@ -181,7 +181,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
         'limit' => 0,
       ],
     ]);
-    $membershipTypes = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
+    $membershipTypes = $membershipTypesResult['values'] ?? NULL;
 
     foreach ($membershipTypes as $key => $value) {
       $membershipTypes[$key]['action'] = CRM_Core_Action::formLink(self::membershipTypeslinks(),

--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -43,7 +43,7 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
         'status',
         'membership_type',
       ] as $fld) {
-        $membership[$dao->id][$fld] = CRM_Utils_Array::value($fld, $statusANDType[$dao->id]);
+        $membership[$dao->id][$fld] = $statusANDType[$dao->id][$fld] ?? NULL;
       }
       if (!empty($statusANDType[$dao->id]['is_current_member'])) {
         $membership[$dao->id]['active'] = TRUE;

--- a/CRM/Member/PseudoConstant.php
+++ b/CRM/Member/PseudoConstant.php
@@ -96,7 +96,7 @@ class CRM_Member_PseudoConstant extends CRM_Core_PseudoConstant {
 
     $value = NULL;
     if ($id) {
-      $value = CRM_Utils_Array::value($id, self::$membershipStatus[$cacheKey]);
+      $value = self::$membershipStatus[$cacheKey][$id] ?? NULL;
     }
     else {
       $value = self::$membershipStatus[$cacheKey];

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -357,7 +357,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
       }
 
       //carry campaign on selectors.
-      $row['campaign'] = CRM_Utils_Array::value($result->member_campaign_id, $allCampaigns);
+      $row['campaign'] = $allCampaigns[$result->member_campaign_id] ?? NULL;
       $row['campaign_id'] = $result->member_campaign_id;
 
       if (!empty($row['member_is_test'])) {

--- a/CRM/Member/StateMachine/Search.php
+++ b/CRM/Member/StateMachine/Search.php
@@ -69,7 +69,7 @@ class CRM_Member_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -68,8 +68,8 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
         $defaults['goal_amount'] = CRM_Utils_Money::format($defaults['goal_amount'], NULL, '%a');
       }
 
-      $defaults['pcp_title'] = CRM_Utils_Array::value('title', $defaults);
-      $defaults['pcp_intro_text'] = CRM_Utils_Array::value('intro_text', $defaults);
+      $defaults['pcp_title'] = $defaults['title'] ?? NULL;
+      $defaults['pcp_intro_text'] = $defaults['intro_text'] ?? NULL;
     }
 
     if ($this->get('action') & CRM_Core_Action::ADD) {
@@ -79,8 +79,8 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
       $defaults['is_notify'] = 1;
     }
 
-    $this->_contactID = CRM_Utils_Array::value('contact_id', $defaults);
-    $this->_contriPageId = CRM_Utils_Array::value('page_id', $defaults);
+    $this->_contactID = $defaults['contact_id'] ?? NULL;
+    $this->_contriPageId = $defaults['page_id'] ?? NULL;
 
     return $defaults;
   }

--- a/CRM/PCP/Form/Contribute.php
+++ b/CRM/PCP/Form/Contribute.php
@@ -47,7 +47,7 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
     if (isset($this->_id)) {
       $params = ['entity_id' => $this->_id, 'entity_table' => 'civicrm_contribution_page'];
       CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCPBlock', $params, $defaults);
-      $defaults['pcp_active'] = CRM_Utils_Array::value('is_active', $defaults);
+      $defaults['pcp_active'] = $defaults['is_active'] ?? NULL;
       // Assign contribution page ID to pageId for referencing in PCP.hlp - since $id is overwritten there. dgg
       $this->assign('pageId', $this->_id);
     }

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -48,7 +48,7 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
 
       $params = ['entity_id' => $this->_id, 'entity_table' => 'civicrm_event'];
       CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCPBlock', $params, $defaults);
-      $defaults['pcp_active'] = CRM_Utils_Array::value('is_active', $defaults);
+      $defaults['pcp_active'] = $defaults['is_active'] ?? NULL;
       // Assign contribution page ID to pageId for referencing in PCP.hlp - since $id is overwritten there. dgg
       $this->assign('pageId', $this->_id);
     }

--- a/CRM/PCP/Form/PCP.php
+++ b/CRM/PCP/Form/PCP.php
@@ -43,8 +43,8 @@ class CRM_PCP_Form_PCP extends CRM_Core_Form {
     }
 
     if (!$this->_action) {
-      $this->_action = CRM_Utils_Array::value('action', $_GET);
-      $this->_id = CRM_Utils_Array::value('id', $_GET);
+      $this->_action = $_GET['action'] ?? NULL;
+      $this->_id = $_GET['id'] ?? NULL;
     }
     else {
       $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);

--- a/CRM/PCP/Page/PCPInfo.php
+++ b/CRM/PCP/Page/PCPInfo.php
@@ -139,7 +139,7 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
 
     if ($pcpInfo['contact_id'] == $session->get('userID')) {
       $owner = $pageInfo;
-      $owner['status'] = CRM_Utils_Array::value($pcpInfo['status_id'], $pcpStatus);
+      $owner['status'] = $pcpStatus[$pcpInfo['status_id']] ?? NULL;
 
       $this->assign('owner', $owner);
 

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -157,7 +157,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
         }
       }
     }
-    $paymentParams['status_id'] = CRM_Utils_Array::value('status_id', $params);
+    $paymentParams['status_id'] = $params['status_id'] ?? NULL;
 
     $pledge = self::add($params);
     if (is_a($pledge, 'CRM_Core_Error')) {
@@ -195,7 +195,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
         'actual_amount',
       );
       foreach ($paymentKeys as $key) {
-        $paymentParams[$key] = CRM_Utils_Array::value($key, $params, NULL);
+        $paymentParams[$key] = $params[$key] ?? NULL;
       }
       CRM_Pledge_BAO_PledgePayment::create($paymentParams);
     }
@@ -626,8 +626,8 @@ GROUP BY  currency
 
     // check for online pledge.
     if (!empty($params['receipt_from_email'])) {
-      $userName = CRM_Utils_Array::value('receipt_from_name', $params);
-      $userEmail = CRM_Utils_Array::value('receipt_from_email', $params);
+      $userName = $params['receipt_from_name'] ?? NULL;
+      $userEmail = $params['receipt_from_email'] ?? NULL;
     }
     elseif (!empty($params['from_email_id'])) {
       $receiptFrom = $params['from_email_id'];
@@ -638,8 +638,8 @@ GROUP BY  currency
     }
     else {
       // set the domain values.
-      $userName = CRM_Utils_Array::value('name', $domainValues);
-      $userEmail = CRM_Utils_Array::value('email', $domainValues);
+      $userName = $domainValues['name'] ?? NULL;
+      $userEmail = $domainValues['email'] ?? NULL;
     }
 
     if (!isset($receiptFrom)) {

--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -90,7 +90,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
     $pledgeBlock = new CRM_Pledge_DAO_PledgeBlock();
 
     // fix for pledge_frequency_unit
-    $freqUnits = CRM_Utils_Array::value('pledge_frequency_unit', $params);
+    $freqUnits = $params['pledge_frequency_unit'] ?? NULL;
 
     if ($freqUnits && is_array($freqUnits)) {
       unset($params['pledge_frequency_unit']);
@@ -231,7 +231,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
             1 => CRM_Utils_Money::format(CRM_Utils_Array::value('scheduled_amount', $payment), CRM_Utils_Array::value('scheduled_amount_currency', $payment)),
             2 => $payment['scheduled_date'] ?? NULL,
           ));
-          $paymentID = CRM_Utils_Array::value('id', $payment);
+          $paymentID = $payment['id'] ?? NULL;
           $payments[] = $form->createElement('checkbox', $paymentID, NULL, $label, array('amount' => CRM_Utils_Array::value('scheduled_amount', $payment)));
         }
       }
@@ -241,7 +241,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
           1 => CRM_Utils_Money::format(CRM_Utils_Array::value('scheduled_amount', $nextPayment), CRM_Utils_Array::value('scheduled_amount_currency', $nextPayment)),
           2 => $nextPayment['scheduled_date'] ?? NULL,
         ));
-        $paymentID = CRM_Utils_Array::value('id', $nextPayment);
+        $paymentID = $nextPayment['id'] ?? NULL;
         $payments[] = $form->createElement('checkbox', $paymentID, NULL, $label, array('amount' => CRM_Utils_Array::value('scheduled_amount', $nextPayment)));
       }
       // give error if empty or build form for payment.

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -205,7 +205,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     }
 
     $showAdditionalInfo = FALSE;
-    $this->_formType = CRM_Utils_Array::value('formType', $_GET);
+    $this->_formType = $_GET['formType'] ?? NULL;
 
     $defaults = [];
 
@@ -446,12 +446,12 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       'campaign_id',
     ];
     foreach ($fields as $f) {
-      $params[$f] = CRM_Utils_Array::value($f, $formValues);
+      $params[$f] = $formValues[$f] ?? NULL;
     }
 
     // format amount
     $params['amount'] = CRM_Utils_Rule::cleanMoney(CRM_Utils_Array::value('amount', $formValues));
-    $params['currency'] = CRM_Utils_Array::value('currency', $formValues);
+    $params['currency'] = $formValues['currency'] ?? NULL;
     $params['original_installment_amount'] = ($params['amount'] / $params['installments']);
 
     $dates = ['create_date', 'start_date', 'acknowledge_date', 'cancel_date'];

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -167,8 +167,8 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
    */
   public static function &links() {
     $args = func_get_args();
-    $hideOption = CRM_Utils_Array::value(0, $args);
-    $key = CRM_Utils_Array::value(1, $args);
+    $hideOption = $args[0] ?? NULL;
+    $key = $args[1] ?? NULL;
 
     $extraParams = ($key) ? "&key={$key}" : NULL;
 
@@ -299,7 +299,7 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
       }
 
       // carry campaign on selectors.
-      $row['campaign'] = CRM_Utils_Array::value($result->pledge_campaign_id, $allCampaigns);
+      $row['campaign'] = $allCampaigns[$result->pledge_campaign_id] ?? NULL;
       $row['campaign_id'] = $result->pledge_campaign_id;
 
       // add pledge status name

--- a/CRM/Pledge/StateMachine/Search.php
+++ b/CRM/Pledge/StateMachine/Search.php
@@ -69,7 +69,7 @@ class CRM_Pledge_StateMachine_Search extends CRM_Core_StateMachine {
    */
   public function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
-    $value = CRM_Utils_Array::value('task', $_POST);
+    $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {
       $value = $this->_controller->get('task');
     }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -32,7 +32,7 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
    * @throws \Exception
    */
   public static function create(&$params) {
-    $id = CRM_Utils_Array::value('id', $params);
+    $id = $params['id'] ?? NULL;
     if ($id) {
       CRM_Utils_Hook::pre('edit', 'LineItem', $id, $params);
       $op = CRM_Core_Action::UPDATE;
@@ -45,8 +45,8 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
     // unset entity table and entity id in $params
     // we never update the entity table and entity id during update mode
     if ($id) {
-      $entity_id = CRM_Utils_Array::value('entity_id', $params);
-      $entity_table = CRM_Utils_Array::value('entity_table', $params);
+      $entity_id = $params['entity_id'] ?? NULL;
+      $entity_table = $params['entity_table'] ?? NULL;
       unset($params['entity_id'], $params['entity_table']);
     }
     else {
@@ -242,7 +242,7 @@ WHERE li.contribution_id = %1";
 
     $getTaxDetails = FALSE;
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $invoicing = $invoiceSettings['invoicing'] ?? NULL;
 
     $dao = CRM_Core_DAO::executeQuery("$selectClause $fromClause $whereClause $orderByClause", $params);
     while ($dao->fetch()) {
@@ -286,7 +286,7 @@ WHERE li.contribution_id = %1";
     }
     if ($invoicing) {
       // @todo - this is an inappropriate place to be doing form level assignments.
-      $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
+      $taxTerm = $invoiceSettings['tax_term'] ?? NULL;
       $smarty = CRM_Core_Smarty::singleton();
       $smarty->assign('taxTerm', $taxTerm);
       $smarty->assign('getTaxDetails', $getTaxDetails);
@@ -329,7 +329,7 @@ WHERE li.contribution_id = %1";
     else {
       CRM_Price_BAO_PriceFieldValue::getValues($fid, $options, 'weight', TRUE);
     }
-    $fieldTitle = CRM_Utils_Array::value('label', $fields);
+    $fieldTitle = $fields['label'] ?? NULL;
     if (!$fieldTitle) {
       $fieldTitle = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', $fid, 'label');
     }
@@ -533,7 +533,7 @@ WHERE li.contribution_id = %1";
     if (!$entityId) {
       $priceSetDetails = CRM_Price_BAO_PriceSet::getDefaultPriceSet($entityTable);
       $totalAmount = CRM_Utils_Array::value('partial_payment_total', $params, CRM_Utils_Array::value('total_amount', $params));
-      $financialType = CRM_Utils_Array::value('financial_type_id', $params);
+      $financialType = $params['financial_type_id'] ?? NULL;
       foreach ($priceSetDetails as $values) {
         if ($entityTable == 'membership') {
           if ($isRelatedID != $values['membership_type_id']) {

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -294,7 +294,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
       $is_pay_later = 1;
     }
     elseif (isset($qf->_values)) {
-      $is_pay_later = CRM_Utils_Array::value('is_pay_later', $qf->_values);
+      $is_pay_later = $qf->_values['is_pay_later'] ?? NULL;
     }
 
     $otherAmount = $qf->get('values');
@@ -325,15 +325,15 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     $valueFieldName = 'amount';
     $seperator = '|';
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
-    $displayOpt = CRM_Utils_Array::value('tax_display_settings', $invoiceSettings);
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $taxTerm = $invoiceSettings['tax_term'] ?? NULL;
+    $displayOpt = $invoiceSettings['tax_display_settings'] ?? NULL;
+    $invoicing = $invoiceSettings['invoicing'] ?? NULL;
     switch ($field->html_type) {
       case 'Text':
         $optionKey = key($customOption);
         $count = CRM_Utils_Array::value('count', $customOption[$optionKey], '');
         $max_value = CRM_Utils_Array::value('max_value', $customOption[$optionKey], '');
-        $taxAmount = CRM_Utils_Array::value('tax_amount', $customOption[$optionKey]);
+        $taxAmount = $customOption[$optionKey]['tax_amount'] ?? NULL;
         if (isset($taxAmount) && $displayOpt && $invoicing) {
           $qf->assign('displayOpt', $displayOpt);
           $qf->assign('taxTerm', $taxTerm);
@@ -400,7 +400,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         }
 
         foreach ($customOption as $opId => $opt) {
-          $taxAmount = CRM_Utils_Array::value('tax_amount', $opt);
+          $taxAmount = $opt['tax_amount'] ?? NULL;
           if ($field->is_display_amounts) {
             $opt['label'] = !empty($opt['label']) ? $opt['label'] . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
             $preHelpText = $postHelpText = '';
@@ -512,7 +512,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $selectOption = $allowedOptions = $priceVal = [];
 
         foreach ($customOption as $opt) {
-          $taxAmount = CRM_Utils_Array::value('tax_amount', $opt);
+          $taxAmount = $opt['tax_amount'] ?? NULL;
           $count = CRM_Utils_Array::value('count', $opt, '');
           $max_value = CRM_Utils_Array::value('max_value', $opt, '');
 
@@ -568,7 +568,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         $check = [];
         foreach ($customOption as $opId => $opt) {
-          $taxAmount = CRM_Utils_Array::value('tax_amount', $opt);
+          $taxAmount = $opt['tax_amount'] ?? NULL;
           $count = CRM_Utils_Array::value('count', $opt, '');
           $max_value = CRM_Utils_Array::value('max_value', $opt, '');
 

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -39,7 +39,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
     $fieldValueBAO->copyValues($params);
 
     // CRM-16189
-    $priceFieldID = CRM_Utils_Array::value('price_field_id', $params);
+    $priceFieldID = $params['price_field_id'] ?? NULL;
 
     $id = CRM_Utils_Array::value('id', $ids, CRM_Utils_Array::value('id', $params));
 
@@ -102,7 +102,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
       }
     }
 
-    $financialType = CRM_Utils_Array::value('financial_type_id', $params, NULL);
+    $financialType = $params['financial_type_id'] ?? NULL;
     if (!$financialType && $id) {
       $financialType = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $id, 'financial_type_id', 'id');
     }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -61,7 +61,7 @@ class CRM_Price_BAO_PriceSet extends CRM_Price_DAO_PriceSet {
       $params['extends'] = CRM_Utils_Array::implodePadded($params['extends']);
     }
     else {
-      $priceSetID = CRM_Utils_Array::value('id', $params);
+      $priceSetID = $params['id'] ?? NULL;
     }
     $priceSetBAO = new CRM_Price_BAO_PriceSet();
     $priceSetBAO->copyValues($params);
@@ -340,7 +340,7 @@ WHERE     cpf.price_set_id = %1";
       }
     }
     else {
-      $fid = CRM_Utils_Array::value('fid', $params);
+      $fid = $params['fid'] ?? NULL;
     }
 
     if (isset($fid)) {
@@ -603,8 +603,8 @@ WHERE  id = %1";
 
       $form->_priceSetId = $priceSetId;
       $priceSet = self::getSetDetail($priceSetId, $required, $validOnly);
-      $form->_priceSet = CRM_Utils_Array::value($priceSetId, $priceSet);
-      $form->_values['fee'] = CRM_Utils_Array::value('fields', $form->_priceSet);
+      $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
+      $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
 
       //get the price set fields participant count.
       if ($entityTable == 'civicrm_event') {
@@ -829,7 +829,7 @@ WHERE  id = %1";
     }
 
     $priceSet = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly);
-    $form->_priceSet = CRM_Utils_Array::value($priceSetId, $priceSet);
+    $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
     $validPriceFieldIds = array_keys($form->_priceSet['fields']);
     $form->_quickConfig = $quickConfig = 0;
     if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config')) {
@@ -900,7 +900,7 @@ WHERE  id = %1";
         (CRM_Utils_Array::value('visibility', $field) == 'admin' && $adminFieldVisible == TRUE) ||
         !$validFieldsOnly
       ) {
-        $options = CRM_Utils_Array::value('options', $field);
+        $options = $field['options'] ?? NULL;
         if ($className == 'CRM_Contribute_Form_Contribution_Main' && $component = 'membership') {
           $userid = $form->getVar('_membershipContactID');
           $checklifetime = self::checkCurrentMembership($options, $userid);

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -574,7 +574,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
           for ($index = 1; $index <= self::NUM_OPTION; $index++) {
 
             $isOptionSet = !empty($fields['option_label'][$index]) || !empty($fields['option_amount'][$index]);
-            $currentOptionVisibility = CRM_Utils_Array::value($fields['option_visibility_id'][$index], $visibilityOptions);
+            $currentOptionVisibility = $visibilityOptions[$fields['option_visibility_id'][$index]] ?? NULL;
 
             if ($isOptionSet && $currentOptionVisibility == 'public') {
               $errors["option_visibility_id[{$index}]"] = ts('\'Admin\' field should only have \'Admin\' visibility options.');

--- a/CRM/Price/Form/Set.php
+++ b/CRM/Price/Form/Set.php
@@ -269,7 +269,7 @@ class CRM_Price_Form_Set extends CRM_Core_Form {
     $params['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $params, FALSE);
 
     $compIds = [];
-    $extends = CRM_Utils_Array::value('extends', $params);
+    $extends = $params['extends'] ?? NULL;
     if (is_array($extends)) {
       foreach ($extends as $compId => $selected) {
         if ($selected) {

--- a/CRM/Price/Page/Field.php
+++ b/CRM/Price/Page/Field.php
@@ -111,8 +111,8 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
 
     // display taxTerm for priceFields
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $taxTerm = $invoiceSettings['tax_term'] ?? NULL;
+    $invoicing = $invoiceSettings['invoicing'] ?? NULL;
     $getTaxDetails = FALSE;
     $taxRate = CRM_Core_PseudoConstant::getTaxRates();
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes);
@@ -126,7 +126,7 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
         $params = ['price_field_id' => $priceFieldBAO->id];
 
         CRM_Price_BAO_PriceFieldValue::retrieve($params, $optionValues);
-        $priceField[$priceFieldBAO->id]['price'] = CRM_Utils_Array::value('amount', $optionValues);
+        $priceField[$priceFieldBAO->id]['price'] = $optionValues['amount'] ?? NULL;
         $financialTypeId = $optionValues['financial_type_id'];
         if ($invoicing && isset($taxRate[$financialTypeId])) {
           $priceField[$priceFieldBAO->id]['tax_rate'] = $taxRate[$financialTypeId];

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -130,8 +130,8 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
     $taxRate = CRM_Core_PseudoConstant::getTaxRates();
     // display taxTerm for priceFields
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
-    $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
+    $taxTerm = $invoiceSettings['tax_term'] ?? NULL;
+    $invoicing = $invoiceSettings['invoicing'] ?? NULL;
     $getTaxDetails = FALSE;
     foreach ($customOption as $id => $values) {
       $action = array_sum(array_keys(self::actionLinks()));

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -994,7 +994,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     if (!$register && empty($fields['_qf_Edit_upload_duplicate'])) {
       // fix for CRM-3240
       if (!empty($fields['email-Primary'])) {
-        $fields['email'] = CRM_Utils_Array::value('email-Primary', $fields);
+        $fields['email'] = $fields['email-Primary'] ?? NULL;
       }
 
       // fix for CRM-6141
@@ -1187,7 +1187,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
       }
     }
 
-    $addToGroupId = CRM_Utils_Array::value('add_to_group_id', $this->_ufGroup);
+    $addToGroupId = $this->_ufGroup['add_to_group_id'] ?? NULL;
     if (!empty($addToGroupId)) {
       //run same check whether group is a mailing list
       $groupTypes = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group',

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -188,7 +188,7 @@ SELECT module,is_reserved
       $this->_cancelURL = str_replace('&amp;', '&', $this->_cancelURL);
 
       // also retain error URL if set
-      $this->_errorURL = CRM_Utils_Array::value('errorURL', $_POST);
+      $this->_errorURL = $_POST['errorURL'] ?? NULL;
       if ($this->_errorURL) {
         // we do this gross hack since qf also does entity replacement
         $this->_errorURL = str_replace('&amp;', '&', $this->_errorURL);
@@ -252,7 +252,7 @@ SELECT module,is_reserved
       ]);
       foreach (explode(',', $this->returnExtra) as $field) {
         $field = trim($field);
-        $this->ajaxResponse['extra'][$field] = CRM_Utils_Array::value($field, $contact);
+        $this->ajaxResponse['extra'][$field] = $contact[$field] ?? NULL;
       }
     }
 

--- a/CRM/Profile/Page/Listings.php
+++ b/CRM/Profile/Page/Listings.php
@@ -205,7 +205,7 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
         }
       }
 
-      $customField = CRM_Utils_Array::value($name, $this->_customFields);
+      $customField = $this->_customFields[$name] ?? NULL;
 
       if (!empty($_POST) && empty($_POST[$name])) {
         if ($customField) {
@@ -410,7 +410,7 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
       CRM_Core_Error::statusBounce(ts('This profile does not have the map feature turned on.'));
     }
 
-    $groupId = CRM_Utils_Array::value('limit_listings_group_id', $details);
+    $groupId = $details['limit_listings_group_id'] ?? NULL;
 
     // add group id to params if a uf group belong to a any group
     if ($groupId) {

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -220,7 +220,7 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
           $dateFields[$fieldIDs[$key]] = 1;
           $actualPHPFormats = CRM_Utils_Date::datePluginToPHPFormats();
           $dateFormat = (array) CRM_Utils_Array::value($returnValues['date_format'], $actualPHPFormats);
-          $timeFormat = CRM_Utils_Array::value('time_format', $returnValues);
+          $timeFormat = $returnValues['time_format'] ?? NULL;
         }
 
         $optionValuePairs = CRM_Core_BAO_CustomOption::getCustomOption($fieldIDs[$key]);
@@ -233,12 +233,12 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
         $options[$fieldIDs[$key]]['attributes']['html_type'] = $returnValues['html_type'];
         $options[$fieldIDs[$key]]['attributes']['data_type'] = $returnValues['data_type'];
         $options[$fieldIDs[$key]]['attributes']['is_required'] = !empty($returnValues['is_required']);
-        $options[$fieldIDs[$key]]['attributes']['default_value'] = CRM_Utils_Array::value('default_value', $returnValues);
-        $options[$fieldIDs[$key]]['attributes']['is_view'] = CRM_Utils_Array::value('is_view', $returnValues);
+        $options[$fieldIDs[$key]]['attributes']['default_value'] = $returnValues['default_value'] ?? NULL;
+        $options[$fieldIDs[$key]]['attributes']['is_view'] = $returnValues['is_view'] ?? NULL;
 
         $options[$fieldIDs[$key]]['attributes']['format']
-          = $options[$fieldIDs[$key]]['attributes']['date_format'] = CRM_Utils_Array::value('date_format', $returnValues);
-        $options[$fieldIDs[$key]]['attributes']['time_format'] = CRM_Utils_Array::value('time_format', $returnValues);
+          = $options[$fieldIDs[$key]]['attributes']['date_format'] = $returnValues['date_format'] ?? NULL;
+        $options[$fieldIDs[$key]]['attributes']['time_format'] = $returnValues['time_format'] ?? NULL;
       }
       $linkAction = array_sum(array_keys($this->links()));
     }

--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -307,9 +307,9 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
 
           if (strpos($name, '-') !== FALSE) {
             $value = explode('-', $name);
-            $fieldName = CRM_Utils_Array::value(0, $value);
-            $lType = CRM_Utils_Array::value(1, $value);
-            $type = CRM_Utils_Array::value(2, $value);
+            $fieldName = $value[0] ?? NULL;
+            $lType = $value[1] ?? NULL;
+            $type = $value[2] ?? NULL;
 
             if (!in_array($fieldName, $multipleFields)) {
               if ($lType == 'Primary') {
@@ -380,7 +380,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
     if ($this->_multiRecordTableName &&
       !array_key_exists($this->_multiRecordTableName, $this->_query->_whereTables)
     ) {
-      $additionalFromClause = CRM_Utils_Array::value($this->_multiRecordTableName, $this->_query->_tables);
+      $additionalFromClause = $this->_query->_tables[$this->_multiRecordTableName] ?? NULL;
       $returnQuery = TRUE;
     }
 
@@ -436,7 +436,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
       foreach ($vars as $key => $field) {
         $field = $vars[$key];
         $fieldArray = explode('-', $field['name']);
-        $fieldType = CRM_Utils_Array::value('2', $fieldArray);
+        $fieldType = $fieldArray['2'] ?? NULL;
         if (is_numeric(CRM_Utils_Array::value('1', $fieldArray))) {
           if (!in_array($fieldType, $multipleFields)) {
             $locationType = new CRM_Core_DAO_LocationType();
@@ -513,14 +513,14 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
       ) {
         if (strpos($key, '-') !== FALSE) {
           $value = explode('-', $key);
-          $fieldName = CRM_Utils_Array::value(0, $value);
-          $id = CRM_Utils_Array::value(1, $value);
-          $type = CRM_Utils_Array::value(2, $value);
+          $fieldName = $value[0] ?? NULL;
+          $id = $value[1] ?? NULL;
+          $type = $value[2] ?? NULL;
 
           if (!in_array($fieldName, $multipleFields)) {
             $locationTypeName = NULL;
             if (is_numeric($id)) {
-              $locationTypeName = CRM_Utils_Array::value($id, $locationTypes);
+              $locationTypeName = $locationTypes[$id] ?? NULL;
             }
             else {
               if ($id == 'Primary') {

--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -97,8 +97,8 @@ class CRM_Queue_Runner {
     $this->queue = $runnerSpec['queue'];
     $this->errorMode = CRM_Utils_Array::value('errorMode', $runnerSpec, self::ERROR_ABORT);
     $this->isMinimal = CRM_Utils_Array::value('isMinimal', $runnerSpec, FALSE);
-    $this->onEnd = CRM_Utils_Array::value('onEnd', $runnerSpec, NULL);
-    $this->onEndUrl = CRM_Utils_Array::value('onEndUrl', $runnerSpec, NULL);
+    $this->onEnd = $runnerSpec['onEnd'] ?? NULL;
+    $this->onEndUrl = $runnerSpec['onEndUrl'] ?? NULL;
     $this->pathPrefix = CRM_Utils_Array::value('pathPrefix', $runnerSpec, 'civicrm/queue');
     $this->buttons = CRM_Utils_Array::value('buttons', $runnerSpec, ['retry' => TRUE, 'skip' => TRUE]);
     // perhaps this value should be randomized?

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -114,10 +114,10 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
    */
   public static function &create(&$params) {
     if (isset($params['report_header'])) {
-      $params['header'] = CRM_Utils_Array::value('report_header', $params);
+      $params['header'] = $params['report_header'] ?? NULL;
     }
     if (isset($params['report_footer'])) {
-      $params['footer'] = CRM_Utils_Array::value('report_footer', $params);
+      $params['footer'] = $params['report_footer'] ?? NULL;
     }
 
     // build navigation parameters
@@ -131,8 +131,8 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
       $navigationParams['label'] = $params['title'];
       $navigationParams['name'] = $params['title'];
 
-      $navigationParams['current_parent_id'] = CRM_Utils_Array::value('parent_id', $navigationParams);
-      $navigationParams['parent_id'] = CRM_Utils_Array::value('parent_id', $params);
+      $navigationParams['current_parent_id'] = $navigationParams['parent_id'] ?? NULL;
+      $navigationParams['parent_id'] = $params['parent_id'] ?? NULL;
       $navigationParams['is_active'] = 1;
 
       if ($permission = CRM_Utils_Array::value('permission', $params)) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -614,7 +614,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         CRM_Utils_System::civiExit();
       }
 
-      $formValues = CRM_Utils_Array::value('form_values', $this->_instanceValues);
+      $formValues = $this->_instanceValues['form_values'] ?? NULL;
       if ($formValues) {
         $this->_formValues = CRM_Utils_String::unserialize($formValues);
       }
@@ -947,8 +947,8 @@ class CRM_Report_Form extends CRM_Core_Form {
             if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE
             ) {
               if (is_array($field['default'])) {
-                $this->_defaults["{$fieldName}_from"] = CRM_Utils_Array::value('from', $field['default']);
-                $this->_defaults["{$fieldName}_to"] = CRM_Utils_Array::value('to', $field['default']);
+                $this->_defaults["{$fieldName}_from"] = $field['default']['from'] ?? NULL;
+                $this->_defaults["{$fieldName}_to"] = $field['default']['to'] ?? NULL;
                 $this->_defaults["{$fieldName}_relative"] = 0;
               }
               else {
@@ -957,8 +957,8 @@ class CRM_Report_Form extends CRM_Core_Form {
             }
             else {
               if ((CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_INT) && is_array($field['default'])) {
-                $this->_defaults["{$fieldName}_min"] = CRM_Utils_Array::value('min', $field['default']);
-                $this->_defaults["{$fieldName}_max"] = CRM_Utils_Array::value('max', $field['default']);
+                $this->_defaults["{$fieldName}_min"] = $field['default']['min'] ?? NULL;
+                $this->_defaults["{$fieldName}_max"] = $field['default']['max'] ?? NULL;
               }
               $this->_defaults["{$fieldName}_value"] = $field['default'];
             }
@@ -1216,11 +1216,11 @@ class CRM_Report_Form extends CRM_Core_Form {
               $colGroups[$tableName]['use_accordian_for_field_selection'] = TRUE;
             }
 
-            $colGroups[$tableName]['fields'][$fieldName] = CRM_Utils_Array::value('title', $field);
+            $colGroups[$tableName]['fields'][$fieldName] = $field['title'] ?? NULL;
             if ($groupTitle && empty($colGroups[$tableName]['group_title'])) {
               $colGroups[$tableName]['group_title'] = $groupTitle;
             }
-            $options[$fieldName] = CRM_Utils_Array::value('title', $field);
+            $options[$fieldName] = $field['title'] ?? NULL;
           }
         }
       }
@@ -2741,9 +2741,9 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
   public function selectClause(&$tableName, $tableKey, &$fieldName, &$field) {
     if (!empty($field['pseudofield'])) {
       $alias = "{$tableName}_{$fieldName}";
-      $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-      $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-      $this->_columnHeaders["{$tableName}_{$fieldName}"]['dbAlias'] = CRM_Utils_Array::value('dbAlias', $field);
+      $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+      $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+      $this->_columnHeaders["{$tableName}_{$fieldName}"]['dbAlias'] = $field['dbAlias'] ?? NULL;
       $this->_selectAliases[] = $alias;
       return ' 1 as  ' . $alias;
     }
@@ -3031,7 +3031,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
 
           // Record any section headers for assignment to the template
           if (!empty($orderBy['section'])) {
-            $orderByField['pageBreak'] = CRM_Utils_Array::value('pageBreak', $orderBy);
+            $orderByField['pageBreak'] = $orderBy['pageBreak'] ?? NULL;
             $this->_sections[$orderByField['tplField']] = $orderByField;
           }
         }
@@ -3326,16 +3326,16 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             $value = NULL;
             if ($op) {
               $pair = $this->getOperationPair(
                 CRM_Utils_Array::value('operatorType', $field),
                 $fieldName
               );
-              $min = CRM_Utils_Array::value("{$fieldName}_min", $this->_params);
-              $max = CRM_Utils_Array::value("{$fieldName}_max", $this->_params);
-              $val = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+              $min = $this->_params["{$fieldName}_min"] ?? NULL;
+              $max = $this->_params["{$fieldName}_max"] ?? NULL;
+              $val = $this->_params["{$fieldName}_value"] ?? NULL;
               if (in_array($op, ['bw', 'nbw']) && ($min || $max)) {
                 $value = "{$pair[$op]} $min " . ts('and') . " $max";
               }
@@ -5317,8 +5317,8 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   protected function addBasicFieldToSelect($tableName, $fieldName, $field, $select) {
     $alias = "{$tableName}_{$fieldName}";
     $select[] = "{$field['dbAlias']} as $alias";
-    $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-    $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+    $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+    $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
     $this->_selectAliases[] = $alias;
     return $select;
   }
@@ -5955,7 +5955,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   protected function getSelectClauseWithGroupConcatIfNotGroupedBy($tableName, &$fieldName, &$field) {
     if ($this->groupConcatTested && (!empty($this->_groupByArray) || $this->isForceGroupBy)) {
       if ((empty($field['statistics']) || in_array('GROUP_CONCAT', $field['statistics']))) {
-        $label = CRM_Utils_Array::value('title', $field);
+        $label = $field['title'] ?? NULL;
         $alias = $field['tplField'] ?? "{$tableName}_{$fieldName}";
         $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $label;
         $this->_selectAliases[] = $alias;
@@ -5983,24 +5983,24 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       if (CRM_Utils_Array::value('operatorType', $field) ==
         CRM_Report_Form::OP_MONTH
       ) {
-        $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
-        $value = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+        $op = $this->_params["{$fieldName}_op"] ?? NULL;
+        $value = $this->_params["{$fieldName}_value"] ?? NULL;
         if (is_array($value) && !empty($value)) {
           return "(month({$field['dbAlias']}) $op (" . implode(', ', $value) .
             '))';
         }
       }
       else {
-        $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-        $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-        $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
-        $fromTime = CRM_Utils_Array::value("{$fieldName}_from_time", $this->_params);
-        $toTime = CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params);
+        $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+        $from = $this->_params["{$fieldName}_from"] ?? NULL;
+        $to = $this->_params["{$fieldName}_to"] ?? NULL;
+        $fromTime = $this->_params["{$fieldName}_from_time"] ?? NULL;
+        $toTime = $this->_params["{$fieldName}_to_time"] ?? NULL;
         return $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type'], $fromTime, $toTime);
       }
     }
     else {
-      $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+      $op = $this->_params["{$fieldName}_op"] ?? NULL;
       if ($op) {
         return $this->whereClause($field,
           $op,

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -536,14 +536,14 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
             continue;
           }
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op && !($fieldName == "contact_{$recordType}" && ($op != 'nnll' || $op != 'nll'))) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -260,15 +260,15 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
               else {
                 $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
               }
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
             }
           }
         }
@@ -364,14 +364,14 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -250,7 +250,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
           $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
 
           // Set default title
-          $title = CRM_Utils_Array::value('title', $field);
+          $title = $field['title'] ?? NULL;
           // Check for an override.
           if (!empty($this->_columnTitleOverrides["{$tableName}_{$fieldName}"])) {
             $title = $this->_columnTitleOverrides["{$tableName}_{$fieldName}"];
@@ -309,14 +309,14 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
           $clause = NULL;
 
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
@@ -371,7 +371,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
    */
   private function _surveyCoverSheet() {
     $coverSheet = NULL;
-    $surveyIds = CRM_Utils_Array::value('survey_id_value', $this->_params);
+    $surveyIds = $this->_params['survey_id_value'] ?? NULL;
     if (CRM_Utils_System::isNull($surveyIds)) {
       return $coverSheet;
     }
@@ -498,7 +498,7 @@ INNER JOIN  civicrm_option_value val ON ( val.option_group_id = survey.result_id
    * @param $rows
    */
   private function _formatSurveyResult(&$rows) {
-    $surveyIds = CRM_Utils_Array::value('survey_id_value', $this->_params);
+    $surveyIds = $this->_params['survey_id_value'] ?? NULL;
     if (CRM_Utils_System::isNull($surveyIds) ||
       empty($this->_params['fields']['result']) ||
       !in_array($this->_outputMode, array('print', 'pdf'))
@@ -523,16 +523,16 @@ INNER JOIN  civicrm_survey survey ON ( survey.result_id = grp.id )
       $resultSet[$result->id][$result->value] = $result->label;
     }
 
-    $statusId = CRM_Utils_Array::value('status_id_value', $this->_params);
-    $respondentStatus = CRM_Utils_Array::value($statusId, self::$_surveyRespondentStatus);
+    $statusId = $this->_params['status_id_value'] ?? NULL;
+    $respondentStatus = self::$_surveyRespondentStatus[$statusId] ?? NULL;
 
-    $surveyId = CRM_Utils_Array::value(0, $surveyIds);
+    $surveyId = $surveyIds[0] ?? NULL;
     foreach ($rows as & $row) {
       if (!empty($row['civicrm_activity_survey_id'])) {
         $surveyId = $row['civicrm_activity_survey_id'];
       }
       $result = CRM_Utils_Array::value($surveyId, $resultSet, array());
-      $resultLabel = CRM_Utils_Array::value('civicrm_activity_result', $row);
+      $resultLabel = $row['civicrm_activity_result'] ?? NULL;
       if ($respondentStatus == 'Reserved') {
         $row['civicrm_activity_result'] = implode(' | ', array_keys($result));
       }
@@ -549,7 +549,7 @@ INNER JOIN  civicrm_survey survey ON ( survey.result_id = grp.id )
    * @param $rows
    */
   private function _formatSurveyResponseData(&$rows) {
-    $surveyIds = CRM_Utils_Array::value('survey_id_value', $this->_params);
+    $surveyIds = $this->_params['survey_id_value'] ?? NULL;
     if (CRM_Utils_System::isNull($surveyIds) ||
       empty($this->_params['fields']['survey_response'])
     ) {
@@ -586,8 +586,8 @@ INNER JOIN  civicrm_survey survey ON ( survey.result_id = grp.id )
     }
 
     //do check respondent status.
-    $statusId = CRM_Utils_Array::value('status_id_value', $this->_params);
-    $respondentStatus = CRM_Utils_Array::value($statusId, self::$_surveyRespondentStatus);
+    $statusId = $this->_params['status_id_value'] ?? NULL;
+    $respondentStatus = self::$_surveyRespondentStatus[$statusId] ?? NULL;
 
     if (!$hasResponseData &&
       ($respondentStatus != 'Reserved')
@@ -655,7 +655,7 @@ INNER JOIN  civicrm_custom_group cg ON ( cg.id = cf.custom_group_id )
         if ($respondentStatus == 'Reserved' &&
           in_array($this->_outputMode, array('print', 'pdf'))
         ) {
-          $optGrpId = CRM_Utils_Array::value('option_group_id', $responseFields[$name]);
+          $optGrpId = $responseFields[$name]['option_group_id'] ?? NULL;
           $options = CRM_Utils_Array::value($optGrpId, $fieldValueMap, array());
           $value = implode(' | ', array_keys($options));
         }
@@ -671,7 +671,7 @@ INNER JOIN  civicrm_custom_group cg ON ( cg.id = cf.custom_group_id )
   }
 
   private function _addSurveyResponseColumns() {
-    $surveyIds = CRM_Utils_Array::value('survey_id_value', $this->_params);
+    $surveyIds = $this->_params['survey_id_value'] ?? NULL;
     if (CRM_Utils_System::isNull($surveyIds) ||
       empty($this->_params['fields']['survey_response'])
     ) {

--- a/CRM/Report/Form/Case/Demographics.php
+++ b/CRM/Report/Form/Case/Demographics.php
@@ -250,7 +250,7 @@ where (cg.extends='Contact' OR cg.extends='Individual' OR cg.extends_entity_colu
             }
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
           }
         }
@@ -308,18 +308,18 @@ where (cg.extends='Contact' OR cg.extends='Individual' OR cg.extends_entity_colu
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if ($field['operatorType'] & CRM_Report_Form::OP_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, CRM_Utils_Type::T_DATE);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               // handle special case
               if ($fieldName == 'case_id_filter') {
-                $choice = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+                $choice = $this->_params["{$fieldName}_value"] ?? NULL;
                 if ($choice == 1) {
                   $clause = "({$this->_aliases['civicrm_case']}.id Is Not Null)";
                 }

--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -350,7 +350,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             }
 
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
           }
         }
@@ -417,15 +417,15 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
           $clause = NULL;
 
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
           }
           else {
 
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($fieldName == 'case_type_id' &&
               !empty($this->_params['case_type_id_value'])
             ) {

--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -209,7 +209,7 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             }
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
           }
         }

--- a/CRM/Report/Form/Case/TimeSpent.php
+++ b/CRM/Report/Form/Case/TimeSpent.php
@@ -183,9 +183,9 @@ class CRM_Report_Form_Case_TimeSpent extends CRM_Report_Form {
             )
           ) {
 
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
 
             if ($fieldName == 'activity_type_id') {
               $this->has_activity_type = TRUE;
@@ -240,18 +240,18 @@ class CRM_Report_Form_Case_TimeSpent extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               // handle special case
               if ($fieldName == 'case_id_filter') {
-                $choice = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+                $choice = $this->_params["{$fieldName}_value"] ?? NULL;
                 if ($choice == 1) {
                   $clause = "({$this->_aliases['civicrm_case_activity']}.id Is Not Null)";
                 }

--- a/CRM/Report/Form/Contact/CurrentEmployer.php
+++ b/CRM/Report/Form/Contact/CurrentEmployer.php
@@ -196,8 +196,8 @@ class CRM_Report_Form_Contact_CurrentEmployer extends CRM_Report_Form {
           ) {
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
           }
         }
       }
@@ -239,14 +239,14 @@ FROM civicrm_contact {$this->_aliases['civicrm_contact']}
           $clause = NULL;
           if (CRM_Utils_Array::value('operatorType', $field) & CRM_Report_Form::OP_DATE
           ) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -389,8 +389,8 @@ class CRM_Report_Form_Contact_Detail extends CRM_Report_Form {
             //isolate the select clause compoenent wise
             if (in_array($table['alias'], $this->_component)) {
               $select[$table['alias']][] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeadersComponent[$table['alias']]["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeadersComponent[$table['alias']]["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+              $this->_columnHeadersComponent[$table['alias']]["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeadersComponent[$table['alias']]["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
             }
             elseif ($table['alias'] ==
               $this->_aliases['civicrm_activity_target'] ||
@@ -413,12 +413,12 @@ class CRM_Report_Form_Contact_Detail extends CRM_Report_Form {
 
               $tableName = $table['alias'];
               $select['activity_civireport'][] = "$tableName.display_name as {$tableName}_{$fieldName}, $addContactId ";
-              $this->_columnHeadersComponent['activity_civireport']["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeadersComponent['activity_civireport']["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+              $this->_columnHeadersComponent['activity_civireport']["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeadersComponent['activity_civireport']["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }
           }
@@ -606,14 +606,14 @@ HERESQL;
           $clause = NULL;
           if (CRM_Utils_Array::value('operatorType', $field) & CRM_Report_Form::OP_DATE
           ) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             $clause = $this->whereClause($field,
               $op,
               CRM_Utils_Array::value("{$fieldName}_value", $this->_params),

--- a/CRM/Report/Form/Contact/Log.php
+++ b/CRM/Report/Form/Contact/Log.php
@@ -136,7 +136,7 @@ class CRM_Report_Form_Contact_Log extends CRM_Report_Form {
           ) {
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
           }
         }
@@ -181,14 +181,14 @@ class CRM_Report_Form_Contact_Log extends CRM_Report_Form {
           $clause = NULL;
           if (CRM_Utils_Array::value('operatorType', $field) & CRM_Report_Form::OP_DATE
           ) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Contact/LoggingSummary.php
+++ b/CRM/Report/Form/Contact/LoggingSummary.php
@@ -294,7 +294,7 @@ class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
 
     $detail = $this->_logTables[$entity];
     $tableName = CRM_Utils_Array::value('table_name', $detail, $entity);
-    $clause = CRM_Utils_Array::value('entity_table', $detail);
+    $clause = $detail['entity_table'] ?? NULL;
     $clause = $clause ? "AND entity_log_civireport.entity_table = 'civicrm_contact'" : NULL;
 
     $joinClause = "
@@ -302,7 +302,7 @@ INNER JOIN civicrm_contact modified_contact_civireport
         ON (entity_log_civireport.{$detail['fk']} = modified_contact_civireport.id {$clause})";
 
     if (!empty($detail['joins'])) {
-      $clause = CRM_Utils_Array::value('entity_table', $detail);
+      $clause = $detail['entity_table'] ?? NULL;
       $clause = $clause ? "AND fk_table.entity_table = 'civicrm_contact'" : NULL;
       $joinClause = "
 INNER JOIN `{$this->loggingDB}`.{$detail['joins']['table']} fk_table ON {$detail['joins']['join']}

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -372,8 +372,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
               $this->_phoneField_b = TRUE;
             }
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
           }
         }
       }
@@ -454,9 +454,9 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
 
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($fieldName == 'active_period_date') {
               $clause = $this->activeClause($field['name'], $relative, $from, $to, $field['type']);
@@ -466,14 +466,14 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               if (($tableName == 'civicrm_contact' ||
                   $tableName == 'civicrm_contact_b') &&
                 ($fieldName == 'contact_type_a' ||
                   $fieldName == 'contact_type_b')
               ) {
-                $cTypes = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+                $cTypes = $this->_params["{$fieldName}_value"] ?? NULL;
                 $contactTypes = $contactSubTypes = [];
                 if (!empty($cTypes)) {
                   foreach ($cTypes as $ctype) {
@@ -630,7 +630,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
   }
 
   public function beginPostProcessCommon() {
-    $originalRelationshipTypeIdValue = CRM_Utils_Array::value('relationship_type_id_value', $this->_params);
+    $originalRelationshipTypeIdValue = $this->_params['relationship_type_id_value'] ?? NULL;
     if ($originalRelationshipTypeIdValue) {
       $relationshipTypes = [];
       $direction = [];

--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -450,7 +450,7 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
                 break;
             }
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
           }
         }
       }
@@ -533,14 +533,14 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
               END";
           }
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
@@ -674,7 +674,7 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
       }
 
       if (!empty($row['civicrm_financial_trxn_card_type_id'])) {
-        $rows[$rowNum]['civicrm_financial_trxn_card_type_id'] = CRM_Utils_Array::value($row['civicrm_financial_trxn_card_type_id'], $creditCardTypes);
+        $rows[$rowNum]['civicrm_financial_trxn_card_type_id'] = $creditCardTypes[$row['civicrm_financial_trxn_card_type_id']] ?? NULL;
         $entryFound = TRUE;
       }
 

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -697,7 +697,7 @@ UNION ALL
         $entryFound = TRUE;
       }
       if (!empty($row['civicrm_batch_batch_id'])) {
-        $rows[$rowNum]['civicrm_batch_batch_id'] = CRM_Utils_Array::value($row['civicrm_batch_batch_id'], $batches);
+        $rows[$rowNum]['civicrm_batch_batch_id'] = $batches[$row['civicrm_batch_batch_id']] ?? NULL;
         $entryFound = TRUE;
       }
       if (!empty($row['civicrm_financial_trxn_card_type_id'])) {

--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -326,7 +326,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
           ) {
             if ($tableName == 'civicrm_relationship') {
               $this->_relationshipColumns["{$tableName}_{$fieldName}"] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
               continue;
             }
@@ -355,7 +355,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }
             if (!empty($field['no_display'])) {
@@ -403,14 +403,14 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
           }
           elseif (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE
           ) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Contribute/HouseholdSummary.php
+++ b/CRM/Report/Form/Contribute/HouseholdSummary.php
@@ -214,8 +214,8 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
 
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
           }
         }
@@ -250,13 +250,13 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               if ($fieldName == 'relationship_type_id') {
                 $clause = "{$this->_aliases['civicrm_relationship']}.relationship_type_id=" . $this->relationshipId;

--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -219,8 +219,8 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
 
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
           }
         }
@@ -257,14 +257,14 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               if ($fieldName == 'relationship_type_id') {
                 $clause = "{$this->_aliases['civicrm_relationship']}.relationship_type_id=" . $this->relationshipId;

--- a/CRM/Report/Form/Contribute/PCP.php
+++ b/CRM/Report/Form/Contribute/PCP.php
@@ -250,13 +250,13 @@ LEFT JOIN civicrm_event {$this->_aliases['civicrm_event']}
           $clause = NULL;
 
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
 
             if ($op) {
               $clause = $this->whereClause($field,

--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -293,9 +293,9 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
       if (!empty($this->_params['calculated_end_date_' . $suffix])) {
         // The calculated date field is in use - spring into action
         // Gather values
-        $relative = CRM_Utils_Array::value("calculated_end_date_relative", $this->_params);
-        $from = CRM_Utils_Array::value("calculated_end_date_from", $this->_params);
-        $to = CRM_Utils_Array::value("calculated_end_date_to", $this->_params);
+        $relative = $this->_params["calculated_end_date_relative"] ?? NULL;
+        $from = $this->_params["calculated_end_date_from"] ?? NULL;
+        $to = $this->_params["calculated_end_date_to"] ?? NULL;
         $end_date_db_alias = $this->_columns['civicrm_contribution_recur']['filters']['end_date']['dbAlias'];
         $end_date_type = $this->_columns['civicrm_contribution_recur']['filters']['end_date']['type'];
         $start_date_type = $this->_columns['civicrm_contribution_recur']['filters']['start_date']['type'];

--- a/CRM/Report/Form/Contribute/RecurSummary.php
+++ b/CRM/Report/Form/Contribute/RecurSummary.php
@@ -166,8 +166,8 @@ class CRM_Report_Form_Contribute_RecurSummary extends CRM_Report_Form {
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
             }
           }
         }
@@ -222,9 +222,9 @@ class CRM_Report_Form_Contribute_RecurSummary extends CRM_Report_Form {
 
     $entryFound = FALSE;
 
-    $startDateFrom = CRM_Utils_Array::value("start_date_to", $this->_params);
-    $startDateTo = CRM_Utils_Array::value("start_date_from", $this->_params);
-    $startDateRelative = CRM_Utils_Array::value("start_date_relative", $this->_params);
+    $startDateFrom = $this->_params["start_date_to"] ?? NULL;
+    $startDateTo = $this->_params["start_date_from"] ?? NULL;
+    $startDateRelative = $this->_params["start_date_relative"] ?? NULL;
 
     $startedDateSql = $this->dateClause('start_date', $startDateRelative, $startDateFrom, $startDateTo);
     $startedDateSql = $startedDateSql ? $startedDateSql : " ( 1 ) ";
@@ -236,7 +236,7 @@ class CRM_Report_Form_Contribute_RecurSummary extends CRM_Report_Form {
 
     foreach ($rows as $rowNum => $row) {
 
-      $paymentInstrumentId = CRM_Utils_Array::value('civicrm_contribution_recur_payment_instrument_id', $row);
+      $paymentInstrumentId = $row['civicrm_contribution_recur_payment_instrument_id'] ?? NULL;
 
       $rows[$rowNum]['civicrm_contribution_recur_start_date'] = 0;
       $rows[$rowNum]['civicrm_contribution_recur_cancel_date'] = 0;

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -263,17 +263,17 @@ class CRM_Report_Form_Contribute_Repeat extends CRM_Report_Form {
               $select[] = $field['clause'];
 
               // FIXME: dirty hack for setting columnHeaders
-              $this->_columnHeaders["{$field['alias']}_{$field['name']}_sum"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$field['alias']}_{$field['name']}_sum"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$field['alias']}_{$field['name']}_sum"]['title'] = $field['title'];
-              $this->_columnHeaders["{$field['alias']}_{$field['name']}_count"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$field['alias']}_{$field['name']}_count"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$field['alias']}_{$field['name']}_count"]['title'] = $field['title'];
               continue;
             }
 
             // only include statistics columns if set
             $select[] = "{$field['dbAlias']} as {$field['alias']}_{$field['name']}";
-            $this->_columnHeaders["{$field['alias']}_{$field['name']}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$field['alias']}_{$field['name']}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$field['alias']}_{$field['name']}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$field['alias']}_{$field['name']}"]['title'] = $field['title'] ?? NULL;
             if (!empty($field['no_display'])) {
               $this->_columnHeaders["{$field['alias']}_{$field['name']}"]['no_display'] = TRUE;
             }
@@ -386,14 +386,14 @@ LEFT JOIN $this->tempTableRepeat2 {$this->_aliases['civicrm_contribution']}2
     foreach ($this->_columns['civicrm_contribution']['filters'] as $fieldName => $field) {
       $clause = NULL;
       if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-        $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-        $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-        $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+        $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+        $from = $this->_params["{$fieldName}_from"] ?? NULL;
+        $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
         $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
       }
       else {
-        $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+        $op = $this->_params["{$fieldName}_op"] ?? NULL;
         if ($op) {
           $clause = $this->whereClause($field,
             $op,
@@ -450,7 +450,7 @@ LEFT JOIN $this->tempTableRepeat2 {$this->_aliases['civicrm_contribution']}2
       ) {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
-          $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+          $op = $this->_params["{$fieldName}_op"] ?? NULL;
           if ($op) {
             $clause = $this->whereClause($field,
               $op,

--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -369,7 +369,7 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }
           }

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -423,8 +423,8 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
             }
           }
         }
@@ -580,7 +580,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
   public function statistics(&$rows) {
     $statistics = parent::statistics($rows);
 
-    $softCredit = CRM_Utils_Array::value('soft_amount', $this->_params['fields']);
+    $softCredit = $this->_params['fields']['soft_amount'] ?? NULL;
     $onlySoftCredit = $softCredit && !CRM_Utils_Array::value('total_amount', $this->_params['fields']);
     if (!isset($this->_groupByArray['civicrm_contribution_currency'])) {
       $this->_groupByArray['civicrm_contribution_currency'] = 'currency';

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -294,7 +294,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }
             if (!empty($field['no_display'])) {
@@ -341,16 +341,16 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
           }
           elseif (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE
           ) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -204,8 +204,8 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
   public static function formRule($fields, $files, $self) {
     $errors = [];
 
-    $op = CRM_Utils_Array::value('total_range_op', $fields);
-    $val = CRM_Utils_Array::value('total_range_value', $fields);
+    $op = $fields['total_range_op'] ?? NULL;
+    $val = $fields['total_range_value'] ?? NULL;
 
     if (!in_array($op, [
       'eq',
@@ -244,16 +244,16 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
@@ -266,7 +266,7 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
 
           if (!empty($clause)) {
             if ($fieldName == 'total_range') {
-              $value = CRM_Utils_Array::value("total_range_value", $this->_params);
+              $value = $this->_params["total_range_value"] ?? NULL;
               $this->_outerCluase = " WHERE (( @rows := @rows + 1) <= {$value}) ";
               $this->_groupLimit = " LIMIT {$value}";
             }

--- a/CRM/Report/Form/Event/IncomeCountSummary.php
+++ b/CRM/Report/Form/Event/IncomeCountSummary.php
@@ -179,7 +179,7 @@ class CRM_Report_Form_Event_IncomeCountSummary extends CRM_Report_Form {
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }
           }
@@ -210,16 +210,16 @@ class CRM_Report_Form_Event_IncomeCountSummary extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Event/ParticipantListCount.php
+++ b/CRM/Report/Form/Event/ParticipantListCount.php
@@ -406,7 +406,7 @@ class CRM_Report_Form_Event_ParticipantListCount extends CRM_Report_Form {
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }
           }

--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -446,16 +446,16 @@ ORDER BY  cv.label
             }
             $alias = "{$tableName}_{$fieldName}";
             $select[] = "{$field['dbAlias']} as $alias";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
             $this->_selectAliases[] = $alias;
           }
         }
       }
     }
     //add blank column at the end
-    $blankcols = CRM_Utils_Array::value('blank_column_end', $this->_params);
+    $blankcols = $this->_params['blank_column_end'] ?? NULL;
     if ($blankcols) {
       for ($i = 1; $i <= $blankcols; $i++) {
         $select[] = " '' as blankColumnEnd_{$i}";
@@ -537,19 +537,19 @@ ORDER BY  cv.label
           $clause = NULL;
 
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
 
             if ($fieldName == 'rid') {
-              $value = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+              $value = $this->_params["{$fieldName}_value"] ?? NULL;
               if (!empty($value)) {
                 $operator = '';
                 if ($op == 'notin') {
@@ -704,9 +704,9 @@ ORDER BY  cv.label
       }
 
       // Convert display name to link
-      $displayName = CRM_Utils_Array::value('civicrm_contact_sort_name_linked', $row);
-      $cid = CRM_Utils_Array::value('civicrm_contact_id', $row);
-      $id = CRM_Utils_Array::value('civicrm_participant_participant_record', $row);
+      $displayName = $row['civicrm_contact_sort_name_linked'] ?? NULL;
+      $cid = $row['civicrm_contact_id'] ?? NULL;
+      $id = $row['civicrm_participant_participant_record'] ?? NULL;
 
       if ($displayName && $cid && $id) {
         $url = CRM_Report_Utils_Report::getNextUrl('contact/detail',

--- a/CRM/Report/Form/Event/Summary.php
+++ b/CRM/Report/Form/Event/Summary.php
@@ -125,16 +125,16 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
@@ -239,8 +239,8 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form {
             !empty($this->_params['fields'][$fieldName])
           ) {
 
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
           }
         }
       }
@@ -328,7 +328,7 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form {
     $countEvent = NULL;
     if (!empty($this->_params['charts'])) {
       foreach ($rows as $key => $value) {
-        $graphRows['totalAmount'][] = $graphRows['value'][] = CRM_Utils_Array::value('totalAmount', $rows[$key]);
+        $graphRows['totalAmount'][] = $graphRows['value'][] = $rows[$key]['totalAmount'] ?? NULL;
         $graphRows[$this->_interval][] = substr($rows[$key]['civicrm_event_title'], 0, 12) . "..(" .
           $rows[$key]['civicrm_event_id'] . ") ";
       }

--- a/CRM/Report/Form/Grant/Statistics.php
+++ b/CRM/Report/Form/Grant/Statistics.php
@@ -200,8 +200,8 @@ class CRM_Report_Form_Grant_Statistics extends CRM_Report_Form {
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
 
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
           }
         }
       }
@@ -239,16 +239,16 @@ WHERE {$this->_aliases['civicrm_grant']}.amount_total IS NOT NULL
 
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if (($fieldName == 'grant_report_received') &&
               (CRM_Utils_Array::value("{$fieldName}_value", $this->_params) ===
                 0)
@@ -380,7 +380,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       }
 
       if (!empty($values['civicrm_grant_grant_type_id'])) {
-        $grantType = CRM_Utils_Array::value($values['civicrm_grant_grant_type_id'], $grantTypes);
+        $grantType = $grantTypes[$values['civicrm_grant_grant_type_id']] ?? NULL;
         $grantStatistics['civicrm_grant_grant_type_id']['title'] = ts('By Grant Type');
         self::getStatistics($grantStatistics['civicrm_grant_grant_type_id'], $grantType, $values,
           $awardedGrants, $awardedGrantsAmount
@@ -388,7 +388,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       }
 
       if (array_key_exists('civicrm_worldregion_name', $values)) {
-        $region = CRM_Utils_Array::value('civicrm_worldregion_name', $values);
+        $region = $values['civicrm_worldregion_name'] ?? NULL;
         $region = ($region) ? $region : 'Unassigned';
         $grantStatistics['civicrm_worldregion_name']['title'] = ts('By Region');
         self::getStatistics($grantStatistics['civicrm_worldregion_name'], $region, $values,
@@ -397,7 +397,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       }
 
       if (array_key_exists('civicrm_address_country_id', $values)) {
-        $country = CRM_Utils_Array::value($values['civicrm_address_country_id'], $countries);
+        $country = $countries[$values['civicrm_address_country_id']] ?? NULL;
         $country = ($country) ? $country : 'Unassigned';
         $grantStatistics['civicrm_address_country_id']['title'] = ts('By Country');
         self::getStatistics($grantStatistics['civicrm_address_country_id'], $country, $values,
@@ -414,7 +414,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       }
 
       if (array_key_exists('civicrm_contact_gender_id', $values)) {
-        $genderLabel = CRM_Utils_Array::value($values['civicrm_contact_gender_id'], $gender);
+        $genderLabel = $gender[$values['civicrm_contact_gender_id']] ?? NULL;
         $genderLabel = ($genderLabel) ? $genderLabel : 'Unassigned';
         $grantStatistics['civicrm_contact_gender_id']['title'] = ts('By Gender');
         self::getStatistics($grantStatistics['civicrm_contact_gender_id'], $genderLabel, $values,
@@ -424,7 +424,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
 
       foreach ($values as $customField => $customValue) {
         if (strstr($customField, 'civicrm_value_')) {
-          $customFieldTitle = CRM_Utils_Array::value('title', $this->_columnHeaders[$customField]);
+          $customFieldTitle = $this->_columnHeaders[$customField]['title'] ?? NULL;
           $customGroupTitle = explode('_custom', strstr($customField, 'civicrm_value_'));
           $customGroupTitle = $this->_columns[$customGroupTitle[0]]['group_title'];
           $grantStatistics[$customGroupTitle]['title'] = ts('By %1', [1 => $customGroupTitle]);

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -239,7 +239,7 @@ class CRM_Report_Form_Instance {
 
     if ($instanceID) {
       // this is already retrieved via Form.php
-      $defaults['description'] = CRM_Utils_Array::value('description', $defaults);
+      $defaults['description'] = $defaults['description'] ?? NULL;
       if (!empty($defaults['header'])) {
         $defaults['report_header'] = $defaults['header'];
       }
@@ -258,7 +258,7 @@ class CRM_Report_Form_Instance {
         $params = ['id' => $defaults['navigation_id']];
         CRM_Core_BAO_Navigation::retrieve($params, $navigationDefaults);
         $defaults['is_navigation'] = 1;
-        $defaults['parent_id'] = CRM_Utils_Array::value('parent_id', $navigationDefaults);
+        $defaults['parent_id'] = $navigationDefaults['parent_id'] ?? NULL;
         if (!empty($navigationDefaults['is_active'])) {
           $form->assign('is_navigation', TRUE);
         }

--- a/CRM/Report/Form/Mailing/Bounce.php
+++ b/CRM/Report/Form/Mailing/Bounce.php
@@ -271,9 +271,9 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
             }
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
           }
         }
       }
@@ -337,14 +337,14 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($this->_aliases[$tableName] . '.' . $field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
 
             if ($op) {
               $clause = $this->whereClause($field,

--- a/CRM/Report/Form/Mailing/Clicks.php
+++ b/CRM/Report/Form/Mailing/Clicks.php
@@ -229,9 +229,9 @@ class CRM_Report_Form_Mailing_Clicks extends CRM_Report_Form {
             }
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
           }
         }
       }

--- a/CRM/Report/Form/Mailing/Detail.php
+++ b/CRM/Report/Form/Mailing/Detail.php
@@ -279,17 +279,17 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
               'reply_id',
             ])) {
               $select[] = "IF({$field['dbAlias']} IS NULL, 'No', 'Yes') as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
               unset($this->_columns[$tableName]['fields'][$fieldName]);
               $columns[$tableName][$fieldName] = $field;
             }
             elseif ($fieldName == 'delivery_id') {
               $select[] = "IF(mailing_event_bounce_civireport.id IS NOT NULL, 'Bounced', IF(mailing_event_delivered_civireport.id IS NOT NULL, 'Successful', 'Unknown')) as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
               unset($this->_columns[$tableName]['fields'][$fieldName]);
               $columns[$tableName][$fieldName] = $field;
             }

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -218,9 +218,9 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
             }
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
           }
         }
       }

--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -356,7 +356,7 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
                 $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
               }
             }
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
           }
         }
@@ -410,14 +410,14 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($this->_aliases[$tableName] . '.' . $field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
 
             if ($op) {
               if ($fieldName == 'relationship_type_id') {

--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -406,15 +406,15 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
             elseif ($fieldName == 'first_donation_date' ||
               $fieldName == 'first_donation_amount'
             ) {
-              $baseField = CRM_Utils_Array::value('base_field', $field);
+              $baseField = $field['base_field'] ?? NULL;
               $select[] = "{$this->_aliases['civicrm_contribution']}.{$baseField} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
           }
         }
@@ -640,8 +640,8 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
         if (array_key_exists('fields', $table)) {
           foreach ($table['fields'] as $fieldName => $field) {
             if (!empty($field['csv_display']) && !empty($field['no_display'])) {
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
           }
         }
@@ -716,7 +716,7 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
       }
 
       if (!empty($row['civicrm_batch_batch_id'])) {
-        $rows[$rowNum]['civicrm_batch_batch_id'] = CRM_Utils_Array::value($row['civicrm_batch_batch_id'], $batches);
+        $rows[$rowNum]['civicrm_batch_batch_id'] = $batches[$row['civicrm_batch_batch_id']] ?? NULL;
         $entryFound = TRUE;
       }
 

--- a/CRM/Report/Form/Member/Lapse.php
+++ b/CRM/Report/Form/Member/Lapse.php
@@ -173,7 +173,7 @@ class CRM_Report_Form_Member_Lapse extends CRM_Report_Form {
             !empty($this->_params['fields'][$fieldName])
           ) {
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
           }
         }
@@ -223,16 +223,16 @@ class CRM_Report_Form_Member_Lapse extends CRM_Report_Form {
           $clause = NULL;
 
           if ($field['operatorType'] & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -272,12 +272,12 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
                 $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
               }
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['operatorType'] = CRM_Utils_Array::value('operatorType', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['operatorType'] = $field['operatorType'] ?? NULL;
             }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['operatorType'] = CRM_Utils_Array::value('operatorType', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['operatorType'] = $field['operatorType'] ?? NULL;
             }
           }
         }
@@ -446,8 +446,8 @@ GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
     $graphRows = [];
     $count = 0;
     $membershipTypeValues = CRM_Member_PseudoConstant::membershipType();
-    $isMembershipType = CRM_Utils_Array::value('membership_type_id', $this->_params['group_bys']);
-    $isJoiningDate = CRM_Utils_Array::value('join_date', $this->_params['group_bys']);
+    $isMembershipType = $this->_params['group_bys']['membership_type_id'] ?? NULL;
+    $isJoiningDate = $this->_params['group_bys']['join_date'] ?? NULL;
     if (!empty($this->_params['charts'])) {
       foreach ($rows as $key => $row) {
         if (!($row['civicrm_membership_join_date_subtotal'] &&
@@ -457,8 +457,8 @@ GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
           continue;
         }
         if ($isMembershipType) {
-          $join_date = CRM_Utils_Array::value('civicrm_membership_join_date_start', $row);
-          $displayInterval = CRM_Utils_Array::value('civicrm_membership_join_date_interval', $row);
+          $join_date = $row['civicrm_membership_join_date_start'] ?? NULL;
+          $displayInterval = $row['civicrm_membership_join_date_interval'] ?? NULL;
           if ($join_date) {
             list($year, $month) = explode('-', $join_date);
           }
@@ -493,8 +493,8 @@ GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
           $display[$membershipType] = $row['civicrm_contribution_total_amount_sum'];
         }
         else {
-          $graphRows['receive_date'][] = CRM_Utils_Array::value('civicrm_membership_join_date_start', $row);
-          $graphRows[$this->_interval][] = CRM_Utils_Array::value('civicrm_membership_join_date_interval', $row);
+          $graphRows['receive_date'][] = $row['civicrm_membership_join_date_start'] ?? NULL;
+          $graphRows[$this->_interval][] = $row['civicrm_membership_join_date_interval'] ?? NULL;
           $graphRows['value'][] = $row['civicrm_contribution_total_amount_sum'];
           $count++;
         }

--- a/CRM/Report/Form/Membership/Summary.php
+++ b/CRM/Report/Form/Membership/Summary.php
@@ -182,16 +182,16 @@ LEFT  JOIN civicrm_contribution  {$this->_aliases['civicrm_contribution']}
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if ($field['type'] & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Pledge/Detail.php
+++ b/CRM/Report/Form/Pledge/Detail.php
@@ -331,16 +331,16 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Pledge/Pbnp.php
+++ b/CRM/Report/Form/Pledge/Pbnp.php
@@ -181,8 +181,8 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
             !empty($this->_params['fields'][$fieldName])
           ) {
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
           }
         }
       }

--- a/CRM/Report/Form/Pledge/Summary.php
+++ b/CRM/Report/Form/Pledge/Summary.php
@@ -309,16 +309,16 @@ class CRM_Report_Form_Pledge_Summary extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             if ($relative || $from || $to) {
               $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Form/Walklist/Walklist.php
+++ b/CRM/Report/Form/Walklist/Walklist.php
@@ -119,14 +119,14 @@ FROM       civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom
           $clause = NULL;
 
           if ($field['type'] & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,

--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -25,7 +25,7 @@ class CRM_Report_Utils_Get {
    * @return mixed|null
    */
   public static function getTypedValue($name, $type) {
-    $value = CRM_Utils_Array::value($name, $_GET);
+    $value = $_GET[$name] ?? NULL;
     if ($value === NULL) {
       return NULL;
     }
@@ -188,7 +188,7 @@ class CRM_Report_Utils_Get {
    * @param $defaults
    */
   public static function processChart(&$defaults) {
-    $chartType = CRM_Utils_Array::value("charts", $_GET);
+    $chartType = $_GET["charts"] ?? NULL;
     if (in_array($chartType, [
       'barChart',
       'pieChart',

--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -188,9 +188,9 @@ WHERE  inst.report_id = %1";
     $params['from'] = '"' . $domainEmailName . '" <' . $domainEmailAddress . '>';
     //$domainEmailName;
     $params['toName'] = "";
-    $params['toEmail'] = CRM_Utils_Array::value('email_to', $instanceInfo);
-    $params['cc'] = CRM_Utils_Array::value('email_cc', $instanceInfo);
-    $params['subject'] = CRM_Utils_Array::value('email_subject', $instanceInfo);
+    $params['toEmail'] = $instanceInfo['email_to'] ?? NULL;
+    $params['cc'] = $instanceInfo['email_cc'] ?? NULL;
+    $params['subject'] = $instanceInfo['email_subject'] ?? NULL;
     if (empty($instanceInfo['attachments'])) {
       $instanceInfo['attachments'] = [];
     }
@@ -251,7 +251,7 @@ WHERE  inst.report_id = %1";
     $value = NULL;
     foreach ($rows as $row) {
       foreach ($columnHeaders as $k => $v) {
-        $value = CRM_Utils_Array::value($v, $row);
+        $value = $row[$v] ?? NULL;
         if (isset($value)) {
           // Remove HTML, unencode entities, and escape quotation marks.
           $value = str_replace('"', '""', html_entity_decode(strip_tags($value)));
@@ -395,7 +395,7 @@ WHERE  inst.report_id = %1";
    * @return array
    */
   public static function processReport($params) {
-    $instanceId = CRM_Utils_Array::value('instanceId', $params);
+    $instanceId = $params['instanceId'] ?? NULL;
 
     // hack for now, CRM-8358
     $_REQUEST['instanceId'] = $instanceId;
@@ -502,7 +502,7 @@ WHERE  inst.report_id = %1";
             // (e.g., values for 'nll' and 'nnll' ops are blank),
             // so store them temporarily and examine below.
             $string_values[$basename] = $field_value;
-            $op_values[$basename] = CRM_Utils_Array::value("{$basename}_op", $params);
+            $op_values[$basename] = $params["{$basename}_op"] ?? NULL;
           }
           elseif ($suffix == '_op') {
             // These filters can have an effect even without a value

--- a/CRM/SMS/BAO/Provider.php
+++ b/CRM/SMS/BAO/Provider.php
@@ -78,7 +78,7 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
    * @return array saved values
    */
   public static function create(&$params) {
-    $id = CRM_Utils_Array::value('id', $params);
+    $id = $params['id'] ?? NULL;
 
     if ($id) {
       CRM_Utils_Hook::pre('edit', 'SmsProvider', $id, $params);

--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -71,7 +71,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
       }
 
       $defaults['includeGroups'] = $mailingGroups['civicrm_group']['Include'];
-      $defaults['excludeGroups'] = CRM_Utils_Array::value('Exclude', $mailingGroups['civicrm_group']);
+      $defaults['excludeGroups'] = $mailingGroups['civicrm_group']['Exclude'] ?? NULL;
 
       $defaults['includeMailings'] = CRM_Utils_Array::value('Include', CRM_Utils_Array::value('civicrm_mailing', $mailingGroups));
       $defaults['excludeMailings'] = CRM_Utils_Array::value('Exclude', CRM_Utils_Array::value('civicrm_mailing', $mailingGroups));

--- a/CRM/SMS/Form/Upload.php
+++ b/CRM/SMS/Form/Upload.php
@@ -227,7 +227,7 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
         $params['msg_template_id'] = $msgTemplate->id;
       }
       else {
-        $params['msg_template_id'] = CRM_Utils_Array::value('SMStemplate', $formValues);
+        $params['msg_template_id'] = $formValues['SMStemplate'] ?? NULL;
       }
       $this->set('template', $params['msg_template_id']);
     }
@@ -299,7 +299,7 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
       }
       else {
         if (!empty($params['text_message'])) {
-          $messageCheck = CRM_Utils_Array::value('text_message', $params);
+          $messageCheck = $params['text_message'] ?? NULL;
           if ($messageCheck && (strlen($messageCheck) > CRM_SMS_Provider::MAX_SMS_CHAR)) {
             $errors['text_message'] = ts("You can configure the SMS message body up to %1 characters", [1 => CRM_SMS_Provider::MAX_SMS_CHAR]);
           }

--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -35,9 +35,9 @@ abstract class CRM_SMS_Provider {
    * @throws CRM_Core_Exception
    */
   public static function &singleton($providerParams = array(), $force = FALSE) {
-    $mailingID = CRM_Utils_Array::value('mailing_id', $providerParams);
-    $providerID = CRM_Utils_Array::value('provider_id', $providerParams);
-    $providerName = CRM_Utils_Array::value('provider', $providerParams);
+    $mailingID = $providerParams['mailing_id'] ?? NULL;
+    $providerID = $providerParams['provider_id'] ?? NULL;
+    $providerName = $providerParams['provider'] ?? NULL;
 
     if (!$providerID && $mailingID) {
       $providerID = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $mailingID, 'sms_provider_id', 'id');
@@ -141,7 +141,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
     }
 
     if (!$sourceContactID) {
-      $sourceContactID = CRM_Utils_Array::value('Contact', $headers);
+      $sourceContactID = $headers['Contact'] ?? NULL;
     }
     if (!$sourceContactID) {
       return FALSE;

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -140,7 +140,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
         continue;
       }
       $this->_selectFields[$name] = $field['title'];
-      $this->_hasLocationTypes[$name] = CRM_Utils_Array::value('hasLocationType', $field);
+      $this->_hasLocationTypes[$name] = $field['hasLocationType'] ?? NULL;
     }
 
     // lets add group, tag and current_employer to this list
@@ -187,7 +187,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       CRM_Core_BAO_UFField::retrieve($params, $defaults);
 
       // set it to null if so (avoids crappy E_NOTICE errors below
-      $defaults['location_type_id'] = CRM_Utils_Array::value('location_type_id', $defaults);
+      $defaults['location_type_id'] = $defaults['location_type_id'] ?? NULL;
 
       //CRM-20861 - Include custom fields defined for address to set its default location type to 0.
       $specialFields = array_merge(CRM_Core_BAO_UFGroup::getLocationFields(), $addressCustomFields);
@@ -245,8 +245,8 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
         else {
           $this->_mapperFields[$key][$key1] = $value1['title'];
         }
-        $hasLocationTypes[$key][$key1] = CRM_Utils_Array::value('hasLocationType', $value1);
-        $hasWebsiteTypes[$key][$key1] = CRM_Utils_Array::value('hasWebsiteType', $value1);
+        $hasLocationTypes[$key][$key1] = $value1['hasLocationType'] ?? NULL;
+        $hasWebsiteTypes[$key][$key1] = $value1['hasWebsiteType'] ?? NULL;
         // hide the 'is searchable' field for 'File' custom data
         if (isset($value1['data_type']) &&
           isset($value1['html_type']) &&
@@ -700,7 +700,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     if (array_key_exists($profileFieldName, $checkPrimary)) {
       $whereCheck = $checkPrimary[$profileFieldName];
     }
-    $potentialLocationType = CRM_Utils_Array::value(2, $fields['field_name']);
+    $potentialLocationType = $fields['field_name'][2] ?? NULL;
 
     if ($whereCheck && $potentialLocationType == 0) {
       $primaryOfSameTypeFound = '';
@@ -761,7 +761,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     }
 
     $isCustomField = FALSE;
-    $profileFieldName = CRM_Utils_Array::value(1, $fields['field_name']);
+    $profileFieldName = $fields['field_name'][1] ?? NULL;
     if ($profileFieldName) {
       //get custom field id
       $customFieldId = explode('_', $profileFieldName);

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -264,8 +264,8 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
 
       $params = ['id' => $this->_id];
       CRM_Core_BAO_UFGroup::retrieve($params, $defaults);
-      $defaults['group'] = CRM_Utils_Array::value('limit_listings_group_id', $defaults);
-      $defaults['add_contact_to_group'] = CRM_Utils_Array::value('add_to_group_id', $defaults);
+      $defaults['group'] = $defaults['limit_listings_group_id'] ?? NULL;
+      $defaults['add_contact_to_group'] = $defaults['add_to_group_id'] ?? NULL;
       //get the uf join records for current uf group
       $ufJoinRecords = CRM_Core_BAO_UFGroup::getUFJoinRecord($this->_id);
       foreach ($ufJoinRecords as $key => $value) {

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -464,7 +464,7 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
 
         foreach ($valueParts as $val) {
           if (CRM_Utils_Rule::integer($val)) {
-            $groupTypeValues[$val] = CRM_Utils_Array::value($val, $valueLabels);
+            $groupTypeValues[$val] = $valueLabels[$val] ?? NULL;
           }
         }
 

--- a/CRM/Upgrade/Incremental/php/FourFive.php
+++ b/CRM/Upgrade/Incremental/php/FourFive.php
@@ -331,7 +331,7 @@ DROP KEY `{$dao->CONSTRAINT_NAME}`";
             if (count($data_value) == 0 && $op == 'or') {
               $customOption = CRM_Core_BAO_CustomOption::getCustomOption($fieldID);
               foreach ($customOption as $option) {
-                $data_value[] = CRM_Utils_Array::value('value', $option);
+                $data_value[] = $option['value'] ?? NULL;
               }
             }
 

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -59,7 +59,7 @@ class CRM_Utils_Address {
 
     $formatted = $format;
 
-    $fullPostalCode = CRM_Utils_Array::value('postal_code', $fields);
+    $fullPostalCode = $fields['postal_code'] ?? NULL;
     if (!empty($fields['postal_code_suffix'])) {
       $fullPostalCode .= "-$fields[postal_code_suffix]";
     }
@@ -194,7 +194,7 @@ class CRM_Utils_Address {
     // also sub all token fields
     if ($tokenFields) {
       foreach ($tokenFields as $token) {
-        $replacements["{$token}"] = CRM_Utils_Array::value("{$token}", $fields);
+        $replacements["{$token}"] = $fields["{$token}"] ?? NULL;
       }
     }
 
@@ -320,7 +320,7 @@ class CRM_Utils_Address {
 
     $addressFields = [];
     foreach ($addressParts as $name => $field) {
-      $value = CRM_Utils_Array::value($field, $params);
+      $value = $params[$field] ?? NULL;
       $alternateName = 'billing_' . $name . '_id-' . $billingLocationTypeID;
       $alternate2 = 'billing_' . $name . '-' . $billingLocationTypeID;
       if (isset($params[$alternate2]) && !isset($params[$alternateName])) {

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -915,7 +915,7 @@ class CRM_Utils_Array {
     foreach ($matrix as $pos => $oldRow) {
       $newRow = [];
       foreach ($columns as $column) {
-        $newRow[$column] = CRM_Utils_Array::value($column, $oldRow);
+        $newRow[$column] = $oldRow[$column] ?? NULL;
       }
       $newRows[$pos] = $newRow;
     }

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -211,8 +211,8 @@ class CRM_Utils_Chart {
     }
 
     // legend
-    $chartData['xname'] = CRM_Utils_Array::value('xname', $rows);
-    $chartData['yname'] = CRM_Utils_Array::value('yname', $rows);
+    $chartData['xname'] = $rows['xname'] ?? NULL;
+    $chartData['yname'] = $rows['yname'] ?? NULL;
 
     // carry some chart params if pass.
     foreach ([

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -950,12 +950,12 @@ class CRM_Utils_Date {
    */
   public static function intervalAdd($unit, $interval, $date, $dontCareTime = FALSE) {
     if (is_array($date)) {
-      $hour = CRM_Utils_Array::value('H', $date);
-      $minute = CRM_Utils_Array::value('i', $date);
-      $second = CRM_Utils_Array::value('s', $date);
-      $month = CRM_Utils_Array::value('M', $date);
-      $day = CRM_Utils_Array::value('d', $date);
-      $year = CRM_Utils_Array::value('Y', $date);
+      $hour = $date['H'] ?? NULL;
+      $minute = $date['i'] ?? NULL;
+      $second = $date['s'] ?? NULL;
+      $month = $date['M'] ?? NULL;
+      $day = $date['d'] ?? NULL;
+      $year = $date['Y'] ?? NULL;
     }
     else {
       extract(date_parse($date));

--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -157,8 +157,8 @@ function _civicrm_api3_deprecated_activity_formatted_param(&$params, &$values, $
       elseif ($type == 'Select' || $type == 'Radio') {
         $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
         foreach ($customOption as $customFldID => $customValue) {
-          $val = CRM_Utils_Array::value('value', $customValue);
-          $label = CRM_Utils_Array::value('label', $customValue);
+          $val = $customValue['value'] ?? NULL;
+          $label = $customValue['label'] ?? NULL;
           $label = strtolower($label);
           $value = strtolower(trim($value));
           if (($value == $label) || ($value == strtolower($val))) {
@@ -434,7 +434,7 @@ function _civicrm_api3_deprecated_add_formatted_param(&$values, &$params) {
           // mark an entry in fields array since we want the value of custom field to be copied
           $fields['Address'][$key] = NULL;
 
-          $htmlType = CRM_Utils_Array::value('html_type', $customFields[$customFieldID]);
+          $htmlType = $customFields[$customFieldID]['html_type'] ?? NULL;
           switch ($htmlType) {
             case 'CheckBox':
             case 'Multi-Select':
@@ -548,8 +548,8 @@ function _civicrm_api3_deprecated_add_formatted_param(&$values, &$params) {
  *   <type>
  */
 function _civicrm_api3_deprecated_duplicate_formatted_contact($params) {
-  $id = CRM_Utils_Array::value('id', $params);
-  $externalId = CRM_Utils_Array::value('external_identifier', $params);
+  $id = $params['id'] ?? NULL;
+  $externalId = $params['external_identifier'] ?? NULL;
   if ($id || $externalId) {
     $contact = new CRM_Contact_DAO_Contact();
 
@@ -755,7 +755,7 @@ function _civicrm_api3_deprecated_contact_check_params(
     if (empty($params['contact_type'])) {
       return civicrm_api3_create_error("No Contact Type");
     }
-    $fields = CRM_Utils_Array::value($params['contact_type'], $required);
+    $fields = $required[$params['contact_type']] ?? NULL;
     if ($fields == NULL) {
       return civicrm_api3_create_error("Invalid Contact Type: {$params['contact_type']}");
     }

--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -60,7 +60,7 @@ class CRM_Utils_Geocode_Google {
       $add .= ',+';
     }
 
-    $city = CRM_Utils_Array::value('city', $values);
+    $city = $values['city'] ?? NULL;
     if ($city) {
       $add .= '+' . urlencode(str_replace('', '+', $city));
       $add .= ',+';

--- a/CRM/Utils/GlobalStack.php
+++ b/CRM/Utils/GlobalStack.php
@@ -76,11 +76,11 @@ class CRM_Utils_GlobalStack {
     foreach ($new as $globalKey => $values) {
       if (is_array($values)) {
         foreach ($values as $key => $value) {
-          $frame[$globalKey][$key] = CRM_Utils_Array::value($key, $GLOBALS[$globalKey]);
+          $frame[$globalKey][$key] = $GLOBALS[$globalKey][$key] ?? NULL;
         }
       }
       else {
-        $frame[$globalKey] = CRM_Utils_Array::value($globalKey, $GLOBALS);
+        $frame[$globalKey] = $GLOBALS[$globalKey] ?? NULL;
       }
     }
     return $frame;

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -167,7 +167,7 @@ class CRM_Utils_Mail {
     $defaultReturnPath = CRM_Core_BAO_MailSettings::defaultReturnPath();
     $includeMessageId = CRM_Core_BAO_MailSettings::includeMessageId();
     $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
-    $from = CRM_Utils_Array::value('from', $params);
+    $from = $params['from'] ?? NULL;
     if (!$defaultReturnPath) {
       $defaultReturnPath = self::pluckEmailFromHeader($from);
     }
@@ -180,9 +180,9 @@ class CRM_Utils_Mail {
       return FALSE;
     }
 
-    $textMessage = CRM_Utils_Array::value('text', $params);
-    $htmlMessage = CRM_Utils_Array::value('html', $params);
-    $attachments = CRM_Utils_Array::value('attachments', $params);
+    $textMessage = $params['text'] ?? NULL;
+    $htmlMessage = $params['html'] ?? NULL;
+    $attachments = $params['attachments'] ?? NULL;
 
     // CRM-6224
     if (trim(CRM_Utils_String::htmlToText($htmlMessage)) == '') {
@@ -203,13 +203,13 @@ class CRM_Utils_Mail {
 
     // On some servers mail() fails when 'Cc' or 'Bcc' headers are defined but empty.
     foreach (['Cc', 'Bcc'] as $optionalHeader) {
-      $headers[$optionalHeader] = CRM_Utils_Array::value(strtolower($optionalHeader), $params);
+      $headers[$optionalHeader] = $params[strtolower($optionalHeader)] ?? NULL;
       if (empty($headers[$optionalHeader])) {
         unset($headers[$optionalHeader]);
       }
     }
 
-    $headers['Subject'] = CRM_Utils_Array::value('subject', $params);
+    $headers['Subject'] = $params['subject'] ?? NULL;
     $headers['Content-Type'] = $htmlMessage ? 'multipart/mixed; charset=utf-8' : 'text/plain; charset=utf-8';
     $headers['Content-Disposition'] = 'inline';
     $headers['Content-Transfer-Encoding'] = '8bit';
@@ -286,10 +286,10 @@ class CRM_Utils_Mail {
       // get emails from headers, since these are
       // combination of name and email addresses.
       if (!empty($headers['Cc'])) {
-        $to[] = CRM_Utils_Array::value('Cc', $headers);
+        $to[] = $headers['Cc'] ?? NULL;
       }
       if (!empty($headers['Bcc'])) {
-        $to[] = CRM_Utils_Array::value('Bcc', $headers);
+        $to[] = $headers['Bcc'] ?? NULL;
         unset($headers['Bcc']);
       }
     }

--- a/CRM/Utils/PDF/Label.php
+++ b/CRM/Utils/PDF/Label.php
@@ -190,7 +190,7 @@ class CRM_Utils_PDF_Label extends TCPDF {
       $metric = $this->format['metric'];
     }
     else {
-      $value = CRM_Utils_Array::value($name, $this->defaults);
+      $value = $this->defaults[$name] ?? NULL;
       $metric = $this->defaults['metric'];
     }
     if ($convert) {

--- a/CRM/Utils/Pager.php
+++ b/CRM/Utils/Pager.php
@@ -240,7 +240,7 @@ class CRM_Utils_Pager extends Pager_Sliding {
    */
   public function getCurrentLocation() {
     $config = CRM_Core_Config::singleton();
-    $path = CRM_Utils_Array::value($config->userFrameworkURLVar, $_GET);
+    $path = $_GET[$config->userFrameworkURLVar] ?? NULL;
     return CRM_Utils_System::url($path, CRM_Utils_System::getLinksUrl(self::PAGE_ID, FALSE, TRUE), FALSE, NULL, FALSE) . $this->getCurrentPageID();
   }
 

--- a/CRM/Utils/PagerAToZ.php
+++ b/CRM/Utils/PagerAToZ.php
@@ -132,7 +132,7 @@ class CRM_Utils_PagerAToZ {
 
     $qfKey = NULL;
     if (isset($query->_formValues)) {
-      $qfKey = CRM_Utils_Array::value('qfKey', $query->_formValues);
+      $qfKey = $query->_formValues['qfKey'] ?? NULL;
     }
     if (empty($qfKey)) {
       // CRM-20943 Can only pass variables by reference and also cannot use $this so using $empty setting to NULL which is default.

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -175,13 +175,13 @@ class CRM_Utils_REST {
     $requestParams = CRM_Utils_Request::exportValues();
 
     // Get the function name being called from the q parameter in the query string
-    $q = CRM_Utils_Array::value('q', $requestParams);
+    $q = $requestParams['q'] ?? NULL;
     // or for the rest interface, from fnName
-    $r = CRM_Utils_Array::value('fnName', $requestParams);
+    $r = $requestParams['fnName'] ?? NULL;
     if (!empty($r)) {
       $q = $r;
     }
-    $entity = CRM_Utils_Array::value('entity', $requestParams);
+    $entity = $requestParams['entity'] ?? NULL;
     if (empty($entity) && !empty($q)) {
       $args = explode('/', $q);
       // If the function isn't in the civicrm namespace, reject the request.
@@ -204,8 +204,8 @@ class CRM_Utils_REST {
       // or the api format (entity+action)
       $args = [];
       $args[0] = 'civicrm';
-      $args[1] = CRM_Utils_Array::value('entity', $requestParams);
-      $args[2] = CRM_Utils_Array::value('action', $requestParams);
+      $args[1] = $requestParams['entity'] ?? NULL;
+      $args[2] = $requestParams['action'] ?? NULL;
     }
 
     // Everyone should be required to provide the server key, so the whole
@@ -213,7 +213,7 @@ class CRM_Utils_REST {
     // first check for civicrm site key
     if (!CRM_Utils_System::authenticateKey(FALSE)) {
       $docLink = CRM_Utils_System::docURL2("Managing Scheduled Jobs", TRUE, NULL, NULL, NULL, "wiki");
-      $key = CRM_Utils_Array::value('key', $requestParams);
+      $key = $requestParams['key'] ?? NULL;
       if (empty($key)) {
         return self::error("FATAL: mandatory param 'key' missing. More info at: " . $docLink);
       }
@@ -516,10 +516,10 @@ class CRM_Utils_REST {
       CRM_Utils_JSON::output($error);
     }
 
-    $q = CRM_Utils_Array::value('fnName', $requestParams);
+    $q = $requestParams['fnName'] ?? NULL;
     if (!$q) {
-      $entity = CRM_Utils_Array::value('entity', $requestParams);
-      $action = CRM_Utils_Array::value('action', $requestParams);
+      $entity = $requestParams['entity'] ?? NULL;
+      $action = $requestParams['action'] ?? NULL;
       if (!$entity || !$action) {
         $err = [
           'error_message' => 'missing mandatory params "entity=" or "action="',
@@ -535,7 +535,7 @@ class CRM_Utils_REST {
     }
 
     // get the class name, since all ajax functions pass className
-    $className = CRM_Utils_Array::value('className', $requestParams);
+    $className = $requestParams['className'] ?? NULL;
 
     // If the function isn't in the civicrm namespace, reject the request.
     if (($args[0] != 'civicrm' && count($args) != 3) && !$className) {
@@ -578,7 +578,7 @@ class CRM_Utils_REST {
    */
   public function loadCMSBootstrap() {
     $requestParams = CRM_Utils_Request::exportValues();
-    $q = CRM_Utils_Array::value('q', $requestParams);
+    $q = $requestParams['q'] ?? NULL;
     $args = explode('/', $q);
 
     // Proceed with bootstrap for "?entity=X&action=Y"

--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -222,7 +222,7 @@ class CRM_Utils_Request {
    *   The desired value.
    */
   public static function retrieveComponent($attributes) {
-    $url = CRM_Utils_Array::value('action', $attributes);
+    $url = $attributes['action'] ?? NULL;
     // Whilst the following is a fallible universal test for urlencoded URLs,
     // thankfully the "action" URL has a limited and predictable form and
     // therefore this comparison is sufficient for our purposes.

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -308,9 +308,9 @@ class CRM_Utils_Rule {
   public static function currentDate($date, $monthRequired = TRUE) {
     $config = CRM_Core_Config::singleton();
 
-    $d = CRM_Utils_Array::value('d', $date);
-    $m = CRM_Utils_Array::value('M', $date);
-    $y = CRM_Utils_Array::value('Y', $date);
+    $d = $date['d'] ?? NULL;
+    $m = $date['M'] ?? NULL;
+    $y = $date['Y'] ?? NULL;
 
     if (!$d && !$m && !$y) {
       return TRUE;
@@ -318,7 +318,7 @@ class CRM_Utils_Rule {
 
     // CRM-9017 CiviContribute/CiviMember form with expiration date format 'm Y'
     if (!$m && !empty($date['m'])) {
-      $m = CRM_Utils_Array::value('m', $date);
+      $m = $date['m'] ?? NULL;
     }
 
     $day = $mon = 1;
@@ -889,13 +889,13 @@ class CRM_Utils_Rule {
   public static function qfDate($date) {
     $config = CRM_Core_Config::singleton();
 
-    $d = CRM_Utils_Array::value('d', $date);
-    $m = CRM_Utils_Array::value('M', $date);
-    $y = CRM_Utils_Array::value('Y', $date);
+    $d = $date['d'] ?? NULL;
+    $m = $date['M'] ?? NULL;
+    $y = $date['Y'] ?? NULL;
     if (isset($date['h']) ||
       isset($date['g'])
     ) {
-      $m = CRM_Utils_Array::value('M', $date);
+      $m = $date['M'] ?? NULL;
     }
 
     if (!$d && !$m && !$y) {

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -83,7 +83,7 @@ class CRM_Utils_System {
   public static function makeURL($urlVar, $includeReset = FALSE, $includeForce = TRUE, $path = NULL, $absolute = FALSE) {
     if (empty($path)) {
       $config = CRM_Core_Config::singleton();
-      $path = CRM_Utils_Array::value($config->userFrameworkURLVar, $_GET);
+      $path = $_GET[$config->userFrameworkURLVar] ?? NULL;
       if (empty($path)) {
         return '';
       }
@@ -376,7 +376,7 @@ class CRM_Utils_System {
    *   url
    */
   public static function crmURL($params) {
-    $p = CRM_Utils_Array::value('p', $params);
+    $p = $params['p'] ?? NULL;
     if (!isset($p)) {
       $p = self::currentPath();
     }
@@ -420,7 +420,7 @@ class CRM_Utils_System {
     $url = $default;
 
     $session = CRM_Core_Session::singleton();
-    $referer = CRM_Utils_Array::value('HTTP_REFERER', $_SERVER);
+    $referer = $_SERVER['HTTP_REFERER'] ?? NULL;
 
     if ($referer && !empty($names)) {
       foreach ($names as $name) {
@@ -465,7 +465,7 @@ class CRM_Utils_System {
     // this is kinda hackish but not sure how to do it right
     $url = str_replace('&amp;', '&', $url);
 
-    $context['output'] = CRM_Utils_Array::value('snippet', $_GET);
+    $context['output'] = $_GET['snippet'] ?? NULL;
 
     $parsedUrl = CRM_Utils_Url::parseUrl($url);
     CRM_Utils_Hook::alterRedirect($parsedUrl, $context);
@@ -1245,7 +1245,7 @@ class CRM_Utils_System {
    *   IP address of logged in user.
    */
   public static function ipAddress($strictIPV4 = TRUE) {
-    $address = CRM_Utils_Array::value('REMOTE_ADDR', $_SERVER);
+    $address = $_SERVER['REMOTE_ADDR'] ?? NULL;
 
     $config = CRM_Core_Config::singleton();
     if ($config->userSystem->is_drupal && function_exists('ip_address')) {

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -564,7 +564,7 @@ AND    u.status = 1
       return TRUE;
     }
 
-    $uid = CRM_Utils_Array::value('uid', $params);
+    $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       // Load the user we need to check Backdrop permissions.
       $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -511,7 +511,7 @@ AND    u.status = 1
       return TRUE;
     }
 
-    $uid = CRM_Utils_Array::value('uid', $params);
+    $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       //load user, we need to check drupal permissions.
       $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -165,8 +165,8 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     $user = NULL;
 
     if (!empty($row)) {
-      $dbName = CRM_Utils_Array::value('name', $row);
-      $dbEmail = CRM_Utils_Array::value('mail', $row);
+      $dbName = $row['name'] ?? NULL;
+      $dbEmail = $row['mail'] ?? NULL;
       if (strtolower($dbName) == strtolower($name)) {
         $errors['cms_name'] = ts('The username %1 is already taken. Please select another username.',
           [1 => $name]
@@ -460,7 +460,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     }
     global $user;
     // If $uid is passed in, authentication has been done already.
-    $uid = CRM_Utils_Array::value('uid', $params);
+    $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       //load user, we need to check drupal permissions.
       $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -133,8 +133,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     }
 
     if (!empty($row)) {
-      $dbName = CRM_Utils_Array::value('username', $row);
-      $dbEmail = CRM_Utils_Array::value('email', $row);
+      $dbName = $row['username'] ?? NULL;
+      $dbEmail = $row['email'] ?? NULL;
       if (strtolower($dbName) == strtolower($name)) {
         $errors['cms_name'] = ts('The username %1 is already taken. Please select another username.',
           [1 => $name]

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -456,8 +456,8 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   public function loadBootStrap($params = [], $loadUser = TRUE, $throwError = TRUE, $realPath = NULL) {
     global $wp, $wp_rewrite, $wp_the_query, $wp_query, $wpdb, $current_site, $current_blog, $current_user;
 
-    $name = CRM_Utils_Array::value('name', $params);
-    $pass = CRM_Utils_Array::value('pass', $params);
+    $name = $params['name'] ?? NULL;
+    $pass = $params['pass'] ?? NULL;
 
     if (!defined('WP_USE_THEMES')) {
       define('WP_USE_THEMES', FALSE);
@@ -483,7 +483,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
     }
     require_once $cmsRootPath . DIRECTORY_SEPARATOR . 'wp-includes/pluggable.php';
-    $uid = CRM_Utils_Array::value('uid', $params);
+    $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       $name = $name ? $name : trim(CRM_Utils_Array::value('name', $_REQUEST));
       $pass = $pass ? $pass : trim(CRM_Utils_Array::value('pass', $_REQUEST));

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -601,10 +601,10 @@ class CRM_Utils_Token {
       $value = "{action.$token}";
     }
     else {
-      $value = CRM_Utils_Array::value($token, $addresses);
+      $value = $addresses[$token] ?? NULL;
 
       if ($value == NULL) {
-        $value = CRM_Utils_Array::value($token, $urls);
+        $value = $urls[$token] ?? NULL;
       }
 
       if ($value && $html) {
@@ -722,7 +722,7 @@ class CRM_Utils_Token {
       $noReplace = TRUE;
     }
     elseif ($token == 'checksum') {
-      $hash = CRM_Utils_Array::value('hash', $contact);
+      $hash = $contact['hash'] ?? NULL;
       $contactID = CRM_Utils_Array::retrieveValueRecursive($contact, 'contact_id');
       $cs = CRM_Contact_BAO_Contact_Utils::generateChecksum($contactID,
         NULL,
@@ -844,7 +844,7 @@ class CRM_Utils_Token {
     $html = FALSE,
     $escapeSmarty = FALSE
   ) {
-    $value = CRM_Utils_Array::value("{$category}.{$token}", $contact);
+    $value = $contact["{$category}.{$token}"] ?? NULL;
 
     if ($value && !$html) {
       $value = str_replace('&amp;', '&', $value);
@@ -1641,7 +1641,7 @@ class CRM_Utils_Token {
     }
     $field = civicrm_api3($entity, 'getfield', ['action' => 'get', 'name' => $token, 'get_options' => 'get']);
     $field = $field['values'];
-    $fieldType = CRM_Utils_Array::value('type', $field);
+    $fieldType = $field['type'] ?? NULL;
     // Boolean fields
     if ($fieldType == CRM_Utils_Type::T_BOOLEAN && empty($field['options'])) {
       $field['options'] = [ts('No'), ts('Yes')];

--- a/CRM/Utils/Verp.php
+++ b/CRM/Utils/Verp.php
@@ -64,8 +64,8 @@ class CRM_Utils_Verp {
     $sdomain = $match[2];
 
     preg_match('/(.+)\@([^\@]+)$/', $recipient, $match);
-    $rlocal = CRM_Utils_Array::value(1, $match);
-    $rdomain = CRM_Utils_Array::value(2, $match);
+    $rlocal = $match[1] ?? NULL;
+    $rdomain = $match[2] ?? NULL;
 
     foreach (self::$encodeMap as $char => $code) {
       $rlocal = preg_replace('/' . preg_quote($char) . '/i', "+$code", $rlocal);

--- a/CRM/Utils/Wrapper.php
+++ b/CRM/Utils/Wrapper.php
@@ -46,7 +46,7 @@ class CRM_Utils_Wrapper {
    */
   public function run($formName, $formLabel = NULL, $arguments = NULL) {
     if (is_array($arguments)) {
-      $mode = CRM_Utils_Array::value('mode', $arguments);
+      $mode = $arguments['mode'] ?? NULL;
       $imageUpload = !empty($arguments['imageUpload']);
       $addSequence = !empty($arguments['addSequence']);
       $attachUpload = !empty($arguments['attachUpload']);
@@ -71,10 +71,10 @@ class CRM_Utils_Wrapper {
     if (array_key_exists('urlToSession', $arguments)) {
       if (is_array($arguments['urlToSession'])) {
         foreach ($arguments['urlToSession'] as $params) {
-          $urlVar = CRM_Utils_Array::value('urlVar', $params);
-          $sessionVar = CRM_Utils_Array::value('sessionVar', $params);
-          $type = CRM_Utils_Array::value('type', $params);
-          $default = CRM_Utils_Array::value('default', $params);
+          $urlVar = $params['urlVar'] ?? NULL;
+          $sessionVar = $params['sessionVar'] ?? NULL;
+          $type = $params['type'] ?? NULL;
+          $default = $params['default'] ?? NULL;
           $abort = CRM_Utils_Array::value('abort', $params, FALSE);
 
           $value = NULL;

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -590,11 +590,11 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
  */
 function _civicrm_api3_get_query_object($params, $mode, $entity) {
   $options = _civicrm_api3_get_options_from_params($params, TRUE, $entity, 'get');
-  $sort = CRM_Utils_Array::value('sort', $options, NULL);
-  $offset = CRM_Utils_Array::value('offset', $options);
-  $rowCount = CRM_Utils_Array::value('limit', $options);
+  $sort = $options['sort'] ?? NULL;
+  $offset = $options['offset'] ?? NULL;
+  $rowCount = $options['limit'] ?? NULL;
   $inputParams = CRM_Utils_Array::value('input_params', $options, []);
-  $returnProperties = CRM_Utils_Array::value('return', $options, NULL);
+  $returnProperties = $options['return'] ?? NULL;
   if (empty($returnProperties)) {
     $returnProperties = CRM_Contribute_BAO_Query::defaultReturnProperties($mode);
   }
@@ -1969,7 +1969,7 @@ function _civicrm_api_get_custom_fields($entity, &$params) {
   $entity = _civicrm_api_get_camel_name($entity);
   if ($entity == 'Contact') {
     // Use sub-type if available, otherwise "NULL" to fetch from all contact types
-    $entity = CRM_Utils_Array::value('contact_type', $params);
+    $entity = $params['contact_type'] ?? NULL;
   }
   $customfields = CRM_Core_BAO_CustomField::getFields($entity,
     FALSE,
@@ -2009,7 +2009,7 @@ function _civicrm_api_get_custom_fields($entity, &$params) {
  */
 function _civicrm_api3_swap_out_aliases(&$apiRequest, $fields) {
   foreach ($fields as $field => $values) {
-    $uniqueName = CRM_Utils_Array::value('uniqueName', $values);
+    $uniqueName = $values['uniqueName'] ?? NULL;
     if (!empty($values['api.aliases'])) {
       // if aliased field is not set we try to use field alias
       if (!isset($apiRequest['params'][$field])) {
@@ -2037,7 +2037,7 @@ function _civicrm_api3_swap_out_aliases(&$apiRequest, $fields) {
       && $field != $uniqueName
       && array_key_exists($uniqueName, $apiRequest['params'])
     ) {
-      $apiRequest['params'][$field] = CRM_Utils_Array::value($values['uniqueName'], $apiRequest['params']);
+      $apiRequest['params'][$field] = $apiRequest['params'][$values['uniqueName']] ?? NULL;
       // note that it would make sense to unset the original field here but tests need to be in place first
     }
   }
@@ -2286,7 +2286,7 @@ function _civicrm_api3_api_match_pseudoconstant(&$fieldValue, $entity, $fieldNam
     return;
   }
 
-  $options = CRM_Utils_Array::value('options', $fieldInfo);
+  $options = $fieldInfo['options'] ?? NULL;
 
   if (!$options) {
     if (strtolower($entity) == 'profile' && !empty($fieldInfo['entity'])) {
@@ -2457,7 +2457,7 @@ function _civicrm_api3_deprecation_check($entity, $result = []) {
  * @return mixed
  */
 function _civicrm_api3_field_value_check(&$params, $fieldName, $type = NULL) {
-  $fieldValue = CRM_Utils_Array::value($fieldName, $params);
+  $fieldValue = $params[$fieldName] ?? NULL;
   $op = NULL;
 
   if (!empty($fieldValue) && is_array($fieldValue) &&
@@ -2465,7 +2465,7 @@ function _civicrm_api3_field_value_check(&$params, $fieldName, $type = NULL) {
       $type == 'String' && strstr(key($fieldValue), 'EMPTY'))
   ) {
     $op = key($fieldValue);
-    $fieldValue = CRM_Utils_Array::value($op, $fieldValue);
+    $fieldValue = $fieldValue[$op] ?? NULL;
   }
   return [$fieldValue, $op];
 }
@@ -2491,8 +2491,8 @@ function _civicrm_api3_field_value_check(&$params, $fieldName, $type = NULL) {
 function _civicrm_api3_basic_array_get($entity, $params, $records, $idCol, $filterableFields) {
   $options = _civicrm_api3_get_options_from_params($params, TRUE, $entity, 'get');
   // TODO // $sort = CRM_Utils_Array::value('sort', $options, NULL);
-  $offset = CRM_Utils_Array::value('offset', $options);
-  $limit = CRM_Utils_Array::value('limit', $options);
+  $offset = $options['offset'] ?? NULL;
+  $limit = $options['limit'] ?? NULL;
 
   $matches = [];
 

--- a/extern/url.php
+++ b/extern/url.php
@@ -9,12 +9,12 @@ $config = CRM_Core_Config::singleton();
 // To keep backward compatibility for URLs generated
 // by CiviCRM < 1.7, we check for the q variable as well.
 if (isset($_GET['qid'])) {
-  $queue_id = CRM_Utils_Array::value('qid', $_GET);
+  $queue_id = $_GET['qid'] ?? NULL;
 }
 else {
-  $queue_id = CRM_Utils_Array::value('q', $_GET);
+  $queue_id = $_GET['q'] ?? NULL;
 }
-$url_id = CRM_Utils_Array::value('u', $_GET);
+$url_id = $_GET['u'] ?? NULL;
 
 if (!$url_id) {
   echo "Missing input parameters\n";

--- a/tools/bin/scripts/NormalizePhone.php
+++ b/tools/bin/scripts/NormalizePhone.php
@@ -52,7 +52,7 @@ function run() {
       }
     }
     if (!$$var) {
-      $$var = CRM_Utils_Array::value($var, $_REQUEST);
+      $$var = $_REQUEST[$var] ?? NULL;
     }
     $_REQUEST[$var] = $$var;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This is part of a series of PRs to update an old code pattern. `CRM_Utils_Array::value()` can in many cases be swapped for the new PHP7 `??` operator.

Technical Details
----------------------------------------
This PR was done entirely by regex find/replace. It targets variable assignments that use a single `CRM_Utils_Array::value()` call where the 3rd param is either NULL or omitted.

No manual tweaking was done, only regex. The two patterns used were:

- ` = CRM_Utils_Array::value\(([^,]+), ([^(),]+)\);$`
- ` = CRM_Utils_Array::value\(([^,]+), ([^(),]+), NULL\);$`

For additional safety, this was done with file filter set to `.php`, case-sensitive enabled, and comments and string literals excluded.

![Screenshot from 2020-03-13 09-32-54](https://user-images.githubusercontent.com/2874912/76625500-c1e1c380-650d-11ea-87b3-eaf9f9b3c49c.png)

Comments
----------------------------------------
With 1,698 lines affected, IMO there's only one way to do this: treat it like a mass code autoformat like the one @twomice did a few years ago. Trust the regex, trust the unit tests, do a little spot-checking for sanity's sake, but do not attempt manual review.