### PR TITLE
[REF] move buildQuickForm function to the trait

### DIFF
--- a/CRM/Activity/Form/Task/Email.php
+++ b/CRM/Activity/Form/Task/Email.php
@@ -34,17 +34,6 @@ class CRM_Activity_Form_Task_Email extends CRM_Activity_Form_Task {
   }
 
   /**
-   * Build the form object.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function buildQuickForm() {
-    // Enable form element.
-    $this->assign('emailTask', TRUE);
-    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array

--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -77,17 +77,6 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
   }
 
   /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    //enable form element
-    $this->assign('suppressForm', FALSE);
-    $this->assign('emailTask', TRUE);
-
-    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -63,9 +63,23 @@ trait CRM_Contact_Form_Task_EmailTrait {
 
   /**
    * Store only "bcc" contact ids.
+   *
    * @var array
    */
   public $_bccContactIds = [];
+
+  /**
+   * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function buildQuickForm() {
+    // Suppress form might not be required but perhaps there was a risk some other  process had set it to TRUE.
+    $this->assign('suppressForm', FALSE);
+    $this->assign('emailTask', TRUE);
+
+    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
+  }
 
   /**
    * Process the form after the input has been submitted and validated.

--- a/CRM/Contribute/Form/Task/Email.php
+++ b/CRM/Contribute/Form/Task/Email.php
@@ -35,16 +35,6 @@ class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
   }
 
   /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    //enable form element
-    $this->assign('emailTask', TRUE);
-
-    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array

--- a/CRM/Event/Form/Task/Email.php
+++ b/CRM/Event/Form/Task/Email.php
@@ -36,16 +36,6 @@ class CRM_Event_Form_Task_Email extends CRM_Event_Form_Task {
   }
 
   /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    //enable form element
-    $this->assign('emailTask', TRUE);
-
-    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array

--- a/CRM/Member/Form/Task/Email.php
+++ b/CRM/Member/Form/Task/Email.php
@@ -41,19 +41,6 @@ class CRM_Member_Form_Task_Email extends CRM_Member_Form_Task {
   }
 
   /**
-   * Build the form object.
-   *
-   * @return void
-   * @throws \CRM_Core_Exception
-   */
-  public function buildQuickForm() {
-    //enable form element
-    $this->assign('emailTask', TRUE);
-
-    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array


### PR DESCRIPTION

Overview
----------------------------------------
Minor code tidy up on send-email tasks - no impact on  functionality

Before
----------------------------------------
Duplication  of  buildQuickForm

After
----------------------------------------
Function shared via trait

Technical Details
----------------------------------------
Note that Contact had an extra assign. It seems likely the  extra  assign  is not required  but it
would not be a bad thing on the others


Comments
----------------------------------------
