### PR TITLE
[NFC] Use helper / api to delete contacts in tests

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -668,7 +668,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $contactId = $contact->id;
 
     //delete contact permanently.
-    CRM_Contact_BAO_Contact::deleteContact($contactId, FALSE, TRUE);
+    $this->contactDelete($contactId);
 
     //Now check DB for location elements.
     //Now check DB for Address

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
@@ -77,7 +77,7 @@ DELETE FROM civicrm_contact_type
     }
     $this->assertEquals($contact->first_name, 'Anne');
     $this->assertEquals($contact->contact_type, 'Individual');
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
 
     //check for Type:Organization
     $params = [
@@ -91,7 +91,7 @@ DELETE FROM civicrm_contact_type
     }
     $this->assertEquals($contact->organization_name, 'Compumentor');
     $this->assertEquals($contact->contact_type, 'Organization');
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
 
     //check for Type:Household
     $params = [
@@ -105,7 +105,7 @@ DELETE FROM civicrm_contact_type
     }
     $this->assertEquals($contact->household_name, 'John Does home');
     $this->assertEquals($contact->contact_type, 'Household');
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
 
     //check for Type:Individual, Subtype:Student
     $params = [
@@ -122,7 +122,7 @@ DELETE FROM civicrm_contact_type
     $this->assertEquals($contact->first_name, 'Bill');
     $this->assertEquals($contact->contact_type, 'Individual');
     $this->assertEquals(str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $contact->contact_sub_type), $this->student);
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
 
     //check for Type:Organization, Subtype:Sponsor
     $params = [
@@ -138,7 +138,7 @@ DELETE FROM civicrm_contact_type
     $this->assertEquals($contact->organization_name, 'Conservation Corp');
     $this->assertEquals($contact->contact_type, 'Organization');
     $this->assertEquals(str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $contact->contact_sub_type), $this->sponsor);
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
   }
 
   /**
@@ -170,7 +170,7 @@ DELETE FROM civicrm_contact_type
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Individual');
     $this->assertEquals(str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $updatedContact->contact_sub_type), $this->student);
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
 
     $params = [
       'organization_name' => 'Compumentor',
@@ -195,7 +195,7 @@ DELETE FROM civicrm_contact_type
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Organization');
     $this->assertEquals(str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $updatedContact->contact_sub_type), $this->sponsor);
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
   }
 
   /**
@@ -228,7 +228,7 @@ DELETE FROM civicrm_contact_type
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Individual');
     $this->assertEquals(str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $updatedContact->contact_sub_type), $this->parent);
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
 
     $params = [
       'organization_name' => 'Compumentor',
@@ -255,7 +255,7 @@ DELETE FROM civicrm_contact_type
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Organization');
     $this->assertEquals(str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $updatedContact->contact_sub_type), $this->team);
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
 
     $params = [
       'first_name' => 'Anne',
@@ -283,7 +283,7 @@ DELETE FROM civicrm_contact_type
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Individual');
     $this->assertEquals($updatedContact->contact_sub_type, 'null');
-    CRM_Contact_BAO_Contact::deleteContact($contact->id);
+    $this->contactDelete($contact->id);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -99,13 +99,13 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   /**
    * Test that import parser will not fail when same external_identifier found of deleted contact.
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function testImportParserWtihDeletedContactExternalIdentifier() {
     $contactId = $this->individualCreate([
-      "external_identifier" => "ext-1",
+      'external_identifier' => 'ext-1',
     ]);
-    CRM_Contact_BAO_Contact::deleteContact($contactId);
+    $this->callAPISuccess('Contact', 'delete', ['id' => $contactId]);
     list($originalValues, $result) = $this->setUpBaseContact([
       'external_identifier' => 'ext-1',
     ]);

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -248,7 +248,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $contact = CRM_Contact_BAO_Contact::findById($existing_contact->id);
     $this->assertEquals($existing_contact->id, $contact->id);
     $deleted_contact_id = $existing_contact->id;
-    CRM_Contact_BAO_Contact::deleteContact($contact->id, FALSE, TRUE);
+    $this->contactDelete($contact->id);
     $exception_thrown = FALSE;
     try {
       $deleted_contact = CRM_Contact_BAO_Contact::findById($deleted_contact_id);


### PR DESCRIPTION
Overview
----------------------------------------
Switch to using helpers rather than calling BAO function directly

Before
----------------------------------------
calls in test class to ```CRM_Contact_BAO_Contact::deleteContact```

After
----------------------------------------
Uses helper for hard delete & api for soft delete

Technical Details
----------------------------------------
CRM_Contact_BAO_Contact::deleteContact has a silly signature - let's use it less  - with the goal to later cleaning up the signature we don't restore within the delete function. 

Comments
----------------------------------------

