### PR TITLE
[REF] Ensure that if key is not 0 in  for drupal8 username and email …

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -141,7 +141,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
         return $v->getPropertyPath() == 'name';
       }));
       if (count($violations) > 0) {
-        $errors['cms_name'] = (string) $violations[0]->getMessage();
+        $arrayKey = key($violations);
+        $errors['cms_name'] = (string) $violations[$arrayKey]->getMessage();
       }
     }
 
@@ -159,7 +160,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
         return $v->getPropertyPath() == 'mail';
       }));
       if (count($violations) > 0) {
-        $errors[$emailName] = (string) $violations[0]->getMessage();
+        $arrayKey = key($violations);
+        $errors[$emailName] = (string) $violations[$arrayKey]->getMessage();
       }
     }
   }


### PR DESCRIPTION
…check errors are still reported correctly

Overview
----------------------------------------
Working on some code locally that was doing a precheck on whether an email or user name already existed. I found that when just checking an email it was having the violation keyed as 2 rather than 0 and as such there was a PHP error of call to member function getMessage on null

Before
----------------------------------------
Code assumes the violation will always be keyed as 0

After
----------------------------------------
Code can work with which ever key the violation is actually

ping @mlutfy @dsnopek @demeritcowboy 