### PR TITLE
[REF] Remove duplicate checks for an array key existing

### DIFF
--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -52,16 +52,13 @@ class CRM_Contact_Form_Edit_CustomData {
    *   Reference to the form object.
    */
   public static function buildQuickForm(&$form) {
-    if (!empty($form->_submitValues)) {
-      if ($customValueCount = CRM_Utils_Array::value('hidden_custom_group_count', $form->_submitValues)) {
-        if (is_array($customValueCount)) {
-          if (array_key_exists(0, $customValueCount)) {
-            unset($customValueCount[0]);
-          }
-          $form->_customValueCount = $customValueCount;
-          $form->assign('customValueCount', $customValueCount);
-        }
+    $customValueCount = $form->_submitValues['hidden_custom_group_count'] ?? NULL;
+    if (is_array($customValueCount)) {
+      if (array_key_exists(0, $customValueCount)) {
+        unset($customValueCount[0]);
       }
+      $form->_customValueCount = $customValueCount;
+      $form->assign('customValueCount', $customValueCount);
     }
     CRM_Custom_Form_CustomData::buildQuickForm($form);
 

--- a/CRM/Contact/Page/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Page/Inline/CommunicationPreferences.php
@@ -40,7 +40,7 @@ class CRM_Contact_Page_Inline_CommunicationPreferences extends CRM_Core_Page {
     $communicationStyle = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'communication_style_id');
     if (!empty($communicationStyle)) {
       if (!empty($defaults['communication_style_id'])) {
-        $defaults['communication_style_display'] = $communicationStyle[CRM_Utils_Array::value('communication_style_id', $defaults)];
+        $defaults['communication_style_display'] = $communicationStyle[$defaults['communication_style_id']];
       }
       else {
         // Make sure the field is displayed as long as it is active, even if it is unset for this contact.

--- a/CRM/Contact/Page/Inline/Demographics.php
+++ b/CRM/Contact/Page/Inline/Demographics.php
@@ -36,7 +36,7 @@ class CRM_Contact_Page_Inline_Demographics extends CRM_Core_Page {
 
     if (!empty($defaults['gender_id'])) {
       $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
-      $defaults['gender_display'] = $gender[CRM_Utils_Array::value('gender_id', $defaults)];
+      $defaults['gender_display'] = $gender[$defaults['gender_id']];
     }
     $this->assignFieldMetadataToTemplate('Contact');
 

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -183,7 +183,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $communicationStyle = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'communication_style_id');
     if (!empty($communicationStyle)) {
       if (!empty($defaults['communication_style_id'])) {
-        $defaults['communication_style_display'] = $communicationStyle[CRM_Utils_Array::value('communication_style_id', $defaults)];
+        $defaults['communication_style_display'] = $communicationStyle[$defaults['communication_style_id']];
       }
       else {
         // Make sure the field is displayed as long as it is active, even if it is unset for this contact.

--- a/CRM/Contact/Page/View/Vcard.php
+++ b/CRM/Contact/Page/View/Vcard.php
@@ -73,7 +73,7 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
     }
 
     if (!empty($defaults['birth_date'])) {
-      $vcard->setBirthday(CRM_Utils_Array::value('birth_date', $defaults));
+      $vcard->setBirthday($defaults['birth_date']);
     }
 
     if (!empty($defaults['home_URL'])) {
@@ -98,11 +98,11 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
         $locality = $location['city'] ?? NULL;
         $region = NULL;
         if (!empty($location['state_province_id'])) {
-          $region = $stateProvices[CRM_Utils_Array::value('state_province_id', $location)];
+          $region = $stateProvices[$location['state_province_id']];
         }
         $country = NULL;
         if (!empty($location['country_id'])) {
-          $country = $countries[CRM_Utils_Array::value('country_id', $location)];
+          $country = $countries[$location['country_id']];
         }
 
         $postcode = $location['postal_code'] ?? NULL;

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -562,7 +562,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     switch ($profileContactType) {
       case 'Individual':
         if (array_key_exists('prefix_id', $params)) {
-          $honorName = CRM_Utils_Array::value(CRM_Utils_Array::value('prefix_id', $params),
+          $honorName = CRM_Utils_Array::value($params['prefix_id'],
             CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'prefix_id')
           );
           unset($profileFields['prefix_id']);
@@ -571,7 +571,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
         unset($profileFields['first_name']);
         unset($profileFields['last_name']);
         if (array_key_exists('suffix_id', $params)) {
-          $honorName .= ' ' . CRM_Utils_Array::value(CRM_Utils_Array::value('suffix_id', $params),
+          $honorName .= ' ' . CRM_Utils_Array::value($params['suffix_id'],
               CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'suffix_id')
             );
           unset($profileFields['suffix_id']);

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -101,7 +101,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
       $pledgeParams['create_date'] = $pledgeParams['start_date'] = $pledgeParams['scheduled_date'] = date("Ymd");
       if (!empty($params['start_date'])) {
-        $pledgeParams['frequency_day'] = intval(date("d", strtotime(CRM_Utils_Array::value('start_date', $params))));
+        $pledgeParams['frequency_day'] = intval(date("d", strtotime($params['start_date'])));
         $pledgeParams['start_date'] = $pledgeParams['scheduled_date'] = date('Ymd', strtotime(CRM_Utils_Array::value('start_date', $params)));
       }
       $pledgeParams['status_id'] = $contribution->contribution_status_id;
@@ -947,10 +947,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           foreach ($lineItemValue as $key => $value) {
             if (isset($value['tax_amount']) && isset($value['tax_rate'])) {
               if (isset($dataArray[$value['tax_rate']])) {
-                $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + CRM_Utils_Array::value('tax_amount', $value);
+                $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + $value['tax_amount'];
               }
               else {
-                $dataArray[$value['tax_rate']] = $value['tax_amount'] ?? NULL;
+                $dataArray[$value['tax_rate']] = $value['tax_amount'];
               }
             }
           }

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -108,7 +108,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
 
     // show billing address location details, if exists
     if (!empty($values['address_id'])) {
-      $addressParams = ['id' => CRM_Utils_Array::value('address_id', $values)];
+      $addressParams = ['id' => $values['address_id']];
       $addressDetails = CRM_Core_BAO_Address::getValues($addressParams, FALSE, 'id');
       $addressDetails = array_values($addressDetails);
       $values['billing_address'] = $addressDetails[0]['display'];

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -66,8 +66,8 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
 
       $addressExists = self::dataExists($value);
       if (empty($value['id'])) {
-        if (!empty($addresses) && array_key_exists(CRM_Utils_Array::value('location_type_id', $value), $addresses)) {
-          $value['id'] = $addresses[CRM_Utils_Array::value('location_type_id', $value)];
+        if (!empty($addresses) && !empty($value['location_type_id']) && array_key_exists($value['location_type_id'], $addresses)) {
+          $value['id'] = $addresses[$value['location_type_id']];
         }
       }
 

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -90,7 +90,7 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
 
     // CRM-4377 (ab)uses the module column
     if (isset($params['module'])) {
-      $dao->module = $params['module'] ?? NULL;
+      $dao->module = $params['module'];
     }
     $dao->entity_table = $params['entity_table'] ?? NULL;
     $dao->entity_id = $params['entity_id'] ?? NULL;
@@ -143,7 +143,7 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
 
     // CRM-4377 (ab)uses the module column
     if (isset($params['module'])) {
-      $dao->module = $params['module'] ?? NULL;
+      $dao->module = $params['module'];
     }
     $dao->entity_table = $params['entity_table'] ?? NULL;
     $dao->entity_id = $params['entity_id'] ?? NULL;

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1049,7 +1049,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
     // Add the billing names to the billing address, if a billing name is set
     if (!empty($params['billing_first_name'])) {
-      $params["address_name-{$form->_bltID}"] = CRM_Utils_Array::value('billing_first_name', $params) . ' ' . CRM_Utils_Array::value('billing_middle_name', $params) . ' ' . CRM_Utils_Array::value('billing_last_name', $params);
+      $params["address_name-{$form->_bltID}"] = $params['billing_first_name'] . ' ' . CRM_Utils_Array::value('billing_middle_name', $params) . ' ' . CRM_Utils_Array::value('billing_last_name', $params);
       $fields["address_name-{$form->_bltID}"] = 1;
     }
 

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -114,10 +114,10 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
    */
   public static function &create(&$params) {
     if (isset($params['report_header'])) {
-      $params['header'] = $params['report_header'] ?? NULL;
+      $params['header'] = $params['report_header'];
     }
     if (isset($params['report_footer'])) {
-      $params['footer'] = $params['report_footer'] ?? NULL;
+      $params['footer'] = $params['report_footer'];
     }
 
     // build navigation parameters

--- a/CRM/Report/Form/Grant/Statistics.php
+++ b/CRM/Report/Form/Grant/Statistics.php
@@ -388,8 +388,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       }
 
       if (array_key_exists('civicrm_worldregion_name', $values)) {
-        $region = $values['civicrm_worldregion_name'] ?? NULL;
-        $region = ($region) ? $region : 'Unassigned';
+        $region = $values['civicrm_worldregion_name'] ?: 'Unassigned';
         $grantStatistics['civicrm_worldregion_name']['title'] = ts('By Region');
         self::getStatistics($grantStatistics['civicrm_worldregion_name'], $region, $values,
           $awardedGrants, $awardedGrantsAmount
@@ -397,8 +396,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       }
 
       if (array_key_exists('civicrm_address_country_id', $values)) {
-        $country = $countries[$values['civicrm_address_country_id']] ?? NULL;
-        $country = ($country) ? $country : 'Unassigned';
+        $country = $countries[$values['civicrm_address_country_id']] ?? 'Unassigned';
         $grantStatistics['civicrm_address_country_id']['title'] = ts('By Country');
         self::getStatistics($grantStatistics['civicrm_address_country_id'], $country, $values,
           $awardedGrants, $awardedGrantsAmount
@@ -414,8 +412,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       }
 
       if (array_key_exists('civicrm_contact_gender_id', $values)) {
-        $genderLabel = $gender[$values['civicrm_contact_gender_id']] ?? NULL;
-        $genderLabel = ($genderLabel) ? $genderLabel : 'Unassigned';
+        $genderLabel = $gender[$values['civicrm_contact_gender_id']] ?? 'Unassigned';
         $grantStatistics['civicrm_contact_gender_id']['title'] = ts('By Gender');
         self::getStatistics($grantStatistics['civicrm_contact_gender_id'], $genderLabel, $values,
           $awardedGrants, $awardedGrantsAmount

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -930,7 +930,7 @@ function civicrm_api3_contact_getquick($params) {
   // Contact's based of relationhip type
   $relType = NULL;
   if (!empty($params['rel'])) {
-    $relation = explode('_', CRM_Utils_Array::value('rel', $params));
+    $relation = explode('_', $params['rel']);
     $relType = CRM_Utils_Type::escape($relation[0], 'Integer');
     $rel = CRM_Utils_Type::escape($relation[2], 'String');
   }

--- a/extern/url.php
+++ b/extern/url.php
@@ -8,12 +8,8 @@ CRM_Core_Config::singleton();
 
 // To keep backward compatibility for URLs generated
 // by CiviCRM < 1.7, we check for the q variable as well.
-if (isset($_GET['qid'])) {
-  $queue_id = $_GET['qid'] ?? NULL;
-}
-else {
-  $queue_id = $_GET['q'] ?? NULL;
-}
+$queue_id = $_GET['qid'] ?? $_GET['q'] ?? NULL;
+
 $url_id = $_GET['u'] ?? NULL;
 
 if (!$url_id) {


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup - fixes up situations where we check if an array key exists, and then immediately check again.

Before
----------------------------------------
Double check, first in a conditional, then again with `CRM_Utils_Array::value` or coalesce.

After
----------------------------------------
Removed second check. Once is enough.
