### PR TITLE
Fix bug on handling 'is_required'

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -164,7 +164,7 @@ trait CRM_Admin_Form_SettingTrait {
       if (isset($quickFormType)) {
         $options = $props['options'] ?? NULL;
         if ($options) {
-          if ($props['html_type'] === 'Select' && isset($props['is_required']) && $props['is_required'] === FALSE && !isset($options[''])) {
+          if ($quickFormType === 'Select' && isset($props['is_required']) && $props['is_required'] === FALSE && !isset($options[''])) {
             // If the spec specifies the field is not required add a null option.
             // Why not if empty($props['is_required']) - basically this has been added to the spec & might not be set to TRUE
             // when it is true.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug that affects extensions using the generic form to render non-required select fields

Before
----------------------------------------
- Install https://github.com/eileenmcnaughton/uk.squiffle.assignee*
- load the settings page
- note that 'none' is not an option for the group field, even through it is defined correctly


** (this is a patched version of @aydun's extension with fixes to comply better with more recent code changes - I will submit a PR back to the copy @aydun maintains once it is in gitlab or github)

After
----------------------------------------
'none' loads as an option for the group field on the settings page

Technical Details
----------------------------------------
The code was expecting 'Select' but we encourage 'select' in the settings spec

However, we DO know the case to expect for the quickFormType - so check that instead

Comments
----------------------------------------
@mattwire maybe one you have good familiarity with