### PR TITLE
dev/core#1676 - E_NOTICE because of missing brackets for order of operations

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -841,7 +841,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $addCaptcha[$field['group_id']] = $field['add_captcha'];
       }
 
-      if (($name == 'email-Primary') || ($name == 'email-' . $primaryLocationType ?? "")) {
+      if (($name == 'email-Primary') || ($name == 'email-' . ($primaryLocationType ?? ""))) {
         $emailPresent = TRUE;
         $this->_mail = $name;
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1676

One way to reproduce:
1. Go to `civicrm/profile/create?gid=4&reset=1`. This is the New Individual profile in a stock install.
2. Red box with `Notice: Undefined variable: primaryLocationType in CRM_Profile_Form->buildQuickForm() (line 844 of blah/CRM/Profile/Form.php)`.


Technical Details
----------------------------------------
The `.` operator has higher precedence than `??`.

Compare these two when $b is not set.

`php -r "echo 'a' . $b ?? '';"`

vs

`php -r "echo 'a' . ($b ?? '');"`

It was wrong before the recent ?? replacement too when it used `isset($b) ? $b : ""` , but there was no notice because the isset fails right away, and so goes straight to the empty string without evaluating the middle part. Now it immediately tries to evaluate 'a' . $b, which gives the notice.


