### PR TITLE
Remove assigns for   atypefile

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -227,14 +227,11 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     CRM_Core_Form_RecurringEntity::preProcess('civicrm_activity');
-    $this->_atypefile = $_GET['atypefile'] ?? NULL;
-    $this->assign('atypefile', FALSE);
-    if ($this->_atypefile) {
-      $this->assign('atypefile', TRUE);
-    }
 
     $session = CRM_Core_Session::singleton();
     $this->_currentUserId = CRM_Core_Session::getLoggedInContactID();


### PR DESCRIPTION


Overview
----------------------------------------
Removes some obsolete lines 

Before
----------------------------------------
'atypefile' assigned to the template - but no longer used

After
----------------------------------------
not assigned

Technical Details
----------------------------------------
This is old code - I  traced back it's introduction to  https://github.com/civicrm/civicrm-svn/commit/fb3038000356998e43b0c9aea67f0186f7e41516
which relates to https://issues.civicrm.org/jira/browse/CRM-3829?page=com.atlassian.streams.streams-jira-plugin:activity-stream-issue-tab

At that time the template used the variable- ie https://github.com/civicrm/civicrm-svn/commit/fb3038000356998e43b0c9aea67f0186f7e41516#diff-6fc7e9552ffce6cf4cb7680854ef7b70R4

But that is no longer the case

Comments
----------------------------------------

