### PR TITLE
[REF] Replace \CRM_Utils_Array::value with ??

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -93,7 +93,7 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
       $stateProvince = \CRM_Core_PseudoConstant::stateProvince();
       $loc['street_address'] = $actionSearchResult->street_address;
       $loc['city'] = $actionSearchResult->city;
-      $loc['state_province'] = \CRM_Utils_Array::value($actionSearchResult->state_province_id, $stateProvince);
+      $loc['state_province'] = $stateProvince[$actionSearchResult->state_province_id] ?? NULL;
       $loc['postal_code'] = $actionSearchResult->postal_code;
       //$entityTokenParams[$tokenEntity][$field] = \CRM_Utils_Address::format($loc);
       $row->tokens($entity, $field, \CRM_Utils_Address::format($loc));
@@ -115,7 +115,7 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
       }
       elseif (!empty($actionSearchResult->entityID)) {
         $info = \CRM_Contribute_BAO_Contribution::getPaymentInfo($actionSearchResult->entityID, 'event');
-        $balancePay = \CRM_Utils_Array::value('balance', $info);
+        $balancePay = $info['balance'] ?? NULL;
         $balancePay = \CRM_Utils_Money::format($balancePay);
       }
       $row->tokens($entity, $field, $balancePay);

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -147,7 +147,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       'id' => $this->_mailingID,
       'contact_id' => $contactId,
     ]);
-    $mailing = \CRM_Utils_Array::value('values', $result);
+    $mailing = $result['values'] ?? NULL;
 
     $title = NULL;
     if (isset($mailing['body_html']) && empty($_GET['text'])) {

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -325,8 +325,8 @@ class Kernel {
    */
   public function formatApiException($e, $apiRequest) {
     $data = $e->getExtraParams();
-    $data['entity'] = \CRM_Utils_Array::value('entity', $apiRequest);
-    $data['action'] = \CRM_Utils_Array::value('action', $apiRequest);
+    $data['entity'] = $apiRequest['entity'] ?? NULL;
+    $data['action'] = $apiRequest['action'] ?? NULL;
 
     if (\CRM_Utils_Array::value('debug', \CRM_Utils_Array::value('params', $apiRequest))
       // prevent recursion

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -210,7 +210,7 @@ abstract class SelectQuery {
       if (!isset($fkField['FKApiSpec'])) {
         $fkField['FKApiSpec'] = \_civicrm_api_get_fields($fkField['FKApiName']);
       }
-      $fieldInfo = \CRM_Utils_Array::value($fieldName, $fkField['FKApiSpec']);
+      $fieldInfo = $fkField['FKApiSpec'][$fieldName] ?? NULL;
 
       $keyColumn = \CRM_Utils_Array::value('FKKeyColumn', $fkField, 'id');
       if (!$fieldInfo || !isset($fkField['FKApiSpec'][$keyColumn])) {
@@ -259,7 +259,7 @@ abstract class SelectQuery {
   protected function getJoinInfo(&$fkField, $stack) {
     if ($fkField['name'] == 'entity_id') {
       $entityTableParam = substr(implode('.', $stack), 0, -2) . 'table';
-      $entityTable = \CRM_Utils_Array::value($entityTableParam, $this->where);
+      $entityTable = $this->where[$entityTableParam] ?? NULL;
       if ($entityTable && is_string($entityTable) && \CRM_Core_DAO_AllCoreTables::getClassForTable($entityTable)) {
         $fkField['FKClassName'] = \CRM_Core_DAO_AllCoreTables::getClassForTable($entityTable);
         $fkField['FKApiName'] = \CRM_Core_DAO_AllCoreTables::getBriefName($fkField['FKClassName']);

--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -106,7 +106,7 @@ class ChainSubscriber implements EventSubscriberInterface {
 
         $subaction = empty($subAPI[2]) ? $action : $subAPI[2];
         $subParams = [
-          'debug' => \CRM_Utils_Array::value('debug', $params),
+          'debug' => $params['debug'] ?? NULL,
         ];
         $subEntity = _civicrm_api_get_entity_name_from_camel($subAPI[1]);
 

--- a/Civi/API/Subscriber/I18nSubscriber.php
+++ b/Civi/API/Subscriber/I18nSubscriber.php
@@ -50,10 +50,10 @@ class I18nSubscriber implements EventSubscriberInterface {
 
     $params = $apiRequest['params'];
     if ($apiRequest['version'] < 4) {
-      $language = !empty($params['options']['language']) ? $params['options']['language'] : \CRM_Utils_Array::value('option.language', $params);
+      $language = $params['options']['language'] ?? $params['option.language'] ?? NULL;
     }
     else {
-      $language = \CRM_Utils_Array::value('language', $params);
+      $language = $params['language'] ?? NULL;
     }
     if ($language) {
       $this->setLocale($language, $apiRequest['id']);

--- a/Civi/Angular/Page/Modules.php
+++ b/Civi/Angular/Page/Modules.php
@@ -77,19 +77,19 @@ class Modules extends \CRM_Core_Page {
 
     switch ($event->asset) {
       case 'angular-modules.json':
-        $moduleNames = $page->parseModuleNames(\CRM_Utils_Array::value('modules', $event->params), $angular);
+        $moduleNames = $page->parseModuleNames($event->params['modules'] ?? NULL, $angular);
         $event->mimeType = 'application/json';
         $event->content = json_encode($page->getMetadata($moduleNames, $angular));
         break;
 
       case 'angular-modules.js':
-        $moduleNames = $page->parseModuleNames(\CRM_Utils_Array::value('modules', $event->params), $angular);
+        $moduleNames = $page->parseModuleNames($event->params['modules'] ?? NULL, $angular);
         $event->mimeType = 'application/javascript';
         $event->content = $page->digestJs($angular->getResources($moduleNames, 'js', 'path'));
         break;
 
       case 'angular-modules.css':
-        $moduleNames = $page->parseModuleNames(\CRM_Utils_Array::value('modules', $event->params), $angular);
+        $moduleNames = $page->parseModuleNames($event->params['modules'] ?? NULL, $angular);
         $event->mimeType = 'text/css';
         $event->content = \CRM_Utils_File::concat($angular->getResources($moduleNames, 'css', 'path'), "\n");
 

--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -221,7 +221,7 @@ class SettingsManager {
       ]);
       $defaults = [];
       foreach ($specs as $key => $spec) {
-        $defaults[$key] = \CRM_Utils_Array::value('default', $spec);
+        $defaults[$key] = $spec['default'] ?? NULL;
       }
       \CRM_Utils_Array::extend($defaults, self::getSystemDefaults($entity));
       $this->cache->set($cacheKey, $defaults);


### PR DESCRIPTION
Part of ongoing refactoring to reduce reliance on an old function.
This catches ones that the previous regex missed because of the leading backslash.