### PR TITLE
dev/report#31 - Api4 Explorer: Support SQL functions and HAVING clause

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -28,6 +28,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       'schema' => (array) \Civi\Api4\Entity::get()->setChain(['fields' => ['$name', 'getFields']])->execute(),
       'links' => (array) \Civi\Api4\Entity::getLinks()->execute(),
       'docs' => \Civi\Api4\Utils\ReflectionUtils::parseDocBlock($apiDoc->getDocComment()),
+      'functions' => self::getSqlFunctions(),
       'groupOptions' => array_column((array) $groupOptions, 'options', 'name'),
     ];
     Civi::resources()
@@ -47,6 +48,27 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
     ]);
     $loader->load();
     parent::run();
+  }
+
+  /**
+   * Gets info about all available sql functions
+   * @return array
+   */
+  public static function getSqlFunctions() {
+    $fns = [];
+    foreach (glob(Civi::paths()->getPath('[civicrm.root]/Civi/Api4/Query/SqlFunction*.php')) as $file) {
+      $matches = [];
+      if (preg_match('/(SqlFunction[A-Z_]+)\.php$/', $file, $matches)) {
+        $className = '\Civi\Api4\Query\\' . $matches[1];
+        if (is_subclass_of($className, '\Civi\Api4\Query\SqlFunction')) {
+          $fns[] = [
+            'name' => $className::getName(),
+            'params' => $className::getParams(),
+          ];
+        }
+      }
+    }
+    return $fns;
   }
 
 }

--- a/Civi/Api4/Generic/AbstractQueryAction.php
+++ b/Civi/Api4/Generic/AbstractQueryAction.php
@@ -62,9 +62,9 @@ abstract class AbstractQueryAction extends AbstractAction {
   /**
    * Maximum number of $ENTITIES to return.
    *
-   * Defaults to unlimited.
+   * Defaults to `0` - unlimited.
    *
-   * Note: the Api Explorer sets this to 25 by default to avoid timeouts.
+   * Note: the Api Explorer sets this to `25` by default to avoid timeouts.
    * Change or remove this default for your application code.
    *
    * @var int
@@ -74,7 +74,7 @@ abstract class AbstractQueryAction extends AbstractAction {
   /**
    * Zero-based index of first $ENTITY to return.
    *
-   * Defaults to "0" - first $ENTITY found.
+   * Defaults to `0` - first $ENTITY found.
    *
    * @var int
    */

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -161,10 +161,9 @@ abstract class SqlFunction extends SqlExpression {
    * Get the name of this sql function.
    * @return string
    */
-  public function getName(): string {
-    $className = get_class($this);
-    $pos = strrpos($className, 'SqlFunction');
-    return substr($className, $pos + 11);
+  public static function getName(): string {
+    $className = static::class;
+    return substr($className, strrpos($className, 'SqlFunction') + 11);
   }
 
   /**

--- a/ang/api4Explorer/Clause.html
+++ b/ang/api4Explorer/Clause.html
@@ -4,11 +4,11 @@
     <i class="crm-i fa-trash"></i>
   </button>
 </div>
-<div class="api4-where-group-sortable" ng-model="data.where" ui-sortable="{axis: 'y', connectWith: '.api4-where-group-sortable', containment: '.api4-where-fieldset', over: onSortOver, start: onSort, stop: onSort}">
-  <div class="api4-input form-inline clearfix" ng-repeat="(index, clause) in data.where">
+<div class="api4-clause-group-sortable" ng-model="data.clauses" ui-sortable="{axis: 'y', connectWith: '.api4-clause-group-sortable', containment: '.api4-clause-fieldset', over: onSortOver}" ui-sortable-start="onSort" ui-sortable-stop="onSort">
+  <div class="api4-input form-inline clearfix" ng-repeat="(index, clause) in data.clauses">
     <div class="api4-clause-badge" title="{{ ts('Drag to reposition') }}">
       <span class="badge badge-info">
-        <span ng-if="!index && !data.groupParent">Where</span>
+        <span ng-if="!index && !data.groupParent">{{ data.type }}</span>
         <span ng-if="index || data.groupParent">{{ data.op }}</span>
         <i class="crm-i fa-arrows"></i>
       </span>
@@ -18,7 +18,7 @@
       <select class="form-control api4-operator" ng-model="clause[1]" ng-options="o for o in operators" ></select>
       <input class="form-control" ng-model="clause[2]" api4-exp-value="{field: clause[0], op: clause[1]}" />
     </div>
-    <fieldset class="clearfix" ng-if="clause[0] === 'AND' || clause[0] === 'OR' || clause[0] === 'NOT'" crm-api4-where-clause="{where: clause[1], op: clause[0], fields: data.fields, operators: data.operators, groupParent: data.where, groupIndex: index}">
+    <fieldset class="clearfix" ng-if="clause[0] === 'AND' || clause[0] === 'OR' || clause[0] === 'NOT'" crm-api4-clause="{type: data.type, clauses: clause[1], op: clause[0], fields: data.fields, groupParent: data.clauses, groupIndex: index}">
     </fieldset>
   </div>
 </div>

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -112,7 +112,19 @@
               <input class="collapsible-optgroups form-control" ng-model="controls.orderBy" crm-ui-select="{data: fieldsAndJoins}" placeholder="Add orderBy" />
             </div>
           </fieldset>
-
+          <fieldset ng-if="availableParams.limit && availableParams.offset">
+            <div class="api4-input form-inline">
+              <span ng-mouseenter="help('limit', availableParams.limit)" ng-mouseleave="help()">
+                <label for="api4-param-limit">limit<span class="crm-marker" ng-if="availableParams.limit.required"> *</span></label>
+                <input class="form-control" type="number" min="0" id="api4-param-limit" ng-model="params.limit"/>
+              </span>
+              <span ng-mouseenter="help('offset', availableParams.offset)" ng-mouseleave="help()">
+                <label for="api4-param-offset">offset<span class="crm-marker" ng-if="availableParams.offset.required"> *</span></label>
+                <input class="form-control" type="number" min="0" id="api4-param-offset" ng-model="params.offset"/>
+              </span>
+              <a href class="crm-hover-button" title="Clear" ng-click="clearParam('limit');clearParam('offset');" ng-show="!!params.limit || !!params.offset"><i class="crm-i fa-times"></i></a>
+            </div>
+          </fieldset>
           <fieldset ng-if="availableParams.chain" ng-mouseenter="help('chain', availableParams.chain)" ng-mouseleave="help()">
             <legend>chain</legend>
             <div class="api4-input form-inline" ng-repeat="clause in params.chain" api4-exp-chain="clause" entities="entities" main-entity="entity" >

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -84,18 +84,19 @@
             <div class="api4-input form-inline">
               <input class="collapsible-optgroups form-control" ng-model="controls[name]" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: fieldList(name), placeholder: ts('Add %1', {1: name.slice(0, -1)})}"/>
             </div>
-          </fieldset><fieldset ng-if="availableParams.groupBy" ng-mouseenter="help('groupBy', availableParams.groupBy)" ng-mouseleave="help()">
-          <legend>groupBy<span class="crm-marker" ng-if="availableParams.groupBy.required"> *</span></legend>
-          <div ng-model="params.groupBy" ui-sortable="{axis: 'y'}">
-            <div class="api4-input form-inline" ng-repeat="(pos, field) in params.groupBy">
-              <i class="crm-i fa-arrows"></i>
-              <input class="collapsible-optgroups form-control" ng-model="params.groupBy[pos]" crm-ui-select="{data: fieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+          </fieldset>
+          <fieldset ng-if="availableParams.groupBy" ng-mouseenter="help('groupBy', availableParams.groupBy)" ng-mouseleave="help()">
+            <legend>groupBy<span class="crm-marker" ng-if="availableParams.groupBy.required"> *</span></legend>
+            <div ng-model="params.groupBy" ui-sortable="{axis: 'y'}">
+              <div class="api4-input form-inline" ng-repeat="(pos, field) in params.groupBy">
+                <i class="crm-i fa-arrows"></i>
+                <input class="collapsible-optgroups form-control" ng-model="params.groupBy[pos]" crm-ui-select="{data: fieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+              </div>
             </div>
-          </div>
-          <div class="api4-input form-inline">
-            <input class="collapsible-optgroups form-control" ng-model="controls.groupBy" crm-ui-select="{data: fieldsAndJoins}" placeholder="Add groupBy" />
-          </div>
-        </fieldset>
+            <div class="api4-input form-inline">
+              <input class="collapsible-optgroups form-control" ng-model="controls.groupBy" crm-ui-select="{data: fieldsAndJoins}" placeholder="Add groupBy" />
+            </div>
+          </fieldset>
           <fieldset ng-if="availableParams.orderBy" ng-mouseenter="help('orderBy', availableParams.orderBy)" ng-mouseleave="help()">
             <legend>orderBy<span class="crm-marker" ng-if="availableParams.orderBy.required"> *</span></legend>
             <div ng-model="params.orderBy" ui-sortable="{axis: 'y'}">

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -107,6 +107,8 @@
               <input class="collapsible-optgroups form-control huge" ng-model="controls.groupBy" crm-ui-select="{data: fieldsAndJoinsAndFunctions}" placeholder="Add groupBy" />
             </div>
           </fieldset>
+          <fieldset ng-if="availableParams.having" class="api4-clause-fieldset" ng-mouseenter="help('having', availableParams.having)" ng-mouseleave="help()" crm-api4-clause="{type: 'having', clauses: params.having, required: availableParams.having.required, op: 'AND', label: 'having', fields: havingOptions}">
+          </fieldset>
           <fieldset ng-if="availableParams.orderBy" ng-mouseenter="help('orderBy', availableParams.orderBy)" ng-mouseleave="help()">
             <legend>orderBy<span class="crm-marker" ng-if="availableParams.orderBy.required"> *</span></legend>
             <div ng-model="params.orderBy" ui-sortable="{axis: 'y'}">

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -53,13 +53,14 @@
           <fieldset class="api4-input form-inline" ng-mouseenter="help('select', availableParams.select)" ng-mouseleave="help()" ng-if="availableParams.select && !isSelectRowCount()">
             <legend>select<span class="crm-marker" ng-if="availableParams.select.required"> *</span></legend>
             <div ng-model="params.select" ui-sortable="{axis: 'y'}">
-              <div class="api4-input form-inline" ng-repeat="item in params.select">
+              <div class="api4-input form-inline" ng-repeat="item in params.select track by $index">
                 <i class="crm-i fa-arrows"></i>
-                <input class="collapsible-optgroups form-control" ng-model="item" crm-ui-select="{data: selectFieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+                <input class="form-control huge" type="text" ng-model="params.select[$index]" />
+                <a href class="crm-hover-button" title="Clear" ng-click="clearParam('select', $index)"><i class="crm-i fa-times"></i></a>
               </div>
             </div>
             <div class="api4-input form-inline">
-              <input class="collapsible-optgroups form-control" ng-model="controls.select" crm-ui-select="{data: selectFieldsAndJoins}" placeholder="Add select" />
+              <input class="collapsible-optgroups form-control huge" ng-model="controls.select" crm-ui-select="{data: fieldsAndJoinsAndFunctionsAndWildcards}" placeholder="Add select" />
             </div>
           </fieldset>
           <div class="api4-input form-inline" ng-mouseenter="help('fields', availableParams.fields)" ng-mouseleave="help()"ng-if="availableParams.fields">
@@ -96,13 +97,14 @@
           <fieldset ng-if="availableParams.groupBy" ng-mouseenter="help('groupBy', availableParams.groupBy)" ng-mouseleave="help()">
             <legend>groupBy<span class="crm-marker" ng-if="availableParams.groupBy.required"> *</span></legend>
             <div ng-model="params.groupBy" ui-sortable="{axis: 'y'}">
-              <div class="api4-input form-inline" ng-repeat="(pos, field) in params.groupBy">
+              <div class="api4-input form-inline" ng-repeat="item in params.groupBy track by $index">
                 <i class="crm-i fa-arrows"></i>
-                <input class="collapsible-optgroups form-control" ng-model="params.groupBy[pos]" crm-ui-select="{data: fieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+                <input class="form-control huge" type="text" ng-model="params.groupBy[$index]" />
+                <a href class="crm-hover-button" title="Clear" ng-click="clearParam('groupBy', $index)"><i class="crm-i fa-times"></i></a>
               </div>
             </div>
             <div class="api4-input form-inline">
-              <input class="collapsible-optgroups form-control" ng-model="controls.groupBy" crm-ui-select="{data: fieldsAndJoins}" placeholder="Add groupBy" />
+              <input class="collapsible-optgroups form-control huge" ng-model="controls.groupBy" crm-ui-select="{data: fieldsAndJoinsAndFunctions}" placeholder="Add groupBy" />
             </div>
           </fieldset>
           <fieldset ng-if="availableParams.orderBy" ng-mouseenter="help('orderBy', availableParams.orderBy)" ng-mouseleave="help()">
@@ -110,15 +112,16 @@
             <div ng-model="params.orderBy" ui-sortable="{axis: 'y'}">
               <div class="api4-input form-inline" ng-repeat="clause in params.orderBy">
                 <i class="crm-i fa-arrows"></i>
-                <input class="collapsible-optgroups form-control" ng-model="clause[0]" crm-ui-select="{data: fieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+                <input class="form-control huge" type="text" ng-model="clause[0]" />
                 <select class="form-control" ng-model="clause[1]">
                   <option value="ASC">ASC</option>
                   <option value="DESC">DESC</option>
                 </select>
+                <a href class="crm-hover-button" title="Clear" ng-click="clearParam('orderBy', $index)"><i class="crm-i fa-times"></i></a>
               </div>
             </div>
             <div class="api4-input form-inline">
-              <input class="collapsible-optgroups form-control" ng-model="controls.orderBy" crm-ui-select="{data: fieldsAndJoins}" placeholder="Add orderBy" />
+              <input class="collapsible-optgroups form-control huge" ng-model="controls.orderBy" crm-ui-select="{data: fieldsAndJoinsAndFunctions}" placeholder="Add orderBy" />
             </div>
           </fieldset>
           <fieldset ng-if="availableParams.limit && availableParams.offset">

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -50,10 +50,18 @@
             </label>
             <a href class="crm-hover-button" title="Clear" ng-click="clearParam(name)" ng-show="params[name] !== null"><i class="crm-i fa-times"></i></a>
           </div>
-          <div class="api4-input form-inline" ng-mouseenter="help('select', availableParams.select)" ng-mouseleave="help()" ng-if="availableParams.select && !isSelectRowCount()">
-            <label for="api4-param-select">select<span class="crm-marker" ng-if="availableParams.select.required"> *</span></label>
-            <input class="collapsible-optgroups form-control" ng-list crm-ui-select="{data: selectFieldsAndJoins, multiple: true}" placeholder="*" id="api4-param-select" ng-model="params.select" style="width: 85%;"/>
-          </div>
+          <fieldset class="api4-input form-inline" ng-mouseenter="help('select', availableParams.select)" ng-mouseleave="help()" ng-if="availableParams.select && !isSelectRowCount()">
+            <legend>select<span class="crm-marker" ng-if="availableParams.select.required"> *</span></legend>
+            <div ng-model="params.select" ui-sortable="{axis: 'y'}">
+              <div class="api4-input form-inline" ng-repeat="item in params.select">
+                <i class="crm-i fa-arrows"></i>
+                <input class="collapsible-optgroups form-control" ng-model="item" crm-ui-select="{data: selectFieldsAndJoins, allowClear: true, placeholder: 'Field'}" />
+              </div>
+            </div>
+            <div class="api4-input form-inline">
+              <input class="collapsible-optgroups form-control" ng-model="controls.select" crm-ui-select="{data: selectFieldsAndJoins}" placeholder="Add select" />
+            </div>
+          </fieldset>
           <div class="api4-input form-inline" ng-mouseenter="help('fields', availableParams.fields)" ng-mouseleave="help()"ng-if="availableParams.fields">
             <label for="api4-param-fields">fields<span class="crm-marker" ng-if="availableParams.fields.required"> *</span></label>
             <input class="form-control" ng-list crm-ui-select="{data: fields, multiple: true}" id="api4-param-fields" ng-model="params.fields" style="width: 85%;"/>

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -73,7 +73,7 @@
             <textarea class="form-control" type="{{ param.type[0] === 'int' && param.type.length === 1 ? 'number' : 'text' }}" id="api4-param-{{ name }}" ng-model="params[name]">
             </textarea>
           </div>
-          <fieldset ng-if="availableParams.where" class="api4-where-fieldset" ng-mouseenter="help('where', availableParams.where)" ng-mouseleave="help()" crm-api4-where-clause="{where: params.where, required: availableParams.where.required, op: 'AND', label: 'where', fields: fieldsAndJoins}">
+          <fieldset ng-if="availableParams.where" class="api4-clause-fieldset" ng-mouseenter="help('where', availableParams.where)" ng-mouseleave="help()" crm-api4-clause="{type: 'where', clauses: params.where, required: availableParams.where.required, op: 'AND', label: 'where', fields: fieldsAndJoins}">
           </fieldset>
           <fieldset ng-repeat="name in ['values', 'defaults']" ng-if="availableParams[name]" ng-mouseenter="help(name, availableParams[name])" ng-mouseleave="help()">
             <legend>{{ name }}<span class="crm-marker" ng-if="availableParams[name].required"> *</span></legend>

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -377,7 +377,7 @@
               deep: format === 'json'
             });
           }
-          if (typeof objectParams[name] !== 'undefined' || name === 'groupBy') {
+          if (typeof objectParams[name] !== 'undefined' || name === 'groupBy' || name === 'select') {
             $scope.$watch('params.' + name, function(values) {
               // Remove empty values
               _.each(values, function(clause, index) {
@@ -390,7 +390,7 @@
               var field = value;
               $timeout(function() {
                 if (field) {
-                  if (name === 'groupBy') {
+                  if (name === 'groupBy' || name === 'select') {
                     $scope.params[name].push(field);
                   } else {
                     var defaultOp = _.cloneDeep(objectParams[name]);

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -238,6 +238,9 @@
 
     $scope.isSpecial = function(name) {
       var specialParams = ['select', 'fields', 'action', 'where', 'values', 'defaults', 'orderBy', 'chain', 'groupBy'];
+      if ($scope.availableParams.limit && $scope.availableParams.offset) {
+        specialParams.push('limit', 'offset');
+      }
       return _.contains(specialParams, name);
     };
 

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -790,12 +790,12 @@
     };
   });
 
-  angular.module('api4Explorer').directive('crmApi4WhereClause', function($timeout) {
+  angular.module('api4Explorer').directive('crmApi4Clause', function($timeout) {
     return {
       scope: {
-        data: '=crmApi4WhereClause'
+        data: '=crmApi4Clause'
       },
-      templateUrl: '~/api4Explorer/WhereClause.html',
+      templateUrl: '~/api4Explorer/Clause.html',
       link: function (scope, element, attrs) {
         var ts = scope.ts = CRM.ts();
         scope.newClause = '';
@@ -803,7 +803,7 @@
         scope.operators = CRM.vars.api4.operators;
 
         scope.addGroup = function(op) {
-          scope.data.where.push([op, []]);
+          scope.data.clauses.push([op, []]);
         };
 
         scope.removeGroup = function() {
@@ -811,7 +811,7 @@
         };
 
         scope.onSort = function(event, ui) {
-          $('.api4-where-fieldset').toggleClass('api4-sorting', event.type === 'sortstart');
+          $(element).closest('.api4-clause-fieldset').toggleClass('api4-sorting', event.type === 'sortstart');
           $('.api4-input.form-inline').css('margin-left', '');
         };
 
@@ -828,12 +828,12 @@
           var field = value;
           $timeout(function() {
             if (field) {
-              scope.data.where.push([field, '=', '']);
+              scope.data.clauses.push([field, '=', '']);
               scope.newClause = null;
             }
           });
         });
-        scope.$watch('data.where', function(values) {
+        scope.$watch('data.clauses', function(values) {
           // Remove empty values
           _.each(values, function(clause, index) {
             if (typeof clause !== 'undefined' && !clause[0]) {

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -25,6 +25,7 @@
     $scope.entities = entities;
     $scope.actions = actions;
     $scope.fields = [];
+    $scope.havingOptions = [];
     $scope.fieldsAndJoins = [];
     $scope.fieldsAndJoinsAndFunctions = [];
     $scope.fieldsAndJoinsAndFunctionsAndWildcards = [];
@@ -107,15 +108,6 @@
         default:
           return str + 's';
       }
-    }
-
-    // Turn a flat array into a select2 array
-    function arrayToSelect2(array) {
-      var out = [];
-      _.each(array, function(item) {
-        out.push({id: item, text: item});
-      });
-      return out;
     }
 
     // Reformat an existing array of objects for compatibility with select2
@@ -242,7 +234,7 @@
     };
 
     $scope.isSpecial = function(name) {
-      var specialParams = ['select', 'fields', 'action', 'where', 'values', 'defaults', 'orderBy', 'chain', 'groupBy'];
+      var specialParams = ['select', 'fields', 'action', 'where', 'values', 'defaults', 'orderBy', 'chain', 'groupBy', 'having'];
       if ($scope.availableParams.limit && $scope.availableParams.offset) {
         specialParams.push('limit', 'offset');
       }
@@ -409,6 +401,16 @@
                 }
               });
             }, true);
+          }
+          if (name === 'select' && actionInfo.params.having) {
+            $scope.$watchCollection('params.select', function(values) {
+              $scope.havingOptions.length = 0;
+              _.each(values, function(item) {
+                var pieces = item.split(' AS '),
+                  alias = _.trim(pieces[pieces.length - 1]);
+                $scope.havingOptions.push({id: alias, text: alias});
+              });
+            });
           }
           if (typeof objectParams[name] !== 'undefined' || name === 'groupBy' || name === 'select') {
             $scope.$watch('controls.' + name, function(value) {

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -143,6 +143,10 @@
   display: inline-block;
 }
 
+#bootstrap-theme.api4-explorer-page i.fa-arrows {
+  cursor: move;
+}
+
 #bootstrap-theme.api4-explorer-page .api4-clause-badge {
   width: 55px;
   display: inline-block;

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -129,13 +129,13 @@
   top: -2px;
 }
 
-#bootstrap-theme.api4-explorer-page .api4-where-fieldset fieldset {
+#bootstrap-theme.api4-explorer-page .api4-clause-fieldset fieldset {
   float: right;
   width: calc(100% - 58px);
   margin-top: -8px;
 }
 
-#bootstrap-theme.api4-explorer-page .api4-where-fieldset.api4-sorting fieldset .api4-where-group-sortable {
+#bootstrap-theme.api4-explorer-page .api4-clause-fieldset.api4-sorting fieldset .api4-clause-group-sortable {
   min-height: 3.5em;
 }
 

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -203,6 +203,10 @@ div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children.opt
   content: "\f0d7";
 }
 
+#bootstrap-theme.api4-explorer-page .form-control.huge {
+  width: 25em;
+}
+
 /* Another weird shoreditch fix */
 #bootstrap-theme .form-inline div.checkbox {
   margin-right: 1em;

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -29,6 +29,14 @@ use Civi\Api4\Contribution;
  */
 class SqlFunctionTest extends UnitTestCase {
 
+  public function testGetFunctions() {
+    $functions = array_column(\CRM_Api4_Page_Api4Explorer::getSqlFunctions(), NULL, 'name');
+    $this->assertArrayHasKey('SUM', $functions);
+    $this->assertArrayNotHasKey('', $functions);
+    $this->assertArrayNotHasKey('SqlFunction', $functions);
+    $this->assertEquals(1, $functions['MAX']['params'][0]['expr']);
+  }
+
   public function testGroupAggregates() {
     $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
     Contribution::save()


### PR DESCRIPTION
Overview
----------------------------------------
This adds UI support for new APIv4 features. Sql functions and aliases are now available in the API explorer, as is the HAVING clause.

See also: https://lab.civicrm.org/dev/report/-/issues/31

Before
----------------------------------------
UI didn't show new features.

After
----------------------------------------
UI updated.

Technical Details
----------------------------------------
Includes tests for loading SQL function metadata.