### PR TITLE
Fix display of payment processor title in cancelSubscription form

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -141,7 +141,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         $searchRange,
         'send_cancel_request',
         ts('Send cancellation request to %1 ?',
-          [1 => $this->_paymentProcessorObj->_processorName])
+          [1 => $this->_paymentProcessorObj->getTitle()])
       );
     }
     else {

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -623,6 +623,15 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Get the title of the payment processor to display to the user
+   *
+   * @return string
+   */
+  public function getTitle() {
+    return $this->getPaymentProcessor()['title'] ?? $this->getPaymentProcessor()['name'];
+  }
+
+  /**
    * Getter for accessing member vars.
    *
    * @todo believe this is unused

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -97,13 +97,25 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     $pps = [];
     if (!empty($this->_paymentProcessors)) {
       foreach ($this->_paymentProcessors as $key => $processor) {
-        $pps[$key] = $processor['title'] ?? $processor['name'];
+        $pps[$key] = $this->getPaymentProcessorTitle($processor);
       }
     }
     if ($this->getPayLaterLabel()) {
       $pps[0] = $this->getPayLaterLabel();
     }
     return $pps;
+  }
+
+  /**
+   * Get the title of the payment processor to display to the user
+   * Note: There is an identical function in CRM_Core_Payment
+   *
+   * @param array $processor
+   *
+   * @return string
+   */
+  protected function getPaymentProcessorTitle($processor) {
+    return $processor['title'] ?? $processor['name'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix the display of the payment processor title on the cancel subscription form

Before
----------------------------------------
Payment processor title not displayed properly if deprecated _processorName property not implemented (eg. GoCardless).

After
----------------------------------------
Payment processor title displayed properly:
![image](https://user-images.githubusercontent.com/2052161/77101024-89128480-6a0e-11ea-9f11-bf939ec8b8f8.png)


Technical Details
----------------------------------------
The `_processorName` property on the payment processor is deprecated but still used in various places. We have `civicrm_payment_processor.title` and `.name` which should be used - title is newer but is used in preference to name for display to the end user.

Comments
----------------------------------------
@eileenmcnaughton Please could you take a look - I'm adding a new function `getTitle()` to `CRM_Core_Payment` but not sure that's best because you can't, for example, use it in `CRM_Financial_Form_FrontEndPaymentFormTrait`. We should find a way to make it work for both.