### PR TITLE
REF Remove redundant param from completeOrder

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1675,7 +1675,7 @@ WHERE      activity.id IN ($activityIds)";
    * Add activity for Membership/Event/Contribution.
    *
    * @param object $activity
-   *   (reference) particular component object.
+   *   particular component object.
    * @param string $activityType
    *   For Membership Signup or Renewal.
    * @param int $targetContactID
@@ -1685,7 +1685,7 @@ WHERE      activity.id IN ($activityIds)";
    * @return bool|NULL
    */
   public static function addActivity(
-    &$activity,
+    $activity,
     $activityType = 'Membership Signup',
     $targetContactID = NULL,
     $params = []

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4403,7 +4403,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @param array $ids
    * @param array $objects
    * @param CRM_Core_Transaction $transaction
-   * @param CRM_Contribute_BAO_Contribution $contribution
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
    *   Note that our goal is that this would only ever be called from payment.create and never handle financials (only
@@ -4413,7 +4412,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder($input, &$ids, $objects, $transaction, $contribution, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, &$ids, $objects, $transaction, $isPostPaymentCreate = FALSE) {
+    $contribution = $objects['contribution'];
     $primaryContributionID = $contribution->id ?? $objects['first_contribution']->id;
     // The previous details are used when calculating line items so keep it before any code that 'does something'
     if (!empty($contribution->id)) {

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -477,9 +477,7 @@ class CRM_Core_Payment_BaseIPN {
    * @throws \CiviCRM_API3_Exception
    */
   public function completeTransaction(&$input, &$ids, &$objects, &$transaction) {
-    $contribution = &$objects['contribution'];
-
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction, $contribution);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction);
   }
 
   /**

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -676,7 +676,7 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
   $input['pan_truncation'] = $params['pan_truncation'] ?? NULL;
   $transaction = new CRM_Core_Transaction();
   return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction,
-     $contribution, CRM_Utils_Array::value('is_post_payment_create', $params));
+     CRM_Utils_Array::value('is_post_payment_create', $params));
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
$contribution is available via $objects so use that instead of passing separately - it does not need to be passed by reference as it is never "set" once we are in completeOrder.

Partial from #17032

Before
----------------------------------------
Two ways of accessing the "same" object - via $objects['contribution'] or via $contribution directly.

After
----------------------------------------
Just one instance of the object. Easier to understand/maintain/improve.

Technical Details
----------------------------------------
completeOrder is hard to understand, uses a mixture or objects and arrays to refer to the same and to different contributions. This makes it slightly easier!

Comments
----------------------------------------
