### PR TITLE
Remove  deprecated cleaning  of money in  the  BAO layer

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -103,30 +103,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       throw new CRM_Core_Exception($message);
     }
 
-    // first clean up all the money fields
-    $moneyFields = [
-      'total_amount',
-      'net_amount',
-      'fee_amount',
-      'non_deductible_amount',
-    ];
-
-    //if priceset is used, no need to cleanup money
-    if (!empty($params['skipCleanMoney'])) {
-      $moneyFields = [];
-    }
-    else {
-      // @todo put a deprecated here - this should be done in the form layer.
-      $params['skipCleanMoney'] = FALSE;
-      Civi::log()->warning('Deprecated code path. Money should always be clean before it hits the BAO.', array('civi.tag' => 'deprecated'));
-    }
-
-    foreach ($moneyFields as $field) {
-      if (isset($params[$field])) {
-        $params[$field] = CRM_Utils_Rule::cleanMoney($params[$field]);
-      }
-    }
-
     //set defaults in create mode
     if (!$contributionID) {
       CRM_Core_DAO::setCreateDefaults($params, self::getDefaults());


### PR DESCRIPTION
Overview
----------------------------------------
Any code that  passed dirty money  to the Contribution::create BAO will  have been seeing
deprecation notices  for  over  2  years so we can remove this handling  now.  The  supported method is via the  api & v3 api does  the cleaning
whereas  v4 expects it to be pre-cleaned  - perhaps it's time to remove  this & leave it to  the
calling code


<img width="777" alt="Screen Shot 2020-04-02 at 12 02 22 PM" src="https://user-images.githubusercontent.com/336308/78194502-da744680-74d9-11ea-9e57-059f764ee9d5.png">


Before
----------------------------------------
Calling Contribution::create with skipCleanMoney bypasses money cleaning. Calling it with does   the cleanMoney thing - but has been emitting deprecation notices for  2 years

After
----------------------------------------
BAO no longer does money cleaning. Forms expected  to  do it  or to access BAO through v3 api (the former  is  preferred - ie  formatting on the form layer)

Technical Details
----------------------------------------

Comments
----------------------------------------
@mattwire 