### PR TITLE
dev/core#1651 and dev/core#1637 - Inline editing not working on many admin screens and other js packages issues

### DIFF
--- a/js/jquery/jquery.crmEditable.js
+++ b/js/jquery/jquery.crmEditable.js
@@ -168,7 +168,7 @@
           });
       }
 
-      CRM.loadScript(CRM.config.packagesBase + 'jquery/plugins/jquery.jeditable.min.js').done(function() {
+      CRM.loadScript(CRM.config.packagesBase.replace(/\/+$/, '') + '/jquery/plugins/jquery.jeditable.min.js').done(function() {
         $i.editable(callback, settings);
       });
 

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -370,7 +370,7 @@
           "theme": 'classic',
           "dots": false,
           "icons": false,
-          "url": CRM.config.packagesBase + 'jquery/plugins/jstree/themes/classic/style.css'
+          "url": CRM.config.packagesBase.replace(/\/+$/, '') + '/jquery/plugins/jstree/themes/classic/style.css'
         },
         'plugins': ['themes', 'json_data', 'ui', 'search']
       }).bind('loaded.jstree', function () {

--- a/js/wysiwyg/crm.ckeditor.js
+++ b/js/wysiwyg/crm.ckeditor.js
@@ -54,8 +54,8 @@
 
     function initialize() {
       var
-        browseUrl = CRM.config.packagesBase + "kcfinder/browse.php?cms=civicrm",
-        uploadUrl = CRM.config.packagesBase + "kcfinder/upload.php?cms=civicrm&format=json",
+        browseUrl = CRM.config.packagesBase.replace(/\/+$/, '') + "/kcfinder/browse.php?cms=civicrm",
+        uploadUrl = CRM.config.packagesBase.replace(/\/+$/, '') + "/kcfinder/upload.php?cms=civicrm&format=json",
         preset = $(item).data('preset') || 'default',
         // This variable is always an array but a legacy extension could be setting it as a string.
         customConfig = (typeof CRM.config.CKEditorCustomConfig === 'string') ? CRM.config.CKEditorCustomConfig :


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1651

Go to any admin screen with option value-like entries, like phone types or activity types. Try to click on one of the inline-editable fields. Nothing happens.

Also https://lab.civicrm.org/dev/core/issues/1637 for related issues with kcfinder and mailing screen.

Technical Details
----------------------------------------
This commit changed something and in a default stock install the url gets formed incorrectly: https://github.com/civicrm/civicrm-core/commit/3130950c51d3ceadc913495e8dc52125bb22503e#diff-db0ac48007cde9731cada1cf69334517

Comments
----------------------------------------
If it's not obvious the regex removes any trailing slashes that might already be there, then the slash gets added as part of the following string.

Affects 5.23.