### PR TITLE
Allow setting metadata to use the `table` option. Update example setting `default_invoice_page`.

### DIFF
--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -147,15 +147,24 @@ class SettingsMetadata {
       if (empty($spec['pseudoconstant'])) {
         continue;
       }
+      $pseudoconstant = $spec['pseudoconstant'];
       // It would be nice if we could leverage CRM_Core_PseudoConstant::get() somehow,
       // but it's tightly coupled to DAO/field. However, if you really need to support
       // more pseudoconstant types, then probably best to refactor it. For now, KISS.
-      if (!empty($spec['pseudoconstant']['callback'])) {
-        $spec['options'] = Resolver::singleton()->call($spec['pseudoconstant']['callback'], []);
+      if (!empty($pseudoconstant['callback'])) {
+        $spec['options'] = Resolver::singleton()->call($pseudoconstant['callback'], []);
       }
-      elseif (!empty($spec['pseudoconstant']['optionGroupName'])) {
-        $keyColumn = \CRM_Utils_Array::value('keyColumn', $spec['pseudoconstant'], 'value');
-        $spec['options'] = \CRM_Core_OptionGroup::values($spec['pseudoconstant']['optionGroupName'], FALSE, FALSE, TRUE, NULL, 'label', TRUE, FALSE, $keyColumn);
+      elseif (!empty($pseudoconstant['optionGroupName'])) {
+        $keyColumn = \CRM_Utils_Array::value('keyColumn', $pseudoconstant, 'value');
+        $spec['options'] = \CRM_Core_OptionGroup::values($pseudoconstant['optionGroupName'], FALSE, FALSE, TRUE, NULL, 'label', TRUE, FALSE, $keyColumn);
+      }
+      if (!empty($pseudoconstant['table'])) {
+        $params = [
+          'condition' => $pseudoconstant['condition'] ?? [],
+          'keyColumn' => $pseudoconstant['keyColumn'] ?? NULL,
+          'labelColumn' => $pseudoconstant['labelColumn'] ?? NULL,
+        ];
+        $spec['options'] = \CRM_Core_PseudoConstant::renderOptionsFromTablePseudoconstant($pseudoconstant, $params, ($spec['localize_context'] ?? NULL), 'get');
       }
     }
   }

--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -188,8 +188,9 @@ return [
     'quick_form_type' => 'Select',
     'default' => NULL,
     'pseudoconstant' => [
-      // @todo - handle table style pseudoconstants for settings & avoid deprecated function.
-      'callback' => 'CRM_Contribute_PseudoConstant::contributionPage',
+      'table' => 'civicrm_contribution_page',
+      'keyColumn' => 'id',
+      'labelColumn' => 'title',
     ],
     'html_type' => 'select',
     'add' => '4.7',

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -15,17 +15,29 @@
  */
 class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
 
+  /**
+   * Original value of civicrm_setting global.
+   * @var array
+   */
+  private $origSetting;
+
   public function setUp() {
     parent::setUp();
     global $civicrm_setting;
     $this->origSetting = $civicrm_setting;
-    CRM_Utils_Cache::singleton()->flush();
+    CRM_Utils_Cache::singleton()->clear();
   }
 
+  /**
+   * Clean up after test.
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function tearDown() {
     global $civicrm_setting;
     $civicrm_setting = $this->origSetting;
-    CRM_Utils_Cache::singleton()->flush();
+    $this->quickCleanup(['civicrm_contribution']);
+    CRM_Utils_Cache::singleton()->clear();
     parent::tearDown();
   }
 
@@ -225,6 +237,15 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
     Civi::service('settings_manager')->useMandatory();
     $environment = CRM_Core_Config::environment();
     $this->assertEquals('Development', $environment);
+  }
+
+  /**
+   * Test that options defined as a pseudoconstant can be converted to options.
+   */
+  public function testPseudoConstants() {
+    $this->contributionPageCreate();
+    $metadata = \Civi\Core\SettingsMetadata::getMetadata(['name' => ['default_invoice_page']], NULL, TRUE);
+    $this->assertEquals('Test Contribution Page', $metadata['default_invoice_page']['options'][1]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
A setting may specify a list of acceptable options (`pseudoconstant`). This PR adds another mechanism (`table`) for defining that list, and it specifically updates one setting (`default_invoice_page`) to use the new mechanism.

The mechanism matches an equivalent mechanism available in DAO fields.

See also, developer documentation: https://github.com/civicrm/civicrm-dev-docs/pull/784

Before
----------------------------------------
The setting `default_invoice_page` in CiviContribute displays a list of contribution pages:
    
<img width="453" alt="Screen Shot 2020-03-26 at 3 55 23 PM" src="https://user-images.githubusercontent.com/336308/77605609-40ad1680-6f7a-11ea-9bb0-89d251c706fc.png">

The list is generated by a `callback` function (which performs the DB queries).

After
----------------------------------------
The setting `default_invoice_page` in CiviContribute settings displays the same list of contribution pages.

However, the `callback` metadata is replaced with `table` metadata.    

Technical Details
----------------------------------------
This change will reduce the temptation to call silly core functions from extensions....

Comments
----------------------------------------

Builds off  https://github.com/civicrm/civicrm-core/pull/16902