### PR TITLE
Fix setting outBound_option readonly in UI

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -28,17 +28,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-
-    $outBoundOption = [
-      CRM_Mailing_Config::OUTBOUND_OPTION_MAIL => ts('mail()'),
-      CRM_Mailing_Config::OUTBOUND_OPTION_SMTP => ts('SMTP'),
-      CRM_Mailing_Config::OUTBOUND_OPTION_SENDMAIL => ts('Sendmail'),
-      CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED => ts('Disable Outbound Email'),
-      CRM_Mailing_Config::OUTBOUND_OPTION_REDIRECT_TO_DB => ts('Redirect to Database'),
-    ];
-    $this->addRadio('outBound_option', ts('Select Mailer'), $outBoundOption);
-
-    $props = array();
+    $props = [];
     $settings = Civi::settings()->getMandatory('mailing_backend') ?? [];
     //Load input as readonly whose values are overridden in civicrm.settings.php.
     foreach ($settings as $setting => $value) {
@@ -47,6 +37,15 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         $setStatus = TRUE;
       }
     }
+
+    $outBoundOption = [
+      CRM_Mailing_Config::OUTBOUND_OPTION_MAIL => ts('mail()'),
+      CRM_Mailing_Config::OUTBOUND_OPTION_SMTP => ts('SMTP'),
+      CRM_Mailing_Config::OUTBOUND_OPTION_SENDMAIL => ts('Sendmail'),
+      CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED => ts('Disable Outbound Email'),
+      CRM_Mailing_Config::OUTBOUND_OPTION_REDIRECT_TO_DB => ts('Redirect to Database'),
+    ];
+    $this->addRadio('outBound_option', ts('Select Mailer'), $outBoundOption, $props['outBound_option'] ?? []);
 
     CRM_Utils_System::setTitle(ts('Settings - Outbound Mail'));
     $this->add('text', 'sendmail_path', ts('Sendmail Path'));


### PR DESCRIPTION
Overview
----------------------------------------
Follow on from #16451 

Fix setting the SMTP outbound option readonly.

Before
----------------------------------------
outBound_option readonly ignored in UI. It was actually working, just not shown as frozen in UI.

After
----------------------------------------
Elements frozen if you set in civicrm.settings.php:
`$civicrm_setting['mailing']['mailing_backend']['outBound_option'] = 5;`

![image](https://user-images.githubusercontent.com/2052161/76686810-3869e880-6616-11ea-9fa1-f91dfbc65611.png)


Technical Details
----------------------------------------
readonly attribute was set *after* adding the element!

Comments
----------------------------------------
@yashodha you were interested in this? I think it actually already works with the SMTP authentication setting because of #16451