### PR TITLE
Fixed fatal error for class not found when managed hook is invoked du…

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -160,7 +160,7 @@ abstract class CRM_Utils_Hook {
     // Instead of not calling any hooks we only call those we know to be frequently important - if a particular extension wanted
     // to avoid this they could do an early return on CRM_Core_Config::singleton()->isUpgradeMode
     // Futther discussion is happening at https://lab.civicrm.org/dev/core/issues/1460
-    $upgradeFriendlyHooks = ['civicrm_alterSettingsFolders', 'civicrm_alterSettingsMetaData', 'civicrm_triggerInfo', 'civicrm_alterLogTables', 'civicrm_container', 'civicrm_permission', 'civicrm_managed'];
+    $upgradeFriendlyHooks = ['civicrm_alterSettingsFolders', 'civicrm_alterSettingsMetaData', 'civicrm_triggerInfo', 'civicrm_alterLogTables', 'civicrm_container', 'civicrm_permission', 'civicrm_managed', 'civicrm_config'];
     if (CRM_Core_Config::singleton()->isUpgradeMode() && !in_array($fnSuffix, $upgradeFriendlyHooks)) {
       return;
     }


### PR DESCRIPTION
…ring upgrade

Overview
----------------------------------------
For https://civicrm.stackexchange.com/questions/35285/is-this-wordpress-critical-error-after-upgrade-to-5-24-1-serious

Regression from 5.22.1 (https://github.com/civicrm/civicrm-core/pull/16521)

Before
----------------------------------------
Failed to load class after upgrade

After
----------------------------------------
Upgraded Civi without error

Technical Details
----------------------------------------
Since hook_civicrm_config() is not invoked while upgrade the get_include_path() doesn't have path for extension which may cause fatal error when managed hook is invoked.