### PR TITLE
APIv4 - convert Result object to array when running through json_encode

### DIFF
--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -22,7 +22,7 @@ namespace Civi\Api4\Generic;
  *       For example, BasicReplaceAction returns ReplaceResult which includes the additional $deleted property to list any items deleted by the operation.
  *  3. Provide convenience methods like `$result->first()` and `$result->indexBy($field)`.
  */
-class Result extends \ArrayObject {
+class Result extends \ArrayObject implements \JsonSerializable {
   /**
    * @var string
    */
@@ -122,6 +122,13 @@ class Result extends \ArrayObject {
    */
   public function column($name) {
     return array_column($this->getArrayCopy(), $name, $this->indexedBy);
+  }
+
+  /**
+   * @return array
+   */
+  public function jsonSerialize() {
+    return $this->getArrayCopy();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/ResultTest.php
+++ b/tests/phpunit/api/v4/Action/ResultTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ * $Id$
+ *
+ */
+
+
+namespace api\v4\Action;
+
+use Civi\Api4\Contact;
+use api\v4\UnitTestCase;
+
+/**
+ * @group headless
+ */
+class ResultTest extends UnitTestCase {
+
+  public function testJsonSerialize() {
+    $result = Contact::getFields()->setCheckPermissions(FALSE)->setIncludeCustom(FALSE)->execute();
+    $json = json_encode($result);
+    $this->assertStringStartsWith('[{"', $json);
+    $this->assertTrue(is_array(json_decode($json)));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This cleans up APIv4 results when being passed to `json_encode`.

Before
----------------------------------------
Entire Result object was getting serialized leading to some weird output. You'd have to cast it to an array before passing to `json_encode`.

After
----------------------------------------
Only the array gets serialized.
