### PR TITLE
[REF] Start transitioning EmailCommon class to a trait

### DIFF
--- a/CRM/Activity/Form/Task/Email.php
+++ b/CRM/Activity/Form/Task/Email.php
@@ -19,26 +19,12 @@
  * This class provides the functionality to email a group of contacts.
  */
 class CRM_Activity_Form_Task_Email extends CRM_Activity_Form_Task {
-
-  /**
-   * Are we operating in "single mode", i.e. sending email to one
-   * specific contact?
-   *
-   * @var bool
-   */
-  public $_single = FALSE;
-
-  public $_noEmails = FALSE;
-
-  /**
-   * All the existing templates in the system.
-   *
-   * @var array
-   */
-  public $_templates;
+  use CRM_Contact_Form_Task_EmailTrait;
 
   /**
    * Build all the data structures needed to build the form.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function preProcess() {
     CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
@@ -49,18 +35,13 @@ class CRM_Activity_Form_Task_Email extends CRM_Activity_Form_Task {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     // Enable form element.
     $this->assign('emailTask', TRUE);
     CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
   }
 
   /**

--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -20,29 +20,7 @@
  */
 class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
 
-  /**
-   * Are we operating in "single mode".
-   *
-   * Single mode means sending email to one specific contact.
-   *
-   * @var bool
-   */
-  public $_single = FALSE;
-
-  /**
-   * Are we operating in "single mode", i.e. sending email to one
-   * specific contact?
-   *
-   * @var bool
-   */
-  public $_noEmails = FALSE;
-
-  /**
-   * All the existing templates in the system.
-   *
-   * @var array
-   */
-  public $_templates = NULL;
+  use CRM_Contact_Form_Task_EmailTrait;
 
   /**
    * Store "to" contact details.
@@ -137,13 +115,6 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
     $this->assign('emailTask', TRUE);
 
     CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
   }
 
   /**

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class provides the common functionality for tasks that send emails.
+ */
+trait CRM_Contact_Form_Task_EmailTrait {
+
+  /**
+   * Are we operating in "single mode", i.e. sending email to one
+   * specific contact?
+   *
+   * @var bool
+   */
+  public $_single = FALSE;
+
+  public $_noEmails = FALSE;
+
+  /**
+   * All the existing templates in the system.
+   *
+   * @var array
+   */
+  public $_templates;
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function postProcess() {
+    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
+  }
+
+}

--- a/CRM/Contribute/Form/Task/Email.php
+++ b/CRM/Contribute/Form/Task/Email.php
@@ -19,23 +19,7 @@
  * This class provides the functionality to email a group of contacts.
  */
 class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
-
-  /**
-   * Are we operating in "single mode", i.e. sending email to one
-   * specific contact?
-   *
-   * @var bool
-   */
-  public $_single = FALSE;
-
-  public $_noEmails = FALSE;
-
-  /**
-   * All the existing templates in the system.
-   *
-   * @var array
-   */
-  public $_templates = NULL;
+  use CRM_Contact_Form_Task_EmailTrait;
 
   /**
    * Build all the data structures needed to build the form.
@@ -58,13 +42,6 @@ class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
     $this->assign('emailTask', TRUE);
 
     CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
   }
 
   /**

--- a/CRM/Event/Form/Task/Email.php
+++ b/CRM/Event/Form/Task/Email.php
@@ -13,7 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id: Email.php 45499 2013-02-08 12:31:05Z kurund $
  */
 
 /**
@@ -21,29 +20,7 @@
  * contacts.
  */
 class CRM_Event_Form_Task_Email extends CRM_Event_Form_Task {
-
-  /**
-   * Are we operating in "single mode", i.e. sending email to one
-   * specific contact?
-   *
-   * @var bool
-   */
-  public $_single = FALSE;
-
-  /**
-   * Are we operating in "single mode", i.e. sending email to one
-   * specific contact?
-   *
-   * @var bool
-   */
-  public $_noEmails = FALSE;
-
-  /**
-   * All the existing templates in the system.
-   *
-   * @var array
-   */
-  public $_templates = NULL;
+  use CRM_Contact_Form_Task_EmailTrait;
 
   /**
    * Build all the data structures needed to build the form.
@@ -66,13 +43,6 @@ class CRM_Event_Form_Task_Email extends CRM_Event_Form_Task {
     $this->assign('emailTask', TRUE);
 
     CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
   }
 
   /**

--- a/CRM/Member/Form/Task/Email.php
+++ b/CRM/Member/Form/Task/Email.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id: Email.php 45499 2013-02-08 12:31:05Z kurund $
- *
  */
 
 /**
@@ -22,34 +20,15 @@
  * contacts.
  */
 class CRM_Member_Form_Task_Email extends CRM_Member_Form_Task {
-
-  /**
-   * Are we operating in "single mode", i.e. sending email to one
-   * specific contact?
-   *
-   * @var bool
-   */
-  public $_single = FALSE;
-
-  /**
-   * Are we operating in "single mode", i.e. sending email to one
-   * specific contact?
-   *
-   * @var bool
-   */
-  public $_noEmails = FALSE;
-
-  /**
-   * All the existing templates in the system.
-   *
-   * @var array
-   */
-  public $_templates = NULL;
+  use CRM_Contact_Form_Task_EmailTrait;
 
   /**
    * Build all the data structures needed to build the form.
    *
    * @return void
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function preProcess() {
     CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
@@ -64,24 +43,14 @@ class CRM_Member_Form_Task_Email extends CRM_Member_Form_Task {
   /**
    * Build the form object.
    *
-   *
    * @return void
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     //enable form element
     $this->assign('emailTask', TRUE);
 
     CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   *
-   *
-   * @return void
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
This change does not change behaviour but starts the process of using a trait to cleanup the EmailCommon class (which is currently awful)

Before
----------------------------------------
Form passed to static functions

After
----------------------------------------
Starting to use a trait

Technical Details
----------------------------------------
This is a really awful class - I've added a trait &  moved the calls from the various forms to that trait
so the code  on EmailCommon for buildForm is now only called once. I will follow up with more the same

Comments
----------------------------------------

