### PR TITLE
CRM_Core_I18n - Provide a better label for new/unknown locales

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -193,7 +193,7 @@ class CRM_Core_I18n {
           if (preg_match('/^[a-z][a-z]_[A-Z][A-Z]$/', $filename)) {
             $codes[] = $filename;
             if (!isset($all[$filename])) {
-              $all[$filename] = $labels[$filename];
+              $all[$filename] = $labels[$filename] ?? "($filename)";
             }
           }
         }


### PR DESCRIPTION
Overview
--------

Mixing the current `l10n` data with a stable `civicrm-core` codebase leads to warnings/failures about the locale `nl_BE` (even if you don't use that locale). This patch aims to make `civicrm-core` more *forward-compatible* as `l10n` evolves.

Suppose you add data-files for a new language/locale in the `l10n` folder - and then you navigate to the screen `civicrm/admin/setting/localization?reset=1`. How is this new language presented?

Before
------

The new language appears in the admin UI as a blank item.

![Screen Shot 2020-04-07 at 9 12 38 PM](https://user-images.githubusercontent.com/1336047/78744325-1feba600-7916-11ea-9efd-88dc9a3735c8.png)

Every page in the app displays a warning about the unrecognized locale, even if your system never uses that locale.

When running automated tests, the warning can lead to a large number of false-negatives. 

After
-----

The new language appears in the admin UI with a placeholder name (based on the code).

![Screen Shot 2020-04-07 at 9 12 12 PM](https://user-images.githubusercontent.com/1336047/78744321-1f530f80-7916-11ea-81c0-456621ea1924.png)

Also, the pervasive warning goes away.

Comment
-------

We've just had an issue where a new language (`nl_BE`) was added to the `l10n` data-set, and then all automated test-suites for all versions (incl `5.25` RC and `5.24` stable) started to throw numerous errors (about the unrecognized locale) on unrelated PRs. The issue is that `l10n` data is generally evergreen (so new languages can be added at anytime), but each branch/tag of `civicrm-core` has multiple hard-coded language lists (which locks in the list for a given release). 

Mixing the current `l10n` with a stable `civicrm-core` leads to the warnings/failures. This patch tries to make the symptom less painful when mixing/matching different revisions of `civicrm-core` and `l10n`.
