### PR TITLE
dev/report#31 - APIv4 - Support GROUP BY and aggregate functions

### DIFF
--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -81,7 +81,7 @@ abstract class AbstractGetAction extends AbstractQueryAction {
    */
   protected function expandSelectClauseWildcards() {
     $wildFields = array_filter($this->select, function($item) {
-      return strpos($item, '*') !== FALSE && strpos($item, '.') === FALSE;
+      return strpos($item, '*') !== FALSE && strpos($item, '.') === FALSE && strpos($item, '(') === FALSE && strpos($item, ' ') === FALSE;
     });
     foreach ($wildFields as $item) {
       $pos = array_search($item, array_values($this->select));

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -44,6 +44,13 @@ class DAOGetAction extends AbstractGetAction {
    */
   protected $select = [];
 
+  /**
+   * Field(s) by which to group the results.
+   *
+   * @var array
+   */
+  protected $groupBy = [];
+
   public function _run(Result $result) {
     $this->setDefaultWhereClause();
     $this->expandSelectClauseWildcards();
@@ -61,6 +68,31 @@ class DAOGetAction extends AbstractGetAction {
       \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
     }
     return $result;
+  }
+
+  /**
+   * @return array
+   */
+  public function getGroupBy(): array {
+    return $this->groupBy;
+  }
+
+  /**
+   * @param array $groupBy
+   * @return $this
+   */
+  public function setGroupBy(array $groupBy) {
+    $this->groupBy = $groupBy;
+    return $this;
+  }
+
+  /**
+   * @param string $field
+   * @return $this
+   */
+  public function addGroupBy(string $field) {
+    $this->groupBy[] = $field;
+    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -64,6 +64,10 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
       'data_type' => 'String',
     ];
     $fields[] = [
+      'name' => 'column_name',
+      'data_type' => 'String',
+    ];
+    $fields[] = [
       'name' => 'custom_field_id',
       'data_type' => 'Integer',
     ];

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -134,6 +134,11 @@ trait DAOActionTrait {
         $item['contact_id'] = $entityId;
       }
 
+      // FIXME: Weird thing the Contribution BAO expects
+      if ($this->getEntityName() == 'Contribution') {
+        $item['skipCleanMoney'] = TRUE;
+      }
+
       if ($this->getCheckPermissions()) {
         $this->checkContactPermissions($baoName, $item);
       }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -61,6 +61,11 @@ class Api4SelectQuery extends SelectQuery {
   public $debugOutput = NULL;
 
   /**
+   * @var array
+   */
+  public $groupBy = [];
+
+  /**
    * @param \Civi\Api4\Generic\DAOGetAction $apiGet
    */
   public function __construct($apiGet) {
@@ -68,6 +73,7 @@ class Api4SelectQuery extends SelectQuery {
     $this->checkPermissions = $apiGet->getCheckPermissions();
     $this->select = $apiGet->getSelect();
     $this->where = $apiGet->getWhere();
+    $this->groupBy = $apiGet->getGroupBy();
     $this->orderBy = $apiGet->getOrderBy();
     $this->limit = $apiGet->getLimit();
     $this->offset = $apiGet->getOffset();
@@ -100,6 +106,7 @@ class Api4SelectQuery extends SelectQuery {
     $this->buildWhereClause();
     $this->buildOrderBy();
     $this->buildLimit();
+    $this->buildGroupBy();
     return $this->query->toSQL();
   }
 
@@ -115,20 +122,21 @@ class Api4SelectQuery extends SelectQuery {
       $this->debugOutput['sql'][] = $sql;
     }
     $query = \CRM_Core_DAO::executeQuery($sql);
-
+    $i = 0;
     while ($query->fetch()) {
+      $id = $query->id ?? $i++;
       if (in_array('row_count', $this->select)) {
         $results[]['row_count'] = (int) $query->c;
         break;
       }
-      $results[$query->id] = [];
+      $results[$id] = [];
       foreach ($this->select as $alias) {
         $returnName = $alias;
         if ($this->isOneToOneField($alias)) {
           $alias = str_replace('.', '_', $alias);
-          $results[$query->id][$returnName] = property_exists($query, $alias) ? $query->$alias : NULL;
+          $results[$id][$returnName] = property_exists($query, $alias) ? $query->$alias : NULL;
         }
-      };
+      }
     }
     $event = new PostSelectQueryEvent($results, $this);
     \Civi::dispatcher()->dispatch(Events::POST_SELECT_QUERY, $event);
@@ -145,8 +153,10 @@ class Api4SelectQuery extends SelectQuery {
       return;
     }
     else {
-      // Always select id field
-      $this->select = array_merge(['id'], $this->select);
+      // Always select ID (unless we're doing groupBy).
+      if (!$this->groupBy) {
+        $this->select = array_merge(['id'], $this->select);
+      }
 
       // Expand wildcards in joins (the api wrapper already expanded non-joined wildcards)
       $wildFields = array_filter($this->select, function($item) {
@@ -206,6 +216,20 @@ class Api4SelectQuery extends SelectQuery {
   protected function buildLimit() {
     if (!empty($this->limit) || !empty($this->offset)) {
       $this->query->limit($this->limit, $this->offset);
+    }
+  }
+
+  /**
+   *
+   */
+  protected function buildGroupBy() {
+    foreach ($this->groupBy as $field) {
+      if ($this->isOneToOneField($field) && $this->getField($field)) {
+        $this->query->groupBy($field['sql_name']);
+      }
+      else {
+        throw new \API_Exception("Invalid field. Cannot group by $field");
+      }
     }
   }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -42,12 +42,6 @@ class Api4SelectQuery extends SelectQuery {
   protected $apiVersion = 4;
 
   /**
-   * @var array
-   *   Maps select fields to [<table_alias>, <column_alias>]
-   */
-  protected $fkSelectAliases = [];
-
-  /**
    * @var \Civi\Api4\Service\Schema\Joinable\Joinable[]
    *   The joinable tables that have been joined so far
    */
@@ -82,9 +76,9 @@ class Api4SelectQuery extends SelectQuery {
     }
     $baoName = CoreUtil::getBAOFromApiName($this->entity);
     $this->entityFieldNames = array_column($baoName::fields(), 'name');
-    $this->apiFieldSpec = $apiGet->entityFields();
-    foreach ($this->apiFieldSpec as $key => $field) {
-      $this->apiFieldSpec[$key]['sql_name'] = '`' . self::MAIN_TABLE_ALIAS . '`.`' . $field['column_name'] . '`';
+    foreach ($apiGet->entityFields() as $path => $field) {
+      $field['sql_name'] = '`' . self::MAIN_TABLE_ALIAS . '`.`' . $field['column_name'] . '`';
+      $this->addSpecField($path, $field);
     }
 
     $this->constructQueryObject($baoName);
@@ -145,6 +139,7 @@ class Api4SelectQuery extends SelectQuery {
   }
 
   protected function buildSelectClause() {
+    // An empty select is the same as *
     if (empty($this->select)) {
       $this->select = $this->entityFieldNames;
     }
@@ -172,18 +167,18 @@ class Api4SelectQuery extends SelectQuery {
     }
     foreach ($this->select as $fieldName) {
       $field = $this->getField($fieldName);
-      if (!$this->isOneToOneField($fieldName)) {
-        continue;
-      }
-      elseif ($field) {
-        $this->query->select($field['sql_name'] . " AS `$fieldName`");
-      }
       // Remove unknown fields without raising an error
-      else {
+      if (!$field) {
         $this->select = array_diff($this->select, [$fieldName]);
         if (is_array($this->debugOutput)) {
           $this->debugOutput['undefined_fields'][] = $fieldName;
         }
+      }
+      elseif ($field['is_many']) {
+        continue;
+      }
+      elseif ($field) {
+        $this->query->select($field['sql_name'] . " AS `$fieldName`");
       }
     }
   }
@@ -315,8 +310,7 @@ class Api4SelectQuery extends SelectQuery {
       $this->joinFK($fieldName);
     }
     $field = $this->apiFieldSpec[$fieldName] ?? NULL;
-    // Check if field exists and we have permission to view it
-    if ($field && (!$this->checkPermissions || empty($field['permission']) || \CRM_Core_Permission::check($field['permission']))) {
+    if ($field) {
       return $field;
     }
     elseif ($strict) {
@@ -329,13 +323,12 @@ class Api4SelectQuery extends SelectQuery {
    * Joins a path and adds all fields in the joined eneity to apiFieldSpec
    *
    * @param $key
-   * @return bool
    * @throws \API_Exception
    * @throws \Exception
    */
   protected function joinFK($key) {
     if (isset($this->apiFieldSpec[$key])) {
-      return TRUE;
+      return;
     }
 
     $pathArray = explode('.', $key);
@@ -347,15 +340,24 @@ class Api4SelectQuery extends SelectQuery {
     $pathString = implode('.', $pathArray);
 
     if (!$joiner->canJoin($this, $pathString)) {
-      return FALSE;
+      return;
     }
 
     $joinPath = $joiner->join($this, $pathString);
+
+    $isMany = FALSE;
+    foreach ($joinPath as $joinable) {
+      if ($joinable->getJoinType() === Joinable::JOIN_TYPE_ONE_TO_MANY) {
+        $isMany = TRUE;
+      }
+    }
+
     /** @var \Civi\Api4\Service\Schema\Joinable\Joinable $lastLink */
     $lastLink = array_pop($joinPath);
 
     // Custom field names are already prefixed
-    if ($lastLink instanceof CustomGroupJoinable) {
+    $isCustom = $lastLink instanceof CustomGroupJoinable;
+    if ($isCustom) {
       array_pop($pathArray);
     }
     $prefix = $pathArray ? implode('.', $pathArray) . '.' : '';
@@ -364,10 +366,11 @@ class Api4SelectQuery extends SelectQuery {
     foreach ($lastLink->getEntityFields() as $fieldObject) {
       $fieldArray = ['entity' => $joinEntity] + $fieldObject->toArray();
       $fieldArray['sql_name'] = '`' . $lastLink->getAlias() . '`.`' . $fieldArray['column_name'] . '`';
-      $this->apiFieldSpec[$prefix . $fieldArray['name']] = $fieldArray;
+      $fieldArray['is_custom'] = $isCustom;
+      $fieldArray['is_join'] = TRUE;
+      $fieldArray['is_many'] = $isMany;
+      $this->addSpecField($prefix . $fieldArray['name'], $fieldArray);
     }
-
-    return TRUE;
   }
 
   /**
@@ -572,6 +575,22 @@ class Api4SelectQuery extends SelectQuery {
     }
 
     return $path;
+  }
+
+  /**
+   * @param $path
+   * @param $field
+   */
+  private function addSpecField($path, $field) {
+    // Only add field to spec if we have permission
+    if ($this->checkPermissions && !empty($field['permission']) && !\CRM_Core_Permission::check($field['permission'])) {
+      $this->apiFieldSpec[$path] = FALSE;
+      return;
+    }
+    $defaults = [];
+    $defaults['is_custom'] = $defaults['is_join'] = $defaults['is_many'] = FALSE;
+    $field += $defaults;
+    $this->apiFieldSpec[$path] = $field;
   }
 
 }

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -1,0 +1,144 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Base class for SqlColumn, SqlString, SqlBool, and SqlFunction classes.
+ *
+ * These are used to validate and format sql expressions in Api4 select queries.
+ *
+ * @package Civi\Api4\Query
+ */
+abstract class SqlExpression {
+
+  /**
+   * @var array
+   */
+  protected $fields = [];
+
+  /**
+   * @var string|null
+   */
+  protected $alias;
+
+  /**
+   * The argument string.
+   * @var string
+   */
+  protected $arg = '';
+
+  /**
+   * SqlFunction constructor.
+   * @param string $arg
+   * @param string|null $alias
+   */
+  public function __construct(string $arg, $alias = NULL) {
+    $this->arg = $arg;
+    $this->alias = $alias;
+    $this->initialize();
+  }
+
+  abstract protected function initialize();
+
+  /**
+   * Converts a string to a SqlExpression object.
+   *
+   * E.g. the expression "SUM(foo)" would return a SqlFunctionSUM object.
+   *
+   * @param string $expression
+   * @param bool $parseAlias
+   * @param array $mustBe
+   * @param array $cantBe
+   * @return SqlExpression
+   * @throws \API_Exception
+   */
+  public static function convert(string $expression, $parseAlias = FALSE, $mustBe = [], $cantBe = ['SqlWild']) {
+    $as = $parseAlias ? strrpos($expression, ' AS ') : FALSE;
+    $expr = $as ? substr($expression, 0, $as) : $expression;
+    $alias = $as ? \CRM_Utils_String::munge(substr($expression, $as + 4)) : NULL;
+    $bracketPos = strpos($expr, '(');
+    $firstChar = substr($expr, 0, 1);
+    $lastChar = substr($expr, -1);
+    // Function
+    if ($bracketPos && $lastChar === ')') {
+      $fnName = substr($expr, 0, $bracketPos);
+      if ($fnName !== strtoupper($fnName)) {
+        throw new \API_Exception('Sql function must be uppercase.');
+      }
+      $className = 'SqlFunction' . $fnName;
+      $expr = substr($expr, $bracketPos + 1, -1);
+    }
+    // String expression
+    elseif ($firstChar === $lastChar && in_array($firstChar, ['"', "'"], TRUE)) {
+      $className = 'SqlString';
+    }
+    elseif ($expr === 'NULL') {
+      $className = 'SqlNull';
+    }
+    elseif ($expr === '*') {
+      $className = 'SqlWild';
+    }
+    elseif (is_numeric($expr)) {
+      $className = 'SqlNumber';
+    }
+    // If none of the above, assume it's a field name
+    else {
+      $className = 'SqlField';
+    }
+    $className = __NAMESPACE__ . '\\' . $className;
+    if (!class_exists($className)) {
+      throw new \API_Exception('Unable to parse sql expression: ' . $expression);
+    }
+    $sqlExpression = new $className($expr, $alias);
+    foreach ($cantBe as $cant) {
+      if (is_a($sqlExpression, __NAMESPACE__ . '\\' . $cant)) {
+        throw new \API_Exception('Illegal sql expression.');
+      }
+    }
+    if ($mustBe) {
+      foreach ($mustBe as $must) {
+        if (is_a($sqlExpression, __NAMESPACE__ . '\\' . $must)) {
+          return $sqlExpression;
+        }
+      }
+      throw new \API_Exception('Illegal sql expression.');
+    }
+    return $sqlExpression;
+  }
+
+  /**
+   * Returns the field names of all sql columns that are arguments to this expression.
+   *
+   * @return array
+   */
+  public function getFields(): array {
+    return $this->fields;
+  }
+
+  /**
+   * Renders expression to a sql string, replacing field names with column names.
+   *
+   * @param array $fieldList
+   * @return string
+   */
+  abstract public function render(array $fieldList): string;
+
+  /**
+   * Returns the alias to use for SELECT AS.
+   *
+   * @return string
+   */
+  public function getAlias(): string {
+    return $this->alias ?? $this->fields[0] ?? \CRM_Utils_String::munge($this->arg);
+  }
+
+}

--- a/Civi/Api4/Query/SqlField.php
+++ b/Civi/Api4/Query/SqlField.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql column expression
+ */
+class SqlField extends SqlExpression {
+
+  protected function initialize() {
+    $this->fields[] = $this->arg;
+  }
+
+  public function render(array $fieldList): string {
+    if (empty($fieldList[$this->arg])) {
+      throw new \API_Exception("Invalid field '{$this->arg}'");
+    }
+    return $fieldList[$this->arg]['sql_name'];
+  }
+
+}

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -1,0 +1,190 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Base class for all Sql functions.
+ *
+ * @package Civi\Api4\Query
+ */
+abstract class SqlFunction extends SqlExpression {
+
+  protected static $params = [];
+
+  protected $args = [];
+
+  /**
+   * Parse the argument string into an array of function arguments
+   */
+  protected function initialize() {
+    $arg = $this->arg;
+    foreach ($this->getParams() as $param) {
+      $prefix = $this->captureKeyword($param['prefix'], $arg);
+      if ($param['expr'] && isset($prefix) || in_array('', $param['prefix']) || !$param['optional']) {
+        $this->captureExpressions($arg, $param['expr'], $param['must_be'], $param['cant_be']);
+        $this->captureKeyword($param['suffix'], $arg);
+      }
+    }
+  }
+
+  /**
+   * Shift a keyword off the beginning of the argument string and into the argument array.
+   *
+   * @param array $keywords
+   *   Whitelist of keywords
+   * @param string $arg
+   * @return mixed|null
+   */
+  private function captureKeyword($keywords, &$arg) {
+    foreach (array_filter($keywords) as $key) {
+      if (strpos($arg, $key . ' ') === 0) {
+        $this->args[] = $key;
+        $arg = ltrim(substr($arg, strlen($key)));
+        return $key;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Shifts 0 or more expressions off the argument string and into the argument array
+   *
+   * @param string $arg
+   * @param int $limit
+   * @param array $mustBe
+   * @param array $cantBe
+   * @throws \API_Exception
+   */
+  private function captureExpressions(&$arg, $limit, $mustBe, $cantBe) {
+    $captured = 0;
+    $arg = ltrim($arg);
+    while ($arg) {
+      $item = $this->captureExpression($arg);
+      $arg = ltrim(substr($arg, strlen($item)));
+      $expr = SqlExpression::convert($item, FALSE, $mustBe, $cantBe);
+      $this->fields = array_merge($this->fields, $expr->getFields());
+      if ($captured) {
+        $this->args[] = ',';
+      }
+      $this->args[] = $expr;
+      $captured++;
+      // Keep going if we have a comma indicating another expression follows
+      if ($captured < $limit && substr($arg, 0, 1) === ',') {
+        $arg = ltrim(substr($arg, 1));
+      }
+      else {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Scans the beginning of a string for an expression; stops when it hits delimiter
+   *
+   * @param $arg
+   * @return string
+   */
+  private function captureExpression($arg) {
+    $chars = str_split($arg);
+    $isEscaped = $quote = NULL;
+    $item = '';
+    $quotes = ['"', "'"];
+    $brackets = [
+      ')' => '(',
+    ];
+    $enclosures = array_fill_keys($brackets, 0);
+    foreach ($chars as $index => $char) {
+      if (!$isEscaped && in_array($char, $quotes, TRUE)) {
+        // Open quotes - we'll ignore everything inside
+        if (!$quote) {
+          $quote = $char;
+        }
+        // Close quotes
+        elseif ($char === $quote) {
+          $quote = NULL;
+        }
+      }
+      if (!$quote) {
+        // Delineates end of expression
+        if (($char == ',' || $char == ' ') && !array_filter($enclosures)) {
+          return $item;
+        }
+        // Open brackets - we'll ignore delineators inside
+        if (isset($enclosures[$char])) {
+          $enclosures[$char]++;
+        }
+        // Close brackets
+        if (isset($brackets[$char]) && $enclosures[$brackets[$char]]) {
+          $enclosures[$brackets[$char]]--;
+        }
+      }
+      $item .= $char;
+      // We are escaping the next char if this is a backslash not preceded by an odd number of backslashes
+      $isEscaped = $char === '\\' && ((strlen($item) - strlen(rtrim($item, '\\'))) % 2);
+    }
+    return $item;
+  }
+
+  public function render(array $fieldList): string {
+    $output = $this->getName() . '(';
+    foreach ($this->args as $index => $arg) {
+      if ($index && $arg !== ',') {
+        $output .= ' ';
+      }
+      if (is_object($arg)) {
+        $output .= $arg->render($fieldList);
+      }
+      else {
+        $output .= $arg;
+      }
+    }
+    return $output . ')';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getAlias(): string {
+    return $this->alias ?? $this->getName() . ':' . implode('_', $this->fields);
+  }
+
+  /**
+   * Get the name of this sql function.
+   * @return string
+   */
+  public function getName(): string {
+    $className = get_class($this);
+    $pos = strrpos($className, 'SqlFunction');
+    return substr($className, $pos + 11);
+  }
+
+  /**
+   * Get the param metadata for this sql function.
+   * @return array
+   */
+  public static function getParams(): array {
+    $params = [];
+    foreach (static::$params as $param) {
+      // Merge in defaults to ensure each param has these properties
+      $params[] = $param + [
+        'prefix' => [],
+        'expr' => 1,
+        'suffix' => [],
+        'optional' => FALSE,
+        'must_be' => [],
+        'cant_be' => ['SqlWild'],
+      ];
+    }
+    return $params;
+  }
+
+}

--- a/Civi/Api4/Query/SqlFunctionAVG.php
+++ b/Civi/Api4/Query/SqlFunctionAVG.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionAVG extends SqlFunction {
+
+  protected static $params = [
+    [
+      'prefix' => ['', 'DISTINCT', 'ALL'],
+      'expr' => 1,
+      'must_be' => ['SqlField'],
+    ],
+  ];
+
+}

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionCOUNT extends SqlFunction {
+
+  protected static $params = [
+    [
+      'prefix' => ['', 'DISTINCT', 'ALL'],
+      'expr' => 1,
+      'must_be' => ['SqlField', 'SqlWild'],
+      'cant_be' => [],
+    ],
+  ];
+
+}

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionMAX extends SqlFunction {
+
+  protected static $params = [
+    [
+      'prefix' => ['', 'DISTINCT', 'ALL'],
+      'expr' => 1,
+      'must_be' => ['SqlField'],
+    ],
+  ];
+
+}

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionMIN extends SqlFunction {
+
+  protected static $params = [
+    [
+      'prefix' => ['', 'DISTINCT', 'ALL'],
+      'expr' => 1,
+      'must_be' => ['SqlField'],
+    ],
+  ];
+
+}

--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionSUM extends SqlFunction {
+
+  protected static $params = [
+    [
+      'prefix' => ['', 'DISTINCT', 'ALL'],
+      'expr' => 1,
+      'must_be' => ['SqlField'],
+    ],
+  ];
+
+}

--- a/Civi/Api4/Query/SqlNull.php
+++ b/Civi/Api4/Query/SqlNull.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * NULL sql expression
+ */
+class SqlNull extends SqlExpression {
+
+  protected function initialize() {
+  }
+
+  public function render(array $fieldList): string {
+    return 'NULL';
+  }
+
+}

--- a/Civi/Api4/Query/SqlNumber.php
+++ b/Civi/Api4/Query/SqlNumber.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Numeric sql expression
+ */
+class SqlNumber extends SqlExpression {
+
+  protected function initialize() {
+    \CRM_Utils_Type::validate($this->arg, 'Float');
+  }
+
+  public function render(array $fieldList): string {
+    return $this->arg;
+  }
+
+}

--- a/Civi/Api4/Query/SqlString.php
+++ b/Civi/Api4/Query/SqlString.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * String sql expression
+ */
+class SqlString extends SqlExpression {
+
+  protected function initialize() {
+    // Remove surrounding quotes
+    $str = substr($this->arg, 1, -1);
+    // Unescape the outer quote character inside the string to prevent double-escaping in render()
+    $quot = substr($this->arg, 0, 1);
+    $backslash = chr(0) . 'backslash' . chr(0);
+    $this->arg = str_replace(['\\\\', "\\$quot", $backslash], [$backslash, $quot, '\\\\'], $str);
+  }
+
+  public function render(array $fieldList): string {
+    return '"' . \CRM_Core_DAO::escapeString($this->arg) . '"';
+  }
+
+}

--- a/Civi/Api4/Query/SqlWild.php
+++ b/Civi/Api4/Query/SqlWild.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Wild * sql expression
+ */
+class SqlWild extends SqlExpression {
+
+  protected function initialize() {
+  }
+
+  public function render(array $fieldList): string {
+    return '*';
+  }
+
+}

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -84,20 +84,35 @@
             <div class="api4-input form-inline">
               <input class="collapsible-optgroups form-control" ng-model="controls[name]" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: fieldList(name), placeholder: ts('Add %1', {1: name.slice(0, -1)})}"/>
             </div>
-          </fieldset>
+          </fieldset><fieldset ng-if="availableParams.groupBy" ng-mouseenter="help('groupBy', availableParams.groupBy)" ng-mouseleave="help()">
+          <legend>groupBy<span class="crm-marker" ng-if="availableParams.groupBy.required"> *</span></legend>
+          <div ng-model="params.groupBy" ui-sortable="{axis: 'y'}">
+            <div class="api4-input form-inline" ng-repeat="(pos, field) in params.groupBy">
+              <i class="crm-i fa-arrows"></i>
+              <input class="collapsible-optgroups form-control" ng-model="params.groupBy[pos]" crm-ui-select="{data: fieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+            </div>
+          </div>
+          <div class="api4-input form-inline">
+            <input class="collapsible-optgroups form-control" ng-model="controls.groupBy" crm-ui-select="{data: fieldsAndJoins}" placeholder="Add groupBy" />
+          </div>
+        </fieldset>
           <fieldset ng-if="availableParams.orderBy" ng-mouseenter="help('orderBy', availableParams.orderBy)" ng-mouseleave="help()">
             <legend>orderBy<span class="crm-marker" ng-if="availableParams.orderBy.required"> *</span></legend>
-            <div class="api4-input form-inline" ng-repeat="clause in params.orderBy">
-              <input class="collapsible-optgroups form-control" ng-model="clause[0]" crm-ui-select="{data: fieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
-              <select class="form-control" ng-model="clause[1]">
-                <option value="ASC">ASC</option>
-                <option value="DESC">DESC</option>
-              </select>
+            <div ng-model="params.orderBy" ui-sortable="{axis: 'y'}">
+              <div class="api4-input form-inline" ng-repeat="clause in params.orderBy">
+                <i class="crm-i fa-arrows"></i>
+                <input class="collapsible-optgroups form-control" ng-model="clause[0]" crm-ui-select="{data: fieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+                <select class="form-control" ng-model="clause[1]">
+                  <option value="ASC">ASC</option>
+                  <option value="DESC">DESC</option>
+                </select>
+              </div>
             </div>
             <div class="api4-input form-inline">
               <input class="collapsible-optgroups form-control" ng-model="controls.orderBy" crm-ui-select="{data: fieldsAndJoins}" placeholder="Add orderBy" />
             </div>
           </fieldset>
+
           <fieldset ng-if="availableParams.chain" ng-mouseenter="help('chain', availableParams.chain)" ng-mouseleave="help()">
             <legend>chain</legend>
             <div class="api4-input form-inline" ng-repeat="clause in params.chain" api4-exp-chain="clause" entities="entities" main-entity="entity" >

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -237,7 +237,7 @@
     };
 
     $scope.isSpecial = function(name) {
-      var specialParams = ['select', 'fields', 'action', 'where', 'values', 'defaults', 'orderBy', 'chain'];
+      var specialParams = ['select', 'fields', 'action', 'where', 'values', 'defaults', 'orderBy', 'chain', 'groupBy'];
       return _.contains(specialParams, name);
     };
 
@@ -374,7 +374,7 @@
               deep: format === 'json'
             });
           }
-          if (typeof objectParams[name] !== 'undefined') {
+          if (typeof objectParams[name] !== 'undefined' || name === 'groupBy') {
             $scope.$watch('params.' + name, function(values) {
               // Remove empty values
               _.each(values, function(clause, index) {
@@ -387,13 +387,17 @@
               var field = value;
               $timeout(function() {
                 if (field) {
-                  var defaultOp = _.cloneDeep(objectParams[name]);
-                  if (name === 'chain') {
-                    var num = $scope.params.chain.length;
-                    defaultOp[0] = field;
-                    field = 'name_me_' + num;
+                  if (name === 'groupBy') {
+                    $scope.params[name].push(field);
+                  } else {
+                    var defaultOp = _.cloneDeep(objectParams[name]);
+                    if (name === 'chain') {
+                      var num = $scope.params.chain.length;
+                      defaultOp[0] = field;
+                      field = 'name_me_' + num;
+                    }
+                    $scope.params[name].push([field, defaultOp]);
                   }
-                  $scope.params[name].push([field, defaultOp]);
                   $scope.controls[name] = null;
                 }
               });

--- a/tests/phpunit/api/v4/Action/SqlExpressionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlExpressionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Contact;
+
+/**
+ * @group headless
+ */
+class SqlExpressionTest extends UnitTestCase {
+
+  public function testSelectNull() {
+    Contact::create()->addValue('first_name', 'bob')->setCheckPermissions(FALSE)->execute();
+    $result = Contact::get()
+      ->addSelect('NULL AS nothing', 'NULL', 'NULL AS b*d char', 'first_name AS firsty')
+      ->addWhere('first_name', '=', 'bob')
+      ->setLimit(1)
+      ->execute()
+      ->first();
+    $this->assertNull($result['nothing']);
+    $this->assertNull($result['NULL']);
+    $this->assertNull($result['b_d_char']);
+    $this->assertEquals('bob', $result['firsty']);
+    $this->assertArrayNotHasKey('b*d char', $result);
+  }
+
+  public function testSelectNumbers() {
+    Contact::create()->addValue('first_name', 'bob')->setCheckPermissions(FALSE)->execute();
+    $result = Contact::get()
+      ->addSelect('first_name', 123, 45.678, '-55 AS neg')
+      ->addWhere('first_name', '=', 'bob')
+      ->setLimit(1)
+      ->execute()
+      ->first();
+    $this->assertEquals('bob', $result['first_name']);
+    $this->assertEquals('123', $result['123']);
+    $this->assertEquals('-55', $result['neg']);
+    $this->assertEquals('45.678', $result['45_678']);
+  }
+
+  public function testSelectStrings() {
+    Contact::create()->addValue('first_name', 'bob')->setCheckPermissions(FALSE)->execute();
+    $result = Contact::get()
+      ->addSelect('first_name AS bob')
+      ->addSelect('"hello world" AS hi')
+      ->addSelect('"can\'t \"quote\"" AS quot')
+      ->addWhere('first_name', '=', 'bob')
+      ->setLimit(1)
+      ->execute()
+      ->first();
+    $this->assertEquals('bob', $result['bob']);
+    $this->assertEquals('hello world', $result['hi']);
+    $this->assertEquals('can\'t "quote"', $result['quot']);
+  }
+
+}

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Contact;
+use Civi\Api4\Contribution;
+
+/**
+ * @group headless
+ */
+class SqlFunctionTest extends UnitTestCase {
+
+  public function testGroupAggregates() {
+    $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
+    Contribution::save()
+      ->setCheckPermissions(FALSE)
+      ->setDefaults(['contact_id' => $cid, 'financial_type_id' => 1])
+      ->setRecords([
+        ['total_amount' => 100, 'receive_date' => '2020-01-01'],
+        ['total_amount' => 200, 'receive_date' => '2020-01-01'],
+        ['total_amount' => 300, 'receive_date' => '2020-01-01'],
+        ['total_amount' => 400, 'receive_date' => '2020-01-01'],
+      ])
+      ->execute();
+    $agg = Contribution::get()
+      ->setCheckPermissions(FALSE)
+      ->addGroupBy('contact_id')
+      ->addWhere('contact_id', '=', $cid)
+      ->addSelect('AVG(total_amount) AS average')
+      ->addSelect('SUM(total_amount)')
+      ->addSelect('MAX(total_amount)')
+      ->addSelect('MIN(total_amount)')
+      ->addSelect('COUNT(*) AS count')
+      ->execute()
+      ->first();
+    $this->assertEquals(250, $agg['average']);
+    $this->assertEquals(1000, $agg['SUM:total_amount']);
+    $this->assertEquals(400, $agg['MAX:total_amount']);
+    $this->assertEquals(100, $agg['MIN:total_amount']);
+    $this->assertEquals(4, $agg['count']);
+  }
+
+}

--- a/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
+++ b/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ * $Id$
+ *
+ */
+
+
+namespace api\v4\Query;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Query\SqlExpression;
+
+/**
+ * @group headless
+ */
+class SqlExpressionParserTest extends UnitTestCase {
+
+  public function aggregateFunctions() {
+    return [
+      ['AVG'],
+      ['COUNT'],
+      ['MAX'],
+      ['MIN'],
+      ['SUM'],
+    ];
+  }
+
+  /**
+   * @param string|\Civi\Api4\Query\SqlFunction $fnName
+   * @dataProvider aggregateFunctions
+   */
+  public function testAggregateFuncitons($fnName) {
+    $className = 'Civi\Api4\Query\SqlFunction' . $fnName;
+    $params = $className::getParams();
+    $this->assertNotEmpty($params[0]['prefix']);
+    $this->assertEmpty($params[0]['suffix']);
+
+    $sqlFn = new $className('total');
+    $this->assertEquals($fnName, $sqlFn->getName());
+    $this->assertEquals(['total'], $sqlFn->getFields());
+    $this->assertCount(1, $this->getArgs($sqlFn));
+
+    $sqlFn = SqlExpression::convert($fnName . '(DISTINCT stuff)');
+    $this->assertEquals($fnName, $sqlFn->getName());
+    $this->assertEquals("Civi\Api4\Query\SqlFunction$fnName", get_class($sqlFn));
+    $this->assertEquals($params, $sqlFn->getParams());
+    $this->assertEquals(['stuff'], $sqlFn->getFields());
+    $this->assertCount(2, $this->getArgs($sqlFn));
+
+    try {
+      $sqlFn = SqlExpression::convert($fnName . '(*)');
+      if ($fnName === 'COUNT') {
+        $this->assertTrue(is_a($this->getArgs($sqlFn)[0], 'Civi\Api4\Query\SqlWild'));
+      }
+      else {
+        $this->fail('SqlWild should only be allowed in COUNT.');
+      }
+    }
+    catch (\API_Exception $e) {
+      $this->assertContains('Illegal', $e->getMessage());
+    }
+  }
+
+  /**
+   * @param \Civi\Api4\Query\SqlFunction $fn
+   * @return array
+   * @throws \ReflectionException
+   */
+  private function getArgs($fn) {
+    $ref = new \ReflectionClass($fn);
+    $args = $ref->getProperty('args');
+    $args->setAccessible(TRUE);
+    return $args->getValue($fn);
+  }
+
+}

--- a/tests/phpunit/api/v4/UnitTestCase.php
+++ b/tests/phpunit/api/v4/UnitTestCase.php
@@ -25,6 +25,8 @@ use api\v4\Traits\TestDataLoaderTrait;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
+require_once 'api/Exception.php';
+
 /**
  * @group headless
  */


### PR DESCRIPTION
Overview
----------------------------------------
Builds out the APIv4 framework to support GROUP BY and different types of expressions in clauses that previously only accepted the names of fields. These expressions can now include numbers, NULL, strings, and whitelisted SQL functions. The framework can in theory handle most SQL functions, but this first PR adds support for the aggregate functions AVG, COUNT, MAX, MIN & SUM.

See also: https://lab.civicrm.org/dev/report/-/issues/31

Before
----------------------------------------
No GROUP BY. Can only SELECT field names.

After
----------------------------------------
GROUP BY, SELECT and ORDER BY can take a wide variety of sql expressions in addition to the usual field names.

Technical Details
----------------------------------------
In order to parse and validate SQL expressions, I created a hierarchy of classes. Every string passed to the api (including simple fieldnames) is converted to an object, and each object knows how to validate itself and convert field names to column names.

If the object represents a SQL function, it parses its argument string and recursively creates more objects to represent each of the expressions passed in as parameters. This should allow the flexibility of nesting function calls within function calls, which is quite handy when writing sql queries.

Note: the SqlFunction objects don't understand what the functions actually DO, they just know what parameters they are allowed to accept.
