### PR TITLE
Mitigate flaky test failure about "CRM_Utils_Check_Component_Env->checkVersion()"

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -471,7 +471,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         'warning' => CRM_Utils_Check::severityMap(\Psr\Log\LogLevel::WARNING) ,
         'critical' => CRM_Utils_Check::severityMap(\Psr\Log\LogLevel::CRITICAL),
       ];
-      foreach ($vc->getVersionMessages() as $msg) {
+      foreach ($vc->getVersionMessages() ?? [] as $msg) {
         $messages[] = new CRM_Utils_Check_Message(__FUNCTION__ . '_' . $msg['name'],
           $msg['message'], $msg['title'], $severities[$msg['severity']], 'fa-cloud-upload');
       }


### PR DESCRIPTION
Overview
-----------

The function `CRM_Utils_Check_Component_Env->checkVersion()` relies on an external data feed. If there's an error fetching feed, then we wind up with a PHP warning. This bubbles up to false-negatives in the test suite. This problem should be tracked in a different way.

Before
----------------------------------------

This warning can manifest on random pages:

<img width="934" alt="Screen Shot 2020-04-08 at 9 33 47 PM" src="https://user-images.githubusercontent.com/1336047/78858240-ab316e00-79e0-11ea-8e69-dccd965efd38.png">

It can also manifest as random test-failures. I recently saw these [false-negatives](https://test.civicrm.org/job/CiviCRM-Core-Matrix/7904/BKPROF=max,CIVIVER=5.24,SUITES=phpunit-crm,label=bknix-tmp/):

```
CRM_Contact_Page_View_UserDashBoardTest.testDashboardContentContributionsWithInvoicingEnabled
CRM_Contact_Page_View_UserDashBoardTest.testDashboardContentContributions
CRM_Core_Page_HookTest.testFormsCallBuildFormOnce
CRM_Core_Page_HookTest.testPagesCallPageRunOnce
```

After
----------------------------------------

The warning is suppressed.

Technical Details
----------------------

To test this, I used the following to reproduce the problem and observe the mitigation:

```diff
diff --git a/CRM/Utils/Check.php b/CRM/Utils/Check.php
index e8eb744ab2..097f36052c 100644
--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -66,7 +66,7 @@ class CRM_Utils_Check {
   public function showPeriodicAlerts() {
     if (CRM_Core_Permission::check('administer CiviCRM')) {
       $session = CRM_Core_Session::singleton();
-      if ($session->timer('check_' . __CLASS__, self::CHECK_TIMER)) {
+      if (TRUE || $session->timer('check_' . __CLASS__, self::CHECK_TIMER)) {

         // Best attempt at re-securing folders
         $config = CRM_Core_Config::singleton();
diff --git a/CRM/Utils/VersionCheck.php b/CRM/Utils/VersionCheck.php
index 0b3b9fa460..bc69a65660 100644
--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -114,6 +114,7 @@ class CRM_Utils_VersionCheck {
    *     Ex: 'info', 'notice', 'warning', 'critical'.
    */
   public function getVersionMessages() {
+    return NULL;
     return $this->isInfoAvailable ? $this->versionInfo : NULL;
   }
```

Comments
----------------------

I'm not usually a fan of suppressing warnings. It is legit to have some QA signals if `latest.civicrm.org` is unavailable. However, its better to use uptime monitoring for that web-service. It shouldn't manifest in random unit-tests or PHP warnings on random pages.
