### PR TITLE
dev/core#1684 - Use PSR-4 autoloader instead of PSR-0 for "Civi" namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
     "psr-0": {
       "PHPUnit_": ["packages/"],
       "Civi": "",
-      "Civi\\": [".", "tests/phpunit/"]
+      "Civi\\": ["tests/phpunit/"]
     },
     "psr-4": {
-      "Civi\\": ["setup/src/"]
+      "Civi\\": [".", "setup/src/"]
     }
   },
   "include-path": ["vendor/tecnickcom"],


### PR DESCRIPTION
Overview
----------------------------------------
This change is to allow underscores in class names, which were being misinterpreted as directory separators.

Before
----------------------------------------
Classes in the `\Civi` namespace could not contain underscores.

After
----------------------------------------
Classes in the `\Civi` namespace can contain underscores.

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/1684
