### PR TITLE
Add option to create related activities when creating cases thru the API

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -147,7 +147,7 @@ function _civicrm_api3_case_create_xmlProcessor($params, $caseBAO) {
   $xmlProcessorParams = [
     'clientID' => $params['contact_id'] ?? NULL,
     'creatorID' => $params['creator_id'] ?? NULL,
-    'standardTimeline' => 1,
+    'standardTimeline' => $params['standard_timeline'] ?? NULL,
     'activityTypeName' => 'Open Case',
     'caseID' => $params['id'] ?? NULL,
     'subject' => $params['subject'] ?? NULL,
@@ -217,6 +217,12 @@ function _civicrm_api3_case_create_spec(&$params) {
     'name' => 'medium_id',
     'title' => 'Activity Medium',
     'type' => CRM_Utils_Type::T_INT,
+  ];
+  $params['standard_timeline'] = [
+    'api.default' => 1,
+    'title' => 'Standard Timeline?',
+    'description' => 'Add activities from the Standard Timeline (default = yes). If No, the case will have no activities.',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
   ];
 }
 

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -998,4 +998,18 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $this->assertNotEquals($case_2['created_date'], $case_2['modified_date']);
   }
 
+  /**
+   * Test create function without standard timeline
+   */
+  public function testCaseCreateWithoutActivities() {
+    $params = $this->_params;
+    $params['standard_timeline'] = 0;
+    $result = $this->callAPISuccess('case', 'create', $params);
+    $id = $result['id'];
+
+    // Check result
+    $result = $this->callAPISuccess('Activity', 'get', ['case_id' => $id]);
+    $this->assertEquals($result['count'], 0);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
When creating cases thru tAPIv3 the standard timeline activities are ALWAYS added and there is no way to stop this from happening in the ui. This pr adds a new parameter to APIv3 Case.create "Standard Timeline?" which allows the user to say whether or not to create the standard timeline activities.

NOTE: There does not appear to be a case entity in APIv4 yet.

Before
----------------------------------------
When creating a  new case thru APIv3 all standard timeline activities are generated always.

After
----------------------------------------
With this change there is a new parameter "standard_timeline" which defaults to yes.

If yes all standard timeline activities are created

If no standard timeline activities are NOT created
