### PR TITLE
[NFC] Add in unit test to ensure that APIv4 Doesn't accept an invalid…

### DIFF
--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -109,4 +109,27 @@ class Api4SelectQueryTest extends UnitTestCase {
     $this->assertCount(2, $result['phones']);
   }
 
+  public function testInvaidSort() {
+    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $query = new Api4SelectQuery($api);
+    $query->select[] = 'id';
+    $query->select[] = 'first_name';
+    $query->select[] = 'phones.phone';
+    $query->where[] = ['first_name', '=', 'Phoney'];
+    $query->orderBy = ['first_name' => 'sleep(1)'];
+    try {
+      $results = $query->run();
+      $this->fail('An Exception Should have been raised');
+    }
+    catch (\API_Exception $e) {
+    }
+    $query->orderBy = ['sleep(1)', 'ASC'];
+    try {
+      $results = $query->run();
+      $this->fail('An Exception Should have been raised');
+    }
+    catch (\API_Exception $e) {
+    }
+  }
+
 }


### PR DESCRIPTION
… sort

Overview
----------------------------------------
This just adds a little defence for us proving that APIv4 doesn't at the moment accept an invalid sort parameter

Before
----------------------------------------
No Test

After
----------------------------------------
Test

ping @eileenmcnaughton @colemanw 