### PR TITLE
[NFC/TEST] Resurrect unfinished test for getRelatedCases()

### DIFF
--- a/CRM/Case/Form/Activity/LinkCases.php
+++ b/CRM/Case/Form/Activity/LinkCases.php
@@ -131,7 +131,7 @@ class CRM_Case_Form_Activity_LinkCases {
    * @param array $params
    * @param CRM_Activity_BAO_Activity $activity
    */
-  public static function endPostProcess(&$form, &$params, &$activity) {
+  public static function endPostProcess($form, $params, $activity) {
     $activityId = $activity->id;
     $linkCaseID = $params['link_to_case_id'] ?? NULL;
 


### PR DESCRIPTION
Overview
----------------------------------------
This resurrects a 6 year old unfinished test because tests are cool, and also this test counts as a test for another PR which I'll post in a few seconds. It has nothing to do with this, but writing a test for that other PR has little value and would only fail on windows, so here is a test in lieu.

Also note that in endPostProcess() the ampersands can go because:
* $form is never used
* $params and $activity are never altered