### PR TITLE
Generalise typo3/phar-stream-wrapper so CiviCRM can be installed on D8.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",
     "xkerman/restricted-unserialize": "~1.1",
-    "typo3/phar-stream-wrapper": "^3.0"
+    "typo3/phar-stream-wrapper": "^2 || ^3.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37569326ca90c5f0e9c6d2df125ebbc9",
+    "content-hash": "00d8b8be8e838f8ff098162f88af562c",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM v5.24.3 cannot be installed onto a Drupal 8.7 (or earlier) site using straight composer because there is a conflict between CiviCRM's requirement of ^3 and drupal's ^2.1.1.

This problem does not affect Drupal 8.8 (or later).

Before
----------------------------------------
CiviCRM cannot be installed on drupal 8.7 using composer from v5.24.3 onwards

After
----------------------------------------
CiviCRM can be installed ontop of Drupal8.7 using composer

ping @totten 