### PR TITLE
[REF] APIv4 - Restructure the way get query objects are constucted

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -726,13 +726,9 @@ ORDER BY   gc.contact_id, g.children
    * @throws CRM_Core_Exception
    */
   protected static function getApiSQL($savedSearchID, array $savedSearch): array {
-    $api = \Civi\API\Request::create($savedSearch['api_entity'], 'get', $savedSearch['api_params']);
-    $query = new \Civi\Api4\Query\Api4SelectQuery($api->getEntityName(), FALSE, $api->entityFields());
-    $query->select = ['id'];
-    $query->where = $api->getWhere();
-    $query->orderBy = $api->getOrderBy();
-    $query->limit = $api->getLimit();
-    $query->offset = $api->getOffset();
+    $apiParams = ['select' => ['id'], 'checkPermissions' => FALSE] + $savedSearch['api_params'];
+    $api = \Civi\API\Request::create($savedSearch['api_entity'], 'get', $apiParams);
+    $query = new \Civi\Api4\Query\Api4SelectQuery($api);
     $sql = $query->getSql();
     return [
       'select' => substr($sql, 0, strpos($sql, 'FROM')),

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -85,7 +85,7 @@ abstract class SelectQuery {
     $baoName = _civicrm_api3_get_BAO($entity);
     $bao = new $baoName();
 
-    $this->entityFieldNames = _civicrm_api3_field_names(_civicrm_api3_build_fields_array($bao));
+    $this->entityFieldNames = array_column($baoName::fields(), 'name');
     $this->apiFieldSpec = $this->getFields();
 
     $this->query = \CRM_Utils_SQL_Select::from($bao->tableName() . ' ' . self::MAIN_TABLE_ALIAS);

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -38,7 +38,7 @@ class DAODeleteAction extends AbstractBatchAction {
       throw new \API_Exception('Cannot delete ' . $this->getEntityName() . ' with no "where" parameter specified');
     }
 
-    $items = $this->getObjects();
+    $items = $this->getBatchRecords();
     if ($items) {
       $result->exchangeArray($this->deleteObjects($items));
     }

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -21,6 +21,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Query\Api4SelectQuery;
+
 /**
  * Retrieve $ENTITIES based on criteria specified in the `where` parameter.
  *
@@ -46,6 +48,19 @@ class DAOGetAction extends AbstractGetAction {
     $this->setDefaultWhereClause();
     $this->expandSelectClauseWildcards();
     $result->exchangeArray($this->getObjects());
+  }
+
+  /**
+   * @return array|int
+   */
+  protected function getObjects() {
+    $query = new Api4SelectQuery($this);
+
+    $result = $query->run();
+    if (is_array($result)) {
+      \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
+    }
+    return $result;
   }
 
 }

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -66,7 +66,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
     }
 
     // Batch update 1 or more records based on WHERE clause
-    $items = $this->getObjects();
+    $items = $this->getBatchRecords();
     foreach ($items as &$item) {
       $item = $this->values + $item;
     }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -21,7 +21,6 @@
 namespace Civi\Api4\Generic\Traits;
 
 use Civi\Api4\Utils\FormattingUtil;
-use Civi\Api4\Query\Api4SelectQuery;
 
 /**
  * @method string getLanguage()
@@ -77,26 +76,6 @@ trait DAOActionTrait {
       }
     }
     return $values;
-  }
-
-  /**
-   * @return array|int
-   */
-  protected function getObjects() {
-    $query = new Api4SelectQuery($this->getEntityName(), $this->getCheckPermissions(), $this->entityFields());
-    $query->select = $this->getSelect();
-    $query->where = $this->getWhere();
-    $query->orderBy = $this->getOrderBy();
-    $query->limit = $this->getLimit();
-    $query->offset = $this->getOffset();
-    if ($this->getDebug()) {
-      $query->debugOutput =& $this->_debugOutput;
-    }
-    $result = $query->run();
-    if (is_array($result)) {
-      \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
-    }
-    return $result;
   }
 
   /**

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -457,11 +457,13 @@ function _civicrm_api3_store_values(&$fields, &$params, &$values) {
 /**
  * Returns field names of the given entity fields.
  *
+ * @deprecated
  * @param array $fields
  *   Fields array to retrieve the field names for.
  * @return array
  */
 function _civicrm_api3_field_names($fields) {
+  CRM_Core_Error::deprecatedFunctionWarning('array_column');
   $result = [];
   foreach ($fields as $key => $value) {
     if (!empty($value['name'])) {

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryComplexJoinTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryComplexJoinTest.php
@@ -46,8 +46,8 @@ class Api4SelectQueryComplexJoinTest extends UnitTestCase {
   }
 
   public function testWithComplexRelatedEntitySelect() {
-    $query = new Api4SelectQuery('Contact', FALSE, civicrm_api4('Contact', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
-    $query->select[] = 'id';
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);    $query->select[] = 'id';
     $query->select[] = 'display_name';
     $query->select[] = 'phones.*_id';
     $query->select[] = 'emails.email';
@@ -83,8 +83,8 @@ class Api4SelectQueryComplexJoinTest extends UnitTestCase {
   }
 
   public function testWithSelectOfOrphanDeepValues() {
-    $query = new Api4SelectQuery('Contact', FALSE, civicrm_api4('Contact', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
-    $query->select[] = 'id';
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);    $query->select[] = 'id';
     $query->select[] = 'first_name';
     // emails not selected
     $query->select[] = 'emails.location_type.name';
@@ -95,7 +95,8 @@ class Api4SelectQueryComplexJoinTest extends UnitTestCase {
   }
 
   public function testOrderDoesNotMatter() {
-    $query = new Api4SelectQuery('Contact', FALSE, civicrm_api4('Contact', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);
     $query->select[] = 'id';
     $query->select[] = 'first_name';
     // before emails selection

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -51,7 +51,8 @@ class Api4SelectQueryTest extends UnitTestCase {
   public function testWithSingleWhereJoin() {
     $phoneNum = $this->getReference('test_phone_1')['phone'];
 
-    $query = new Api4SelectQuery('Contact', FALSE, civicrm_api4('Contact', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);
     $query->where[] = ['phones.phone', '=', $phoneNum];
     $results = $query->run();
 
@@ -61,7 +62,8 @@ class Api4SelectQueryTest extends UnitTestCase {
   public function testOneToManyJoin() {
     $phoneNum = $this->getReference('test_phone_1')['phone'];
 
-    $query = new Api4SelectQuery('Contact', FALSE, civicrm_api4('Contact', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);
     $query->select[] = 'id';
     $query->select[] = 'first_name';
     $query->select[] = 'phones.phone';
@@ -79,7 +81,8 @@ class Api4SelectQueryTest extends UnitTestCase {
     $phoneNum = $this->getReference('test_phone_1')['phone'];
     $contact = $this->getReference('test_contact_1');
 
-    $query = new Api4SelectQuery('Phone', FALSE, civicrm_api4('Phone', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
+    $api = \Civi\API\Request::create('Phone', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);
     $query->select[] = 'id';
     $query->select[] = 'phone';
     $query->select[] = 'contact.display_name';
@@ -93,7 +96,8 @@ class Api4SelectQueryTest extends UnitTestCase {
   }
 
   public function testOneToManyMultipleJoin() {
-    $query = new Api4SelectQuery('Contact', FALSE, civicrm_api4('Contact', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);
     $query->select[] = 'id';
     $query->select[] = 'first_name';
     $query->select[] = 'phones.phone';

--- a/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
+++ b/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
@@ -48,7 +48,8 @@ class OptionValueJoinTest extends UnitTestCase {
   }
 
   public function testCommunicationMethodJoin() {
-    $query = new Api4SelectQuery('Contact', FALSE, civicrm_api4('Contact', 'getFields', ['includeCustom' => FALSE, 'checkPermissions' => FALSE, 'action' => 'get'], 'name'));
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);
     $query->select[] = 'first_name';
     $query->select[] = 'preferred_communication_method.label';
     $query->where[] = ['preferred_communication_method', 'IS NOT NULL'];


### PR DESCRIPTION
Overview
----------------------------------------
Makes the api4 code a bit more sensible.

Before
----------------------------------------
Lots of work to construct an `Api4SelectQuery` object.

After
----------------------------------------
Object constructs itself.

Technical Details
----------------------------------------
I also removed the coupling between non-get actions and the `Api4SelectQuery` object to make more room for complex stuff in get like groupBy that isn't in update or delete.