### PR TITLE
[REF] Move form specific handling back to the relevant form.

### DIFF
--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -76,6 +76,9 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
 
   /**
    * Build all the data structures needed to build the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     // store case id if present
@@ -110,9 +113,12 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
     else {
       CRM_Utils_System::setTitle(ts('New Email'));
     }
+    if ($this->_context === 'search') {
+      $this->_single = TRUE;
+    }
     CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
 
-    if (!$cid && $this->_context != 'standalone') {
+    if (!$cid && $this->_context !== 'standalone') {
       parent::preProcess();
     }
 

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -48,13 +48,9 @@ class CRM_Contact_Form_Task_EmailCommon {
    * @throws \CiviCRM_API3_Exception
    */
   public static function preProcessFromAddress(&$form, $bounce = TRUE) {
-    $form->_single = FALSE;
-    $className = CRM_Utils_System::getClassName($form);
-    if (property_exists($form, '_context') &&
-      $form->_context != 'search' &&
-      $className == 'CRM_Contact_Form_Task_Email'
-    ) {
-      $form->_single = TRUE;
+    if (!isset($form->_single)) {
+      // @todo ensure this is already set.
+      $form->_single = FALSE;
     }
 
     $form->_emails = [];


### PR DESCRIPTION


Overview
----------------------------------------
Moves code specific to one form out of a shared class

Before
----------------------------------------
Code specific to CRM_Contact_Form_Task_Email is in the shared CRM_Contact_Form_Task_EmailCommon function

After
----------------------------------------
Code moved back to own form

Technical Details
----------------------------------------
The shared function has handling to set ->_single if the class is CRM_Contact_Form_Task_Email -
this seems pretty obviously not functionality that is shared so it should be on the CRM_Contact_Form_Task_Email
class

Comments
----------------------------------------
