### PR TITLE
dev/core#1679: Ensure Paypal IPN always updates the next scheduled p…

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -159,6 +159,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
         }
         else {
           $recur->modified_date = $now;
+          $recur->next_sched_contribution_date = date('Y-m-d', strtotime('+' . $recur->frequency_interval . ' ' . $recur->frequency_unit, strtotime($recur->next_sched_contribution_date)));
         }
 
         // make sure the contribution status is not done


### PR DESCRIPTION
…ayment date when recording the latest payment

Overview
----------------------------------------
This PR aims to resolve issue dev/core 1679 by getting the Paypal IPN to always update the next scheduled contribution date for recurring payments.

Before
----------------------------------------
The Paypal IPN did not update the next scheduled contribution date, thus causing the responsibility for this action to fall to the default algorithm, which is faulty.  That algorithm also fails to update this information should the transaction fall after midnight local time.  After the first failure, this algorithm never allows for the ongoing update of this date.

After
----------------------------------------
The Paypal IPN now updates the next scheduled contribution date regardless of the timing of the actual contribution.

Technical Details
----------------------------------------
This solution avoids solving the actual problem, which is the faulty default algorithm to determine the next scheduled contribution date.  While this PR solves the problem for Paypal, it's possible that IPNs for other payment processors may run into the same trouble by relying on this unreliable default algorithm.  This algorithm appears to be on lines 861 to 865 of CRM/Contribute/BAO/ContributionRecur.php.  It has the following comments, which I believe are accurate: "Only update next sched date if it's empty or 'just now' because payment processors may be managing the scheduled date themselves as core did not previously provide any help."

To me, it appears that the algorithm is trying to determine whether or not the payment processor is managing the next scheduled date by comparing the receive date of the transaction to the next scheduled date.  I believe there ought to be a more direct way of informing whether or not the payment processor is managing this date rather than inferring that possibility in that (faulty) way.

However, I cannot personally think of a more suitable algorithm, so therefore I am proposing avoiding it altogether for Paypal, which suits our purposes.

