### PR TITLE
fixed mapping when using custom field for contact sub type

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -82,6 +82,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $this->_mapperFields = $this->get('fields');
     $this->_importTableName = $this->get('importTableName');
     $this->_onDuplicate = $this->get('onDuplicate');
+    $this->_contactSubType = $this->get('contactSubType');
     $highlightedFields = [];
     $highlightedFields[] = 'email';
     $highlightedFields[] = 'external_identifier';


### PR DESCRIPTION
Overview
----------------------------------------

https://civicrm.stackexchange.com/questions/35240/import-mapping-dont-save-for-custom-fields-on-contact-subtypes

Before
----------------------------------------
Mappings not populated for contact subtype custom fields.

After
----------------------------------------
Mappings populated for contact subtype custom fields.