### PR TITLE
Remove deprecated parameter

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2389,17 +2389,12 @@ WHERE      civicrm_membership.is_test = 0
    *
    * @param array $params
    *   Array of submitted params.
-   * @param array $ids
-   *   (@return CRM_Contribute_BAO_Contribution
    *
    * @return CRM_Contribute_BAO_Contribution
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function recordMembershipContribution(&$params, $ids = []) {
-    if (!empty($ids)) {
-      CRM_Core_Error::deprecatedFunctionWarning('no $ids array');
-    }
+  public static function recordMembershipContribution(&$params) {
     $membershipId = $params['membership_id'];
     $contributionParams = [];
     $config = CRM_Core_Config::singleton();


### PR DESCRIPTION


Overview
----------------------------------------
This parameter was deprecated a while back - we obviously used caution at the time
but we can remove it now

Before
----------------------------------------
Function signature is 
```
public static function recordMembershipContribution(&$params, $ids = []) {
```
but $ids is unused & deprecated

After
----------------------------------------
function signature is 
```
public static function recordMembershipContribution(&$params) {
```

Technical Details
----------------------------------------
Generally we leave a deprecation notice for a minimum of 6 months & then clean up deprecated code ad hoc - this has served it's time

Comments
----------------------------------------

