### PR TITLE
API tests - remove unnecessary check for v4

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -23,12 +23,7 @@ trait Api3TestTrait {
    * @return array
    */
   public function versionThreeAndFour() {
-    $r = [[3]];
-    global $civicrm_root;
-    if (file_exists("$civicrm_root/Civi/Api4") || file_exists("$civicrm_root/ext/api4")) {
-      $r[] = [4];
-    }
-    return $r;
+    return [[3], [4]];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Removes an unnecessary holdover from when APIv4 was an extension transitioning into core.

Before
----------------------------------------
Extra code.

After
----------------------------------------
Gone.
