### PR TITLE
[REF] Update Contact email form to use the trait for EmailCommon functions

### DIFF
--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -29,6 +29,8 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
+    // @todo - more of the handling in this function should be move to the trait. Notably the title part is
+    //  not set on other forms that share the trait.
     // store case id if present
     $this->_caseId = CRM_Utils_Request::retrieve('caseid', 'String', $this, FALSE);
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
@@ -64,17 +66,21 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
     if ($this->_context === 'search') {
       $this->_single = TRUE;
     }
-    CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
-
-    if (!$cid && $this->_context !== 'standalone') {
-      parent::preProcess();
+    if ($cid || $this->_context === 'standalone') {
+      // When search context is false the parent pre-process is not set. That avoids it changing the
+      // redirect url & attempting to set the search params of the form. It may have only
+      // historical significance.
+      $this->setIsSearchContext(FALSE);
     }
-
-    $this->assign('single', $this->_single);
-    if (CRM_Core_Permission::check('administer CiviCRM')) {
-      $this->assign('isAdmin', 1);
-    }
+    $this->traitPreProcess();
   }
+
+  /**
+   * Stub function  as EmailTrait calls this.
+   *
+   * @todo move some code from preProcess into here.
+   */
+  public function setContactIDs() {}
 
   /**
    * List available tokens for this form.

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -69,16 +69,60 @@ trait CRM_Contact_Form_Task_EmailTrait {
   public $_bccContactIds = [];
 
   /**
+   * Is the form being loaded from a search action.
+   *
+   * @var bool
+   */
+  public $isSearchContext = TRUE;
+
+  /**
+   * Getter for isSearchContext.
+   *
+   * @return bool
+   */
+  public function isSearchContext(): bool {
+    return $this->isSearchContext;
+  }
+
+  /**
+   * Setter for isSearchContext.
+   *
+   * @param bool $isSearchContext
+   */
+  public function setIsSearchContext(bool $isSearchContext) {
+    $this->isSearchContext = $isSearchContext;
+  }
+
+  /**
    * Build all the data structures needed to build the form.
    *
    * @throws \CiviCRM_API3_Exception
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
+    $this->traitPreProcess();
+  }
+
+  /**
+   * Call trait preProcess function.
+   *
+   * This function exists as a transitional arrangement so classes overriding
+   * preProcess can still call it. Ideally it will be melded into preProcess later.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function traitPreProcess() {
     CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
-    parent::preProcess();
+    if ($this->isSearchContext()) {
+      // Currently only the contact email form is callable outside search context.
+      parent::preProcess();
+    }
     $this->setContactIDs();
     $this->assign('single', $this->_single);
+    if (CRM_Core_Permission::check('administer CiviCRM')) {
+      $this->assign('isAdmin', 1);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Update Contact email form to use the trait for EmailCommon functions

Before
----------------------------------------
CRM_Contact_Form_Task_Email does not share trait preProcess code

After
----------------------------------------
Code from trait used by CRM_Contact_Form_Task_Email  where  they overlap

Specifically the goal is to move interaction with CRM_Contact_Form_Task_EmailCommon to the trait  class (and then to copy it directly onto the trait class & deprecate CRM_Contact_Form_Task_EmailCommon to the extent possible with an aim to eventual removal

Technical Details
----------------------------------------
- I had to rename the existing preProcess function so it could be called  from both
- I dug into  ```$this->assign('isAdmin', 1);``` and it affects the help message. It  seems  to be only on the contact form task by omission rather than design
- the reason CRM_Contact_Form_Task_Email only calls it's parent sometimes is obscure but this maintains tha.

Comments
----------------------------------------
