### PR TITLE
[REF] Cleanup is_array(CRM_Utils_Array::value()) pattern

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -149,7 +149,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
 
     $transaction = new CRM_Core_Transaction();
-    if (is_array(CRM_Utils_Array::value('source_record_id', $params))) {
+    if (isset($params['source_record_id']) && is_array($params['source_record_id'])) {
       $sourceRecordIds = implode(',', $params['source_record_id']);
     }
     else {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -516,16 +516,11 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    * Check if there is data to create the object.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
    *
    * @return bool
    */
-  public static function dataExists(&$params) {
-    // return if no data present
-    if (!is_array(CRM_Utils_Array::value('contact_check', $params))) {
-      return FALSE;
-    }
-    return TRUE;
+  public static function dataExists($params) {
+    return (isset($params['contact_check']) && is_array($params['contact_check']));
   }
 
   /**

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1807,7 +1807,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     }
 
     foreach ($locationFields as $locKeys) {
-      if (is_array(CRM_Utils_Array::value($locKeys, $params))) {
+      if (isset($params[$locKeys]) && is_array($params[$locKeys])) {
         foreach ($params[$locKeys] as $key => $value) {
           if ($modeFill) {
             $getValue = CRM_Utils_Array::retrieveValueRecursive($contact, $locKeys);

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -423,7 +423,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
       $dashlet->id = $dashboardID;
     }
 
-    if (is_array(CRM_Utils_Array::value('permission', $params))) {
+    if (isset($params['permission']) && is_array($params['permission'])) {
       $params['permission'] = implode(',', $params['permission']);
     }
     $dashlet->copyValues($params);

--- a/CRM/Custom/Page/Group.php
+++ b/CRM/Custom/Page/Group.php
@@ -303,7 +303,7 @@ class CRM_Custom_Page_Group extends CRM_Core_Page {
         $customGroup[$key]["extends_entity_column_value"] = $colValue;
       }
       else {
-        if (is_array(CRM_Utils_Array::value($type, $subTypes))) {
+        if (isset($subTypes[$type]) && is_array($subTypes[$type])) {
           $customGroup[$key]["extends_entity_column_value"] = ts("Any");
         }
       }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1410,7 +1410,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
       // Reminder should be sent only to the direct membership
       unset($params['reminder_date']);
       // unset the custom value ids
-      if (is_array(CRM_Utils_Array::value('custom', $params))) {
+      if (isset($params['custom']) && is_array($params['custom'])) {
         foreach ($params['custom'] as $k => $values) {
           foreach ($values as $i => $value) {
             unset($params['custom'][$k][$i]['id']);

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -741,14 +741,11 @@ INNER  JOIN  civicrm_custom_field cf ON ( cg.id = cf.custom_group_id )
       if (empty($this->_columns[$resTable]['alias'])) {
         $this->_columns[$resTable]['alias'] = "{$resTable}_survey_response";
       }
-      if (!is_array(CRM_Utils_Array::value('fields', $this->_columns[$resTable]))) {
-        $this->_columns[$resTable]['fields'] = array();
+      if (empty($this->_columns[$resTable]['fields'])) {
+        $this->_columns[$resTable]['fields'] = [];
       }
 
-      if (in_array($this->_outputMode, array(
-        'print',
-        'pdf',
-      ))) {
+      if (in_array($this->_outputMode, ['print', 'pdf'])) {
         $this->_columnTitleOverrides["{$resTable}_{$fieldName}"] = 'Q' . $fieldCnt;
         $fieldCnt++;
       }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -659,10 +659,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
 
     // Get the menu for above URL.
     $item = CRM_Core_Menu::get($path);
-    if (!empty(CRM_Utils_Array::value('is_public', $item))) {
-      return TRUE;
-    }
-    return FALSE;
+    return !empty($item['is_public']);
   }
 
   /**

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -513,7 +513,7 @@ function _civicrm_api3_generic_get_metadata_options(&$metadata, $apiRequest, $fi
   }
 
   $options = civicrm_api($apiRequest['entity'], 'getoptions', ['version' => 3, 'field' => $fieldname, 'context' => $context]);
-  if (is_array(CRM_Utils_Array::value('values', $options))) {
+  if (isset($options['values']) && is_array($options['values'])) {
     $metadata[$fieldname]['options'] = $options['values'];
   }
 }

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -135,7 +135,7 @@ function civicrm_api3_setting_getoptions($params) {
   $domainId = $params['domain_id'] ?? NULL;
   $specs = \Civi\Core\SettingsMetadata::getMetadata(['name' => $params['field']], $domainId, TRUE);
 
-  if (empty($specs[$params['field']]) || !is_array(CRM_Utils_Array::value('options', $specs[$params['field']]))) {
+  if (!isset($specs[$params['field']]['options']) || !is_array($specs[$params['field']]['options'])) {
     throw new API_Exception("The field '" . $params['field'] . "' has no associated option list.");
   }
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -183,7 +183,7 @@ function civicrm_api3_create_success($values = 1, $params = [], $entity = NULL, 
     }
 
     $allFields = [];
-    if ($action !== 'getfields' && is_array($apiFields) && is_array(CRM_Utils_Array::value('values', $apiFields))) {
+    if ($action !== 'getfields' && isset($apiFields['values']) && is_array($apiFields['values'])) {
       $allFields = array_keys($apiFields['values']);
     }
     $paramFields = array_keys($params);


### PR DESCRIPTION
Overview
----------------------------------------
General cleanup when passing `CRM_Utils_Array::value()` result into another function. Simplify expressions while preserving the meaning.

Technical Details
----------------------------------------
Passing `CRM_Utils_Array::value()` into `is_array()` can be simplified by adding `isset()` in front.