### PR TITLE
dev/core#1646 Merge Case Modal not showing relevant cases

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -498,6 +498,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
       'check_permissions' => TRUE,
       'contact_id' => $this->_contactID,
       'is_deleted' => 0,
+      'option.limit' => 0,
       'id' => ['!=' => $this->_caseID],
       'return' => ['id', 'start_date', 'case_type_id.title'],
     ]);


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/1646

Before
----------------------------------------
Case type dropdown shows no more than 25 cases

After
----------------------------------------
Case type dropdown shows all cases

Technical Details
----------------------------------------
The API has a default limit of 25

Comments
----------------------------------------
Might be an issue if somebody has too many cases, which *can* happen. 

@demeritcowboy writes: 
> As noted in the comments in the description, the dropdown might be unwieldy if they have a ton of cases for the same client. Note the dropdown includes closed cases too, since merging to a closed case is perfectly normal, so the number of entries in the list will always be increasing.
