### PR TITLE
[REF] Fixes a bug in Message Template create API where by user permissions checks were being done on system workflow messages

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -87,10 +87,12 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
           }
         }
         else {
-          if (!empty($params['workflow_id']) && !CRM_Core_Permission::check('edit system workflow message templates')) {
-            throw new \Civi\API\Exception\UnauthorizedException(ts('%1', [1 => $systemWorkflowPermissionDeniedMessage]));
+          if (!empty($params['workflow_id'])) {
+            if (!CRM_Core_Permission::check('edit system workflow message templates')) {
+              throw new \Civi\API\Exception\UnauthorizedException(ts('%1', [1 => $systemWorkflowPermissionDeniedMessage]));
+            }
           }
-          if (!CRM_Core_Permission::check('edit user-driven message templates')) {
+          elseif (!CRM_Core_Permission::check('edit user-driven message templates')) {
             throw new \Civi\API\Exception\UnauthorizedException(ts('%1', [1 => $userWorkflowPermissionDeniedMessage]));
           }
         }

--- a/tests/phpunit/api/v3/MessageTemplateTest.php
+++ b/tests/phpunit/api/v3/MessageTemplateTest.php
@@ -103,6 +103,10 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
       'msg_subject' => 'test msg permission subject',
       'check_permissions' => TRUE,
     ]);
+    $newEntityParams = $entity['values'][$entity['id']];
+    unset($newEntityParams['id']);
+    $newEntityParams['check_permissions'] = TRUE;
+    $this->callAPISuccess('MessageTemplate', 'create', $newEntityParams);
     // verify with all 3 permissions someone can do everything.
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'edit system workflow message templates',


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug when creating a new system workflow message template i.e without an ID and with check_permissions turned on will cause the user message template permission to be checked incorrectly

Before
----------------------------------------
When user doesn't have edit all message template permission both system workflow and user workflow permissions are checked when adding a new system workflow tempalte

After
----------------------------------------
Only system workflow template permission is checked

ping @eileenmcnaughton 