### PR TITLE
log error message instead of throwing exception

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -63,7 +63,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $contact = reset($contact);
         if (!$contact || is_a($contact, 'CRM_Core_Error')) {
           // FIXME: Need to differentiate errors which kill the batch vs the individual row.
-          CRM_Core_Error::debug_log_message("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
+          \Civi::log()->debug("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
           continue;
         }
 

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -63,7 +63,8 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $contact = reset($contact);
         if (!$contact || is_a($contact, 'CRM_Core_Error')) {
           // FIXME: Need to differentiate errors which kill the batch vs the individual row.
-          throw new TokenException("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
+          CRM_Core_Error::debug_log_message("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
+          continue;
         }
 
         //update value of custom field token


### PR DESCRIPTION
Overview
----------------------------------------
log error message instead of throwing exception

Before
----------------------------------------
can cause the scheduled job to fail if the token data for a contact is not generated properly.

After
----------------------------------------
log the error and carry on for the rest of the contacts.
