### PR TITLE
Case Details field is empty

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -355,6 +355,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     if (!empty($params['case_type_id'])) {
       $params['case_type'] = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $params['case_type_id'], 'name', 'id');
       $params['subject'] = $params['activity_subject'];
+      $params['details'] = $params['activity_details'];
     }
     $caseObj = CRM_Case_BAO_Case::create($params);
     $this->_caseId = $params['case_id'] = $caseObj->id;


### PR DESCRIPTION
Overview
----------------------------------------
When user creates new case using core form (non webform) the details field value is not saved.

Steps to reproduce:
1. Go to **Cases -> New Case**.
1. Fill in all the fields, including **Details** and click **Save**.
1. Case entity is created, but **Details** are emtpy.

Before
----------------------------------------
The **Details** field of case entity is empty (respective field of *civicrm_case* table is empty).
![screencast](https://lab.civicrm.org/dev/core/uploads/70934a3fc5c5460f2898b78056bb615e/case-details.gif)

After
----------------------------------------
The **Details** field of case entity has have a value.

Technical Details
----------------------------------------
Somehow only **Subject** field is taken from submitted form to *Case* entity, so let's take **Details** field too.

Comments
----------------------------------------
Related issue: https://lab.civicrm.org/dev/core/-/issues/1692