### PR TITLE
fixes dev/core#1683 set profile frontend title

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -146,7 +146,7 @@ SELECT module,is_reserved
 
     }
     else {
-      $groupTitle = $this->_ufGroup['title'];
+      $groupTitle = CRM_Core_BAO_UFGroup::getFrontEndTitle($this->_ufGroup['id']);
     }
     CRM_Utils_System::setTitle($groupTitle);
     $this->assign('recentlyViewed', FALSE);


### PR DESCRIPTION
Overview
----------------------------------------
The relatively new "Public Title" field in profile settings was implemented for use in contribution forms, but not for standalone profile create/edit mode.

Before
----------------------------------------

1. create a new profile and give it a different public title from the profile name.
2. view the profile in create or edit mode. note that the profile name is used, not the public title, as expected.

After
----------------------------------------
Profile displays public title.