### PR TITLE
CRM_Core_I18n - Provide a better label for new/unknown locales

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -193,7 +193,7 @@ class CRM_Core_I18n {
           if (preg_match('/^[a-z][a-z]_[A-Z][A-Z]$/', $filename)) {
             $codes[] = $filename;
             if (!isset($all[$filename])) {
-              $all[$filename] = $labels[$filename];
+              $all[$filename] = $labels[$filename] ?? "($filename)";
             }
           }
         }


### PR DESCRIPTION
Overview
--------

Suppose you add new/unrecognized data files in the `l10n` folder - and then
you navigate to the screen `civicrm/admin/setting/localization?reset=1`.

Before
------

The new language appears in the admin UI as a blank item.

Every page in the app displays a warning about the unrecognized locale.

After
-----

The new language appears in the admin UI with a placeholder name (based on the code).

The warnings are not displayed.

Comment
-------

We've just had an issue where a new language was added to the `l10n`
data-set, and then all automated test-suites for all versions (incl `5.25`
RC and `5.24` stable) started to throw blocker errors on unrelated PRs.
This is because the `l10n` data is generally evergreen, but each branch/tag
of `civicrm-core` has the list hard-coded in multiple spots.

This patch tries to make the symptom less painful when mixing/matching
different revisions of `civicrm-core.git` and `l10n.git`.

5.24 port of https://github.com/civicrm/civicrm-core/pull/17021