### PR TITLE
APIv4 - Don't automatically set domain.

### DIFF
--- a/CRM/Core/BAO/MailSettings.php
+++ b/CRM/Core/BAO/MailSettings.php
@@ -128,8 +128,9 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
     }
 
     if (empty($params['id'])) {
-      $params['is_ssl'] = CRM_Utils_Array::value('is_ssl', $params, FALSE);
-      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
+      $params['is_ssl'] = $params['is_ssl'] ?? FALSE;
+      $params['is_default'] = $params['is_default'] ?? FALSE;
+      $params['domain_id'] = $params['domain_id'] ?? CRM_Core_Config::domainID();
     }
 
     //handle is_default.

--- a/CRM/Core/BAO/MailSettings.php
+++ b/CRM/Core/BAO/MailSettings.php
@@ -135,9 +135,9 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
 
     //handle is_default.
     if (!empty($params['is_default'])) {
+      $domain = $params['domain_id'] ?? CRM_Core_DAO::getFieldValue(__CLASS__, $params['id'], 'domain_id');
       $query = 'UPDATE civicrm_mail_settings SET is_default = 0 WHERE domain_id = %1';
-      $queryParams = [1 => [CRM_Core_Config::domainID(), 'Integer']];
-      CRM_Core_DAO::executeQuery($query, $queryParams);
+      CRM_Core_DAO::executeQuery($query, [1 => [$domain, 'Integer']]);
     }
 
     $mailSettings = new CRM_Core_DAO_MailSettings();

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -42,6 +42,9 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
         'return' => 'payment_instrument_id',
       ]);
     }
+    if (empty($params['id']) && empty($params['domain_id'])) {
+      $params['domain_id'] = $params['domain_id'] ?? CRM_Core_Config::domainID();
+    }
     $processor = new CRM_Financial_DAO_PaymentProcessor();
     $processor->copyValues($params);
 

--- a/Civi/Api4/Service/Spec/Provider/FieldDomainIdSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FieldDomainIdSpecProvider.php
@@ -31,7 +31,7 @@ class FieldDomainIdSpecProvider implements Generic\SpecProviderInterface {
   public function modifySpec(RequestSpec $spec) {
     $domainIdField = $spec->getFieldByName('domain_id');
     if ($domainIdField) {
-      $domainIdField->setRequired(FALSE)->setDefaultValue('current_domain');;
+      $domainIdField->setRequired(FALSE);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
In 60142ef this field was set to be handled automatically across all entities, however this caused problems with entities like optionValue where it can be NULL.
So setting a default needs to be the job of the BAO.

Before
----------------------------------------
In all api4 entities, `domain_id` field not required and given default value.

After
----------------------------------------
In all api4 entities, `domain_id` field not required but *not* given default value.
The underlying BAO create function can do that.

Comments
----------------------------------------
Most BAO create functions already set this default, so it should be fine.