### PR TITLE
dev/core#1718 membership batch entry join date fix

### DIFF
--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -375,7 +375,7 @@ function updateContactInfo(blockNo, prefix) {
                 cj('select[id="member_option_' + blockNo + '"]').prop('disabled', false).val(2);
                 cj('select[id="field_' + blockNo + '_membership_type_0"]').val(memTypeContactId).change();
                 cj('select[id="field_' + blockNo + '_membership_type_1"]').val(membershipTypeId).change();
-                cj('#field_' + blockNo + '_' + 'join_date').val(membershipJoinDate).trigger('change');
+                cj('#field_' + blockNo + '_' + 'membership_join_date').val(membershipJoinDate).trigger('change');
                 cj('#field_' + blockNo + '_' + 'membership_start_date').val(membershipStartDate).trigger('change');
               }
               });


### PR DESCRIPTION
Overview
----------------------------------------
When using the membership batch entry tool, if you select a contact with an existing membership it prepopulates with existing data. The join date is not prefilled because of an incorrect field name reference.

Before
----------------------------------------
Join date is not populated with existing data.

After
----------------------------------------
Join date is populated with existing data.
