### PR TITLE
dev/core#1663 - Fix warning on relationship form

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -413,6 +413,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         }
       }
     }
+    $optionContext = $extra['option_context'] ?? NULL;
+    unset($extra['option_context']);
+
     $element = $this->addElement($type, $name, $label, $attributes, $extra);
     if (HTML_QuickForm::isError($element)) {
       CRM_Core_Error::fatal(HTML_QuickForm::errorMessage($element));
@@ -435,9 +438,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
 
     // Add context for the editing of option groups
-    if (isset($extra['option_context'])) {
-      $context = json_encode($extra['option_context']);
-      $element->setAttribute('data-option-edit-context', $context);
+    if ($optionContext) {
+      $element->setAttribute('data-option-edit-context', json_encode($optionContext));
     }
 
     return $element;


### PR DESCRIPTION
Overview
----------------------------------------
PHP warning display on add relationship form.

Before
----------------------------------------
To replicate - simply open a relationship form on a new window.

![image](https://user-images.githubusercontent.com/5929648/77040085-42586680-69dd-11ea-836b-c00cbb9a650b.png)

After
----------------------------------------
No warnings displayed.

Technical Details
----------------------------------------
Seems `option_context` was added in https://github.com/civicrm/civicrm-core/pull/11853/files#diff-f9397c2b103c68ffb588679b5d4784a2. As we're only interested in adding the json string  to it later in the code, this PR change avoids the array value to be added while creating the element.

I'm not sure why we can't simply add `data-option-edit-context` json attribute in the [relationship form](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/Form/Relationship.php#L302) itself? thoughts @mickadoo @colemanw ? 

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1663