### PR TITLE
Fix checking permissions in api3 profile get

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -63,7 +63,7 @@ function civicrm_api3_profile_get($params) {
       NULL,
       FALSE,
       NULL,
-      empty($params['check_permissions']) ? FALSE : TRUE,
+      empty($params['check_permissions']),
       NULL,
       CRM_Core_Permission::EDIT
     );


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an apparent bug in api3 code where a boolean value needs to be inverted.

Technical Details
----------------------------------------
This is confusing so I'm gonna break it down here as much for myself as anyone reading this:

- `civicrm_api3_profile_get` takes a param called `check_permissions`.
  If **true**, permissions **will** be checked.
- `CRM_Core_BAO_UFGroup::getFields` takes a param called `$skipPermission`.
  If **true**, permissions **will not** be checked.
- The expression being passed into `$skipPermission` was `empty($params['check_permissions']) ? FALSE : TRUE`.
  That's a confusing way of saying `a = a`; the value stays the same.
- The problem is that the two functions expect their respective permission params to have opposite meanings, so in passing this param through from one function to the other, it needs to be inverted.

Comments
----------------------------------------
Whew! Brain hurts.