### PR TITLE
Fix setting of next_sched_contribution_date when doing repeattransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -211,7 +211,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       CRM_Contribute_BAO_ContributionRecur::updateOnNewPayment(
         (!empty($params['contribution_recur_id']) ? $params['contribution_recur_id'] : $params['prevContribution']->contribution_recur_id),
         $contributionStatus,
-        CRM_Utils_Array::value('receive_date', $params)
+        $params['receive_date'] ?? NULL
       );
     }
 

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -859,6 +859,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
 
     if (!empty($existing['installments']) && self::isComplete($recurringContributionID, $existing['installments'])) {
       $params['contribution_status_id'] = 'Completed';
+      $params['next_sched_contribution_date'] = '';
     }
     else {
       // Update next_sched_contribution_date in the following circumstances:

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -821,13 +821,16 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    *   Payment status - this correlates to the machine name of the contribution status ID ie
    *   - Completed
    *   - Failed
-   * @param string $effectiveDate
+   * @param string $contributionReceiveDate
    *
    * @throws \CiviCRM_API3_Exception
    */
-  public static function updateOnNewPayment($recurringContributionID, $paymentStatus, $effectiveDate) {
+  public static function updateOnNewPayment($recurringContributionID, $paymentStatus, $contributionReceiveDate) {
+    // If contributionReceiveDate matches next_sched_contribution_date we update next_sched_contribution_date by one period
+    $contributionReceiveDate = $contributionReceiveDate
+      ? date('Y-m-d H:i:s', strtotime($contributionReceiveDate))
+      : date('Y-m-d') . '00:00:00';
 
-    $effectiveDate = $effectiveDate ? date('Y-m-d', strtotime($effectiveDate)) : date('Y-m-d');
     if (!in_array($paymentStatus, ['Completed', 'Failed'])) {
       return;
     }
@@ -858,11 +861,13 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       $params['contribution_status_id'] = 'Completed';
     }
     else {
-      // Only update next sched date if it's empty or 'just now' because payment processors may be managing
-      // the scheduled date themselves as core did not previously provide any help.
-      if (empty($existing['next_sched_contribution_date']) || strtotime($existing['next_sched_contribution_date']) ==
-        strtotime($effectiveDate)) {
-        $params['next_sched_contribution_date'] = date('Y-m-d', strtotime('+' . $existing['frequency_interval'] . ' ' . $existing['frequency_unit'], strtotime($effectiveDate)));
+      // Update next_sched_contribution_date in the following circumstances:
+      // - If it's empty.
+      // - If it is older than the contribution receive date.
+      // If we update, set it to the contribution receive date + recur frequency unit * interval
+      if (empty($existing['next_sched_contribution_date'])
+        || strtotime($existing['next_sched_contribution_date']) <= strtotime($contributionReceiveDate)) {
+        $params['next_sched_contribution_date'] = date('Y-m-d H:i:s', strtotime('+' . $existing['frequency_interval'] . ' ' . $existing['frequency_unit'], strtotime($contributionReceiveDate)));
       }
     }
     civicrm_api3('ContributionRecur', 'create', $params);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3110,7 +3110,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
         'next_sched_contribution_date' => '2012-02-29',
       ],
       'receive_date' => '2012-02-29 16:00:00',
-      'expected' => '2012-03-29 00:00:00',
+      'expected' => '2012-03-29 16:00:00',
     ];
     return $result;
   }


### PR DESCRIPTION
Overview
----------------------------------------
When calling `Contribution.repeattransaction` API for a recurring contribution it is supposed to update the `contribution_recur.next_sched_contribution_date` field if the new `contribution.receive_date` matches the existing `contribution_recur.next_sched_contribution_date`. 
But it doesn't because the time is stripped before comparing.

Before
----------------------------------------
`next_sched_contribution_date` only updated if empty.

After
----------------------------------------
`next_sched_contribution_date` updated if empty or <= contribution receive_date.

Technical Details
----------------------------------------
Comparing a date eg. 2020-03-05 to a datetime eg. 2020-03-05 15:43:23 doesn't match! It seems silly to truncate the time element of the receive date as the contribution will arrive at a specific time, even if that time is midnight.

Comments
----------------------------------------
