### PR TITLE
APIv4 - Add support for HAVING clause

### DIFF
--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -29,6 +29,9 @@ use Civi\Api4\Query\Api4SelectQuery;
  * Use the `select` param to determine which fields are returned, defaults to `[*]`.
  *
  * Perform joins on other related entities using a dot notation.
+ *
+ * @method $this setHaving(array $clauses)
+ * @method array getHaving()
  */
 class DAOGetAction extends AbstractGetAction {
   use Traits\DAOActionTrait;
@@ -50,6 +53,15 @@ class DAOGetAction extends AbstractGetAction {
    * @var array
    */
   protected $groupBy = [];
+
+  /**
+   * Clause for filtering results after grouping and filters are applied.
+   *
+   * Each expression should correspond to an item from the SELECT array.
+   *
+   * @var array
+   */
+  protected $having = [];
 
   public function _run(Result $result) {
     $this->setDefaultWhereClause();
@@ -92,6 +104,21 @@ class DAOGetAction extends AbstractGetAction {
    */
   public function addGroupBy(string $field) {
     $this->groupBy[] = $field;
+    return $this;
+  }
+
+  /**
+   * @param string $expr
+   * @param string $op
+   * @param mixed $value
+   * @return $this
+   * @throws \API_Exception
+   */
+  public function addHaving(string $expr, string $op, $value = NULL) {
+    if (!in_array($op, \CRM_Core_DAO::acceptedSQLOperators())) {
+      throw new \API_Exception('Unsupported operator');
+    }
+    $this->having[] = [$expr, $op, $value];
     return $this;
   }
 

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -26,23 +26,24 @@ abstract class SqlExpression {
   protected $fields = [];
 
   /**
+   * The SELECT alias (if null it will be calculated by getAlias)
    * @var string|null
    */
   protected $alias;
 
   /**
-   * The argument string.
+   * The raw expression, minus the alias.
    * @var string
    */
-  protected $arg = '';
+  protected $expr = '';
 
   /**
    * SqlFunction constructor.
-   * @param string $arg
+   * @param string $expr
    * @param string|null $alias
    */
-  public function __construct(string $arg, $alias = NULL) {
-    $this->arg = $arg;
+  public function __construct(string $expr, $alias = NULL) {
+    $this->expr = $expr;
     $this->alias = $alias;
     $this->initialize();
   }
@@ -68,14 +69,13 @@ abstract class SqlExpression {
     $bracketPos = strpos($expr, '(');
     $firstChar = substr($expr, 0, 1);
     $lastChar = substr($expr, -1);
-    // Function
+    // If there are brackets but not the first character, we have a function
     if ($bracketPos && $lastChar === ')') {
       $fnName = substr($expr, 0, $bracketPos);
       if ($fnName !== strtoupper($fnName)) {
         throw new \API_Exception('Sql function must be uppercase.');
       }
       $className = 'SqlFunction' . $fnName;
-      $expr = substr($expr, $bracketPos + 1, -1);
     }
     // String expression
     elseif ($firstChar === $lastChar && in_array($firstChar, ['"', "'"], TRUE)) {
@@ -133,12 +133,19 @@ abstract class SqlExpression {
   abstract public function render(array $fieldList): string;
 
   /**
+   * @return string
+   */
+  public function getExpr(): string {
+    return $this->expr;
+  }
+
+  /**
    * Returns the alias to use for SELECT AS.
    *
    * @return string
    */
   public function getAlias(): string {
-    return $this->alias ?? $this->fields[0] ?? \CRM_Utils_String::munge($this->arg);
+    return $this->alias ?? $this->fields[0] ?? \CRM_Utils_String::munge($this->expr);
   }
 
 }

--- a/Civi/Api4/Query/SqlField.php
+++ b/Civi/Api4/Query/SqlField.php
@@ -17,14 +17,14 @@ namespace Civi\Api4\Query;
 class SqlField extends SqlExpression {
 
   protected function initialize() {
-    $this->fields[] = $this->arg;
+    $this->fields[] = $this->expr;
   }
 
   public function render(array $fieldList): string {
-    if (empty($fieldList[$this->arg])) {
-      throw new \API_Exception("Invalid field '{$this->arg}'");
+    if (empty($fieldList[$this->expr])) {
+      throw new \API_Exception("Invalid field '{$this->expr}'");
     }
-    return $fieldList[$this->arg]['sql_name'];
+    return $fieldList[$this->expr]['sql_name'];
   }
 
 }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -26,7 +26,7 @@ abstract class SqlFunction extends SqlExpression {
    * Parse the argument string into an array of function arguments
    */
   protected function initialize() {
-    $arg = $this->arg;
+    $arg = trim(substr($this->expr, strpos($this->expr, '(') + 1, -1));
     foreach ($this->getParams() as $param) {
       $prefix = $this->captureKeyword($param['prefix'], $arg);
       if ($param['expr'] && isset($prefix) || in_array('', $param['prefix']) || !$param['optional']) {

--- a/Civi/Api4/Query/SqlNumber.php
+++ b/Civi/Api4/Query/SqlNumber.php
@@ -17,11 +17,11 @@ namespace Civi\Api4\Query;
 class SqlNumber extends SqlExpression {
 
   protected function initialize() {
-    \CRM_Utils_Type::validate($this->arg, 'Float');
+    \CRM_Utils_Type::validate($this->expr, 'Float');
   }
 
   public function render(array $fieldList): string {
-    return $this->arg;
+    return $this->expr;
   }
 
 }

--- a/Civi/Api4/Query/SqlString.php
+++ b/Civi/Api4/Query/SqlString.php
@@ -18,15 +18,15 @@ class SqlString extends SqlExpression {
 
   protected function initialize() {
     // Remove surrounding quotes
-    $str = substr($this->arg, 1, -1);
+    $str = substr($this->expr, 1, -1);
     // Unescape the outer quote character inside the string to prevent double-escaping in render()
-    $quot = substr($this->arg, 0, 1);
+    $quot = substr($this->expr, 0, 1);
     $backslash = chr(0) . 'backslash' . chr(0);
-    $this->arg = str_replace(['\\\\', "\\$quot", $backslash], [$backslash, $quot, '\\\\'], $str);
+    $this->expr = str_replace(['\\\\', "\\$quot", $backslash], [$backslash, $quot, '\\\\'], $str);
   }
 
   public function render(array $fieldList): string {
-    return '"' . \CRM_Core_DAO::escapeString($this->arg) . '"';
+    return '"' . \CRM_Core_DAO::escapeString($this->expr) . '"';
   }
 
 }

--- a/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
+++ b/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
@@ -49,7 +49,7 @@ class SqlExpressionParserTest extends UnitTestCase {
     $this->assertNotEmpty($params[0]['prefix']);
     $this->assertEmpty($params[0]['suffix']);
 
-    $sqlFn = new $className('total');
+    $sqlFn = new $className($fnName . '(total)');
     $this->assertEquals($fnName, $sqlFn->getName());
     $this->assertEquals(['total'], $sqlFn->getFields());
     $this->assertCount(1, $this->getArgs($sqlFn));


### PR DESCRIPTION
Overview
----------------------------------------
Allows the APIv4 query to have a HAVING clause.

Technical Details
----------------------------------------
Fields referenced in the HAVING clause must be in the SELECT clause as well (HAVING can reference them by their name or alias if used for expressions).

Comments
----------------------------------------
TODO: Make it look nice in the API Explorer.
