### PR TITLE
dev/core#1675 - Temporary regression fix for case add timeline

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -156,6 +156,11 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
         $this->createActivity($activityTypeXML, $params);
       }
     }
+
+    // @todo dev/core#1675 - This is a temporary regression fix. Needs a
+    // proper fix.
+    $tx = new CRM_Core_Transaction();
+    $tx->commit();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Detailed reproduction steps in ticket. When you add a timeline to a case using the Add Timeline dropdown near the middle of manage case it doesn't attach the last activity in the timeline to the case. The activity is created, but left on the non-case side.

Regression in 5.23 caused by DB package upgrade causing changes to how DB works with CRM_Core_Transaction, so the last transaction doesn't get committed.

This is a temp fix not the ideal fix, but I'm thinking for regression purposes at least against 5.24?

Technical Details
----------------------------------------
Lots of details in ticket.

Comments
----------------------------------------
The existing unit test for api case addtimeline didn't catch this because the transaction runs in an isolation level where the method of retrieving the resulting activities and checking them still succeeds even though they aren't committed to the db yet. I took a quick look at seeing if there was an easy way to deal with this in tests but I didn't see anything simple.