### PR TITLE
dev/report#28 - Join date field has no label on constituent detail report

### DIFF
--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -208,7 +208,9 @@ class CRM_Report_Form_Contact_Detail extends CRM_Report_Form {
             'title' => ts('Membership Type'),
             'default' => TRUE,
           ],
-          'join_date' => NULL,
+          'join_date' => [
+            'title' => ts('Join Date'),
+          ],
           'membership_start_date' => [
             'title' => ts('Start Date'),
             'default' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/report/issues/28

1. Go to the constituent detail report.
1. On the columns tab there's a checkbox that has no label, near membership fields.

Before
----------------------------------------
![pr-pre](https://user-images.githubusercontent.com/6799125/76912067-ae1bd000-6906-11ea-8391-5df206606160.jpg)

Weird

After
----------------------------------------
![pr-post](https://user-images.githubusercontent.com/6799125/76912078-b5db7480-6906-11ea-973f-15e4d4e87817.jpg)

Checkbox label now says Join Date, which is what the field is.

Note if you run the report the date format the field uses is different from the other date fields, but this is a [separate issue](https://lab.civicrm.org/dev/report/issues/29), and also happens on the membership detail report.

Technical Details
----------------------------------------
The field definition has always been just NULL since the report was first added. Possibly something else changed somewhere so that before it just skipped it and didn't show the checkbox at all but then at some point it started showing up as a blank checkbox.

I just copied from the membership detail report where the field does have a label.

