### PR TITLE
dev/core#1652 - Check for change case type activity on case activity form doesn't work

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -145,17 +145,6 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       );
     }
     if (!$this->_activityId) {
-      $caseTypes = CRM_Case_PseudoConstant::caseType();
-
-      if (empty($caseTypes) && ($this->_activityTypeName == 'Change Case Type') && !$this->_caseId) {
-        $url = CRM_Utils_System::url('civicrm/contact/view/case',
-          "reset=1&action=view&cid={$this->_currentlyViewedContactId}&id={$caseIds}&show=1"
-        );
-        $session = CRM_Core_Session::singleton();
-        $session->pushUserContext($url);
-        CRM_Core_Error::statusBounce(ts("You do not have any active Case Types"));
-      }
-
       // check if activity count is within the limit
       $xmlProcessor = new CRM_Case_XMLProcessor_Process();
       foreach ($this->_caseId as $casePos => $caseId) {

--- a/CRM/Case/Form/Activity/ChangeCaseType.php
+++ b/CRM/Case/Form/Activity/ChangeCaseType.php
@@ -68,7 +68,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
       $form->_caseType[$form->_caseTypeId] = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $form->_caseTypeId, 'title');
     }
 
-    $form->addField('case_type_id', ['context' => 'create', 'entity' => 'Case']);
+    $form->addField('case_type_id', ['context' => 'create', 'entity' => 'Case'], TRUE);
 
     // timeline
     $form->addYesNo('is_reset_timeline', ts('Reset Case Timeline?'), NULL, TRUE);

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -57,6 +57,14 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
           $form->_action = CRM_Core_Action::ADD;
         },
       ],
+      // This one is a bit flawed but the only point of this test is to catch
+      // simple stuff. This will catch e.g. "undefined index" and similar.
+      'Find Contacts' => [
+        'CRM_Contact_Form_Search_Basic',
+        function(CRM_Core_Form $form) {
+          $form->_action = CRM_Core_Action::BASIC;
+        },
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1652

This isn't the thing I was looking to fix but getting this out of the way will make it less distracting. I'm not sure what the scenario for this check is in real life but if all your case types are disabled then the intent seems to be that when you try to change a case type it will warn you when go to create a Change Case Type activity, but it's flawed in a couple ways. Given the rarity of the situation I've opted for the simple route of making the field required, so at least you don't get a fatal error on save.

To reproduce:
1. Create a case.
2. Disable all your case types.
3. Go back to manage case and create a Change Case Type activity.
4. Just click Save.
5. Before it would give a fatal error. Now it says field is required.

Technical Details
----------------------------------------
Detailed in lab ticket. Has name/label issues as well as a check against !something which seems to be wrong.

Since one of the deleted lines is an assignment of $session, I checked to see if it was used outside the deleted lines but it isn't.

Comments
----------------------------------------
Has test, which has nothing to do with this issue but it was ... hard ... so I opted for any kind of test. I'd argue the attached test is more useful, since it's for contact search which is used everywhere.
