### PR TITLE
dev/core#57 On Behalf Of fails to populate in Email Receipt

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1704,7 +1704,11 @@ WHERE      activity.id IN ($activityIds)";
       // create activity record only for Completed Contributions
       $contributionCompletedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
       if ($activity->contribution_status_id != $contributionCompletedStatusId) {
-        return NULL;
+        //For onbehalf payments, create a scheduled activity.
+        if (empty($params['on_behalf'])) {
+          return NULL;
+        }
+        $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Scheduled');
       }
       $activityType = $component = 'Contribution';
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2885,6 +2885,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
 
+    $relatedContact = CRM_Contribute_BAO_Contribution::getOnbehalfIds($this->id);
+    if (!empty($relatedContact['individual_id'])) {
+      $ids['related_contact'] = $relatedContact['individual_id'];
+    }
+
     if ($paymentProcessorID) {
       $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID,
         $this->is_test ? 'test' : 'live'
@@ -4552,10 +4557,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     if (empty($contribution->_relatedObjects['participant']) && !empty($contribution->_relatedObjects['membership'])) {
       // @fixme Can we remove this if altogether? - we removed the participant if / else and left relatedObjects['participant'] to ensure behaviour didn't change but it is probably not required.
       // @todo - use getRelatedMemberships instead
-      $contribution->contribution_status_id = $contributionParams['contribution_status_id'];
       $contribution->trxn_id = $input['trxn_id'] ?? NULL;
       $contribution->receive_date = CRM_Utils_Date::isoToMysql($contribution->receive_date);
     }
+    $contribution->contribution_status_id = $contributionParams['contribution_status_id'];
 
     CRM_Core_Error::debug_log_message("Contribution record updated successfully");
     $transaction->commit();

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1011,15 +1011,19 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     //create contribution activity w/ individual and target
     //activity w/ organisation contact id when onbelf, CRM-4027
+    $actParams = [];
     $targetContactID = NULL;
-    if (!empty($params['hidden_onbehalf_profile'])) {
+    if (!empty($params['onbehalf_contact_id'])) {
+      $actParams = [
+        'source_contact_id' => $params['onbehalf_contact_id'],
+        'on_behalf' => TRUE,
+      ];
       $targetContactID = $contribution->contact_id;
-      $contribution->contact_id = $contactID;
     }
 
     // create an activity record
     if ($contribution) {
-      CRM_Activity_BAO_Activity::addActivity($contribution, NULL, $targetContactID);
+      CRM_Activity_BAO_Activity::addActivity($contribution, NULL, $targetContactID, $actParams);
     }
 
     $transaction->commit();

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -138,6 +138,40 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertRegExp("/Paid later via page ID: $contributionPageID2/", $contribution['contribution_source']);
     // check that contribution status is changed to 'Completed' from 'Pending'
     $this->assertEquals('Completed', $contribution['contribution_status']);
+
+    //delete contribution.
+    $this->callAPISuccess('contribution', 'delete', [
+      'id' => $processConfirmResult['contribution']->id,
+    ]);
+
+    //Process on behalf contribution.
+    unset($form->_params['contribution_id']);
+    $form->_contactID = $form->_values['related_contact'] = $form->_params['onbehalf_contact_id'] = $contactID;
+    $form->_params['contact_id'] = $this->organizationCreate();
+    $this->callAPISuccess('Relationship', 'create', [
+      'contact_id_a' => $contactID,
+      'contact_id_b' => $form->_params['contact_id'],
+      'relationship_type_id' => 5,
+      'is_current_employer' => 1,
+    ]);
+    $processConfirmResult = CRM_Contribute_BAO_Contribution_Utils::processConfirm($form,
+      $form->_params,
+      $form->_params['onbehalf_contact_id'],
+      $form->_values['financial_type_id'],
+      0, FALSE
+    );
+    //check if contribution is created on org.
+    $contribution = $this->callAPISuccessGetSingle('Contribution', [
+      'contact_id' => $form->_params['onbehalf_contact_id'],
+    ]);
+
+    $activity = civicrm_api3('Activity', 'get', [
+      'sequential' => 1,
+      'source_record_id' => $contribution['id'],
+      'contact_id' => $form->_params['onbehalf_contact_id'],
+      'activity_type_id' => "Contribution",
+    ]);
+    $this->assertEquals(1, $activity['count']);
   }
 
 }

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -192,7 +192,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->assertTrue(substr($contribution['contribution_source'], 0, 20) == "Online Contribution:");
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
-    $IPN = new CRM_Core_Payment_AuthorizeNetIPN(array_merge(['receive_date' => '1 July 2010'], $this->getRecurSubsequentTransaction()));
+    $IPN = new CRM_Core_Payment_AuthorizeNetIPN(array_merge(['receive_date' => '2010-07-01'], $this->getRecurSubsequentTransaction()));
     $IPN->main();
     $contribution = $this->callAPISuccess('contribution', 'get', [
       'contribution_recur_id' => $this->_contributionRecurID,


### PR DESCRIPTION
Overview
----------------------------------------
When a Contribution is submitted and "On Behalf Of" is specified, the section on the emailed receipt does not render the On Behalf Of profile information.

Before
----------------------------------------
On behalf profile missing from email receipt if anonymous user submits the contribution page.

<img width="506" alt="Screenshot 2020-04-08 at 5 57 40 PM" src="https://user-images.githubusercontent.com/5929648/78784580-33a11600-79c3-11ea-9573-43592ea7ffc7.png">

After
----------------------------------------
On behalf section is shown correctly in receipt email.

![image](https://user-images.githubusercontent.com/5929648/78784543-24ba6380-79c3-11ea-822b-6521b841be68.png)


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/57