### PR TITLE
dev/core#667 Fix bug where entity_tags are not deleted by 'soft FK'

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1009,7 +1009,8 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     $transaction = new CRM_Core_Transaction();
 
     if ($skipUndelete) {
-      CRM_Utils_Hook::pre('delete', $contactType, $id, CRM_Core_DAO::$_nullArray);
+      $hookParams = ['check_permissions' => $checkPermissions];
+      CRM_Utils_Hook::pre('delete', $contactType, $id, $hookParams);
 
       //delete billing address if exists.
       CRM_Contribute_BAO_Contribution::deleteAddress(NULL, $id);

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -255,6 +255,17 @@ class CRM_Core_DAO_AllCoreTables {
   }
 
   /**
+   * Convert the entity name into a table name.
+   *
+   * @param string $entityBriefName
+   *
+   * @return FALSE|string
+   */
+  public static function getTableForEntityName($entityBriefName) {
+    return self::getTableForClass(self::getFullName($entityBriefName));
+  }
+
+  /**
    * Reinitialise cache.
    *
    * @param bool $fresh

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -335,6 +335,7 @@ class Container {
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, ['\Civi\Core\LocalizationInitializer', 'initialize']);
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
     $dispatcher->addListener('hook_civicrm_pre', ['\Civi\Core\Event\PreEvent', 'dispatchSubevent'], 100);
+    $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);
     $dispatcher->addListener('hook_civicrm_post', ['\Civi\Core\Event\PostEvent', 'dispatchSubevent'], 100);
     $dispatcher->addListener('hook_civicrm_post::Activity', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_post::Case', ['\Civi\CCase\Events', 'fireCaseChange']);

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2978,9 +2978,13 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   /**
    * Test that delete with skip undelete respects permissions.
    * TODO: Api4
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testContactDeletePermissions() {
     $contactID = $this->individualCreate();
+    $tag = $this->callAPISuccess('Tag', 'create', ['name' => 'to be deleted']);
+    $this->callAPISuccess('EntityTag', 'create', ['entity_id' => $contactID, 'tag_id' => $tag['id']]);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
     $this->callAPIFailure('Contact', 'delete', [
       'id' => $contactID,
@@ -2992,6 +2996,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'check_permissions' => 0,
       'skip_undelete' => 1,
     ]);
+    $this->callAPISuccessGetCount('EntityTag', ['entity_id' => $contactID], 0);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where deleting a contact does not delete tags associated with the contact

Before
----------------------------------------
1) Create a contact with a tag
2) Delete the contact (don't delete to trash, full delete)
3) check entity_tag record still exists in civicrm_entity_tag

After
----------------------------------------
entity_tag record is cleaned up

Technical Details
----------------------------------------
This utilises an approach @colemanw & @totten & I discussed about switching to a pre hook rather than ad hoc function calls. It's an initial foray & it would be good to limit it to being called on delete. Other entities could do with this - e.g the participants are deleted & then the participant notes in the current flow - I'm pretty sure the note  won't be deleted due to the participant going first.

Comments
----------------------------------------

