### PR TITLE
[REF] Call makeCSVTable function directly from writeRows

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2360,15 +2360,15 @@ LIMIT $offset, $limit
   }
 
   /**
+   * Write rows to the csv.
+   *
    * @param array $headerRows
-   * @param array $componentDetails
+   * @param array $rows
    */
-  protected function writeRows(array $headerRows, array $componentDetails) {
-    CRM_Core_Report_Excel::writeCSVFile($this->getExportFileName(),
-      $headerRows,
-      $componentDetails,
-      FALSE
-    );
+  protected function writeRows(array $headerRows, array $rows) {
+    if (!empty($rows)) {
+      CRM_Core_Report_Excel::makeCSVTable($headerRows, $rows, FALSE);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor code simplification 

Before
----------------------------------------
ExportProcessor calls CRM_Core_Report_Excel::writeCSVFile with $outputHeader = FALSE - this is the same as just calling CRM_Core_Report_Excel::makeCSVTable

After
----------------------------------------
It  just  calls CRM_Core_Report_Excel::makeCSVTable

Technical Details
----------------------------------------
This is just a minor simplification

Comments
----------------------------------------

