### PR TITLE
respect file fields that have been configured as view only in profiles

### DIFF
--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -157,7 +157,9 @@
                 &nbsp;{$form.$phone_ext_field.html}
                 {/if}
               {else}
-                {$form.$n.html}
+                {if $field.html_type neq 'File' || ($field.html_type eq 'File' && !$field.is_view)}
+                   {$form.$n.html}
+                {/if}
                 {if $field.html_type eq 'Autocomplete-Select'}
                   {if $field.data_type eq 'ContactReference'}
                     {include file="CRM/Custom/Form/ContactReference.tpl" element_name = $n}
@@ -170,7 +172,9 @@
 
           {if $form.$n.type eq 'file'}
             <div class="crm-section file_displayURL-section file_displayURL{$n}-section"><div class="content">{$customFiles.$n.displayURL}</div></div>
-            <div class="crm-section file_deleteURL-section file_deleteURL{$n}-section"><div class="content">{$customFiles.$n.deleteURL}</div></div>
+            {if !$fields.$n.is_view}
+               <div class="crm-section file_deleteURL-section file_deleteURL{$n}-section"><div class="content">{$customFiles.$n.deleteURL}</div></div>
+            {/if}
           {/if}
         {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate
===================

* Create a custom field of type *File*
* Use this field in a profile with all fields read only (with *View Only* setting as TRUE)
* Open the profile in edit mode for a contact
* All fields will be in read only mode except file field with the option to change /delete file 

Before
----------------------------------------
Config
![profile_config](https://user-images.githubusercontent.com/3455173/79334990-e41c9600-7f3e-11ea-9dc3-12b119648c76.png)

Before
![file_before](https://user-images.githubusercontent.com/3455173/79335013-ee3e9480-7f3e-11ea-8e1e-aacea54dbac5.png)

After
----------------------------------------
![profile_after](https://user-images.githubusercontent.com/3455173/79335018-f4cd0c00-7f3e-11ea-871c-f500ae0fb6f3.png)
