### PR TITLE
dev/core#1708 Use civi url for mailing urls

### DIFF
--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -72,11 +72,11 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
       }
       $id = $tracker->id;
 
-      $redirect = CRM_Utils_System::externUrl('extern/url', "u=$id");
+      $redirect = CRM_Utils_System::previouslyExternUrl('civicrm/mailing/url', ['u=' => $id]);
       $urlCache[$mailing_id . $url] = $redirect;
     }
 
-    $returnUrl = CRM_Utils_System::externUrl('extern/url', "u=$id&qid=$queue_id");
+    $returnUrl = CRM_Utils_System::previouslyExternUrl('civicrm/mailing/url', ['u=' => $id, 'qid' => $queue_id]);
 
     if ($hrefExists) {
       $returnUrl = "href='{$returnUrl}' rel='nofollow'";

--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Redirects a user to the full url from a mailing url.
+ */
+class CRM_Mailing_Page_Url extends CRM_Core_Page {
+
+  /**
+   * Redirect the user to the specified url.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function run() {
+    $queue_id = CRM_Utils_Request::retrieveValue('qid', 'Integer');
+    $url_id = CRM_Utils_Request::retrieveValue('u', 'Integer', NULL, TRUE);
+    $url = CRM_Mailing_Event_BAO_TrackableURLOpen::track($queue_id, $url_id);
+
+    // CRM-7103
+    // Looking for additional query variables and append them when redirecting.
+    $query_param = $_GET;
+    unset($query_param['qid'], $query_param['u']);
+    $query_string = http_build_query($query_param);
+
+    if (strlen($query_string) > 0) {
+      // Parse the url to preserve the fragment.
+      $pieces = parse_url($url);
+
+      if (isset($pieces['fragment'])) {
+        $url = str_replace('#' . $pieces['fragment'], '', $url);
+      }
+
+      // Handle additional query string params.
+      if ($query_string) {
+        if (stristr($url, '?')) {
+          $url .= '&' . $query_string;
+        }
+        else {
+          $url .= '?' . $query_string;
+        }
+      }
+
+      // slap the fragment onto the end per URL spec
+      if (isset($pieces['fragment'])) {
+        $url .= '#' . $pieces['fragment'];
+      }
+    }
+    CRM_Utils_System::redirect($url);
+  }
+
+}

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -206,4 +206,9 @@
     <page_callback>CRM_Mailing_Page_AJAX::getContactMailings</page_callback>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/mailing/url</path>
+    <page_callback>CRM_Mailing_Page_Url</page_callback>
+    <access_arguments>1</access_arguments>
+  </item>
 </menu>

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -319,6 +319,31 @@ class CRM_Utils_System {
   }
 
   /**
+   * Generate a url for a url that used to be an externUrl, still calling the old hook.
+   *
+   * Note that the reason why these bypass the main website dates back to some assumptions about difficulty
+   * and speed from around 2007. However, the Rest path does have some added complexity.
+   *
+   * @param string $url
+   * @param array $query
+   *
+   * @return string
+   */
+  public static function previouslyExternUrl($url, array $query): string {
+    $parsedUrl = CRM_Utils_Url::parseUrl(CRM_Utils_System::url($url, $query, TRUE, NULL, FALSE, TRUE));
+    $event = \Civi\Core\Event\GenericHookEvent::create([
+      'url' => &$parsedUrl,
+      'path' => $url,
+      'query' => $query,
+      'absolute' => TRUE,
+    ]);
+    Civi::service('dispatcher')->dispatch('hook_civicrm_alterExternUrl', $event);
+    return $parsedUrl;
+  }
+
+  /**
+   * Path of the current page e.g. 'civicrm/contact/view'
+   *
    * @deprecated
    * @see \CRM_Utils_System::currentPath
    *

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -200,7 +200,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertRegExp(
         ";" .
         // body_html
-        "<p>You can go to <a href=['\"].*extern/url\.php\?u=\d+&amp\\;qid=\d+['\"] rel='nofollow'>Google</a>" .
+        "<p>You can go to <a href=['\"].*civicrm/mailing/url\.php\?u=\d+&amp\\;qid=\d+['\"] rel='nofollow'>Google</a>" .
         " or <a href=\"http.*civicrm/mailing/optout.*\">opt out</a>.</p>\n" .
         // Default footer
         "Sample Footer for HTML formatted content" .
@@ -219,7 +219,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         "\n" .
         "Links:\n" .
         "------\n" .
-        "\\[1\\] .*extern/url\.php\?u=\d+&qid=\d+\n" .
+        "\\[1\\] http.*civicrm/mailing/url\.php\?u=\d+&qid=\d+\n" .
         "\\[2\\] http.*civicrm/mailing/optout.*\n" .
         "\n" .
         // Default footer
@@ -280,8 +280,8 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
     // Tracking enabled
     $cases[] = [
       '<p><a href="http://example.net/">Foo</a></p>',
-      ';<p><a href=[\'"].*extern/url\.php\?u=\d+.*[\'"]>Foo</a></p>;',
-      ';\\[1\\] .*extern/url\.php\?u=\d+.*;',
+      ';<p><a href=[\'"].*civicrm/mailing/url\.php\?u=\d+.*[\'"]>Foo</a></p>;',
+      ';\\[1\\] .*civicrm/mailing/url\.php\?u=\d+.*;',
       ['url_tracking' => 1],
     ];
     $cases[] = [
@@ -311,7 +311,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       // but not in HTML emails.
       "<p>Please go to: http://example.net/</p>",
       ";<p>Please go to: http://example\.net/</p>;",
-      ';Please go to: .*extern/url.php\?u=\d+&qid=\d+;',
+      ';Please go to: .*civicrm/mailing.php\?u=\d+&qid=\d+;',
       ['url_tracking' => 1],
     ];
 
@@ -322,6 +322,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
    * Generate a fully-formatted mailing (with body_html content).
    *
    * @dataProvider urlTrackingExamples
+   * @throws \CRM_Core_Exception
    */
   public function testUrlTracking($inputHtml, $htmlUrlRegex, $textUrlRegex, $params) {
     $caseName = print_r(['inputHtml' => $inputHtml, 'params' => $params], 1);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1708

Before
----------------------------------------
url path is in extern

After
----------------------------------------
url path uses CMS

Technical Details
----------------------------------------

Comments
----------------------------------------
Note that I have not tested this - I did it as feedback on @aydun's questions in gitlab