### PR TITLE
dev/user-interface#14 Fix membership_status_id url handling (recent regression).

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -973,6 +973,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
     ];
     //CRM-6161 fix for customdata export
     $fields = array_merge($fields, $membershipStatus, CRM_Core_BAO_CustomField::getFieldsForImport('Membership'));
+    $fields['membership_status_id'] = $membershipStatus['membership_status'];
     return $fields;
   }
 

--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -506,8 +506,16 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
       'membership_start_date',
       'membership_end_date',
       'membership_type_id',
+      'membership_status_id',
     ];
     $metadata = civicrm_api3('Membership', 'getfields', [])['values'];
+    // We should really have a unique name in the url but to reduce risk of regression just hacking
+    // here for now, since this is being done as an rc fix & the other is moderately risky.
+    // https://lab.civicrm.org/dev/user-interface/-/issues/14
+    $metadata['membership_status_id'] = $metadata['status_id'];
+    // It can't be autoadded due to ^^.
+    $metadata['membership_status_id']['is_pseudofield'] = TRUE;
+    unset($metadata['status_id']);
     return array_intersect_key($metadata, array_flip($fields));
   }
 

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -263,7 +263,8 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       return;
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String');
+    // @todo Most of the  below is likely no longer required.
+    $status = CRM_Utils_Request::retrieve('membership_status_id', 'String');
     if ($status) {
       $status = explode(',', $status);
       $this->_formValues['membership_status_id'] = $this->_defaults['membership_status_id'] = (array) $status;

--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -168,18 +168,18 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     foreach ($membershipSummary as $typeID => $details) {
       if (!$isCurrentMonth) {
         $membershipSummary[$typeID]['total']['total']['url'] = CRM_Utils_System::url('civicrm/member/search',
-          "reset=1&force=1&start=&end=$ymd&status=$status&membership_type_id=$typeID"
+          "reset=1&force=1&start=&end=$ymd&membership_status_id=$status&membership_type_id=$typeID"
         );
-        $membershipSummary[$typeID]['total_owner']['total_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&start=&end=$ymd&status=$status&membership_type_id=$typeID&owner=1");
+        $membershipSummary[$typeID]['total_owner']['total_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&start=&end=$ymd&membership_status_id=$status&membership_type_id=$typeID&owner=1");
       }
       else {
         $membershipSummary[$typeID]['total']['total']['url'] = CRM_Utils_System::url('civicrm/member/search',
-          "reset=1&force=1&status=$status"
+          "reset=1&force=1&membership_status_id=$status"
         );
-        $membershipSummary[$typeID]['total_owner']['total_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1");
+        $membershipSummary[$typeID]['total_owner']['total_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&owner=1");
       }
-      $membershipSummary[$typeID]['current']['total']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&membership_type_id=$typeID");
-      $membershipSummary[$typeID]['current_owner']['current_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&membership_type_id=$typeID&owner=1");
+      $membershipSummary[$typeID]['current']['total']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&membership_type_id=$typeID");
+      $membershipSummary[$typeID]['current_owner']['current_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&membership_type_id=$typeID&owner=1");
     }
 
     $totalCount = [];
@@ -249,14 +249,14 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     $totalCount['current']['total'] = array(
       'count' => $totalCountCurrent,
       'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status"
+        "reset=1&force=1&membership_status_id=$status"
       ),
     );
 
     $totalCount['total']['total'] = array(
       'count' => $totalCountTotal,
       'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status"
+        "reset=1&force=1&membership_status_id=$status"
       ),
     );
 
@@ -264,7 +264,7 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
       $totalCount['total']['total'] = array(
         'count' => $totalCountTotal,
         'url' => CRM_Utils_System::url('civicrm/member/search',
-          "reset=1&force=1&status=$status&start=&end=$ymd"
+          "reset=1&force=1&membership_status_id=$status&start=&end=$ymd"
         ),
       );
     }
@@ -274,33 +274,33 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     //LCD add owner values
     $totalCount['premonth_owner']['premonth_owner'] = array(
       'count' => $totalCountPreMonth_owner,
-      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$preMonth&end=$preMonthEnd&owner=1"),
+      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=$preMonth&end=$preMonthEnd&owner=1"),
     );
 
     $totalCount['month_owner']['month_owner'] = array(
       'count' => $totalCountMonth_owner,
-      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$monthStart&end=$ymd&owner=1"),
+      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=$monthStart&end=$ymd&owner=1"),
     );
 
     $totalCount['year_owner']['year_owner'] = array(
       'count' => $totalCountYear_owner,
-      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$yearStart&end=$ymd&owner=1"),
+      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=$yearStart&end=$ymd&owner=1"),
     );
 
     $totalCount['current_owner']['current_owner'] = array(
       'count' => $totalCountCurrent_owner,
-      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1"),
+      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&owner=1"),
     );
 
     $totalCount['total_owner']['total_owner'] = array(
       'count' => $totalCountTotal_owner,
-      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1"),
+      //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&owner=1"),
     );
 
     if (!$isCurrentMonth) {
       $totalCount['total_owner']['total_owner'] = array(
         'count' => $totalCountTotal_owner,
-        //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=&end=$ymd&owner=1"),
+        //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=&end=$ymd&owner=1"),
       );
     }
     //LCD end


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a recent  regression   whereby  the links to membership  search from   the membership  dashboard  don't filter correctly  on export

Before
----------------------------------------
On membership dashboard click through to a group of members - they  should be filtered by  membership type & status in the url
In actions dropdown click 'Export members'
Export list - and  see that other  statuses  are included

After
----------------------------------------
Correct list of statuses & types exported

Technical Details
----------------------------------------

The right fix here is to fix the xml to the  field setting it to export & adding a uniquename.

However, with our search focus moving on to the new search functionality in the pipeline & us having had
a hiatus on dealing with  search  code I think this more conservative change + a rc focus makes sense
at the  moment

Comments
----------------------------------------
https://lab.civicrm.org/dev/user-interface/-/issues/14
