### PR TITLE
dev/translation#40 - Fix crash when change language on installer page

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -138,6 +138,11 @@ global $tsLocale;
 $tsLocale = 'en_US';
 $seedLanguage = 'en_US';
 
+// Backwards compatibility with default location of l10n files
+if (!defined('CIVICRM_L10N_BASEDIR') && file_exists($crmPath . DIRECTORY_SEPARATOR . 'l10n')) {
+  define('CIVICRM_L10N_BASEDIR', $crmPath . DIRECTORY_SEPARATOR . 'l10n');
+}
+
 // CRM-16801 This validates that seedLanguage is valid by looking in $langs.
 // NB: the variable is initial a $_REQUEST for the initial page reload,
 // then becomes a $_POST when the installation form is submitted.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/translation/issues/40

1. Go to install civi.
1. Choose a non-english language.
1. Page reloads and crashes.

Before
----------------------------------------
White screen and PHP Fatal error:  Uncaught RuntimeException: Undefined constant: CIVICRM_TEMPLATE_COMPILEDIR in http://example.org/sites/all/modules/civicrm/CRM/Utils/File.php:583

After
----------------------------------------
Works

Technical Details
----------------------------------------
It tries to evaluate [civicrm.private] which defaults to CIVICRM_TEMPLATE_COMPILEDIR, but this doesn't exist yet. Setting the L10N setting, which was newly introduced, avoids the evaluation.

Comments
----------------------------------------
Affects all 5.23 versions too.
