### PR TITLE
dev/core#1677 Fix multisite regression on domain membership types

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -814,10 +814,14 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    *
    * Since this is used from the batched script caching helps.
    *
+   * Caching is by domain - if that hits any issues we should add a new function getDomainMembershipTypes
+   * or similar rather than 'just add another param'! but this is closer to earlier behaviour so 'should' be OK.
+   *
    * @throws \CiviCRM_API3_Exception
    */
   public static function getAllMembershipTypes() {
-    if (!Civi::cache('metadata')->has(__CLASS__ . __FUNCTION__)) {
+    $cacheString = __CLASS__ . __FUNCTION__ . CRM_Core_Config::domainID();
+    if (!Civi::cache('metadata')->has($cacheString)) {
       $types = civicrm_api3('MembershipType', 'get', ['options' => ['limit' => 0, 'sort' => 'weight']])['values'];
       $taxRates = CRM_Core_PseudoConstant::getTaxRates();
       $keys = ['description', 'relationship_type_id', 'relationship_direction', 'max_related'];
@@ -840,9 +844,9 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
         }
         $types[$id]['minimum_fee_with_tax'] = (float) $types[$id]['minimum_fee'] * $multiplier;
       }
-      Civi::cache('metadata')->set(__CLASS__ . __FUNCTION__, $types);
+      Civi::cache('metadata')->set($cacheString, $types);
     }
-    return Civi::cache('metadata')->get(__CLASS__ . __FUNCTION__);
+    return Civi::cache('metadata')->get($cacheString);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a regression where membership types bleed between domains

Before
----------------------------------------
Memberships for other domains visible

After
----------------------------------------
Only current domain visible

Technical Details
----------------------------------------
I was a bit tempted to leave this function doing what it says on the box & add another along the lines of getPermissionedMembershipTypes - ie getDomainMemberrshipTypes  - but it is a bit further from historical code. I could be convinced... There are only 2 places in core that call this & I think only one would be changed if we did that

Comments
----------------------------------------
