### PR TITLE
dev/core#1331 Add missing parameter to translation string

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -12,7 +12,7 @@
   <div class="messages status no-popup">
     <div class="icon inform-icon"></div>
     <p>{ts}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. Please be aware that any changes that you make here may not be reflected in the payment processor. Please ensure that you alter the related subscription at the payment processor.{/ts}</p>
-    {if $cancelAutoRenew}<p>{ts}To stop the automatic renewal:
+    {if $cancelAutoRenew}<p>{ts 1=$cancelAutoRenew}To stop the automatic renewal:
       <a href="%1">Cancel auto-renew</a>
     {/ts}</p>{/if}
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
When doing some testing, I realised that I'd missed a parameter from the translation string in #16609. This PR adds that parameter.

This fixes an issue that prevented the user from cancelling an auto-renew membership in the edit membership screen.

![image](https://user-images.githubusercontent.com/13518928/77338712-a0a98000-6d22-11ea-8f71-ff0e5c8a6131.png)


Before
----------------------------------------
Clicking on 'Cancel auto-renew' does nothing because the URL is incorrect.

After
----------------------------------------
Clicking on 'Cancel auto-renew' takes the user to the correct page.

Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.
