### PR TITLE
Standardise what we pass to tokenProcessor so we don't have to add specific handling in each class for actionSchedule

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -145,7 +145,7 @@ class CRM_Activity_Tokens extends AbstractTokenSubscriber {
     ];
 
     // Get ActivityID either from actionSearchResult (for scheduled reminders) if exists
-    $activityId = $row->context['actionSearchResult']->entityID ?? $row->context[$this->getEntityContextSchema()];
+    $activityId = $row->context[$this->getEntityContextSchema()];
 
     $activity = $prefetch['activity'][$activityId];
 

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -690,8 +690,14 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
    * @return array
    */
   public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::activityTokens(), $tokens);
+    $tokenProcessor = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      'schema' => ['activityId'],
+    ]);
+    $tokens = $tokenProcessor->listTokens();
+
+    $tokens = array_merge(CRM_Core_SelectValues::contactTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -112,6 +112,25 @@ class TokenProcessor {
   protected $next = 0;
 
   /**
+   * Get a mapping from entity_table to context (currently used by actionSchedule to map parameters)
+   *
+   * @param string $entityTable eg. civicrm_activity
+   *
+   * @return string|null
+   */
+  public static function getEntityTableToSchemaMapping($entityTable) {
+    $mapping = [
+      'civicrm_activity' => 'activityId',
+      'civicrm_contact' => 'contactId',
+      'civicrm_contribution' => 'contributionId',
+    ];
+    if (array_key_exists($entityTable, $mapping)) {
+      return $mapping[$entityTable];
+    }
+    return NULL;
+  }
+
+  /**
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
    * @param array $context
    */

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -112,6 +112,8 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'activity_date_time' => '20120615100000',
       'is_current_revision' => 1,
       'is_deleted' => 0,
+      'subject' => 'Phone call',
+      'details' => 'A phone call about a bear',
     ];
     $this->fixtures['contact'] = [
       'is_deceased' => 0,
@@ -949,6 +951,27 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       [
         'body_html' => '/^--UNDEFINED--$/',
         'body_text' => '/^Hello world$/',
+      ],
+    ];
+
+    // In this example, we test activity tokens
+    $activityTokens = '{activity.subject};;{activity.details};;{activity.activity_date_time}';
+    $activity = $this->fixtures['phonecall'];
+    $activityTokensExpected = "Phone call;;A phone call about a bear;;June 15th, 2012 10:00 AM";
+    $cases[4] = [
+      // Schedule definition.
+      [
+        'subject' => "subj $someTokensTmpl",
+        'body_html' => "html {$activityTokens}",
+        'body_text' => "text {$activityTokens}",
+      ],
+      // Assertions (regex).
+      [
+        'from_name' => '/^FIXME$/',
+        'from_email' => '/^info@EXAMPLE.ORG$/',
+        'subject' => "/^subj $someTokensExpected\$/",
+        'body_html' => "/^html $activityTokensExpected\$/",
+        'body_text' => "/^text $activityTokensExpected\$/",
       ],
     ];
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently when implementing an entity for tokenProcessor we have to try two different ways of getting the parameters - depending on if we were invoked via actionschedule (scheduled reminders) or via a "standard" tokenProcessor context (eg. activity search -> print document / emailapi extension with tokenprocessor (https://lab.civicrm.org/mattwire/emailapi/-/tree/newtokenprocessor)).

This PR modifies the parameters passed by actionschedule to be "standard" so that we can simplify the entity classes for tokenProcessor. Here, the work has been done for activities.

Also note the example - switching over the actionschedule token selector to use tokenProcessor to retrieve the list of activity tokens - as that is what is actually available to be processed!

Before
----------------------------------------
Two sets of parameters to check.

After
----------------------------------------
Just one set of parameters.

Technical Details
----------------------------------------
Explained above in overview.  `getEntityTableToSchemaMapping()` function is not necessarily in the right place - we need a way of mapping from entity table to the context version - ideas welcome!

Comments
----------------------------------------
@eileenmcnaughton @aydun Be great if you have time to look at this as it will help with moving forward with the tokenProcessor more quickly!