### PR TITLE
Capitalise PAN truncation

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -295,7 +295,7 @@ function _civicrm_api3_payment_create_spec(&$params) {
     'pan_truncation' => [
       'name' => 'pan_truncation',
       'type' => CRM_Utils_Type::T_STRING,
-      'title' => ts('Pan Truncation'),
+      'title' => ts('PAN Truncation'),
       'description' => ts('Last 4 digits of credit card'),
       'maxlength' => 4,
       'size' => 4,


### PR DESCRIPTION


Overview
----------------------------------------
From chat translation channel:

"Pan truncation" should be written "PAN truncation" for Truncation of the primary account number (credit card number). Now it's obvious to translate!

Before
----------------------------------------
 'title' => ts('Pan Truncation'),


After
----------------------------------------
  'title' => ts('PAN Truncation'),

Technical Details
----------------------------------------


Comments
----------------------------------------

