### PR TITLE
Support multi-select for auto-complete field

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1080,7 +1080,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    * @return string
    */
   private static function formatDisplayValue($value, $field, $entityId = NULL) {
-
     if (self::isSerialized($field) && !is_array($value)) {
       $value = CRM_Utils_Array::explodePadded($value);
     }
@@ -1499,6 +1498,16 @@ SELECT id
       else {
         $value = '';
       }
+    }
+
+    if ($customFields[$customFieldId]['html_type'] == 'Autocomplete-Select'
+      && $customFields[$customFieldId]['data_type'] != 'ContactReference'
+      && isset($value)
+    ) {
+      if (!is_array($value)) {
+        $value = explode(',', $value);
+      }
+      $value = CRM_Utils_Array::implodePadded($value);
     }
 
     if (($customFields[$customFieldId]['html_type'] == 'Multi-Select' ||
@@ -2604,7 +2613,10 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
     // Fields retrieved via api are an array, or from the dao are an object. We'll accept either.
     $html_type = is_object($field) ? $field->html_type : $field['html_type'];
     // FIXME: Currently the only way to know if data is serialized is by looking at the html_type. It would be cleaner to decouple this.
-    return ($html_type === 'CheckBox' || strpos($html_type, 'Multi') !== FALSE);
+    return ($field['html_type'] == 'CheckBox'
+      || ($field['html_type'] == 'Autocomplete-Select' && $field['data_type'] != 'ContactReference')
+      || strpos($field['html_type'], 'Multi') !== FALSE
+    );
   }
 
   /**

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -444,6 +444,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
                             $cgTable.extends_entity_column_id,
                             $cfTable.is_view,
                             $cfTable.option_group_id,
+                            $cfTable.attributes,
                             $cfTable.date_format,
                             $cfTable.time_format,
                             $cgTable.is_multiple,
@@ -519,6 +520,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $fields[$dao->id]['custom_group_id'] = $dao->custom_group_id;
           $fields[$dao->id]['extends'] = $dao->extends;
           $fields[$dao->id]['is_search_range'] = $dao->is_search_range;
+          $fields[$dao->id]['attributes'] = $dao->attributes;
           $fields[$dao->id]['extends_entity_column_value'] = $dao->extends_entity_column_value;
           $fields[$dao->id]['extends_entity_column_id'] = $dao->extends_entity_column_id;
           $fields[$dao->id]['is_view'] = $dao->is_view;
@@ -1502,6 +1504,7 @@ SELECT id
 
     if ($customFields[$customFieldId]['html_type'] == 'Autocomplete-Select'
       && $customFields[$customFieldId]['data_type'] != 'ContactReference'
+      && stripos($customFields[$customFieldId]['attributes'], 'multiple=') !== FALSE
       && isset($value)
     ) {
       if (!is_array($value)) {
@@ -2612,10 +2615,13 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
   public static function isSerialized($field) {
     // Fields retrieved via api are an array, or from the dao are an object. We'll accept either.
     $html_type = is_object($field) ? $field->html_type : $field['html_type'];
+    $data_type = is_object($field) ? $field->data_type : $field['data_type'];
+    $attributes = is_object($field) ? $field->attributes : $field['attributes'];
     // FIXME: Currently the only way to know if data is serialized is by looking at the html_type. It would be cleaner to decouple this.
-    return ($field['html_type'] == 'CheckBox'
-      || ($field['html_type'] == 'Autocomplete-Select' && $field['data_type'] != 'ContactReference')
-      || strpos($field['html_type'], 'Multi') !== FALSE
+    return ($html_type == 'CheckBox'
+      || ($html_type == 'Autocomplete-Select' && $data_type != 'ContactReference'
+        && stripos($attributes, 'multiple=') !== FALSE
+      ) || strpos($html_type, 'Multi') !== FALSE
     );
   }
 

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -745,7 +745,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $contactId = $this->individualCreate(['custom_' . $fieldId => 'Y']);
     $value = $this->callAPISuccessGetValue('Contact', [
       'id' => $contactId,
-      'return' => 'custom_' . $fieldId
+      'return' => 'custom_' . $fieldId,
     ]);
     $this->assertEquals('Y', $value);
   }
@@ -766,7 +766,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $contactId = $this->individualCreate(['custom_' . $fieldId => ['Y', 'G']]);
     $value = $this->callAPISuccessGetValue('Contact', [
       'id' => $contactId,
-      'return' => 'custom_' . $fieldId
+      'return' => 'custom_' . $fieldId,
     ]);
     $this->assertTrue($value === array_keys($colors));
   }

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -731,4 +731,44 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $this->assertEquals($expectedDisplayValue, CRM_Core_BAO_CustomField::displayValue($file['id'], $fileField['id']));
   }
 
+  /**
+   * Test for single select Autocomplete custom field.
+   *
+   */
+  public function testSingleSelectAutoComplete() {
+    $customGroupId = $this->customGroupCreate([
+      'extends' => 'Individual',
+    ])['id'];
+    $fieldId = $this->createAutoCompleteCustomField([
+      'custom_group_id' => $customGroupId,
+    ])['id'];
+    $contactId = $this->individualCreate(['custom_' . $fieldId => 'Y']);
+    $value = $this->callAPISuccessGetValue('Contact', [
+      'id' => $contactId,
+      'return' => 'custom_' . $fieldId
+    ]);
+    $this->assertEquals('Y', $value);
+  }
+
+  /**
+   * Test for multi select Autocomplete custom field.
+   *
+   */
+  public function testMultiSelectAutoComplete() {
+    $customGroupId = $this->customGroupCreate([
+      'extends' => 'Individual',
+    ])['id'];
+    $fieldId = $this->createAutoCompleteCustomField([
+      'custom_group_id' => $customGroupId,
+      'attributes' => ' multiple="1" ',
+    ])['id'];
+    $colors = ['Y' => 'Yellow', 'G' => 'Green'];
+    $contactId = $this->individualCreate(['custom_' . $fieldId => ['Y', 'G']]);
+    $value = $this->callAPISuccessGetValue('Contact', [
+      'id' => $contactId,
+      'return' => 'custom_' . $fieldId
+    ]);
+    $this->assertTrue($value === array_keys($colors));
+  }
+
 }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -3009,4 +3009,59 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->callAPISuccess('address', 'create', $params);
   }
 
+  /**
+   * Test for single select Autocomplete custom field.
+   *
+   */
+  public function testSingleSelectAutoComplete() {
+    $customGroupId = $this->customGroupCreate([
+      'extends' => 'Individual',
+    ])['id'];
+    $fieldId = $this->createAutoCompleteCustomField([
+      'custom_group_id' => $customGroupId,
+    ])['id'];
+    $contactId = $this->individualCreate(['custom_' . $fieldId => 'Y']);
+    $selectedFields = [
+      ['name' => 'contact_id'],
+      ['name' => "custom_{$fieldId}"],
+    ];
+
+    $this->doExportTest([
+      'ids' => [$contactId],
+      'fields' => $selectedFields,
+      'exportMode' => CRM_Export_Form_Select::CONTACT_EXPORT,
+    ]);
+    $row = $this->csv->fetchOne();
+    $this->assertEquals('Yellow', $row['Pick Color - Autocomplete']);
+  }
+
+  /**
+   * Test for multi select Autocomplete custom field.
+   *
+   */
+  public function testMultiSelectAutoComplete() {
+    $customGroupId = $this->customGroupCreate([
+      'extends' => 'Individual',
+    ])['id'];
+    $fieldId = $this->createAutoCompleteCustomField([
+      'custom_group_id' => $customGroupId,
+      'attributes' => ' multiple="1" ',
+    ])['id'];
+    $colors = ['Y' => 'Yellow', 'G' => 'Green'];
+    $contactId = $this->individualCreate(['custom_' . $fieldId => ['Y', 'G']]);
+
+    $selectedFields = [
+      ['name' => 'contact_id'],
+      ['name' => "custom_{$fieldId}"],
+    ];
+
+    $this->doExportTest([
+      'ids' => [$contactId],
+      'fields' => $selectedFields,
+      'exportMode' => CRM_Export_Form_Select::CONTACT_EXPORT,
+    ]);
+    $row = $this->csv->fetchOne();
+    $this->assertEquals(implode(', ', $colors), $row['Pick Color - Autocomplete']);
+  }
+
 }

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -250,7 +250,56 @@ trait CRMTraits_Custom_CustomDataTrait {
    * @return array
    */
   protected function createSelectCustomField(array $params): array {
-    $optionValue = [
+
+    $optionValue = $this->getOptions();
+    $params = array_merge([
+      'label' => 'Pick Color',
+      'html_type' => 'Select',
+      'data_type' => 'String',
+      'weight' => 2,
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+      'option_values' => $optionValue,
+    ], $params);
+
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    return $customField['values'][$customField['id']];
+  }
+
+  /**
+   * Create custom Autocomplete field.
+   *
+   * @param array $params
+   *   Parameter overrides, must include custom_group_id.
+   *
+   * @return array
+   */
+  protected function createAutoCompleteCustomField(array $params): array {
+
+    $optionValue = $this->getOptions();
+    $params = array_merge([
+      'label' => 'Pick Color - Autocomplete',
+      'html_type' => 'Autocomplete-Select',
+      'data_type' => 'String',
+      'weight' => 2,
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+      'option_values' => $optionValue,
+    ], $params);
+
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    return $customField['values'][$customField['id']];
+  }
+
+  /**
+   * Array of dummy options.
+   *
+   * @return array
+   */
+  protected function getOptions() {
+    return [
       [
         'label' => 'Red',
         'value' => 'R',
@@ -270,20 +319,6 @@ trait CRMTraits_Custom_CustomDataTrait {
         'is_active' => 1,
       ],
     ];
-
-    $params = array_merge([
-      'label' => 'Pick Color',
-      'html_type' => 'Select',
-      'data_type' => 'String',
-      'weight' => 2,
-      'is_required' => 1,
-      'is_searchable' => 0,
-      'is_active' => 1,
-      'option_values' => $optionValue,
-    ], $params);
-
-    $customField = $this->callAPISuccess('custom_field', 'create', $params);
-    return $customField['values'][$customField['id']];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Support multi-select for auto-complete custom field

Before
----------------------------------------
![After](https://user-images.githubusercontent.com/2053075/60543081-52280180-9d0d-11e9-85e4-f8a235e8a2fe.gif)


After
----------------------------------------
![Before](https://user-images.githubusercontent.com/2053075/60543098-5e13c380-9d0d-11e9-9de3-19e33f2059de.gif)

Technical Details
----------------------------------------
CiviCRM doesn't provide ability to make auto complete custom field to select multiple field through unless you specify multiple=1 in attribute either using api or updating the attribute field in civicrm_custom_field.