### PR TITLE
Fix 'selectedChild' parameter for pages with tabs

### DIFF
--- a/templates/CRM/Admin/Page/Extensions.tpl
+++ b/templates/CRM/Admin/Page/Extensions.tpl
@@ -85,7 +85,7 @@
     </script>
     {/literal}
 
-    {include file="CRM/common/TabSelected.tpl" defaultTab="summary"}
+    {include file="CRM/common/TabHeader.tpl" defaultTab="summary"}
 
     {* Refresh buttons *}
     {literal}

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -157,7 +157,7 @@
     {/foreach}
   </div>
 </div>
-{include file="CRM/common/TabSelected.tpl" defaultTab="user"}
+{include file="CRM/common/TabHeader.tpl"}
 
 {elseif $action ne 1 and $action ne 2 and $action ne 4 and $action ne 8}
   <div class="messages status no-popup">

--- a/templates/CRM/Event/Form/ManageEvent/Tab.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Tab.tpl
@@ -91,4 +91,3 @@ CRM.$(function($) {
 </script>
 {/literal}
 {include file="CRM/Event/Form/ManageEvent/ConfirmRepeatMode.tpl" entityID=$id entityTable="civicrm_event"}
-{include file="CRM/common/TabSelected.tpl" defaultTab="settings"}

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -142,7 +142,7 @@
         </div>{* reserved profile*}
 
   </div>
-{include file="CRM/common/TabSelected.tpl" defaultTab="user-profiles"}
+{include file="CRM/common/TabHeader.tpl"}
 
     {else}
     {if $action ne 1} {* When we are adding an item, we should not display this message *}

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -37,3 +37,4 @@
   {/if}
   <div class="clear"></div>
 </div> {* crm-content-block ends here *}
+{include file="CRM/common/TabSelected.tpl" defaultTab="settings"}


### PR DESCRIPTION
Overview
----------------------------------------
This makes sure we always load the required javascript to allow selecting a tab via the URL parameter `selectedChild`. This was not working with events and some of the others but was working with the contact summary tabs.

Before
----------------------------------------
Tab selected via `selectedChild` URL parameter not working on various pages.

After
----------------------------------------
Tab selected via `selectedChild` URL parameter working on various pages.

Technical Details
----------------------------------------
In order to work, the javascript in TabSelected.tpl must be loaded. But in many cases it was not. It is now loaded whenever TabHeader.tpl is loaded - it *may* make sense to combine the two template files.

Comments
----------------------------------------

Testing
----------------------------------------
To test, navigate to each of the pages which have tabs and try the following URLs and check expected results. *(modify the first part to match the test system)*
##### Profiles:
- http://d7master.localhost/civicrm/admin/uf/group?reset=1 - User profiles tab selected
- http://d7master.localhost/civicrm/admin/uf/group?reset=1&selectedChild=reserved-profiless - Reserved profile tab selected

##### Manage event:
- http://d7master.localhost/civicrm/event/manage/settings?reset=1&action=update&id=8 - Info and settings tab selected
- http://d7master.localhost/civicrm/event/manage/settings?reset=1&action=update&id=8&selectedChild=fee - Fees tab selected

##### Contact summary:
- http://d7master.localhost/civicrm/contact/view?reset=1&cid=135 - Summary tab selected
- http://d7master.localhost/civicrm/contact/view?reset=1&cid=135&selectedChild=contribute - Contributions tab selected

##### MessageTemplates:
- http://d7master.localhost/civicrm/admin/messageTemplates?reset=1 - User-driven messages tab selected
- http://d7master.localhost/civicrm/admin/messageTemplates?reset=1&selectedChild=workflow - System workflow messages tab selected

##### Extensions:
- http://d7master.localhost/civicrm/admin/extensions?reset=1 - Extensions tab selected
- http://d7master.localhost/civicrm/admin/extensions?reset=1&selectedChild=addnew - Add new tab selected