### PR TITLE
Deprecate unused/unneeded pseudoconstant functions

### DIFF
--- a/CRM/Admin/Page/EventTemplate.php
+++ b/CRM/Admin/Page/EventTemplate.php
@@ -76,7 +76,7 @@ class CRM_Admin_Page_EventTemplate extends CRM_Core_Page_Basic {
 
     $eventTypes = CRM_Event_PseudoConstant::eventType();
     $participantRoles = CRM_Event_PseudoConstant::participantRole();
-    $participantListings = CRM_Event_PseudoConstant::participantListing();
+    $participantListings = CRM_Event_BAO_Event::buildOptions('participant_listing_id');
 
     //find all event templates.
     $eventTemplate->is_template = TRUE;

--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -69,6 +69,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
   /**
    * Status of personal campaign page
    * @var array
+   * @deprecated
    */
   private static $pcpStatus;
 
@@ -342,12 +343,13 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
    *
    * The static array pcpStatus is returned
    *
-   *
+   * @deprecated
    * @param string $column
    * @return array
    *   array reference of all PCP activity statuses
    */
   public static function &pcpStatus($column = 'label') {
+    CRM_Core_Error::deprecatedFunctionWarning('Function pcpStatus will be removed');
     if (NULL === self::$pcpStatus) {
       self::$pcpStatus = [];
     }

--- a/CRM/Event/PseudoConstant.php
+++ b/CRM/Event/PseudoConstant.php
@@ -46,8 +46,8 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
 
   /**
    * Participant Listing
-   *
    * @var array
+   * @deprecated
    */
   private static $participantListing;
 
@@ -67,6 +67,7 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
   /**
    * Personal campaign pages
    * @var array
+   * @deprecated
    */
   private static $pcPage;
 
@@ -205,13 +206,13 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
   /**
    * Get all the participant listings.
    *
-   *
+   * @deprecated
    * @param int $id
-   *
    * @return array|string
    *   array reference of all participant listings if any
    */
   public static function &participantListing($id = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('Function participantListing will be removed');
     if (!self::$participantListing) {
       self::$participantListing = [];
       self::$participantListing = CRM_Core_OptionGroup::values('participant_listing');
@@ -285,12 +286,13 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
   /**
    * Get all the Personal campaign pages.
    *
-   *
+   * @deprecated
    * @param int $id
    * @return array
    *   array reference of all pcp if any
    */
   public static function &pcPage($id = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('Function pcPage will be removed');
     if (!self::$pcPage) {
       CRM_Core_PseudoConstant::populate(self::$pcPage,
         'CRM_PCP_DAO_PCP',


### PR DESCRIPTION
Overview
----------------------------------------
Many years ago we started restructuring our pseudoconstant classes to move away from individual functions like these. Eventually we'll remove them all.

Before
----------------------------------------
1 unused function and 2 barely used.

After
----------------------------------------
Marked deprecated for future removal.
