### PR TITLE
[REF] Simplify obtuse boolean expressions

### DIFF
--- a/CRM/Campaign/Form/Search/Campaign.php
+++ b/CRM/Campaign/Form/Search/Campaign.php
@@ -45,7 +45,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
     $this->_searchTab = CRM_Utils_Request::retrieve('type', 'String', $this, FALSE, 'campaign');
 
     //when we do load tab, lets load the default objects.
-    $this->assign('force', ($this->_force || $this->_searchTab) ? TRUE : FALSE);
+    $this->assign('force', $this->_force || $this->_searchTab);
     $this->assign('searchParams', json_encode($this->get('searchParams')));
     $this->assign('buildSelector', $this->_search);
     $this->assign('searchFor', $this->_searchTab);

--- a/CRM/Campaign/Form/Search/Petition.php
+++ b/CRM/Campaign/Form/Search/Petition.php
@@ -36,7 +36,7 @@ class CRM_Campaign_Form_Search_Petition extends CRM_Core_Form {
     $this->_searchTab = CRM_Utils_Request::retrieve('type', 'String', $this, FALSE, 'petition');
 
     //when we do load tab, lets load the default objects.
-    $this->assign('force', ($this->_force || $this->_searchTab) ? TRUE : FALSE);
+    $this->assign('force', $this->_force || $this->_searchTab);
     $this->assign('searchParams', json_encode($this->get('searchParams')));
     $this->assign('buildSelector', $this->_search);
     $this->assign('searchFor', $this->_searchTab);

--- a/CRM/Campaign/Form/Search/Survey.php
+++ b/CRM/Campaign/Form/Search/Survey.php
@@ -36,7 +36,7 @@ class CRM_Campaign_Form_Search_Survey extends CRM_Core_Form {
     $this->_searchTab = CRM_Utils_Request::retrieve('type', 'String', $this, FALSE, 'survey');
 
     //when we do load tab, lets load the default objects.
-    $this->assign('force', ($this->_force || $this->_searchTab) ? TRUE : FALSE);
+    $this->assign('force', $this->_force || $this->_searchTab);
     $this->assign('searchParams', json_encode($this->get('searchParams')));
     $this->assign('buildSelector', $this->_search);
     $this->assign('searchFor', $this->_searchTab);

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2550,15 +2550,15 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
       if (in_array($actTypeName, $singletonNames)) {
         $allow = FALSE;
         if ($operation == 'File On Case') {
-          $allow = (in_array($actTypeName, $doNotFileNames)) ? FALSE : TRUE;
+          $allow = !in_array($actTypeName, $doNotFileNames);
         }
         if (in_array($operation, $actionOperations)) {
           $allow = TRUE;
           if ($operation == 'edit') {
-            $allow = (in_array($actTypeName, $allowEditNames)) ? TRUE : FALSE;
+            $allow = in_array($actTypeName, $allowEditNames);
           }
           elseif ($operation == 'delete') {
-            $allow = (in_array($actTypeName, $doNotDeleteNames)) ? FALSE : TRUE;
+            $allow = !in_array($actTypeName, $doNotDeleteNames);
           }
         }
       }
@@ -2740,7 +2740,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
 
     //lets check for case configured.
     $allCasesCount = CRM_Case_BAO_Case::caseCount(NULL, FALSE);
-    $configured['configured'] = ($allCasesCount) ? TRUE : FALSE;
+    $configured['configured'] = (bool) $allCasesCount;
     if (!$configured['configured']) {
       //do check for case type and case status.
       $caseTypes = CRM_Case_PseudoConstant::caseType('title', FALSE);

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1935,9 +1935,9 @@ ORDER BY civicrm_email.is_primary DESC";
         $name = $dao->display_name;
       }
       $email = $dao->email;
-      $doNotEmail = $dao->do_not_email ? TRUE : FALSE;
-      $onHold = $dao->on_hold ? TRUE : FALSE;
-      $isDeceased = $dao->is_deceased ? TRUE : FALSE;
+      $doNotEmail = (bool) $dao->do_not_email;
+      $onHold = (bool) $dao->on_hold;
+      $isDeceased = (bool) $dao->is_deceased;
       return [$name, $email, $doNotEmail, $onHold, $isDeceased];
     }
     return [NULL, NULL, NULL, NULL, NULL];

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -55,11 +55,7 @@ class CRM_Contact_BAO_Contact_Utils {
         $imageInfo[$contactType]['url'] = $imageUrl;
       }
       else {
-        $isSubtype = (array_key_exists('parent_id', $typeInfo) &&
-          $typeInfo['parent_id']
-        ) ? TRUE : FALSE;
-
-        if ($isSubtype) {
+        if (!empty($typeInfo['parent_id'])) {
           $type = CRM_Contact_BAO_ContactType::getBasicType($typeInfo['name']) . '-subtype';
         }
         else {
@@ -118,7 +114,7 @@ FROM   civicrm_contact
 WHERE  id IN ( $idString )
 ";
     $count = CRM_Core_DAO::singleValueQuery($query);
-    return $count > 1 ? TRUE : FALSE;
+    return $count > 1;
   }
 
   /**

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -46,7 +46,7 @@ class CRM_Contact_BAO_ContactType extends CRM_Contact_DAO_ContactType {
    */
   public static function isActive($contactType) {
     $contact = self::contactTypeInfo(FALSE);
-    $active = array_key_exists($contactType, $contact) ? TRUE : FALSE;
+    $active = array_key_exists($contactType, $contact);
     return $active;
   }
 

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -161,7 +161,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         $this->assign('otherUfName', $otherUser ? $otherUser['name'] : NULL);
       }
 
-      $cmsUser = ($mainUfId && $otherUfId) ? TRUE : FALSE;
+      $cmsUser = $mainUfId && $otherUfId;
       $this->assign('user', $cmsUser);
 
       $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($this->_cid, $this->_oid);

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -183,7 +183,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
    */
   public static function isSearchContext($context) {
     $searchContext = CRM_Utils_Array::value($context, self::validContext());
-    return $searchContext ? TRUE : FALSE;
+    return (bool) $searchContext;
   }
 
   public static function setModeValues() {

--- a/CRM/Contact/Form/Task/ProximityCommon.php
+++ b/CRM/Contact/Form/Task/ProximityCommon.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_Task_ProximityCommon {
    */
   public static function buildQuickForm($form, $proxSearch) {
     // is proximity search required (2) or optional (1)?
-    $proxRequired = ($proxSearch == 2 ? TRUE : FALSE);
+    $proxRequired = ($proxSearch == 2);
     $form->assign('proximity_search', TRUE);
 
     $form->add('text', 'prox_street_address', ts('Street Address'), NULL, FALSE);

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -237,7 +237,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
    * @return bool
    */
   protected static function isPaymentTransaction($form) {
-    return ($form->_amount >= 0.0) ? TRUE : FALSE;
+    return $form->_amount >= 0.0;
   }
 
   /**

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -279,7 +279,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
       $this->_online = $values['contribution_recur_id'] ?? NULL;
     }
 
-    $this->assign('isOnline', $this->_online ? TRUE : FALSE);
+    $this->assign('isOnline', (bool) $this->_online);
 
     //to get note id
     $daoNote = new CRM_Core_BAO_Note();

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1683,7 +1683,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $action,
       $pledgePaymentID,
       $contribution->id,
-      (CRM_Utils_Array::value('option_type', $formValues) == 2) ? TRUE : FALSE,
+      ($formValues['option_type'] ?? 0) == 2,
       $formValues['total_amount'],
       CRM_Utils_Array::value('total_amount', $this->_defaults),
       $formValues['contribution_status_id'],

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1537,7 +1537,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
         // @todo Move this into CRM_Member_BAO_Membership::processMembership
         if (!empty($membershipContribution)) {
-          $pending = ($membershipContribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')) ? TRUE : FALSE;
+          $pending = $membershipContribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
         }
         else {
           $pending = $this->getIsPending();

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -602,7 +602,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $self->_useForMember
       )
     ) {
-      $isTest = ($self->_action & CRM_Core_Action::PREVIEW) ? TRUE : FALSE;
+      $isTest = $self->_action & CRM_Core_Action::PREVIEW;
       $lifeMember = CRM_Member_BAO_Membership::getAllContactMembership($self->_membershipContactID, $isTest, TRUE);
 
       $membershipOrgDetails = CRM_Member_BAO_MembershipType::getMembershipTypeOrganization();

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1149,7 +1149,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->_currentMemberships = [];
 
       $membershipTypeIds = $membershipTypes = $radio = [];
-      $membershipPriceset = (!empty($this->_priceSetId) && $this->_useForMember) ? TRUE : FALSE;
+      $membershipPriceset = (!empty($this->_priceSetId) && $this->_useForMember);
 
       $allowAutoRenewMembership = $autoRenewOption = FALSE;
       $autoRenewMembershipTypeOptions = [];
@@ -1283,7 +1283,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->assign('allowAutoRenewMembership', $allowAutoRenewMembership);
       $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
       //give preference to user submitted auto_renew value.
-      $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted()) ? TRUE : FALSE;
+      $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted());
       $this->assign('takeUserSubmittedAutoRenew', $takeUserSubmittedAutoRenew);
 
       // Assign autorenew option (0:hide,1:optional,2:required) so we can use it in confirmation etc.

--- a/CRM/Contribute/Page/PaymentInfo.php
+++ b/CRM/Contribute/Page/PaymentInfo.php
@@ -30,7 +30,7 @@ class CRM_Contribute_Page_PaymentInfo extends CRM_Core_Page {
   }
 
   public function browse() {
-    $getTrxnInfo = $this->_context == 'transaction' ? TRUE : FALSE;
+    $getTrxnInfo = $this->_context == 'transaction';
     $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, $getTrxnInfo, TRUE);
     if ($this->_context == 'payment_info') {
       $this->assign('paymentInfo', $paymentInfo);

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -216,7 +216,7 @@ class CRM_Core_Action {
       if (!$mask || !array_key_exists('bit', $link) || ($mask & $link['bit'])) {
         $extra = isset($link['extra']) ? self::replace($link['extra'], $values) : NULL;
 
-        $frontend = (isset($link['fe'])) ? TRUE : FALSE;
+        $frontend = isset($link['fe']);
 
         if (isset($link['qs']) && !CRM_Utils_System::isNull($link['qs'])) {
           $urlPath = CRM_Utils_System::url(self::replace($link['url'], $values),

--- a/CRM/Core/BAO/ActionLog.php
+++ b/CRM/Core/BAO/ActionLog.php
@@ -36,7 +36,7 @@ class CRM_Core_BAO_ActionLog extends CRM_Core_DAO_ActionLog {
 
     $actionLog->copyValues($params);
 
-    $edit = ($actionLog->id) ? TRUE : FALSE;
+    $edit = (bool) $actionLog->id;
     if ($edit) {
       CRM_Utils_Hook::pre('edit', 'ActionLog', $actionLog->id, $actionLog);
     }

--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -72,8 +72,8 @@ class CRM_Core_BAO_CMSUser {
     $showCMS = FALSE;
 
     $isDrupal = $config->userSystem->is_drupal;
-    $isJoomla = ucfirst($config->userFramework) == 'Joomla' ? TRUE : FALSE;
-    $isWordPress = $config->userFramework == 'WordPress' ? TRUE : FALSE;
+    $isJoomla = ucfirst($config->userFramework) == 'Joomla';
+    $isWordPress = $config->userFramework == 'WordPress';
 
     if (!$config->userSystem->isUserRegistrationPermitted()) {
       // Do not build form if CMS is not configured to allow creating users.
@@ -148,8 +148,8 @@ class CRM_Core_BAO_CMSUser {
     $config = CRM_Core_Config::singleton();
 
     $isDrupal = $config->userSystem->is_drupal;
-    $isJoomla = ucfirst($config->userFramework) == 'Joomla' ? TRUE : FALSE;
-    $isWordPress = $config->userFramework == 'WordPress' ? TRUE : FALSE;
+    $isJoomla = ucfirst($config->userFramework) == 'Joomla';
+    $isWordPress = $config->userFramework == 'WordPress';
 
     $errors = [];
     if ($isDrupal || $isJoomla || $isWordPress) {

--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -128,7 +128,7 @@ class CRM_Core_BAO_ConfigSetting {
    */
   public static function applyLocale($settings, $activatedLocales) {
     // are we in a multi-language setup?
-    $multiLang = $activatedLocales ? TRUE : FALSE;
+    $multiLang = (bool) $activatedLocales;
 
     // set the current language
     $chosenLocale = NULL;

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -273,7 +273,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     $escapedValue = CRM_Core_DAO::VALUE_SEPARATOR . CRM_Core_DAO::escapeString($columnValue) . CRM_Core_DAO::VALUE_SEPARATOR;
     $dao->whereAdd("extends_entity_column_value LIKE \"%$escapedValue%\"");
     //$dao->extends_entity_column_value = $columnValue;
-    return $dao->find() ? TRUE : FALSE;
+    return (bool) $dao->find();
   }
 
   /**
@@ -673,7 +673,7 @@ ORDER BY civicrm_custom_group.weight,
     if ($getCount) {
       return $recordExists;
     }
-    return $recordExists ? TRUE : FALSE;
+    return (bool) $recordExists;
   }
 
   /**
@@ -2103,7 +2103,7 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
   public static function hasReachedMaxLimit($customGroupId, $entityId) {
     // check whether the group is multiple
     $isMultiple = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupId, 'is_multiple');
-    $isMultiple = ($isMultiple) ? TRUE : FALSE;
+    $isMultiple = (bool) $isMultiple;
     $hasReachedMax = FALSE;
     if ($isMultiple &&
       ($maxMultiple = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupId, 'max_multiple'))

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -473,7 +473,7 @@ AND    $cond
       }
       $fields[$dao->table_name][] = $dao->fieldID;
       $select[$dao->table_name][] = "{$dao->column_name} AS custom_{$dao->fieldID}";
-      $isMultiple[$dao->table_name] = $dao->is_multiple ? TRUE : FALSE;
+      $isMultiple[$dao->table_name] = (bool) $dao->is_multiple;
       $file[$dao->table_name][$dao->fieldID] = $dao->fieldDataType;
     }
 

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -150,7 +150,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
       $numberDomains = CRM_Core_DAO::singleValueQuery($query);
       $session->set('numberDomains', $numberDomains);
     }
-    return $numberDomains > 1 ? TRUE : FALSE;
+    return $numberDomains > 1;
   }
 
   /**
@@ -240,7 +240,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    */
   public static function isDomainGroup($groupId) {
     $domainGroupID = self::getGroupId();
-    return $domainGroupID == $groupId ? TRUE : FALSE;
+    return $domainGroupID == (bool) $groupId;
   }
 
   /**

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -585,8 +585,7 @@ MODIFY      {$columnName} varchar( $length )
   public static function checkIfFieldExists($tableName, $columnName, $i18nRewrite = TRUE) {
     $query = "SHOW COLUMNS FROM $tableName LIKE '%1'";
     $dao = CRM_Core_DAO::executeQuery($query, [1 => [$columnName, 'Alphanumeric']], TRUE, NULL, FALSE, $i18nRewrite);
-    $result = $dao->fetch() ? TRUE : FALSE;
-    return $result;
+    return (bool) $dao->fetch();
   }
 
   /**

--- a/CRM/Core/BAO/StatusPreference.php
+++ b/CRM/Core/BAO/StatusPreference.php
@@ -59,7 +59,7 @@ class CRM_Core_BAO_StatusPreference extends CRM_Core_DAO_StatusPreference {
 
     $statusPreference->copyValues($params);
 
-    $edit = ($statusPreference->id) ? TRUE : FALSE;
+    $edit = (bool) $statusPreference->id;
     if ($edit) {
       CRM_Utils_Hook::pre('edit', 'StatusPreference', $statusPreference->id, $statusPreference);
     }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1804,7 +1804,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     $rule = $field['rule'];
     $view = $field['is_view'];
     $required = ($mode == CRM_Profile_Form::MODE_SEARCH) ? FALSE : $field['is_required'];
-    $search = ($mode == CRM_Profile_Form::MODE_SEARCH) ? TRUE : FALSE;
+    $search = $mode == CRM_Profile_Form::MODE_SEARCH;
     $isShared = CRM_Utils_Array::value('is_shared', $field, 0);
 
     // do not display view fields in drupal registration form
@@ -2573,7 +2573,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
         }
       }
 
-      $validProfile = (empty($required)) ? TRUE : FALSE;
+      $validProfile = (empty($required));
     }
 
     return $validProfile;

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -232,7 +232,7 @@ WHERE  domain_id = %1
           $localCustomData = $localeCustomArray[$lang];
           // Traverse status array "enabled" "disabled"
           foreach ($localCustomData as $status => $matchTypes) {
-            $params["is_active"] = ($status == "enabled") ? TRUE : FALSE;
+            $params["is_active"] = $status == "enabled";
             // Traverse Match Type array "wildcardMatch" "exactMatch"
             foreach ($matchTypes as $matchType => $words) {
               $params["match_type"] = $matchType;

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -305,7 +305,7 @@ abstract class CRM_Core_Component_Info {
    *   true if component needs search integration
    */
   public function usesSearch() {
-    return $this->info['search'] ? TRUE : FALSE;
+    return (bool) $this->info['search'];
   }
 
   /**

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -821,7 +821,7 @@ class CRM_Core_DAO extends DB_DataObject {
     }
 
     if ($object->find(TRUE)) {
-      return ($daoID && $object->id == $daoID) ? TRUE : FALSE;
+      return $daoID && $object->id == $daoID;
     }
     else {
       return TRUE;
@@ -920,7 +920,7 @@ class CRM_Core_DAO extends DB_DataObject {
       $show[$tableName] = $dao->Create_Table;
     }
 
-    return preg_match("/\b$constraint\b/i", $show[$tableName]) ? TRUE : FALSE;
+    return (bool) preg_match("/\b$constraint\b/i", $show[$tableName]);
   }
 
   /**
@@ -947,7 +947,7 @@ class CRM_Core_DAO extends DB_DataObject {
         $show[$tableName] = $dao->Create_Table;
       }
 
-      $result = preg_match("/\bCONSTRAINT\b\s/i", $show[$tableName]) ? TRUE : FALSE;
+      $result = (bool) preg_match("/\bCONSTRAINT\b\s/i", $show[$tableName]);
       if ($result == TRUE) {
         continue;
       }
@@ -985,7 +985,7 @@ class CRM_Core_DAO extends DB_DataObject {
     }
     $constraint = "`FK_{$tableName}_{$columnName}`";
     $pattern = "/\bCONSTRAINT\b\s+%s\s+\bFOREIGN\s+KEY\b\s/i";
-    return preg_match(sprintf($pattern, $constraint), $show[$tableName]) ? TRUE : FALSE;
+    return (bool) preg_match(sprintf($pattern, $constraint), $show[$tableName]);
   }
 
   /**
@@ -1037,8 +1037,7 @@ LIKE %1
     $params = [1 => [$tableName, 'String']];
 
     $dao = CRM_Core_DAO::executeQuery($query, $params);
-    $result = $dao->fetch() ? TRUE : FALSE;
-    return $result;
+    return (bool) $dao->fetch();
   }
 
   /**
@@ -1064,7 +1063,7 @@ SELECT version
 FROM   civicrm_domain
 ";
     $dbVersion = CRM_Core_DAO::singleValueQuery($query);
-    return trim($version) == trim($dbVersion) ? TRUE : FALSE;
+    return trim($version) == trim($dbVersion);
   }
 
   /**

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -730,7 +730,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $className = isset($trace['class']) ? ($trace['class'] . $trace['type']) : '';
 
       // Do not show args for a few password related functions
-      $skipArgs = ($className == 'DB::' && $fnName == 'connect') ? TRUE : FALSE;
+      $skipArgs = $className == 'DB::' && $fnName == 'connect';
 
       if (!empty($trace['args'])) {
         foreach ($trace['args'] as $arg) {

--- a/CRM/Core/Key.php
+++ b/CRM/Core/Key.php
@@ -135,7 +135,7 @@ class CRM_Core_Key {
     }
 
     // ensure that hash is a 32 digit hex number
-    return preg_match('#[0-9a-f]{32}#i', $hash) ? TRUE : FALSE;
+    return (bool) preg_match('#[0-9a-f]{32}#i', $hash);
   }
 
 }

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -216,7 +216,7 @@ class CRM_Core_Menu {
     );
     $fieldsPresent = array();
     foreach ($fieldsToPropagate as $field) {
-      $fieldsPresent[$field] = CRM_Utils_Array::value($field, $menu[$path]) !== NULL ? TRUE : FALSE;
+      $fieldsPresent[$field] = isset($menu[$path][$field]);
     }
 
     $args = explode('/', $path);

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -261,7 +261,7 @@ class CRM_Core_OptionValue {
     }
 
     if ($object->find(TRUE)) {
-      return ($daoID && $object->id == $daoID) ? TRUE : FALSE;
+      return $daoID && $object->id == $daoID;
     }
     else {
       return TRUE;

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -354,7 +354,7 @@ abstract class CRM_Core_Payment {
    * @return bool
    */
   protected function supportsLiveMode() {
-    return empty($this->_paymentProcessor['is_test']) ? TRUE : FALSE;
+    return empty($this->_paymentProcessor['is_test']);
   }
 
   /**
@@ -363,7 +363,7 @@ abstract class CRM_Core_Payment {
    * @return bool
    */
   protected function supportsTestMode() {
-    return empty($this->_paymentProcessor['is_test']) ? FALSE : TRUE;
+    return !empty($this->_paymentProcessor['is_test']);
   }
 
   /**

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -278,7 +278,7 @@ class CRM_Core_Permission {
     }
 
     $groups = self::ufGroup($type);
-    return !empty($groups) && in_array($gid, $groups) ? TRUE : FALSE;
+    return !empty($groups) && in_array($gid, $groups);
   }
 
   /**
@@ -1627,7 +1627,7 @@ class CRM_Core_Permission {
    * @return bool
    */
   public static function isMultisiteEnabled() {
-    return Civi::settings()->get('is_enabled') ? TRUE : FALSE;
+    return (bool) Civi::settings()->get('is_enabled');
   }
 
   /**

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -185,7 +185,7 @@ class CRM_Core_PseudoConstant {
     // Historically this was 'false' but according to the notes in
     // CRM_Core_DAO::buildOptionsContext it should be context dependent.
     // timidly changing for 'search' only to fix world_region in search options.
-    $localizeDefault = in_array($context, ['search']) ? TRUE : FALSE;
+    $localizeDefault = in_array($context, ['search']);
     // Merge params with defaults
     $params += [
       'grouping' => FALSE,

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -687,7 +687,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @throws \CiviCRM_API3_Exception
    */
   public static function batchMerge($rgid, $gid = NULL, $mode = 'safe', $batchLimit = 1, $isSelected = 2, $criteria = [], $checkPermissions = TRUE, $reloadCacheIfEmpty = NULL, $searchLimit = 0) {
-    $redirectForPerformance = ($batchLimit > 1) ? TRUE : FALSE;
+    $redirectForPerformance = $batchLimit > 1;
     if ($mode === 'aggressive' && $checkPermissions && !CRM_Core_Permission::check('force merge duplicate contacts')) {
       throw new CRM_Core_Exception(ts('Insufficient permissions for aggressive mode batch merge'));
     }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -274,7 +274,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     self::assignProfiles($this);
 
     //consider total amount.
-    $this->assign('isAmountzero', ($this->_totalAmount <= 0) ? TRUE : FALSE);
+    $this->assign('isAmountzero', $this->_totalAmount <= 0);
 
     $contribButton = ts('Continue');
     $this->addButtons([
@@ -562,7 +562,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           $value['participant_register_date'] = $this->_values['participant']['register_date'];
         }
 
-        $createContrib = ($value['amount'] != 0) ? TRUE : FALSE;
+        $createContrib = $value['amount'] != 0;
         // force to create zero amount contribution, CRM-5095
         if (!$createContrib && ($value['amount'] == 0)
           && $this->_priceSetId && $this->_lineItem

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -120,7 +120,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     $this->assign('trxn_id', $this->_trxnId);
 
     //cosider total amount.
-    $this->assign('isAmountzero', ($this->_totalAmount <= 0) ? TRUE : FALSE);
+    $this->assign('isAmountzero', $this->_totalAmount <= 0);
 
     $this->assign('defaultRole', FALSE);
     if (CRM_Utils_Array::value('defaultRole', $this->_params[0]) == 1) {

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -344,7 +344,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
         $statusClass = $statusClasses[$statusId];
       }
 
-      $row['showConfirmUrl'] = ($statusClass == 'Pending') ? TRUE : FALSE;
+      $row['showConfirmUrl'] = $statusClass == 'Pending';
 
       if (!empty($row['participant_is_test'])) {
         $row['participant_status'] = CRM_Core_TestEntity::appendTestText($row['participant_status']);

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -171,7 +171,7 @@ class CRM_Extension_Browser {
     }
 
     // 3 minutes ago for now
-    $outdated = (int) $timestamp < (time() - 180) ? TRUE : FALSE;
+    $outdated = (int) $timestamp < (time() - 180);
 
     if (!$timestamp || $outdated) {
       $remotes = json_decode($this->grabRemoteJson(), TRUE);

--- a/CRM/Extension/Manager/Report.php
+++ b/CRM/Extension/Manager/Report.php
@@ -79,7 +79,7 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
     $id = $cr[$customReports[$info->key]];
     $optionValue = CRM_Core_BAO_OptionValue::del($id);
 
-    return $optionValue ? TRUE : FALSE;
+    return (bool) $optionValue;
   }
 
   /**

--- a/CRM/Extension/Manager/Search.php
+++ b/CRM/Extension/Manager/Search.php
@@ -58,7 +58,7 @@ class CRM_Extension_Manager_Search extends CRM_Extension_Manager_Base {
     $ids = [];
     $optionValue = CRM_Core_BAO_OptionValue::add($params, $ids);
 
-    return $optionValue ? TRUE : FALSE;
+    return (bool) $optionValue;
   }
 
   /**

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -134,7 +134,7 @@ class CRM_Extension_Mapper {
    */
   public function isExtensionKey($key) {
     // check if the string is an extension name or the class
-    return (strpos($key, '.') !== FALSE) ? TRUE : FALSE;
+    return strpos($key, '.') !== FALSE;
   }
 
   /**

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -448,7 +448,7 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
     $capabilitiesString = implode('', $capabilities);
     if (!isset(\Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString])) {
       $result = self::getPaymentProcessors($capabilities);
-      \Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString] = (!empty($result) && array_keys($result) !== [0]) ? TRUE : FALSE;
+      \Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString] = (!empty($result) && array_keys($result) !== [0]);
     }
     return \Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString];
   }

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -255,7 +255,7 @@ class CRM_Financial_Page_AJAX {
     $entityID = isset($_REQUEST['entityID']) ? CRM_Utils_Type::escape($_REQUEST['entityID'], 'String') : NULL;
     $notPresent = isset($_REQUEST['notPresent']) ? CRM_Utils_Type::escape($_REQUEST['notPresent'], 'String') : NULL;
     $statusID = isset($_REQUEST['statusID']) ? CRM_Utils_Type::escape($_REQUEST['statusID'], 'String') : NULL;
-    $search = isset($_REQUEST['search']) ? TRUE : FALSE;
+    $search = isset($_REQUEST['search']);
 
     $params = $_POST;
     if ($sort && $sortOrder) {

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -499,7 +499,7 @@ class CRM_Import_ImportProcessor {
    * @return bool
    */
   protected function isValidRelationshipKey($key) {
-    return !empty($this->getValidRelationships()[$key]) ? TRUE : FALSE;
+    return !empty($this->getValidRelationships()[$key]);
   }
 
   /**

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1107,7 +1107,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     $pEmails = [];
 
     foreach ($pTemplates as $type => $pTemplate) {
-      $html = ($type == 'html') ? TRUE : FALSE;
+      $html = $type == 'html';
       $pEmails[$type] = [];
       $pEmail = &$pEmails[$type];
       $template = &$pTemplates[$type]['template'];
@@ -1148,7 +1148,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $message = new Mail_mime("\n");
 
-    $useSmarty = defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY ? TRUE : FALSE;
+    $useSmarty = defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY;
     if ($useSmarty) {
       $smarty = CRM_Core_Smarty::singleton();
       // also add the contact tokens to the template
@@ -1300,7 +1300,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         $mailing->templates[$type] = CRM_Utils_Token::replaceDomainTokens(
           $mailing->templates[$type],
           $domain,
-          $type == 'html' ? TRUE : FALSE,
+          $type == 'html',
           $tokens[$type]
         );
         $mailing->templates[$type] = CRM_Utils_Token::replaceMailingTokens($mailing->templates[$type], $mailing, NULL, $tokens[$type]);
@@ -1329,7 +1329,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     $token = $token_a['token'];
     $data = $token;
 
-    $useSmarty = defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY ? TRUE : FALSE;
+    $useSmarty = defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY;
 
     if ($type == 'embedded_url') {
       $embed_data = [];

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -178,9 +178,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
 
     $enableWorkflow = Civi::settings()->get('civimail_workflow');
 
-    return ($enableWorkflow &&
-      $config->userSystem->is_drupal
-    ) ? TRUE : FALSE;
+    return $enableWorkflow && $config->userSystem->is_drupal;
   }
 
   /**

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -379,7 +379,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
 
       $isRecur = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->membershipID, 'contribution_recur_id');
 
-      $autoRenew = $isRecur ? TRUE : FALSE;
+      $autoRenew = (bool) $isRecur;
     }
 
     if (!empty($values['is_test'])) {

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -144,7 +144,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
       unset($params['is_navigation']);
     }
 
-    $viewMode = !empty($params['view_mode']) ? $params['view_mode'] : FALSE;
+    $viewMode = !empty($params['view_mode']);
     if ($viewMode) {
       // Do not save to the DB - it's saved in the url.
       unset($params['view_mode']);

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -760,8 +760,8 @@ ROUND(AVG({$this->_aliases['civicrm_contribution_soft']}.amount), 2) as civicrm_
     if (!empty($this->_params['charts'])) {
       if (!empty($this->_params['group_bys']['receive_date'])) {
 
-        $contrib = !empty($this->_params['fields']['total_amount']) ? TRUE : FALSE;
-        $softContrib = !empty($this->_params['fields']['soft_amount']) ? TRUE : FALSE;
+        $contrib = !empty($this->_params['fields']['total_amount']);
+        $softContrib = !empty($this->_params['fields']['soft_amount']);
 
         foreach ($rows as $key => $row) {
           if ($row['civicrm_contribution_receive_date_subtotal']) {
@@ -817,7 +817,7 @@ ROUND(AVG({$this->_aliases['civicrm_contribution_soft']}.amount), 2) as civicrm_
     $contributionPages = CRM_Contribute_PseudoConstant::contributionPage();
     //CRM-16338 if both soft-credit and contribution are enabled then process the contribution's
     //total amount's average, count and sum separately and add it to the respective result list
-    $softCredit = (!empty($this->_params['fields']['soft_amount']) && !empty($this->_params['fields']['total_amount'])) ? TRUE : FALSE;
+    $softCredit = (!empty($this->_params['fields']['soft_amount']) && !empty($this->_params['fields']['total_amount']));
     if ($softCredit) {
       $this->from('contribution');
       $this->customDataFrom();

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -299,7 +299,7 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
         'custom_group_id' => $customGroup->id,
         'extends_entity_column_id' => $customGroup->extends_entity_column_id,
         'extends_entity_column_value' => CRM_Utils_Array::explodePadded($customGroup->extends_entity_column_value),
-        'is_reserved' => $customGroup->is_reserved ? TRUE : FALSE,
+        'is_reserved' => (bool) $customGroup->is_reserved,
       ];
       $result['sections'][$sectionName] = $section;
     }

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -310,7 +310,7 @@ SET    version = '$version'
       $version, 'id',
       'version'
     );
-    return $domainID ? TRUE : FALSE;
+    return (bool) $domainID;
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/FourFour.php
+++ b/CRM/Upgrade/Incremental/php/FourFour.php
@@ -719,7 +719,7 @@ CREATE TABLE IF NOT EXISTS `civicrm_word_replacement` (
           foreach ($localeCustomArray as $localCustomData) {
             // Traverse status array "enabled" "disabled"
             foreach ($localCustomData as $status => $matchTypes) {
-              $params["is_active"] = ($status == "enabled") ? TRUE : FALSE;
+              $params["is_active"] = $status == "enabled";
               // Traverse Match Type array "wildcardMatch" "exactMatch"
               foreach ($matchTypes as $matchType => $words) {
                 $params["match_type"] = $matchType;

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -399,7 +399,7 @@ class CRM_Utils_File {
       }
     }
     // support lower and uppercase file extensions
-    return isset($extensions[strtolower($ext)]) ? TRUE : FALSE;
+    return (bool) isset($extensions[strtolower($ext)]);
   }
 
   /**

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -492,7 +492,7 @@ class CRM_Utils_Rule {
       return FALSE;
     }
 
-    return preg_match('/(^-?\d\d*\.\d*$)|(^-?\d\d*$)|(^-?\.\d\d*$)/', $value) ? TRUE : FALSE;
+    return (bool) preg_match('/(^-?\d\d*\.\d*$)|(^-?\d\d*$)|(^-?\.\d\d*$)/', $value);
   }
 
   /**
@@ -513,7 +513,7 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function alphanumeric($value) {
-    return preg_match('/^[a-zA-Z0-9_-]*$/', $value) ? TRUE : FALSE;
+    return (bool) preg_match('/^[a-zA-Z0-9_-]*$/', $value);
   }
 
   /**
@@ -523,7 +523,7 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function numberOfDigit($value, $noOfDigit) {
-    return preg_match('/^\d{' . $noOfDigit . '}$/', $value) ? TRUE : FALSE;
+    return (bool) preg_match('/^\d{' . $noOfDigit . '}$/', $value);
   }
 
   /**
@@ -605,7 +605,7 @@ class CRM_Utils_Rule {
     // Allow values such as -0, 1.024555, -.1
     // We need to support multiple decimal places here, not just the number allowed by locale
     //  otherwise tax calculations break when you want the inclusive amount to be a round number (eg. £10 inc. VAT requires 8.333333333 here).
-    return preg_match('/(^-?\d+\.?\d*$)|(^-?\.\d+$)/', $value) ? TRUE : FALSE;
+    return (bool) preg_match('/(^-?\d+\.?\d*$)|(^-?\.\d+$)/', $value);
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1192,9 +1192,7 @@ class CRM_Utils_System {
    * this function, please go and change the code in the install script as well.
    */
   public static function isSSL() {
-    return (isset($_SERVER['HTTPS']) &&
-        !empty($_SERVER['HTTPS']) &&
-        strtolower($_SERVER['HTTPS']) != 'off') ? TRUE : FALSE;
+    return !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off';
   }
 
   /**

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -687,7 +687,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     $result = [];
     $q = db_query('SELECT name, status FROM {system} WHERE type = \'module\' AND schema_version <> -1');
     while ($row = db_fetch_object($q)) {
-      $result[] = new CRM_Core_Module('drupal.' . $row->name, ($row->status == 1) ? TRUE : FALSE);
+      $result[] = new CRM_Core_Module('drupal.' . $row->name, $row->status == 1);
     }
     return $result;
   }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -541,7 +541,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     foreach ($module_data as $module_name => $extension) {
       if (!isset($extension->info['hidden']) && $extension->origin != 'core') {
         $extension->schema_version = drupal_get_installed_schema_version($module_name);
-        $modules[] = new CRM_Core_Module('drupal.' . $module_name, ($extension->status == 1 ? TRUE : FALSE));
+        $modules[] = new CRM_Core_Module('drupal.' . $module_name, ($extension->status == 1));
       }
     }
     return $modules;

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -294,7 +294,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     $result = [];
     $q = db_query('SELECT name, status FROM {system} WHERE type = \'module\' AND schema_version <> -1');
     foreach ($q as $row) {
-      $result[] = new CRM_Core_Module('drupal.' . $row->name, ($row->status == 1) ? TRUE : FALSE);
+      $result[] = new CRM_Core_Module('drupal.' . $row->name, $row->status == 1);
     }
     return $result;
   }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -693,7 +693,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     foreach ($plugins as $plugin) {
       // question: is the folder really a critical part of the plugin's name?
       $name = implode('.', ['joomla', $plugin['type'], $plugin['folder'], $plugin['element']]);
-      $result[] = new CRM_Core_Module($name, $plugin['enabled'] ? TRUE : FALSE);
+      $result[] = new CRM_Core_Module($name, !empty($plugin['enabled']));
     }
 
     return $result;


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup - simplifies overly complicated boolean expressions.

I noticed a silly pattern used sometimes in our code where an expression is followed by `? TRUE : FALSE`. This is just an overly verbose way of casting a value to boolean. If the value was already a boolean, it does nothing at all. If the value was something else, the `(bool)` cast is a more concise way of doing the same thing.

I went through these and removed the `? TRUE : FALSE` part of each expression, and added `(bool)` if the value wasn't boolean already.

Before
----------------------------------------
Examples like this...

1. `return ($foo > $bar) ? TRUE : FALSE;`
2. `empty($foo[$bar]) ? TRUE : FALSE;`
3. `isset($foo->$bar) ? TRUE : FALSE;`
4. `return $someScalarVal ? TRUE : FALSE;`

After
----------------------------------------
... were replaced with this:

1. `return $foo > $bar;`
2. `empty($foo[$bar]);`
3. `isset($foo->$bar);`
4. `return (bool) $someScalarVal;`

Technical Details
----------------------------------------
Note that only the 4th example needed the cast added as the others (comparison operators, `isset()` and `empty()`) already return a bool.

