### PR TITLE
Export: use X icon `fa-times` for closing things

### DIFF
--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -78,7 +78,7 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
       ],
       [
         'type' => 'done',
-        'icon' => 'fa-ban',
+        'icon' => 'fa-times',
         'name' => ts('Return to Search'),
       ],
       [


### PR DESCRIPTION
See https://docs.civicrm.org/dev/en/latest/framework/ui/#icon-meaning-and-consistency

Overview
----------------------------------------
The button to return to search from choosing export fields should be `fa-times` (an :x:) rather than `fa-ban` (a :no_entry_sign:)

Before
----------------------------------------
:no_entry_sign: 
![image](https://user-images.githubusercontent.com/1682375/79276883-c257dc00-7e76-11ea-9de1-1da07dbe2c9e.png)


After
----------------------------------------
:x: 
![image](https://user-images.githubusercontent.com/1682375/79277298-8b35fa80-7e77-11ea-94a0-d2b6aae27d57.png)


Technical Details
----------------------------------------
See https://docs.civicrm.org/dev/en/latest/framework/ui/#icon-meaning-and-consistency for a reference on this.

The rationale (besides :x: being used everywhere already) is that :no_entry_sign: implies you want to nix something while :x: has the connotation of just wanting to get out of where you are.