### PR TITLE
Fetch latest contribution id for building line items

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -904,7 +904,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     $originalContribution = civicrm_api3('Contribution', 'getsingle', [
       'contribution_recur_id' => $recurId,
       'contribution_test' => '',
-      'options' => ['limit' => 1],
+      'options' => ['limit' => 1, 'sort' => ['id DESC']],
       'return' => ['id', 'financial_type_id'],
     ]);
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContribution['id']);


### PR DESCRIPTION
Overview
----------------------------------------
The logic at various places in Contribution BAO for repeat transaction use latest contribution id to fetch the details that is used to create subsequent contribution for a recurring. However the line item is always fetched using first contribution. 

Possible scenario that it may not work is when you initially purchase 3 auto renew monthly membership 10 years ago i.e 1 for org and  2 for its employee. One of the employee is deceased,  The staff member goes into contact page and updates the contact to set deceased which automatically turns its membership to deceased, updates the recurring amount in payment gateway and also in Civi, updates the latest contribution to remove line item, delete latest payment link from membership payment table etc. But when a subsequent payment is recorded it still creates 3 line items instead of 2 and update the deceased membership. 

Before
----------------------------------------
Fetched lineitem using first contribution id hence the newly contribution didn't match with second latest contribution line item

After
----------------------------------------
Latest and second latest contribution and lineitem are matched