### PR TITLE
[REF] Fix handling of owner url parameter from Membership Dashboard

### DIFF
--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -178,6 +178,22 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
+   * Set defaults.
+   *
+   * @return array
+   * @throws \Exception
+   */
+  public function setDefaultValues() {
+    $this->_defaults = parent::setDefaultValues();
+    //LCD also allow restrictions to membership owner via GET
+    $owner = CRM_Utils_Request::retrieve('owner', 'String');
+    if (in_array($owner, ['0', '1'])) {
+      $this->_defaults['member_is_primary'] = $owner;
+    }
+    return $this->_defaults;
+  }
+
+  /**
    * The post processing of the form gets done here.
    *
    * Key things done during post processing are
@@ -318,12 +334,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive',
       $this
     );
-
-    //LCD also allow restrictions to membership owner via GET
-    $owner = CRM_Utils_Request::retrieve('owner', 'String');
-    if (in_array($owner, ['0', '1'])) {
-      $this->_formValues['member_is_primary'] = $this->_defaults['member_is_primary'] = $owner;
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This picks up a comment from @jitendrapurohit https://github.com/civicrm/civicrm-core/pull/16933#issuecomment-606574561 that the owner url parameter wasn't correctly being passed on for export and related purposes

Before
----------------------------------------
Owner URL param not respected in membership search export

After
----------------------------------------
Owner URL param respected

Technical Details
----------------------------------------
The member_is_primary field has not been added to the entity information yet and this is consistant with some other changes we have done for other url parameters e.g. https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Search.php#L126

ping @jitendrapurohit @eileenmcnaughton 