### PR TITLE
dev/core#1659: Fix Case.get API returning Case Clients As Part of Related Contacts

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1141,6 +1141,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
     }
 
     $values = [];
+    $caseClientCondition = !empty($caseInfo['client_id']) ? "AND cc.id NOT IN (%2)" : '';
     $query = <<<HERESQL
     SELECT cc.display_name as name, cc.sort_name as sort_name, cc.id, cr.relationship_type_id, crt.label_b_a as role, crt.name_b_a as role_name, crt.name_a_b as role_name_reverse, ce.email, cp.phone
     FROM civicrm_relationship cr
@@ -1157,7 +1158,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
      AND cp.is_primary= 1
     WHERE cr.case_id =  %1
      AND cr.is_active
-     AND cc.id NOT IN (%2)
+     {$caseClientCondition}
     UNION
     SELECT cc.display_name as name, cc.sort_name as sort_name, cc.id, cr.relationship_type_id, crt.label_a_b as role, crt.name_a_b as role_name, crt.name_b_a as role_name_reverse, ce.email, cp.phone
     FROM civicrm_relationship cr
@@ -1174,14 +1175,16 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
      AND cp.is_primary= 1
     WHERE cr.case_id =  %1
      AND cr.is_active
-     AND cc.id NOT IN (%2)
+     {$caseClientCondition}
 HERESQL;
 
-    $clientIdType = !empty($caseInfo['client_id']) ? 'CommaSeparatedIntegers' : 'String';
     $params = [
       1 => [$caseID, 'Integer'],
-      2 => [implode(',', $caseInfo['client_id']), $clientIdType],
     ];
+
+    if ($caseClientCondition) {
+      $params[2] = [implode(',', $caseInfo['client_id']), 'CommaSeparatedIntegers'];
+    }
     $dao = CRM_Core_DAO::executeQuery($query, $params);
 
     while ($dao->fetch()) {

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1176,9 +1176,11 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
      AND cr.is_active
      AND cc.id NOT IN (%2)
 HERESQL;
+
+    $clientIdType = !empty($caseInfo['client_id']) ? 'CommaSeparatedIntegers' : 'String';
     $params = [
       1 => [$caseID, 'Integer'],
-      2 => [implode(',', $caseInfo['client_id']), 'String'],
+      2 => [implode(',', $caseInfo['client_id']), $clientIdType],
     ];
     $dao = CRM_Core_DAO::executeQuery($query, $params);
 

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -840,6 +840,53 @@ class api_v3_CaseTest extends CiviCaseTestCase {
   }
 
   /**
+   * Test Case.Get does not return case clients as part of related contacts.
+   *
+   * For multi-client cases, case clients should not be returned in duplicates for contacts.
+   */
+  public function testCaseGetDoesNotReturnClientsAsPartOfRelatedContacts() {
+    $contact1 = $this->individualCreate(['first_name' => 'Aa', 'last_name' => 'Zz']);
+    $contact2 = $this->individualCreate(['first_name' => 'Bb', 'last_name' => 'Zz']);
+    $relContact = $this->individualCreate(['first_name' => 'Rel', 'last_name' => 'Contact']);
+
+    $case = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => [$contact1, $contact2],
+      'subject' => "Test case 1",
+      'case_type_id' => $this->caseTypeId,
+    ]);
+
+    $relType = $this->relationshipTypeCreate(['name_a_b' => 'Test AB', 'name_b_a' => 'Test BA', 'contact_type_b' => 'Individual']);
+    $relContact = $this->individualCreate(['first_name' => 'First', 'last_name' => 'Last']);
+    $_REQUEST = [
+      'rel_type' => "{$relType}_b_a",
+      'rel_contact' => $relContact,
+      'case_id' => $case['id'],
+      'is_unit_test' => TRUE,
+    ];
+    CRM_Contact_Page_AJAX::relationship();
+
+    $result = $this->callAPISuccess('Case', 'get', [
+      'id' => $case['id'],
+      'sequential' => 1,
+      'return' => ['id', 'contacts'],
+    ]);
+
+    $caseContacts = $result['values'][0]['contacts'];
+    $contactIds = array_column($caseContacts, 'contact_id');
+    // We basically need to ensure that the case clients are not returned more than once.
+    // i.e there should be no duplicates for case clients.
+    $caseContactInstances = (array_count_values($contactIds));
+    $this->assertEquals(1, $caseContactInstances[$contact1]);
+    $this->assertEquals(1, $caseContactInstances[$contact2]);
+
+    // Verify that the case clients are not part of related contacts.
+    $relatedContacts = CRM_Case_BAO_Case::getRelatedContacts($case['id']);
+    $relatedContacts = array_column($relatedContacts, 'contact_id');
+    $this->assertNotContains($contact1, $relatedContacts);
+    $this->assertNotContains($contact2, $relatedContacts);
+  }
+
+  /**
    * Test the ability to add a timeline to an existing case.
    *
    * See the case.addtimeline api.


### PR DESCRIPTION
Overview
----------------------------------------
The Case.get API returns case clients as part of related contacts. The case clients are not supposed to be returned as part of the related contacts. 

Before
----------------------------------------
- Issue described above exists.

After
----------------------------------------
The Case.get API no longer returns case clients as part of related contacts. They are excluded.

The condition here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/BAO/Case.php#L1160 is meant to exclude case clients but when the clients are more than one for a case, the parameter here is treated as a String rather than `CommaSeparatedIntegers`, so the SQL end up having conditions like `NOT IN ('2,3')` rather than `NOT IN (2,3)`.

The fix was to treat the Case clients as `CommaSeparatedIntegers`