### PR TITLE
(POC-Test) dev/core#1701  - Demonstrate interaction between joins and limits

### DIFF
--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -91,4 +91,21 @@ class FkJoinTest extends UnitTestCase {
     $this->assertEquals($testPhone['phone'], $firstPhone['phone']);
   }
 
+  public function testJoinWithLimit() {
+    $base = function() {
+      return Contact::get()
+        ->setCheckPermissions(FALSE)
+        ->addSelect('id', 'display_name', 'phones.phone')
+        ->addOrderBy('id', 'DESC');
+    };
+
+    $this->assertEquals(3, $base()->setLimit(3)->execute()->count());
+    $result3 = $base()->setLimit(3)->execute()->getArrayCopy();
+    $this->assertEquals(3, count($result3));
+
+    $this->assertEquals(5, $base()->setLimit(5)->execute()->count());
+    $result5 = $base()->setLimit(5)->execute()->getArrayCopy();
+    $this->assertEquals(5, count($result5));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

This PR adds a unit-test to demonstrate the issue in dev/core#1701 -- i.e. the `limit` is misinterpreted when selecting joined data.

See also: in https://lab.civicrm.org/dev/core/-/issues/1701

After
----------------------------------------

There's a test failure.

Comments
----------------------------------------

We probably don't want to merge this, but I've opened the PR so that it can be seen/executed/cherry-picked and eventually included with a fix.