### PR TITLE
Add MessageTemplate api to v4

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -261,6 +261,10 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
 
   /**
    * Process the form submission.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
@@ -303,12 +307,12 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
         $params['is_active'] = TRUE;
       }
 
-      $messageTemplate = CRM_Core_BAO_MessageTemplate::add($params);
-      CRM_Core_Session::setStatus(ts('The Message Template \'%1\' has been saved.', [1 => $messageTemplate->msg_title]), ts('Saved'), 'success');
+      $messageTemplate = MessageTemplate::save()->setDefaults($params)->setRecords([['id' => $this->_id]])->execute()->first();
+      CRM_Core_Session::setStatus(ts('The Message Template \'%1\' has been saved.', [1 => $messageTemplate['msg_title']]), ts('Saved'), 'success');
 
       if (isset($this->_submitValues['_qf_MessageTemplates_upload'])) {
         // Save button was pressed
-        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/messageTemplates/add', "action=update&id={$messageTemplate->id}&reset=1"));
+        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/messageTemplates/add', "action=update&id={$messageTemplate['id']}&reset=1"));
       }
       // Save and done button was pressed
       if ($this->_workflow_id) {

--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\MessageTemplate;
+
 /**
  *
  * @package CRM
@@ -19,7 +21,7 @@
  * This class generates form components for Message templates
  * used by membership, contributions, event registrations, etc.
  */
-class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
+class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
   /**
    * which (and whether) mailing workflow this template belongs to
    * @var int
@@ -28,20 +30,26 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
 
   /**
    * Is document file is already loaded as default value?
+   *
    * @var bool
    */
   protected $_is_document = FALSE;
 
+  /**
+   * PreProcess form - load existing values.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
   public function preProcess() {
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->_action = CRM_Utils_Request::retrieve('action', 'String',
-      $this, FALSE, 'add'
-    );
+    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');
     $this->assign('action', $this->_action);
-
-    $this->_BAOName = 'CRM_Core_BAO_MessageTemplate';
-    $this->set('BAOName', $this->_BAOName);
-    parent::preProcess();
+    $this->_values = [];
+    if ($this->_id) {
+      $this->_values = (array) MessageTemplate::get()->addWhere('id', '=', $this->_id)->setSelect(['*'])->execute()->first();
+    }
   }
 
   /**

--- a/Civi/Api4/MessageTemplate.php
+++ b/Civi/Api4/MessageTemplate.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4;
+
+/**
+ * MsgTemplate entity.
+ *
+ * This is a collection of MsgTemplate, for reuse in import, export, etc.
+ *
+ * @package Civi\Api4
+ */
+class MessageTemplate extends Generic\DAOEntity {
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Basic add of MessageTemplate entity to apiv4  & use if from core form

Before
----------------------------------------
Not there

After
----------------------------------------
Ta-da

Technical Details
----------------------------------------
I'm looking to cleanup this form to use the apiv4 (I'd rather got the extra step & switch it to an afform but
that seems like too big a leap).

This switches the loading to use apiv4. Note that
1) I decided that it doesn't make sense to setCheckPermissions = FALSE - I think the form should not
be availble to non-permissioned users (& perhaps a hook might like to play a role here).

2) I removed the inheritence from the parent  which seemed to do 3 things
 - added admin.css - none of the classes seemed to apply
 - added iconpicker - didn't seem to apply
 - loaded the defaults - which this change does on the form more succinctly



Comments
----------------------------------------

