### PR TITLE
{contribution.receipt_date} token does not use any CiviCRM date formatter, output in YYYY-MM-DD HH:MM:SS format and {contribution.receive_date} also uses a non-standard format

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1808,8 +1808,10 @@ class CRM_Utils_Token {
         break;
 
       case 'receive_date':
+      case 'receipt_date':
         $value = CRM_Utils_Array::retrieveValueRecursive($contribution, $token);
-        $value = CRM_Utils_Date::customFormat($value, NULL, ['j', 'm', 'Y']);
+        $config = CRM_Core_Config::singleton();
+        $value = CRM_Utils_Date::customFormat($value, $config->dateformatDatetime);
         break;
 
       default:


### PR DESCRIPTION
Overview
----------------------------------------
{contribution.receipt_date} token does not use any CiviCRM date formatter, output in YYYY-MM-DD HH:MM:SS format and {contribution.receive_date} also uses a non-standard format

Before
----------------------------------------
For example, when generating a Thank You letter for a Donation Contribution, these two tokens will return dates/times formatted completely differently.

Contribution, Date Received: 22/04/2010 12:00AM
Contribution, Receipt Date: 01/04/2020 05:28PM

Thank You template::
Receipt date: {contribution.receipt_date}
Receive date: {contribution.receive_date}

Rendered template:
Receipt date: 2020-04-01 17:28:00
Received date: April 22nd, 2010

After
----------------------------------------
After this change the dates are returned with a consistent format using the Date Format: Complete Date and Time.

Rendered template:
Receipt date: April 1st, 2020 5:28 PM
Receive date: April 22nd, 2010 12:00 AM

Technical Details
----------------------------------------
This change removes what I can see as being the only instance of calling customFormat in this way.
$value = CRM_Utils_Date::customFormat($value, NULL, ['j', 'm', 'Y']);

Someone may want to review customFormat to see if there is any cruft refactor required.

Comments
----------------------------------------
None

Agileware Ref: CIVICRM-1465