### PR TITLE
APIv4 - Fix setting offset with no limit

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -241,7 +241,8 @@ class Api4SelectQuery extends SelectQuery {
    */
   protected function buildLimit() {
     if (!empty($this->limit) || !empty($this->offset)) {
-      $this->query->limit($this->limit, $this->offset);
+      // If limit is 0, mysql will actually return 0 results. Instead set to maximum possible.
+      $this->query->limit($this->limit ?: '18446744073709551615', $this->offset);
     }
   }
 

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -58,4 +58,25 @@ class ContactGetTest extends \api\v4\UnitTestCase {
     $this->assertContains($del['id'], $contacts->column('id'));
   }
 
+  public function testGetWithLimit() {
+    $last_name = uniqid('getWithLimitTest');
+
+    $bob = Contact::create()
+      ->setValues(['first_name' => 'Bob', 'last_name' => $last_name])
+      ->execute()->first();
+
+    $jan = Contact::create()
+      ->setValues(['first_name' => 'Jan', 'last_name' => $last_name])
+      ->execute()->first();
+
+    $dan = Contact::create()
+      ->setValues(['first_name' => 'Dan', 'last_name' => $last_name])
+      ->execute()->first();
+
+    $num = Contact::get()->setCheckPermissions(FALSE)->selectRowCount()->execute()->count();
+    $this->assertCount($num - 1, Contact::get()->setCheckPermissions(FALSE)->setLimit(0)->setOffset(1)->execute());
+    $this->assertCount($num - 2, Contact::get()->setCheckPermissions(FALSE)->setLimit(0)->setOffset(2)->execute());
+    $this->assertCount(2, Contact::get()->setCheckPermissions(FALSE)->setLimit(2)->setOffset(0)->execute());
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in APIv4 where setting an offset with no limit would return no results.

Before
----------------------------------------
If offset is given, but no limit, 0 results returned.

After
----------------------------------------
Correct number of results returned.

Technical Details
----------------------------------------
The API treats 0 as "no limit" but mysql does not.
This implements setting an offset with no limit by applying the maximum possible row count, as mysql does not allow `LIMIT NULL`.
See https://stackoverflow.com/questions/255517/mysql-offset-infinite-rows