### PR TITLE
[REF] Reconcile CRM_Utils_System::getUrlPath and CRM_Utils_System::currentPath

### DIFF
--- a/CRM/Contact/Controller/Search.php
+++ b/CRM/Contact/Controller/Search.php
@@ -60,8 +60,7 @@ class CRM_Contact_Controller_Search extends CRM_Core_Controller {
     // see if we can figure out the url and redirect to the right search form
     // note that this happens really early on, so we can't use any of the form or controller
     // variables
-    $config = CRM_Core_Config::singleton();
-    $qString = $_GET[$config->userFrameworkURLVar];
+    $qString = CRM_Utils_System::currentPath();
     $args = "reset=1";
     $path = 'civicrm/contact/search/advanced';
     if (strpos($qString, 'basic') !== FALSE) {

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -442,7 +442,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
         $$stateName->setOptions($options);
       }
       if (property_exists($$stateName, 'urlPath')) {
-        $$stateName->urlPath = explode('/', (string) CRM_Utils_System::getUrlPath());
+        $$stateName->urlPath = explode('/', (string) CRM_Utils_System::currentPath());
       }
       $this->addPage($$stateName);
       $this->addAction($stateName, new HTML_QuickForm_Action_Direct());

--- a/CRM/Core/Page/QUnit.php
+++ b/CRM/Core/Page/QUnit.php
@@ -56,8 +56,7 @@ class CRM_Core_Page_QUnit extends CRM_Core_Page {
    * @return array
    */
   public function getRequestExtAndSuite() {
-    $config = CRM_Core_Config::singleton();
-    $arg = explode('/', $_GET[$config->userFrameworkURLVar]);
+    $arg = explode('/', CRM_Utils_System::currentPath());
 
     if ($arg[1] == 'dev'
       && CRM_Utils_Array::value(2, $arg) == 'qunit'

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1502,7 +1502,7 @@ abstract class CRM_Core_Payment {
    */
   public static function handlePaymentMethod($method, $params = []) {
     if (!isset($params['processor_id']) && !isset($params['processor_name'])) {
-      $q = explode('/', CRM_Utils_Array::value(CRM_Core_Config::singleton()->userFrameworkURLVar, $_GET, ''));
+      $q = explode('/', CRM_Utils_System::currentPath());
       $lastParam = array_pop($q);
       if (is_numeric($lastParam)) {
         $params['processor_id'] = $_GET['processor_id'] = $lastParam;

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -865,7 +865,7 @@ class CRM_Core_Resources {
     ) {
       return TRUE;
     }
-    list($arg0, $arg1) = array_pad(explode('/', CRM_Utils_System::getUrlPath()), 2, '');
+    list($arg0, $arg1) = array_pad(explode('/', CRM_Utils_System::currentPath()), 2, '');
     return ($arg0 === 'civicrm' && in_array($arg1, ['ajax', 'angularprofiles', 'asset']));
   }
 

--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -31,8 +31,7 @@ class CRM_Report_Utils_Report {
       );
     }
     else {
-      $config = CRM_Core_Config::singleton();
-      $args = explode('/', $_GET[$config->userFrameworkURLVar]);
+      $args = explode('/', CRM_Utils_System::currentPath());
 
       // remove 'civicrm/report' from args
       array_shift($args);
@@ -298,15 +297,10 @@ WHERE  inst.report_id = %1";
    */
   public static function getInstanceID() {
 
-    $config = CRM_Core_Config::singleton();
-    $arg = explode('/', $_GET[$config->userFrameworkURLVar]);
+    $arg = explode('/', CRM_Utils_System::currentPath());
 
-    if ($arg[1] == 'report' &&
-      CRM_Utils_Array::value(2, $arg) == 'instance'
-    ) {
-      if (CRM_Utils_Rule::positiveInteger($arg[3])) {
-        return $arg[3];
-      }
+    if (isset($arg[3]) && $arg[1] == 'report' && $arg[2] == 'instance' && CRM_Utils_Rule::positiveInteger($arg[3])) {
+      return $arg[3];
     }
   }
 
@@ -314,15 +308,11 @@ WHERE  inst.report_id = %1";
    * @return string
    */
   public static function getInstancePath() {
-    $config = CRM_Core_Config::singleton();
-    $arg = explode('/', $_GET[$config->userFrameworkURLVar]);
+    $arg = explode('/', CRM_Utils_System::currentPath());
 
-    if ($arg[1] == 'report' &&
-      CRM_Utils_Array::value(2, $arg) == 'instance'
-    ) {
+    if (isset($arg[3]) && $arg[1] == 'report' && $arg[2] == 'instance') {
       unset($arg[0], $arg[1], $arg[2]);
-      $path = trim(CRM_Utils_Type::escape(implode('/', $arg), 'String'), '/');
-      return $path;
+      return trim(CRM_Utils_Type::escape(implode('/', $arg), 'String'), '/');
     }
   }
 

--- a/CRM/Utils/Pager.php
+++ b/CRM/Utils/Pager.php
@@ -239,8 +239,7 @@ class CRM_Utils_Pager extends Pager_Sliding {
    * @return string
    */
   public function getCurrentLocation() {
-    $config = CRM_Core_Config::singleton();
-    $path = $_GET[$config->userFrameworkURLVar] ?? NULL;
+    $path = CRM_Utils_System::currentPath();
     return CRM_Utils_System::url($path, CRM_Utils_System::getLinksUrl(self::PAGE_ID, FALSE, TRUE), FALSE, NULL, FALSE) . $this->getCurrentPageID();
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -81,19 +81,16 @@ class CRM_Utils_System {
    *   The URL fragment.
    */
   public static function makeURL($urlVar, $includeReset = FALSE, $includeForce = TRUE, $path = NULL, $absolute = FALSE) {
-    if (empty($path)) {
-      $config = CRM_Core_Config::singleton();
-      $path = $_GET[$config->userFrameworkURLVar] ?? NULL;
-      if (empty($path)) {
-        return '';
-      }
+    $path = $path ?: CRM_Utils_System::currentPath();
+    if (!$path) {
+      return '';
     }
 
     return self::url(
-        $path,
-        CRM_Utils_System::getLinksUrl($urlVar, $includeReset, $includeForce),
-        $absolute
-      );
+      $path,
+      CRM_Utils_System::getLinksUrl($urlVar, $includeReset, $includeForce),
+      $absolute
+    );
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -322,15 +322,14 @@ class CRM_Utils_System {
   }
 
   /**
-   * Path of the current page e.g. 'civicrm/contact/view'
+   * @deprecated
+   * @see \CRM_Utils_System::currentPath
    *
    * @return string|null
    */
   public static function getUrlPath() {
-    if (isset($_GET[CRM_Core_Config::singleton()->userFrameworkURLVar])) {
-      return $_GET[CRM_Core_Config::singleton()->userFrameworkURLVar];
-    }
-    return NULL;
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Utils_System::currentPath');
+    return self::currentPath();
   }
 
   /**
@@ -356,14 +355,14 @@ class CRM_Utils_System {
   }
 
   /**
-   * What menu path are we currently on. Called for the primary tpl.
+   * Path of the current page e.g. 'civicrm/contact/view'
    *
-   * @return string
+   * @return string|null
    *   the current menu path
    */
   public static function currentPath() {
     $config = CRM_Core_Config::singleton();
-    return trim(CRM_Utils_Array::value($config->userFrameworkURLVar, $_GET), '/');
+    return isset($_GET[$config->userFrameworkURLVar]) ? trim($_GET[$config->userFrameworkURLVar], '/') : NULL;
   }
 
   /**

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -655,7 +655,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    * @return bool
    */
   public function isFrontEndPage() {
-    $path = CRM_Utils_System::getUrlPath();
+    $path = CRM_Utils_System::currentPath();
 
     // Get the menu for above URL.
     $item = CRM_Core_Menu::get($path);

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -78,7 +78,7 @@ class Themes {
 
       \CRM_Utils_Hook::activeTheme($themeKey, [
         'themes' => $this,
-        'page' => \CRM_Utils_Array::value(\CRM_Core_Config::singleton()->userFrameworkURLVar, $_GET),
+        'page' => \CRM_Utils_System::currentPath(),
       ]);
 
       $themes = $this->getAll();


### PR DESCRIPTION
Overview
----------------------------------------
Code refactoring to make looking up the current URL more consistent.

Before
----------------------------------------
- 2 functions that did the same thing (retrieve current url).
- Lots of code using neither function but doing it the hard way directly accessing `$_GET`.

After
----------------------------------------
- Deprecated `CRM_Utils_System::getUrlPath`.
- Switched code to use the non-deprecated `CRM_Utils_System::currentPath`.
- Refactored code accessing `$_GET` directly to use the helper function.
