### PR TITLE
Add DAO::writeRecord and DAO::deleteRecord methods

### DIFF
--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -54,8 +54,9 @@ class DAODeleteAction extends AbstractBatchAction {
     $baoName = $this->getBaoName();
 
     if ($this->getCheckPermissions()) {
-      foreach ($items as $item) {
-        $this->checkContactPermissions($baoName, $item);
+      foreach (array_keys($items) as $key) {
+        $items[$key]['check_permissions'] = TRUE;
+        $this->checkContactPermissions($baoName, $items[$key]);
       }
     }
 
@@ -73,16 +74,8 @@ class DAODeleteAction extends AbstractBatchAction {
     }
     else {
       foreach ($items as $item) {
-        $bao = new $baoName();
-        $bao->id = $item['id'];
-        // delete it
-        $action_result = $bao->delete();
-        if ($action_result) {
-          $ids[] = ['id' => $item['id']];
-        }
-        else {
-          throw new \API_Exception("Could not delete {$this->getEntityName()} id {$item['id']}");
-        }
+        $baoName::deleteRecord($item);
+        $ids[] = ['id' => $item['id']];
       }
     }
     return $ids;

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -166,7 +166,7 @@ trait DAOActionTrait {
         $createResult = $baoName::$method($item);
       }
       else {
-        $createResult = $this->genericCreateMethod($item);
+        $createResult = $baoName::writeRecord($item);
       }
 
       if (!$createResult) {
@@ -178,26 +178,6 @@ trait DAOActionTrait {
     }
     FormattingUtil::formatOutputValues($result, $this->entityFields(), $this->getEntityName());
     return $result;
-  }
-
-  /**
-   * Fallback when a BAO does not contain create or add functions
-   *
-   * @param $params
-   * @return mixed
-   */
-  private function genericCreateMethod($params) {
-    $baoName = $this->getBaoName();
-    $hook = empty($params['id']) ? 'create' : 'edit';
-
-    \CRM_Utils_Hook::pre($hook, $this->getEntityName(), $params['id'] ?? NULL, $params);
-    /** @var \CRM_Core_DAO $instance */
-    $instance = new $baoName();
-    $instance->copyValues($params);
-    $instance->save();
-    \CRM_Utils_Hook::post($hook, $this->getEntityName(), $instance->id, $instance);
-
-    return $instance;
   }
 
   /**
@@ -281,7 +261,7 @@ trait DAOActionTrait {
     else {
       // Fixme: decouple from v3
       require_once 'api/v3/utils.php';
-      _civicrm_api3_check_edit_permissions($baoName, ['check_permissions' => 1] + $item);
+      _civicrm_api3_check_edit_permissions($baoName, $item);
     }
   }
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1325,10 +1325,7 @@ function _civicrm_api3_basic_create($bao_name, &$params, $entity = NULL) {
 /**
  * For BAO's which don't have a create() or add() functions, use this fallback implementation.
  *
- * @fixme There's an intuitive sense that this behavior should be defined somehow in the BAO/DAO class
- * structure. In practice, that requires a fair amount of refactoring and/or kludgery.
- *
- * @param string $bao_name
+ * @param string|CRM_Core_DAO $bao_name
  * @param array $params
  *
  * @throws API_Exception
@@ -1336,26 +1333,8 @@ function _civicrm_api3_basic_create($bao_name, &$params, $entity = NULL) {
  * @return CRM_Core_DAO|NULL
  *   An instance of the BAO
  */
-function _civicrm_api3_basic_create_fallback($bao_name, &$params) {
-  $dao_name = get_parent_class($bao_name);
-  if ($dao_name === 'CRM_Core_DAO' || !$dao_name) {
-    $dao_name = $bao_name;
-  }
-  $entityName = CRM_Core_DAO_AllCoreTables::getBriefName($dao_name);
-  if (empty($entityName)) {
-    throw new API_Exception("Class \"$bao_name\" does not map to an entity name", "unmapped_class_to_entity", [
-      'class_name' => $bao_name,
-    ]);
-  }
-  $hook = empty($params['id']) ? 'create' : 'edit';
-
-  CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-  $instance = new $dao_name();
-  $instance->copyValues($params);
-  $instance->save();
-  CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-
-  return $instance;
+function _civicrm_api3_basic_create_fallback($bao_name, $params) {
+  return $bao_name::writeRecord($params);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Adds generic save and delete functions to the base DAO class where it is inherited by each BAO.

Before
----------------------------------------
Generic functions for save & delete in the api layers.

After
----------------------------------------
Generic functions for save & delete now in the DAO layer where it's more centrally useful.

Technical Details
----------------------------------------
Per discussion on https://lab.civicrm.org/dev/core/issues/1648 this is with an eye toward deprecating and eventually removing all the ad-hoc `create`, `add`, and `del` functions in each BAO, in favor of handling pre/post logic through event listeners.

Comments
----------------------------------------
As the APIv3 code comment said, `"There's an intuitive sense that this behavior should be defined somehow in the BAO/DAO class"`. Now it is :).
Honestly I think the main hangup all these years was thinking of a good name for these functions that didn't conflict with any existing BAO function name.
