### PR TITLE
Add ID to custom group/field admin forms

### DIFF
--- a/templates/CRM/Custom/Page/Field.tpl
+++ b/templates/CRM/Custom/Page/Field.tpl
@@ -23,6 +23,7 @@
          <table id="options" class="row-highlight">
          <thead>
          <tr>
+            <th>{ts}ID{/ts}</th>
             <th>{ts}Field Label{/ts}</th>
             <th>{ts}Data Type{/ts}</th>
             <th>{ts}Field Type{/ts}</th>
@@ -36,6 +37,7 @@
         <tbody>
         {foreach from=$customField item=row}
         <tr id="CustomField-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"}{if NOT $row.is_active} disabled{/if}">
+            <td>{$row.id}</td>
             <td class="crm-editable" data-field="label">{$row.label}</td>
             <td>{$row.data_type}</td>
             <td>{$row.html_type}</td>

--- a/templates/CRM/Custom/Page/Group.tpl
+++ b/templates/CRM/Custom/Page/Group.tpl
@@ -28,6 +28,7 @@
       <table id="options" class="row-highlight">
         <thead>
           <tr>
+            <th>{ts}ID{/ts}</th>
             <th>{ts}Set{/ts}</th>
             <th>{ts}Enabled?{/ts}</th>
             <th>{ts}Used For{/ts}</th>
@@ -40,6 +41,7 @@
         <tbody>
         {foreach from=$rows item=row}
         <tr id="CustomGroup-{$row.id}" data-action="setvalue" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+          <td>{$row.id}</td>
           <td class="crmf-title crm-editable">{$row.title}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{if $row.extends eq 'Contact'}{ts}All Contact Types{/ts}{else}{$row.extends_display}{/if}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Expose custom field/group IDs on admin forms

Before
----------------------------------------
You have to hover over URLs or inspect HTML to find out custom group/field IDs if you need them for APIs, custom integrations etc.

After
----------------------------------------
Groups:
![image](https://user-images.githubusercontent.com/2052161/79011857-e3f65200-7b5c-11ea-976c-6b73819af7a7.png)

Fields:
![image](https://user-images.githubusercontent.com/2052161/79011893-fec8c680-7b5c-11ea-8acd-8597c09d0c4a.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
@JGaunt Can you review?