### PR TITLE
dev/core#1682 - Invalid currency  on sending offline membership receipt.

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -392,7 +392,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   public function buildQuickForm() {
 
     $this->buildQuickEntityForm();
-    $this->assign('currency', CRM_Core_BAO_Country::defaultCurrencySymbol());
+    $this->assign('currency_symbol', CRM_Core_BAO_Country::defaultCurrencySymbol());
     $isUpdateToExistingRecurringMembership = $this->isUpdateToExistingRecurringMembership();
     // build price set form.
     $buildPriceSet = FALSE;
@@ -1617,8 +1617,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     }
 
     if (!empty($lineItem[$this->_priceSetId])) {
-      $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
+      $invoicing = Civi::settings()->get('invoicing');
       $taxAmount = FALSE;
       $totalTaxAmount = 0;
       foreach ($lineItem[$this->_priceSetId] as & $priceFieldOp) {

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -301,7 +301,7 @@
         var taxRates = {/literal}{$taxRates}{literal};
         var taxTerm = {/literal}{$taxTerm|@json_encode}{literal};
         var taxRate = taxRates[allMemberships[memType]['financial_type_id']];
-        var currency = {/literal}{$currency|@json_encode}{literal};
+        var currency = {/literal}{$currency_symbol|@json_encode}{literal};
         var taxAmount = (taxRate/100)*allMemberships[memType]['total_amount_numeric'];
         taxAmount = isNaN (taxAmount) ? 0:taxAmount;
         if (term) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix error on offline membership form when receipt checkbox is enabled.

Before
----------------------------------------
See steps to replicate on gitlab - https://lab.civicrm.org/dev/core/-/issues/1682

![image](https://user-images.githubusercontent.com/5929648/78132664-c4637900-743a-11ea-9ebf-200c8e3b89b2.png)


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
When the membership form is rendered, `currency` variable is set to the symbol value to display it on the form. Same value is carried to the message template which errors on translating the amount value with `{$amount|crmMoney:$currency}` token.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/1682