### PR TITLE
[NFC] Remove a handful of legacy svn notations

### DIFF
--- a/Civi/Api4/Action/Campaign/Get.php
+++ b/Civi/Api4/Action/Campaign/Get.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4\Action\Campaign;

--- a/Civi/Api4/Action/CustomValue/Create.php
+++ b/Civi/Api4/Action/CustomValue/Create.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Action/CustomValue/Get.php
+++ b/Civi/Api4/Action/CustomValue/Get.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Mapping.php
+++ b/Civi/Api4/Mapping.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4;

--- a/Civi/Api4/RelationshipType.php
+++ b/Civi/Api4/RelationshipType.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/GroupCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/GroupCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/MappingCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/MappingCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/NavigationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/NavigationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/NoteCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/NoteCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/PaymentProcessorTypeCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/PaymentProcessorTypeCreationSpecProvider.php
@@ -28,8 +28,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2020
- * $Id$
- *
  */
 namespace Civi\Api4\Service\Spec\Provider;
 

--- a/Civi/Api4/Service/Spec/Provider/PhoneCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/PhoneCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/RelationshipTypeCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/RelationshipTypeCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/TagCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/TagCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/UFFieldCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/UFFieldCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/RequestSpec.php
+++ b/Civi/Api4/Service/Spec/RequestSpec.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/StateProvince.php
+++ b/Civi/Api4/StateProvince.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4;

--- a/Civi/Api4/StatusPreference.php
+++ b/Civi/Api4/StatusPreference.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/System.php
+++ b/Civi/Api4/System.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Tag.php
+++ b/Civi/Api4/Tag.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/UFField.php
+++ b/Civi/Api4/UFField.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/UFGroup.php
+++ b/Civi/Api4/UFGroup.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/UFJoin.php
+++ b/Civi/Api4/UFJoin.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Website.php
+++ b/Civi/Api4/Website.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor comment block cleanup

Before
----------------------------------------
Obsolete
* $Id$

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
This isn't all of them - just some - about 1/4 of remaining ones in apiv4 code
