### PR TITLE
Make transaction param optional in completeOrder

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4403,6 +4403,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @param array $ids
    * @param array $objects
    * @param CRM_Core_Transaction $transaction
+   *   It is not recommended to pass this in. The calling function handle it's own roll back if it wants it.
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
    *   Note that our goal is that this would only ever be called from payment.create and never handle financials (only
@@ -4412,7 +4413,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder($input, &$ids, $objects, $transaction, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, &$ids, $objects, $transaction = NULL, $isPostPaymentCreate = FALSE) {
+    if (!$transaction) {
+      $transaction = new CRM_Core_Transaction();
+    }
     $contribution = $objects['contribution'];
     $primaryContributionID = $contribution->id ?? $objects['first_contribution']->id;
     // The previous details are used when calculating line items so keep it before any code that 'does something'

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -476,7 +476,7 @@ class CRM_Core_Payment_BaseIPN {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function completeTransaction(&$input, &$ids, &$objects, &$transaction) {
+  public function completeTransaction(&$input, &$ids, &$objects, $transaction = NULL) {
     CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction);
   }
 

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -674,9 +674,8 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
   }
   $input['card_type_id'] = $params['card_type_id'] ?? NULL;
   $input['pan_truncation'] = $params['pan_truncation'] ?? NULL;
-  $transaction = new CRM_Core_Transaction();
-  return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction,
-     CRM_Utils_Array::value('is_post_payment_create', $params));
+  return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, NULL,
+    $params['is_post_payment_create'] ?? NULL);
 }
 
 /**


### PR DESCRIPTION


Overview
----------------------------------------
In all the places I checked passing in this param achieved nothing. Let's start by making it optional

Before
----------------------------------------
$transaction required in completeOrder

After
----------------------------------------
Optional param (not recommended)

Technical Details
----------------------------------------
In all instances I looked at it is instantiated & passed in with no DB actions being taken before passing it through - making it a pointless thing to pass around.

Comments
----------------------------------------

