### PR TITLE
core#1700 - Fix Financial ACL Report check

### DIFF
--- a/CRM/Utils/Check/Component/FinancialTypeAcls.php
+++ b/CRM/Utils/Check/Component/FinancialTypeAcls.php
@@ -20,7 +20,7 @@ class CRM_Utils_Check_Component_FinancialTypeAcls extends CRM_Utils_Check_Compon
     $messages = [];
     $ftAclSetting = Civi::settings()->get('acl_financial_type');
     $financialAclExtension = civicrm_api3('extension', 'get', ['key' => 'biz.jmaconsulting.financialaclreport', 'sequential' => 1]);
-    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['values'][0]['status'] != 'Installed') || $financialAclExtension['count'] !== 1)) {
+    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['values'][0]['status'] != 'installed') || $financialAclExtension['count'] !== 1)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('CiviCRM will in the future require the extension %1 for CiviCRM Reports to work correctly with the Financial Type ACLs. The extension can be downloaded <a href="%2">here</a>', [


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/1700

Overview
----------------------------------------
If Financial Type ACLs are enabled, you're warned you need to install the extension `biz.jmaconsulting.financialaclreport`.  This warning persists even after installing the extension.

Reproduction steps
----------------------------------------
1. Turn on Financial ACLs (**Administer » CiviContribute » CiviContribute Component Settings**).
1. Install `biz.jmaconsulting.financialaclreport`.

Current behaviour
----------------------------------------
The System Status screen still says that you need to install the extension.

Expected behaviour
----------------------------------------
The warning should disappear.

Comments
----------------------------------------
This happens because the check is doing an API call to `Extension.get` to see if status equals `Installed`.  However, the status is actually `installed`, with a lowercase `i`.