### PR TITLE
[REF] Remove & from before variable

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -227,6 +227,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     CRM_Core_Form_RecurringEntity::preProcess('civicrm_activity');
@@ -629,7 +631,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     // Enable form element (ActivityLinks sets this true).
     $this->assign('suppressForm', FALSE);
 
-    $element = &$this->add('select', 'activity_type_id', ts('Activity Type'),
+    $element = $this->add('select', 'activity_type_id', ts('Activity Type'),
       ['' => '- ' . ts('select') . ' -'] + $this->_fields['followup_activity_type_id']['attributes'],
       FALSE, [
         'onchange' => "CRM.buildCustomData( 'Activity', this.value, false, false, false, false, false, false, {$this->_currentlyViewedContactId});",


### PR DESCRIPTION


Overview
----------------------------------------
Removes a legacy coding construct

Before
----------------------------------------
<img width="786" alt="Screen Shot 2020-03-25 at 5 39 01 PM" src="https://user-images.githubusercontent.com/336308/77502526-f8c9b900-6ebf-11ea-82bd-6d71e76ec977.png">


After
----------------------------------------
No change -ie 


<img width="797" alt="Screen Shot 2020-03-25 at 5 39 36 PM" src="https://user-images.githubusercontent.com/336308/77502676-5e1daa00-6ec0-11ea-9010-dfa04e85b7b7.png">



Technical Details
----------------------------------------
I couldn't see how this & could do anything useful given it's an object & testing shows the form is unchanged

Comments
----------------------------------------
