### PR TITLE
dev/core#1566 Fix display value for money radio custom field

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -187,6 +187,20 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
           '' => '',
         ],
       ],
+      [
+        'data_type' => 'Money',
+        'html_type' => 'Radio',
+        'option_values' => [
+          '10' => '10 USD',
+          '10.1' => '10.1 USD',
+          '10.99' => '10.99 USD',
+        ],
+        'tests' => [
+          '10 USD' => '10.00',
+          '10.1 USD' => '10.10',
+          '10.99 USD' => '10.99',
+        ],
+      ],
     ];
     foreach ($fieldsToCreate as $num => $field) {
       $params = $field + ['label' => 'test field ' . $num, 'custom_group_id' => $customGroup['id']];


### PR DESCRIPTION
Overview
----------------------------------------
The CustomValue.gettree API returns custom fields and its values for an entity. When the custom field is of data type Money and the field type is Select/Radio. The CustomValue.gettree does not return any value for the display field for the custom field even though there is data in the field.
Now it's fixed.

How to reproduce
----------------------------------------
1. Create custom group for a Case.
1. Create custom field in that group: Money / Radio.
1. Add some options like (value => label): 1 => 1 USD, 2 => 2 USD, 3.5 => 3.5 USD.
1. Create a Case and set some value for money field, e.g. 2 USD.
1. Run an api query to get Case data - respective display value would be empty.

```php
$result = civicrm_api3('CustomValue', 'gettree', [
  'entity_id' => 29,
  'entity_type' => "Case",
]);

//Result
{
  "is_error": 0,
  "version": 3,
  "count": 2,
  "values": {
    "Apha_Num": {
      "id": "11",
      "name": "Apha_Num",
      "table_name": "civicrm_value_apha_num_11",
      "title": "Apha Num",
      "extends": "Case",
      "is_public": "1",
      "fields": {
        "Money_Select": {
          "value": {
            "id": "9",
            "data": "2.00",
            "display": "" // THE DISPLAY FIELD IS EMPTY
          },
          "id": "40",
          "name": "Money_Select",
          "label": "Money Select",
          "column_name": "money_select_40",
          "data_type": "Money",
          "html_type": "Select",
          "option_group_id": "119",
          "in_selector": "0"
        }
      }
    }
  }
}
```

Before
----------------------------------------
The **display** property was empty hense empty value displayed to the user:
![image](https://user-images.githubusercontent.com/39520000/78666777-8786fe80-78e0-11ea-843f-c1b217a9ac10.png)

After
----------------------------------------
The **display** property has value hense proper field value is displayed to the user:
![image](https://user-images.githubusercontent.com/39520000/78666962-d0d74e00-78e0-11ea-8856-99a421637408.png)

Technical Details
----------------------------------------
The issue was line 1075 of *CRM_Core_BAO_CustomField::formatDisplayValue()* method:
```$display = CRM_Utils_Array::value($value, $field['options'], '');```

For float type (see Number and Money) `$value` would be decimal like `1.00` (because it is stored in db as decimal), while options array key would be integer like `1`. In this case expression on line above would return empty string (default value), despite the fact that matching option exists in the array.
In such cases we could just get `intval($value)` and fetch matching option again, but this would not work if key is float like `5.6`. So we need to remove trailing zeros to make it work as expected.