### PR TITLE
dev/core#1643 - Make civicrm-setup (especially drupal 8) work on windows

### DIFF
--- a/CRM/Core/CodeGen/Util/Xml.php
+++ b/CRM/Core/CodeGen/Util/Xml.php
@@ -12,6 +12,8 @@ class CRM_Core_CodeGen_Util_Xml {
    * @return SimpleXMLElement|bool
    */
   public static function parse($file) {
+    // xinclude() only works with forward slashes
+    $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);
     $dom = new DomDocument();
     $xmlString = file_get_contents($file);
     $dom->loadXML($xmlString);


### PR DESCRIPTION
Overview
----------------------------------------
In the past there was really only Gencode.php, and it worked as-is on windows. There are now becoming more consumers of the CRM/Core/GenCode functions, like civicrm-setup, and making sure all of them use forward slashes all the time except for exec/system calls is difficult. This at least fireproofs the xml xinclude() function which flat out fails if you give it backslashes.

To reproduce the failure try to install drupal 8 on windows using steps at https://lab.civicrm.org/dev/core/-/issues/1643#note_33452

You can also, on windows, just do `cv php:eval "$x = CRM_Core_CodeGen_Util_Xml::parse('C:\\path\\to\\civicrm/xml/schema/Schema.xml'); var_dump($x);"` using backwards slashes for the first part of the path and note that the var_dump contains no tables. Do it again with all forward slashes and it will contain the tables.

Before
----------------------------------------
civicrm-setup silently seems to succeed, but it quickly becomes obvious no tables were created.

After
----------------------------------------
Can install on windows using civicrm-setup / cv core:install

Technical Details
----------------------------------------
Details in ticket. The change is a no-op for linux.

Comments
----------------------------------------
It makes no sense to write a test for this because it only fails on windows, and the whole test framework/install process fails if it's broken so it would be pretty obvious even without a test. Instead I made a test at https://github.com/civicrm/civicrm-core/pull/16885 for something unrelated.
