### PR TITLE
dev/core#1703: Created a system extension tab on the manage extension screen

### DIFF
--- a/templates/CRM/Admin/Page/Extensions.tpl
+++ b/templates/CRM/Admin/Page/Extensions.tpl
@@ -35,6 +35,12 @@
               <em>&nbsp;</em>
               </a>
             </li>
+            <li id="tab_summary" class="crm-tab-button">
+              <a href="#extensions-system" title="{ts}System Extensions{/ts}">
+              <span> </span> {ts}System Extensions{/ts}
+              <em>&nbsp;</em>
+            </a>
+            </li>
             <li id="tab_addnew" class="crm-tab-button">
               <a href="#extensions-addnew" title="{ts}Add New{/ts}">
               <span> </span> {ts}Add New{/ts}
@@ -45,6 +51,9 @@
 
         <div id="extensions-main" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
             {include file="CRM/Admin/Page/Extensions/Main.tpl"}
+        </div>
+        <div id="extensions-system" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
+          {include file="CRM/Admin/Page/Extensions/System.tpl"}
         </div>
         <div id="extensions-addnew" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
             {if $extAddNewEnabled}

--- a/templates/CRM/Admin/Page/Extensions/System.tpl
+++ b/templates/CRM/Admin/Page/Extensions/System.tpl
@@ -1,0 +1,55 @@
+{*
+Display a table of locally-available extensions.
+
+Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
+*}
+{if $localExtensionRows}
+  <div id="extensions">
+    <div class="messages help">
+      <i class="fa fa-warning">&nbsp;</i>
+      {ts}System extensions are required to run CiviCRM. Disabling is discouraged!{/ts}
+    </div>
+    {strip}
+    {* handle enable/disable actions*}
+    <table id="extensions" class="display">
+      <thead>
+        <tr>
+          <th>{ts}Extension name (key){/ts}</th>
+          <th>{ts}Status{/ts}</th>
+          <th>{ts}Version{/ts}</th>
+          <th>{ts}Type{/ts}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {foreach from=$hiddenExtensionRows key=extKey item=row}
+        <tr id="extension-{$row.file}" class="crm-entity crm-extension-{$row.file}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.upgradable} extension-upgradable{elseif $row.status eq 'installed'} extension-installed{/if}">
+          <td class="crm-extensions-label">
+              <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>({$row.key})
+              {if $extAddNewEnabled && $remoteExtensionRows[$extKey] && $remoteExtensionRows[$extKey].is_upgradeable}
+                {capture assign='upgradeURL'}{crmURL p='civicrm/admin/extensions' q="action=update&id=$extKey&key=$extKey"}{/capture}
+                <div class="crm-extensions-upgrade">{ts 1=$upgradeURL}Version {$remoteExtensionRows[$extKey].version} is available. <a href="%1">Upgrade</a>{/ts}</div>
+              {/if}
+          </td>
+          <td class="crm-extensions-label">{$row.statusLabel} {if $row.upgradable}<br/>({ts}Outdated{/ts}){/if}</td>
+          <td class="crm-extensions-label">{$row.version} {if $row.upgradable}<br/>({$row.upgradeVersion}){/if}</td>
+          <td class="crm-extensions-description">{$row.type|capitalize}</td>
+          <td>{$row.action|replace:'xx':$row.id}</td>
+        </tr>
+        <tr class="hiddenElement" id="crm-extensions-details-{$row.file}">
+            <td>
+                {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row localExtensionRows=$localExtensionRows remoteExtensionRows=$remoteExtensionRows}
+            </td>
+            <td></td><td></td><td></td><td></td>
+        </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    {/strip}
+  </div>
+{else}
+  <div class="messages status no-popup">
+       <div class="icon inform-icon"></div>
+      {ts 1="https://civicrm.org/extensions"}There are no extensions to display. Click the "Add New" tab to browse and install extensions posted on the <a href="%1">public CiviCRM Extensions Directory</a>. If you have downloaded extensions manually and don't see them here, try clicking the "Refresh" button.{/ts}
+  </div>
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Since CiviCRM 5.24 hidden extensions are shipped with CiviCRM, such as Sequential Credit Notes.
Those extension do not show up in manage extensions screen.

Before
----------------------------------------

Hidden extensions are not shown to a system administrator on the manage system extensions page.

![Screenshot_20200412_213642](https://user-images.githubusercontent.com/4126292/79078460-d67dcb00-7d08-11ea-8efe-5479ee3079ed.png)

After
----------------------------------------

The manage extensions page also contain a tab for System Extensions showing the hidden extensions.

![Screenshot_20200412_214828](https://user-images.githubusercontent.com/4126292/79078512-28beec00-7d09-11ea-8319-7c92d608018b.png)

Comments
----------------------------------------

I am open for any better texts for the warning of a system administrator. 

Also the documentation should be updated after this PR got merged. 

See also: https://lab.civicrm.org/dev/core/-/issues/1703
