### PR TITLE
[REF] Remove titleHeader var

### DIFF
--- a/CRM/Core/Report/Excel.php
+++ b/CRM/Core/Report/Excel.php
@@ -26,17 +26,13 @@ class CRM_Core_Report_Excel {
    *   column headers.
    * @param array $rows
    *   result set rows.
-   * @param string $titleHeader
    * @param bool $outputHeader
    *
    * @return mixed
    *   empty if output is printed, else output
    *
    */
-  public static function makeCSVTable($header, $rows, $titleHeader = NULL, $outputHeader = TRUE) {
-    if ($titleHeader) {
-      echo $titleHeader;
-    }
+  public static function makeCSVTable($header, $rows, $outputHeader = TRUE) {
 
     $config = CRM_Core_Config::singleton();
     $seperator = $config->fieldSeparator;
@@ -156,14 +152,12 @@ class CRM_Core_Report_Excel {
    *   An array of the headers.
    * @param array $rows
    *   An array of arrays of the table contents.
-   * @param string $titleHeader
-   *   If set this will be the title in the CSV.
    * @param bool $outputHeader
    *   Should we output the header row.
    *
    * @return void
    */
-  public static function writeCSVFile($fileName, $header, $rows, $titleHeader = NULL, $outputHeader = TRUE) {
+  public static function writeCSVFile($fileName, $header, $rows, $outputHeader = TRUE) {
     if ($outputHeader) {
       CRM_Utils_System::download(CRM_Utils_String::munge($fileName),
         'text/x-csv',
@@ -174,7 +168,7 @@ class CRM_Core_Report_Excel {
     }
 
     if (!empty($rows)) {
-      return self::makeCSVTable($header, $rows, $titleHeader, $outputHeader);
+      return self::makeCSVTable($header, $rows, $outputHeader);
     }
   }
 

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2356,7 +2356,7 @@ LIMIT $offset, $limit
     // the Windows variant but is tested with MS Excel for Mac (Office 365 v 16.31)
     // and it continues to work on Libre Office, Numbers, Notes etc.
     echo "\xEF\xBB\xBF";
-    CRM_Core_Report_Excel::makeCSVTable($headerRows, [], NULL, TRUE);
+    CRM_Core_Report_Excel::makeCSVTable($headerRows, [], TRUE);
   }
 
   /**
@@ -2367,7 +2367,6 @@ LIMIT $offset, $limit
     CRM_Core_Report_Excel::writeCSVFile($this->getExportFileName(),
       $headerRows,
       $componentDetails,
-      NULL,
       FALSE
     );
   }


### PR DESCRIPTION


Overview
----------------------------------------
Removes $titleHeader  param that  is never passed in, and, logically, it would break the csv if it was

Before
----------------------------------------
```
 
 public static function writeCSVFile($fileName, $header, $rows, $titleHeader = NULL, $outputHeader = TRUE) {
```
- called from  3 places but only 1 passes more than the first 3 params & titleHeader is set to NULL

```
public static function makeCSVTable($header, $rows, $titleHeader = NULL, $outputHeader = TRUE) {
```
- called from 2 places. One is writeCSVFile which only passes NULL for $titleHeader  and the other place was passing in NULL

After
----------------------------------------
```
public static function writeCSVFile($fileName, $header, $rows, $outputHeader = TRUE) {

 public static function makeCSVTable($header, $rows, $outputHeader = TRUE) {
```

Technical Details
----------------------------------------
Minor code cleanup - no impact other than readability

Comments
----------------------------------------

