### PR TITLE
dev/core#1645 fix  regression  by removing form inheritance

### DIFF
--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -18,7 +18,7 @@
 /**
  * This class generates form components for Financial Type Account
  */
-class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
+class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
 
   /**
    * The financial type id saved to the session for an update.
@@ -102,6 +102,28 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
+    if ($this->_action & CRM_Core_Action::VIEW || $this->_action & CRM_Core_Action::PREVIEW) {
+      $this->addButtons([
+        [
+          'type' => 'cancel',
+          'name' => ts('Done'),
+          'isDefault' => TRUE,
+        ],
+      ]);
+    }
+    else {
+      $this->addButtons([
+        [
+          'type' => 'next',
+          'name' => $this->_action & CRM_Core_Action::DELETE ? ts('Delete') : ts('Save'),
+          'isDefault' => TRUE,
+        ],
+        [
+          'type' => 'cancel',
+          'name' => ts('Cancel'),
+        ],
+      ]);
+    }
     $this->setPageTitle(ts('Financial Type Account'));
 
     if ($this->_action & CRM_Core_Action::DELETE) {
@@ -169,22 +191,6 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
       TRUE
     );
 
-    $this->addButtons([
-      [
-        'type' => 'next',
-        'name' => ts('Save'),
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => 'next',
-        'name' => ts('Save and New'),
-        'subName' => 'new',
-      ],
-      [
-        'type' => 'cancel',
-        'name' => ts('Cancel'),
-      ],
-    ]);
     $this->addFormRule(['CRM_Financial_Form_FinancialTypeAccount', 'formRule'], $this);
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Fixes rc regression impacting on assign financial type loading

Before
----------------------------------------
Click on Administer > CiviContribute > Financial Types.
Beside a Financial Type, click on Accounts. (The popup form is https://dmaster.demo.civicrm.org/civicrm/admin/financial/financialType?reset=1).
Click on Assign Account button. (The url is of form https://dmaster.demo.civicrm.org/civicrm/admin/financial/financialType/accounts?action=add&reset=1&aid=3).
An error is presented "Network Error
Unable to reach the server. Please refresh this page in your browser and try again.". Opening the url directly shows "This page isn’t workingdmaster.demo.civicrm.org is currently unable to handle this request.
HTTP ERROR 500."

After
----------------------------------------
Loads

Technical Details
----------------------------------------
The Assign  Account form is failing to load because it inherits indirectly from CRM_Admin_Form which
now has a different visibility on the _id property.

I  took a look and there really is no reason for this complex  inheritence - this is a standalone form
and the setDefaults of  the parent seems of no use, let alone the parent's parent.

Assign, edit & browse seem to still work fine

Note there are 4 other forms inheriting from CRM_Contribute_Form  - I think they shouldn't but none of the others should be affected by this bug

Comments
----------------------------------------
@mattwire this relates to your change
