### PR TITLE
dev/core#1673 Ensure that SQL statements are not duplicated in the de…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1427,6 +1427,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     ];
 
     $this->assignTabs();
+    $this->sqlFormattedArray = [];
     $this->sqlArray[] = $sql;
     foreach ($this->sqlArray as $sql) {
       foreach (['LEFT JOIN'] as $term) {


### PR DESCRIPTION
…veloper tab of reports

Overview
----------------------------------------
This ensures that the formatted SQL only contains unique SQL statements rather than duplicated ones. 

Before
----------------------------------------
Load up the contribution summary report and check the developer tab and note that one of the 2 SQLs is printed twice on the developer tab

After
----------------------------------------
Correct number of SQL statements are rendered

Technical Details
----------------------------------------
The problem is that you have 2 form variables

$this->sqlArray and $this->sqlFormattedArray and the issue is that when it is first called both are empty. So the buildQuery SQL is added to both correctly. The 2nd time it gets called from within the statistics function in the contribuiton summary report. The sqlArray already has the build report query in it so it gets looped in again when we do the foreach loop so gets re-formated again and re-added to the sqlformattedArray variable. This fixes it by resetting the sqlFormattedArray variable before the foreach

ping @eileenmcnaughton @monishdeb 