### PR TITLE
dev/core#1656 Remove duplicate label

### DIFF
--- a/templates/CRM/Mailing/Form/Search/Common.tpl
+++ b/templates/CRM/Mailing/Form/Search/Common.tpl
@@ -10,7 +10,6 @@
   {$form.mailing_job_status.html}
 </td>
 </tr>
-<tr><td><label>{ts}Mailing Date{/ts}</label></td></tr>
 <tr>
 {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="mailing_job_start_date"}
 </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Removes a duplicate label (trivial regression)

Before
----------------------------------------
<img width="925" alt="Screen Shot 2020-03-31 at 8 24 49 PM" src="https://user-images.githubusercontent.com/336308/77998783-1bf7db00-738e-11ea-86bc-c5ce004e827b.png">


After
----------------------------------------
<img width="816" alt="Screen Shot 2020-03-31 at 8 25 48 PM" src="https://user-images.githubusercontent.com/336308/77998800-21edbc00-738e-11ea-9fe6-263902db5471.png">


Technical Details
----------------------------------------


Comments
----------------------------------------
