### PR TITLE
Allow to specify entity subtype for tokenprocessor

### DIFF
--- a/CRM/Core/TokenTrait.php
+++ b/CRM/Core/TokenTrait.php
@@ -6,12 +6,14 @@ trait CRM_Core_TokenTrait {
   private $customFieldTokens;
 
   /**
-   * CRM_Entity_Tokens constructor.
+   * CRM_Core_TokenTrait constructor.
+   *
+   * @param int $entitySubType
    */
-  public function __construct() {
+  public function __construct($entitySubType = NULL) {
     parent::__construct($this->getEntityName(), array_merge(
       $this->getBasicTokens(),
-      $this->getCustomFieldTokens()
+      $this->getCustomFieldTokens($entitySubType)
     ));
   }
 
@@ -75,10 +77,13 @@ trait CRM_Core_TokenTrait {
    * Get the tokens for custom fields
    * @return array token name => token label
    */
-  protected function getCustomFieldTokens() {
-    if (!isset($this->customFieldTokens)) {
-      $this->customFieldTokens = \CRM_Utils_Token::getCustomFieldTokens(ucfirst($this->getEntityName()));
+  protected function getCustomFieldTokens($entitySubType = NULL) {
+    $customTokens = [];
+    $tokenName = 'custom_%d';
+    foreach (CRM_Core_BAO_CustomField::getFields(ucfirst($this->getEntityName()), FALSE, FALSE, $entitySubType) as $id => $info) {
+      $customTokens[sprintf($tokenName, $id)] = $info['label'];
     }
+    $this->customFieldTokens = $customTokens;
     return $this->customFieldTokens;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This allows an entity subtype (eg. for activities / cases) to be selected so that only relevant tokens are available. This is not yet used anywhere but could be enable for any UI that uses tokenProcessor with a specific entity subtype and a token selector.

Before
----------------------------------------
Cannot specify an entity subtype for tokenProcessor.

After
----------------------------------------
Can specify an entity subtype for tokenProcessor.

Technical Details
----------------------------------------
Allow a parameter `$entitySubType` to be passed in. This only affects the customfield tokens that are available for the entity.
Remove local caching on `customFieldTokens` property as `CRM_Core_BAO_CustomField::getFields()` has caching and we don't want to cache here in case we change the subtype.

Comments
----------------------------------------
@eileenmcnaughton @aydun I'm trying to add in a few "missing" bits and cleanup before extending to other entities. I've tested this by setting `$entitySubType` directly in the constructor. I have a follow-up PR to add case tokens for tokenProcessor and intend to add a test for that that also covers this.