### PR TITLE
dev/core#1685 - Search builder returns DB error on Group => Empty filter

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2990,8 +2990,8 @@ class CRM_Contact_BAO_Query {
     // even one group might equate to multiple when looking at children so IN is simpler.
     // @todo - also look at != casting but there are rows below to review.
     $opReplacements = [
-      'EMPTY' => 'NULL',
-      'NOT EMPTY' => 'NOT NULL',
+      'IS EMPTY' => 'IS NULL',
+      'IS NOT EMPTY' => 'IS NOT NULL',
       '=' => 'IN',
     ];
     if (isset($opReplacements[$op])) {

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -862,6 +862,10 @@ civicrm_relationship.is_active = 1 AND
     $queryObj = new CRM_Contact_BAO_Query([['group', '=', $groupID, 0, 0], ['group_contact_status', 'IN', ['Removed' => 1], 0, 0]]);
     $resultDAO = $queryObj->searchQuery();
     $this->assertEquals(1, $resultDAO->N);
+
+    $queryObj = new CRM_Contact_BAO_Query([['group', 'IS NOT EMPTY', '', 0, 0], ['group_contact_status', 'IN', ['Removed' => 1], 0, 0]]);
+    $resultDAO = $queryObj->searchQuery();
+    $this->assertEquals(1, $resultDAO->N);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix DB error on Group => Empty filter via search builder.

Before
----------------------------------------
See steps to replicate on gitlab - https://lab.civicrm.org/dev/core/-/issues/1685

![image](https://user-images.githubusercontent.com/5929648/78221559-37272f80-74e1-11ea-9535-afc181db570f.png)

After
----------------------------------------
Fixes the error and displays the search result correctly.

Comments
----------------------------------------
relates to https://github.com/civicrm/civicrm-core/pull/14618. ping @eileenmcnaughton 

Gitlab - https://lab.civicrm.org/dev/core/-/issues/1685
 
Unit test added.
