### PR TITLE
Remove outputHeader as a param for writeCSVFile as it is always true

### DIFF
--- a/CRM/Core/Report/Excel.php
+++ b/CRM/Core/Report/Excel.php
@@ -152,23 +152,20 @@ class CRM_Core_Report_Excel {
    *   An array of the headers.
    * @param array $rows
    *   An array of arrays of the table contents.
-   * @param bool $outputHeader
-   *   Should we output the header row.
    *
    * @return void
    */
-  public static function writeCSVFile($fileName, $header, $rows, $outputHeader = TRUE) {
-    if ($outputHeader) {
-      CRM_Utils_System::download(CRM_Utils_String::munge($fileName),
-        'text/x-csv',
-        CRM_Core_DAO::$_nullObject,
-        'csv',
-        FALSE
-      );
-    }
+  public static function writeCSVFile($fileName, $header, $rows) {
+    $null = NULL;
+    CRM_Utils_System::download(CRM_Utils_String::munge($fileName),
+      'text/x-csv',
+      $null,
+      'csv',
+      FALSE
+    );
 
     if (!empty($rows)) {
-      return self::makeCSVTable($header, $rows, $outputHeader);
+      return self::makeCSVTable($header, $rows, TRUE);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes a meaningless parameter

Before
----------------------------------------
```
public static function writeCSVFile($fileName, $header, $rows, $outputHeader = TRUE)
```

After
----------------------------------------
```
public static function writeCSVFile($fileName, $header, $rows)
```

Technical Details
----------------------------------------
The calls to this function do not pass the last parameter

Comments
----------------------------------------

