### PR TITLE
dev/wp#46 - Fix overlarge select2 elements in WordPress 5.3+

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3040,6 +3040,7 @@ tbody.scrollContent tr.alternateRow {
 }
 .crm-container .select2-container-multi .select2-choices .select2-search-field input {
   padding: 4px;
+  min-height: unset;  /* Overide style imposed by WordPress 5.3 - see https://lab.civicrm.org/dev/wordpress/issues/46 */
 }
 .crm-container .select2-search-choice-close {
   top: 2px;


### PR DESCRIPTION
Overview
----------------------------------------
Changes in the visual look of WordPress 5.3 have caused some select2 elements too appear larger than they should.

The issue is that WordPress sets a minimum height on `input` elements. I have fixed this issue by unsetting the minimum height.

See [issue #46](https://lab.civicrm.org/dev/wordpress/issues/46#note_33173) for more details.

Before
----------------------------------------
A section of the Advanced Search form in WordPress 5.3. Note the height of the 'Select Tags' field is inconsistent with other elements.

![WordPress 5 3 CiviCRM 5 23 Ubuntu Firefox Before](https://user-images.githubusercontent.com/13518928/78389567-d419c380-75da-11ea-9dc4-1e680715f676.png)

After
----------------------------------------
The same section after this change.

![WordPress 5 3 CiviCRM 5 23 Ubuntu Firefox After](https://user-images.githubusercontent.com/13518928/78389564-d3812d00-75da-11ea-992f-8e79cc2b012c.png)

Technical Details
----------------------------------------
Screenshots taken in Firefox on Ubuntu 18.04. Other browser/OS combinations may vary.

I have tested this (and #16882) in the following OS/browsers:

* Windows 10: Chrome, Firefox, Edge, IE
* Android: Chrome, Samsung Internet
* Ubuntu: Chrome, Firefox

And the following CMSs:

* Drupal 7
* Drupal 8
* WordPress 5.2
* WordPress 5.4
* Backdrop

Help testing in Safari and Chrome on Mac OS and iOS would be appreciated. Ditto for Joomla.

Comments
----------------------------------------
See related PR #16882 for an issue with the `select` element in WordPress 5.3.
