### PR TITLE
Deprecate use of  in OptionGroup::add() function

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -31,17 +31,14 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    * @param array $params
    *   Input parameters.
    *
-   * @return object
+   * @return CRM_Core_DAO_OptionValue
+   * @throws \CRM_Core_Exception
    */
   public static function create($params) {
     if (empty($params['id'])) {
       self::setDefaults($params);
     }
-    $ids = [];
-    if (!empty($params['id'])) {
-      $ids = ['optionValue' => $params['id']];
-    }
-    return CRM_Core_BAO_OptionValue::add($params, $ids);
+    return CRM_Core_BAO_OptionValue::add($params);
   }
 
   /**
@@ -151,9 +148,14 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    *   deprecated Reference array contains the id.
    *
    * @return \CRM_Core_DAO_OptionValue
+   *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function add(&$params, $ids = []) {
+    if (!empty($ids['optionValue']) && empty($params['id'])) {
+      CRM_Core_Error::deprecatedFunctionWarning('$params[\'id\'] should be set, $ids is deprecated');
+    }
     $id = $params['id'] ?? $ids['optionValue'] ?? NULL;
     // CRM-10921: do not reset attributes to default if this is an update
     //@todo consider if defaults are being set in the right place. 'dumb' defaults like

--- a/CRM/Extension/Manager/Report.php
+++ b/CRM/Extension/Manager/Report.php
@@ -53,7 +53,6 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
     $weight = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_OptionValue',
       ['option_group_id' => $this->groupId]
     );
-    $ids = [];
     $params = [
       'label' => $info->label . ' (' . $info->key . ')',
       'value' => $info->typeInfo['reportUrl'],
@@ -65,7 +64,7 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
       'is_active' => 1,
     ];
 
-    $optionValue = CRM_Core_BAO_OptionValue::add($params, $ids);
+    $optionValue = CRM_Core_BAO_OptionValue::add($params);
   }
 
   /**

--- a/CRM/Extension/Manager/Search.php
+++ b/CRM/Extension/Manager/Search.php
@@ -55,8 +55,7 @@ class CRM_Extension_Manager_Search extends CRM_Extension_Manager_Base {
       'is_active' => 1,
     ];
 
-    $ids = [];
-    $optionValue = CRM_Core_BAO_OptionValue::add($params, $ids);
+    $optionValue = CRM_Core_BAO_OptionValue::add($params);
 
     return $optionValue ? TRUE : FALSE;
   }


### PR DESCRIPTION


Overview
----------------------------------------
Deprecates a legacy code construct

Before
----------------------------------------
Passing $ids is not recommended but there is no visibility on that

After
----------------------------------------
Passing data in $ids is deprecated - at some point we will remove the variable from the function

Technical Details
----------------------------------------
We agreed some time back not to use  as part of add, create signatures

Comments
----------------------------------------
