### PR TITLE
dev/core#1668 - Avoid E_NOTICE when removing last dashlet

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -506,7 +506,7 @@ LIMIT {$offset}, {$rowCount}
   public static function dashboard() {
     switch ($_REQUEST['op']) {
       case 'save_columns':
-        CRM_Core_BAO_Dashboard::saveDashletChanges($_REQUEST['columns']);
+        CRM_Core_BAO_Dashboard::saveDashletChanges($_REQUEST['columns'] ?? NULL);
         break;
 
       case 'delete_dashlet':


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1668

1. Go to /civicrm/dashboard
1. Remove all dashlets.
1. Look in drupal watchdog: `Notice: Undefined index: columns in CRM_Contact_Page_AJAX::dashboard() (line 509 of .../CRM/Contact/Page/AJAX.php)`

Subsequent visits to a blank dashboard are fine but you can make the notice come back by adding a dashlet and then removing it again.