### PR TITLE
[NFC] Use strict comparison where  possible

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -276,7 +276,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     // if we're not adding new one, there must be an id to
     // an activity we're trying to work on.
     if ($this->_action != CRM_Core_Action::ADD &&
-      get_class($this->controller) != 'CRM_Contact_Controller_Search'
+      get_class($this->controller) !== 'CRM_Contact_Controller_Search'
     ) {
       $this->_activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     }
@@ -315,7 +315,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     // Check the mode when this form is called either single or as
     // search task action.
     if ($this->_activityTypeId ||
-      $this->_context == 'standalone' ||
+      $this->_context === 'standalone' ||
       $this->_currentlyViewedContactId
     ) {
       $this->_single = TRUE;
@@ -386,7 +386,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $qfKey = NULL;
     }
 
-    if ($this->_context == 'fulltext') {
+    if ($this->_context === 'fulltext') {
       $keyName = '&qfKey';
       $urlParams = 'force=1';
       $urlString = 'civicrm/contact/search/custom';
@@ -410,21 +410,21 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $urlParams = 'reset=1';
       $urlString = 'civicrm/dashboard';
     }
-    elseif ($this->_context == 'search') {
+    elseif ($this->_context === 'search') {
       $urlParams = 'force=1';
       if ($qfKey) {
         $urlParams .= "&qfKey=$qfKey";
       }
       $path = CRM_Utils_System::currentPath();
-      if ($this->_compContext == 'advanced') {
+      if ($this->_compContext === 'advanced') {
         $urlString = 'civicrm/contact/search/advanced';
       }
-      elseif ($path == 'civicrm/group/search'
-        || $path == 'civicrm/contact/search'
-        || $path == 'civicrm/contact/search/advanced'
-        || $path == 'civicrm/contact/search/custom'
-        || $path == 'civicrm/group/search'
-        || $path == 'civicrm/contact/search/builder'
+      elseif ($path === 'civicrm/group/search'
+        || $path === 'civicrm/contact/search'
+        || $path === 'civicrm/contact/search/advanced'
+        || $path === 'civicrm/contact/search/custom'
+        || $path === 'civicrm/group/search'
+        || $path === 'civicrm/contact/search/builder'
       ) {
         $urlString = $path;
       }
@@ -433,7 +433,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       }
       $this->assign('searchKey', $qfKey);
     }
-    elseif ($this->_context != 'caseActivity') {
+    elseif ($this->_context !== 'caseActivity') {
       $urlParams = "action=browse&reset=1&cid={$this->_currentlyViewedContactId}&selectedChild=activity";
       $urlString = 'civicrm/contact/view';
     }
@@ -530,7 +530,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     // if we're editing...
     if (isset($this->_activityId)) {
 
-      if ($this->_context != 'standalone') {
+      if ($this->_context !== 'standalone') {
         $this->assign('target_contact_value',
           CRM_Utils_Array::value('target_contact_value', $defaults)
         );
@@ -652,10 +652,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         $attribute = $values['attributes'] ?? NULL;
         $required = !empty($values['required']);
 
-        if ($values['type'] == 'select' && empty($attribute)) {
+        if ($values['type'] === 'select' && empty($attribute)) {
           $this->addSelect($field, ['entity' => 'activity'], $required);
         }
-        elseif ($values['type'] == 'entityRef') {
+        elseif ($values['type'] === 'entityRef') {
           $this->addEntityRef($field, $values['label'], $attribute, $required);
         }
         else {
@@ -731,7 +731,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     $this->add('datepicker', 'followup_date', ts('in'));
 
     // Only admins and case-workers can change the activity source
-    if (!CRM_Core_Permission::check('administer CiviCRM') && $this->_context != 'caseActivity') {
+    if (!CRM_Core_Permission::check('administer CiviCRM') && $this->_context !== 'caseActivity') {
       $this->getElement('source_contact_id')->freeze();
     }
 
@@ -823,7 +823,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    */
   public static function formRule($fields, $files, $self) {
     // skip form rule if deleting
-    if (CRM_Utils_Array::value('_qf_Activity_next_', $fields) == 'Delete') {
+    if (($fields['_qf_Activity_next_'] ?? NULL) === 'Delete') {
       return TRUE;
     }
     $errors = [];
@@ -958,7 +958,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $this->_activityId
     );
 
-    $params['is_multi_activity'] = CRM_Utils_Array::value('separation', $params) == 'separate';
+    $params['is_multi_activity'] = ($params['separation'] ?? NULL) === 'separate';
 
     $activity = [];
     if (!empty($params['is_multi_activity']) &&
@@ -977,7 +977,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     }
 
     // Redirect to contact page or activity view in standalone mode
-    if ($this->_context == 'standalone') {
+    if ($this->_context === 'standalone') {
       if (count($params['target_contact_id']) == 1) {
         $url = CRM_Utils_System::url('civicrm/contact/view', ['cid' => CRM_Utils_Array::first($params['target_contact_id']), 'selectedChild' => 'activity']);
       }
@@ -1038,6 +1038,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    *   Associated array of submitted values.
    *
    * @return self|null|object
+   * @throws \CRM_Core_Exception
    */
   protected function processActivity(&$params) {
     $activityAssigned = [];
@@ -1161,8 +1162,11 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
   /**
    * Shorthand for getting id by display name (makes code more readable)
-   * @param $displayName
+   *
+   * @param string $displayName
+   *
    * @return null|string
+   * @throws \CRM_Core_Exception
    */
   protected function _getIdByDisplayName($displayName) {
     return CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
@@ -1174,8 +1178,11 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
   /**
    * Shorthand for getting display name by id (makes code more readable)
-   * @param $id
+   *
+   * @param int $id
+   *
    * @return null|string
+   * @throws \CRM_Core_Exception
    */
   protected function _getDisplayNameById($id) {
     return CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1894,7 +1894,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
    * @param int $entityId
    *
    * @return array|int
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public static function buildCustomDataView(&$form, &$groupTree, $returnCount = FALSE, $gID = NULL, $prefix = NULL, $customValueId = NULL, $entityId = NULL) {
     $details = [];


### PR DESCRIPTION


Overview
----------------------------------------
Minor code standards cleanup

Before
----------------------------------------
Non-strict comparison used when comparing against strings

After
----------------------------------------
Strict comparison used

Technical Details
----------------------------------------
Also fixes a couple of comments & uses of Array::value

Comments
----------------------------------------
Strict comparison should always be used where possible
