### PR TITLE
dev/core#1701 - Fix APIv4 1-to-many joins

### DIFF
--- a/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
@@ -113,7 +113,7 @@ class PostSelectQuerySubscriber implements EventSubscriberInterface {
     $joinedDotSelects = array_filter(
       $query->getSelect(),
       function ($select) use ($query) {
-        return strpos($select, '.') && array_filter($query->getPathJoinTypes($select));
+        return strpos($select, '.') && !is_numeric($select) && $query->isOneToManyField($select);
       }
     );
 

--- a/Civi/Api4/Utils/ArrayInsertionUtil.php
+++ b/Civi/Api4/Utils/ArrayInsertionUtil.php
@@ -21,6 +21,8 @@
 
 namespace Civi\Api4\Utils;
 
+use Civi\Api4\Service\Schema\Joinable\Joinable;
+
 class ArrayInsertionUtil {
 
   /**
@@ -37,7 +39,7 @@ class ArrayInsertionUtil {
    */
   public static function insert(&$array, $parts, $values) {
     $key = key($parts);
-    $isMulti = array_shift($parts);
+    $isMulti = array_shift($parts) === Joinable::JOIN_TYPE_ONE_TO_MANY;
     if (!isset($array[$key])) {
       $array[$key] = $isMulti ? [] : NULL;
     }

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -91,4 +91,24 @@ class FkJoinTest extends UnitTestCase {
     $this->assertEquals($testPhone['phone'], $firstPhone['phone']);
   }
 
+  public function testJoinWithLimit() {
+    $base = function() {
+      return Contact::get()
+        ->setCheckPermissions(FALSE)
+        ->addWhere('id', 'IN', [$this->getReference('test_contact_1')['id'], $this->getReference('test_contact_2')['id']])
+        ->addSelect('id', 'display_name', 'phones.phone')
+        ->setDebug(TRUE)
+        ->addOrderBy('id', 'DESC');
+    };
+
+    $result1 = $base()->setLimit(1)->execute();
+    $result2 = $base()->setLimit(2)->execute();
+    $this->assertCount(2, $result2);
+    $this->assertCount(1, $result1);
+    $this->assertNotContains('DISTINCT', $result1->debug['sql'][0]);
+    $this->assertContains('LIMIT', $result1->debug['sql'][0]);
+    // FIXME: secondary query should not contain LIMIT. Needs work.
+    // $this->assertNotContains('LIMIT', $result1->debug['sql'][1]);
+  }
+
 }

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryComplexJoinTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryComplexJoinTest.php
@@ -47,7 +47,8 @@ class Api4SelectQueryComplexJoinTest extends UnitTestCase {
 
   public function testWithComplexRelatedEntitySelect() {
     $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
-    $query = new Api4SelectQuery($api);    $query->select[] = 'id';
+    $query = new Api4SelectQuery($api);
+    $query->select[] = 'id';
     $query->select[] = 'display_name';
     $query->select[] = 'phones.*_id';
     $query->select[] = 'emails.email';
@@ -84,7 +85,8 @@ class Api4SelectQueryComplexJoinTest extends UnitTestCase {
 
   public function testWithSelectOfOrphanDeepValues() {
     $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
-    $query = new Api4SelectQuery($api);    $query->select[] = 'id';
+    $query = new Api4SelectQuery($api);
+    $query->select[] = 'id';
     $query->select[] = 'first_name';
     // emails not selected
     $query->select[] = 'emails.location_type.name';

--- a/tests/phpunit/api/v4/Utils/ArrayInsertionServiceTest.php
+++ b/tests/phpunit/api/v4/Utils/ArrayInsertionServiceTest.php
@@ -21,6 +21,7 @@
 
 namespace api\v4\Utils;
 
+use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Civi\Api4\Utils\ArrayInsertionUtil;
 use api\v4\UnitTestCase;
 
@@ -31,7 +32,7 @@ class ArrayInsertionServiceTest extends UnitTestCase {
 
   public function testInsertWillWork() {
     $arr = [];
-    $path = ['foo' => FALSE, 'bar' => FALSE];
+    $path = ['foo' => Joinable::JOIN_TYPE_ONE_TO_ONE, 'bar' => Joinable::JOIN_TYPE_ONE_TO_ONE];
     $inserter = new ArrayInsertionUtil();
     $inserter::insert($arr, $path, ['LALA']);
 
@@ -70,8 +71,8 @@ class ArrayInsertionServiceTest extends UnitTestCase {
       ],
     ];
 
-    $emailPath = ['emails' => TRUE];
-    $locationPath = ['emails' => TRUE, 'location' => FALSE];
+    $emailPath = ['emails' => Joinable::JOIN_TYPE_ONE_TO_MANY];
+    $locationPath = ['emails' => Joinable::JOIN_TYPE_ONE_TO_MANY, 'location' => Joinable::JOIN_TYPE_ONE_TO_ONE];
     $inserter = new ArrayInsertionUtil();
 
     foreach ($contacts as &$contact) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in APIv4 joins.
See https://lab.civicrm.org/dev/core/-/issues/1701

Before
----------------------------------------
LIMIT not working correctly with joins.

After
----------------------------------------
This test passes now, although there are still problems to be addressed.

Technical Details
----------------------------------------
When doing WHERE or ORDER BY an n-to-many join, it adds DISTINCT to the query.
When doing SELECT on an n-to-many join, it avoids adding a join to the query at all, as it gets handled in the postQuerySubscriber.

Comments
----------------------------------------
The way postQuerySubscriber composes the query is still wrong. But at least this test now passes.
Will follow up with further fixes.
