### PR TITLE
[regression] core#1688 - false positive on missing custom field check

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -121,8 +121,8 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
       }
       foreach ($group['form_values'] as $formValues) {
         if (isset($formValues[0]) && (strpos($formValues[0], 'custom_') === 0)) {
-          list(, $customFieldID) = explode('custom_', $formValues[0]);
-          if (!in_array($customFieldID, $customFieldIds, TRUE)) {
+          list(, $customFieldID) = explode('_', $formValues[0]);
+          if (!in_array((int) $customFieldID, $customFieldIds, TRUE)) {
             $problematicSG[CRM_Contact_BAO_SavedSearch::getName($group['id'], 'id')] = [
               'title' => CRM_Contact_BAO_SavedSearch::getName($group['id'], 'title'),
               'cfid' => $customFieldID,


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/1688

Overview
----------------------------------------
Any custom field that can take multiple values (multi-select, checkboxes, etc) will return a false positive for missing custom fields on the API call `System.check`.

Before
----------------------------------------
False positives

After
----------------------------------------
No false positives

Technical Details
----------------------------------------
The current code assumes that any saved search that has a form value starting with `custom_` will end with an integer (e.g. `custom_18`).  However, multi-select fields' form values have an operator - e.g. `custom_18_operator`).  The check grabs `18_operator` and compares it to a list of existing custom field IDs, and of course comes up empty.

Comments
----------------------------------------
I confirmed that deleting this field will still correctly trigger a warning.  I gave detailed replicated steps on the Gitlab ticket.
