### PR TITLE
Follow up PR for #16845 - Fix form error when  variable is NULL

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -413,8 +413,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         }
       }
     }
-    $optionContext = $extra['option_context'] ?? NULL;
-    unset($extra['option_context']);
+    $optionContext = NULL;
+    if (!empty($extra['option_context'])) {
+      $optionContext = $extra['option_context'];
+      unset($extra['option_context']);
+    }
 
     $element = $this->addElement($type, $name, $label, $attributes, $extra);
     if (HTML_QuickForm::isError($element)) {


### PR DESCRIPTION
Overview
----------------------------------------
Follow up PR for #16845 - Fix issues on the form when `$extra` is set as NULL

Before
----------------------------------------
Errors displayed on Price set field form Eg https://dmaster.demo.civicrm.org/civicrm/admin/price/field?reset=1&action=add&sid=9

![image](https://user-images.githubusercontent.com/5929648/78129259-eb1eb100-7434-11ea-9862-f635fdc8dc58.png)


After
----------------------------------------
Fixed.


Comments
----------------------------------------
Fixes the part of code changed in https://github.com/civicrm/civicrm-core/pull/16845. ping @yashodha 

https://github.com/civicrm/civicrm-core/pull/16845 is not included in rc so doing a master PR.