### PR TITLE
[REF] Remove redundant call to build permissions

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3876,6 +3876,9 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * Buld contact acl clause
    * @deprecated in favor of buildPermissionClause
    *
+   * Note that if the buildPermissionClause function is called (which most reports do from
+   * buildQuery then the results of this function are re-calculated and overwritten.
+   *
    * @param string $tableAlias
    */
   public function buildACLClause($tableAlias = 'contact_a') {

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -742,14 +742,6 @@ ROUND(AVG({$this->_aliases['civicrm_contribution_soft']}.amount), 2) as civicrm_
   }
 
   /**
-   * Post process function.
-   */
-  public function postProcess() {
-    $this->buildACLClause($this->_aliases['civicrm_contact']);
-    parent::postProcess();
-  }
-
-  /**
    * Build chart.
    *
    * @param array $rows


### PR DESCRIPTION


Overview
----------------------------------------
Per the comments I added to the function the output of this permissions clause is overwritten. I stepped through
this in the process of reviewing the datepicker PR & confirmed it

Before
----------------------------------------
Override postProcess function calls ```$this->buildACLClause($this->_aliases['civicrm_contact']);``` but I have confirmed the results of that are overwritten

After
----------------------------------------
Poof

Technical Details
----------------------------------------
@seamuslee001  @monishdeb  @yashodha @MegaphoneJon  - I think we have suspected these fn calls were obsolete for a while but I can now confirm that any form that calls ```buildACLClause``` and then calls ```parent::postProcess ```will have the output of ```buildACLClause``` ovewritten

```parent::postProcess ```calls
 ```$sql = $this->buildQuery();``` which calls
 ```$this->buildPermissionClause();```
which does

```
    // Override output from buildACLClause
    $this->_aclFrom = NULL;
    $this->_aclWhere = implode(' AND ', $ret);
```



Comments
----------------------------------------

