### PR TITLE
(REF) dev/core#1637, dev/core#1651 - Restore format of packagesBase 

### DIFF
--- a/js/jquery/jquery.crmEditable.js
+++ b/js/jquery/jquery.crmEditable.js
@@ -168,7 +168,7 @@
           });
       }
 
-      CRM.loadScript(CRM.config.packagesBase.replace(/\/+$/, '') + '/jquery/plugins/jquery.jeditable.min.js').done(function() {
+      CRM.loadScript(CRM.config.packagesBase + 'jquery/plugins/jquery.jeditable.min.js').done(function() {
         $i.editable(callback, settings);
       });
 

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -370,7 +370,7 @@
           "theme": 'classic',
           "dots": false,
           "icons": false,
-          "url": CRM.config.packagesBase.replace(/\/+$/, '') + '/jquery/plugins/jstree/themes/classic/style.css'
+          "url": CRM.config.packagesBase + 'jquery/plugins/jstree/themes/classic/style.css'
         },
         'plugins': ['themes', 'json_data', 'ui', 'search']
       }).bind('loaded.jstree', function () {

--- a/js/wysiwyg/crm.ckeditor.js
+++ b/js/wysiwyg/crm.ckeditor.js
@@ -54,8 +54,8 @@
 
     function initialize() {
       var
-        browseUrl = CRM.config.packagesBase.replace(/\/+$/, '') + "/kcfinder/browse.php?cms=civicrm",
-        uploadUrl = CRM.config.packagesBase.replace(/\/+$/, '') + "/kcfinder/upload.php?cms=civicrm&format=json",
+        browseUrl = CRM.config.packagesBase + "kcfinder/browse.php?cms=civicrm",
+        uploadUrl = CRM.config.packagesBase + "kcfinder/upload.php?cms=civicrm&format=json",
         preset = $(item).data('preset') || 'default',
         // This variable is always an array but a legacy extension could be setting it as a string.
         customConfig = (typeof CRM.config.CKEditorCustomConfig === 'string') ? CRM.config.CKEditorCustomConfig :

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -12,7 +12,9 @@
 (function($) {ldelim}
   // Config settings
   CRM.config.userFramework = {$config->userFramework|@json_encode};
+  {* resourceBase: The URL of `civicrm-core` assets. Ends with "/". *}
   CRM.config.resourceBase = {$config->userFrameworkResourceURL|@json_encode};
+  {* packageseBase: The URL of `civicrm-packages` assets. Ends with "/". *}
   CRM.config.packagesBase = {capture assign=packagesBase}{crmResURL expr='[civicrm.packages]/'}{/capture}{$packagesBase|@json_encode};
   CRM.config.lcMessages = {$config->lcMessages|@json_encode};
   CRM.config.locale = {$locale|@json_encode};

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -13,7 +13,7 @@
   // Config settings
   CRM.config.userFramework = {$config->userFramework|@json_encode};
   CRM.config.resourceBase = {$config->userFrameworkResourceURL|@json_encode};
-  CRM.config.packagesBase = {capture assign=packagesBase}{crmResURL expr='[civicrm.packages]/.'}{/capture}{$packagesBase|@json_encode};
+  CRM.config.packagesBase = {capture assign=packagesBase}{crmResURL expr='[civicrm.packages]/'}{/capture}{$packagesBase|@json_encode};
   CRM.config.lcMessages = {$config->lcMessages|@json_encode};
   CRM.config.locale = {$locale|@json_encode};
   CRM.config.cid = {$cid|@json_encode};


### PR DESCRIPTION
Overview
----------------------------------------

This is an alternative to #16779 / #16780. I think #16780 is better/simpler, but it had a defect, which is addressed here - and ultimately leads to the smallest/simplest patch.

Before and After
----------------------------------------

* In 5.22.x, there's a `resourceBase` but no `packagesBase`.
* In 5.23.0, there's both `resourceBase` and `packagesBase`, and they both end in `/`.
* In 5.23.1,  `resourceBase` and `packagesBase` diverge -- `packagesBase` accidentally loses its `/`. Consumers break.
* In PR 16779,   `resourceBase` and `packagesBase` remain diverged -- and every consumer of `packagesBase` is made defensive.
* In PR 16780, `resourceBase` and `packagesBase`  are once again aligned (both ending in `/`)... but `packagesBase` is miscomputed.
* In this PR, `resourceBase` and `packagesBase`  are once again aligned (both ending in `/`).

Comments
----------------------------------------

* This is fundamentally a simple one-character fix (cc8f6f14b036b1b5a444667f7533bf36da51253a) for dev/core#1651, but the PR looks bigger because of the revert (1ff4b7b) and some small docblocks (605ee23).
* One might suggest shipping with #16779 because it's been reviewed -- and deferring cleanup to `master` (5.25 or 5.26). The problem is that this will lock-in the ambiguity in the content of `packagesBase`: with any new code (*core or contrib*) which references `packagesBase`, they'll either assume that there is no `/` or they'll have to reproduce the defensive snippets. The former means we can't bring `resourceBase` and `packagesBase` back into alignment (without a break), and the latter spreads the mess around.
