### PR TITLE
[REF] CustomGroup - cleanup handling of serialized fields in old function

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1595,9 +1595,7 @@ ORDER BY civicrm_custom_group.weight,
           ) {
             $valid = CRM_Core_BAO_CustomValue::typecheck($field['data_type'], $value);
           }
-          if ($field['html_type'] == 'CheckBox' ||
-            $field['html_type'] == 'Multi-Select'
-          ) {
+          if (CRM_Core_BAO_CustomField::isSerialized($field)) {
             $value = str_replace("|", ",", $value);
             $mulValues = explode(',', $value);
             $customOption = CRM_Core_BAO_CustomOption::getCustomOption($key, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
More cleanup toward getting sanity in our custom field handling.
Use new isSeralized method rather than looking at html_type to figure out how to handle the data.

Before
----------------------------------------
Old function old.

After
----------------------------------------
Old function updated.

Comments
----------------------------------------
The function didn't appear to be correctly handling Multi-Select Country or Multi-Select State/Prov fields so this should also fix that.