### PR TITLE
[NFC] Remove all the places where tests unnecessarily pass  to Membership::create

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -131,6 +131,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
     // Now call create() to modify an existing Membership
     $params = [
+      'id' => $membershipId,
       'contact_id' => $contactId,
       'membership_type_id' => $this->_membershipTypeID,
       'join_date' => date('Ymd', strtotime('2006-01-21')),
@@ -140,10 +141,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [
-      'membership' => $membershipId,
-    ];
-    CRM_Member_BAO_Membership::create($params, $ids);
+    CRM_Member_BAO_Membership::create($params);
 
     $membershipTypeId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId,
       'membership_type_id', 'contact_id',
@@ -176,8 +174,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $ids = [];
-    CRM_Member_BAO_Membership::create($params, $ids);
+    CRM_Member_BAO_Membership::create($params);
 
     $membershipId1 = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'
@@ -193,8 +190,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 0,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    CRM_Member_BAO_Membership::create($params, $ids);
+
+    CRM_Member_BAO_Membership::create($params);
 
     $membershipId2 = $this->assertDBNotNull('CRM_Member_BAO_Membership', 'source123', 'id',
       'source', 'Database check for created membership.'
@@ -237,8 +234,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    CRM_Member_BAO_Membership::create($params, $ids);
+
+    CRM_Member_BAO_Membership::create($params);
 
     $membershipId1 = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'
@@ -259,8 +256,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    CRM_Member_BAO_Membership::create($params, $ids);
+
+    CRM_Member_BAO_Membership::create($params);
 
     $membershipId2 = $this->assertDBNotNull('CRM_Member_BAO_Membership', 'PaySource', 'id',
       'source', 'Database check for created membership.'
@@ -410,8 +407,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    $membership = CRM_Member_BAO_Membership::create($params, $ids);
+
+    $membership = CRM_Member_BAO_Membership::create($params);
     $membershipId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'
     );
@@ -480,8 +477,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $statusId,
     ];
 
-    $ids = [];
-    $membership = CRM_Member_BAO_Membership::create($params, $ids);
+    $membership = CRM_Member_BAO_Membership::create($params);
 
     $membershipId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'
@@ -551,8 +547,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_override_end_date' => date('Ymd', strtotime('-1 day')),
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    $createdMembership = CRM_Member_BAO_Membership::create($params, $ids);
+
+    $createdMembership = CRM_Member_BAO_Membership::create($params);
 
     CRM_Member_BAO_Membership::updateAllMembershipStatus();
 
@@ -579,8 +575,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_override_end_date' => date('Ymd', time()),
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    $createdMembership = CRM_Member_BAO_Membership::create($params, $ids);
+
+    $createdMembership = CRM_Member_BAO_Membership::create($params);
 
     CRM_Member_BAO_Membership::updateAllMembershipStatus();
 
@@ -606,8 +602,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    $createdMembership = CRM_Member_BAO_Membership::create($params, $ids);
+
+    $createdMembership = CRM_Member_BAO_Membership::create($params);
 
     CRM_Member_BAO_Membership::updateAllMembershipStatus();
 
@@ -821,8 +817,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    CRM_Member_BAO_Membership::create($params, $ids);
+
+    CRM_Member_BAO_Membership::create($params);
 
     $membershipId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'

--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -308,8 +308,8 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    $ids = [];
-    $membership = CRM_Member_BAO_Membership::create($params, $ids);
+
+    $membership = CRM_Member_BAO_Membership::create($params);
 
     $membershipRenewDates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membership->id);
 

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1169,6 +1169,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
   /**
    * CRM-18503 - Test membership join date is correctly set for fixed memberships.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testMembershipJoinDateFixed() {
     $memStatus = CRM_Member_PseudoConstant::membershipStatus();
@@ -1185,9 +1187,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'skipStatusCal' => 1,
       'is_for_organization' => 1,
     ];
-    // @todo stop passing empty $ids
-    $ids = [];
-    $membership = CRM_Member_BAO_Membership::create($params, $ids);
+    $membership = CRM_Member_BAO_Membership::create($params);
 
     // Update membership to 'Completed' and check the dates.
     $memParams = [


### PR DESCRIPTION
Overview
----------------------------------------

The param is deprecated - no reasonn to pass in the tests

Before
----------------------------------------
```CRM_Member_BAO_Membership::create($params, $ids);```

After
----------------------------------------
```CRM_Member_BAO_Membership::create($params);```

Technical Details
----------------------------------------
As long as tests still pass this has no further impacts

Comments
----------------------------------------

