### PR TITLE
Dev 1674 5.23

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -83,7 +83,7 @@ class CRM_Api4_Services {
       $path = \CRM_Utils_File::addTrailingSlash(dirname($location)) . str_replace('\\', DIRECTORY_SEPARATOR, $namespace);
       try {
         $resource = new \Symfony\Component\Config\Resource\DirectoryResource($path, ';\.php$;');
-        $container->addResource($resource);
+        $addResource = false;
         foreach (glob("$path*.php") as $file) {
           $matches = [];
           preg_match('/(\w*)\.php$/', $file, $matches);
@@ -92,7 +92,11 @@ class CRM_Api4_Services {
           if ($serviceClass->isInstantiable()) {
             $definition = $container->register(str_replace('\\', '_', $serviceName), $serviceName);
             $definition->addTag($tag);
+            $addResource = true;
           }
+        }
+        if ($addResource) {
+          $container->addResource($resource);
         }
       }
       catch (\InvalidArgumentException $e) {

--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -83,7 +83,7 @@ class CRM_Api4_Services {
       $path = \CRM_Utils_File::addTrailingSlash(dirname($location)) . str_replace('\\', DIRECTORY_SEPARATOR, $namespace);
       try {
         $resource = new \Symfony\Component\Config\Resource\DirectoryResource($path, ';\.php$;');
-        $addResource = false;
+        $addResource = FALSE;
         foreach (glob("$path*.php") as $file) {
           $matches = [];
           preg_match('/(\w*)\.php$/', $file, $matches);
@@ -92,7 +92,7 @@ class CRM_Api4_Services {
           if ($serviceClass->isInstantiable()) {
             $definition = $container->register(str_replace('\\', '_', $serviceName), $serviceName);
             $definition->addTag($tag);
-            $addResource = true;
+            $addResource = TRUE;
           }
         }
         if ($addResource) {


### PR DESCRIPTION
Overview
----------------------------------------
The civicrm container should be cached and build once. However if an extension is installed and enabled and it does not contain the directories `Civi/Api4/Event/Subscriber` and `Civi/Api4/Service/Spec/Provider` the container is rebuild upon every request.

This ia non-functional change. 

Before
----------------------------------------

The civicrm container is rebuild upon every request. 

After
----------------------------------------

The civicrm container is loaded from cache. 

How to test
----------------------------------------

1. Install an extension which does not contain the mentioned directories. E.g. civirules
2. Check whether CiviCRM still works.

Comments
----------------------------------------

This fixes API4 functionality in CiviCRM Core. I will also provide a separate PR for the api4 extension. However I am also convinced that this should not be in core at all.

See also https://lab.civicrm.org/dev/core/-/issues/1674

@eileenmcnaughton is this what you mean for a PR against the RC branch? I did not find any RC branch...