### PR TITLE
PoC Don't copy contribution custom data when calling Contribution.repeattransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2643,7 +2643,6 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
 
       $createContribution = civicrm_api3('Contribution', 'create', $contributionParams);
       $contribution->id = $createContribution['id'];
-      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($contributionParams['contribution_recur_id'], $contribution->id);
       self::handleMembershipIDOverride($contribution->id, $input);
       return TRUE;
     }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -540,11 +540,13 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
 
   /**
    * Copy custom data of the initial contribution into its recurring contributions.
+   * @deprecated This is a broken function! It always copies from the first contribution, not the template or latest.
    *
    * @param int $recurId
    * @param int $targetContributionId
    */
   public static function copyCustomValues($recurId, $targetContributionId) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use the API to copy custom values for contributions');
     if ($recurId && $targetContributionId) {
       // get the initial contribution id of recur id
       $sourceContributionId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $recurId, 'id', 'contribution_recur_id');

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -250,7 +250,6 @@ class CRM_Core_Payment_BaseIPN {
     //copy initial contribution custom fields for recurring contributions
     if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id) {
       CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($objects['contributionRecur']->id, $contribution->id);
-      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($objects['contributionRecur']->id, $contribution->id);
     }
 
     if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
@@ -334,7 +333,6 @@ class CRM_Core_Payment_BaseIPN {
     //copy initial contribution custom fields for recurring contributions
     if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id) {
       CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($objects['contributionRecur']->id, $contribution->id);
-      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($objects['contributionRecur']->id, $contribution->id);
     }
 
     if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {


### PR DESCRIPTION
Overview
----------------------------------------
When calling `contribution.repeattransaction` all contribution custom values are copied over from the first contribution. This is not correct as it should be copying either from the latest contribution or the template contribution. Or it should not copy at all?

This is particularly a problem for extensions such as giftaid (https://github.com/mattwire/uk.co.compucorp.civicrm.giftaid/issues/6) which add custom data on a per-contribution basis for the batch ID and do NOT want it copying across.

Before
----------------------------------------
Custom data always copied across from first contribution.

After
----------------------------------------
Custom data not copied across.

Technical Details
----------------------------------------


Comments
----------------------------------------
Perhaps we need a flag on the custom fields to indicate if the values should be copied to new entities?
@colemanw @pradpnayak As you've just been doing some major refactoring on custom fields and database storage - maybe you have some ideas how we could flag whether to copy a custom field value or not when copying the entity?
