### PR TITLE
Merge code - remove UPDATE IGNORE+Delete & just use reliable update

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -543,8 +543,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
           $preOperationSqls = self::operationSql($mainId, $otherId, $table, $tableOperations);
           $sqls = array_merge($sqls, $preOperationSqls);
-          $sqls[] = "UPDATE IGNORE $table SET $field = $mainId WHERE $field = $otherId";
-          $sqls[] = "DELETE FROM $table WHERE $field = $otherId";
+          $sqls[] = "UPDATE $table SET $field = $mainId WHERE $field = $otherId";
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This updates the Merger code so instead of don't a tolerant UPDATE IGNORE followed by a DELETE it does an 'intolerant' UPDATE.

There are 2 reasons
1) risk - we are potentially deleting data without understanding why - #17060 removed the only reason it should fail so if it still fails what are we deleting?
2) the delete is a locking query - if we don't need it let's not do it

Before
----------------------------------------
When moving data the codes uses (for example)

UPDATE IGNORE civicrm_contact SET primary_contact_id = 41372076`; DELETE FROM civicrm_contact WHERE primary_contact_id = 41372076

After
----------------------------------------
UPDATE civicrm_contact SET primary_contact_id = 41372076`;

Technical Details
----------------------------------------
Now that https://github.com/civicrm/civicrm-core/pull/17060 is merged I believe this is no longer required

Comments
----------------------------------------
I came across DELETE FROM civicrm_contact WHERE primary_contact_id = 41372076 as a query involved in a deadlock during a batch merge and felt discomfort about whether this was always safe and also whether we could reduce locking queries in deduping (which this is)


