### PR TITLE
Fix setting custom field TextArea attributes

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1965,8 +1965,8 @@ WHERE  id IN ( %1, %2 )
       }
     }
 
-    // since we need to save option group id :)
-    if (!isset($params['attributes']) && strtolower($htmlType) == 'textarea') {
+    // Set default textarea attributes
+    if ($op == 'create' && !isset($params['attributes']) && $htmlType == 'TextArea') {
       $params['attributes'] = 'rows=4, cols=60';
     }
     return $params;


### PR DESCRIPTION
Overview
----------------------------------------
Fix code that was potentially overwriting attributes for existing fields during update ops.

Before
----------------------------------------
Attributes could be overwritten during update.

After
----------------------------------------
Defaults only set for create; preserved for update.

Comments
----------------------------------------
The comment made no sense whatsoever, but was friendly enough to end with a smiley :)