### PR TITLE
Add / make fit for purpose email.getlist api call

### DIFF
--- a/api/v3/Email.php
+++ b/api/v3/Email.php
@@ -23,6 +23,9 @@
  *
  * @return array
  *   API result array
+ *
+ * @throws \API_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
  */
 function civicrm_api3_email_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Email');
@@ -37,7 +40,6 @@ function civicrm_api3_email_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_email_create_spec(&$params) {
-  // TODO a 'clever' default should be introduced
   $params['is_primary']['api.default'] = 0;
   $params['email']['api.required'] = 1;
   $params['contact_id']['api.required'] = 1;
@@ -55,6 +57,10 @@ function _civicrm_api3_email_create_spec(&$params) {
  *
  * @return array
  *   API result array.
+ *
+ * @throws \API_Exception
+ * @throws \CiviCRM_API3_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
  */
 function civicrm_api3_email_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -71,4 +77,33 @@ function civicrm_api3_email_delete($params) {
  */
 function civicrm_api3_email_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}
+
+/**
+ * Set default getlist parameters.
+ *
+ * @see _civicrm_api3_generic_getlist_defaults
+ *
+ * @param array $request
+ *
+ * @return array
+ */
+function _civicrm_api3_email_getlist_defaults(&$request) {
+  return [
+    'description_field' => [
+      'contact_id.sort_name',
+      'email',
+    ],
+    'params' => [
+      'on_hold' => 0,
+      'contact_id.is_deleted' => 0,
+      'contact_id.is_deceased' => 0,
+      'contact_id.do_not_email' => 0,
+    ],
+    'label_field' => 'contact_id.sort_name',
+    // If no results from sort_name try email.
+    'search_field' => 'contact_id.sort_name',
+    'search_field_fallback' => 'email',
+  ];
+
 }

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -14,13 +14,18 @@
   */
 class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
 
+  /**
+   * Set up for tests.
+   *
+   * @throws \CRM_Core_Exception
+   */
   protected function setUp() {
     parent::setUp();
     $this->_contactIds = [
       $this->individualCreate(['first_name' => 'Antonia', 'last_name' => 'D`souza']),
       $this->individualCreate(['first_name' => 'Anthony', 'last_name' => 'Collins']),
     ];
-    $this->_optionValue = $this->callApiSuccess('optionValue', 'create', [
+    $this->_optionValue = $this->callAPISuccess('optionValue', 'create', [
       'label' => '"Seamus Lee" <seamus@example.com>',
       'option_group_id' => 'from_email_address',
     ]);
@@ -28,6 +33,8 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
 
   /**
    * Test generating domain emails
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testDomainEmailGeneration() {
     $emails = CRM_Core_BAO_Email::domainEmails();
@@ -39,6 +46,13 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
     $this->assertEquals('"Seamus Lee" <seamus@example.com>', $optionValue['values'][$this->_optionValue['id']]['label']);
   }
 
+  /**
+   * Test email uses signature.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
   public function testPostProcessWithSignature() {
     $mut = new CiviMailUtils($this, TRUE);
     Civi::settings()->set('allow_mail_from_logged_in_contact', 1);

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3683,6 +3683,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * CRM-15443 - ensure getlist api does not return deleted contacts.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetlistExcludeConditions() {
     $name = 'Scarabée';


### PR DESCRIPTION
Overview
----------------------------------------
Brings email.getlist api to functional parity with old ad hoc CRM_Contact_Page_AJAX::getContactEmail  so we can switch calls over & deprecate / remove that



Before
----------------------------------------
Email.getlist api not really usable for entity reference fields due to gaps below

After
----------------------------------------
Parity with the legacy function

Technical Details
----------------------------------------
The function CRM_Contact_Page_AJAX::getContactEmail is one of our  earlier  ajax attempts & this approach has been largely
replaced with entity Reference fields. In order to switch over we need to bring Email.getlist api to parity which  means
1) searching on sortname first, if less than 10 results on emails include emails
2) appropriate respect for includeWildCardInName (this should already be in the generic getlist)
3) filter out on_hold, is_deceased, do_not_email
4) acl support (should already  be part of the api).

The trickiest of these to support is the first - because we need to avoid using a non-performant OR
My current solution is the idea of a fallback field to search if the search results are less than the limit.
in most cases this won't require a second query but when it does it should be fairly quick.

Comments
----------------------------------------
A notable gap is the ability to filter on groups & tags which don't easily join onto email.get in apiv3. I have left out of scope for now

Note this can be  tested on the bcc field on https://github.com/civicrm/civicrm-core/pull/16936 (not the submit part as I haven't done that side yet). The current PR in that cleanup chain is https://github.com/civicrm/civicrm-core/pull/16954


