### PR TITLE
Respect 'Donot notify activity type' setting

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -601,11 +601,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
             $mailStatus = ts("A copy of the activity has also been sent to selected contact(s).");
           }
           else {
-            $actTypeId = civicrm_api3('Activity', 'getvalue', [
-              'return' => 'activity_type_id',
-              'id' => $vval['actId'],
-            ]);
-            if (!in_array($actTypeId, Civi::settings()->get('do_not_notify_assignees_for'))) {
+            if (!in_array($this->_activityTypeId, Civi::settings()->get('do_not_notify_assignees_for'))) {
               $this->_relatedContacts = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames(
                 [$vval['actId']], TRUE, FALSE
               );

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -601,8 +601,16 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
             $mailStatus = ts("A copy of the activity has also been sent to selected contact(s).");
           }
           else {
-            $this->_relatedContacts = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames([$vval['actId']], TRUE, FALSE);
-            $mailStatus .= ' ' . ts("A copy of the activity has also been sent to assignee contact(s).");
+            $actTypeId = civicrm_api3('Activity', 'getvalue', [
+              'return' => 'activity_type_id',
+              'id' => $vval['actId'],
+            ]);
+            if (!in_array($actTypeId, Civi::settings()->get('do_not_notify_assignees_for'))) {
+              $this->_relatedContacts = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames(
+                [$vval['actId']], TRUE, FALSE
+              );
+              $mailStatus .= ' ' . ts("A copy of the activity has also been sent to assignee contact(s).");
+            }
           }
           //build an associative array with unique email addresses.
           foreach ($params[$val] as $key => $value) {

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -594,6 +594,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       $selectedContacts[] = 'assignee_contact_id';
     }
 
+    $dndActivityTypes = Civi::settings()->get('do_not_notify_assignees_for') ?? [];
     foreach ($vvalue as $vkey => $vval) {
       foreach ($selectedContacts as $dnt => $val) {
         if (array_key_exists($val, $params) && !CRM_Utils_Array::crmIsEmptyArray($params[$val])) {
@@ -601,7 +602,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
             $mailStatus = ts("A copy of the activity has also been sent to selected contact(s).");
           }
           else {
-            if (!in_array($this->_activityTypeId, Civi::settings()->get('do_not_notify_assignees_for'))) {
+            if (!in_array($this->_activityTypeId, $dndActivityTypes)) {
               $this->_relatedContacts = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames(
                 [$vval['actId']], TRUE, FALSE
               );


### PR DESCRIPTION
Overview
----------------------------------------
When submitting activity from case, assignee contact still gets email even though the activity type is included in 'Do not notify assignees for' setting under Display Preference. However it obeys the setting when sent from Activity form. Is this intentional? 

https://civicrm.stackexchange.com/questions/35096/case-activity-doest-respect-do-not-notify-assignees-for
https://lab.civicrm.org/dev/core/issues/1582
https://lab.civicrm.org/dev/core/issues/1649


Before
----------------------------------------
Email send to assignee contact even though activity is restricted not to send

After
----------------------------------------
Obeys 'Do not notify assignees for' setting  and donot send email for assignee