### PR TITLE
[REF] Cleanup uses of CRM_Utils_Array::value related to numbers

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -757,7 +757,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       ];
       $activities[$id]['activity_type_name'] = CRM_Core_PseudoConstant::getName('CRM_Activity_BAO_Activity', 'activity_type_id', $activity['activity_type_id']);
       $activities[$id]['activity_type'] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $activity['activity_type_id']);
-      $activities[$id]['target_contact_count'] = CRM_Utils_Array::value('target_contact_count', $activity, 0);
+      $activities[$id]['target_contact_count'] = $activity['target_contact_count'] ?? 0;
       if (!empty($activity['target_contact_count'])) {
         $displayedTarget = civicrm_api3('ActivityContact', 'get', [
           'activity_id' => $id,
@@ -1356,7 +1356,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         $smsProviderParams['To'] = '';
       }
 
-      $doNotSms = CRM_Utils_Array::value('do_not_sms', $contact, 0);
+      $doNotSms = $contact['do_not_sms'] ?? 0;
 
       if ($doNotSms) {
         $errMsgs[] = PEAR::raiseError('Contact Does not accept SMS', NULL, PEAR_ERROR_RETURN);
@@ -2462,7 +2462,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
       'activity_date_time' => $params['activity_date_time'] ?? NULL,
       'check_permissions' => 1,
       'options' => [
-        'offset' => CRM_Utils_Array::value('offset', $params, 0),
+        'offset' => $params['offset'] ?? 0,
       ],
     ];
 

--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -341,7 +341,7 @@ class CRM_Admin_Page_AJAX {
    * Used by jstree to incrementally load tags
    */
   public static function getTagTree() {
-    $parent = CRM_Utils_Type::escape(CRM_Utils_Array::value('parent_id', $_GET, 0), 'Integer');
+    $parent = CRM_Utils_Type::escape(($_GET['parent_id'] ?? 0), 'Integer');
     $substring = CRM_Utils_Type::escape(CRM_Utils_Array::value('str', $_GET), 'String');
     $result = [];
 

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -412,7 +412,7 @@ class CRM_Contact_Form_Search_Criteria {
       'street_unit' => [ts('Apt/Unit/Suite'), $attributes['street_unit'], NULL, NULL],
     ];
 
-    $parseStreetAddress = CRM_Utils_Array::value('street_address_parsing', $addressOptions, 0);
+    $parseStreetAddress = $addressOptions['street_address_parsing'] ?? 0;
     $form->assign('parseStreetAddress', $parseStreetAddress);
     foreach ($elements as $name => $v) {
       list($title, $attributes, $select, $multiSelect) = $v;

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -57,7 +57,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     $errorFiles = ['sqlImport.errors', 'sqlImport.conflicts', 'sqlImport.duplicates', 'sqlImport.mismatch'];
 
     // check for post max size avoid when called twice
-    $snippet = CRM_Utils_Array::value('snippet', $_GET, 0);
+    $snippet = $_GET['snippet'] ?? 0;
     if (empty($snippet)) {
       CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -181,7 +181,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       'id' => $recurID,
       'return' => ['payment_processor_id'],
     ]);
-    return (int) CRM_Utils_Array::value('payment_processor_id', $recur, 0);
+    return (int) ($recur['payment_processor_id'] ?? 0);
   }
 
   /**

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -399,7 +399,7 @@ class CRM_Core_BAO_Block {
     }
 
     // contact_id in params might be empty or the string 'null' so cast to integer
-    $contactId = (int) CRM_Utils_Array::value('contact_id', $params);
+    $contactId = (int) ($params['contact_id'] ?? 0);
     // If id is set & we haven't been passed a contact_id, retrieve it
     if (!empty($params['id']) && !isset($params['contact_id'])) {
       $entity = new $class();

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -496,7 +496,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     foreach ($params as $dashboardIDs) {
       $contactID = CRM_Utils_Array::value('contact_id', $dashboardIDs);
       $dashboardID = CRM_Utils_Array::value('dashboard_id', $dashboardIDs);
-      $column = CRM_Utils_Array::value('column_no', $dashboardIDs, 0);
+      $column = $dashboardIDs['column_no'] ?? 0;
       $columns[$column][$dashboardID] = 0;
     }
     self::saveDashletChanges($columns, $contactID);

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -373,7 +373,6 @@ class CRM_Core_Menu {
         $values[$item['adminGroup']] = array();
         $values[$item['adminGroup']]['fields'] = array();
       }
-      $weight = CRM_Utils_Array::value('weight', $item, 0);
       $values[$item['adminGroup']]['fields']["{weight}.{$item['title']}"] = $value;
       $values[$item['adminGroup']]['component_id'] = $item['component_id'];
     }

--- a/CRM/Core/Smarty/plugins/function.crmKey.php
+++ b/CRM/Core/Smarty/plugins/function.crmKey.php
@@ -29,8 +29,5 @@
  *   the generated key
  */
 function smarty_function_crmKey($params, &$smarty) {
-  return CRM_Core_Key::get(
-      $params['name'],
-      CRM_Utils_Array::value('addSequence', $params, 0)
-    );
+  return CRM_Core_Key::get($params['name'], $params['addSequence'] ?? FALSE);
 }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -421,7 +421,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {
-      $eventId = (int) CRM_Utils_Array::value('event_id', $_POST);
+      $eventId = (int) ($_POST['event_id'] ?? 0);
       // Custom data of type participant role
       // Note: Some earlier commits imply $_POST['role_id'] could be a comma separated string,
       //       not sure if that ever really happens

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -205,7 +205,7 @@ class CRM_Utils_Chart {
     }
 
     // rotate the x labels.
-    $chartData['xLabelAngle'] = CRM_Utils_Array::value('xLabelAngle', $rows, 0);
+    $chartData['xLabelAngle'] = $rows['xLabelAngle'] ?? 0;
     if (!empty($rows['tip'])) {
       $chartData['tip'] = $rows['tip'];
     }

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -858,7 +858,7 @@ function civicrm_api3_contact_getquick($params) {
   }
   $actualSelectElements = implode(', ', $actualSelectElements);
   $from = implode(' ', $from);
-  $limit = (int) CRM_Utils_Array::value('limit', $params);
+  $limit = (int) ($params['limit'] ?? 0);
   $limit = $limit > 0 ? $limit : Civi::settings()->get('search_autocomplete_count');
 
   // add acl clause here

--- a/api/v3/DashboardContact.php
+++ b/api/v3/DashboardContact.php
@@ -73,7 +73,7 @@ function _civicrm_api3_dashboard_contact_create_spec(&$params) {
 function _civicrm_api3_dashboard_contact_check_params(&$params) {
   $dashboard_id = CRM_Utils_Array::value('dashboard_id', $params);
   if ($dashboard_id) {
-    $allDashlets = CRM_Core_BAO_Dashboard::getDashlets(TRUE, CRM_Utils_Array::value('check_permissions', $params, 0));
+    $allDashlets = CRM_Core_BAO_Dashboard::getDashlets(TRUE, $params['check_permissions'] ?? FALSE);
     if (!isset($allDashlets[$dashboard_id])) {
       return civicrm_api3_create_error('Invalid or inaccessible dashboard ID');
     }

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -678,7 +678,7 @@ function civicrm_api3_job_group_rebuild($params) {
     throw new API_Exception('Could not acquire lock, another GroupRebuild process is running');
   }
 
-  $limit = CRM_Utils_Array::value('limit', $params, 0);
+  $limit = $params['limit'] ?? 0;
 
   CRM_Contact_BAO_GroupContactCache::loadAll(NULL, $limit);
   $lock->release();

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -776,25 +776,21 @@ function _civicrm_api3_apply_filters_to_dao($filterField, $filterValue, &$dao) {
 function _civicrm_api3_get_options_from_params($params, $queryObject = FALSE, $entity = '', $action = '') {
   $lowercase_entity = _civicrm_api_get_entity_name_from_camel($entity);
   $is_count = FALSE;
-  $sort = CRM_Utils_Array::value('sort', $params, 0);
-  $sort = CRM_Utils_Array::value('option.sort', $params, $sort);
-  $sort = CRM_Utils_Array::value('option_sort', $params, $sort);
 
-  $offset = CRM_Utils_Array::value('offset', $params, 0);
-  $offset = CRM_Utils_Array::value('option.offset', $params, $offset);
   // dear PHP thought it would be a good idea to transform a.b into a_b in the get/post
-  $offset = CRM_Utils_Array::value('option_offset', $params, $offset);
+  $sort = $params['option_sort'] ?? $params['option.sort'] ?? $params['sort'] ?? 0;
+  $offset = $params['option_offset'] ?? $params['option.offset'] ?? $params['offset'] ?? 0;
 
   $limit = CRM_Utils_Array::value('rowCount', $params, 25);
   $limit = CRM_Utils_Array::value('option.limit', $params, $limit);
   $limit = CRM_Utils_Array::value('option_limit', $params, $limit);
 
-  if (is_array(CRM_Utils_Array::value('options', $params))) {
+  if (isset($params['options']) && is_array($params['options'])) {
     // is count is set by generic getcount not user
-    $is_count = CRM_Utils_Array::value('is_count', $params['options']);
-    $offset = CRM_Utils_Array::value('offset', $params['options'], $offset);
-    $limit  = CRM_Utils_Array::value('limit', $params['options'], $limit);
-    $sort   = CRM_Utils_Array::value('sort', $params['options'], $sort);
+    $is_count = $params['options']['is_count'] ?? FALSE;
+    $offset = $params['options']['offset'] ?? $offset;
+    $limit = CRM_Utils_Array::value('limit', $params['options'], $limit);
+    $sort = $params['options']['sort'] ?? $sort;
   }
 
   $returnProperties = [];
@@ -869,9 +865,7 @@ function _civicrm_api3_get_options_from_params($params, $queryObject = FALSE, $e
     elseif ($n === 'id') {
       $inputParams[$lowercase_entity . '_id'] = $v;
     }
-    elseif (in_array($n, $otherVars)) {
-    }
-    else {
+    elseif (!in_array($n, $otherVars)) {
       $inputParams[$n] = $v;
       if ($v && !is_array($v) && stristr($v, 'SELECT')) {
         throw new API_Exception('invalid string');

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -287,7 +287,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
       $membetype = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($type);
       $fieldParams['option_id'] = [1 => $priceFieldValue['id']];
       $fieldParams['option_label'][$rowCount] = CRM_Utils_Array::value('name', $membetype);
-      $fieldParams['option_amount'][$rowCount] = CRM_Utils_Array::value('minimum_fee', $membetype, 0);
+      $fieldParams['option_amount'][$rowCount] = $membetype['minimum_fee'] ?? 0;
       $fieldParams['option_weight'][$rowCount] = CRM_Utils_Array::value('weight', $membetype);
       $fieldParams['option_description'][$rowCount] = CRM_Utils_Array::value('description', $membetype);
       $fieldParams['option_financial_type_id'][$rowCount] = CRM_Utils_Array::value('financial_type_id', $membetype);


### PR DESCRIPTION
Overview
----------------------------------------
Some manual cleanup around the areas of code where CRM_Utils_Array::value is used for a number defaulting to 0. Fixes test failures in #16768.

Before
----------------------------------------
Messier code.

After
----------------------------------------
Neater code.

Technical Details
----------------------------------------
This was manual cleanup, not regex find/replace. The expressions are not always identical before/after, but should work the same in their particular contexts of possible inputs and expected outputs.