### PR TITLE
APIv4 - Improve saveSearch popup in Explorer

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -21,16 +21,18 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
 
   public function run() {
     $apiDoc = new ReflectionFunction('civicrm_api4');
+    $groupOptions = civicrm_api4('Group', 'getFields', ['loadOptions' => TRUE, 'select' => ['options', 'name'], 'where' => [['name', 'IN', ['visibility', 'group_type']]]]);
     $vars = [
       'operators' => \CRM_Core_DAO::acceptedSQLOperators(),
       'basePath' => Civi::resources()->getUrl('civicrm'),
       'schema' => (array) \Civi\Api4\Entity::get()->setChain(['fields' => ['$name', 'getFields']])->execute(),
       'links' => (array) \Civi\Api4\Entity::getLinks()->execute(),
       'docs' => \Civi\Api4\Utils\ReflectionUtils::parseDocBlock($apiDoc->getDocComment()),
+      'groupOptions' => array_column((array) $groupOptions, 'options', 'name'),
     ];
     Civi::resources()
       ->addVars('api4', $vars)
-      ->addPermissions(['access debug output'])
+      ->addPermissions(['access debug output', 'edit groups', 'administer reserved groups'])
       ->addScriptFile('civicrm', 'js/load-bootstrap.js')
       ->addScriptFile('civicrm', 'bower_components/js-yaml/dist/js-yaml.min.js')
       ->addScriptFile('civicrm', 'bower_components/marked/marked.min.js')

--- a/ang/api4Explorer.ang.php
+++ b/ang/api4Explorer.ang.php
@@ -13,5 +13,5 @@ return [
     'ang/api4Explorer',
   ],
   'basePages' => [],
-  'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'crmRouteBinder', 'ui.sortable', 'api4', 'ngSanitize', 'dialogService'],
+  'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'crmRouteBinder', 'ui.sortable', 'api4', 'ngSanitize', 'dialogService', 'checklist-model'],
 ];

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -26,7 +26,7 @@
             </span>
             <input class="form-control api4-index" type="search" ng-model="index" ng-mouseenter="help('index', paramDoc('$index'))" ng-mouseleave="help()" placeholder="{{ ts('Index') }}" />
             <button class="btn btn-success pull-right" crm-icon="fa-bolt" ng-disabled="!entity || !action || loading" ng-click="execute()" ng-mouseenter="help(ts('Execute'), executeDoc())" ng-mouseleave="help()">{{ ts('Execute') }}</button>
-            <button class="btn btn-primary pull-right" crm-icon="fa-save" ng-show="entity === 'Contact' && action === 'get'" ng-click="save()" ng-mouseenter="help(ts('Save smart group'), saveDoc())" ng-mouseleave="help()">{{ ts('Save...') }}</button>
+            <button class="btn btn-primary pull-right" crm-icon="fa-save" ng-show="perm.editGroups && entity === 'Contact' && action === 'get'" ng-click="save()" ng-mouseenter="help(ts('Save smart group'), saveDoc())" ng-mouseleave="help()">{{ ts('Save...') }}</button>
           </div>
         </div>
         <div class="panel-body">

--- a/ang/api4Explorer/SaveSearch.html
+++ b/ang/api4Explorer/SaveSearch.html
@@ -1,13 +1,25 @@
 <form id="bootstrap-theme">
   <div ng-controller="SaveSearchCtrl">
-    <input class="form-control" id="api-save-search-select-group" ng-model="model.id" crm-entityref="{entity: 'Group', api: {extra: ['saved_search_id', 'description'], params: {is_hidden: 0, is_active: 1, 'saved_search_id.api_entity': model.entity}}, select: {allowClear: true, placeholder: ts('Select existing group')}}" >
+    <input class="form-control" id="api-save-search-select-group" ng-model="model.id" crm-entityref="groupEntityRefParams" >
     <label ng-show="!model.id">{{ ts('Or') }}</label>
     <input class="form-control" placeholder="Create new group" ng-model="model.title" ng-show="!model.id">
+    <hr />
     <label>{{ ts('Description:') }}</label>
-    <textarea ng-model="model.description"></textarea>
+    <textarea class="form-control" ng-model="model.description"></textarea>
+    <label>{{ ts('Group Type:') }}</label>
+    <div class="form-inline">
+      <div class="checkbox" ng-repeat="(key, label) in options.group_type">
+        <label>
+          <input type="checkbox" checklist-model="model.group_type" checklist-value="key">
+          {{ label }}
+        </label>
+      </div>
+    </div>
+    <label>{{ ts('Visibility:') }}</label>
+    <select class="form-control" ng-model="model.visibility" ng-options="name as value for (name, value) in options.visibility"></select>
     <hr />
     <div class="buttons pull-right">
-      <button ng-click="cancel()" class="btn btn-danger">{{ ts('Cancel') }}</button>
+      <button type="button" ng-click="cancel()" class="btn btn-danger">{{ ts('Cancel') }}</button>
       <button ng-click="save()" class="btn btn-primary" ng-disabled="!model.title && !model.id">{{ ts('Save') }}</button>
     </div>
   </div>

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -199,6 +199,14 @@ div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children.opt
   content: "\f0d7";
 }
 
+/* Another weird shoreditch fix */
+#bootstrap-theme .form-inline div.checkbox {
+  margin-right: 1em;
+}
+#bootstrap-theme .form-inline div.checkbox label input[type=checkbox] {
+  margin: 0;
+}
+
 /**
  * Shims so the UI isn't completely broken when a Bootstrap theme is not installed
  */


### PR DESCRIPTION
Overview
----------------------------------------
Improves saving smart groups from the Api Explorer.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/76965893-7c513c00-68fb-11ea-8b68-7fbc9d812ec2.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/76965765-3c8a5480-68fb-11ea-86fc-1c791815de20.png)

Technical Details
----------------------------------------
- UI adjusts to users' permission level for creating/administering groups
- Existing group selector auto-opens
- Styling fixed
- Group type and visibility fields exposed