### PR TITLE
APIv4 - Only adjust domain_id if required

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/FieldDomainIdSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FieldDomainIdSpecProvider.php
@@ -30,7 +30,7 @@ class FieldDomainIdSpecProvider implements Generic\SpecProviderInterface {
    */
   public function modifySpec(RequestSpec $spec) {
     $domainIdField = $spec->getFieldByName('domain_id');
-    if ($domainIdField) {
+    if ($domainIdField && $domainIdField->isRequired()) {
       $domainIdField->setRequired(FALSE)->setDefaultValue('current_domain');;
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to #16911
In 60142ef this field was set to be handled automatically across all entities, however this caused problems with entities like optionValue where it can be NULL. This lifts the default if the field is not required.

Before
----------------------------------------
In all api4 entities, `domain_id` field not required and given default value.

After
----------------------------------------
In all api4 entities, `domain_id` field not required and given default value *only if required in the database*.
