### PR TITLE
dev/core#1662 - Saved mappings doesn't work for all use cases

### DIFF
--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -488,6 +488,7 @@ class CRM_Import_ImportProcessor {
    */
   protected function getNameFromLabel($label) {
     $titleMap = array_flip($this->getMetadataTitles());
+    $label = str_replace(' (match to contact)', '', $label);
     return $titleMap[$label] ?? '';
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix the loading of saved mapping.

Before
----------------------------------------
Saved Mapping does not load all the fields(fields having `match on contact` in its label) on mapping page. To replicate.

- Visit the import screen
- Save the mapping with the following fields 

![image](https://user-images.githubusercontent.com/5929648/77058244-2e236200-69fb-11ea-8285-ab4c3a34db42.png)

- Visit the import screen again.
- Select the csv and mapping on the first screen (Do not select "First row contains column headers" checkbox). 
- Submit and proceed to the mapping page. The saved mapping does not load the email field on this page.

![image](https://user-images.githubusercontent.com/5929648/77059018-49db3800-69fc-11ea-89c6-6398ae6b659c.png)

Also, a notice error is displayed on the top of the page 

>Notice: Undefined index: in CRM_Import_ImportProcessor->loadSavedMapping() (line 451 of /Users/jitendra/src/civicrm/CRM/Import/ImportProcessor.php).


After
----------------------------------------
Mapping fields are loaded correctly. No error is shown on the page.


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/issues/1662

ping @pradpnayak @eileenmcnaughton 