### PR TITLE
APIv4 - Require contribution amount to be already clean

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -134,6 +134,11 @@ trait DAOActionTrait {
         $item['contact_id'] = $entityId;
       }
 
+      // FIXME: Weird thing the Contribution BAO expects
+      if ($this->getEntityName() == 'Contribution') {
+        $item['skipCleanMoney'] = TRUE;
+      }
+
       if ($this->getCheckPermissions()) {
         $this->checkContactPermissions($baoName, $item);
       }


### PR DESCRIPTION
Overview
----------------------------------------
APIv3 cleans money values before passing them to the BAO, but that can be surprising to developers.
For APIv4 we'll expect a pure numeric value to be passed in.

Before
----------------------------------------
CleanMoney not specified by APIv4, resulting in a warning emitted from the BAO:

> Deprecated code path. Money should always be clean before it hits the BAO.

After
----------------------------------------
BAO happy.
