### PR TITLE
[REF] Fix PCP getPcpDashboardInfo to be tested & use sensible functions

### DIFF
--- a/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
+++ b/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
@@ -29,7 +29,7 @@ trait CRMTraits_PCP_PCPTestTrait {
     $supporterProfile = CRM_Core_DAO::createTestObject('CRM_Core_DAO_UFGroup');
     $supporterProfileId = $supporterProfile->id;
 
-    $params = array(
+    $params = [
       'entity_table' => 'civicrm_contribution_page',
       'entity_id' => $contribPageId,
       'supporter_profile_id' => $supporterProfileId,
@@ -39,7 +39,7 @@ trait CRMTraits_PCP_PCPTestTrait {
       'tellfriend_limit' => 1,
       'link_text' => 'Create your own PCP',
       'is_active' => 1,
-    );
+    ];
 
     return $params;
   }
@@ -56,7 +56,7 @@ trait CRMTraits_PCP_PCPTestTrait {
     $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');
     $contribPageId = $contribPage->id;
 
-    $params = array(
+    $params = [
       'contact_id' => $contactId,
       'status_id' => '1',
       'title' => 'My PCP',
@@ -68,7 +68,7 @@ trait CRMTraits_PCP_PCPTestTrait {
       'is_honor_roll' => 1,
       'goal_amount' => 10000.00,
       'is_active' => 1,
-    );
+    ];
 
     return $params;
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1841,6 +1841,8 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'civicrm_participant',
       'civicrm_participant_payment',
       'civicrm_pledge',
+      'civicrm_pcp_block',
+      'civicrm_pcp',
       'civicrm_pledge_block',
       'civicrm_pledge_payment',
       'civicrm_price_set_entity',


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup to use our preferred functions & avoid  bad practices like $$component

Before
----------------------------------------
Use of deprecated calls to get keys & labels, hard to read due to $$component

After
----------------------------------------
Uses preferred methods $$component replaced by a function

Technical Details
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/16771

Comments
----------------------------------------

I removed a parent-blocking tearDown - not too sure what the implications will be for the tests - might be some fails to clean up