### PR TITLE
Add email link in case summary

### DIFF
--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -45,7 +45,7 @@
             {foreach from=$caseRoles.client item=client}
               <tr class="crm-case-caseview-display_name">
                 <td class="label-left bold" style="padding: 0px; border: none;">
-                  <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts}View contact record{/ts}">{$client.display_name}</a>
+                  <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts}View contact record{/ts}">{$client.display_name}</a>{if $client.email}{crmAPI var='email_type_id' entity='OptionValue' action='getsingle' return="value" name="Email" option_group_id="activity_type"}<span class="crm-case-caseview-email"><a class="crm-hover-button crm-popup" href="{crmURL p='civicrm/activity/email/add' q="reset=1&action=add&atype=`$email_type_id.value`&cid=`$client.contact_id`&caseid=`$caseId`"}" title="{ts 1=$client.email|escape}Email: %1{/ts}"><i class="crm-i fa-envelope"></i></a></span>{/if}
                 </td>
               </tr>
               {if $client.phone}


### PR DESCRIPTION
Overview
----------------------------------------
Currently, to email a case client it takes several clicks, I'm proposing a quicker (one-click) method to email the case client.

Before
----------------------------------------
The two options to email a client are:
- Scroll down, open the roles section, locate the client relationship and click the email icon. Email pop-up screen is launched with the primary email address filled in.
- Select 'email action from add activity drop-down, type in client's name in the To field, select desired email address
![image](https://user-images.githubusercontent.com/34744834/78269644-dfd09180-74d7-11ea-9d39-1ad25f9d45b3.png)

After
----------------------------------------
Click the email icon next to the client's name at the top of the screen. Email pop up screen is prefilled with the primary email address.
![image](https://user-images.githubusercontent.com/34744834/78269548-bc0d4b80-74d7-11ea-9597-074b2730456a.png)

Comments
----------------------------------------
I recognize that the action is the exact same as if you had opened the roles section and clicked the email icon. But in my opinion (and because we have open custom data on our cases) that is a bit lengthy of a process. If we are already providing the phone in the summary section if felt natural to include an email link as well.
