### PR TITLE
Mailing Report: hide the HTML preview

### DIFF
--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -167,9 +167,7 @@
 <tr>
   <td class="label nowrap">{ts}HTML Message{/ts}</td>
   <td>
-    {$report.mailing.body_html|mb_truncate:30|escape|nl2br}
-    <br/>
-    <strong><a class="crm-popup" href='{$htmlViewURL}'>&raquo; {ts}View complete message{/ts}</a></strong>
+    <a class="crm-popup" href='{$htmlViewURL}'>&raquo; {ts}View complete message{/ts}</a>
   </td>
 </tr>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------

When viewing a mailing report, it displays a preview of the HTML. Only so much can be said in 30 characters of HTML, so it looks like this:

![Capture d’écran de 2020-03-25 17-16-24](https://user-images.githubusercontent.com/254741/77586481-a9ce5480-6ebc-11ea-83c6-24fe77e5c65d.png)

I'm pretty sure everyone here just got used to ignoring that "DOCTYPE html PUBLIC" string. I really don't see the purpose of it.

After
----------------------------------------

Removed the HTML preview, as well as the bold/strong:

![Capture d’écran de 2020-03-25 17-17-09](https://user-images.githubusercontent.com/254741/77586569-d1252180-6ebc-11ea-9b68-a6527941c088.png)


