### PR TITLE
Find all the tests that rely on ad-hoc resetting of this static

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5331,10 +5331,6 @@ LIMIT 1;";
       $membershipParams['is_override'] = FALSE;
       $membershipParams['status_override_end_date'] = 'null';
 
-      //CRM-17723 - reset static $relatedContactIds array()
-      // @todo move it to Civi Statics.
-      $var = TRUE;
-      CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
       civicrm_api3('Membership', 'create', $membershipParams);
     }
   }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1325,25 +1325,14 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @param CRM_Core_DAO $dao
    *   Membership object.
    *
-   * @param bool $reset
-   *
    * @return array|null
    *   Membership details, if created.
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function createRelatedMemberships(&$params, &$dao, $reset = FALSE) {
-    // CRM-4213 check for loops, using static variable to record contacts already processed.
-    if (!isset(\Civi::$statics[__CLASS__]['related_contacts'])) {
-      \Civi::$statics[__CLASS__]['related_contacts'] = [];
-    }
-    if ($reset) {
-      // CRM-17723.
-      unset(\Civi::$statics[__CLASS__]['related_contacts']);
-      return FALSE;
-    }
-    $relatedContactIds = &\Civi::$statics[__CLASS__]['related_contacts'];
+  public static function createRelatedMemberships(&$params, &$dao) {
+    $relatedContactIds = [];
 
     $membership = new CRM_Member_DAO_Membership();
     $membership->id = $dao->id;
@@ -1351,7 +1340,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
     // required since create method doesn't return all the
     // parameters in the returned membership object
     if (!$membership->find(TRUE)) {
-      return;
+      return NULL;
     }
     $deceasedStatusId = array_search('Deceased', CRM_Member_PseudoConstant::membershipStatus());
     // FIXME : While updating/ renewing the
@@ -1402,6 +1391,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
 
     //lets cleanup related membership if any.
     if (empty($relatedContacts)) {
+      // This is deeply truely madly wrong - refer to function name....
       self::deleteRelatedMemberships($membership->id);
     }
     else {

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -2089,10 +2089,6 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->assertEquals($organizationMembershipID, $expiredInheritedRelationship['owner_membership_id']);
     $this->assertMembershipStatus('Grace', (int) $expiredInheritedRelationship['status_id']);
 
-    // Reset static $relatedContactIds array in createRelatedMemberships(),
-    // to avoid bug where inherited membership gets deleted.
-    $var = TRUE;
-    CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
     // Check that after running process_membership job, statuses are correct.
     $this->callAPISuccess('Job', 'process_membership', []);
 


### PR DESCRIPTION
Remove static from createRelatedMemberships

If you do 2 updates on a membership it can result in related memberships being deleted as they are treated as
'already processed'. This static was added to prevent a loop a la https://issues.civicrm.org/jira/browse/CRM-4213

However, we need a better method - ie a DB lookup because this has caused ongoing related bugs - latest being
https://lab.civicrm.org/dev/membership/issues/21 because it's too clunky & unreliable

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
