### PR TITLE
Convert bcc field to use an entity reference.

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -345,4 +345,24 @@ AND    reset_date IS NULL
     return CRM_Contact_BAO_Contact::deleteObjectWithPrimary('Email', $id);
   }
 
+  /**
+   * Get filters for entity reference fields.
+   *
+   * @return array
+   */
+  public static function getEntityRefFilters() {
+    $contactFields = CRM_Contact_BAO_Contact::getEntityRefFilters();
+    foreach ($contactFields as $index => &$contactField) {
+      if (!empty($contactField['entity'])) {
+        // For now email_getlist can't parse state, country etc.
+        unset($contactFields[$index]);
+      }
+      elseif ($contactField['key'] !== 'contact_id') {
+        $contactField['entity'] = 'Contact';
+        $contactField['key'] = 'contact_id.' . $contactField['key'];
+      }
+    }
+    return $contactFields;
+  }
+
 }

--- a/api/v3/Email.php
+++ b/api/v3/Email.php
@@ -91,7 +91,6 @@ function civicrm_api3_email_get($params) {
 function _civicrm_api3_email_getlist_defaults(&$request) {
   return [
     'description_field' => [
-      'contact_id.sort_name',
       'email',
     ],
     'params' => [
@@ -100,6 +99,10 @@ function _civicrm_api3_email_getlist_defaults(&$request) {
       'contact_id.is_deceased' => 0,
       'contact_id.do_not_email' => 0,
     ],
+    // Note that changing this to display name affects query performance. The label field is used
+    // for sorting & mysql will prefer to use the index on the ORDER BY field. So if this is changed
+    // to display name then the filtering will bypass the index. In testing this took around 30 times
+    // as long.
     'label_field' => 'contact_id.sort_name',
     // If no results from sort_name try email.
     'search_field' => 'contact_id.sort_name',

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -125,12 +125,10 @@ CRM.$(function($) {
 
   {/literal}
   var toContact = {if $toContact}{$toContact}{else}''{/if},
-    ccContact = {if $ccContact}{$ccContact}{else}''{/if},
-    bccContact = {if $bccContact}{$bccContact}{else}''{/if};
+    ccContact = {if $ccContact}{$ccContact}{else}''{/if};
   {literal}
   emailSelect('#to', toContact);
   emailSelect('#cc_id', ccContact);
-  emailSelect('#bcc_id', bccContact);
 });
 
 


### PR DESCRIPTION
Overview
----------------------------------------
This changes the bcc field on all email fields to use an entity reference fields. This gives significant code simplification as well as extending filtering on the field

Note I've restricted to the bcc field for now as having  it different makes it easier to do comparitive
testing. The other fields will follow once this is merged

Before
----------------------------------------
Custom js & php code for this use case - same as the cc field.

<img width="421" alt="Screen Shot 2020-04-13 at 4 31 06 PM" src="https://user-images.githubusercontent.com/336308/79092199-3c6b6080-7da4-11ea-8a19-98704efb6d1e.png">


After
----------------------------------------
Entity reference box
<img width="502" alt="Screen Shot 2020-04-13 at 4 30 21 PM" src="https://user-images.githubusercontent.com/336308/79092162-1e056500-7da4-11ea-9aad-3d0c4413bb52.png">


Technical Details
----------------------------------------
@mfb - I did some testing on this & in my tests it performs well - it uses 2 queries not a union (if required ) but avoids the OR

@colemanw can you try this out? Note I've ONLY done the bcc field so far & as yet tags & groups don't filter

Comments
----------------------------------------

