### PR TITLE
dev/core#561 Add in deprecation notice on addDateRange funtion

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1315,6 +1315,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param bool $displayTime
    */
   public function addDateRange($name, $from = '_from', $to = '_to', $label = 'From:', $dateFormat = 'searchDate', $required = FALSE, $displayTime = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use CRM_Core_Form::addDatePickerRange insted');
     if ($displayTime) {
       $this->addDateTime($name . $from, $label, $required, ['formatType' => $dateFormat]);
       $this->addDateTime($name . $to, ts('To:'), $required, ['formatType' => $dateFormat]);


### PR DESCRIPTION
Overview
----------------------------------------
Following the various work on https://lab.civicrm.org/dev/core/issues/561 this now adds in a deprecation warning on what is now considered a deprecated function which uses jcalander to render the date fields

Before
----------------------------------------
Function not deprecated

After
----------------------------------------
Function declared as deprecated

ping @eileenmcnaughton 