### PR TITLE
dev/core#1672 Ensure that a langauge prefix is added to urls when cal…

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -21,6 +21,11 @@
     if (!mode) {
       mode = CRM.config && CRM.config.isFrontend ? 'front' : 'back';
     }
+    if (CRM.config) {
+      if (CRM.config.locale !== 'en_US') {
+        path = CRM.config.locale.substring(0, 2) + '/' + path;
+      }
+    }
     query = query || '';
     var frag = path.split('?');
     var url = tplURL[mode].replace("civicrm-placeholder-url-path", frag[0]);


### PR DESCRIPTION
…led from crm.Url so correct translation of field lables is returned

Overview
----------------------------------------
This aims to resolve a problem where by when you dynamically load a set of custom fields front end custom form without the use of a profile the wrong locale of the label can be returned

Before
----------------------------------------
Wrong locale information is returned defaults to the system primary

After
----------------------------------------
Correct locale

Technical Details
----------------------------------------
I'm not sure if this solution is the correct one it works in my specific case but would appreciate thoughts from others on this 

ping @mattwire @mlutfy @christianwach 