### PR TITLE
dev/translation#4 - Refine upgrade steps for modifying nl_NL

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentySix.php
@@ -79,16 +79,16 @@ class CRM_Upgrade_Incremental_php_FiveTwentySix extends CRM_Upgrade_Incremental_
       'is_active' => 1,
     ]);
     // Update the existing nl_NL entry.
-    \Civi\Api4\OptionValue::update()
-      ->addWhere('name', '=', 'nl_NL')
-      // Adding check against label in case they've customized it, in which
+    $sql = CRM_Utils_SQL::interpolate('UPDATE civicrm_option_value SET label = @newLabel WHERE option_group_id = #group AND name = @name AND label IN (@oldLabels)', [
+      'name' => 'nl_NL',
+      'newLabel' => ts('Dutch (Netherlands)'),
+      // Adding check against old label in case they've customized it, in which
       // case we don't want to overwrite that. The ts() part is tricky since
       // it depends if they installed it in English first.
-      ->addClause('OR', ['label', '=', 'Dutch'], ['label', '=', ts('Dutch')])
-      ->addValue('label', ts('Dutch (Netherlands)'))
-      ->setLimit(1)
-      ->setCheckPermissions(FALSE)
-      ->execute();
+      'oldLabels' => ['Dutch', ts('Dutch')],
+      'group' => CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_option_group WHERE name = "languages"'),
+    ]);
+    CRM_Core_DAO::executeQuery($sql);
     return TRUE;
   }
 

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -18,6 +18,38 @@
 class CRM_Utils_SQL {
 
   /**
+   * Given a string like "UPDATE some_table SET !field = @value", replace "!field" and "@value".
+   *
+   * This is syntactic sugar for using CRM_Utils_SQL_*::interpolate() without an OOP representation of the query.
+   *
+   * @param string $expr SQL expression
+   * @param null|array $args a list of values to insert into the SQL expression; keys are prefix-coded:
+   *   prefix '@' => escape SQL
+   *   prefix '#' => literal number, skip escaping but do validation
+   *   prefix '!' => literal, skip escaping and validation
+   *   if a value is an array, then it will be imploded
+   *
+   * PHP NULL's will be treated as SQL NULL's. The PHP string "null" will be treated as a string.
+   *
+   * @return string
+   */
+  public static function interpolate($expr, $args) {
+    if (!isset(Civi::$statics[__CLASS__][__FUNCTION__])) {
+      Civi::$statics[__CLASS__][__FUNCTION__] = new class extends CRM_Utils_SQL_BaseParamQuery {
+
+        public function __construct() {
+          $this->mode = CRM_Utils_SQL_BaseParamQuery::INTERPOLATE_INPUT;
+          $this->strict();
+        }
+
+      };
+    }
+    /** @var \CRM_Utils_SQL_BaseParamQuery $qb */
+    $qb = Civi::$statics[__CLASS__][__FUNCTION__];
+    return $qb->strict()->interpolate($expr, $args);
+  }
+
+  /**
    * Helper function for adding the permissioned subquery from one entity onto another
    *
    * @param string $entity

--- a/tests/phpunit/CRM/Utils/SQLTest.php
+++ b/tests/phpunit/CRM/Utils/SQLTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Class CRM_Utils_SQLTest
+ * @group headless
+ */
+class CRM_Utils_SQLTest extends CiviUnitTestCase {
+
+  public function testInterpolate() {
+    // This function is a thin wrapper for `CRM_Utils_SQL_BaseParamQuery::interpolate()`, which already has
+    // lots of coverage in other test classes. This test just checks the basic wiring.
+    $sql = CRM_Utils_SQL::interpolate('FROBNICATE some_table WITH MAX(!dynamicField) OVER #times USING (@list) OR (#ids) OR @item', [
+      '!dynamicField' => 'the(field)',
+      '#times' => 123,
+      '@list' => ['abc def', '45'],
+      '#ids' => [6, 7, 8],
+      '@item' => "it's text",
+    ]);
+    $this->assertEquals('FROBNICATE some_table WITH MAX(the(field)) OVER 123 USING ("abc def", "45") OR (6, 7, 8) OR "it\\\'s text"', $sql);
+  }
+
+  public function testInterpolateBad() {
+    try {
+      CRM_Utils_SQL::interpolate("UPDATE !the_table SET !the_field = @THE_VALUE", [
+        // MISSING: 'the_table'
+        'the_field' => 'my_field',
+        'the_value' => 'ny value',
+      ]);
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertRegExp(';Cannot build query. Variable "!the_table" is unknown.;', $e->getMessage());
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This refines the upgrader step added in #17027.

CC @demeritcowboy @seamuslee001 

Before
----------------------------------------
* Upgrader step uses APIv4, which is likely to have reliability issues in future upgrades
    * See: https://docs.civicrm.org/dev/en/latest/framework/upgrade/#tips-prefer-simple-sql-semantics-over-apibaodao
* Upgrader step is missing `option_group_id` filter

After
----------------------------------------

* Upgrader uses SQL
* Upgrader includes `option_group_id` filter
