### PR TITLE
Follow up on fix on updating memberships when a contact is deceased

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -421,13 +421,15 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       self::unsetProtectedFields($contacts);
     }
 
-    // Edit Membership Status
-    $deceasedParams = [
-      'contact_id' => CRM_Utils_Array::value('contact_id', $params),
-      'is_deceased' => CRM_Utils_Array::value('is_deceased', $params, FALSE),
-      'deceased_date' => CRM_Utils_Array::value('deceased_date', $params, NULL),
-    ];
-    CRM_Member_BAO_Membership::updateMembershipStatus($deceasedParams, $params['contact_type']);
+    if (!empty($params['is_deceased'])) {
+      // Edit Membership Status
+      $deceasedParams = [
+        'contact_id' => $contact->id,
+        'is_deceased' => $params['is_deceased'],
+        'deceased_date' => $params['deceased_date'] ?? NULL,
+      ];
+      CRM_Member_BAO_Membership::updateMembershipStatus($deceasedParams, $params['contact_type']);
+    }
 
     return $contact;
   }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -907,16 +907,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $params['deceased_date'] = NULL;
     }
 
-    if (isset($params['contact_id'])) {
-      // process membership status for deceased contact
-      $deceasedParams = [
-        'contact_id' => $params['contact_id'] ?? NULL,
-        'is_deceased' => $params['is_deceased'] ?? FALSE,
-        'deceased_date' => $params['deceased_date'] ?? NULL,
-      ];
-      $updateMembershipMsg = CRM_Member_BAO_Membership::updateMembershipStatus($deceasedParams, $this->_contactType);
-    }
-
     // action is taken depending upon the mode
     if ($this->_action & CRM_Core_Action::UPDATE) {
       CRM_Utils_Hook::pre('edit', $params['contact_type'], $params['contact_id'], $params);
@@ -1014,9 +1004,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     if (!empty($parseStatusMsg)) {
       $message .= "<br />$parseStatusMsg";
-    }
-    if (!empty($updateMembershipMsg)) {
-      $message .= "<br />$updateMembershipMsg";
     }
 
     $session = CRM_Core_Session::singleton();

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2680,8 +2680,8 @@ WHERE      civicrm_membership.is_test = 0
    */
   public static function updateMembershipStatus($deceasedParams, $contactType) {
     $updateMembershipMsg = NULL;
-    $contactId = $deceasedParams['contact_id'] ?? NULL;
-    $deceasedDate = $deceasedParams['deceased_date'] ?? NULL;
+    $contactId = $deceasedParams['contact_id'];
+    $deceasedDate = $deceasedParams['deceased_date'];
 
     // process to set membership status to deceased for both active/inactive membership
     if ($contactId &&
@@ -2689,11 +2689,7 @@ WHERE      civicrm_membership.is_test = 0
       !empty($deceasedParams['is_deceased'])
     ) {
 
-      $session = CRM_Core_Session::singleton();
-      $userId = $session->get('userID');
-      if (!$userId) {
-        $userId = $contactId;
-      }
+      $userId = CRM_Core_Session::getLoggedInContactID() ?: $contactId;
 
       // get deceased status id
       $allStatus = CRM_Member_PseudoConstant::membershipStatus();
@@ -2750,16 +2746,16 @@ WHERE      civicrm_membership.is_test = 0
           'is_current_revision' => 1,
           'is_deleted' => 0,
         ];
-        $activityResult = civicrm_api('activity', 'create', $activityParam);
+        civicrm_api('activity', 'create', $activityParam);
 
         $memCount++;
       }
 
       // set status msg
       if ($memCount) {
-        $updateMembershipMsg = ts("%1 Current membership(s) for this contact have been set to 'Deceased' status.",
+        CRM_Core_Session::setStatus(ts("%1 Current membership(s) for this contact have been set to 'Deceased' status.",
           [1 => $memCount]
-        );
+        ));
       }
     }
     return $updateMembershipMsg;


### PR DESCRIPTION
Overview
----------------------------------------
This removes the now-duplicate call from the Contact edit form & fixes it such that the message would appear for any logged in action that causes this (notably the 2 ways of editing the contact at the moment.)



Before
----------------------------------------
updateMembershipStatus called twice when deceasing a contact from contact-edit form (no bad effect other than code complexity) and message regarding updates to memberships only displayed for the contact-edit & not the inline edit

After
----------------------------------------
This shows for main edit
<img width="349" alt="Screen Shot 2020-03-16 at 12 51 42 PM" src="https://user-images.githubusercontent.com/336308/76713419-64f04280-6785-11ea-8567-cd7fd601ee0c.png">

And for inline edit 
<img width="319" alt="Screen Shot 2020-03-16 at 12 56 10 PM" src="https://user-images.githubusercontent.com/336308/76713439-8a7d4c00-6785-11ea-8b93-923c81d7d429.png">



Technical Details
----------------------------------------


Comments
----------------------------------------
Note it might change the way the messages look from one message to more than one - this  feels like the benefits are arguable enough that it's not worth worrying about
