### PR TITLE
dev/joomla#26 - Fix path derivation when CMS is rooted in a subdir

### DIFF
--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -38,19 +38,19 @@ class Paths {
       ->register('civicrm.packages', function () {
         return [
           'path' => \Civi::paths()->getPath('[civicrm.root]/packages/'),
-          'url' => \Civi::paths()->getUrl('[civicrm.root]/packages/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/packages/', 'absolute'),
         ];
       })
       ->register('civicrm.vendor', function () {
         return [
           'path' => \Civi::paths()->getPath('[civicrm.root]/vendor/'),
-          'url' => \Civi::paths()->getUrl('[civicrm.root]/vendor/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/vendor/', 'absolute'),
         ];
       })
       ->register('civicrm.bower', function () {
         return [
           'path' => \Civi::paths()->getPath('[civicrm.root]/bower_components/'),
-          'url' => \Civi::paths()->getUrl('[civicrm.root]/bower_components/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/bower_components/', 'absolute'),
         ];
       })
       ->register('civicrm.files', function () {

--- a/tests/phpunit/Civi/Core/PathsTest.php
+++ b/tests/phpunit/Civi/Core/PathsTest.php
@@ -101,4 +101,52 @@ class PathsTest extends \CiviUnitTestCase {
     $this->assertEquals("$cmsRoot/foo", $p->getUrl('foo'));
   }
 
+  /**
+   * This test demonstrates how to (and how not to) compute a derivative path variable.
+   */
+  public function testAbsoluteRelativeConversions() {
+    $gstack = \CRM_Utils_GlobalStack::singleton();
+    $gstack->push(['_SERVER' => ['HTTP_HOST' => 'example.com']]);
+    $cleanup = \CRM_Utils_AutoClean::with([$gstack, 'pop']);
+
+    $paths = new Paths();
+    $paths->register('test.base', function () {
+      return [
+        'path' => '/var/foo/',
+        'url' => 'http://example.com/foo/',
+      ];
+    });
+    $paths->register('test.goodsub', function () use ($paths) {
+      return [
+        'path' => $paths->getPath('[test.base]/good/'),
+        'url' => $paths->getUrl('[test.base]/good/', 'absolute'),
+      ];
+    });
+    $paths->register('test.badsub', function () use ($paths) {
+      return [
+        'path' => $paths->getPath('[test.base]/bad/'),
+        // This *looks* OK, but `getUrl()` by default uses `$preferFormat==relative`.
+        // The problem is that `$civicrm_paths['...']['url']` is interpreted as relative to CMS root,
+        // and `getUrl(..., 'relative')` is interpreted as relative to HTTP root.
+        // So this definition misbehaves on sites where the CMS root and HTTP root are different.
+        'url' => $paths->getUrl('[test.base]/bad/'),
+      ];
+    });
+
+    // The test.base works as explicitly defined...
+    $this->assertEquals('/var/foo', $paths->getPath('[test.base]/.'));
+    $this->assertEquals('http://example.com/foo', $paths->getUrl('[test.base]/.', 'absolute'));
+    $this->assertEquals('/foo', $paths->getUrl('[test.base]/.', 'relative'));
+
+    // The test.goodsub works as expected...
+    $this->assertEquals('/var/foo/good', $paths->getPath('[test.goodsub]/.'));
+    $this->assertEquals('http://example.com/foo/good', $paths->getUrl('[test.goodsub]/.', 'absolute'));
+    $this->assertEquals('/foo/good', $paths->getUrl('[test.goodsub]/.', 'relative'));
+
+    // The test.badsub doesn't work as expected.
+    $this->assertEquals('/var/foo/bad', $paths->getPath('[test.badsub]/.'));
+    $this->assertNotEquals('http://example.com/foo/bad', $paths->getUrl('[test.badsub]/.', 'absolute'));
+    $this->assertNotEquals('/foo/bad', $paths->getUrl('[test.badsub]/.', 'relative'));
+  }
+
 }

--- a/tests/phpunit/Civi/Core/PathsTest.php
+++ b/tests/phpunit/Civi/Core/PathsTest.php
@@ -117,18 +117,21 @@ class PathsTest extends \CiviUnitTestCase {
       ];
     });
     $paths->register('test.goodsub', function () use ($paths) {
+      // This is a stand-in for how [civicrm.bower], [civicrm.packages], [civicrm.vendor] currently work.
       return [
         'path' => $paths->getPath('[test.base]/good/'),
         'url' => $paths->getUrl('[test.base]/good/', 'absolute'),
       ];
     });
     $paths->register('test.badsub', function () use ($paths) {
+      // This is a stand-in for how [civicrm.bower], [civicrm.packages], [civicrm.vendor] used to work (incorrectly).
       return [
         'path' => $paths->getPath('[test.base]/bad/'),
-        // This *looks* OK, but `getUrl()` by default uses `$preferFormat==relative`.
-        // The problem is that `$civicrm_paths['...']['url']` is interpreted as relative to CMS root,
-        // and `getUrl(..., 'relative')` is interpreted as relative to HTTP root.
-        // So this definition misbehaves on sites where the CMS root and HTTP root are different.
+        // The following *looks* OK, but it's not. Note that `getUrl()` by default uses `$preferFormat==relative`.
+        // Both registered URLs (`register()`, `$civicrm_paths`) and outputted URLs (`getUrl()`)
+        // can be in relative form. However, they are relative to different bases: registrations are
+        // relative to CMS root, and outputted URLs are relative to HTTP root. They are often the same, but...
+        // on deployments where they differ, this example will misbehave.
         'url' => $paths->getUrl('[test.base]/bad/'),
       ];
     });


### PR DESCRIPTION
Overview
--------

CiviCRM is deployed inside a CMS. The CMS is usually deployed at the HTTP root (`http://example.org`), but it is sometimes deployed in a subdirectory (`http://example.org/my-cms`).

Some asset URLs are computed using the variables `[civicrm.bower]`, `[civicrm.packages]`, and `[civicrm.vendor]`, which are derived from the value of `[civicrm.root]`.  However, if the site is deployed in a subdirectory, then the computation of `[civicrm.bower]` (etc) can misbehave. 

(The problem has been reported in 5.23. It may or may not have misbehaved in prior versions, but it was more obscure/less important in prior versions - in 5.23, it matters more.)

See: https://lab.civicrm.org/dev/joomla/issues/26#note_33465

Before
------

When the URL for `[civicrm.bower]` (or similar) is derived, and if the environment uses HTTP on the default port (80/443), then the URL goes through multiple filters - first, from absolute to relative, and then later from relative back to absolute.  In the process, the base may be inadvertently changed.

In dev/joomla#26, this was observed to produce redundant URL elements.

After
-----

When the URL for `[civicrm.bower]` (or similar) is derived, it is computed in absolute format - and simply kept that way.

Comments
--------

Regarding test coverage, there are two relevant unit-tests. This PR only updates one.

* `E2E\Core\PathUrlTest`: This is a more concrete smoke test which demonstrates functional problems with variables like `[civicrm.bower]`.  It should already catch problems like dev/joomla#26...  but only if you run the E2E suite on a site where the CMS was deployed to a subdirectory.  Currently, the list of build-types available in CI doesn't have such a site.
* `Civi\Core\PathsTest`: This is a more abstract, headless test to examine edge-cases in `Civi\Core\Paths`. It does not specifically check for `[civicrm.bower]` or similar variables (b/c the URL routing is ill-defined in a headless context). However, I've updated it to compare/contrast the working and non-working ways to derive variables.

My local dev environment doesn't support low-number ports (eg port 80), so I cannot reproduce or validate this issue precisely. It's particularly important to do some `r-run` during PR review.