### PR TITLE
(POC, WIP) Allow querying APIv4 with SQL expressions

### DIFF
--- a/Civi/Api4.php
+++ b/Civi/Api4.php
@@ -1,0 +1,118 @@
+<?php
+namespace Civi;
+
+class Api4 {
+
+  /**
+   * @param string $sql
+   *   A SQL expression, which will be evaluated via APIv4.
+   *
+   *   Ex: "SELECT id, display_name FROM Contact"
+   *   Ex: "SYS SELECT id, display_name FROM Contact"
+   *
+   *   By default, the query is executed with permissions of the current logged-in user.
+   *   The "SYS" prefix specifies
+   * @param array|NULL $vars
+   *   A list of values to interpolate
+   * @return \Civi\Api4\Generic\AbstractAction
+   * @throws \CRM_Core_Exception
+   */
+  public static function sql($sql, $vars = NULL) {
+    list($entity, $action, $params) = self::parseSql($sql, $vars);
+    // DEBUG: print_r(['entity'=> $entity, 'action' => $action, 'params' => $params]);
+    require_once 'api/api.php';
+    return \Civi\API\Request::create($entity, $action, $params);
+  }
+
+  /**
+   * @param $sql
+   * @param $vars
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  private static function parseSql($sql, $vars) {
+    // FIXME: Consider a parser cache. But take care about $vars...
+
+    if (!isset(\Civi::$statics[__CLASS__]['parser'])) {
+      \Civi::$statics[__CLASS__]['parser'] = new \PHPSQL\Parser();
+    }
+
+    $assert = function ($bool, $msg = '') use ($sql) {
+      if (!$bool) {
+        throw new \CRM_Core_Exception("Failed to parse APIv4-SQL: $msg\n($sql)");
+      }
+    };
+
+    $assert($vars === NULL, 'FIXME: Interpolation');
+
+    $entity = $action = NULL;
+    $params = ['version' => 4];
+
+    if (substr($sql, 0, 4) === 'SYS ') {
+      $params['checkPermissions'] = FALSE;
+      $sql = substr($sql, 4);
+    }
+
+    $p = \Civi::$statics[__CLASS__]['parser'];
+    $expr = $p->parse($sql);
+    // DEBUG: print_r($expr);
+
+    switch (TRUE) {
+
+      case isset($expr['SELECT']):
+        $assert(count($expr['FROM'] === 1), 'FROM clause should have only specify one entity');
+        $assert(count($expr['SELECT'] >= 1), 'SELECT clause shoudl have at least one value');
+        $entity = $expr['FROM'][0]['table'];
+        $action = 'get';
+
+        foreach ($expr['SELECT'] as $select) {
+          $assert($select['alias'] === FALSE, "FIXME: Map column aliases");
+          $params['select'][] = $select['base_expr'];
+        }
+
+        if (isset($expr['WHERE'])) {
+          $where = $expr['WHERE'];
+          $assert(count($where) === 3 && $where[0]['expr_type'] === 'colref' && $where[1]['expr_type'] === 'operator' && $where[2]['expr_type'] === 'const',
+            'FIXME: Map more advanced WHERE expressions');
+          $params['where'][] = [
+            $where[0]['base_expr'],
+            $where[1]['base_expr'],
+            $where[2]['base_expr'],
+          ];
+        }
+
+        if (!empty($expr['LIMIT']['rowcount'])) {
+          $params['limit'] = $expr['LIMIT']['rowcount'];
+        }
+        if (!empty($expr['LIMIT']['offset'])) {
+          $params['offset'] = $expr['LIMIT']['offset'];
+        }
+
+        foreach ($expr['ORDER'] ?? [] as $orderBy) {
+          $assert($orderBy['expr_type'] === 'colref', 'ORDER BY only supports basic columns');
+          $params['orderBy'][$orderBy['base_expr']] = $orderBy['direction'];
+        }
+
+        break;
+
+      case isset($expr['INSERT']):
+        $assert(0, 'FIXME: INSERT');
+        $assert(count($expr['INSERT']) === 1, 'INSERT clause should have one entity');
+        $entity = $expr['INSERT'][0]['table'];
+        $action = 'create';
+        break;
+
+      case isset($expr['UPDATE']):
+        $assert(0, 'FIXME: UPDATE');
+        $assert(count($expr['SET']) >= 1, 'UPDATE clause should have at least one SET');
+        $action = 'update';
+        break;
+
+      default:
+        throw new \CRM_Core_Exception("Unrecognized SQL verb");
+    }
+
+    return [$entity, $action, $params];
+  }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
     "civicrm/composer-downloads-plugin": "^2.0",
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",
-    "xkerman/restricted-unserialize": "~1.1"
+    "xkerman/restricted-unserialize": "~1.1",
+    "soundintheory/php-sql-parser": "^1.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c8e8054f45d5bdd4e18f45701527d2b",
+    "content-hash": "8c2c313c105cf03bcd0c695548764e30",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1850,6 +1850,60 @@
             "time": "2019-02-22T07:42:52+00:00"
         },
         {
+            "name": "soundintheory/php-sql-parser",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/soundintheory/php-sql-parser.git",
+                "reference": "dcb81216a13be124d21711b8fefb6e80db7af472"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/soundintheory/php-sql-parser/zipball/dcb81216a13be124d21711b8fefb6e80db7af472",
+                "reference": "dcb81216a13be124d21711b8fefb6e80db7af472",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPSQL": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "André Rothe",
+                    "email": "phosco@gmx.de",
+                    "homepage": "https://www.phosco.info",
+                    "role": "Committer"
+                },
+                {
+                    "name": "Justin Swanhart",
+                    "email": "greenlion@gmail.com",
+                    "homepage": "http://code.google.com/u/greenlion@gmail.com/",
+                    "role": "Owner"
+                },
+                {
+                    "name": "Andy White",
+                    "homepage": "https://github.com/soundintheory",
+                    "role": "maintainer"
+                },
+                {
+                    "name": "Dan Vande More",
+                    "homepage": "https://github.com/fimbulvetr",
+                    "role": "contributor"
+                }
+            ],
+            "description": "SQL parsing tools for PHP",
+            "time": "2013-08-09T21:16:50+00:00"
+        },
+        {
             "name": "symfony/config",
             "version": "v2.8.50",
             "source": {
@@ -2431,9 +2485,7 @@
             "version": "3.0.0+php53",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip",
-                "reference": null,
-                "shasum": null
+                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip"
             },
             "require": {
                 "php": ">=5.3.0"
@@ -2721,5 +2773,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Preface
----------------------------------------

As I was reading some of the PRs for [dev/report#31](https://lab.civicrm.org/dev/report/-/issues/31) like #16947 and #17047, I was struck by the sense that they were, essentially, expanding APIv4's PHP API to incorporate a small DSL within the `select` (e.g. `$params['select'][]='avg(fee_amount) as average_fee';`)

This struck me for a couple reasons. On one hand, it's bit confusing because my impression is that APIv4's PHP API is supposed to be a straight-up 'query-builder' pattern using methods and arrays which are amenable to data-integration and complex UIs, so the DSL feels out-of-character. On the other hand, I can relate because I found it easier to use APIv4 through a DSL (*ahem* `cv api4` and [dev/core#1489](https://lab.civicrm.org/dev/core/-/issues/1489)). 

To be sure, I think that it's useful to have both a DSL-pattern (for simple improvisations) and a query-builder-pattern (for data-integrations and complex UI building). Ideally, you would be able to summon either pattern when convenient, and you'd be able to interchange them.

But there's a problem with the current design -- the `select` DSL and for `cv api4` DSL don't currently work together.

If only there were some standard DSL for writing queries, that could be interpreted consistently in different layers. Maybe something which already had existing parsers. Something that would take the name of the data-set and a list of return-values and a list of filters...

Overview
----------------------------------------

This is a proof-of-concept for `\Civi\Api4::sql($expr)` which allows you to construct an APIv4 call using a SQL expression.

Consider a query written in APIv4's query-building notation:

```php
\Civi\Api4\Contact::get()
  ->addSelect('id', 'display_name', 'phones.phone')
  ->addWhere('id', '>', 10)
  ->execute();
```

Of course, in a DSL like SQL, you don't need as many funny symbols. It's just one line:

```sql
SELECT id, display_name, phones.phone FROM Contact WHERE id > 10
```

Before
----------------------------------------

You have to use query-builder notation all the time.

After
----------------------------------------

You can construct the APIv4 query like so:

```php
\Civi\Api4::sql('SELECT id, display_name, phones.phone FROM Contact WHERE id > 10')
  ->execute();
```

For good and ill, this will execute APIv4 -- applying the same permission model, custom-data mechanics, option-value-mappings, BAO fiddly-bits, etc.

You can also mingle the styles -- seeding a base-query with the SQL and then mixing-in extra bits with the query-building interface:

```php
\Civi\Api4::sql('SELECT id, display_name, phones.phone FROM Contact WHERE id > 10')
  ->setLimit(10)
  ->addOrderBy('display_name')
  ->execute();
```

Comments
----------------------------------------

1. It may be confusing for some people that MySQL-SQL and APIv4-SQL are different dialects. One could take a cue from Doctrine, Hibernate, Salesforce, etal and rebrand it. (API4QL? 4QL? A4? Fourql? CiviQL? ad nauseum)

2. You can see this in action by checking out the PR and running one of these commands:

```bash
## Run a query as demo user (permissioned)
cv ev -U demo  'return Civi\Api4::sql("SELECT display_name, phones.phone FROM Contact ORDER BY id desc LIMIT 5")->execute();'

## Run a query as the system (un-permissioned)
cv ev 'return Civi\Api4::sql("SYS SELECT display_name, phones.phone FROM Contact ORDER BY id desc LIMIT 5")->execute();'
```

3. Benchmarking data for some PHP-SQL parsers: https://gist.github.com/totten/409f9f1f6d96a17d83e1d100e2eca3a6

4. This PR is a "proof-of-concept" for a few reasons. Trivially, it doesn't have a unit-test, and there's a lot of 'FIXME' bits for mapping different parts of the query. Additionally, some of the functionality will be more doable as `dev/report#31` progresses in supporting SQL-features in APv4 queries. More broadly, I think there should be a bit more thought to the inter-change of structured/query-building representations and DSL/pithy representations. Maybe things like this would allow you freely move among notations:

   ```php
   $get = Civi\Api4\Contact::get()
    ->withParams([...query fragment expressed like APIv4 $params...])
    ->withSql('...query fragment expressed like SQL...');
   $result = $get->execute(); // Returns the result-set.
   $paramArray = $get->toParams(); // Returns a list of $params that are equivalent to $get.
   $sqlExpr = $get->toSQL(); // Returns a SQL string that is equivalent to $get.
   ```
