### PR TITLE
CiviMail - Fix “Missing parameters” error in unsubscribe confirmation

### DIFF
--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -122,7 +122,6 @@ WHERE  email = %2
     }
 
     $contact_id = $q->contact_id;
-    $transaction = new CRM_Core_Transaction();
 
     $mailing_id = civicrm_api3('MailingJob', 'getvalue', ['id' => $job_id, 'return' => 'mailing_id']);
     $mailing_type = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $mailing_id, 'mailing_type', 'id');
@@ -262,7 +261,7 @@ WHERE  email = %2
         $groups[$do->group_id] = $do->title;
       }
     }
-
+    $transaction = new CRM_Core_Transaction();
     $contacts = [$contact_id];
     foreach ($groups as $group_id => $group_name) {
       $notremoved = FALSE;

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -121,7 +121,6 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
       CRM_Core_Session::setStatus($statusMsg, '', 'error');
 
     }
-
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix issue with form values not being available on submit
    
Possible fix for https://civicrm.stackexchange.com/questions/35323/missing-parameters-error-in-unsubscribe-confirmation
    
   

Before
----------------------------------------
Per https://civicrm.stackexchange.com/questions/35323/missing-parameters-error-in-unsubscribe-confirmation 

After
----------------------------------------
Submit works

Technical Details
----------------------------------------
 The theory is that not having committed the transaction is causing the session not to be saved

Comments
----------------------------------------

