### PR TITLE
Allow other base tables for api4-based smart groups

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -64,6 +64,8 @@ class Api4SelectQuery extends SelectQuery {
    */
   public $groupBy = [];
 
+  public $forceSelectId = TRUE;
+
   /**
    * @var array
    */
@@ -82,6 +84,8 @@ class Api4SelectQuery extends SelectQuery {
     $this->limit = $apiGet->getLimit();
     $this->offset = $apiGet->getOffset();
     $this->having = $apiGet->getHaving();
+    // Always select ID of main table unless grouping is used
+    $this->forceSelectId = !$this->groupBy;
     if ($apiGet->getDebug()) {
       $this->debugOutput =& $apiGet->_debugOutput;
     }
@@ -158,8 +162,7 @@ class Api4SelectQuery extends SelectQuery {
       return;
     }
     else {
-      // Always select ID (unless we're doing groupBy).
-      if (!$this->groupBy) {
+      if ($this->forceSelectId) {
         $this->select = array_merge(['id'], $this->select);
       }
 

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -26,7 +26,7 @@
             </span>
             <input class="form-control api4-index" type="search" ng-model="index" ng-mouseenter="help('index', paramDoc('$index'))" ng-mouseleave="help()" placeholder="{{:: ts('Index') }}" />
             <button class="btn btn-success pull-right" crm-icon="fa-bolt" ng-disabled="!entity || !action || loading" ng-click="execute()" ng-mouseenter="help(ts('Execute'), executeDoc())" ng-mouseleave="help()">{{:: ts('Execute') }}</button>
-            <button class="btn btn-primary pull-right" crm-icon="fa-save" ng-show="perm.editGroups && entity === 'Contact' && action === 'get'" ng-click="save()" ng-mouseenter="help(ts('Save smart group'), saveDoc())" ng-mouseleave="help()">{{:: ts('Save...') }}</button>
+            <button class="btn btn-primary pull-right" crm-icon="fa-save" ng-show="perm.editGroups && action === 'get'" ng-click="save()" ng-mouseenter="help(ts('Save smart group'), saveDoc())" ng-mouseleave="help()">{{:: ts('Save...') }}</button>
           </div>
         </div>
         <div class="panel-body">

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -752,7 +752,8 @@
     $scope.saveDoc = function() {
       return {
         description: ts('Save API call as a smart group.'),
-        comment: ts('Allows you to create a SavedSearch containing the WHERE clause of this API call.'),
+        comment: ts('Create a SavedSearch using these API params to populate a smart group.') +
+          '\n\n' + ts('NOTE: you must select contact id as the only field.')
       };
     };
 
@@ -761,6 +762,15 @@
     writeCode();
 
     $scope.save = function() {
+      $scope.params.limit = $scope.params.offset = 0;
+      if ($scope.params.chain.length) {
+        CRM.alert(ts('Smart groups are not compatible with API chaining.'), ts('Error'), 'error', {expires: 5000});
+        return;
+      }
+      if ($scope.params.select.length !== 1 || !_.includes($scope.params.select[0], 'id')) {
+        CRM.alert(ts('To create a smart group, the API must select contact id and no other fields.'), ts('Error'), 'error', {expires: 5000});
+        return;
+      }
       var model = {
         title: '',
         description: '',
@@ -771,10 +781,11 @@
         params: JSON.parse(angular.toJson($scope.params))
       };
       model.params.version = 4;
-      delete model.params.select;
       delete model.params.chain;
       delete model.params.debug;
       delete model.params.limit;
+      delete model.params.offset;
+      delete model.params.orderBy;
       delete model.params.checkPermissions;
       var options = CRM.utils.adjustDialogDefaults({
         width: '500px',

--- a/tests/phpunit/api/v4/Entity/SavedSearchTest.php
+++ b/tests/phpunit/api/v4/Entity/SavedSearchTest.php
@@ -23,13 +23,14 @@ namespace api\v4\Entity;
 
 use api\v4\UnitTestCase;
 use Civi\Api4\Contact;
+use Civi\Api4\Email;
 
 /**
  * @group headless
  */
 class SavedSearchTest extends UnitTestCase {
 
-  public function testApi4SmartGroup() {
+  public function testContactSmartGroup() {
     $in = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'yes')->addValue('do_not_phone', TRUE)->execute()->first();
     $out = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'no')->addValue('do_not_phone', FALSE)->execute()->first();
 
@@ -44,12 +45,42 @@ class SavedSearchTest extends UnitTestCase {
         ],
       ],
       'chain' => [
-        'group' => ['Group', 'create', ['values' => ['title' => 'Hello Test', 'saved_search_id' => '$id']], 0],
+        'group' => ['Group', 'create', ['values' => ['title' => 'Contact Test', 'saved_search_id' => '$id']], 0],
       ],
     ])->first();
 
     // Oops we don't have an api4 syntax yet for selecting contacts in a group.
     $ins = civicrm_api3('Contact', 'get', ['group' => $savedSearch['group']['name'], 'options' => ['limit' => 0]]);
+    $this->assertEquals(1, count($ins['values']));
+    $this->assertArrayHasKey($in['id'], $ins['values']);
+    $this->assertArrayNotHasKey($out['id'], $ins['values']);
+  }
+
+  public function testEmailSmartGroup() {
+    $in = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'yep')->execute()->first();
+    $out = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'nope')->execute()->first();
+    $email = uniqid() . '@' . uniqid();
+    Email::create()->setCheckPermissions(FALSE)->addValue('email', $email)->addValue('contact_id', $in['id'])->execute();
+
+    $savedSearch = civicrm_api4('SavedSearch', 'create', [
+      'values' => [
+        'api_entity' => 'Email',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['contact_id'],
+          'where' => [
+            ['email', '=', $email],
+          ],
+        ],
+      ],
+      'chain' => [
+        'group' => ['Group', 'create', ['values' => ['title' => 'Email Test', 'saved_search_id' => '$id']], 0],
+      ],
+    ])->first();
+
+    // Oops we don't have an api4 syntax yet for selecting contacts in a group.
+    $ins = civicrm_api3('Contact', 'get', ['group' => $savedSearch['group']['name'], 'options' => ['limit' => 0]]);
+    $this->assertEquals(1, count($ins['values']));
     $this->assertArrayHasKey($in['id'], $ins['values']);
     $this->assertArrayNotHasKey($out['id'], $ins['values']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Expands support for API based smart groups, allowing any api entity as the starting point, not just `Contact`.

Before
----------------------------------------
Could only create a smart group from `Contact` API entity.

After
----------------------------------------
Any API entity allowed. The API explorer supports this, and also now provides some rudimentary validation to ensure contact_id is selected by the API query.

Technical Details
----------------------------------------
The `GroupContactCache` was tacking on an additional `WHERE` clause to exclude removed group contacts. I converted it to a `HAVING` clause for API queries because that's more flexible.
