### PR TITLE
Don't pass empty ids parameter, fix fatal

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -92,6 +92,9 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
    *   Create or delete.
    * @param array $owner
    *   Primary membership info (membership_id, contact_id, membership_type ...).
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function relAction($action, $owner) {
     switch ($action) {
@@ -119,16 +122,14 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
           'skipStatusCal' => TRUE,
           'createActivity' => TRUE,
         ];
-        // @todo stop passing $ids here (we are only doing so because of passbyreference)
-        $ids = [];
-        CRM_Member_BAO_Membership::create($params, $ids);
+        CRM_Member_BAO_Membership::create($params);
         $relatedDisplayName = CRM_Contact_BAO_Contact::displayName($params['contact_id']);
         CRM_Core_Session::setStatus(ts('Related membership for %1 has been created.', [1 => $relatedDisplayName]),
           ts('Membership Added'), 'success');
         break;
 
       default:
-        CRM_Core_Error::fatal(ts("Invalid action specified in URL"));
+        throw new CRM_Core_Exception(ts('Invalid action specified in URL'));
     }
 
     // Redirect back to membership view page for the owner, without the relAction parameters


### PR DESCRIPTION
Overview
----------------------------------------
$ids is an optional parameter in Membership::create - we should not pass it if it has no meaning

Also -replace fatal with an exception

Before
----------------------------------------
```

        $ids = [];
        CRM_Member_BAO_Membership::create($params, $ids);
```

After
----------------------------------------
```
 CRM_Member_BAO_Membership::create($params);
```

Technical Details
----------------------------------------
There is no other reference to $ids in the changed function

Comments
----------------------------------------

