### PR TITLE
dev/joomla#26 - Fix path derivation when CMS is rooted in a subdir

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.23.4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.23.4.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.23.4 during upgrade *}

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -38,19 +38,19 @@ class Paths {
       ->register('civicrm.packages', function () {
         return [
           'path' => \Civi::paths()->getPath('[civicrm.root]/packages/'),
-          'url' => \Civi::paths()->getUrl('[civicrm.root]/packages/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/packages/', 'absolute'),
         ];
       })
       ->register('civicrm.vendor', function () {
         return [
           'path' => \Civi::paths()->getPath('[civicrm.root]/vendor/'),
-          'url' => \Civi::paths()->getUrl('[civicrm.root]/vendor/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/vendor/', 'absolute'),
         ];
       })
       ->register('civicrm.bower', function () {
         return [
           'path' => \Civi::paths()->getPath('[civicrm.root]/bower_components/'),
-          'url' => \Civi::paths()->getUrl('[civicrm.root]/bower_components/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/bower_components/', 'absolute'),
         ];
       })
       ->register('civicrm.files', function () {

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,6 +15,15 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 5.23.4
+
+Released March 24, 2020
+
+- **[Synopsis](release-notes/5.23.4.md#synopsis)**
+- **[Bugs resolved](release-notes/5.23.4.md#bugs)**
+- **[Credits](release-notes/5.23.4.md#credits)**
+- **[Feedback](release-notes/5.23.4.md#feedback)**
+
 ## CiviCRM 5.23.3
 
 Released March 16, 2020

--- a/release-notes/5.23.4.md
+++ b/release-notes/5.23.4.md
@@ -1,0 +1,38 @@
+# CiviCRM 5.23.4
+
+Released March 24, 2020.
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |         |
+|:--------------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                                   |   no    |
+| Change the database schema?                                     |   no    |
+| Alter the API?                                                  |   no    |
+| Require attention to configuration options?                     |   no    |
+| Fix problems installing or upgrading to a previous version?     |   no    |
+| Introduce features?                                             |   no    |
+| **Fix bugs?**                                                   | **yes** |
+
+## <a name="bugs"></a>Bugs resolved
+
+** **_Various_: Fix malformed URLs when CMS root is a subdirectory ([dev/joomla#26](https://lab.civicrm.org/dev/joomla/issues/26): [#16887](https://github.com/civicrm/civicrm-core/pull/16887))**
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+Tadpole Collective - Kevin Cristiano; Stephen Palmstrom; Squiffle Consulting - Aidan
+Saunders; Nicol Wistreich; JMA Consulting - Seamus Lee; howardshand; CiviCRM - Tim Otten;
+Andy Burns; Andrew Thompson
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Tim Otten and Andrew Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.23.3',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.23.4',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/tests/phpunit/Civi/Core/PathsTest.php
+++ b/tests/phpunit/Civi/Core/PathsTest.php
@@ -101,4 +101,52 @@ class PathsTest extends \CiviUnitTestCase {
     $this->assertEquals("$cmsRoot/foo", $p->getUrl('foo'));
   }
 
+  /**
+   * This test demonstrates how to (and how not to) compute a derivative path variable.
+   */
+  public function testAbsoluteRelativeConversions() {
+    $gstack = \CRM_Utils_GlobalStack::singleton();
+    $gstack->push(['_SERVER' => ['HTTP_HOST' => 'example.com']]);
+    $cleanup = \CRM_Utils_AutoClean::with([$gstack, 'pop']);
+
+    $paths = new Paths();
+    $paths->register('test.base', function () {
+      return [
+        'path' => '/var/foo/',
+        'url' => 'http://example.com/foo/',
+      ];
+    });
+    $paths->register('test.goodsub', function () use ($paths) {
+      return [
+        'path' => $paths->getPath('[test.base]/good/'),
+        'url' => $paths->getUrl('[test.base]/good/', 'absolute'),
+      ];
+    });
+    $paths->register('test.badsub', function () use ($paths) {
+      return [
+        'path' => $paths->getPath('[test.base]/bad/'),
+        // This *looks* OK, but `getUrl()` by default uses `$preferFormat==relative`.
+        // The problem is that `$civicrm_paths['...']['url']` is interpreted as relative to CMS root,
+        // and `getUrl(..., 'relative')` is interpreted as relative to HTTP root.
+        // So this definition misbehaves on sites where the CMS root and HTTP root are different.
+        'url' => $paths->getUrl('[test.base]/bad/'),
+      ];
+    });
+
+    // The test.base works as explicitly defined...
+    $this->assertEquals('/var/foo', $paths->getPath('[test.base]/.'));
+    $this->assertEquals('http://example.com/foo', $paths->getUrl('[test.base]/.', 'absolute'));
+    $this->assertEquals('/foo', $paths->getUrl('[test.base]/.', 'relative'));
+
+    // The test.goodsub works as expected...
+    $this->assertEquals('/var/foo/good', $paths->getPath('[test.goodsub]/.'));
+    $this->assertEquals('http://example.com/foo/good', $paths->getUrl('[test.goodsub]/.', 'absolute'));
+    $this->assertEquals('/foo/good', $paths->getUrl('[test.goodsub]/.', 'relative'));
+
+    // The test.badsub doesn't work as expected.
+    $this->assertEquals('/var/foo/bad', $paths->getPath('[test.badsub]/.'));
+    $this->assertNotEquals('http://example.com/foo/bad', $paths->getUrl('[test.badsub]/.', 'absolute'));
+    $this->assertNotEquals('/foo/bad', $paths->getUrl('[test.badsub]/.', 'relative'));
+  }
+
 }

--- a/tests/phpunit/Civi/Core/PathsTest.php
+++ b/tests/phpunit/Civi/Core/PathsTest.php
@@ -117,18 +117,21 @@ class PathsTest extends \CiviUnitTestCase {
       ];
     });
     $paths->register('test.goodsub', function () use ($paths) {
+      // This is a stand-in for how [civicrm.bower], [civicrm.packages], [civicrm.vendor] currently work.
       return [
         'path' => $paths->getPath('[test.base]/good/'),
         'url' => $paths->getUrl('[test.base]/good/', 'absolute'),
       ];
     });
     $paths->register('test.badsub', function () use ($paths) {
+      // This is a stand-in for how [civicrm.bower], [civicrm.packages], [civicrm.vendor] used to work (incorrectly).
       return [
         'path' => $paths->getPath('[test.base]/bad/'),
-        // This *looks* OK, but `getUrl()` by default uses `$preferFormat==relative`.
-        // The problem is that `$civicrm_paths['...']['url']` is interpreted as relative to CMS root,
-        // and `getUrl(..., 'relative')` is interpreted as relative to HTTP root.
-        // So this definition misbehaves on sites where the CMS root and HTTP root are different.
+        // The following *looks* OK, but it's not. Note that `getUrl()` by default uses `$preferFormat==relative`.
+        // Both registered URLs (`register()`, `$civicrm_paths`) and outputted URLs (`getUrl()`)
+        // can be in relative form. However, they are relative to different bases: registrations are
+        // relative to CMS root, and outputted URLs are relative to HTTP root. They are often the same, but...
+        // on deployments where they differ, this example will misbehave.
         'url' => $paths->getUrl('[test.base]/bad/'),
       ];
     });

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.23.3</version_no>
+  <version_no>5.23.4</version_no>
 </version>


### PR DESCRIPTION
Backport #16887 from 5.24 RC to 5.23 stable. Add release notes.