### PR TITLE
Simplify groupContactCache - remove redundant query

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -505,10 +505,7 @@ WHERE  id IN ( $groupIDs )
     self::clearGroupContactCache($groupID);
 
     foreach ($contactQueries as $contactQuery) {
-      if (empty($contactQuery['select']) || empty($contactQuery['from'])) {
-        continue;
-      }
-      if (CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) {$contactQuery['from']}") > 0) {
+      if (!empty($contactQuery['select']) && !empty($contactQuery['from'])) {
         CRM_Core_DAO::executeQuery("INSERT IGNORE INTO $tempTable (group_id, contact_id) {$contactQuery['select']} {$contactQuery['from']}");
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes an unnecessary query when filling the smart group cache.

Before
----------------------------------------
This was essentially running the same query twice, once with COUNT and then again with INSERT.

After
----------------------------------------
Skip the count as the INSERT will do nothing if there are no results.

Comments
--------------------------------------
This refactoring is toward supporting API-based smart groups. See #17003