### PR TITLE
Fix multiselect/checkbox custom field defaults on registration profile

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1858,13 +1858,13 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
     if (!empty($form->_fields)) {
       $removeCustomFieldTypes = ['Participant'];
 
-      foreach ($form->_fields as $name => $dontCare) {
+      foreach ($form->_fields as $name => $fieldInfo) {
         if ((substr($name, 0, 7) == 'custom_' && !$form->_allowConfirmation
           && !CRM_Core_BAO_CustomGroup::checkCustomField(substr($name, 7), $removeCustomFieldTypes))
           || substr($name, 0, 12) == 'participant_') {
           continue;
         }
-        $fields[$name] = 1;
+        $fields[$name] = $fieldInfo;
       }
 
       if (!empty($fields)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where certain types of custom fields were not being correctly pre-populated on event registration profiles.

To Reproduce
-------------------------------
1. Create a checkbox or multiselect custom field for contacts.
2. Add it to a profile.
3. Add the profile to an event registration page.
4. Edit your own contact record and fill in some values for that field.
5. Visit the event registration form. Observe the field is not pre-populated with the expected value (while other fields on the form have been correctly filled-in).

Technical Details
----------------------------------------
The `CRM_Core_BAO_UFGroup::setProfileDefaults()` function expects each field to be an array,
but this function was just passing it the number 1. So it did not have enough field metadata
to correctly format each value.

Comments
----------------------------------------
This touches toxic code so this is a minimal bugfix; however additional cleanup and refactoring is needed.