### PR TITLE
[REF] Replace coalesce pattern with coalesce operator

### DIFF
--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -184,7 +184,7 @@ AND civicrm_contact.id IN $idString ";
       $location['displayAddress'] = str_replace('<br />', ', ', addslashes($address));
       $location['url'] = CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $dao->contact_id);
       $location['location_type'] = $dao->location_type;
-      $location['image'] = CRM_Contact_BAO_Contact_Utils::getImage(isset($dao->contact_sub_type) ? $dao->contact_sub_type : $dao->contact_type, $imageUrlOnly, $dao->contact_id
+      $location['image'] = CRM_Contact_BAO_Contact_Utils::getImage($dao->contact_sub_type ?? $dao->contact_type, $imageUrlOnly, $dao->contact_id
       );
       $locations[] = $location;
     }

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -1081,7 +1081,7 @@ WHERE id IN (" . implode(',', $contactIds) . ")";
       if (!empty($contactParams[$greeting . '_id'])) {
         $string = CRM_Core_PseudoConstant::getLabel('CRM_Contact_BAO_Contact', $greeting . '_id', $contactParams[$greeting . '_id']);
       }
-      $string = isset($contactParams[$greeting . '_custom']) ? $contactParams[$greeting . '_custom'] : $string;
+      $string = $contactParams[$greeting . '_custom'] ?? $string;
       if (empty($string)) {
         $tokens[$greeting] = [];
       }

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6407,7 +6407,7 @@ AND   displayRelType.is_active = 1
     foreach ($orderByArray as $orderByClause) {
       $orderByClauseParts = explode(' ', trim($orderByClause));
       $field = $orderByClauseParts[0];
-      $direction = isset($orderByClauseParts[1]) ? $orderByClauseParts[1] : 'asc';
+      $direction = $orderByClauseParts[1] ?? 'asc';
       $fieldSpec = $this->getMetadataForRealField($field);
 
       // This is a hacky add-in for primary address joins. Feel free to iterate as it is unit tested.
@@ -6901,8 +6901,8 @@ AND   displayRelType.is_active = 1
       // This seems to be the only anomaly.
       $fieldName = 'id';
     }
-    $pseudoField = isset($this->_pseudoConstantsSelect[$fieldName]) ? $this->_pseudoConstantsSelect[$fieldName] : [];
-    $field = isset($this->_fields[$fieldName]) ? $this->_fields[$fieldName] : $pseudoField;
+    $pseudoField = $this->_pseudoConstantsSelect[$fieldName] ?? [];
+    $field = $this->_fields[$fieldName] ?? $pseudoField;
     $field = array_merge($field, $pseudoField);
     if (!empty($field) && empty($field['name'])) {
       // standardising field formatting here - over time we can phase out variants.

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -501,7 +501,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           $defaults[$name][$instance]['location_type_id'] = $locationType->id;
         }
         else {
-          $locTypeId = isset($locationTypeKeys[$instance - 1]) ? $locationTypeKeys[$instance - 1] : $locationType->id;
+          $locTypeId = $locationTypeKeys[$instance - 1] ?? $locationType->id;
           $defaults[$name][$instance]['location_type_id'] = $locTypeId;
         }
 
@@ -653,7 +653,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           if ($name == 'openid' && !empty($blockValues[$name])) {
             $oid = new CRM_Core_DAO_OpenID();
             $oid->openid = $openIds[$instance] = CRM_Utils_Array::value($name, $blockValues);
-            $cid = isset($contactId) ? $contactId : 0;
+            $cid = $contactId ?? 0;
             if ($oid->find(TRUE) && ($oid->contact_id != $cid)) {
               $errors["{$name}[$instance][openid]"] = ts('%1 already exist.', [1 => $blocks['OpenID']]);
             }

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -73,7 +73,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
         $fName = $fieldName;
       }
 
-      $groupID = isset($form->_grid) ? $form->_grid : NULL;
+      $groupID = $form->_grid ?? NULL;
       if ($groupID && $visibility) {
         $ids = [$groupID => $groupID];
       }

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -367,7 +367,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
         $taskParams['deletedContacts'] = CRM_Utils_Array::value('deleted_contacts', $this->_formValues);
       }
       $className = $this->_modeValue['taskClassName'];
-      $taskParams['ssID'] = isset($this->_ssID) ? $this->_ssID : NULL;
+      $taskParams['ssID'] = $this->_ssID ?? NULL;
       $this->_taskList += $className::permissionedTaskTitles(CRM_Core_Permission::getPermission(), $taskParams);
     }
 

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -110,8 +110,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
   public static function postProcess(&$form) {
     $formValues = $form->controller->exportValues($form->getName());
     list($formValues, $categories, $html_message, $messageToken, $returnProperties) = self::processMessageTemplate($formValues);
-    $skipOnHold = isset($form->skipOnHold) ? $form->skipOnHold : FALSE;
-    $skipDeceased = isset($form->skipDeceased) ? $form->skipDeceased : TRUE;
+    $skipOnHold = $form->skipOnHold ?? FALSE;
+    $skipDeceased = $form->skipDeceased ?? TRUE;
     $html = $activityIds = [];
 
     // CRM-16725 Skip creation of activities if user is previewing their PDF letter(s)

--- a/CRM/Contact/Form/Task/Print.php
+++ b/CRM/Contact/Form/Task/Print.php
@@ -66,7 +66,7 @@ class CRM_Contact_Form_Task_Print extends CRM_Contact_Form_Task {
     $selectorName = $this->controller->selectorName();
     require_once str_replace('_', DIRECTORY_SEPARATOR, $selectorName) . '.php';
 
-    $returnP = isset($returnProperties) ? $returnProperties : "";
+    $returnP = $returnProperties ?? "";
     $customSearchClass = $this->get('customSearchClass');
     $this->assign('customSearchID', $this->get('customSearchID'));
     $selector = new $selectorName($customSearchClass,

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -628,9 +628,9 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         $updateMappingFields->column_number = $i;
 
         $mapperKeyParts = explode('_', $mapperKeys[$i][0], 3);
-        $id = isset($mapperKeyParts[0]) ? $mapperKeyParts[0] : NULL;
-        $first = isset($mapperKeyParts[1]) ? $mapperKeyParts[1] : NULL;
-        $second = isset($mapperKeyParts[2]) ? $mapperKeyParts[2] : NULL;
+        $id = $mapperKeyParts[0] ?? NULL;
+        $first = $mapperKeyParts[1] ?? NULL;
+        $second = $mapperKeyParts[2] ?? NULL;
         if (($first == 'a' && $second == 'b') || ($first == 'b' && $second == 'a')) {
           $updateMappingFields->relationship_type_id = $id;
           $updateMappingFields->relationship_direction = "{$first}_{$second}";
@@ -638,14 +638,14 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           // get phoneType id and provider id separately
           // before updating mappingFields of phone and IM for related contact, CRM-3140
           if (CRM_Utils_Array::value('1', $mapperKeys[$i]) == 'url') {
-            $updateMappingFields->website_type_id = isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
+            $updateMappingFields->website_type_id = $mapperKeys[$i][2] ?? NULL;
           }
           else {
             if (CRM_Utils_Array::value('1', $mapperKeys[$i]) == 'phone') {
-              $updateMappingFields->phone_type_id = isset($mapperKeys[$i][3]) ? $mapperKeys[$i][3] : NULL;
+              $updateMappingFields->phone_type_id = $mapperKeys[$i][3] ?? NULL;
             }
             elseif (CRM_Utils_Array::value('1', $mapperKeys[$i]) == 'im') {
-              $updateMappingFields->im_provider_id = isset($mapperKeys[$i][3]) ? $mapperKeys[$i][3] : NULL;
+              $updateMappingFields->im_provider_id = $mapperKeys[$i][3] ?? NULL;
             }
             $updateMappingFields->location_type_id = isset($mapperKeys[$i][2]) && is_numeric($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
           }
@@ -657,14 +657,14 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           // to store phoneType id and provider id separately
           // before updating mappingFields for phone and IM, CRM-3140
           if (CRM_Utils_Array::value('0', $mapperKeys[$i]) == 'url') {
-            $updateMappingFields->website_type_id = isset($mapperKeys[$i][1]) ? $mapperKeys[$i][1] : NULL;
+            $updateMappingFields->website_type_id = $mapperKeys[$i][1] ?? NULL;
           }
           else {
             if (CRM_Utils_Array::value('0', $mapperKeys[$i]) == 'phone') {
-              $updateMappingFields->phone_type_id = isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
+              $updateMappingFields->phone_type_id = $mapperKeys[$i][2] ?? NULL;
             }
             elseif (CRM_Utils_Array::value('0', $mapperKeys[$i]) == 'im') {
-              $updateMappingFields->im_provider_id = isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
+              $updateMappingFields->im_provider_id = $mapperKeys[$i][2] ?? NULL;
             }
             $locationTypeID = $parserParameters['mapperLocType'][$i];
             // location_type_id is NULL for non-location fields, and for Primary location.
@@ -747,9 +747,9 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $saveMappingFields->column_number = $i;
 
     $mapperKeyParts = explode('_', $mapperKeys[$i][0], 3);
-    $id = isset($mapperKeyParts[0]) ? $mapperKeyParts[0] : NULL;
-    $first = isset($mapperKeyParts[1]) ? $mapperKeyParts[1] : NULL;
-    $second = isset($mapperKeyParts[2]) ? $mapperKeyParts[2] : NULL;
+    $id = $mapperKeyParts[0] ?? NULL;
+    $first = $mapperKeyParts[1] ?? NULL;
+    $second = $mapperKeyParts[2] ?? NULL;
     if (($first == 'a' && $second == 'b') || ($first == 'b' && $second == 'a')) {
       $saveMappingFields->name = ucwords(str_replace("_", " ", $mapperKeys[$i][1]));
       $saveMappingFields->relationship_type_id = $id;
@@ -757,14 +757,14 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       // to get phoneType id and provider id separately
       // before saving mappingFields of phone and IM for related contact, CRM-3140
       if (CRM_Utils_Array::value('1', $mapperKeys[$i]) == 'url') {
-        $saveMappingFields->website_type_id = isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
+        $saveMappingFields->website_type_id = $mapperKeys[$i][2] ?? NULL;
       }
       else {
         if (CRM_Utils_Array::value('1', $mapperKeys[$i]) == 'phone') {
-          $saveMappingFields->phone_type_id = isset($mapperKeys[$i][3]) ? $mapperKeys[$i][3] : NULL;
+          $saveMappingFields->phone_type_id = $mapperKeys[$i][3] ?? NULL;
         }
         elseif (CRM_Utils_Array::value('1', $mapperKeys[$i]) == 'im') {
-          $saveMappingFields->im_provider_id = isset($mapperKeys[$i][3]) ? $mapperKeys[$i][3] : NULL;
+          $saveMappingFields->im_provider_id = $mapperKeys[$i][3] ?? NULL;
         }
         $saveMappingFields->location_type_id = (isset($mapperKeys[$i][2]) && $mapperKeys[$i][2] !== 'Primary') ? $mapperKeys[$i][2] : NULL;
       }
@@ -775,14 +775,14 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       // to get phoneType id and provider id separately
       // before saving mappingFields of phone and IM, CRM-3140
       if (CRM_Utils_Array::value('0', $mapperKeys[$i]) == 'url') {
-        $saveMappingFields->website_type_id = isset($mapperKeys[$i][1]) ? $mapperKeys[$i][1] : NULL;
+        $saveMappingFields->website_type_id = $mapperKeys[$i][1] ?? NULL;
       }
       else {
         if (CRM_Utils_Array::value('0', $mapperKeys[$i]) == 'phone') {
-          $saveMappingFields->phone_type_id = isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
+          $saveMappingFields->phone_type_id = $mapperKeys[$i][2] ?? NULL;
         }
         elseif (CRM_Utils_Array::value('0', $mapperKeys[$i]) == 'im') {
-          $saveMappingFields->im_provider_id = isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : NULL;
+          $saveMappingFields->im_provider_id = $mapperKeys[$i][2] ?? NULL;
         }
         $saveMappingFields->location_type_id = is_numeric($locationTypeID) ? $locationTypeID : NULL;
       }

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -165,8 +165,8 @@ class CRM_Contact_Import_ImportJob {
 
       $fldNameParts = explode('_', $fldName, 3);
       $id = $fldNameParts[0];
-      $first = isset($fldNameParts[1]) ? $fldNameParts[1] : NULL;
-      $second = isset($fldNameParts[2]) ? $fldNameParts[2] : NULL;
+      $first = $fldNameParts[1] ?? NULL;
+      $second = $fldNameParts[2] ?? NULL;
       if (($first == 'a' && $second == 'b') ||
         ($first == 'b' && $second == 'a')
       ) {
@@ -294,7 +294,7 @@ class CRM_Contact_Import_ImportJob {
 
     if ($newGroupName) {
       /* Create a new group */
-      $newGroupType = isset($newGroupType) ? $newGroupType : array();
+      $newGroupType = $newGroupType ?? array();
       $gParams = array(
         'title' => $newGroupName,
         'description' => $newGroupDesc,

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -719,13 +719,13 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           list($locType) = explode("-email", $property);
           $onholdProperty = "{$locType}-on_hold";
 
-          $row[$property] = isset($result->$property) ? $result->$property : NULL;
+          $row[$property] = $result->$property ?? NULL;
           if (!empty($row[$property]) && !empty($result->$onholdProperty)) {
             $row[$property] .= " (On Hold)";
           }
         }
         else {
-          $row[$property] = isset($result->$property) ? $result->$property : NULL;
+          $row[$property] = $result->$property ?? NULL;
         }
       }
 

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -329,7 +329,7 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
         }
       }
       if (!$empty) {
-        $contactID = isset($dao->contact_id) ? $dao->contact_id : NULL;
+        $contactID = $dao->contact_id ?? NULL;
 
         $row['checkbox'] = CRM_Core_Form::CB_PREFIX . $contactID;
         $row['action'] = CRM_Core_Action::formLink($links,

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -201,7 +201,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
 
             $mappingHeader = array_keys($this->_mapperFields, $mappingName[$i]);
             // reusing contact_type field array for soft credit
-            $softField = isset($mappingContactType[$i]) ? $mappingContactType[$i] : 0;
+            $softField = $mappingContactType[$i] ?? 0;
 
             if (!$softField) {
               $js .= "{$formName}['mapper[$i][1]'].style.display = 'none';\n";
@@ -338,7 +338,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       ];
       $params = [
         'used' => 'Unsupervised',
-        'contact_type' => isset($contactTypes[$contactTypeId]) ? $contactTypes[$contactTypeId] : '',
+        'contact_type' => $contactTypes[$contactTypeId] ?? '',
       ];
       list($ruleFields, $threshold) = CRM_Dedupe_BAO_RuleGroup::dedupeRuleFieldsWeight($params);
       $weightSum = 0;
@@ -446,8 +446,8 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
           $softCreditFields[$i] = $mapperSoftCredit[$i];
         }
         $mapperSoftCreditType[$i] = [
-          'value' => isset($mapperKeys[$i][2]) ? $mapperKeys[$i][2] : '',
-          'label' => isset($softCreditTypes[$mapperKeys[$i][2]]) ? $softCreditTypes[$mapperKeys[$i][2]] : '',
+          'value' => $mapperKeys[$i][2] ?? '',
+          'label' => $softCreditTypes[$mapperKeys[$i][2]] ?? '',
         ];
       }
       else {
@@ -483,7 +483,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
         $updateMappingFields->name = $mapper[$i];
 
         //reuse contact_type field in db to store fields associated with soft credit
-        $updateMappingFields->contact_type = isset($mapperSoftCredit[$i]) ? $mapperSoftCredit[$i] : NULL;
+        $updateMappingFields->contact_type = $mapperSoftCredit[$i] ?? NULL;
         $updateMappingFields->save();
       }
     }
@@ -504,7 +504,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
         $saveMappingFields->name = $mapper[$i];
 
         //reuse contact_type field in db to store fields associated with soft credit
-        $saveMappingFields->contact_type = isset($mapperSoftCredit[$i]) ? $mapperSoftCredit[$i] : NULL;
+        $saveMappingFields->contact_type = $mapperSoftCredit[$i] ?? NULL;
         $saveMappingFields->save();
       }
       $this->set('savedMapping', $saveMappingFields->mapping_id);

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -109,7 +109,7 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
     foreach ($mapper as $key => $value) {
       $mapperKeys[$key] = $mapper[$key][0];
       if (isset($mapper[$key][0]) && $mapper[$key][0] == 'soft_credit' && isset($mapper[$key])) {
-        $mapperSoftCredit[$key] = isset($mapper[$key][1]) ? $mapper[$key][1] : '';
+        $mapperSoftCredit[$key] = $mapper[$key][1] ?? '';
         $mapperSoftCreditType[$key] = $mapperSoftCreditType[$key]['value'];
       }
       else {

--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -110,7 +110,7 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    */
   public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
     $actionSearchResult = $row->context['actionSearchResult'];
-    $fieldValue = isset($actionSearchResult->{"contrib_$field"}) ? $actionSearchResult->{"contrib_$field"} : NULL;
+    $fieldValue = $actionSearchResult->{"contrib_$field"} ?? NULL;
 
     $aliasTokens = $this->getAliasTokens();
     if (in_array($field, ['total_amount', 'fee_amount', 'net_amount'])) {

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -57,7 +57,7 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule {
    */
   public static function getMapping($id) {
     $mappings = self::getMappings();
-    return isset($mappings[$id]) ? $mappings[$id] : NULL;
+    return $mappings[$id] ?? NULL;
   }
 
   /**

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -121,7 +121,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
   public static function add(&$params, $fixAddress = FALSE) {
 
     $address = new CRM_Core_DAO_Address();
-    $checkPermissions = isset($params['check_permissions']) ? $params['check_permissions'] : TRUE;
+    $checkPermissions = $params['check_permissions'] ?? TRUE;
 
     // fixAddress mode to be done
     if ($fixAddress) {
@@ -548,12 +548,12 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       'supplemental_address_2' => $this->supplemental_address_2,
       'supplemental_address_3' => $this->supplemental_address_3,
       'city' => $this->city,
-      'state_province_name' => isset($this->state_name) ? $this->state_name : "",
-      'state_province' => isset($this->state) ? $this->state : "",
-      'postal_code' => isset($this->postal_code) ? $this->postal_code : "",
-      'postal_code_suffix' => isset($this->postal_code_suffix) ? $this->postal_code_suffix : "",
-      'country' => isset($this->country) ? $this->country : "",
-      'world_region' => isset($this->world_region) ? $this->world_region : "",
+      'state_province_name' => $this->state_name ?? "",
+      'state_province' => $this->state ?? "",
+      'postal_code' => $this->postal_code ?? "",
+      'postal_code_suffix' => $this->postal_code_suffix ?? "",
+      'country' => $this->country ?? "",
+      'world_region' => $this->world_region ?? "",
     ];
 
     if (isset($this->county_id) && $this->county_id) {
@@ -1033,7 +1033,7 @@ SELECT is_primary,
     }
 
     // Default to TRUE if not set to maintain api backward compatibility.
-    $createRelationship = isset($params['add_relationship']) ? $params['add_relationship'] : TRUE;
+    $createRelationship = $params['add_relationship'] ?? TRUE;
 
     // unset contact id
     $skipFields = ['is_primary', 'location_type_id', 'is_billing', 'contact_id'];

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -184,7 +184,7 @@ LIMIT 1;";
    */
   public static function getRefundTransactionTrxnID($contributionID) {
     $ids = self::getRefundTransactionIDs($contributionID);
-    return isset($ids['trxn_id']) ? $ids['trxn_id'] : NULL;
+    return $ids['trxn_id'] ?? NULL;
   }
 
   /**
@@ -392,7 +392,7 @@ WHERE ceft.entity_id = %1";
     if (!$amount) {
       return FALSE;
     }
-    $contributionId = isset($params['contribution']->id) ? $params['contribution']->id : $params['contribution_id'];
+    $contributionId = $params['contribution']->id ?? $params['contribution_id'];
     if (empty($params['financial_type_id'])) {
       $financialTypeId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'financial_type_id', 'id');
     }

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -870,17 +870,17 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
    * @return array
    */
   protected static function loadSavedMapping($mappingLocation, int $x, int $i, $mappingName, $mapperFields, $mappingContactType, $mappingRelation, array $specialFields, $mappingPhoneType, array $defaults, array $noneArray, $mappingImProvider, $mappingOperator, $mappingValue) {
-    $locationId = isset($mappingLocation[$x][$i]) ? $mappingLocation[$x][$i] : 0;
+    $locationId = $mappingLocation[$x][$i] ?? 0;
     if (isset($mappingName[$x][$i])) {
       if (is_array($mapperFields[$mappingContactType[$x][$i]])) {
 
         if (isset($mappingRelation[$x][$i])) {
-          $relLocationId = isset($mappingLocation[$x][$i]) ? $mappingLocation[$x][$i] : 0;
+          $relLocationId = $mappingLocation[$x][$i] ?? 0;
           if (!$relLocationId && in_array($mappingName[$x][$i], $specialFields)) {
             $relLocationId = " ";
           }
 
-          $relPhoneType = isset($mappingPhoneType[$x][$i]) ? $mappingPhoneType[$x][$i] : NULL;
+          $relPhoneType = $mappingPhoneType[$x][$i] ?? NULL;
 
           $defaults["mapper[$x][$i]"] = [
             $mappingContactType[$x][$i],
@@ -910,8 +910,8 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
           $noneArray[] = [$x, $i, 2];
         }
         else {
-          $phoneType = isset($mappingPhoneType[$x][$i]) ? $mappingPhoneType[$x][$i] : NULL;
-          $imProvider = isset($mappingImProvider[$x][$i]) ? $mappingImProvider[$x][$i] : NULL;
+          $phoneType = $mappingPhoneType[$x][$i] ?? NULL;
+          $imProvider = $mappingImProvider[$x][$i] ?? NULL;
           if (!$locationId && in_array($mappingName[$x][$i], $specialFields)) {
             $locationId = " ";
           }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -464,7 +464,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     if (isset($field->phone_type_id)) {
       $name .= "-{$field->phone_type_id}";
     }
-    $fieldMetaData = CRM_Utils_Array::value($name, $importableFields, (isset($importableFields[$field->field_name]) ? $importableFields[$field->field_name] : []));
+    $fieldMetaData = CRM_Utils_Array::value($name, $importableFields, ($importableFields[$field->field_name] ?? []));
 
     // No lie: this is bizarre; why do we need to mix so many UFGroup properties into UFFields?
     // I guess to make field self sufficient with all the required data and avoid additional calls
@@ -485,12 +485,12 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       'visibility' => $field->visibility,
       'in_selector' => $field->in_selector,
       'rule' => CRM_Utils_Array::value('rule', CRM_Utils_Array::value($field->field_name, $importableFields)),
-      'location_type_id' => isset($field->location_type_id) ? $field->location_type_id : NULL,
-      'website_type_id' => isset($field->website_type_id) ? $field->website_type_id : NULL,
-      'phone_type_id' => isset($field->phone_type_id) ? $field->phone_type_id : NULL,
+      'location_type_id' => $field->location_type_id ?? NULL,
+      'website_type_id' => $field->website_type_id ?? NULL,
+      'phone_type_id' => $field->phone_type_id ?? NULL,
       'group_id' => $group->id,
-      'add_to_group_id' => isset($group->add_to_group_id) ? $group->add_to_group_id : NULL,
-      'add_captcha' => isset($group->add_captcha) ? $group->add_captcha : NULL,
+      'add_to_group_id' => $group->add_to_group_id ?? NULL,
+      'add_captcha' => $group->add_captcha ?? NULL,
       'field_type' => $field->field_type,
       'field_id' => $field->id,
       'pseudoconstant' => CRM_Utils_Array::value(

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -175,7 +175,7 @@ class CRM_Core_Block {
     if (!(self::$_properties)) {
       self::initProperties();
     }
-    return isset(self::$_properties[$id][$property]) ? self::$_properties[$id][$property] : NULL;
+    return self::$_properties[$id][$property] ?? NULL;
   }
 
   /**
@@ -439,7 +439,7 @@ class CRM_Core_Block {
       $value['url'] = CRM_Utils_System::url($short['path'], $short['query'], FALSE);
     }
     $value['title'] = $short['title'];
-    $value['ref'] = isset($short['ref']) ? $short['ref'] : '';
+    $value['ref'] = $short['ref'] ?? '';
     if (!empty($short['shortCuts'])) {
       foreach ($short['shortCuts'] as $shortCut) {
         $value['shortCuts'][] = self::setShortcutValues($shortCut);

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -224,7 +224,7 @@ class CRM_Core_Config_MagicMerge {
     }
 
     $type = $this->map[$k][0];
-    $name = isset($this->map[$k][1]) ? $this->map[$k][1] : $k;
+    $name = $this->map[$k][1] ?? $k;
 
     switch ($type) {
       case 'setting':
@@ -358,7 +358,7 @@ class CRM_Core_Config_MagicMerge {
     }
     unset($this->cache[$k]);
     $type = $this->map[$k][0];
-    $name = isset($this->map[$k][1]) ? $this->map[$k][1] : $k;
+    $name = $this->map[$k][1] ?? $k;
 
     switch ($type) {
       case 'setting':

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -45,8 +45,8 @@ class CRM_Core_DAO_AllCoreTables {
         $entityType['name'],
         $entityType['class'],
         $entityType['table'],
-        isset($entityType['fields_callback']) ? $entityType['fields_callback'] : NULL,
-        isset($entityType['links_callback']) ? $entityType['links_callback'] : NULL
+        $entityType['fields_callback'] ?? NULL,
+        $entityType['links_callback'] ?? NULL
       );
     }
 

--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -44,5 +44,5 @@ function _civicrm_api3_permissions($entity, $action, &$params) {
   // Translate specific actions into their generic equivalents
   $action = CRM_Core_Permission::getGenericAction($action);
 
-  return isset($perm[$action]) ? $perm[$action] : $perm['default'];
+  return $perm[$action] ?? $perm['default'];
 }

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -570,7 +570,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     if (!empty(\Civi::$statics[__CLASS__]['userFrameworkLogging'])) {
       // should call $config->userSystem->logger($message) here - but I got a situation where userSystem was not an object - not sure why
       if ($config->userSystem->is_drupal and function_exists('watchdog')) {
-        watchdog('civicrm', '%message', ['%message' => $message], isset($priority) ? $priority : WATCHDOG_DEBUG);
+        watchdog('civicrm', '%message', ['%message' => $message], $priority ?? WATCHDOG_DEBUG);
       }
     }
 
@@ -1005,8 +1005,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function deprecatedFunctionWarning($newMethod) {
     $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-    $callerFunction = isset($dbt[1]['function']) ? $dbt[1]['function'] : NULL;
-    $callerClass = isset($dbt[1]['class']) ? $dbt[1]['class'] : NULL;
+    $callerFunction = $dbt[1]['function'] ?? NULL;
+    $callerClass = $dbt[1]['class'] ?? NULL;
     Civi::log()->warning("Deprecated function $callerClass::$callerFunction, use $newMethod.", ['civi.tag' => 'deprecated']);
   }
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -487,7 +487,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $this->ajaxResponse['buttonName'] = str_replace('_qf_' . $this->getAttribute('id') . '_', '', $this->controller->getButtonName());
       $this->ajaxResponse['action'] = $this->_action;
       if (isset($this->_id) || isset($this->id)) {
-        $this->ajaxResponse['id'] = isset($this->id) ? $this->id : $this->_id;
+        $this->ajaxResponse['id'] = $this->id ?? $this->_id;
       }
       CRM_Core_Page_AJAX::returnJsonResponse($this->ajaxResponse);
     }
@@ -1442,7 +1442,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // Handle custom field
     if (strpos($name, 'custom_') === 0 && is_numeric($name[7])) {
       list(, $id) = explode('_', $name);
-      $label = isset($props['label']) ? $props['label'] : CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'label', $id);
+      $label = $props['label'] ?? CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'label', $id);
       $gid = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'option_group_id', $id);
       if (CRM_Utils_Array::value('context', $props) != 'search') {
         $props['data-option-edit-path'] = array_key_exists('option_url', $props) ? $props['option_url'] : 'civicrm/admin/options/' . CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $gid);
@@ -1460,7 +1460,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           break;
         }
       }
-      $label = isset($props['label']) ? $props['label'] : $fieldSpec['title'];
+      $label = $props['label'] ?? $fieldSpec['title'];
       if (CRM_Utils_Array::value('context', $props) != 'search') {
         $props['data-option-edit-path'] = array_key_exists('option_url', $props) ? $props['option_url'] : CRM_Core_PseudoConstant::getOptionEditUrl($fieldSpec);
       }
@@ -1525,10 +1525,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // Core field - get metadata.
     $fieldSpec = civicrm_api3($props['entity'], 'getfield', $props);
     $fieldSpec = $fieldSpec['values'];
-    $fieldSpecLabel = isset($fieldSpec['html']['label']) ? $fieldSpec['html']['label'] : CRM_Utils_Array::value('title', $fieldSpec);
+    $fieldSpecLabel = $fieldSpec['html']['label'] ?? CRM_Utils_Array::value('title', $fieldSpec);
     $label = CRM_Utils_Array::value('label', $props, $fieldSpecLabel);
 
-    $widget = isset($props['type']) ? $props['type'] : $fieldSpec['html']['type'];
+    $widget = $props['type'] ?? $fieldSpec['html']['type'];
     if ($widget == 'TextArea' && $context == 'search') {
       $widget = 'Text';
     }
@@ -1547,7 +1547,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $options = $props['options'];
       }
       else {
-        $options = isset($fieldSpec['options']) ? $fieldSpec['options'] : NULL;
+        $options = $fieldSpec['options'] ?? NULL;
       }
       if ($context == 'search') {
         $widget = $widget == 'Select2' ? $widget : 'Select';
@@ -1579,7 +1579,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       case 'Number':
       case 'Email':
         //TODO: Autodetect ranges
-        $props['size'] = isset($props['size']) ? $props['size'] : 60;
+        $props['size'] = $props['size'] ?? 60;
         return $this->add(strtolower($widget), $name, $label, $props, $required);
 
       case 'hidden':
@@ -1587,8 +1587,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
       case 'TextArea':
         //Set default columns and rows for textarea.
-        $props['rows'] = isset($props['rows']) ? $props['rows'] : 4;
-        $props['cols'] = isset($props['cols']) ? $props['cols'] : 60;
+        $props['rows'] = $props['rows'] ?? 4;
+        $props['cols'] = $props['cols'] ?? 60;
         if (empty($props['maxlength']) && isset($fieldSpec['length'])) {
           $props['maxlength'] = $fieldSpec['length'];
         }
@@ -1610,7 +1610,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         }
 
       case 'Radio':
-        $separator = isset($props['separator']) ? $props['separator'] : NULL;
+        $separator = $props['separator'] ?? NULL;
         unset($props['separator']);
         if (!isset($props['allowClear'])) {
           $props['allowClear'] = !$required;
@@ -1645,13 +1645,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           $this->addYesNo($name, $label, TRUE, FALSE, $props);
           return;
         }
-        $text = isset($props['text']) ? $props['text'] : NULL;
+        $text = $props['text'] ?? NULL;
         unset($props['text']);
         return $this->addElement('checkbox', $name, $label, $text, $props);
 
       //add support for 'Advcheckbox' field
       case 'advcheckbox':
-        $text = isset($props['text']) ? $props['text'] : NULL;
+        $text = $props['text'] ?? NULL;
         unset($props['text']);
         return $this->addElement('advcheckbox', $name, $label, $text, $props);
 
@@ -1671,7 +1671,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         return $this->addEntityRef($name, $label, $props, $required);
 
       case 'Password':
-        $props['size'] = isset($props['size']) ? $props['size'] : 60;
+        $props['size'] = $props['size'] ?? 60;
         return $this->add('password', $name, $label, $props, $required);
 
       // Check datatypes of fields
@@ -1771,7 +1771,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return null
    */
   public function getVar($name) {
-    return isset($this->$name) ? $this->$name : NULL;
+    return $this->$name ?? NULL;
   }
 
   /**

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -238,7 +238,7 @@ class CRM_Core_Invoke {
         $result = $wrapper->run(
           CRM_Utils_Array::value('page_callback', $item),
           CRM_Utils_Array::value('title', $item),
-          isset($pageArgs) ? $pageArgs : NULL
+          $pageArgs ?? NULL
         );
       }
       else {

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -383,7 +383,7 @@ class CRM_Core_Page {
    * @return null
    */
   public function getVar($name) {
-    return isset($this->$name) ? $this->$name : NULL;
+    return $this->$name ?? NULL;
   }
 
   /**

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -124,7 +124,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
       'image/pjpeg' => 'image/jpeg',
 
     ];
-    return isset($badTypes[$type]) ? $badTypes[$type] : $type;
+    return $badTypes[$type] ?? $type;
   }
 
 }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -605,7 +605,7 @@ abstract class CRM_Core_Payment {
    * @return null
    */
   public function getVar($name) {
-    return isset($this->$name) ? $this->$name : NULL;
+    return $this->$name ?? NULL;
   }
 
   /**
@@ -1689,7 +1689,7 @@ INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
     }
 
     // Else default
-    return isset($this->_paymentProcessor['url_recur']) ? $this->_paymentProcessor['url_recur'] : '';
+    return $this->_paymentProcessor['url_recur'] ?? '';
   }
 
   /**

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -100,7 +100,7 @@ class CRM_Core_Payment_Form {
   protected static function addCommonFields(&$form, $paymentFields) {
     $requiredPaymentFields = $paymentFieldsMetadata = [];
     foreach ($paymentFields as $name => $field) {
-      $field['extra'] = isset($field['extra']) ? $field['extra'] : NULL;
+      $field['extra'] = $field['extra'] ?? NULL;
       if ($field['htmlType'] == 'chainSelect') {
         $form->addChainSelect($field['name'], ['required' => FALSE]);
       }

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -1103,7 +1103,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
   protected function mapPaypalParamsToCivicrmParams($fieldMap, $paypalParams) {
     $params = [];
     foreach ($fieldMap as $civicrmField => $paypalField) {
-      $params[$civicrmField] = isset($paypalParams[$paypalField]) ? $paypalParams[$paypalField] : NULL;
+      $params[$civicrmField] = $paypalParams[$paypalField] ?? NULL;
     }
     return $params;
   }

--- a/CRM/Core/Payment/Realex.php
+++ b/CRM/Core/Payment/Realex.php
@@ -276,7 +276,7 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
       if ($data['level'] == $depth) {
         switch ($data['type']) {
           case 'complete':
-            $output[$data['tag']] = isset($data['value']) ? $data['value'] : '';
+            $output[$data['tag']] = $data['value'] ?? '';
             break;
 
           case 'open':
@@ -364,7 +364,7 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
     $this->_setParam('country', $params['country']);
     $this->_setParam('post_code', $params['postal_code']);
     $this->_setParam('order_id', $params['invoiceID']);
-    $params['issue_number'] = (isset($params['issue_number']) ? $params['issue_number'] : '');
+    $params['issue_number'] = ($params['issue_number'] ?? '');
     $this->_setParam('issue_number', $params['issue_number']);
     $this->_setParam('varref', $params['contributionType_name']);
     $comment = $params['description'] . ' (page id:' . $params['contributionPageID'] . ')';

--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -41,7 +41,7 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
    */
   public function __construct($settings) {
     $this->redis = CRM_Utils_Cache_Redis::connect($settings);
-    $this->prefix = isset($settings['prefix']) ? $settings['prefix'] : '';
+    $this->prefix = $settings['prefix'] ?? '';
     $this->prefix .= \CRM_Utils_Cache::DELIMITER . 'prevnext' . \CRM_Utils_Cache::DELIMITER;
   }
 

--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -191,7 +191,7 @@ class CRM_Core_Region {
           break;
 
         case 'callback':
-          $args = isset($snippet['arguments']) ? $snippet['arguments'] : array(&$snippet, &$html);
+          $args = $snippet['arguments'] ?? array(&$snippet, &$html);
           $html .= call_user_func_array($snippet['callback'], $args);
           break;
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -276,7 +276,7 @@ class CRM_Core_Smarty extends Smarty {
     $oldVars = $this->get_template_vars();
     $backupFrame = [];
     foreach ($vars as $key => $value) {
-      $backupFrame[$key] = isset($oldVars[$key]) ? $oldVars[$key] : NULL;
+      $backupFrame[$key] = $oldVars[$key] ?? NULL;
     }
     $this->backupFrames[] = $backupFrame;
 

--- a/CRM/Core/Smarty/plugins/function.crmAttributes.php
+++ b/CRM/Core/Smarty/plugins/function.crmAttributes.php
@@ -27,6 +27,6 @@
  * @return string
  */
 function smarty_function_crmAttributes($params, &$smarty) {
-  $attributes = isset($params['a']) ? $params['a'] : [];
+  $attributes = $params['a'] ?? [];
   return CRM_Utils_String::htmlAttributes($attributes);
 }

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -140,7 +140,7 @@ class CRM_Custom_Form_CustomData {
     }
 
     $gid = (isset($form->_groupID)) ? $form->_groupID : NULL;
-    $getCachedTree = isset($form->_getCachedTree) ? $form->_getCachedTree : TRUE;
+    $getCachedTree = $form->_getCachedTree ?? TRUE;
 
     $subType = $form->_subType;
     if (!is_array($subType) && strstr($subType, CRM_Core_DAO::VALUE_SEPARATOR)) {

--- a/CRM/Custom/Page/Group.php
+++ b/CRM/Custom/Page/Group.php
@@ -296,7 +296,7 @@ class CRM_Custom_Page_Group extends CRM_Core_Page {
               }
             }
             else {
-              $colValue = $colValue ? ($colValue . (isset($subTypes[$type][$sub]) ? ', ' . $subTypes[$type][$sub] : '')) : (isset($subTypes[$type][$sub]) ? $subTypes[$type][$sub] : '');
+              $colValue = $colValue ? ($colValue . (isset($subTypes[$type][$sub]) ? ', ' . $subTypes[$type][$sub] : '')) : ($subTypes[$type][$sub] ?? '');
             }
           }
         }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1554,7 +1554,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           //add dataArray in the receipts in ADD and UPDATE condition
           $dataArray = [];
           if ($this->_action & CRM_Core_Action::ADD) {
-            $line = isset($lineItem[0]) ? $lineItem[0] : [];
+            $line = $lineItem[0] ?? [];
           }
           elseif ($this->_action & CRM_Core_Action::UPDATE) {
             $line = $this->_values['line_items'];

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -519,7 +519,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     //if payment done, no need to build the fee block.
     if (!empty($form->_paymentId)) {
       //fix to display line item in update mode.
-      $form->assign('priceSet', isset($form->_priceSet) ? $form->_priceSet : NULL);
+      $form->assign('priceSet', $form->_priceSet ?? NULL);
       return;
     }
 
@@ -686,7 +686,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
     $skipParticipants = $formattedPriceSetDefaults = [];
     if (!empty($form->_allowConfirmation) && (isset($form->_pId) || isset($form->_additionalParticipantId))) {
-      $participantId = isset($form->_pId) ? $form->_pId : $form->_additionalParticipantId;
+      $participantId = $form->_pId ?? $form->_additionalParticipantId;
       $pricesetDefaults = CRM_Event_Form_EventFees::setDefaultPriceSet($participantId,
         $form->_eventId
       );

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -189,7 +189,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->assign('participantCount', $participantCount);
       $this->assign('lineItems', $lineItems);
 
-      $taskParams['ssID'] = isset($this->_ssID) ? $this->_ssID : NULL;
+      $taskParams['ssID'] = $this->_ssID ?? NULL;
       $tasks = CRM_Event_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission(), $taskParams);
 
       if (isset($this->_ssID)) {

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -518,7 +518,7 @@ class CRM_Export_BAO_ExportProcessor {
    * @return string
    */
   public function getRelationshipValue($relationshipType, $contactID, $field) {
-    return isset($this->relatedContactValues[$relationshipType][$contactID][$field]) ? $this->relatedContactValues[$relationshipType][$contactID][$field] : '';
+    return $this->relatedContactValues[$relationshipType][$contactID][$field] ?? '';
   }
 
   /**

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -532,7 +532,7 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
 
     }
 
-    $ppID = (isset($dao->ppID1) && $dao->ppID1) ? $dao->ppID1 : (isset($dao->ppID2) ? $dao->ppID2 : NULL);
+    $ppID = (isset($dao->ppID1) && $dao->ppID1) ? $dao->ppID1 : ($dao->ppID2 ?? NULL);
     $mode = (isset($dao->is_test) && $dao->is_test) ? 'test' : 'live';
     if (!$ppID || $type == 'id') {
       $result = $ppID;

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -134,7 +134,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
         $groupValues = array(
           'id' => $this->_id,
           'title' => $this->_title,
-          'saved_search_id' => isset($this->_groupValues['saved_search_id']) ? $this->_groupValues['saved_search_id'] : '',
+          'saved_search_id' => $this->_groupValues['saved_search_id'] ?? '',
         );
         if (isset($this->_groupValues['saved_search_id'])) {
           $groupValues['mapping_id'] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch',

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -335,7 +335,7 @@ abstract class CRM_Import_Parser {
       file_put_contents($statusFile, $contents);
     }
     else {
-      $rowCount = isset($this->_rowCount) ? $this->_rowCount : $this->_lineCount;
+      $rowCount = $this->_rowCount ?? $this->_lineCount;
       $currTimestamp = time();
       $totalTime = ($currTimestamp - $startTimestamp);
       $time = ($currTimestamp - $prevTimestamp);

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1523,7 +1523,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   public static function create(&$params, $ids = []) {
 
     if (empty($params['id']) && (array_filter($ids) !== [])) {
-      $params['id'] = isset($ids['mailing_id']) ? $ids['mailing_id'] : $ids['id'];
+      $params['id'] = $ids['mailing_id'] ?? $ids['id'];
       \Civi::log('Parameter $ids is no longer used by Mailing::create. Use the api or just pass $params', ['civi.tag' => 'deprecated']);
     }
 

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -141,7 +141,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       return NULL;
     }
 
-    $contactId = isset($this->_contactID) ? $this->_contactID : 0;
+    $contactId = $this->_contactID ?? 0;
 
     $result = civicrm_api3('Mailing', 'preview', [
       'id' => $this->_mailingID,

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2636,9 +2636,9 @@ WHERE      civicrm_membership.is_test = 0
            * Update status
            */
           $status = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate(
-            isset($updates["start_date"]) ? $updates["start_date"] : $newMembership->start_date,
-            isset($updates["end_date"]) ? $updates["end_date"] : $newMembership->end_date,
-            isset($updates["join_date"]) ? $updates["join_date"] : $newMembership->join_date,
+            $updates["start_date"] ?? $newMembership->start_date,
+            $updates["end_date"] ?? $newMembership->end_date,
+            $updates["join_date"] ?? $newMembership->join_date,
             'today',
             FALSE,
             $newMembershipId,

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -76,8 +76,8 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
   public function postProcess() {
     // TODO: rewrite using contribution token and one letter by contribution
     $this->setContactIDs();
-    $skipOnHold = isset($this->skipOnHold) ? $this->skipOnHold : FALSE;
-    $skipDeceased = isset($this->skipDeceased) ? $this->skipDeceased : TRUE;
+    $skipOnHold = $this->skipOnHold ?? FALSE;
+    $skipDeceased = $this->skipDeceased ?? TRUE;
     CRM_Member_Form_Task_PDFLetterCommon::postProcessMembers(
       $this, $this->_memberIds, $skipOnHold, $skipDeceased, $this->_contactIds
     );

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -45,7 +45,7 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     $this->assign('dataValues', $this->_dataValues);
 
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-    $this->_onDuplicate = $this->get('onDuplicate', isset($onDuplicate) ? $onDuplicate : "");
+    $this->_onDuplicate = $this->get('onDuplicate', $onDuplicate ?? "");
 
     $highlightedFields = array();
     if ($skipColumnHeader) {
@@ -455,9 +455,9 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
         $updateMappingFields->column_number = $i;
 
         $mapperKeyParts = explode('_', $mapperKeys[$i][0], 3);
-        $id = isset($mapperKeyParts[0]) ? $mapperKeyParts[0] : NULL;
-        $first = isset($mapperKeyParts[1]) ? $mapperKeyParts[1] : NULL;
-        $second = isset($mapperKeyParts[2]) ? $mapperKeyParts[2] : NULL;
+        $id = $mapperKeyParts[0] ?? NULL;
+        $first = $mapperKeyParts[1] ?? NULL;
+        $second = $mapperKeyParts[2] ?? NULL;
         $updateMappingFields->name = $mapper[$i];
         $updateMappingFields->save();
       }
@@ -479,9 +479,9 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
         $saveMappingFields->column_number = $i;
 
         $mapperKeyParts = explode('_', $mapperKeys[$i][0], 3);
-        $id = isset($mapperKeyParts[0]) ? $mapperKeyParts[0] : NULL;
-        $first = isset($mapperKeyParts[1]) ? $mapperKeyParts[1] : NULL;
-        $second = isset($mapperKeyParts[2]) ? $mapperKeyParts[2] : NULL;
+        $id = $mapperKeyParts[0] ?? NULL;
+        $first = $mapperKeyParts[1] ?? NULL;
+        $second = $mapperKeyParts[2] ?? NULL;
         $saveMappingFields->name = $mapper[$i];
         $saveMappingFields->save();
       }

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -888,7 +888,7 @@ WHERE pcp.id = %1";
       'contribute' => 'civicrm_contribution_page',
       'civicrm_contribution_page' => 'civicrm_contribution_page',
     ];
-    return isset($entity_table_map[$component]) ? $entity_table_map[$component] : FALSE;
+    return $entity_table_map[$component] ?? FALSE;
   }
 
   /**

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -187,7 +187,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
       }
     }
     $session = CRM_Core_Session::singleton();
-    $contactID = isset($this->_contactID) ? $this->_contactID : $session->get('userID');
+    $contactID = $this->_contactID ?? $session->get('userID');
     if (!$contactID) {
       $contactID = $this->get('contactID');
     }

--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -53,7 +53,7 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
       $contactID = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP', $this->_id, 'contact_id');
     }
 
-    $this->_contactID = isset($contactID) ? $contactID : $session->get('userID');
+    $this->_contactID = $contactID ?? $session->get('userID');
     if (!$this->_pageId) {
       if (!$this->_id) {
         $msg = ts('We can\'t load the requested web page due to an incomplete link. This can be caused by using your browser\'s Back button or by using an incomplete or invalid link.');

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -841,7 +841,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $addCaptcha[$field['group_id']] = $field['add_captcha'];
       }
 
-      if (($name == 'email-Primary') || ($name == 'email-' . isset($primaryLocationType) ? $primaryLocationType : "")) {
+      if (($name == 'email-Primary') || ($name == 'email-' . $primaryLocationType ?? "")) {
         $emailPresent = TRUE;
         $this->_mail = $name;
       }

--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -315,7 +315,7 @@ class CRM_Queue_Runner {
     $result = [];
     $result['is_error'] = $isOK ? 0 : 1;
     $result['exception'] = $exception;
-    $result['last_task_title'] = isset($this->lastTaskTitle) ? $this->lastTaskTitle : '';
+    $result['last_task_title'] = $this->lastTaskTitle ?? '';
     $result['numberOfItems'] = $this->queue->numberOfItems();
     if ($result['numberOfItems'] <= 0) {
       // nothing to do

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -50,7 +50,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
       $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
       $params['domain_id'] = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
       // CRM-17256 set created_id on report creation.
-      $params['created_id'] = isset($params['created_id']) ? $params['created_id'] : CRM_Core_Session::getLoggedInContactID();
+      $params['created_id'] = $params['created_id'] ?? CRM_Core_Session::getLoggedInContactID();
     }
 
     if ($instanceID) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -756,7 +756,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         if (!empty($table[$fieldGrp]) && is_array($table[$fieldGrp])) {
           foreach ($table[$fieldGrp] as $fieldName => $field) {
             // $name is the field name used to reference the BAO/DAO export fields array
-            $name = isset($field['name']) ? $field['name'] : $fieldName;
+            $name = $field['name'] ?? $fieldName;
 
             // Sometimes the field name key in the BAO/DAO export fields array is
             // different from the actual database field name.
@@ -790,8 +790,8 @@ class CRM_Report_Form extends CRM_Core_Form {
             }
 
             // set alias = table-name, unless already set
-            $alias = isset($field['alias']) ? $field['alias'] : (
-              isset($this->_columns[$tableName]['alias']) ? $this->_columns[$tableName]['alias'] : $tableName
+            $alias = $field['alias'] ?? (
+              $this->_columns[$tableName]['alias'] ?? $tableName
             );
             $this->_columns[$tableName][$fieldGrp][$fieldName]['alias'] = $alias;
 

--- a/CRM/Report/Form/Case/TimeSpent.php
+++ b/CRM/Report/Form/Case/TimeSpent.php
@@ -340,13 +340,13 @@ class CRM_Report_Form_Case_TimeSpent extends CRM_Report_Form {
       if (isset($row['civicrm_activity_activity_type_id'])) {
         $entryFound = TRUE;
         $val = $row['civicrm_activity_activity_type_id'];
-        $rows[$rowNum]['civicrm_activity_activity_type_id'] = isset($this->activityTypes[$val]) ? $this->activityTypes[$val] : '';
+        $rows[$rowNum]['civicrm_activity_activity_type_id'] = $this->activityTypes[$val] ?? '';
       }
 
       if (isset($row['civicrm_activity_status_id'])) {
         $entryFound = TRUE;
         $val = $row['civicrm_activity_status_id'];
-        $rows[$rowNum]['civicrm_activity_status_id'] = isset($this->activityStatuses[$val]) ? $this->activityStatuses[$val] : '';
+        $rows[$rowNum]['civicrm_activity_status_id'] = $this->activityStatuses[$val] ?? '';
       }
 
       // The next two make it easier to make pivot tables after exporting to Excel

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -271,7 +271,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
       foreach ($ufJoinRecords as $key => $value) {
         $checked[$value] = 1;
       }
-      $defaults['uf_group_type'] = isset($checked) ? $checked : "";
+      $defaults['uf_group_type'] = $checked ?? "";
 
       $showAdvanced = 0;
       $advFields = [

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -621,7 +621,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
     foreach ($backend as $propertyName => $propertyValue) {
       if (isset($mappings[$propertyName][0]) && preg_match('/^setting/', $mappings[$propertyName][0])) {
         // $mapping format: $propertyName => Array(0 => $type, 1 => $setting|NULL).
-        $settingName = isset($mappings[$propertyName][1]) ? $mappings[$propertyName][1] : $propertyName;
+        $settingName = $mappings[$propertyName][1] ?? $propertyName;
         $settings[$settingName] = $propertyValue;
       }
     }

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -569,10 +569,10 @@ class CRM_Utils_Array {
       $node = &$result;
       foreach ($keys as $key) {
         if (is_array($record)) {
-          $keyvalue = isset($record[$key]) ? $record[$key] : NULL;
+          $keyvalue = $record[$key] ?? NULL;
         }
         else {
-          $keyvalue = isset($record->{$key}) ? $record->{$key} : NULL;
+          $keyvalue = $record->{$key} ?? NULL;
         }
         if (isset($node[$keyvalue]) && !is_array($node[$keyvalue])) {
           $node[$keyvalue] = [];

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -60,8 +60,8 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
    * @return Redis
    */
   public static function connect($config) {
-    $host = isset($config['host']) ? $config['host'] : self::DEFAULT_HOST;
-    $port = isset($config['port']) ? $config['port'] : self::DEFAULT_PORT;
+    $host = $config['host'] ?? self::DEFAULT_HOST;
+    $port = $config['port'] ?? self::DEFAULT_PORT;
     // Ugh.
     $pass = CRM_Utils_Constant::value('CIVICRM_DB_CACHE_PASSWORD');
     $id = implode(':', ['connect', $host, $port /* $pass is constant */]);

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1093,7 +1093,7 @@ class CRM_Utils_Date {
     $from['H'] = $from['i'] = $from['s'] = 0;
     $relativeTermParts = explode('_', $relativeTerm);
     $relativeTermPrefix = $relativeTermParts[0];
-    $relativeTermSuffix = isset($relativeTermParts[1]) ? $relativeTermParts[1] : '';
+    $relativeTermSuffix = $relativeTermParts[1] ?? '';
 
     switch ($unit) {
       case 'year':

--- a/CRM/Utils/Migrate/Export.php
+++ b/CRM/Utils/Migrate/Export.php
@@ -386,8 +386,8 @@ class CRM_Utils_Migrate_Export {
    * @param null $sql
    */
   public function fetch($groupName, $daoName, $sql = NULL) {
-    $idNameFields = isset($this->_xml[$groupName]['idNameFields']) ? $this->_xml[$groupName]['idNameFields'] : NULL;
-    $mappedFields = isset($this->_xml[$groupName]['mappedFields']) ? $this->_xml[$groupName]['mappedFields'] : NULL;
+    $idNameFields = $this->_xml[$groupName]['idNameFields'] ?? NULL;
+    $mappedFields = $this->_xml[$groupName]['mappedFields'] ?? NULL;
 
     $dao = new $daoName();
     if ($sql) {

--- a/CRM/Utils/SQL/Delete.php
+++ b/CRM/Utils/SQL/Delete.php
@@ -89,7 +89,7 @@ class CRM_Utils_SQL_Delete extends CRM_Utils_SQL_BaseParamQuery {
    */
   public function __construct($from, $options = []) {
     $this->from = $from;
-    $this->mode = isset($options['mode']) ? $options['mode'] : self::INTERPOLATE_AUTO;
+    $this->mode = $options['mode'] ?? self::INTERPOLATE_AUTO;
   }
 
   /**

--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -111,7 +111,7 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
    */
   public function __construct($from, $options = []) {
     $this->from = $from;
-    $this->mode = isset($options['mode']) ? $options['mode'] : self::INTERPOLATE_AUTO;
+    $this->mode = $options['mode'] ?? self::INTERPOLATE_AUTO;
   }
 
   /**

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -836,9 +836,9 @@ class CRM_Utils_String {
    */
   public static function simpleParseUrl($url) {
     $parts = parse_url($url);
-    $host = isset($parts['host']) ? $parts['host'] : '';
+    $host = $parts['host'] ?? '';
     $port = isset($parts['port']) ? ':' . $parts['port'] : '';
-    $path = isset($parts['path']) ? $parts['path'] : '';
+    $path = $parts['path'] ?? '';
     $query = isset($parts['query']) ? '?' . $parts['query'] : '';
     return [
       'host+port' => "$host$port",

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -723,7 +723,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   public function getLoggedInUfID() {
     $ufID = NULL;
     $current_user = $this->getLoggedInUserObject();
-    return isset($current_user->ID) ? $current_user->ID : NULL;
+    return $current_user->ID ?? NULL;
   }
 
   /**

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -237,7 +237,7 @@ class CRM_Utils_VersionCheck {
       $this->stats['extensions'][] = [
         'name' => $dao->full_name,
         'enabled' => $dao->is_active,
-        'version' => isset($info->version) ? $info->version : NULL,
+        'version' => $info->version ?? NULL,
       ];
     }
   }

--- a/Civi/API/Provider/ReflectionProvider.php
+++ b/Civi/API/Provider/ReflectionProvider.php
@@ -134,7 +134,7 @@ class ReflectionProvider implements EventSubscriberInterface, ProviderInterface 
    */
   public function getActionNames($version, $entity) {
     $entity = _civicrm_api_get_camel_name($entity, $version);
-    return isset($this->actions[$entity]) ? $this->actions[$entity] : $this->actions['*'];
+    return $this->actions[$entity] ?? $this->actions['*'];
   }
 
 }

--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -73,7 +73,7 @@ class AngularLoader {
     $this->res = \CRM_Core_Resources::singleton();
     $this->angular = \Civi::service('angular');
     $this->region = \CRM_Utils_Request::retrieve('snippet', 'String') ? 'ajax-snippet' : 'html-header';
-    $this->pageName = isset($_GET['q']) ? $_GET['q'] : NULL;
+    $this->pageName = $_GET['q'] ?? NULL;
     $this->modules = [];
   }
 

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -43,7 +43,7 @@ abstract class AbstractCreateAction extends AbstractAction {
    * @return mixed|null
    */
   public function getValue(string $fieldName) {
-    return isset($this->values[$fieldName]) ? $this->values[$fieldName] : NULL;
+    return $this->values[$fieldName] ?? NULL;
   }
 
   /**

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -57,7 +57,7 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
    * @return mixed|null
    */
   public function getValue(string $fieldName) {
-    return isset($this->values[$fieldName]) ? $this->values[$fieldName] : NULL;
+    return $this->values[$fieldName] ?? NULL;
   }
 
   /**

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -108,9 +108,9 @@ trait ArrayQueryActionTrait {
     if (!is_array($condition)) {
       throw new NotImplementedException('Unexpected where syntax; expecting array.');
     }
-    $value = isset($row[$condition[0]]) ? $row[$condition[0]] : NULL;
+    $value = $row[$condition[0]] ?? NULL;
     $operator = $condition[1];
-    $expected = isset($condition[2]) ? $condition[2] : NULL;
+    $expected = $condition[2] ?? NULL;
     switch ($operator) {
       case '=':
       case '!=':

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -144,7 +144,7 @@ class SpecFormatter {
    * @param string $dataTypeName
    */
   public static function setInputTypeAndAttrs(FieldSpec &$fieldSpec, $data, $dataTypeName) {
-    $inputType = isset($data['html']['type']) ? $data['html']['type'] : ArrayHelper::value('html_type', $data);
+    $inputType = $data['html']['type'] ?? ArrayHelper::value('html_type', $data);
     $inputAttrs = ArrayHelper::value('html', $data, []);
     unset($inputAttrs['type']);
 

--- a/Civi/CiUtil/Command/CompareCommand.php
+++ b/Civi/CiUtil/Command/CompareCommand.php
@@ -71,7 +71,7 @@ class CompareCommand {
     foreach ($tests as $test) {
       $values = [];
       foreach ($suites as $suite) {
-        $values[] = isset($suite['results'][$test]) ? $suite['results'][$test] : 'MISSING';
+        $values[] = $suite['results'][$test] ?? 'MISSING';
       }
 
       if (count(array_unique($values)) > 1) {

--- a/Civi/Core/CiviEventInspector.php
+++ b/Civi/Core/CiviEventInspector.php
@@ -133,7 +133,7 @@ class CiviEventInspector {
    * @return CiviEventInspector
    */
   public function add($eventDef) {
-    $name = isset($eventDef['name']) ? $eventDef['name'] : NULL;
+    $name = $eventDef['name'] ?? NULL;
 
     if (!isset($eventDef['type'])) {
       $eventDef['type'] = preg_match('/^hook_/', $eventDef['name']) ? 'hook' : 'object';

--- a/Civi/Core/Resolver.php
+++ b/Civi/Core/Resolver.php
@@ -197,7 +197,7 @@ class ResolverApi {
     }
 
     $result = civicrm_api3($this->url['host'], ltrim($this->url['path'], '/'), $apiParams);
-    return isset($result['values']) ? $result['values'] : NULL;
+    return $result['values'] ?? NULL;
   }
 
   /**

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -179,7 +179,7 @@ class SettingsBag {
    */
   public function get($key) {
     $all = $this->all();
-    return isset($all[$key]) ? $all[$key] : NULL;
+    return $all[$key] ?? NULL;
   }
 
   /**
@@ -190,7 +190,7 @@ class SettingsBag {
    * @return mixed|NULL
    */
   public function getDefault($key) {
-    return isset($this->defaults[$key]) ? $this->defaults[$key] : NULL;
+    return $this->defaults[$key] ?? NULL;
   }
 
   /**
@@ -202,7 +202,7 @@ class SettingsBag {
    * @return mixed|NULL
    */
   public function getExplicit($key) {
-    return (isset($this->values[$key]) ? $this->values[$key] : NULL);
+    return ($this->values[$key] ?? NULL);
   }
 
   /**
@@ -213,7 +213,7 @@ class SettingsBag {
    * @return mixed|NULL
    */
   public function getMandatory($key) {
-    return isset($this->mandatory[$key]) ? $this->mandatory[$key] : NULL;
+    return $this->mandatory[$key] ?? NULL;
   }
 
   /**

--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -291,7 +291,7 @@ class SettingsManager {
 
     if (is_array($civicrm_setting)) {
       foreach ($civicrm_setting as $oldGroup => $values) {
-        $newGroup = isset($rewriteGroups[$oldGroup]) ? $rewriteGroups[$oldGroup] : 'domain';
+        $newGroup = $rewriteGroups[$oldGroup] ?? 'domain';
         $result[$newGroup] = array_merge($result[$newGroup], $values);
       }
     }

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -97,7 +97,7 @@ class Themes {
    */
   public function get($themeKey) {
     $all = $this->getAll();
-    return isset($all[$themeKey]) ? $all[$themeKey] : NULL;
+    return $all[$themeKey] ?? NULL;
   }
 
   /**

--- a/Civi/Core/Transaction/Manager.php
+++ b/Civi/Core/Transaction/Manager.php
@@ -129,7 +129,7 @@ class Manager {
    * @return \Civi\Core\Transaction\Frame
    */
   public function getFrame() {
-    return isset($this->frames[0]) ? $this->frames[0] : NULL;
+    return $this->frames[0] ?? NULL;
   }
 
   /**

--- a/Civi/Test/GenericAssertionsTrait.php
+++ b/Civi/Test/GenericAssertionsTrait.php
@@ -100,7 +100,7 @@ trait GenericAssertionsTrait {
   public function assertArrayValueNotNull($key, &$list) {
     $this->assertArrayKeyExists($key, $list);
 
-    $value = isset($list[$key]) ? $list[$key] : NULL;
+    $value = $list[$key] ?? NULL;
     $this->assertTrue($value,
       sprintf("%s element not null?", $key)
     );

--- a/Civi/Test/Schema.php
+++ b/Civi/Test/Schema.php
@@ -27,7 +27,7 @@ class Schema {
     $tables = $pdo->query($query);
     $result = [];
     foreach ($tables as $table) {
-      $result[] = isset($table['TABLE_NAME']) ? $table['TABLE_NAME'] : $table['table_name'];
+      $result[] = $table['TABLE_NAME'] ?? $table['table_name'];
     }
     return $result;
   }

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -644,13 +644,13 @@ function _civicrm_api3_activity_fill_activity_contact_names(&$activities, $param
     $recordType = $typeMap[$activityContact['record_type_id']];
     if (in_array($recordType, ['target', 'assignee'])) {
       $activities[$activityContact['activity_id']][$recordType . '_contact_id'][] = $contactID;
-      $activities[$activityContact['activity_id']][$recordType . '_contact_name'][$contactID] = isset($activityContact['contact_id.display_name']) ? $activityContact['contact_id.display_name'] : '';
-      $activities[$activityContact['activity_id']][$recordType . '_contact_sort_name'][$contactID] = isset($activityContact['contact_id.sort_name']) ? $activityContact['contact_id.sort_name'] : '';
+      $activities[$activityContact['activity_id']][$recordType . '_contact_name'][$contactID] = $activityContact['contact_id.display_name'] ?? '';
+      $activities[$activityContact['activity_id']][$recordType . '_contact_sort_name'][$contactID] = $activityContact['contact_id.sort_name'] ?? '';
     }
     else {
       $activities[$activityContact['activity_id']]['source_contact_id'] = $contactID;
-      $activities[$activityContact['activity_id']]['source_contact_name'] = isset($activityContact['contact_id.display_name']) ? $activityContact['contact_id.display_name'] : '';
-      $activities[$activityContact['activity_id']]['source_contact_sort_name'] = isset($activityContact['contact_id.sort_name']) ? $activityContact['contact_id.sort_name'] : '';
+      $activities[$activityContact['activity_id']]['source_contact_name'] = $activityContact['contact_id.display_name'] ?? '';
+      $activities[$activityContact['activity_id']]['source_contact_sort_name'] = $activityContact['contact_id.sort_name'] ?? '';
     }
   }
 }

--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -385,7 +385,7 @@ function _civicrm_api3_attachment_parse_params($params) {
 
   $isTrusted = empty($params['check_permissions']);
 
-  $returns = isset($params['return']) ? $params['return'] : [];
+  $returns = $params['return'] ?? [];
   $returns = is_array($returns) ? $returns : [$returns];
   $returnContent = in_array('content', $returns);
 

--- a/api/v3/CaseContact.php
+++ b/api/v3/CaseContact.php
@@ -82,7 +82,7 @@ function _civicrm_api3_case_contact_getlist_output($result, $request, $entity, $
         $row['case_id.subject'],
       ];
       if (!empty($request['image_field'])) {
-        $data['image'] = isset($row[$request['image_field']]) ? $row[$request['image_field']] : '';
+        $data['image'] = $row[$request['image_field']] ?? '';
       }
       $output[] = $data;
     }

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1036,7 +1036,7 @@ function civicrm_api3_contact_getquick($params) {
   while ($dao->fetch()) {
     $t = ['id' => $dao->id];
     foreach ($as as $k) {
-      $t[$k] = isset($dao->$k) ? $dao->$k : '';
+      $t[$k] = $dao->$k ?? '';
     }
     $t['data'] = $dao->data;
     // Replace keys with values when displaying fields from an option list
@@ -1570,7 +1570,7 @@ function _civicrm_api3_contact_getlist_output($result, $request) {
         $data['description'][] = implode(' ', $address);
       }
       if (!empty($request['image_field'])) {
-        $data['image'] = isset($row[$request['image_field']]) ? $row[$request['image_field']] : '';
+        $data['image'] = $row[$request['image_field']] ?? '';
       }
       else {
         $data['icon_class'] = $row['contact_type'];

--- a/api/v3/EntityTag.php
+++ b/api/v3/EntityTag.php
@@ -159,7 +159,7 @@ function civicrm_api3_entity_tag_replace($params) {
     // Lookup pre-existing records
     $preexisting = civicrm_api3('entity_tag', 'get', $baseParams);
     $preexisting = array_column($preexisting['values'], 'tag_id');
-    $toAdd = isset($params['tag_id']) ? $params['tag_id'] : array_column($params['values'], 'tag_id');
+    $toAdd = $params['tag_id'] ?? array_column($params['values'], 'tag_id');
     $toRemove = array_diff($preexisting, $toAdd);
 
     $result = [];

--- a/api/v3/Generic/Getlist.php
+++ b/api/v3/Generic/Getlist.php
@@ -182,7 +182,7 @@ function _civicrm_api3_generic_getlist_output($result, $request, $entity, $field
         }
       };
       if (!empty($request['image_field'])) {
-        $data['image'] = isset($row[$request['image_field']]) ? $row[$request['image_field']] : '';
+        $data['image'] = $row[$request['image_field']] ?? '';
       }
       if (isset($row[$request['color_field']])) {
         $data['color'] = $row[$request['color_field']];
@@ -210,10 +210,10 @@ function _civicrm_api3_generic_getlist_postprocess($result, $request, &$values) 
   if (!empty($result['values'])) {
     foreach (array_values($result['values']) as $num => $row) {
       foreach ($request['extra'] as $field) {
-        $values[$num]['extra'][$field] = isset($row[$field]) ? $row[$field] : NULL;
+        $values[$num]['extra'][$field] = $row[$field] ?? NULL;
       }
       foreach ($chains as $chain) {
-        $values[$num][$chain] = isset($row[$chain]) ? $row[$chain] : NULL;
+        $values[$num][$chain] = $row[$chain] ?? NULL;
       }
     }
   }

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -442,17 +442,17 @@ function _civicrm_api3_profile_getbillingpseudoprofile(&$params) {
 
   if (!empty($result['api.address.get.1']['count'])) {
     foreach ($addressFields as $fieldname) {
-      $values['billing_' . $fieldname . '-' . $locationTypeID] = isset($result['api.address.get.1']['values'][0][$fieldname]) ? $result['api.address.get.1']['values'][0][$fieldname] : '';
+      $values['billing_' . $fieldname . '-' . $locationTypeID] = $result['api.address.get.1']['values'][0][$fieldname] ?? '';
     }
   }
   elseif (!empty($result['api.address.get.2']['count'])) {
     foreach ($addressFields as $fieldname) {
-      $values['billing_' . $fieldname . '-' . $locationTypeID] = isset($result['api.address.get.2']['values'][0][$fieldname]) ? $result['api.address.get.2']['values'][0][$fieldname] : '';
+      $values['billing_' . $fieldname . '-' . $locationTypeID] = $result['api.address.get.2']['values'][0][$fieldname] ?? '';
     }
   }
   else {
     foreach ($addressFields as $fieldname) {
-      $values['billing_' . $fieldname . '-' . $locationTypeID] = isset($result[$fieldname]) ? $result[$fieldname] : '';
+      $values['billing_' . $fieldname . '-' . $locationTypeID] = $result[$fieldname] ?? '';
     }
   }
 

--- a/api/v3/UFGroup.php
+++ b/api/v3/UFGroup.php
@@ -135,7 +135,7 @@ function _civicrm_api3_uf_group_getlist_output($result, $request, $entity, $fiel
         }
       };
       if (!empty($request['image_field'])) {
-        $data['image'] = isset($row[$request['image_field']]) ? $row[$request['image_field']] : '';
+        $data['image'] = $row[$request['image_field']] ?? '';
       }
       $output[] = $data;
     }

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -211,7 +211,7 @@ class civicrm_cli {
         }
         // all other arguments are parameters
         $key = ltrim($arg, '--');
-        $this->_params[$key] = isset($value) ? $value : NULL;
+        $this->_params[$key] = $value ?? NULL;
       }
     }
     return TRUE;

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -67,7 +67,7 @@ function civicrm_main(&$config) {
   global $sqlPath, $crmPath, $cmsPath, $installType;
 
   if ($installType == 'drupal') {
-    $siteDir = isset($config['site_dir']) ? $config['site_dir'] : getSiteDir($cmsPath, $_SERVER['SCRIPT_FILENAME']);
+    $siteDir = $config['site_dir'] ?? getSiteDir($cmsPath, $_SERVER['SCRIPT_FILENAME']);
     civicrm_setup($cmsPath . DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . $siteDir . DIRECTORY_SEPARATOR . 'files'
     );
   }
@@ -212,7 +212,7 @@ function civicrm_config(&$config) {
     'dbName' => addslashes($config['mysql']['database']),
   );
 
-  $params['baseURL'] = isset($config['base_url']) ? $config['base_url'] : civicrm_cms_base();
+  $params['baseURL'] = $config['base_url'] ?? civicrm_cms_base();
   if ($installType == 'drupal' && defined('VERSION')) {
     if (version_compare(VERSION, '8.0') >= 0) {
       $params['cms'] = 'Drupal';

--- a/install/index.php
+++ b/install/index.php
@@ -129,7 +129,7 @@ $installTypeToUF = array(
   'backdrop' => 'Backdrop',
 );
 
-$uf = (isset($installTypeToUF[$installType]) ? $installTypeToUF[$installType] : 'Drupal');
+$uf = ($installTypeToUF[$installType] ?? 'Drupal');
 define('CIVICRM_UF', $uf);
 
 // Set the Locale (required by CRM_Core_Config)
@@ -1916,7 +1916,7 @@ function getSiteDir($cmsPath, $str) {
     preg_quote($modules, CIVICRM_DIRECTORY_SEPARATOR) . "/",
     $_SERVER['SCRIPT_FILENAME'], $matches
   );
-  $siteDir = isset($matches[1]) ? $matches[1] : 'default';
+  $siteDir = $matches[1] ?? 'default';
 
   if (strtolower($siteDir) == 'all') {
     // For this case - use drupal's way of finding out multi-site directory

--- a/setup/plugins/blocks/requirements.tpl.php
+++ b/setup/plugins/blocks/requirements.tpl.php
@@ -37,7 +37,7 @@ uasort($msgs, function($a, $b) {
   <?php foreach ($msgs as $msg):?>
   <tr class="<?php echo 'reqSeverity-' . $msg['severity']; ?>">
     <td><?php echo htmlentities($_tpl_block['severity_labels'][$msg['severity']]); ?></td>
-    <td><?php echo htmlentities(isset($_tpl_block['section_labels'][$msg['section']]) ? $_tpl_block['section_labels'][$msg['section']] : $msg['section']); ?></td>
+    <td><?php echo htmlentities($_tpl_block['section_labels'][$msg['section']] ?? $msg['section']); ?></td>
     <td><?php echo htmlentities($msg['name']); ?></td>
     <td><?php echo htmlentities($msg['message']); ?></td>
   </tr>

--- a/setup/src/Setup/DrupalUtil.php
+++ b/setup/src/Setup/DrupalUtil.php
@@ -47,7 +47,7 @@ class DrupalUtil {
     preg_quote($modules, DIRECTORY_SEPARATOR) . "/",
     $_SERVER['SCRIPT_FILENAME'], $matches
     );
-    $siteDir = isset($matches[1]) ? $matches[1] : 'default';
+    $siteDir = $matches[1] ?? 'default';
 
     if (strtolower($siteDir) == 'all') {
     // For this case - use drupal's way of finding out multi-site directory

--- a/setup/src/Setup/Model.php
+++ b/setup/src/Setup/Model.php
@@ -176,7 +176,7 @@ class Model {
     $field = array_merge($defaults, $field);
 
     if (array_key_exists('value', $field) || !array_key_exists($field['name'], $this->values)) {
-      $this->values[$field['name']] = isset($field['value']) ? $field['value'] : NULL;
+      $this->values[$field['name']] = $field['value'] ?? NULL;
       unset($field['value']);
     }
 
@@ -202,10 +202,10 @@ class Model {
    */
   public function getField($field, $property = NULL) {
     if ($property) {
-      return isset($this->fields[$field][$property]) ? $this->fields[$field][$property] : NULL;
+      return $this->fields[$field][$property] ?? NULL;
     }
     else {
-      return isset($this->fields[$field]) ? $this->fields[$field] : NULL;
+      return $this->fields[$field] ?? NULL;
     }
   }
 

--- a/setup/src/Setup/UI/SetupController.php
+++ b/setup/src/Setup/UI/SetupController.php
@@ -209,7 +209,7 @@ class SetupController implements SetupControllerInterface {
   }
 
   public function getUrl($name) {
-    return isset($this->urls[$name]) ? $this->urls[$name] : NULL;
+    return $this->urls[$name] ?? NULL;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Automatic refactor to replace an older code pattern with a new one.

Before
----------------------------------------
`isset($foo) ? $foo : $bar`

After
----------------------------------------
`$foo ?? $bar`

Technical Details
--------------------------------
Before/after are exactly the same, just uses a more concise notation.

Comments
----------------------------------------
Used a regex with backreference to ensure that before/after are exactly the same.
