### PR TITLE
Cleanup reverse boolean expressions

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -380,7 +380,7 @@ class CRM_Admin_Page_AJAX {
         }
       }
       else {
-        $hasChildTags = empty($childTagIDs[$dao->id]) ? FALSE : TRUE;
+        $hasChildTags = !empty($childTagIDs[$dao->id]);
         $usedFor = (array) explode(',', $dao->used_for);
         $tag = [
           'id' => $dao->id,

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5847,7 +5847,7 @@ AND   displayRelType.is_active = 1
    * @return bool
    */
   public static function caseImportant($op) {
-    return in_array($op, ['LIKE', 'IS NULL', 'IS NOT NULL', 'IS EMPTY', 'IS NOT EMPTY']) ? FALSE : TRUE;
+    return !in_array($op, ['LIKE', 'IS NULL', 'IS NOT NULL', 'IS EMPTY', 'IS NOT EMPTY']);
   }
 
   /**

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -338,7 +338,7 @@ class CRM_Contact_Form_Edit_Address {
           }
         }
         $form->assign('showHideAddressFields', $parsedAddress);
-        $form->assign('loadShowHideAddressFields', empty($parsedAddress) ? FALSE : TRUE);
+        $form->assign('loadShowHideAddressFields', !empty($parsedAddress));
       }
       // end of parse address functionality
     }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -637,7 +637,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $paymentInstrument = FALSE;
     if (!$this->_mode) {
       // payment_instrument isn't required in edit and will not be present when payment block is enabled.
-      $required = $this->_id ? FALSE : TRUE;
+      $required = !$this->_id;
       $checkPaymentID = array_search('Check', CRM_Contribute_PseudoConstant::paymentInstrument('name'));
       $paymentInstrument = $this->add('select', 'payment_instrument_id',
         ts('Payment Method'),
@@ -776,7 +776,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
       $totalAmount = $this->addMoney('total_amount',
         ts('Total Amount'),
-        ($hasPriceSets) ? FALSE : TRUE,
+        !$hasPriceSets,
         $attributes['total_amount'],
         TRUE, 'currency', NULL, $currencyFreeze
       );

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -893,7 +893,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $contactID = $contributionParams['contact_id'];
 
     $isEmailReceipt = !empty($form->_values['is_email_receipt']);
-    $isSeparateMembershipPayment = empty($params['separate_membership_payment']) ? FALSE : TRUE;
+    $isSeparateMembershipPayment = !empty($params['separate_membership_payment']);
     $pledgeID = !empty($params['pledge_id']) ? $params['pledge_id'] : CRM_Utils_Array::value('pledge_id', $form->_values);
     if (!$isSeparateMembershipPayment && !empty($form->_values['pledge_block_id']) &&
       (!empty($params['is_pledge']) || $pledgeID)) {

--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -214,7 +214,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
     // finally assign this chart data to template.
     $this->assign('hasYearlyChart', $yearlyChart);
     $this->assign('hasByMonthChart', $monthlyChart);
-    $this->assign('hasChart', empty($chartData) ? FALSE : TRUE);
+    $this->assign('hasChart', !empty($chartData));
     $this->assign('chartData', json_encode($chartData ?? []));
   }
 

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -846,7 +846,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       $controller->setEmbedded(TRUE);
 
       //CRM-5839 - though we want to process form, get the control back.
-      $controller->setSkipRedirection(($doNotProcess) ? FALSE : TRUE);
+      $controller->setSkipRedirection(!$doNotProcess);
 
       $controller->run();
 
@@ -907,7 +907,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         $controller->setEmbedded(TRUE);
 
         //CRM-5846 - give the control back to drupal.
-        $controller->setSkipRedirection(($doNotProcess) ? FALSE : TRUE);
+        $controller->setSkipRedirection(!$doNotProcess);
         $controller->run();
 
         $template = CRM_Core_Smarty::singleton();

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -190,7 +190,7 @@ class CRM_Core_PseudoConstant {
     $params += [
       'grouping' => FALSE,
       'localize' => $localizeDefault,
-      'onlyActive' => ($context == 'validate' || $context == 'get') ? FALSE : TRUE,
+      'onlyActive' => !($context == 'validate' || $context == 'get'),
       'fresh' => FALSE,
       'context' => $context,
     ];

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -342,7 +342,6 @@ class CRM_Core_Selector_Controller {
       // Merge headers not containing weight to ordered headers
       $finalColumnHeaders = array_merge($reorderedHeaders, $noWeightHeaders);
 
-      $rowsEmpty = count($rows) ? FALSE : TRUE;
       $qill = $this->getQill();
       $summary = $this->getSummary();
       // if we need to store in session, lets update session
@@ -353,7 +352,7 @@ class CRM_Core_Selector_Controller {
         }
         $this->_store->set("{$this->_prefix}rows", $rows);
         $this->_store->set("{$this->_prefix}rowCount", $this->_total);
-        $this->_store->set("{$this->_prefix}rowsEmpty", $rowsEmpty);
+        $this->_store->set("{$this->_prefix}rowsEmpty", !$rows);
         $this->_store->set("{$this->_prefix}qill", $qill);
         $this->_store->set("{$this->_prefix}summary", $summary);
       }
@@ -363,7 +362,7 @@ class CRM_Core_Selector_Controller {
 
         self::$_template->assign_by_ref("{$this->_prefix}columnHeaders", $finalColumnHeaders);
         self::$_template->assign_by_ref("{$this->_prefix}rows", $rows);
-        self::$_template->assign("{$this->_prefix}rowsEmpty", $rowsEmpty);
+        self::$_template->assign("{$this->_prefix}rowsEmpty", !$rows);
         self::$_template->assign("{$this->_prefix}qill", $qill);
         self::$_template->assign("{$this->_prefix}summary", $summary);
       }

--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -240,7 +240,7 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
       $exception->contact_id2 = $cid;
     }
 
-    return $exception->find(TRUE) ? FALSE : TRUE;
+    return !$exception->find(TRUE);
   }
 
   /**

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -263,7 +263,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
 
     $doParentCheck = FALSE;
     if (CRM_Core_Permission::isMultisiteEnabled()) {
-      $doParentCheck = ($this->_id && CRM_Core_BAO_Domain::isDomainGroup($this->_id)) ? FALSE : TRUE;
+      $doParentCheck = !($this->_id && CRM_Core_BAO_Domain::isDomainGroup($this->_id));
     }
 
     $options = array(

--- a/CRM/Report/Form/Grant/Statistics.php
+++ b/CRM/Report/Form/Grant/Statistics.php
@@ -429,9 +429,8 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
           $customGroupTitle = $this->_columns[$customGroupTitle[0]]['group_title'];
           $grantStatistics[$customGroupTitle]['title'] = ts('By %1', [1 => $customGroupTitle]);
 
-          $customData = ($customValue) ? FALSE : TRUE;
           self::getStatistics($grantStatistics[$customGroupTitle], $customFieldTitle, $values,
-            $awardedGrants, $awardedGrantsAmount, $customData
+            $awardedGrants, $awardedGrantsAmount, !$customValue
           );
         }
       }

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -295,7 +295,7 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
       $sectionName = 'cg_' . $customGroup->id;
       $section = [
         'title' => ts('%1: %2', [1 => $title, 2 => $customGroup->title]),
-        'is_addable' => $customGroup->is_reserved ? FALSE : TRUE,
+        'is_addable' => !$customGroup->is_reserved,
         'custom_group_id' => $customGroup->id,
         'extends_entity_column_id' => $customGroup->extends_entity_column_id,
         'extends_entity_column_value' => CRM_Utils_Array::explodePadded($customGroup->extends_entity_column_value),

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -771,7 +771,7 @@ class CRM_Utils_Date {
       $now = self::isoToMysql($now);
     }
 
-    return (strtotime($mysqlDate) >= strtotime($now)) ? FALSE : TRUE;
+    return !(strtotime($mysqlDate) >= strtotime($now));
   }
 
   /**

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1066,7 +1066,7 @@ HTACCESS;
    */
   public static function isValidFileName($fileName = NULL) {
     if ($fileName) {
-      $check = $fileName !== basename($fileName) ? FALSE : TRUE;
+      $check = ($fileName === basename($fileName));
       if ($check) {
         if (substr($fileName, 0, 1) == '/' || substr($fileName, 0, 1) == '.' || substr($fileName, 0, 1) == DIRECTORY_SEPARATOR) {
           $check = FALSE;

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -449,7 +449,7 @@ class CRM_Utils_Rule {
    */
   public static function positiveInteger($value) {
     if (is_int($value)) {
-      return ($value < 0) ? FALSE : TRUE;
+      return !($value < 0);
     }
 
     // CRM-13460
@@ -458,11 +458,7 @@ class CRM_Utils_Rule {
       return FALSE;
     }
 
-    if (preg_match('/^\d+$/', $value)) {
-      return TRUE;
-    }
-
-    return FALSE;
+    return (bool) preg_match('/^\d+$/', $value);
   }
 
   /**

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -606,7 +606,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    */
   public function isUserLoggedIn() {
     $user = JFactory::getUser();
-    return ($user->guest) ? FALSE : TRUE;
+    return !$user->guest;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup related to #16814. Expressions converting value to an inverse boolean can usually be simplified by using `!` instead of an inline conditional.
