### PR TITLE
[NFC] Add Comment to avoid someone removing field only used in CiviCase extension

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -355,6 +355,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     if (!empty($params['case_type_id'])) {
       $params['case_type'] = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $params['case_type_id'], 'name', 'id');
       $params['subject'] = $params['activity_subject'];
+      // 'civicrm_case.details' is not used in core but is used in the CiviCase extension
       $params['details'] = $params['activity_details'];
     }
     $caseObj = CRM_Case_BAO_Case::create($params);

--- a/xml/schema/Case/Case.xml
+++ b/xml/schema/Case/Case.xml
@@ -161,7 +161,7 @@
       <rows>8</rows>
       <cols>60</cols>
     </html>
-    <comment>Details about the meeting (agenda, notes, etc).</comment>
+    <comment>Details populated from Open Case. Only used in the CiviCase extension.</comment>
     <add>1.8</add>
   </field>
   <field>


### PR DESCRIPTION
Overview
----------------------------------------
Followup from https://github.com/civicrm/civicrm-core/pull/16995. To avoid someone removing the field from core since it's not used in core but is (or seems like it will be) used in the civicase extension.

