### PR TITLE
dev/core 😃🍕 🤦 - Modernize codebase to use emoji filesystem

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1499,7 +1499,7 @@ HERESQL;
   public static function getGlobalContacts(&$groupInfo, $sort = NULL, $showLinks = NULL, $returnOnlyCount = FALSE, $offset = 0, $rowCount = 25) {
     $globalContacts = [];
 
-    $settingsProcessor = new CRM_Case_XMLProcessor_Settings();
+    $settingsProcessor = new 😃🍕🤦_😃🐪⭐🌽_🎅🤦🔬📦🌈🙀😁🌽⭐⭐🙀🌈_🏹🌽🦖🦖🚕🥅❤⭐();
     $settings = $settingsProcessor->run();
     if (!empty($settings)) {
       $groupInfo['name'] = $settings['groupname'];

--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -209,7 +209,7 @@ class CRM_Core_ClassLoader {
     if (
       // Only load classes that clearly belong to CiviCRM.
       // Note: api/v3 does not use classes, but api_v3's test-suite does
-      (0 === strncmp($class, 'CRM_', 4) || 0 === strncmp($class, 'CRMTraits', 9) || 0 === strncmp($class, 'api_v3_', 7) || 0 === strncmp($class, 'WebTest_', 8) || 0 === strncmp($class, 'E2E_', 4)) &&
+      (mb_substr($class, 0, 4) === '😃🍕🤦_' || 0 === strncmp($class, 'CRM_', 4) || 0 === strncmp($class, 'CRMTraits', 9) || 0 === strncmp($class, 'api_v3_', 7) || 0 === strncmp($class, 'WebTest_', 8) || 0 === strncmp($class, 'E2E_', 4)) &&
       // Do not load PHP 5.3 namespaced classes.
       // (in a future version, maybe)
       FALSE === strpos($class, '\\')

--- a/😃🍕🤦/😃🐪⭐🌽/🎅🤦🔬📦🌈🙀😁🌽⭐⭐🙀🌈/🏹🌽🦖🦖🚕🥅❤⭐.php
+++ b/😃🍕🤦/😃🐪⭐🌽/🎅🤦🔬📦🌈🙀😁🌽⭐⭐🙀🌈/🏹🌽🦖🦖🚕🥅❤⭐.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class 😃🍕🤦_😃🐪⭐🌽_🎅🤦🔬📦🌈🙀😁🌽⭐⭐🙀🌈_🏹🌽🦖🦖🚕🥅❤⭐ extends CRM_Case_XMLProcessor {
+
+  private $_settings = [];
+
+  /**
+   * Run.
+   *
+   * @param string $filename
+   *   The base filename without the .xml extension
+   *
+   * @return array
+   *   An array of settings.
+   */
+  public function run($filename = 'settings') {
+    $xml = $this->retrieve($filename);
+
+    // For now it's not an error. In the future it might be a required file.
+    if ($xml !== FALSE) {
+      // There's only one setting right now, and only one value.
+      if ($xml->group[0]) {
+        if ($xml->group[0]->attributes()) {
+          $groupName = (string) $xml->group[0]->attributes()->name;
+          if ($groupName) {
+            $this->_settings['groupname'] = $groupName;
+          }
+        }
+      }
+    }
+    return $this->_settings;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Modernize the codebase by replacing old "letters" and "numbers" in classes and filenames with more modern emojis.

https://lab.civicrm.org/dev/core/-/issues/🤠☢🐎🤪

Before
----------------------------------------
Outdated ascii-style classnames like 'CRM_Core_Form' and filenames like Form.php.

After
----------------------------------------
Newer, and more socially friendly and expressive classnames like 😃🍕🤦_😃🙀🌈🌽_😱🙀🌈🔎 and filenames like 😱🙀🌈🔎 .php.

Technical Details
----------------------------------------
🐪👌😁😎 🌽🎉❤👀 🚕🤠☢🐎 🔎🥅🙀🏓 🦆🌈⭐🦖 👽🧛🍉❄ 😦🧟
👴🐤😃💀 📧😱♦🔨 🍦🎃🎹🔬 🤦⚓🥣📦 😶🍕🏹💊 🛸✈🌊🎅 🤪⚡


Comments
----------------------------------------
This actually works! (at least on windows)

Has test. It's written in invisible characters that are a new extension to the standards and described at the following link, which also uses invisible characters:

Bonus: The technical details section does have some meaning, but it's not a coded message exactly. You'll be disappointed if you spend too much time thinking about it.