### PR TITLE
[WIP] See how tests run without UPDATE IGNORE

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -584,7 +584,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       ->setCheckPermissions(FALSE)
       ->setSelect(['table_name'])
       ->addWhere('is_multiple', '=', 0)
-      ->addWhere('extends', 'IN', CRM_Contact_BAO_ContactType::contactTypes())
+      ->addWhere('extends', 'IN', array_merge(['Contact'], CRM_Contact_BAO_ContactType::contactTypes()))
       ->execute()
       ->indexBy('table_name');
     foreach (array_intersect_key($cidRefs, $customTables) as $tableName => $cidSpec) {


### PR DESCRIPTION
Overview
----------------------------------------
Test removing the update ignore to see what fails.
    
I came across ```DELETE FROM civicrm_contact WHERE  primary_contact_id = 41372076``` as a query involved in a deadlock during a batch merge and felt discomfort about  whether this was always safe and also whether we could reduce locking queries in deduping (which this is)

In the first instance I am looking to see if anything tested breaks if I switch back to a safer method
    


Before
----------------------------------------
When moving data the codes uses (for example)

```UPDATE IGNORE civicrm_contact SET primary_contact_id = 41372076`;
DELETE FROM civicrm_contact WHERE  primary_contact_id = 41372076```

After
----------------------------------------
```UPDATE civicrm_contact SET primary_contact_id = 41372076`;```

Technical Details
----------------------------------------
This code goes back to the start
https://github.com/civicrm/civicrm-svn/commit/b74e4bb4b493e81e9b1ed1ff601647a5eddd1e04

Also from mysql manual :

"UPDATE IGNORE statements, including those having an ORDER BY clause, are flagged as unsafe for statement-based replication. (This is because the order in which the rows are updated determines which rows are ignored.) Such statements produce a warning in the error log when using statement-based mode and are written to the binary log using the row-based format when using MIXED mode. (Bug #11758262, Bug #50439) See Section 17.2.1.3, “Determination of Safe and Unsafe Statements in Binary Logging”, for more information."

ALSO 
"UPDATE: With IGNORE, rows for which duplicate-key conflicts occur on a unique key value are not updated. Rows updated to values that would cause data conversion errors are updated to the closest valid values instead."

Comments
----------------------------------------

