### PR TITLE
Revert "temp workaround for dev/core#1675"

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -156,11 +156,6 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
         $this->createActivity($activityTypeXML, $params);
       }
     }
-
-    // @todo dev/core#1675 - This is a temporary regression fix. Needs a
-    // proper fix.
-    $tx = new CRM_Core_Transaction();
-    $tx->commit();
   }
 
   /**


### PR DESCRIPTION
This reverts commit fcd23b884537a19ff2acbc98ca20a43f292c4c42.

Overview
----------------------------------------
Now that https://github.com/civicrm/civicrm-packages/pull/289 I believe we can and should revert this patch 

ping @demeritcowboy @eileenmcnaughton 