### PR TITLE
Fix multiselect/checkbox custom field defaults on contribution online form

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -93,7 +93,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $contribFields = CRM_Contribute_BAO_Contribution::getContributionFields();
 
       // remove component related fields
-      foreach ($this->_fields as $name => $dontCare) {
+      foreach ($this->_fields as $name => $fieldInfo) {
         //don't set custom data Used for Contribution (CRM-1344)
         if (substr($name, 0, 7) == 'custom_') {
           $id = substr($name, 7);
@@ -105,7 +105,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         elseif (array_key_exists($name, $contribFields) || (substr($name, 0, 11) == 'membership_') || (substr($name, 0, 13) == 'contribution_')) {
           continue;
         }
-        $fields[$name] = 1;
+        $fields[$name] = $fieldInfo;
       }
 
       if (!empty($fields)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where certain types of custom fields were not being correctly pre-populated on online contribution  profiles.

Before
----------------------------------------
<img width="575" alt="Screen Shot 2020-04-05 at 22 44 39" src="https://user-images.githubusercontent.com/2053075/78510695-2dc2ef00-778f-11ea-9b07-00ccc339754f.png">


After
----------------------------------------
<img width="517" alt="Screen Shot 2020-04-05 at 22 44 13" src="https://user-images.githubusercontent.com/2053075/78510700-35829380-778f-11ea-8a17-198d6b9d3885.png">


Technical Details
----------------------------------------
The CRM_Core_BAO_UFGroup::setProfileDefaults() function expects each field to be an array,
but this function was just passing it the number 1. So it did not have enough field metadata
to correctly format each value.

