### PR TITLE
Refactor api3 Payment.Get API to support options + most fields in civicrm_financial_trxn

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -479,6 +479,9 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
    *  - 1 Contribution with status = Pending
    *  - 1 Line item
    *  - 1 civicrm_financial_item. This is linked to the line item and has a status of 3
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testSubmitCreditCardInvalid() {
     $form = new CRM_Contribute_Form_Contribution();
@@ -517,6 +520,9 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function creates a billing address if provided.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testSubmitCreditCardWithBillingAddress() {
     $form = new CRM_Contribute_Form_Contribution();


### PR DESCRIPTION

Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/16603 for fix ups on Payment.get

Before
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/16603

After
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/16603

Technical Details
----------------------------------------
@mattwire I took a look at https://github.com/civicrm/civicrm-core/pull/16603 & came to the conclusion that Payment.get is basically FinancialTrxn.get with 3 extras

1) enforced is_payment = 1
2) support for passing in contribution_id
3) contribution_id added to results array.

Given that I was able to reach a similar but slightly different result. Note that I concluded it's not logical to pass in any entity_table other than contribution, so I made that a non-parameter.

Also I removed 'In Progress' from the test as that's not a status we support for contributions (it got into contribution statuses from pledge statuses but there is no core meaning for it - I switched to Pending'


Comments
----------------------------------------
