### PR TITLE
Fix CustomDataView.tpl plain empty memo field.

### DIFF
--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -130,7 +130,7 @@
                       <a href='{crmURL p="civicrm/contact/view" q="reset=1&cid=`$element.contact_ref_id`"}'>
                     {/if}
                     {if $element.field_data_type == 'Memo'}
-                      {$element.field_value|nl2br}
+                      {if $element.field_value}{$element.field_value|nl2br}{else}<br/>{/if}
                     {else}
                       {if $element.field_value}{$element.field_value} {else}<br/>{/if}
                     {/if}


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

- Create a new Custom Field Group: for Contacts, repeatable, in tab form.
- Create 3 fields: a normal text field, a 'note' with TextArea (not wysiwyg), and another text field.
- Then go to a Contact record, and fill in a new instance of that group, but leave the fields empty.
- Then go back to the Contact record, and click 'view' on that entity.

Result: two fields appear to be on the same line.

![custom-fields](https://user-images.githubusercontent.com/254741/76998472-87bc5b80-692b-11ea-8e23-5084d3510e64.gif)


Before
----------------------------------------

Two labels on the same line.

After
----------------------------------------

Each (empty) field on its own line:

![Capture d’écran de 2020-03-18 15-17-44](https://user-images.githubusercontent.com/254741/76998532-a28ed000-692b-11ea-94b7-3b073f57d56f.png)


Technical Details
----------------------------------------

Not very elegant fix, but it's what the rest of the template does.
