### PR TITLE
Improve AngularJS performance with one-time binding for static strings

### DIFF
--- a/ang/api4Explorer/Chain.html
+++ b/ang/api4Explorer/Chain.html
@@ -1,4 +1,4 @@
 <input class="form-control" ng-model="chain[1][0]" crm-ui-select="{data: entities, allowClear: true, placeholder: 'None'}" />
 <select class="form-control api4-chain-action" ng-model="chain[1][1]" ng-options="a for a in actions" ></select>
-<input class="form-control api4-chain-params" ng-model="chain[1][2]" placeholder="{{ ts('Params') }}" />
-<input class="form-control api4-chain-index" ng-model="chain[1][3]" placeholder="{{ ts('Index') }}" />
+<input class="form-control api4-chain-params" ng-model="chain[1][2]" placeholder="{{:: ts('Params') }}" />
+<input class="form-control api4-chain-index" ng-model="chain[1][3]" placeholder="{{:: ts('Index') }}" />

--- a/ang/api4Explorer/Clause.html
+++ b/ang/api4Explorer/Clause.html
@@ -1,12 +1,12 @@
 <legend>{{ data.label || data.op + ' group' }}<span class="crm-marker" ng-if="data.required"> *</span></legend>
 <div class="btn-group btn-group-xs" ng-if="data.groupParent">
-  <button class="btn btn-danger-outline" ng-click="removeGroup()" title="{{ ts('Remove group') }}">
+  <button class="btn btn-danger-outline" ng-click="removeGroup()" title="{{:: ts('Remove group') }}">
     <i class="crm-i fa-trash"></i>
   </button>
 </div>
 <div class="api4-clause-group-sortable" ng-model="data.clauses" ui-sortable="{axis: 'y', connectWith: '.api4-clause-group-sortable', containment: '.api4-clause-fieldset', over: onSortOver}" ui-sortable-start="onSort" ui-sortable-stop="onSort">
   <div class="api4-input form-inline clearfix" ng-repeat="(index, clause) in data.clauses">
-    <div class="api4-clause-badge" title="{{ ts('Drag to reposition') }}">
+    <div class="api4-clause-badge" title="{{:: ts('Drag to reposition') }}">
       <span class="badge badge-info">
         <span ng-if="!index && !data.groupParent">{{ data.type }}</span>
         <span ng-if="index || data.groupParent">{{ data.op }}</span>

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -2,16 +2,16 @@
   <div crm-ui-debug="availableParams"></div>
 
   <h1 crm-page-title>
-    {{ ts('CiviCRM APIv4') }}{{ entity ? (' (' + entity + '::' + action + ')') : '' }}
+    {{:: ts('CiviCRM APIv4') }}{{ entity ? (' (' + entity + '::' + action + ')') : '' }}
   </h1>
 
   <!--This warning will show if bootstrap is unavailable. Normally it will be hidden by the bootstrap .collapse class.-->
   <div class="messages warning no-popup collapse">
     <p>
       <i class="crm-i fa-exclamation-triangle"></i>
-      <strong>{{ ts('Bootstrap theme not found.') }}</strong>
+      <strong>{{:: ts('Bootstrap theme not found.') }}</strong>
     </p>
-    <p>{{ ts('This screen may not work correctly without a bootstrap-based theme such as Shoreditch installed.') }}</p>
+    <p>{{:: ts('This screen may not work correctly without a bootstrap-based theme such as Shoreditch installed.') }}</p>
   </div>
 
   <div class="api4-explorer-row">
@@ -24,9 +24,9 @@
             <span ng-mouseenter="help('action', paramDoc('$action'))" ng-mouseleave="help()">
               <input class="collapsible-optgroups form-control" ng-model="action" ng-disabled="!entity || !actions.length" ng-class="{loading: entity && !actions.length}" crm-ui-select="{placeholder: ts('Action'), data: actions}" />
             </span>
-            <input class="form-control api4-index" type="search" ng-model="index" ng-mouseenter="help('index', paramDoc('$index'))" ng-mouseleave="help()" placeholder="{{ ts('Index') }}" />
-            <button class="btn btn-success pull-right" crm-icon="fa-bolt" ng-disabled="!entity || !action || loading" ng-click="execute()" ng-mouseenter="help(ts('Execute'), executeDoc())" ng-mouseleave="help()">{{ ts('Execute') }}</button>
-            <button class="btn btn-primary pull-right" crm-icon="fa-save" ng-show="perm.editGroups && entity === 'Contact' && action === 'get'" ng-click="save()" ng-mouseenter="help(ts('Save smart group'), saveDoc())" ng-mouseleave="help()">{{ ts('Save...') }}</button>
+            <input class="form-control api4-index" type="search" ng-model="index" ng-mouseenter="help('index', paramDoc('$index'))" ng-mouseleave="help()" placeholder="{{:: ts('Index') }}" />
+            <button class="btn btn-success pull-right" crm-icon="fa-bolt" ng-disabled="!entity || !action || loading" ng-click="execute()" ng-mouseenter="help(ts('Execute'), executeDoc())" ng-mouseleave="help()">{{:: ts('Execute') }}</button>
+            <button class="btn btn-primary pull-right" crm-icon="fa-save" ng-show="perm.editGroups && entity === 'Contact' && action === 'get'" ng-click="save()" ng-mouseenter="help(ts('Save smart group'), saveDoc())" ng-mouseleave="help()">{{:: ts('Save...') }}</button>
           </div>
         </div>
         <div class="panel-body">
@@ -194,13 +194,13 @@
               <i class="fa fa-fw fa-check-circle" ng-if="status === 'success'"></i>
               <i class="fa fa-fw fa-minus-circle" ng-if="status === 'danger'"></i>
               <i class="fa fa-fw fa-spinner fa-pulse" ng-if="status === 'warning'"></i>
-              <span>{{ ts('Result') }}</span>
+              <span>{{:: ts('Result') }}</span>
             </a>
           </li>
           <li role="presentation" ng-if="perm.accessDebugOutput" ng-class="{active: selectedTab.result === 'debug'}">
             <a href ng-click="selectedTab.result = 'debug'">
               <i class="fa fa-fw fa-{{ debug ? 'bug' : 'circle-o' }}"></i>
-              <span>{{ ts('Debug') }}</span>
+              <span>{{:: ts('Debug') }}</span>
             </a>
           </li>
         </ul>
@@ -211,10 +211,10 @@
           <div ng-show="selectedTab.result === 'debug'">
             <pre ng-if="debug" class="prettyprint" ng-bind-html="debug"></pre>
             <p ng-if="!debug">
-              {{ ts('To view debugging output, enable the debug param before executing.') }}
+              {{:: ts('To view debugging output, enable the debug param before executing.') }}
             </p>
             <p ng-if="!debug">
-              {{ ts('Enable backtrace in system settings to see error backtraces.') }}
+              {{:: ts('Enable backtrace in system settings to see error backtraces.') }}
             </p>
           </div>
         </div>

--- a/ang/api4Explorer/SaveSearch.html
+++ b/ang/api4Explorer/SaveSearch.html
@@ -1,12 +1,12 @@
 <form id="bootstrap-theme">
   <div ng-controller="SaveSearchCtrl">
     <input class="form-control" id="api-save-search-select-group" ng-model="model.id" crm-entityref="groupEntityRefParams" >
-    <label ng-show="!model.id">{{ ts('Or') }}</label>
+    <label ng-show="!model.id">{{:: ts('Or') }}</label>
     <input class="form-control" placeholder="Create new group" ng-model="model.title" ng-show="!model.id">
     <hr />
-    <label>{{ ts('Description:') }}</label>
+    <label>{{:: ts('Description:') }}</label>
     <textarea class="form-control" ng-model="model.description"></textarea>
-    <label>{{ ts('Group Type:') }}</label>
+    <label>{{:: ts('Group Type:') }}</label>
     <div class="form-inline">
       <div class="checkbox" ng-repeat="(key, label) in options.group_type">
         <label>
@@ -15,12 +15,12 @@
         </label>
       </div>
     </div>
-    <label>{{ ts('Visibility:') }}</label>
+    <label>{{:: ts('Visibility:') }}</label>
     <select class="form-control" ng-model="model.visibility" ng-options="name as value for (name, value) in options.visibility"></select>
     <hr />
     <div class="buttons pull-right">
-      <button type="button" ng-click="cancel()" class="btn btn-danger">{{ ts('Cancel') }}</button>
-      <button ng-click="save()" class="btn btn-primary" ng-disabled="!model.title && !model.id">{{ ts('Save') }}</button>
+      <button type="button" ng-click="cancel()" class="btn btn-danger">{{:: ts('Cancel') }}</button>
+      <button ng-click="save()" class="btn btn-primary" ng-disabled="!model.title && !model.id">{{:: ts('Save') }}</button>
     </div>
   </div>
 </form>

--- a/ang/crmAttachment/attachments.html
+++ b/ang/crmAttachment/attachments.html
@@ -7,13 +7,13 @@
         <a ng-href="{{file.url}}" target="_blank">{{file.name}}</a>
       </td>
       <td>
-        <input ng-model="file.description" class="crm-form-text" placeholder="{{ts('Description')}}"/>
+        <input ng-model="file.description" class="crm-form-text" placeholder="{{:: ts('Description') }}"/>
       </td>
       <td>
         <a
           crm-icon="fa-trash"
           crm-confirm="{message: ts('Deleting an attachment will completely remove it from server.')}" on-yes="att.deleteFile(file)"
-          title="{{ts('Delete attachment')}}"
+          title="{{:: ts('Delete attachment') }}"
           class="crm-hover-button">
         </a>
       </td>
@@ -23,11 +23,11 @@
     <tr ng-repeat="item in att.uploader.queue" ng-class="{nvReady: item.isReady, nvUploading:item.isUploading, nvUploaded:item.isUploaded,nvSuccess:item.isSuccess,nvCancel:item.isCancel,nvError:item.isError}">
       <td class="filename filename-new">{{item.file.name}}</td>
       <td>
-        <input ng-model="item.crmData.description" class="crm-form-text" placeholder="{{ts('Description')}}"/>
+        <input ng-model="item.crmData.description" class="crm-form-text" placeholder="{{:: ts('Description') }}"/>
         <!-- item.isReady item.isUploading item.isUploaded item.isSuccess item.isCancel item.isError -->
       </td>
       <td>
-        <a crm-icon="fa-times" ng-click="item.remove()" class="crm-hover-button" title="{{ts('Remove unsaved attachment')}}"></a>
+        <a crm-icon="fa-times" ng-click="item.remove()" class="crm-hover-button" title="{{:: ts('Remove unsaved attachment') }}"></a>
       </td>
     </tr>
     </tbody>
@@ -38,10 +38,10 @@
   e.g. http://www.quirksmode.org/dom/inputfile.html
   -->
   <div>
-    {{ts('Add file:')}} <input type="file" nv-file-select uploader="att.uploader" multiple/><br/>
+    {{:: ts('Add file:') }} <input type="file" nv-file-select uploader="att.uploader" multiple/><br/>
   </div>
   <div>
-    {{ts('Alternatively, you may add new files using drag/drop.')}}
+    {{:: ts('Alternatively, you may add new files using drag/drop.') }}
     <span ng-if="max_size">
       {{ts('Each file must be less than %1M in size.', {1: max_size})}}
     </span>

--- a/ang/crmCaseType/activityTypesTable.html
+++ b/ang/crmCaseType/activityTypesTable.html
@@ -6,8 +6,8 @@ Required vars: caseType
   <thead>
   <tr>
     <th></th>
-    <th>{{ts('Activity Type')}}</th>
-    <th>{{ts('Max Instances')}}</th>
+    <th>{{:: ts('Activity Type') }}</th>
+    <th>{{:: ts('Max Instances') }}</th>
     <th></th>
   </tr>
   </thead>
@@ -25,7 +25,7 @@ Required vars: caseType
       <input class="crm-form-text number" type="text" ng-pattern="/^[1-9][0-9]*$/" ng-model="activityType.max_instances">
     </td>
     <td>
-      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.activityTypes, activityType)" title="{{ts('Remove')}}"></a>
+      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.activityTypes, activityType)" title="{{:: ts('Remove') }}"></a>
     </td>
   </tr>
   </tbody>
@@ -38,7 +38,7 @@ Required vars: caseType
            crm-options="activityTypeOptions"
            crm-var="newActivity"
            crm-on-add="addActivityType(newActivity)"
-           placeholder="{{ts('Add activity type')}}"
+           placeholder="{{:: ts('Add activity type') }}"
       ></span>
     </td>
   </tr>

--- a/ang/crmCaseType/caseTypeDetails.html
+++ b/ang/crmCaseType/caseTypeDetails.html
@@ -29,10 +29,10 @@ The original form used table layout; don't know if we have an alternative, CSS-b
       <a crm-ui-lock binding="locks.caseTypeName"></a>
 
       <div ng-show="!isValidName(caseType.name)">
-        <em>{{ts('WARNING: The case type name includes deprecated characters.')}}</em>
+        <em>{{:: ts('WARNING: The case type name includes deprecated characters.') }}</em>
       </div>
       <div ng-show="caseType.id && !locks.caseTypeName">
-        <em>{{ts('WARNING: If any external files or programs reference the old "Name", then they must be updated manually.')}}</em>
+        <em>{{:: ts('WARNING: If any external files or programs reference the old "Name", then they must be updated manually.') }}</em>
       </div>
     </div>
     <div crm-ui-field="{name: 'caseTypeDetailForm.description', title: ts('Description')}">
@@ -42,7 +42,7 @@ The original form used table layout; don't know if we have an alternative, CSS-b
       <input name="is_active" type="checkbox" ng-model="caseType.is_active" ng-true-value="'1'" ng-false-value="'0'"/>
     </div>
     <fieldset class="crm-collapsible">
-      <legend class="collapsible-title">{{ ts('Activity assignment settings') }}</legend>
+      <legend class="collapsible-title">{{:: ts('Activity assignment settings') }}</legend>
       <div>
         <div crm-ui-field="{name: 'caseTypeDetailForm.activityAsgmtGrps', title: ts('Restrict to Groups'), help: hs('activityAsgmtGrps')}">
           <input

--- a/ang/crmCaseType/edit.html
+++ b/ang/crmCaseType/edit.html
@@ -5,7 +5,7 @@ Required vars: caseType
 <h1 crm-page-title>{{caseType.title || ts('New Case Type')}}</h1>
 
 <div class="help">
-  {{ts('Use this screen to define or update the Case Roles, Activity Types, and Timelines for a case type.')}} <a href="https://docs.civicrm.org/user/en/stable/case-management/set-up/" target="_blank">{{ts('Learn more...')}}</a>
+  {{:: ts('Use this screen to define or update the Case Roles, Activity Types, and Timelines for a case type.') }} <a href="https://docs.civicrm.org/user/en/stable/case-management/set-up/" target="_blank">{{:: ts('Learn more...') }}</a>
 </div>
 
 <form name="editCaseTypeForm" unsaved-warning-form>
@@ -15,16 +15,16 @@ Required vars: caseType
 
   <div ng-show="isForkable()" class="crmCaseType-acttab" ui-jq="tabs" ui-options="{show: true, hide: true}">
     <ul>
-      <li><a href="#acttab-roles">{{ts('Case Roles')}}</a></li>
-      <li><a href="#acttab-statuses">{{ts('Case Statuses')}}</a></li>
-      <li><a href="#acttab-actType">{{ts('Activity Types')}}</a></li>
+      <li><a href="#acttab-roles">{{:: ts('Case Roles') }}</a></li>
+      <li><a href="#acttab-statuses">{{:: ts('Case Statuses') }}</a></li>
+      <li><a href="#acttab-actType">{{:: ts('Activity Types') }}</a></li>
       <li ng-repeat="activitySet in caseType.definition.activitySets">
         <a href="#acttab-{{$index}}" class="crmCaseType-editable">
-          <div crm-editable-tab-title title="{{ts('Click to edit')}}">
+          <div crm-editable-tab-title title="{{:: ts('Click to edit') }}">
             <span>{{ activitySet.label }}</span>
           </div>
         </a>
-        <span class="crm-i fa-trash" title="{{ts('Remove')}}"
+        <span class="crm-i fa-trash" title="{{:: ts('Remove') }}"
           ng-hide="activitySet.name == 'standard_timeline'"
           ng-click="removeItem(caseType.definition.activitySets, activitySet)"></span>
         <!-- Weird spacing:
@@ -34,9 +34,9 @@ Required vars: caseType
         -->
       </li>
       <select class="crm-form-select" ng-model="newActivitySetWorkflow" ng-change="addActivitySet(newActivitySetWorkflow); newActivitySetWorkflow='';">
-        <option value="">{{ts('Add...')}}</option>
-        <option value="timeline" ng-show="isNewActivitySetAllowed('timeline')">{{ts('Timeline')}}</option>
-        <option value="sequence" ng-show="isNewActivitySetAllowed('sequence')">{{ts('Sequence')}}</option>
+        <option value="">{{:: ts('Add...') }}</option>
+        <option value="timeline" ng-show="isNewActivitySetAllowed('timeline')">{{:: ts('Timeline') }}</option>
+        <option value="sequence" ng-show="isNewActivitySetAllowed('sequence')">{{:: ts('Sequence') }}</option>
       </select>
     </ul>
 
@@ -53,10 +53,10 @@ Required vars: caseType
 
   <div class="crm-submit-buttons">
     <button crm-icon="fa-check" ng-click="editCaseTypeForm.$setPristine(); save()" ng-disabled="editCaseTypeForm.$invalid">
-      {{ts('Save')}}
+      {{:: ts('Save') }}
     </button>
     <button crm-icon="fa-times" ng-click="editCaseTypeForm.$setPristine(); goto('caseType')">
-      {{ts('Cancel')}}
+      {{:: ts('Cancel') }}
     </button>
   </div>
 </div>

--- a/ang/crmCaseType/list.html
+++ b/ang/crmCaseType/list.html
@@ -2,10 +2,10 @@
 Controller: CaseTypeListsCtrl
 Required vars: caseTypes
 -->
-<h1 crm-page-title>{{ts('Case Types')}}</h1>
+<h1 crm-page-title>{{:: ts('Case Types') }}</h1>
 
 <div class="help">
-  {{ts('A Case Type describes a group of related tasks, interactions, or processes.')}}
+  {{:: ts('A Case Type describes a group of related tasks, interactions, or processes.') }}
 </div>
 
 <div class="crm-content-block crm-block">
@@ -13,10 +13,10 @@ Required vars: caseTypes
   <table class="display">
     <thead>
     <tr>
-      <th>{{ts('Title')}}</th>
-      <th>{{ts('Name')}}</th>
-      <th>{{ts('Description')}}</th>
-      <th>{{ts('Enabled?')}}</th>
+      <th>{{:: ts('Title') }}</th>
+      <th>{{:: ts('Name') }}</th>
+      <th>{{:: ts('Description') }}</th>
+      <th>{{:: ts('Enabled?') }}</th>
       <th></th>
     </tr>
     </thead>
@@ -33,36 +33,36 @@ Required vars: caseTypes
       <!-- FIXME: Can't figure out how styling in other tables gets the nowrap effect... in absence of a consistent fix, KISS -->
       <td style="white-space: nowrap">
         <span>
-          <a class="action-item crm-hover-button" ng-href="#/caseType/{{caseType.id}}">{{ts('Edit')}}</a>
+          <a class="action-item crm-hover-button" ng-href="#/caseType/{{caseType.id}}">{{:: ts('Edit') }}</a>
 
           <!-- The variables used in ng-show below can take on any of the values from the set {0, 1, "0", "1", undefined}, so use explicit ==1 or !=1 to cover all possibilities properly. -->
           <span class="more-panel btn-slide crm-hover-button" ng-show="caseType.is_reserved!=1 || (caseType.is_active!=1 || caseType.is_forked==1)">
-            {{ts('more')}}
+            {{:: ts('more') }}
             <ul class="panel" style="display: none;">
               <li class="panel-item-enable" ng-hide="caseType.is_active==1">
                 <a class="action-item crm-hover-button" ng-click="toggleCaseType(caseType)">
-                  {{ts('Enable')}}
+                  {{:: ts('Enable') }}
                 </a>
               </li>
               <li class="panel-item-disable" ng-show="caseType.is_active==1 && caseType.is_reserved!=1">
                 <a class="action-item crm-hover-button"
                    crm-confirm="{type: 'disable', obj: caseType}"
                    on-yes="toggleCaseType(caseType)">
-                  {{ts('Disable')}}
+                  {{:: ts('Disable') }}
                 </a>
               </li>
               <li class="panel-item-revert" ng-show="caseType.is_forked==1">
                 <a class="action-item crm-hover-button"
                    crm-confirm="{type: 'revert', obj: caseType}"
                    on-yes="revertCaseType(caseType)">
-                  {{ts('Revert')}}
+                  {{:: ts('Revert') }}
                 </a>
               </li>
               <li class="panel-item-delete" ng-show="caseType.is_reserved!=1">
                 <a class="action-item crm-hover-button"
                    crm-confirm="{type: 'delete', obj: caseType}"
                    on-yes="deleteCaseType(caseType)">
-                  {{ts('Delete')}}
+                  {{:: ts('Delete') }}
                 </a>
               </li>
             </ul>
@@ -74,6 +74,6 @@ Required vars: caseTypes
   </table>
 
   <div class="crm-submit-buttons">
-    <a ng-href="#/caseType/new" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('New Case Type')}}</span></a>
+    <a ng-href="#/caseType/new" class="button"><span><i class="crm-i fa-plus-circle"></i> {{:: ts('New Case Type') }}</span></a>
   </div>
 </div>

--- a/ang/crmCaseType/rolesTable.html
+++ b/ang/crmCaseType/rolesTable.html
@@ -5,10 +5,10 @@ Required vars: caseType
 <table>
   <thead>
 	  <tr>
-	    <th>{{ts('Display Label')}}</th>
-	    <th>{{ts('Assign to Creator')}}</th>
-	    <th>{{ts('Is Manager')}}</th>
-	    <th>{{ts('Restrict to Groups')}}</th>
+	    <th>{{:: ts('Display Label') }}</th>
+	    <th>{{:: ts('Assign to Creator') }}</th>
+	    <th>{{:: ts('Is Manager') }}</th>
+	    <th>{{:: ts('Restrict to Groups') }}</th>
 	    <th></th>
 	  </tr>
   </thead>
@@ -23,7 +23,7 @@ Required vars: caseType
 				ng-model="relType.groups"
 			/></td>
 	    <td>
-	      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.caseRoles,relType)" title="{{ts('Remove')}}"></a>
+	      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.caseRoles,relType)" title="{{:: ts('Remove') }}"></a>
 	    </td>
 	  </tr>
   </tbody>
@@ -35,7 +35,7 @@ Required vars: caseType
 	           crm-options="relationshipTypeOptions"
 	           crm-var="newRole"
 	           crm-on-add="addRole(caseType.definition.caseRoles, newRole)"
-             placeholder="{{ts('Add role')}}"
+             placeholder="{{:: ts('Add role') }}"
 	              ></span>
 	    </td>
 	  </tr>

--- a/ang/crmCaseType/sequenceTable.html
+++ b/ang/crmCaseType/sequenceTable.html
@@ -6,7 +6,7 @@ Required vars: activitySet
   <thead>
   <tr>
     <th></th>
-    <th>{{ts('Activity')}}</th>
+    <th>{{:: ts('Activity') }}</th>
     <th></th>
   </tr>
   </thead>
@@ -21,7 +21,7 @@ Required vars: activitySet
       {{ activity.name }}
     </td>
     <td>
-      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(activitySet.activityTypes, activity)" title="{{ts('Remove')}}"></a>
+      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(activitySet.activityTypes, activity)" title="{{:: ts('Remove') }}"></a>
     </td>
   </tr>
   </tbody>
@@ -33,7 +33,7 @@ Required vars: activitySet
            crm-options="activityTypeOptions"
            crm-var="newActivity"
            crm-on-add="addActivity(activitySet, newActivity)"
-           placeholder="{{ts('Add activity')}}"
+           placeholder="{{:: ts('Add activity') }}"
       ></span>
     </td>
   </tr>

--- a/ang/crmCaseType/statusTable.html
+++ b/ang/crmCaseType/statusTable.html
@@ -6,8 +6,8 @@ Required vars: selectedStatuses
   <thead>
   <tr>
     <th></th>
-    <th>{{ts('Name')}}</th>
-    <th>{{ts('Class')}}</th>
+    <th>{{:: ts('Name') }}</th>
+    <th>{{:: ts('Class') }}</th>
   </tr>
   </thead>
 
@@ -28,7 +28,7 @@ Required vars: selectedStatuses
   <tfoot>
   <tr>
     <td></td>
-    <td><a class="crm-hover-button action-item" ng-click="newStatus()" href><i class="crm-i fa-plus"></i> {{ ts('New Status') }}</a></td>
+    <td><a class="crm-hover-button action-item" ng-click="newStatus()" href><i class="crm-i fa-plus"></i> {{:: ts('New Status') }}</a></td>
     <td></td>
   </tr>
   </tfoot>

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -6,12 +6,12 @@ Required vars: activitySet
   <thead>
   <tr>
     <th></th>
-    <th>{{ts('Activity')}}</th>
-    <th>{{ts('Status')}}</th>
-    <th>{{ts('Reference')}}</th>
-    <th>{{ts('Offset')}}</th>
-    <th>{{ts('Select')}}</th>
-    <th>{{ts('Default assignee')}}</th>
+    <th>{{:: ts('Activity') }}</th>
+    <th>{{:: ts('Status') }}</th>
+    <th>{{:: ts('Reference') }}</th>
+    <th>{{:: ts('Offset') }}</th>
+    <th>{{:: ts('Select') }}</th>
+    <th>{{:: ts('Default assignee') }}</th>
     <th></th>
   </tr>
   </thead>
@@ -96,7 +96,7 @@ Required vars: activitySet
          crm-icon="fa-trash"
          ng-show="isActivityRemovable(activitySet, activity)"
          ng-click="removeItem(activitySet.activityTypes, activity)"
-         title="{{ts('Remove')}}">
+         title="{{:: ts('Remove') }}">
       </a>
     </td>
   </tr>
@@ -109,7 +109,7 @@ Required vars: activitySet
            crm-options="activityTypeOptions"
            crm-var="newActivity"
            crm-on-add="addActivity(activitySet, newActivity)"
-           placeholder="{{ts('Add activity')}}"
+           placeholder="{{:: ts('Add activity') }}"
       ></span>
     </td>
   </tr>

--- a/ang/crmCxn/AdvTable.html
+++ b/ang/crmCxn/AdvTable.html
@@ -1,8 +1,8 @@
 <table>
   <thead>
   <tr>
-    <th>{{ts('Property')}}</th>
-    <th>{{ts('Value')}}</th>
+    <th>{{:: ts('Property') }}</th>
+    <th>{{:: ts('Value') }}</th>
   </tr>
   </thead>
   <tbody>

--- a/ang/crmCxn/ConfirmReconnectCtrl.html
+++ b/ang/crmCxn/ConfirmReconnectCtrl.html
@@ -1,13 +1,13 @@
 <div ng-controller="CrmCxnConfirmReconnectCtrl">
   <p>{{ts('Are you sure you want to reconnect \"%1\"?', {1: appMeta.title})}}</p>
 
-  <p>{{ts('Reconnecting will change the connection details (such as callback URLs and permissions). This can be useful in a few cases, such as:')}}</p>
+  <p>{{:: ts('Reconnecting will change the connection details (such as callback URLs and permissions). This can be useful in a few cases, such as:') }}</p>
 
   <ul>
-    <li>{{ts('After your site has migrated to a new URL.')}}</li>
-    <li>{{ts('After the application has migrated to a new URL.')}}</li>
-    <li>{{ts('After the application has changed permission requirements.')}}</li>
-    <li>{{ts('After the application has a major failure or reset.')}}</li>
+    <li>{{:: ts('After your site has migrated to a new URL.') }}</li>
+    <li>{{:: ts('After the application has migrated to a new URL.') }}</li>
+    <li>{{:: ts('After the application has changed permission requirements.') }}</li>
+    <li>{{:: ts('After the application has a major failure or reset.') }}</li>
   </ul>
 
   <div crm-ui-accordion="{title: ts('Permissions: Summary'), collapsed: true}">

--- a/ang/crmCxn/Connectivity.html
+++ b/ang/crmCxn/Connectivity.html
@@ -1,4 +1,4 @@
-<p>{{ts('There was a problem verifying that this site is available on the public Internet.')}}</p>
-<p>{{ts('See also:')}}
-  <a href="https://civicrm.org/inapp/civiconnect-firewall" target="_blank">{{ts('Firewalls and Proxies')}}</a>
+<p>{{:: ts('There was a problem verifying that this site is available on the public Internet.') }}</p>
+<p>{{:: ts('See also:') }}
+  <a href="https://civicrm.org/inapp/civiconnect-firewall" target="_blank">{{:: ts('Firewalls and Proxies') }}</a>
 </p>

--- a/ang/crmCxn/ManageCtrl.html
+++ b/ang/crmCxn/ManageCtrl.html
@@ -10,18 +10,18 @@
 -->
 
 <div class="help">
-  <p>{{ts('Connections provide a simplified way to link your CiviCRM installation to an external service.')}}</p>
+  <p>{{:: ts('Connections provide a simplified way to link your CiviCRM installation to an external service.') }}</p>
 </div>
 
 <div ng-show="cxns.length > 0">
   <span crm-ui-order="{var: 'cxnOrder', defaults: ['-created_date']}"></span>
-  <h3>{{ts('Existing Connections')}}</h3>
+  <h3>{{:: ts('Existing Connections') }}</h3>
   <table class="display">
     <thead>
     <tr>
-      <th>{{ts('Title')}}</th> <!-- <a crm-ui-order-by="[cxnOrder, 'app_meta.appId']"> -->
-      <th>{{ts('Description')}}</th> <!-- <a crm-ui-order-by="[cxnOrder, 'desc']"> -->
-      <th>{{ts('Status')}}</th>
+      <th>{{:: ts('Title') }}</th> <!-- <a crm-ui-order-by="[cxnOrder, 'app_meta.appId']"> -->
+      <th>{{:: ts('Description') }}</th> <!-- <a crm-ui-order-by="[cxnOrder, 'desc']"> -->
+      <th>{{:: ts('Status') }}</th>
       <th></th>
     </tr>
     </thead>
@@ -36,22 +36,22 @@
       <td>{{cxn.is_active=="1" ? ts('Enabled') : ts('Disabled')}}</td>
       <td>
         <span>
-            <a class="action-item crm-hover-button" ng-click="openLink(cxn.app_meta, 'settings', {title: ts('%1: Settings (External)', {1: cxn.app_meta.title})})" ng-show="cxn.app_meta.links.settings">{{ts('Settings')}}</a>
-            <span class="btn-slide crm-hover-button">{{ts('more')}}
+            <a class="action-item crm-hover-button" ng-click="openLink(cxn.app_meta, 'settings', {title: ts('%1: Settings (External)', {1: cxn.app_meta.title})})" ng-show="cxn.app_meta.links.settings">{{:: ts('Settings') }}</a>
+            <span class="btn-slide crm-hover-button">{{:: ts('more') }}
               <ul class="panel" style="display: none;">
                 <li ng-show="cxn.app_meta.links.logs">
                   <a class="action-item crm-hover-button" ng-click="openLink(cxn.app_meta, 'logs', {title: ts('%1: Logs (External)', {1: cxn.app_meta.title})})">
-                    {{ts('Logs')}}
+                    {{:: ts('Logs') }}
                   </a>
                 </li>
                 <li ng-show="cxn.app_meta.links.docs">
                   <a class="action-item crm-hover-button" ng-click="openLink(cxn.app_meta, 'docs', {title: ts('%1: Documentation (External)', {1: cxn.app_meta.title})})">
-                    {{ts('Docs')}}
+                    {{:: ts('Docs') }}
                   </a>
                 </li>
                 <li ng-show="cxn.app_meta.links.support">
                   <a class="action-item crm-hover-button" ng-click="openLink(cxn.app_meta, 'support', {title: ts('%1: Support (External)', {1: cxn.app_meta.title})})">
-                    {{ts('Support')}}
+                    {{:: ts('Support') }}
                   </a>
                 </li>
                 <li>
@@ -61,13 +61,13 @@
                   <a class="action-item crm-hover-button"
                      crm-confirm='{width: "65%", resizable: true, title:ts("%1: Reconnect", {1: cxn.app_meta.title}), templateUrl: "~/crmCxn/ConfirmReconnectCtrl.html", export: {cxn: cxn, appMeta: findAppByAppId(cxn.app_guid)}}'
                      on-yes="reregister(cxn.app_meta)"
-                      >{{ts('Reconnect')}}</a>
+                      >{{:: ts('Reconnect') }}</a>
                 </li>
                 <li>
                   <a class="action-item crm-hover-button"
                      crm-confirm='{width: "65%", resizable: true, title: ts("%1: Disconnect", {1: cxn.app_meta.title}), message: ts("Are you sure you want to disconnect \"%1?\". Doing so may permanently destroy data linkage.", {1: cxn.app_meta.title})}'
                      on-yes="unregister(cxn.app_meta)">
-                    {{ts('Disconnect')}}
+                    {{:: ts('Disconnect') }}
                   </a>
                 </li>
               </ul>
@@ -85,12 +85,12 @@
   <span crm-ui-order="{var: 'availOrder', defaults: ['title']}"></span>
 
 <div class="crm-content-block crm-block crm-connection-block">
-  <h3>{{ts('New Connections')}}</h3>
+  <h3>{{:: ts('New Connections') }}</h3>
   <table class="display">
     <thead>
     <tr>
-      <th><a crm-ui-order-by="[availOrder, 'title']">{{ts('Title')}}</a></th>
-      <th><a crm-ui-order-by="[availOrder, 'desc']">{{ts('Description')}}</a></th>
+      <th><a crm-ui-order-by="[availOrder, 'title']">{{:: ts('Title') }}</a></th>
+      <th><a crm-ui-order-by="[availOrder, 'desc']">{{:: ts('Description') }}</a></th>
       <th></th>
     </tr>
     </thead>
@@ -105,7 +105,7 @@
         <a class="action-item crm-hover-button"
            crm-confirm='{width: "65%", resizable: true, title:ts("%1: Connect", {1: appMeta.title}), templateUrl: "~/crmCxn/ConfirmConnectCtrl.html", export: {appMeta: appMeta}}'
            on-yes="register(appMeta)"
-          >{{ts('Connect')}}</a>
+          >{{:: ts('Connect') }}</a>
       </td>
     </tr>
     </tbody>
@@ -116,5 +116,5 @@
 
 <div ng-show="appMetas.length === 0" class="messages status no-popup">
   <i class="crm-i fa-info-circle"></i>
-  {{ts('No available applications')}}
+  {{:: ts('No available applications') }}
 </div>

--- a/ang/crmCxn/PermTable.html
+++ b/ang/crmCxn/PermTable.html
@@ -1,10 +1,10 @@
 <table>
   <thead>
   <tr>
-    <th>{{ts('Entity')}}</th>
-    <th>{{ts('Action(s)')}}</th>
-    <th>{{ts('Filter(s)')}}</th>
-    <th>{{ts('Field(s)')}}</th>
+    <th>{{:: ts('Entity') }}</th>
+    <th>{{:: ts('Action(s)') }}</th>
+    <th>{{:: ts('Filter(s)') }}</th>
+    <th>{{:: ts('Field(s)') }}</th>
   </tr>
   </thead>
   <tbody>
@@ -12,13 +12,13 @@
       ng-class-even="'even-row even'"
       ng-class-odd="'odd-row odd'">
     <td>
-      <em ng-show="api.entity == '*'">{{ts('Any')}}</em>
+      <em ng-show="api.entity == '*'">{{:: ts('Any') }}</em>
       <code ng-hide="api.entity == '*'">{{api.entity}}</code>
     </td>
     <td>
       <div ng-switch="isString(api.actions)">
           <span ng-switch-when="true">
-            <em ng-show="api.actions == '*'">{{ts('Any')}}</em>
+            <em ng-show="api.actions == '*'">{{:: ts('Any') }}</em>
             <code ng-hide="api.actions == '*'">{{api.actions}}</code>
           </span>
           <span ng-switch-default="">
@@ -27,11 +27,11 @@
       </div>
     </td>
     <td>
-      <em ng-show="!hasRequiredFilters(api)">{{ts('Any')}}</em>
+      <em ng-show="!hasRequiredFilters(api)">{{:: ts('Any') }}</em>
       <div ng-repeat="(field,value) in api.required"><code>{{field}}</code> = "<code>{{value}}</code>"<span ng-show="!$last">, </span></div>
     </td>
     <td>
-      <em ng-show="api.fields == '*'">{{ts('Any')}}</em>
+      <em ng-show="api.fields == '*'">{{:: ts('Any') }}</em>
       <span ng-hide="api.fields == '*'" ng-repeat="field in api.fields"><code>{{field}}</code><span ng-show="!$last">, </span></span>
     </td>
   </tr>

--- a/ang/crmExample/example.html
+++ b/ang/crmExample/example.html
@@ -21,11 +21,11 @@
           <div class="crmMailing-schedule-inner">
             <div>
               <input ng-model="schedule.mode" type="radio" name="send_{{exName}}" value="now" id="schedule-send-now">
-              <label for="schedule-send-now">{{ts('Send immediately')}}</label>
+              <label for="schedule-send-now">{{:: ts('Send immediately') }}</label>
             </div>
             <div>
               <input ng-model="schedule.mode" type="radio" name="send_{{exName}}" value="at" id="schedule-send-at">
-              <label for="schedule-send-at">{{ts('Send at:')}}</label>
+              <label for="schedule-send-at">{{:: ts('Send at:') }}</label>
               <input crm-ui-datepicker ng-model="schedule.datetime" ng-required="schedule.mode == 'at'">
             </div>
           </div>

--- a/ang/crmMailing/BlockPreview.html
+++ b/ang/crmMailing/BlockPreview.html
@@ -8,23 +8,23 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
   -->
   <div class="preview-popup">
     <div ng-show="!mailing.body_html && !mailing.body_text">
-      <em>({{ts('No content to preview')}})</em>
+      <em>({{:: ts('No content to preview') }})</em>
     </div>
     <div ng-hide="!mailing.body_html">
-      <a class="crm-hover-button action-item" crm-icon="fa-television" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{ts('Preview as HTML')}}</a>
+      <a class="crm-hover-button action-item" crm-icon="fa-television" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</a>
     </div>
     <div ng-hide="!mailing.body_html && !mailing.body_text" style="margin-top: 1em;">
-      <a class="crm-hover-button action-item" crm-icon="fa-file-text-o" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{ts('Preview as Plain Text')}}</a>
+      <a class="crm-hover-button action-item" crm-icon="fa-file-text-o" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</a>
     </div>
     <!--
     <div ng-hide="!mailing.body_html && !mailing.body_text">
-      <button ng-disabled="crmMailing.$invalid" ng-click="doPreview('full')">{{ts('Preview')}}</button>
+      <button ng-disabled="crmMailing.$invalid" ng-click="doPreview('full')">{{:: ts('Preview') }}</button>
     </div>
     -->
   </div>
   <div class="preview-contact" ng-form="">
     <div>
-      {{ts('Send test email to:')}}
+      {{:: ts('Send test email to:') }}
       <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a>
     </div>
     <div>
@@ -37,11 +37,11 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
         crm-multiple-email
       />
     </div>
-    <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})" class="crmMailing-btn-primary">{{ts('Send test')}}</button>
+    <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})" class="crmMailing-btn-primary">{{:: ts('Send test') }}</button>
   </div>
   <div class="preview-group" ng-form="">
     <div>
-      {{ts('Send test email to group:')}}
+      {{:: ts('Send test email to group:') }}
       <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a>
     </div>
     <div>
@@ -51,7 +51,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
         class="crm-action-menu fa-envelope-o"
         />
     </div>
-    <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}" on-yes="doSend({gid: testGroup.gid})" class="crmMailing-btn-primary">{{ts('Send test')}}</button>
+    <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}" on-yes="doSend({gid: testGroup.gid})" class="crmMailing-btn-primary">{{:: ts('Send test') }}</button>
   </div>
   <div class="clear"></div>
 </div>

--- a/ang/crmMailing/BlockRecipients.html
+++ b/ang/crmMailing/BlockRecipients.html
@@ -7,9 +7,9 @@
     crm-ui-id="{{crmMailingBlockRecipients.id}}"
     name="{{crmMailingBlockRecipients.name}}"
     ng-required="true" />
-    <a crm-icon="fa-wrench" ng-click="editOptions(mailing)" class="crm-hover-button" title="{{ts('Edit Recipient Options')}}"></a>
+    <a crm-icon="fa-wrench" ng-click="editOptions(mailing)" class="crm-hover-button" title="{{:: ts('Edit Recipient Options') }}"></a>
     <div ng-style="{display: permitRecipientRebuild ? '' : 'inline-block'}">
-      <button ng-click="rebuildRecipients()" ng-show="permitRecipientRebuild" class="crm-button" title="{{ts('Click to refresh recipient count')}}">{{getRecipientsEstimate()}}</button>
-      <a ng-click="previewRecipients()" class="crm-hover-button" title="{{ts('Preview a List of Recipients')}}" style="font-weight: bold;">{{getRecipientCount()}}</a>
+      <button ng-click="rebuildRecipients()" ng-show="permitRecipientRebuild" class="crm-button" title="{{:: ts('Click to refresh recipient count') }}">{{getRecipientsEstimate()}}</button>
+      <a ng-click="previewRecipients()" class="crm-hover-button" title="{{:: ts('Preview a List of Recipients') }}" style="font-weight: bold;">{{getRecipientCount()}}</a>
     </div>
 </div>

--- a/ang/crmMailing/BlockReview.html
+++ b/ang/crmMailing/BlockReview.html
@@ -13,17 +13,17 @@ Required vars: mailing, attachments
           <div ng-controller="EditRecipCtrl">
             <div><a crm-icon="fa-users" class="crm-hover-button action-item" ng-click="previewRecipients()">{{getRecipientCount()}}</a></div>
             <div ng-show="getIncludesAsString(mailing)">
-              (<strong>{{ts('Include:')}}</strong> {{getIncludesAsString(mailing)}})
+              (<strong>{{:: ts('Include:') }}</strong> {{getIncludesAsString(mailing)}})
             </div>
             <div ng-show="getExcludesAsString(mailing)">
-              (<strong>{{ts('Exclude:')}}</strong> <s>{{getExcludesAsString(mailing)}}</s>)
+              (<strong>{{:: ts('Exclude:') }}</strong> <s>{{getExcludesAsString(mailing)}}</s>)
             </div>
           </div>
         </div>
       </div>
       <div crm-ui-field="{title: ts('Content')}">
-        <span ng-show="mailing.body_html"><a crm-icon="fa-television" class="crm-hover-button action-item" ng-click="previewMailing(mailing, 'html')">{{ts('HTML')}}</a></span>
-        <span ng-show="mailing.body_html || mailing.body_text"><a crm-icon="fa-file-text-o" class="crm-hover-button action-item" ng-click="previewMailing(mailing, 'text')">{{ts('Plain Text')}}</a></span>
+        <span ng-show="mailing.body_html"><a crm-icon="fa-television" class="crm-hover-button action-item" ng-click="previewMailing(mailing, 'html')">{{:: ts('HTML') }}</a></span>
+        <span ng-show="mailing.body_html || mailing.body_text"><a crm-icon="fa-file-text-o" class="crm-hover-button action-item" ng-click="previewMailing(mailing, 'text')">{{:: ts('Plain Text') }}</a></span>
       </div>
       <div crm-ui-field="{title: ts('Attachments')}">
         <div ng-repeat="file in attachments.files">
@@ -32,7 +32,7 @@ Required vars: mailing, attachments
         <div ng-repeat="item in attachments.uploader.queue">
           {{item.file.name}}
         </div>
-        <div ng-show="!attachments.files.length && !attachments.uploader.queue.length"><em>{{ts('None')}}</em></div>
+        <div ng-show="!attachments.files.length && !attachments.uploader.queue.length"><em>{{:: ts('None') }}</em></div>
       </div>
       <div ng-if="crmMailingConst.isMultiLingual" crm-ui-field="{title: ts('Language')}">
         {{crmMailingConst.enabledLanguages[mailing.language]}}
@@ -47,10 +47,10 @@ Required vars: mailing, attachments
           <span crm-mailing-review-bool crm-on="mailing.override_verp=='0' && mailing.forward_replies=='1'" crm-title="ts('Forward Replies')"></span>
         </div>
         <div ng-controller="PreviewComponentCtrl">
-          <span ng-show="mailing.override_verp == '0' && mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), mailing.reply_id)">{{ts('Auto-Respond')}}</a></span>
-          <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Opt-out'), mailing.optout_id)">{{ts('Opt-out')}}</a></span>
-          <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Resubscribe'), mailing.resubscribe_id)">{{ts('Resubscribe')}}</a></span>
-          <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Unsubscribe'), mailing.unsubscribe_id)">{{ts('Unsubscribe')}}</a></span>
+          <span ng-show="mailing.override_verp == '0' && mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), mailing.reply_id)">{{:: ts('Auto-Respond') }}</a></span>
+          <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Opt-out'), mailing.optout_id)">{{:: ts('Opt-out') }}</a></span>
+          <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Resubscribe'), mailing.resubscribe_id)">{{:: ts('Resubscribe') }}</a></span>
+          <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Unsubscribe'), mailing.unsubscribe_id)">{{:: ts('Unsubscribe') }}</a></span>
         </div>
       </div>
       <div crm-ui-field="{title: ts('Publication')}">

--- a/ang/crmMailing/BlockSchedule.html
+++ b/ang/crmMailing/BlockSchedule.html
@@ -2,11 +2,11 @@
   <div class="crmMailing-schedule-inner">
     <div>
       <input ng-model="schedule.mode" type="radio" name="send" value="now" id="schedule-send-now"/>
-      <label for="schedule-send-now">{{ts('Send immediately')}}</label>
+      <label for="schedule-send-now">{{:: ts('Send immediately') }}</label>
     </div>
     <div>
       <input ng-model="schedule.mode" type="radio" name="send" value="at" id="schedule-send-at"/>
-      <label for="schedule-send-at">{{ts('Send at:')}}</label>
+      <label for="schedule-send-at">{{:: ts('Send at:') }}</label>
       <input crm-ui-datepicker ng-model="schedule.datetime" ng-required="schedule.mode == 'at'"/>
     </div>
   </div>

--- a/ang/crmMailing/BlockTemplates.html
+++ b/ang/crmMailing/BlockTemplates.html
@@ -1,9 +1,9 @@
 <div ng-controller="MsgTemplateCtrl" class="crm-mailing-templates-row">
-    <input 
+    <input
       type="hidden"
       crm-mailing-templates
       ng-model="mailing.msg_template_id"
       crm-ui-id="{{crmMailingBlockTemplates.id}}"
       name="{{crmMailingBlockTemplates.name}}" />
-  <a crm-icon="fa-floppy-o" ng-if="checkPerm('edit message templates')" ng-click="saveTemplate(mailing)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+  <a crm-icon="fa-floppy-o" ng-if="checkPerm('edit message templates')" ng-click="saveTemplate(mailing)" class="crm-hover-button" title="{{:: ts('Save As') }}"></a>
 </div>

--- a/ang/crmMailing/BodyHtml.html
+++ b/ang/crmMailing/BodyHtml.html
@@ -19,7 +19,7 @@ Required vars: mailing
         ></textarea>
       <span ng-model="body_html_tokens" crm-ui-validate="hasAllTokens(mailing, 'body_html')"></span>
       <div ng-show="htmlForm.$error.crmUiValidate" class="crmMailing-error-link">
-        {{ts('Required tokens are missing.')}} <a class="helpicon" ng-click="checkTokens(mailing, 'body_html', 'insert:body_html')"></a>
+        {{:: ts('Required tokens are missing.') }} <a class="helpicon" ng-click="checkTokens(mailing, 'body_html', 'insert:body_html')"></a>
       </div>
     </div>
   </div>

--- a/ang/crmMailing/BodyText.html
+++ b/ang/crmMailing/BodyText.html
@@ -17,7 +17,7 @@ Required vars: mailing, crmMailingConst
         ></textarea>
       <span ng-model="body_text_tokens" crm-ui-validate="hasAllTokens(mailing, 'body_text')"></span>
       <div ng-show="textForm.$error.crmUiValidate" class="crmMailing-error-link">
-        {{ts('Required tokens are missing.')}} <a class="helpicon" ng-click="checkTokens(mailing, 'body_text', 'insert:body_text')"></a>
+        {{:: ts('Required tokens are missing.') }} <a class="helpicon" ng-click="checkTokens(mailing, 'body_text', 'insert:body_text')"></a>
       </div>
     </div>
   </div>

--- a/ang/crmMailing/EditMailingCtrl/2step.html
+++ b/ang/crmMailing/EditMailingCtrl/2step.html
@@ -43,7 +43,7 @@
         </div>
         <center>
           <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{ts('Submit Mailing')}}</div>
+            <div>{{:: ts('Submit Mailing') }}</div>
           </a>
         </center>
       </div>
@@ -55,8 +55,8 @@
           class="crmMailing-btn-danger-outline"
           ng-disabled="block.check()"
           crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
-          on-yes="delete()">{{ts('Delete Draft')}}</button>
-        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave)" class="crmMailing-btn-secondary-outline">{{ts('Save Draft')}}</button>
+          on-yes="delete()">{{:: ts('Delete Draft') }}</button>
+        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave)" class="crmMailing-btn-secondary-outline">{{:: ts('Save Draft') }}</button>
       </span>
     </div>
   </div>

--- a/ang/crmMailing/EditMailingCtrl/base.html
+++ b/ang/crmMailing/EditMailingCtrl/base.html
@@ -1,7 +1,7 @@
 <div crm-ui-debug="mailing"></div>
 
 <div ng-show="isSubmitted()">
-  {{ts('This mailing has been submitted.')}}
+  {{:: ts('This mailing has been submitted.') }}
 </div>
 
 <form name="crmMailing" novalidate ng-hide="isSubmitted()" ng-include="mailingEditorUrl">

--- a/ang/crmMailing/EditMailingCtrl/unified.html
+++ b/ang/crmMailing/EditMailingCtrl/unified.html
@@ -37,14 +37,14 @@
       <div crm-mailing-block-schedule crm-mailing="mailing"></div>
     </div>
 
-    <button crm-icon="fa-paper-plane" class="crmMailing-btn-primary" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>
-    <button crm-icon="fa-floppy-o" class="crmMailing-btn-secondary-outline" ng-disabled="block.check()" ng-click="save().then(leave)">{{ts('Save Draft')}}</button>
+    <button crm-icon="fa-paper-plane" class="crmMailing-btn-primary" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{:: ts('Submit Mailing') }}</button>
+    <button crm-icon="fa-floppy-o" class="crmMailing-btn-secondary-outline" ng-disabled="block.check()" ng-click="save().then(leave)">{{:: ts('Save Draft') }}</button>
     <button
       crm-icon="fa-trash"
       ng-show="checkPerm('delete in CiviMail')"
       class="crmMailing-btn-danger-outline"
       ng-disabled="block.check()"
       crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
-      on-yes="delete()">{{ts('Delete Draft')}}</button>
+      on-yes="delete()">{{:: ts('Delete Draft') }}</button>
   </div>
 </div>

--- a/ang/crmMailing/EditMailingCtrl/unified2.html
+++ b/ang/crmMailing/EditMailingCtrl/unified2.html
@@ -33,14 +33,14 @@
       <div crm-mailing-block-schedule crm-mailing="mailing"></div>
     </div>
 
-    <button crm-icon="fa-paper-plane" class="crmMailing-btn-primary" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>
-    <button crm-icon="fa-floppy-o" class="crmMailing-secondary-outline" ng-disabled="block.check()" ng-click="save().then(leave)">{{ts('Save Draft')}}</button>
+    <button crm-icon="fa-paper-plane" class="crmMailing-btn-primary" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{:: ts('Submit Mailing') }}</button>
+    <button crm-icon="fa-floppy-o" class="crmMailing-secondary-outline" ng-disabled="block.check()" ng-click="save().then(leave)">{{:: ts('Save Draft') }}</button>
     <button
       crm-icon="fa-trash"
       ng-show="checkPerm('delete in CiviMail')"
       class="crmMailing-btn-danger-outline"
       ng-disabled="block.check()"
       crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
-      on-yes="delete()">{{ts('Delete Draft')}}</button>
+      on-yes="delete()">{{:: ts('Delete Draft') }}</button>
   </div>
 </div>

--- a/ang/crmMailing/EditMailingCtrl/wizard.html
+++ b/ang/crmMailing/EditMailingCtrl/wizard.html
@@ -46,7 +46,7 @@
         </div>
         <center>
           <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{ts('Submit Mailing')}}</div>
+            <div>{{:: ts('Submit Mailing') }}</div>
           </a>
         </center>
       </div>
@@ -58,8 +58,8 @@
           class="crmMailing-btn-danger-outline"
           ng-disabled="block.check()"
           crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
-          on-yes="delete()">{{ts('Delete Draft')}}</button>
-        <button crm-icon="fa-floppy-o" class="crmMailing-btn-secondary-outline" ng-disabled="block.check()" ng-click="save().then(leave)">{{ts('Save Draft')}}</button>
+          on-yes="delete()">{{:: ts('Delete Draft') }}</button>
+        <button crm-icon="fa-floppy-o" class="crmMailing-btn-secondary-outline" ng-disabled="block.check()" ng-click="save().then(leave)">{{:: ts('Save Draft') }}</button>
       </span>
     </div>
   </div>

--- a/ang/crmMailing/EditMailingCtrl/workflow.html
+++ b/ang/crmMailing/EditMailingCtrl/workflow.html
@@ -48,12 +48,12 @@
         </div>
         <center ng-if="!checkPerm('approve mailings') && !checkPerm('access CiviMail')">
           <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{ts('Submit Mailing')}}</div>
+            <div>{{:: ts('Submit Mailing') }}</div>
           </a>
         </center>
         <center ng-if="checkPerm('approve mailings') || checkPerm('access CiviMail')">
           <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="approve('Approved')" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{ts('Submit and Approve Mailing')}}</div>
+            <div>{{:: ts('Submit and Approve Mailing') }}</div>
           </a>
         </center>
       </div>
@@ -65,8 +65,8 @@
           class="crmMailing-btn-danger-outline"
           ng-disabled="block.check()"
           crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
-          on-yes="delete()">{{ts('Delete Draft')}}</button>
-        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave)" class="crmMailing-btn-secondary-outline">{{ts('Save Draft')}}</button>
+          on-yes="delete()">{{:: ts('Delete Draft') }}</button>
+        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave)" class="crmMailing-btn-secondary-outline">{{:: ts('Save Draft') }}</button>
       </span>
     </div>
   </div>

--- a/ang/crmMailing/EditRecipOptionsDialogCtrl.html
+++ b/ang/crmMailing/EditRecipOptionsDialogCtrl.html
@@ -18,7 +18,7 @@
           name="location_type_id"
           ng-model="model.mailing.location_type_id"
           >
-          <option value="">{{ts('Automatic')}}</option>
+          <option value="">{{:: ts('Automatic') }}</option>
           <option ng-repeat="locType in model.fields.location_type_id.options"
                   ng-value="locType.key">{{locType.value}}</option>
         </select>

--- a/ang/crmMailing/EmailBodyCtrl/tokenAlert.html
+++ b/ang/crmMailing/EmailBodyCtrl/tokenAlert.html
@@ -4,38 +4,38 @@
 </p>
 
 <div ng-show="missing['domain.address'] && insertable">
-  <a ng-click="insertToken('domain.address')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('Address')}}</span></a>
+  <a ng-click="insertToken('domain.address')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{:: ts('Address') }}</span></a>
 
   <div class="clear"></div>
 </div>
 
 <p ng-show="missing['action.optOut']">
-  {{ts('The mailing must allow recipients to (a) unsubscribe from the mailing-list or (b) completely opt-out from all mailings. Please insert an unsubscribe or opt-out token.')}}
+  {{:: ts('The mailing must allow recipients to (a) unsubscribe from the mailing-list or (b) completely opt-out from all mailings. Please insert an unsubscribe or opt-out token.') }}
 </p>
 
 <div ng-show="missing['action.optOut'] && insertable">
   <table>
     <thead>
     <tr>
-      <th>{{ts('Via Web')}}</th>
-      <th>{{ts('Via Email')}}</th>
+      <th>{{:: ts('Via Web') }}</th>
+      <th>{{:: ts('Via Email') }}</th>
     </tr>
     </thead>
     <tbody>
     <tr>
       <td>
-        <a ng-click="insertToken('action.unsubscribeUrl')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('Unsubscribe')}}</span></a>
+        <a ng-click="insertToken('action.unsubscribeUrl')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{:: ts('Unsubscribe') }}</span></a>
       </td>
       <td>
-        <a ng-click="insertToken('action.unsubscribe')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('Unsubscribe')}}</span></a>
+        <a ng-click="insertToken('action.unsubscribe')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{:: ts('Unsubscribe') }}</span></a>
       </td>
     </tr>
     <tr>
       <td>
-        <a ng-click="insertToken('action.optOutUrl')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('Opt-out')}}</span></a>
+        <a ng-click="insertToken('action.optOutUrl')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{:: ts('Opt-out') }}</span></a>
       </td>
       <td>
-        <a ng-click="insertToken('action.optOut')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('Opt-out')}}</span></a>
+        <a ng-click="insertToken('action.optOut')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{:: ts('Opt-out') }}</span></a>
       </td>
     </tr>
     </tbody>
@@ -46,8 +46,8 @@
   <table>
     <thead>
     <tr>
-      <th>{{ts('Via Web')}}</th>
-      <th>{{ts('Via Email')}}</th>
+      <th>{{:: ts('Via Web') }}</th>
+      <th>{{:: ts('Via Email') }}</th>
     </tr>
     </thead>
     <tbody>
@@ -72,5 +72,5 @@
 </div>
 
 <p>
-  {{ts('Alternatively, you may select a header or footer which includes the required tokens.')}}
+  {{:: ts('Alternatively, you may select a header or footer which includes the required tokens.') }}
 </p>

--- a/ang/crmMailing/PreviewComponentDialogCtrl.html
+++ b/ang/crmMailing/PreviewComponentDialogCtrl.html
@@ -2,14 +2,14 @@
   <div class="crm-block">
     <div class="crm-group">
       <div class="crm-section" ng-show="model.name">
-        <div class="label">{{ts('Name')}}</div>
+        <div class="label">{{:: ts('Name') }}</div>
         <div class="content">
           {{model.name}}
         </div>
         <div class="clear"></div>
       </div>
       <div class="crm-section" ng-show="model.subject">
-        <div class="label">{{ts('Subject')}}</div>
+        <div class="label">{{:: ts('Subject') }}</div>
         <div class="content">
           {{model.subject}}
         </div>

--- a/ang/crmMailing/PreviewRecipCtrl.html
+++ b/ang/crmMailing/PreviewRecipCtrl.html
@@ -9,17 +9,17 @@
 
     <p ng-show="model.sample.length == model.sampleLimit">{{ts('Below is a sample of the first %1 recipients.', {1: model.sampleLimit})}}</p>
 
-    <p>{{ts('If individual contacts are separately modified, added, or removed, then the final list may change.')}}</p>
+    <p>{{:: ts('If individual contacts are separately modified, added, or removed, then the final list may change.') }}</p>
   </div>
 
   <div ng-show="model.sample == 0">
-    {{ts('No recipients')}}
+    {{:: ts('No recipients') }}
   </div>
   <table ng-show="model.sample.length > 0">
     <thead>
       <tr>
-        <th>{{ts('Name')}}</th>
-        <th>{{ts('Email')}}</th>
+        <th>{{:: ts('Name') }}</th>
+        <th>{{:: ts('Email') }}</th>
       </tr>
     </thead>
     <tbody>

--- a/ang/crmMailing/SaveMsgTemplateDialogCtrl.html
+++ b/ang/crmMailing/SaveMsgTemplateDialogCtrl.html
@@ -1,5 +1,5 @@
 <div ng-controller="SaveMsgTemplateDialogCtrl">
-  <p><em>{{ts('Save the current mailing as a template.')}}</em></p>
+  <p><em>{{:: ts('Save the current mailing as a template.') }}</em></p>
 
   <div ng-hide="!selected">
     <label for="saveopt-mode-update">
@@ -10,7 +10,7 @@
   <div>
     <label type="radio" for="saveopt-mode-add">
       <input type="radio" name="mode" ng-model="saveOpt.mode" value="add" id="saveopt-mode-add">
-      {{ts('Save as:')}}
+      {{:: ts('Save as:') }}
     </label>
     <input type="text" ng-model="saveOpt.newTitle" ng-click="saveOpt.mode='add'" ng-change="saveOpt.mode='add'" />
   </div>

--- a/ang/crmMailingAB/BlockMailing.html
+++ b/ang/crmMailingAB/BlockMailing.html
@@ -28,7 +28,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
             <option value=""></option>
             <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
           </select>
-          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{:: ts('Save As') }}"></a>
         </div>
       </div>
       <div crm-ui-field="{name: 'subform.msg_template_idA', title: ts('Template (A)')}" ng-if="fields.msg_template_idA">
@@ -44,7 +44,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
             <option value=""></option>
             <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
           </select>
-          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{:: ts('Save As') }}"></a>
         </div>
       </div>
       <div crm-ui-field="{name: 'subform.msg_template_idB', title: ts('Template (B)')}" ng-if="fields.msg_template_idB">
@@ -60,7 +60,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
             <option value=""></option>
             <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
           </select>
-          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.b)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+          <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.b)" class="crm-hover-button" title="{{:: ts('Save As') }}"></a>
         </div>
       </div>
     </div>

--- a/ang/crmMailingAB/BlockSetup.html
+++ b/ang/crmMailingAB/BlockSetup.html
@@ -1,7 +1,7 @@
 <div class="crm-block" ng-form="setupForm" crm-ui-id-scope>
   <div class="crm-group">
     <div class="help" ng-if="fields.help">
-      {{ts('A/B testing allows you to send two test mailings to a random subset of your recipients. After collecting and comparing metrics, the more successful mailing will be sent to the remaining recipients.')}}
+      {{:: ts('A/B testing allows you to send two test mailings to a random subset of your recipients. After collecting and comparing metrics, the more successful mailing will be sent to the remaining recipients.') }}
     </div>
     <div crm-ui-field="{name: 'setupForm.abName', title: ts('Name'), help: hs('name')}" ng-if="fields.abName">
       <input type="text"
@@ -41,11 +41,11 @@
       <div crm-mailing-radio-date="schedule" ng-model="abtest.mailings.a.scheduled_date">
           <div>
             <input ng-model="schedule.mode" type="radio" name="send" value="now" id="schedule-send-now"/>
-            <label for="schedule-send-now">{{ts('Send A/B test immediately')}}</label>
+            <label for="schedule-send-now">{{:: ts('Send A/B test immediately') }}</label>
           </div>
           <div>
             <input ng-model="schedule.mode" type="radio" name="send" value="at" id="schedule-send-at"/>
-            <label for="schedule-send-at">{{ts('Send A/B test at:')}}</label>
+            <label for="schedule-send-at">{{:: ts('Send A/B test at:') }}</label>
             <input crm-ui-datepicker ng-model="schedule.datetime"/>
           </div>
       </div>
@@ -54,11 +54,11 @@
       <div crm-mailing-radio-date="assessSched" ng-model="abtest.ab.declare_winning_time">
         <div>
           <input ng-model="assessSched.mode" type="radio" name="assess" value="now" id="schedule-assess-now"/>
-          <label for="schedule-assess-now">{{ts('Assess A/B results on an on-going basis')}}</label>
+          <label for="schedule-assess-now">{{:: ts('Assess A/B results on an on-going basis') }}</label>
         </div>
         <div>
           <input ng-model="assessSched.mode" type="radio" name="assess" value="at" id="schedule-assess-at"/>
-          <label for="schedule-assess-at">{{ts('Assess A/B test at:')}}</label>
+          <label for="schedule-assess-at">{{:: ts('Assess A/B test at:') }}</label>
           <input crm-ui-datepicker ng-model="assessSched.datetime"/>
         </div>
       </div>

--- a/ang/crmMailingAB/EditCtrl/edit.html
+++ b/ang/crmMailingAB/EditCtrl/edit.html
@@ -159,7 +159,7 @@
           crm-abtest="abtest"></div>
         <center>
           <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingAB.$invalid}">
-            <div>{{ts('Submit Mailing')}}</div>
+            <div>{{:: ts('Submit Mailing') }}</div>
           </a>
         </center>
       </div>
@@ -169,9 +169,9 @@
           ng-show="checkPerm('delete in CiviMail')"
           ng-disabled="block.check()"
           crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
-          on-yes="delete()">{{ts('Delete Draft')}}
+          on-yes="delete()">{{:: ts('Delete Draft') }}
         </button>
-        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave) ">{{ts('Save Draft')}}</button>
+        <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave) ">{{:: ts('Save Draft') }}</button>
       </span>
     </div>
   </div>

--- a/ang/crmMailingAB/EditCtrl/report.html
+++ b/ang/crmMailingAB/EditCtrl/report.html
@@ -2,8 +2,8 @@
   Implicit Controller: CrmMailingABEditCtrl
 -->
 <div class="messages help">
-  <div class="msg-title crm-title">{{ts('A/B Test Results')}}: {{abtest.ab.name}}</div>
-  {{ts('This report displays the current results for your A/B test. You can return to this page to view the latest statistics by navigating to "Manage A/B Tests" and clicking "Results".')}}
+  <div class="msg-title crm-title">{{:: ts('A/B Test Results') }}: {{abtest.ab.name}}</div>
+  {{:: ts('This report displays the current results for your A/B test. You can return to this page to view the latest statistics by navigating to "Manage A/B Tests" and clicking "Results".') }}
 </div>
 <div ng-controller="CrmMailingABReportCtrl">
   <table class="crm-mailing-ab-table">
@@ -11,7 +11,7 @@
     <tr ng-show="abtest.ab.status == 'Testing'">
       <td></td>
       <td ng-repeat="am in getActiveMailings()">
-        <button crm-icon="fa-trophy" ng-click="selectWinner(am.name)">{{ts('Select as Final')}}</button>
+        <button crm-icon="fa-trophy" ng-click="selectWinner(am.name)">{{:: ts('Select as Final') }}</button>
       </td>
       <td></td>
     </tr>
@@ -19,36 +19,36 @@
 
     <thead>
     <tr>
-      <th>{{ts('Delivery')}}</th>
+      <th>{{:: ts('Delivery') }}</th>
       <th ng-repeat="am in getActiveMailings()" class="crm-mailing-ab-col">{{am.title}}</th>
-      <th ng-show="abtest.ab.status == 'Testing'">{{ts('Final')}}</th>
+      <th ng-show="abtest.ab.status == 'Testing'">{{:: ts('Final') }}</th>
     </tr>
     </thead>
 
     <tbody>
     <tr>
-      <td>{{ts('Status')}}</td>
+      <td>{{:: ts('Status') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <span ng-repeat="job in am.mailing.jobs" ng-hide="job.is_test == 1 || job.parent_id != null">{{job.status}}</span>
       </td>
-      <td ng-show="abtest.ab.status == 'Testing'">{{ts('Not selected')}}</td>
+      <td ng-show="abtest.ab.status == 'Testing'">{{:: ts('Not selected') }}</td>
     </tr>
     <tr>
-      <td>{{ts('Scheduled')}}</td>
+      <td>{{:: ts('Scheduled') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <div ng-repeat="job in am.mailing.jobs" ng-hide="job.is_test == 1 || job.parent_id != null">{{job.scheduled_date}}</div>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Started at')}}</td>
+      <td>{{:: ts('Started at') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <div ng-repeat="job in am.mailing.jobs" ng-hide="job.is_test == 1 || job.parent_id != null">{{job.start_date || ts('Not started')}}</div>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Completed at')}}</td>
+      <td>{{:: ts('Completed at') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <div ng-repeat="job in am.mailing.jobs" ng-hide="job.is_test == 1 || job.parent_id != null">{{job.end_date || ts('Not completed')}}</div>
       </td>
@@ -58,9 +58,9 @@
 
     <thead>
     <tr>
-      <th>{{ts('Performance')}}</th>
+      <th>{{:: ts('Performance') }}</th>
       <th ng-repeat="am in getActiveMailings()" class="crm-mailing-ab-col">{{am.title}}</th>
-      <th ng-show="abtest.ab.status == 'Testing'">{{ts('Final')}}</th>
+      <th ng-show="abtest.ab.status == 'Testing'">{{:: ts('Final') }}</th>
     </tr>
     </thead>
     <tbody>
@@ -92,63 +92,63 @@
 
     <thead>
     <tr>
-      <th>{{ts('Details')}}</th>
+      <th>{{:: ts('Details') }}</th>
       <th ng-repeat="am in getActiveMailings()" class="crm-mailing-ab-col">{{am.title}}</th>
-      <th ng-show="abtest.ab.status == 'Testing'">{{ts('Final')}}</th>
+      <th ng-show="abtest.ab.status == 'Testing'">{{:: ts('Final') }}</th>
     </tr>
     </thead>
 
     <tbody>
     <tr>
-      <td>{{ts('Mailing Name')}}</td>
+      <td>{{:: ts('Mailing Name') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         {{am.mailing.name}}
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('From')}}</td>
+      <td>{{:: ts('From') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         "{{am.mailing.from_name}}" &lt;{{am.mailing.from_email}}&gt;
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Subject')}}</td>
+      <td>{{:: ts('Subject') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         {{am.mailing.subject}}
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr ng-controller="ViewRecipCtrl">
-      <td>{{ts('Recipients')}}</td>
+      <td>{{:: ts('Recipients') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <div ng-show="getIncludesAsString(am.mailing)">
-          <strong>{{ts('Include:')}}</strong> {{getIncludesAsString(am.mailing)}}
+          <strong>{{:: ts('Include:') }}</strong> {{getIncludesAsString(am.mailing)}}
         </div>
         <div ng-show="getExcludesAsString(am.mailing)">
-          <strong>{{ts('Exclude:')}}</strong> <s>{{getExcludesAsString(am.mailing)}}</s>
+          <strong>{{:: ts('Exclude:') }}</strong> <s>{{getExcludesAsString(am.mailing)}}</s>
         </div>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Content')}}</td>
+      <td>{{:: ts('Content') }}</td>
       <td ng-repeat="am in getActiveMailings()">
-        <a crm-icon="fa-television" class="crm-hover-button action-item" ng-click="previewMailing(am.name,'html')" ng-show="am.mailing.body_html">{{ts('HTML')}}</a>
-        <a crm-icon="fa-file-text-o" class="crm-hover-button action-item" ng-click="previewMailing(am.name,'text')" ng-show="am.mailing.body_text">{{ts('Text')}}</a>
+        <a crm-icon="fa-television" class="crm-hover-button action-item" ng-click="previewMailing(am.name,'html')" ng-show="am.mailing.body_html">{{:: ts('HTML') }}</a>
+        <a crm-icon="fa-file-text-o" class="crm-hover-button action-item" ng-click="previewMailing(am.name,'text')" ng-show="am.mailing.body_text">{{:: ts('Text') }}</a>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Attachments')}}</td>
+      <td>{{:: ts('Attachments') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <div ng-repeat="file in am.attachments.files"><a ng-href="{{file.url}}" target="_blank">{{file.name}}</a></div>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Tracking')}}</td>
+      <td>{{:: ts('Tracking') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <div crm-mailing-review-bool crm-on="am.mailing.url_tracking=='1'" crm-title="ts('Click-Throughs')"></div>
         <div crm-mailing-review-bool crm-on="am.mailing.open_tracking=='1'" crm-title="ts('Opens')"></div>
@@ -156,21 +156,21 @@
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Responding')}}</td>
+      <td>{{:: ts('Responding') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         <div crm-mailing-review-bool crm-on="am.mailing.override_verp=='0'" crm-title="ts('Track Replies')"></div>
         <div crm-mailing-review-bool crm-on="am.mailing.override_verp=='0' && mailing.forward_replies=='1'" crm-title="ts('Forward Replies')"></div>
         <div ng-controller="PreviewComponentCtrl">
-          <div ng-show="am.mailing.override_verp == '0' && mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), am.mailing.reply_id)">{{ts('Auto-Respond')}}</a></div>
-          <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Opt-out'), am.mailing.optout_id)">{{ts('Opt-out')}}</a></div>
-          <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Resubscribe'), am.mailing.resubscribe_id)">{{ts('Resubscribe')}}</a></div>
-          <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Unsubscribe'), am.mailing.unsubscribe_id)">{{ts('Unsubscribe')}}</a></div>
+          <div ng-show="am.mailing.override_verp == '0' && mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), am.mailing.reply_id)">{{:: ts('Auto-Respond') }}</a></div>
+          <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Opt-out'), am.mailing.optout_id)">{{:: ts('Opt-out') }}</a></div>
+          <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Resubscribe'), am.mailing.resubscribe_id)">{{:: ts('Resubscribe') }}</a></div>
+          <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Unsubscribe'), am.mailing.unsubscribe_id)">{{:: ts('Unsubscribe') }}</a></div>
         </div>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
-      <td>{{ts('Publication')}}</td>
+      <td>{{:: ts('Publication') }}</td>
       <td ng-repeat="am in getActiveMailings()">
         {{am.mailing.visibility}}
       </td>

--- a/ang/crmMailingAB/ListCtrl.html
+++ b/ang/crmMailingAB/ListCtrl.html
@@ -8,17 +8,17 @@ Required vars: mailingABList
 <div crm-ui-accordion="{title: ts('Filter'), collapsed: true}">
   <form name="filterForm">
     <span>
-      <input class="big crm-form-text" ng-model="filter.name" placeholder="{{ts('Name')}}"/>
+      <input class="big crm-form-text" ng-model="filter.name" placeholder="{{:: ts('Name') }}"/>
     </span>
     <span>
       <select crm-ui-select style="width: 10em;" ng-model="filter.status">
-        <option value="">{{ts('- Status -')}}</option>
+        <option value="">{{:: ts('- Status -') }}</option>
         <option ng-repeat="o in fields.status.options" ng-value="o.key">{{o.value}}</option>
       </select>
     </span>
     <span>
       <select crm-ui-select style="width: 20em;" ng-model="filter.testing_criteria">
-        <option value="">{{ts('- Test Type -')}}</option>
+        <option value="">{{:: ts('- Test Type -') }}</option>
         <option ng-repeat="o in fields.testing_criteria.options" ng-value="o.key">{{o.value}}</option>
       </select>
     </span>
@@ -29,10 +29,10 @@ Required vars: mailingABList
   <table class="display">
     <thead>
     <tr>
-      <th><a crm-ui-order-by="[myOrder, 'name']">{{ts('Name')}}</a></th>
-      <th><a crm-ui-order-by="[myOrder, 'status']">{{ts('Status')}}</a></th>
-      <th><a crm-ui-order-by="[myOrder, 'testing_criteria']">{{ts('Test Type')}}</a></th>
-      <th><a crm-ui-order-by="[myOrder, 'created_date']">{{ts('Created')}}</a></th>
+      <th><a crm-ui-order-by="[myOrder, 'name']">{{:: ts('Name') }}</a></th>
+      <th><a crm-ui-order-by="[myOrder, 'status']">{{:: ts('Status') }}</a></th>
+      <th><a crm-ui-order-by="[myOrder, 'testing_criteria']">{{:: ts('Test Type') }}</a></th>
+      <th><a crm-ui-order-by="[myOrder, 'created_date']">{{:: ts('Created') }}</a></th>
       <th></th>
     </tr>
     </thead>
@@ -43,8 +43,8 @@ Required vars: mailingABList
       <td>{{crmMailingABCriteria.get(mailingAB.testing_criteria).label}}</td>
       <td>{{mailingAB.created_date}}</td>
       <td>
-        <a class="action-item crm-hover-button" ng-href="#/abtest/{{mailingAB.id}}" ng-show="mailingAB.status == 'Draft'">{{ts('Continue')}}</a>
-        <a class="action-item crm-hover-button" ng-href="#/abtest/{{mailingAB.id}}" ng-show="mailingAB.status != 'Draft'">{{ts('Results')}}</a>
+        <a class="action-item crm-hover-button" ng-href="#/abtest/{{mailingAB.id}}" ng-show="mailingAB.status == 'Draft'">{{:: ts('Continue') }}</a>
+        <a class="action-item crm-hover-button" ng-href="#/abtest/{{mailingAB.id}}" ng-show="mailingAB.status != 'Draft'">{{:: ts('Results') }}</a>
       </td>
     </tr>
     </tbody>
@@ -53,11 +53,11 @@ Required vars: mailingABList
 
 <div ng-show="mailingABList.length === 0" class="messages status no-popup">
   <i class="crm-i fa-info-circle"></i>
-  {{ts('You have no A/B mailings')}}
+  {{:: ts('You have no A/B mailings') }}
 </div>
 
 
 <div class="crm-submit-buttons">
   <br>
-  <a ng-href="#/abtest/new" class="button"><span><i class="crm-i fa-bar-chart"></i> {{ts('New A/B Test')}}</span></a>
+  <a ng-href="#/abtest/new" class="button"><span><i class="crm-i fa-bar-chart"></i> {{:: ts('New A/B Test') }}</span></a>
 </div>

--- a/ang/crmMailingAB/Slider.html
+++ b/ang/crmMailingAB/Slider.html
@@ -1,14 +1,14 @@
 <table class="crm-mailing-ab-slider">
   <tbody>
   <tr>
-    <td style="width: 10em;">{{ts('Test Mailing A')}}</td>
+    <td style="width: 10em;">{{:: ts('Test Mailing A') }}</td>
     <td>
       <div class="slider-test slider-a"></div>
     </td>
     <td style="width: 5em;">({{testValue}}%)</td>
   </tr>
   <tr>
-    <td>{{ts('Test Mailing B')}}</td>
+    <td>{{:: ts('Test Mailing B') }}</td>
     <td>
       <div class="slider-test slider-b"></div>
     </td>
@@ -16,7 +16,7 @@
   </tr>
   </tbody>
   <tr>
-    <td>{{ts('Final Mailing')}}</td>
+    <td>{{:: ts('Final Mailing') }}</td>
     <td>
       <div class="slider-win slider-b"></div>
     </td>

--- a/ang/crmMailingAB/WinnerDialogCtrl.html
+++ b/ang/crmMailingAB/WinnerDialogCtrl.html
@@ -7,11 +7,11 @@
     <div crm-mailing-radio-date="schedule" ng-model="abtest.mailings.c.scheduled_date">
       <div>
         <input ng-model="schedule.mode" type="radio" name="send" value="now" id="schedule-send-now"/>
-        <label for="schedule-send-now">{{ts('Send final mailing immediately')}}</label>
+        <label for="schedule-send-now">{{:: ts('Send final mailing immediately') }}</label>
       </div>
       <div>
         <input ng-model="schedule.mode" type="radio" name="send" value="at" id="schedule-send-at"/>
-        <label for="schedule-send-at">{{ts('Send final mailing at:')}}</label>
+        <label for="schedule-send-at">{{:: ts('Send final mailing at:') }}</label>
         <input crm-ui-datepicker ng-model="schedule.datetime"/>
       </div>
     </div>

--- a/ang/crmStatusPage/SnoozeOptions.html
+++ b/ang/crmStatusPage/SnoozeOptions.html
@@ -1,11 +1,11 @@
 <div ng-if="!status.is_visible">
-  <button ng-click="setPref(status, '', 1)" type="button" >{{ts('Unhide')}}</button>
+  <button ng-click="setPref(status, '', 1)" type="button" >{{:: ts('Unhide') }}</button>
 </div>
 <div ng-if="status.is_visible && status.severity_id >= 2">
-  <button type="button" class="hush-menu-button">{{ts('Hide')}}</button>
+  <button type="button" class="hush-menu-button">{{:: ts('Hide') }}</button>
   <ul style="display:none;">
-    <li ng-click="setPref(status, 'now + 1 week', 0)">{{ts('Remind me again in a week')}}</li>
-    <li ng-click="setPref(status, 'now + 1 month', 0)">{{ts('Remind me again in a month')}}</li>
-    <li ng-click="setPref(status, '', 0)">{{ts('Never remind me again')}}</li>
+    <li ng-click="setPref(status, 'now + 1 week', 0)">{{:: ts('Remind me again in a week') }}</li>
+    <li ng-click="setPref(status, 'now + 1 month', 0)">{{:: ts('Remind me again in a month') }}</li>
+    <li ng-click="setPref(status, '', 0)">{{:: ts('Never remind me again') }}</li>
   </ul>
 </div>

--- a/ang/crmStatusPage/StatusPage.html
+++ b/ang/crmStatusPage/StatusPage.html
@@ -1,7 +1,7 @@
 <div crm-ui-debug="statuses"></div>
 
 <h1 crm-page-title crm-document-title="ts('CiviCRM System Status') + ' (' + countVisible(1) + ')'">
-  {{ts('CiviCRM System Status')}}
+  {{:: ts('CiviCRM System Status') }}
 </h1>
 
 <div id="crm-status-list" crm-ui-tab-set>

--- a/ang/crmUi/wizard.html
+++ b/ang/crmUi/wizard.html
@@ -9,7 +9,7 @@
   </ul>
   <div class="crm-wizard-body" ng-transclude></div>
   <div class="crm-wizard-buttons">
-    <button crm-icon="fa-chevron-left" ng-click="crmUiWizardCtrl.previous()" ng-show="!crmUiWizardCtrl.$first()" class="crmUi-btn-primary">{{ts('Previous')}}</button>
-    <button crm-icon="fa-chevron-right" title="{{!crmUiWizardCtrl.$validStep() ? ts('Complete all required fields first') : ts('Next step')}}" ng-click="crmUiWizardCtrl.next()" ng-show="!crmUiWizardCtrl.$last()" ng-disabled="!crmUiWizardCtrl.$validStep()" class="crmUi-btn-primary">{{ts('Next')}}</button>
+    <button crm-icon="fa-chevron-left" ng-click="crmUiWizardCtrl.previous()" ng-show="!crmUiWizardCtrl.$first()" class="crmUi-btn-primary">{{:: ts('Previous') }}</button>
+    <button crm-icon="fa-chevron-right" title="{{!crmUiWizardCtrl.$validStep() ? ts('Complete all required fields first') : ts('Next step')}}" ng-click="crmUiWizardCtrl.next()" ng-show="!crmUiWizardCtrl.$last()" ng-disabled="!crmUiWizardCtrl.$validStep()" class="crmUi-btn-primary">{{:: ts('Next') }}</button>
   </div>
 </div>

--- a/ang/exportui/export.html
+++ b/ang/exportui/export.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th colspan="6">
-        <label>{{ ts('Contact Type') }}</label>
+        <label>{{:: ts('Contact Type') }}</label>
         <input class="twelve" crm-ui-select="{data: contact_types, placeholder: ts('All'), allowClear: true}" ng-model="data.contact_type" />
       </th>
     </tr>
@@ -21,7 +21,7 @@
         <input class="crm-action-menu fa-plus crm-export-add-field" crm-ui-select="{data: getFields, placeholder: ts('Add field')}" ng-model="new.col" />
         <span ng-if="data.columns.length">
           <button type="button" ng-click="saveMappingDialog()" crm-icon="fa-save">
-            {{ ts('Save Fields') }}
+            {{:: ts('Save Fields') }}
           </button>
         </span>
       </td>

--- a/tests/phpunit/CRM/Utils/HTMLTest.php
+++ b/tests/phpunit/CRM/Utils/HTMLTest.php
@@ -39,6 +39,11 @@ class CRM_Utils_HTMLTest extends CiviUnitTestCase {
       '<div>{{ts("Good morning, Dave")}}</div>',
       ['Good morning, Dave'],
     ];
+    // angular one-time binding notation - great when there are no args
+    $cases[] = [
+      '<div>{{:: ts("One-time binding is more efficient!") }}</div>',
+      ['One-time binding is more efficient!'],
+    ];
     // text, with arg
     $cases[] = [
       '<div>{{ts("Hello world", {1: "whiz"})}}</div>',

--- a/tools/extensions/org.civicrm.angularex/partials/example.html
+++ b/tools/extensions/org.civicrm.angularex/partials/example.html
@@ -1,5 +1,5 @@
 <div>
-  {{ts('Name')}}: <input ng-model="name" type="text"/>
+  {{:: ts('Name') }}: <input ng-model="name" type="text"/>
 </div>
 <div>
   {{ts('Hello, %1!', {1: name})}}


### PR DESCRIPTION
Overview
----------------------------------------
Improves the run speed of all Angular pages in CiviCRM by making use of the one-time binding feature for static strings being passed through ts().

Before
----------------------------------------
Angular pages slower

After
----------------------------------------
Angular pages faster

Technical Details
----------------------------------------
One-time binding prevents unnecessary $watch expressions on values that will never change, making the digest loop faster.
See https://docs.angularjs.org/guide/expression#one-time-binding

Comments
---------
I also included a test case for strings in one-time binding expressions.
