### PR TITLE
dev/user-interface#17 Fix popup confirmation on import forms

### DIFF
--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -151,37 +151,9 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       }
     }
 
-    $path = "_qf_MapField_display=true";
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $form);
-    if (CRM_Utils_Rule::qfKey($qfKey)) {
-      $path .= "&qfKey=$qfKey";
-    }
-
-    $previousURL = CRM_Utils_System::url('civicrm/import/contact', $path, FALSE, NULL, FALSE);
-    $cancelURL = CRM_Utils_System::url('civicrm/import/contact', 'reset=1');
-
-    $buttons = array(
-      array(
-        'type' => 'back',
-        'name' => ts('Previous'),
-        'js' => array('onclick' => "location.href='{$previousURL}'; return false;"),
-      ),
-      array(
-        'type' => 'next',
-        'name' => ts('Import Now'),
-        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-        'isDefault' => TRUE,
-      ),
-      array(
-        'type' => 'cancel',
-        'name' => ts('Cancel'),
-        'js' => array('onclick' => "location.href='{$cancelURL}'; return false;"),
-      ),
-    );
-
-    $this->addButtons($buttons);
-
     $this->addFormRule(array('CRM_Contact_Import_Form_Preview', 'formRule'), $this);
+
+    parent::buildQuickForm();
   }
 
   /**

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -36,21 +36,37 @@ abstract class CRM_Import_Form_Preview extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
+
+    // FIXME: This is a hack...
+    // The tpl contains javascript that starts the import on form submit
+    // Since our back/cancel buttons are of html type "submit" we have to prevent a form submit event when they are clicked
+    // Hacking in some onclick js to make them act more like links instead of buttons
+    $path = CRM_Utils_System::currentPath();
+    $query = ['_qf_MapField_display' => 'true'];
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
+    if (CRM_Utils_Rule::qfKey($qfKey)) {
+      $query['qfKey'] = $qfKey;
+    }
+    $previousURL = CRM_Utils_System::url($path, $query, FALSE, NULL, FALSE);
+    $cancelURL = CRM_Utils_System::url($path, 'reset=1', FALSE, NULL, FALSE);
+
     $this->addButtons([
-        [
-          'type' => 'back',
-          'name' => ts('Previous'),
-        ],
-        [
-          'type' => 'next',
-          'name' => ts('Import Now'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-        ],
-        [
-          'type' => 'cancel',
-          'name' => ts('Cancel'),
-        ],
+      [
+        'type' => 'back',
+        'name' => ts('Previous'),
+        'js' => ['onclick' => "location.href='{$previousURL}'; return false;"],
+      ],
+      [
+        'type' => 'next',
+        'name' => ts('Import Now'),
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+        'js' => ['onclick' => "location.href='{$cancelURL}'; return false;"],
+      ],
     ]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where confirmation popup would appear when hitting the back/cancel buttons, not just the import button, on most import forms.
See https://lab.civicrm.org/dev/user-interface/-/issues/17

Before
----------------------------------------
On step 3 of the import, the back/cancel buttons work normally for Contact import, but for other types of imports they erroneously cause the submit confirmation behavior.
![image](https://user-images.githubusercontent.com/2874912/79154884-4d18d800-7d9e-11ea-963e-226a26eb58ca.png)


After
----------------------------------------
Fixed on all types of imports: activity, contribution, etc.

Technical Details
----------------------------------------
The contact import form contained a hack to prevent a popup confirmation when clicking back/cancel.
This moves the hack to the base class for the benefit of other import forms.
