### PR TITLE
Add pre/post create hooks for OptionValue 

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -38,7 +38,13 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
     if (empty($params['id'])) {
       self::setDefaults($params);
     }
-    return CRM_Core_BAO_OptionValue::add($params);
+
+    $hook = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($hook, 'OptionValue', $params['id'] ?? NULL, $params);
+    $optionValue = CRM_Core_BAO_OptionValue::add($params);
+    CRM_Utils_Hook::post($hook, 'OptionValue', $optionValue->id, $optionValue);
+
+    return $optionValue;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
For Civicase extension it is required to have post create hook to monitor if option value was enabled/disabled. Somehow hooks on create are missing, so this PR will add them.

Technical Details
----------------------------------------
Just updated `CRM_Core_BAO_OptionValue::add()` method to add pre/post create/edit hook calls.