### PR TITLE
Fix batch contact/activity update with radio options

### DIFF
--- a/templates/CRM/common/batchCopy.tpl
+++ b/templates/CRM/common/batchCopy.tpl
@@ -37,7 +37,7 @@
       // wysiwyg editor, advanced multi-select ( to do )
       if ( elementType == 'radio' ) {
         firstElementValue = elementId.filter(':checked').eq(0).val();
-        elementId.filter("[value=" + firstElementValue + "]").prop("checked",true).change();
+        elementId.filter("[value='" + firstElementValue + "']").prop("checked",true).change();
       }
       else if ( elementType == 'checkbox' ) {
         // handle checkbox


### PR DESCRIPTION
To account for radio option values that contain a space, wrap the value name in quotes.

Overview
----------------------------------------
When updating multiple contacts, activities, etc the 'copy value from first row' is problematic with radio options.

Before
----------------------------------------
If the column is a radio field and the value in the first row contains a space, they copy from first row errors and does fails to set the value down the list. Console error shows: 

> Uncaught Error: Syntax error, unrecognized expression: [value=Value with space]

After
----------------------------------------
With the additional quotes around the value, you can copy the radio value from the first row and apply to the entire list.


Comments
----------------------------------------
This only affected the radio values, other field type values with spaces updated without issues.
