### PR TITLE
dev/financial#84 - Fix upgrade failure. Thin-out activation logic for `sequentialcreditnotes`. 

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyFour.php
@@ -75,7 +75,21 @@ class CRM_Upgrade_Incremental_php_FiveTwentyFour extends CRM_Upgrade_Incremental
    * @throws \CiviCRM_API3_Exception
    */
   public static function installCreditNotes(CRM_Queue_TaskContext $ctx) {
-    civicrm_api3('Extension', 'install', ['keys' => 'sequentialcreditnotes']);
+    // Install via direct SQL manipulation. Note that:
+    // (1) This extension has no activation logic.
+    // (2) On new installs, the extension is activated purely via default SQL INSERT.
+    // (3) Caches are flushed at the end of the upgrade.
+    // ($) Over long term, upgrade steps are more reliable in SQL. API/BAO sometimes don't work mid-upgrade.
+    $insert = CRM_Utils_SQL_Insert::into('civicrm_extension')->row([
+      'type' => 'module',
+      'full_name' => 'sequentialcreditnotes',
+      'name' => 'Sequential credit notes',
+      'label' => 'Sequential credit notes',
+      'file' => 'sequentialcreditnotes',
+      'schema_version' => NULL,
+      'is_active' => 1,
+    ]);
+    CRM_Core_DAO::executeQuery($insert->usingReplace()->toSQL());
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------

This fixes an issue with running the upgrade on certain builds. It addresses the problem by reducing the number of services/layers involved with activating the `sequentialcreditnotes` extension.

Related: https://civicrm.stackexchange.com/a/35260/93

Steps to reproduce
------------------

* Create a site based on `wp-demo` with Civi 5.21
* Make a DB snapshot
* Update code to 5.24
* In the web UI, run the DB upgrade
    * Note: It's important to use the web UI. The problem does not reproduce in CLI.

Before
------

(1) The upgrader activates `sequentialcreditnotes` using the `Extension.install` API

(2) The upgrader freezes on "Upgrade DB to 5.24.alpha1". The `CiviCRM.log` includes:

```
Apr 03 14:41:50  [info] Running task: Upgrade DB to 5.24.alpha1: SQL

Apr 03 14:41:55  [info] Running task: Install sequential creditnote extension

Apr 03 14:42:14  [info] $CRM_Queue_ErrorPolicy_reportError = Array
(
    [is_error] => 1
    [is_continue] => 0
    [exception] => Error 1: Uncaught Error: Class 'CRM_Volunteer_Permission' not found in /home/me/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/tools/extensions/civivolunteer/volunteer.php:497
Stack trace:
0 /home/me/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/CRM/Utils/Hook.php(286): volunteer_civicrm_permission(Array)
1 /home/me/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/CRM/Utils/Hook/WordPress.php(139): CRM_Utils_Hook-&gt;runHooks(Array, 'civicrm_permiss...', 1, Array, NULL, NULL, NULL, NULL, NULL)
2 /home/me/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/Civi/Core/CiviEventDispatcher.php(86): CRM_Utils_Hook_WordPress-&gt;invokeViaUF(1, Array, NULL, NULL, NULL, NULL, NULL, 'civicrm_permiss...')
3 /home/me/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/vendor/symfony/event-dispatcher/EventDispatcher.php(184): Civi\Core\CiviEventDispatcher::delegateToUF(Object(Civi\Core\Event\GenericHookEvent), 'hook_civicrm_p
    [last_task_title] => Install sequential creditnote extension
)
```

After
-----

(1) The upgrader activates `sequentialcreditnotes` using a SQL insert.

(2) The upgrade completes. After installation, the `sequentialcreditnotes` extension is active.
