### PR TITLE
Replace CaseType's own XML encoding function

### DIFF
--- a/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
@@ -28,6 +28,18 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
       'xml' => file_get_contents(__DIR__ . '/xml/empty-lists.xml'),
     ];
 
+    $fixtures['statuses'] = [
+      'json' => json_encode([
+        'activitySets' => [],
+        'activityTypes' => [],
+        'caseRoles' => [],
+        'statuses' => ['Ongoing', 'Completed', 'This & That'],
+        //'statuses' => ['Ongoing', 'Completed'],
+        'timelineActivityTypes' => [],
+      ]),
+      'xml' => file_get_contents(__DIR__ . '/xml/statuses.xml'),
+    ];
+
     $fixtures['one-item-in-each'] = [
       'json' => json_encode([
         'activityTypes' => [
@@ -177,6 +189,7 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
       'two-items-in-each',
       'forkable-0',
       'forkable-1',
+      'statuses',
     ] as $key) {
       $cases[] = [$key, $fixtures[$key]['json'], $fixtures[$key]['xml']];
     }

--- a/tests/phpunit/CRM/Case/BAO/xml/empty-defn.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/empty-defn.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
   <name>Housing Support</name>
 </CaseType>

--- a/tests/phpunit/CRM/Case/BAO/xml/empty-node-text.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/empty-node-text.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
   <name>Housing Support</name>
   <ActivityTypes>

--- a/tests/phpunit/CRM/Case/BAO/xml/forkable-0.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/forkable-0.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
   <name>Housing Support</name>
   <forkable>0</forkable>

--- a/tests/phpunit/CRM/Case/BAO/xml/forkable-1.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/forkable-1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
   <name>Housing Support</name>
   <forkable>1</forkable>

--- a/tests/phpunit/CRM/Case/BAO/xml/one-item-in-each.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/one-item-in-each.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
   <name>Housing Support</name>
   <ActivityTypes>

--- a/tests/phpunit/CRM/Case/BAO/xml/statuses.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/statuses.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <CaseType>
   <name>Housing Support</name>
   <ActivityTypes></ActivityTypes>
+  <Statuses>
+    <Status>Ongoing</Status>
+    <Status>Completed</Status>
+    <Status>This &amp; That</Status>
+  </Statuses>
   <ActivitySets></ActivitySets>
   <CaseRoles></CaseRoles>
 </CaseType>
+

--- a/tests/phpunit/CRM/Case/BAO/xml/two-items-in-each.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/two-items-in-each.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
   <name>Housing Support</name>
   <ActivityTypes>

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/FiveTwentyTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/FiveTwentyTest.php
@@ -54,111 +54,111 @@ class CRM_Upgrade_Incremental_php_FiveTwentyTest extends CiviCaseTestCase {
      * don't get borked.
      */
     $newCaseTypeXml = <<<ENDXML
-<?xml version="1.0" encoding="utf-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
-<name>test_type</name>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<max_instances>1</max_instances>
-</ActivityType>
-<ActivityType>
-<name>Email</name>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-</ActivityType>
-<ActivityType>
-<name>Meeting</name>
-</ActivityType>
-<ActivityType>
-<name>Phone Call</name>
-</ActivityType>
-<ActivityType>
-<name>давид</name>
-</ActivityTypes>
-<ActivitySets>
-<ActivitySet>
-<name>standard_timeline</name>
-<label>Standard Timeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<status>Completed</status>
-<label>Open Case</label>
-<default_assignee_type>1</default_assignee_type>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-<ActivitySet>
-<name>timeline_1</name>
-<label>AnotherTimeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>7</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>14</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Benefits Specialist']}_a_b</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>21</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Spouse of']}_a_b</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>28</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Spouse of']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-</ActivitySets>
-<CaseRoles>
-<RelationshipType>
-<name>Senior Services Coordinator</name>
-<creator>1</creator>
-<manager>1</manager>
-</RelationshipType>
-<RelationshipType>
-<name>Spouse of</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist is</name>
-</RelationshipType>
-</CaseRoles>
-<RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
-</CaseType>
+ <name>test_type</name>
+ <ActivityTypes>
+  <ActivityType>
+   <name>Open Case</name>
+   <max_instances>1</max_instances>
+  </ActivityType>
+  <ActivityType>
+   <name>Email</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Follow up</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Meeting</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Phone Call</name>
+  </ActivityType>
+  <ActivityType>
+   <name>давид</name>
+  </ActivityTypes>
+  <ActivitySets>
+   <ActivitySet>
+    <name>standard_timeline</name>
+    <label>Standard Timeline</label>
+    <timeline>true</timeline>
+    <ActivityTypes>
+     <ActivityType>
+      <name>Open Case</name>
+      <status>Completed</status>
+      <label>Open Case</label>
+      <default_assignee_type>1</default_assignee_type>
+     </ActivityType>
+    </ActivityTypes>
+   </ActivitySet>
+   <ActivitySet>
+    <name>timeline_1</name>
+    <label>AnotherTimeline</label>
+    <timeline>true</timeline>
+    <ActivityTypes>
+     <ActivityType>
+      <name>Follow up</name>
+      <label>Follow up</label>
+      <status>Scheduled</status>
+      <reference_activity>Open Case</reference_activity>
+      <reference_offset>7</reference_offset>
+      <reference_select>newest</reference_select>
+      <default_assignee_type>2</default_assignee_type>
+      <default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
+      <default_assignee_contact></default_assignee_contact>
+     </ActivityType>
+     <ActivityType>
+      <name>Follow up</name>
+      <label>Follow up</label>
+      <status>Scheduled</status>
+      <reference_activity>Open Case</reference_activity>
+      <reference_offset>14</reference_offset>
+      <reference_select>newest</reference_select>
+      <default_assignee_type>2</default_assignee_type>
+      <default_assignee_relationship>{$relationshipTypeNames['Benefits Specialist']}_a_b</default_assignee_relationship>
+      <default_assignee_contact></default_assignee_contact>
+     </ActivityType>
+     <ActivityType>
+      <name>Follow up</name>
+      <label>Follow up</label>
+      <status>Scheduled</status>
+      <reference_activity>Open Case</reference_activity>
+      <reference_offset>21</reference_offset>
+      <reference_select>newest</reference_select>
+      <default_assignee_type>2</default_assignee_type>
+      <default_assignee_relationship>{$relationshipTypeNames['Spouse of']}_a_b</default_assignee_relationship>
+      <default_assignee_contact></default_assignee_contact>
+     </ActivityType>
+     <ActivityType>
+      <name>Follow up</name>
+      <label>Follow up</label>
+      <status>Scheduled</status>
+      <reference_activity>Open Case</reference_activity>
+      <reference_offset>28</reference_offset>
+      <reference_select>newest</reference_select>
+      <default_assignee_type>2</default_assignee_type>
+      <default_assignee_relationship>{$relationshipTypeNames['Spouse of']}_b_a</default_assignee_relationship>
+      <default_assignee_contact></default_assignee_contact>
+     </ActivityType>
+    </ActivityTypes>
+   </ActivitySet>
+  </ActivitySets>
+  <CaseRoles>
+   <RelationshipType>
+    <name>Senior Services Coordinator</name>
+    <creator>1</creator>
+    <manager>1</manager>
+   </RelationshipType>
+   <RelationshipType>
+    <name>Spouse of</name>
+   </RelationshipType>
+   <RelationshipType>
+    <name>Benefits Specialist is</name>
+   </RelationshipType>
+  </CaseRoles>
+  <RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
+ </CaseType>
+
 ENDXML;
 
     $dao = new CRM_Case_DAO_CaseType();
@@ -344,173 +344,173 @@ ENDXML;
     switch ($stage) {
       case 1:
         $newCaseTypeXml = <<<ENDXMLSIMPLE
-<?xml version="1.0" encoding="utf-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
-<name>simple</name>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<max_instances>1</max_instances>
-</ActivityType>
-<ActivityType>
-<name>Email</name>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-</ActivityType>
-<ActivityType>
-<name>Meeting</name>
-</ActivityType>
-<ActivityType>
-<name>Phone Call</name>
-</ActivityType>
-</ActivityTypes>
-<ActivitySets>
-<ActivitySet>
-<name>standard_timeline</name>
-<label>Standard Timeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<status>Completed</status>
-<label>Open Case</label>
-<default_assignee_type>1</default_assignee_type>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-<ActivitySet>
-<name>timeline_1</name>
-<label>AnotherTimeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>7</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-</ActivitySets>
-<CaseRoles>
-<RelationshipType>
-<name>Senior Services Coordinator</name>
-<creator>1</creator>
-<manager>1</manager>
-</RelationshipType>
-<RelationshipType>
-<name>Spouse of</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist is</name>
-</RelationshipType>
-<RelationshipType>
-<name>is Wallet Inspector of</name>
-</RelationshipType>
-<RelationshipType>
-<name>has as Wallet Inspector</name>
-</RelationshipType>
-<RelationshipType>
-<name>абвгде</name>
-</RelationshipType>
-<RelationshipType>
-<name>αβγδ changed</name>
-</RelationshipType>
-</CaseRoles>
-<RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
+ <name>simple</name>
+ <ActivityTypes>
+  <ActivityType>
+   <name>Open Case</name>
+   <max_instances>1</max_instances>
+  </ActivityType>
+  <ActivityType>
+   <name>Email</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Follow up</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Meeting</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Phone Call</name>
+  </ActivityType>
+ </ActivityTypes>
+ <ActivitySets>
+  <ActivitySet>
+   <name>standard_timeline</name>
+   <label>Standard Timeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Open Case</name>
+     <status>Completed</status>
+     <label>Open Case</label>
+     <default_assignee_type>1</default_assignee_type>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+  <ActivitySet>
+   <name>timeline_1</name>
+   <label>AnotherTimeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Follow up</name>
+     <label>Follow up</label>
+     <status>Scheduled</status>
+     <reference_activity>Open Case</reference_activity>
+     <reference_offset>7</reference_offset>
+     <reference_select>newest</reference_select>
+     <default_assignee_type>2</default_assignee_type>
+     <default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
+     <default_assignee_contact></default_assignee_contact>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+ </ActivitySets>
+ <CaseRoles>
+  <RelationshipType>
+   <name>Senior Services Coordinator</name>
+   <creator>1</creator>
+   <manager>1</manager>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Spouse of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>is Wallet Inspector of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>has as Wallet Inspector</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>абвгде</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>αβγδ changed</name>
+  </RelationshipType>
+ </CaseRoles>
+ <RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
 </CaseType>
+
 ENDXMLSIMPLE;
 
         $expectedCaseTypeXml = <<<ENDXMLSIMPLEEXPECTED
-<?xml version="1.0" encoding="utf-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
-<name>simple</name>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<max_instances>1</max_instances>
-</ActivityType>
-<ActivityType>
-<name>Email</name>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-</ActivityType>
-<ActivityType>
-<name>Meeting</name>
-</ActivityType>
-<ActivityType>
-<name>Phone Call</name>
-</ActivityType>
-</ActivityTypes>
-<ActivitySets>
-<ActivitySet>
-<name>standard_timeline</name>
-<label>Standard Timeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<status>Completed</status>
-<label>Open Case</label>
-<default_assignee_type>1</default_assignee_type>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-<ActivitySet>
-<name>timeline_1</name>
-<label>AnotherTimeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>7</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-</ActivitySets>
-<CaseRoles>
-<RelationshipType>
-<name>Senior Services Coordinator</name>
-<creator>1</creator>
-<manager>1</manager>
-</RelationshipType>
-<RelationshipType>
-<name>Spouse of</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist is</name>
-</RelationshipType>
-<RelationshipType>
-<name>Wallet Inspector</name>
-</RelationshipType>
-<RelationshipType>
-<name>Wallet Inspector is</name>
-</RelationshipType>
-<RelationshipType>
-<name>абвгде</name>
-</RelationshipType>
-<RelationshipType>
-<name>αβγδ</name>
-</RelationshipType>
-</CaseRoles>
-<RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
+ <name>simple</name>
+ <ActivityTypes>
+  <ActivityType>
+   <name>Open Case</name>
+   <max_instances>1</max_instances>
+  </ActivityType>
+  <ActivityType>
+   <name>Email</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Follow up</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Meeting</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Phone Call</name>
+  </ActivityType>
+ </ActivityTypes>
+ <ActivitySets>
+  <ActivitySet>
+   <name>standard_timeline</name>
+   <label>Standard Timeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Open Case</name>
+     <status>Completed</status>
+     <label>Open Case</label>
+     <default_assignee_type>1</default_assignee_type>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+  <ActivitySet>
+   <name>timeline_1</name>
+   <label>AnotherTimeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Follow up</name>
+     <label>Follow up</label>
+     <status>Scheduled</status>
+     <reference_activity>Open Case</reference_activity>
+     <reference_offset>7</reference_offset>
+     <reference_select>newest</reference_select>
+     <default_assignee_type>2</default_assignee_type>
+     <default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
+     <default_assignee_contact></default_assignee_contact>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+ </ActivitySets>
+ <CaseRoles>
+  <RelationshipType>
+   <name>Senior Services Coordinator</name>
+   <creator>1</creator>
+   <manager>1</manager>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Spouse of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Wallet Inspector</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Wallet Inspector is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>абвгде</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>αβγδ</name>
+  </RelationshipType>
+ </CaseRoles>
+ <RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
 </CaseType>
+
 ENDXMLSIMPLEEXPECTED;
 
         $caseTypeId = $this->addCaseType('simple', $newCaseTypeXml);
@@ -525,185 +525,185 @@ ENDXMLSIMPLEEXPECTED;
         // unchanged if they choose to continue with the upgrade.
 
         $newCaseTypeXml = <<<ENDXMLMIXEDUP
-<?xml version="1.0" encoding="utf-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
-<name>mixedup</name>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<max_instances>1</max_instances>
-</ActivityType>
-<ActivityType>
-<name>Email</name>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-</ActivityType>
-<ActivityType>
-<name>Meeting</name>
-</ActivityType>
-<ActivityType>
-<name>Phone Call</name>
-</ActivityType>
-</ActivityTypes>
-<ActivitySets>
-<ActivitySet>
-<name>standard_timeline</name>
-<label>Standard Timeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<status>Completed</status>
-<label>Open Case</label>
-<default_assignee_type>1</default_assignee_type>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-<ActivitySet>
-<name>timeline_1</name>
-<label>AnotherTimeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>7</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-</ActivitySets>
-<CaseRoles>
-<RelationshipType>
-<name>Senior Services Coordinator</name>
-<creator>1</creator>
-<manager>1</manager>
-</RelationshipType>
-<RelationshipType>
-<name>Spouse of</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist is</name>
-</RelationshipType>
-<RelationshipType>
-<name>is Wallet Inspector of</name>
-</RelationshipType>
-<RelationshipType>
-<name>has as Wallet Inspector</name>
-</RelationshipType>
-<RelationshipType>
-<name>абвгде</name>
-</RelationshipType>
-<RelationshipType>
-<name>αβγδ changed</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist</name>
-</RelationshipType>
-<RelationshipType>
-<name>Mythical Unicorn</name>
-</RelationshipType>
-</CaseRoles>
-<RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
+ <name>mixedup</name>
+ <ActivityTypes>
+  <ActivityType>
+   <name>Open Case</name>
+   <max_instances>1</max_instances>
+  </ActivityType>
+  <ActivityType>
+   <name>Email</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Follow up</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Meeting</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Phone Call</name>
+  </ActivityType>
+ </ActivityTypes>
+ <ActivitySets>
+  <ActivitySet>
+   <name>standard_timeline</name>
+   <label>Standard Timeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Open Case</name>
+     <status>Completed</status>
+     <label>Open Case</label>
+     <default_assignee_type>1</default_assignee_type>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+  <ActivitySet>
+   <name>timeline_1</name>
+   <label>AnotherTimeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Follow up</name>
+     <label>Follow up</label>
+     <status>Scheduled</status>
+     <reference_activity>Open Case</reference_activity>
+     <reference_offset>7</reference_offset>
+     <reference_select>newest</reference_select>
+     <default_assignee_type>2</default_assignee_type>
+     <default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
+     <default_assignee_contact></default_assignee_contact>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+ </ActivitySets>
+ <CaseRoles>
+  <RelationshipType>
+   <name>Senior Services Coordinator</name>
+   <creator>1</creator>
+   <manager>1</manager>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Spouse of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>is Wallet Inspector of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>has as Wallet Inspector</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>абвгде</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>αβγδ changed</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Mythical Unicorn</name>
+  </RelationshipType>
+ </CaseRoles>
+ <RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
 </CaseType>
+
 ENDXMLMIXEDUP;
 
         $expectedCaseTypeXml = <<<ENDXMLMIXEDUPEXPECTED
-<?xml version="1.0" encoding="utf-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
-<name>mixedup</name>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<max_instances>1</max_instances>
-</ActivityType>
-<ActivityType>
-<name>Email</name>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-</ActivityType>
-<ActivityType>
-<name>Meeting</name>
-</ActivityType>
-<ActivityType>
-<name>Phone Call</name>
-</ActivityType>
-</ActivityTypes>
-<ActivitySets>
-<ActivitySet>
-<name>standard_timeline</name>
-<label>Standard Timeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<status>Completed</status>
-<label>Open Case</label>
-<default_assignee_type>1</default_assignee_type>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-<ActivitySet>
-<name>timeline_1</name>
-<label>AnotherTimeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>7</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-</ActivitySets>
-<CaseRoles>
-<RelationshipType>
-<name>Senior Services Coordinator</name>
-<creator>1</creator>
-<manager>1</manager>
-</RelationshipType>
-<RelationshipType>
-<name>Spouse of</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist is</name>
-</RelationshipType>
-<RelationshipType>
-<name>Wallet Inspector</name>
-</RelationshipType>
-<RelationshipType>
-<name>Wallet Inspector is</name>
-</RelationshipType>
-<RelationshipType>
-<name>абвгде</name>
-</RelationshipType>
-<RelationshipType>
-<name>αβγδ</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist</name>
-</RelationshipType>
-<RelationshipType>
-<name>Mythical Unicorn</name>
-</RelationshipType>
-</CaseRoles>
-<RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
+ <name>mixedup</name>
+ <ActivityTypes>
+  <ActivityType>
+   <name>Open Case</name>
+   <max_instances>1</max_instances>
+  </ActivityType>
+  <ActivityType>
+   <name>Email</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Follow up</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Meeting</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Phone Call</name>
+  </ActivityType>
+ </ActivityTypes>
+ <ActivitySets>
+  <ActivitySet>
+   <name>standard_timeline</name>
+   <label>Standard Timeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Open Case</name>
+     <status>Completed</status>
+     <label>Open Case</label>
+     <default_assignee_type>1</default_assignee_type>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+  <ActivitySet>
+   <name>timeline_1</name>
+   <label>AnotherTimeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Follow up</name>
+     <label>Follow up</label>
+     <status>Scheduled</status>
+     <reference_activity>Open Case</reference_activity>
+     <reference_offset>7</reference_offset>
+     <reference_select>newest</reference_select>
+     <default_assignee_type>2</default_assignee_type>
+     <default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
+     <default_assignee_contact></default_assignee_contact>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+ </ActivitySets>
+ <CaseRoles>
+  <RelationshipType>
+   <name>Senior Services Coordinator</name>
+   <creator>1</creator>
+   <manager>1</manager>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Spouse of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Wallet Inspector</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Wallet Inspector is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>абвгде</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>αβγδ</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Mythical Unicorn</name>
+  </RelationshipType>
+ </CaseRoles>
+ <RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
 </CaseType>
+
 ENDXMLMIXEDUPEXPECTED;
 
         $caseTypeId = $this->addCaseType('mixedup', $newCaseTypeXml);
@@ -713,179 +713,179 @@ ENDXMLMIXEDUPEXPECTED;
         ];
 
         $newCaseTypeXml = <<<ENDXMLDIFFNAME
-<?xml version="1.0" encoding="utf-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
-<name>diffname</name>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<max_instances>1</max_instances>
-</ActivityType>
-<ActivityType>
-<name>Email</name>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-</ActivityType>
-<ActivityType>
-<name>Meeting</name>
-</ActivityType>
-<ActivityType>
-<name>Phone Call</name>
-</ActivityType>
-</ActivityTypes>
-<ActivitySets>
-<ActivitySet>
-<name>standard_timeline</name>
-<label>Standard Timeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<status>Completed</status>
-<label>Open Case</label>
-<default_assignee_type>1</default_assignee_type>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-<ActivitySet>
-<name>timeline_1</name>
-<label>AnotherTimeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>7</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-</ActivitySets>
-<CaseRoles>
-<RelationshipType>
-<name>Senior Services Coordinator</name>
-<creator>1</creator>
-<manager>1</manager>
-</RelationshipType>
-<RelationshipType>
-<name>Spouse of</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist is</name>
-</RelationshipType>
-<RelationshipType>
-<name>is Wallet Inspector of</name>
-</RelationshipType>
-<RelationshipType>
-<name>has as Wallet Inspector</name>
-</RelationshipType>
-<RelationshipType>
-<name>абвгде</name>
-</RelationshipType>
-<RelationshipType>
-<name>αβγδ changed</name>
-</RelationshipType>
-<RelationshipType>
-<name>Archenemy of</name>
-</RelationshipType>
-</CaseRoles>
-<RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
+ <name>diffname</name>
+ <ActivityTypes>
+  <ActivityType>
+   <name>Open Case</name>
+   <max_instances>1</max_instances>
+  </ActivityType>
+  <ActivityType>
+   <name>Email</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Follow up</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Meeting</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Phone Call</name>
+  </ActivityType>
+ </ActivityTypes>
+ <ActivitySets>
+  <ActivitySet>
+   <name>standard_timeline</name>
+   <label>Standard Timeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Open Case</name>
+     <status>Completed</status>
+     <label>Open Case</label>
+     <default_assignee_type>1</default_assignee_type>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+  <ActivitySet>
+   <name>timeline_1</name>
+   <label>AnotherTimeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Follow up</name>
+     <label>Follow up</label>
+     <status>Scheduled</status>
+     <reference_activity>Open Case</reference_activity>
+     <reference_offset>7</reference_offset>
+     <reference_select>newest</reference_select>
+     <default_assignee_type>2</default_assignee_type>
+     <default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
+     <default_assignee_contact></default_assignee_contact>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+ </ActivitySets>
+ <CaseRoles>
+  <RelationshipType>
+   <name>Senior Services Coordinator</name>
+   <creator>1</creator>
+   <manager>1</manager>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Spouse of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>is Wallet Inspector of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>has as Wallet Inspector</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>абвгде</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>αβγδ changed</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Archenemy of</name>
+  </RelationshipType>
+ </CaseRoles>
+ <RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
 </CaseType>
+
 ENDXMLDIFFNAME;
 
         $expectedCaseTypeXml = <<<ENDXMLDIFFNAMEEXPECTED
-<?xml version="1.0" encoding="utf-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <CaseType>
-<name>diffname</name>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<max_instances>1</max_instances>
-</ActivityType>
-<ActivityType>
-<name>Email</name>
-</ActivityType>
-<ActivityType>
-<name>Follow up</name>
-</ActivityType>
-<ActivityType>
-<name>Meeting</name>
-</ActivityType>
-<ActivityType>
-<name>Phone Call</name>
-</ActivityType>
-</ActivityTypes>
-<ActivitySets>
-<ActivitySet>
-<name>standard_timeline</name>
-<label>Standard Timeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Open Case</name>
-<status>Completed</status>
-<label>Open Case</label>
-<default_assignee_type>1</default_assignee_type>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-<ActivitySet>
-<name>timeline_1</name>
-<label>AnotherTimeline</label>
-<timeline>true</timeline>
-<ActivityTypes>
-<ActivityType>
-<name>Follow up</name>
-<label>Follow up</label>
-<status>Scheduled</status>
-<reference_activity>Open Case</reference_activity>
-<reference_offset>7</reference_offset>
-<reference_select>newest</reference_select>
-<default_assignee_type>2</default_assignee_type>
-<default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
-<default_assignee_contact></default_assignee_contact>
-</ActivityType>
-</ActivityTypes>
-</ActivitySet>
-</ActivitySets>
-<CaseRoles>
-<RelationshipType>
-<name>Senior Services Coordinator</name>
-<creator>1</creator>
-<manager>1</manager>
-</RelationshipType>
-<RelationshipType>
-<name>Spouse of</name>
-</RelationshipType>
-<RelationshipType>
-<name>Benefits Specialist is</name>
-</RelationshipType>
-<RelationshipType>
-<name>Wallet Inspector</name>
-</RelationshipType>
-<RelationshipType>
-<name>Wallet Inspector is</name>
-</RelationshipType>
-<RelationshipType>
-<name>абвгде</name>
-</RelationshipType>
-<RelationshipType>
-<name>αβγδ</name>
-</RelationshipType>
-<RelationshipType>
-<name>Archenemy of</name>
-</RelationshipType>
-</CaseRoles>
-<RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
+ <name>diffname</name>
+ <ActivityTypes>
+  <ActivityType>
+   <name>Open Case</name>
+   <max_instances>1</max_instances>
+  </ActivityType>
+  <ActivityType>
+   <name>Email</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Follow up</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Meeting</name>
+  </ActivityType>
+  <ActivityType>
+   <name>Phone Call</name>
+  </ActivityType>
+ </ActivityTypes>
+ <ActivitySets>
+  <ActivitySet>
+   <name>standard_timeline</name>
+   <label>Standard Timeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Open Case</name>
+     <status>Completed</status>
+     <label>Open Case</label>
+     <default_assignee_type>1</default_assignee_type>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+  <ActivitySet>
+   <name>timeline_1</name>
+   <label>AnotherTimeline</label>
+   <timeline>true</timeline>
+   <ActivityTypes>
+    <ActivityType>
+     <name>Follow up</name>
+     <label>Follow up</label>
+     <status>Scheduled</status>
+     <reference_activity>Open Case</reference_activity>
+     <reference_offset>7</reference_offset>
+     <reference_select>newest</reference_select>
+     <default_assignee_type>2</default_assignee_type>
+     <default_assignee_relationship>{$relationshipTypeNames['Senior Services Coordinator']}_b_a</default_assignee_relationship>
+     <default_assignee_contact></default_assignee_contact>
+    </ActivityType>
+   </ActivityTypes>
+  </ActivitySet>
+ </ActivitySets>
+ <CaseRoles>
+  <RelationshipType>
+   <name>Senior Services Coordinator</name>
+   <creator>1</creator>
+   <manager>1</manager>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Spouse of</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Benefits Specialist is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Wallet Inspector</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Wallet Inspector is</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>абвгде</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>αβγδ</name>
+  </RelationshipType>
+  <RelationshipType>
+   <name>Archenemy of</name>
+  </RelationshipType>
+ </CaseRoles>
+ <RestrictActivityAsgmtToCmsUser>0</RestrictActivityAsgmtToCmsUser>
 </CaseType>
+
 ENDXMLDIFFNAMEEXPECTED;
 
         $caseTypeId = $this->addCaseType('diffname', $newCaseTypeXml);


### PR DESCRIPTION
The problem is detailed at https://lab.civicrm.org/dev/core/-/issues/1719

In a nutshell:

1. Creating a case type crashes if the `name` of a case status is not valid XML content. e.g. if a name has `&` in it, but other special characters would also cause problems.

2. It dies because it fails to properly encode the value.

3. It uses its own encoding functions instead of a proper XML encoder.

This PR:

1. replaces the homespun XML encoder with php's own built in one, and properly encodes everything.

2. adds a test fixture for the case that `&` is in a status name.

As a side effect, I believe it fixes 1719