### PR TITLE
REF Simplify recordFees function

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3488,14 +3488,13 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *
    * @param array $params
    *   Contribution object, line item array and params for trxn.
-   *
-   *
    * @param array $financialTrxnValues
    *
-   * @return null|\CRM_Core_BAO_FinancialTrxn
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function recordFinancialAccounts(&$params, $financialTrxnValues = NULL) {
-    $skipRecords = $update = $return = $isRelatedId = FALSE;
+    $update = $isRelatedId = FALSE;
 
     $additionalParticipantId = [];
     $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
@@ -3584,7 +3583,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     if ($contributionStatus != 'Failed' &&
       !($contributionStatus == 'Pending' && !$params['contribution']->is_pay_later)
     ) {
-      $skipRecords = TRUE;
       $pendingStatus = [
         'Pending',
         'In Progress',
@@ -3825,10 +3823,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       CRM_Batch_BAO_EntityBatch::create($entityParams);
     }
 
-    // when a fee is charged
-    if (!empty($params['fee_amount']) && (empty($params['prevContribution']) || $params['contribution']->fee_amount != $params['prevContribution']->fee_amount) && $skipRecords) {
-      CRM_Core_BAO_FinancialTrxn::recordFees($params);
-    }
+    // Record any payment processor transaction fees
+    CRM_Core_BAO_FinancialTrxn::recordFees($params);
 
     if (!empty($params['prevContribution']) && $entityTable == 'civicrm_participant'
       && $params['prevContribution']->contribution_status_id != $params['contribution']->contribution_status_id

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -39,31 +39,27 @@ class CRM_Core_BAO_FinancialTrxn extends CRM_Financial_DAO_FinancialTrxn {
     $trxn = new CRM_Financial_DAO_FinancialTrxn();
     $trxn->copyValues($params);
 
-    if (isset($params['fee_amount']) && is_numeric($params['fee_amount'])) {
-      if (!isset($params['total_amount'])) {
-        $trxn->fetch();
-        $params['total_amount'] = $trxn->total_amount;
-      }
-      $trxn->net_amount = $params['total_amount'] - $params['fee_amount'];
+    if (!isset($trxn->total_amount)) {
+      $trxn->fetch();
     }
+    $trxn->net_amount = ($trxn->total_amount ?? 0) - ($trxn->fee_amount ?? 0);
 
-    if (empty($params['id']) && !CRM_Utils_Rule::currencyCode($trxn->currency)) {
+    if (empty($trxn->id) && !CRM_Utils_Rule::currencyCode($trxn->currency)) {
       $trxn->currency = CRM_Core_Config::singleton()->defaultCurrency;
     }
-
     $trxn->save();
 
+    // For an update entity financial transaction record will already exist. Return early.
     if (!empty($params['id'])) {
-      // For an update entity financial transaction record will already exist. Return early.
       return $trxn;
     }
 
     // Save to entity_financial_trxn table.
     $entityFinancialTrxnParams = [
-      'entity_table' => CRM_Utils_Array::value('entity_table', $params, 'civicrm_contribution'),
-      'entity_id' => CRM_Utils_Array::value('entity_id', $params, CRM_Utils_Array::value('contribution_id', $params)),
+      'entity_table' => $params['entity_table'] ?? 'civicrm_contribution',
+      'entity_id' => $params['entity_id'] ?? $params['contribution_id'] ?? NULL,
       'financial_trxn_id' => $trxn->id,
-      'amount' => $params['total_amount'],
+      'amount' => $trxn->total_amount,
     ];
 
     $entityTrxn = new CRM_Financial_DAO_EntityFinancialTrxn();
@@ -380,18 +376,37 @@ WHERE ceft.entity_id = %1";
    * @param array $params
    *   To create trxn entries.
    *
-   * @return bool|void
+   * @throws \CRM_Core_Exception
    */
   public static function recordFees($params) {
-    $domainId = CRM_Core_Config::domainID();
-    $amount = 0;
+    // @todo: These two checks are extracted from CRM_Contribute_BAO_Contribution::recordFinancialAccounts() and should be simplified
+    //   This is the initial "no change" extraction.
+    if (($params['contribution_status_id'] != CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Failed'))
+      && (!($params['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')
+        && !$params['contribution']->is_pay_later))
+    ) {
+      // Record the fees
+    }
+    else {
+      return;
+    }
+    if (!empty($params['fee_amount'])
+      && (empty($params['prevContribution']) || $params['contribution']->fee_amount != $params['prevContribution']->fee_amount)
+    ) {
+      // Record the fees
+    }
+    else {
+      return;
+    }
+
     if (!empty($params['prevContribution'])) {
       $amount = $params['prevContribution']->fee_amount;
     }
     $amount = $params['fee_amount'] - $amount;
     if (!$amount) {
-      return FALSE;
+      return;
     }
+
     $contributionId = $params['contribution']->id ?? $params['contribution_id'];
     if (empty($params['financial_type_id'])) {
       $financialTypeId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'financial_type_id', 'id');
@@ -416,7 +431,7 @@ WHERE ceft.entity_id = %1";
     $fItemParams
       = [
         'financial_account_id' => $financialAccount,
-        'contact_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain', $domainId, 'contact_id'),
+        'contact_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain', CRM_Core_Config::domainID(), 'contact_id'),
         'created_date' => date('YmdHis'),
         'transaction_date' => date('YmdHis'),
         'amount' => $amount,


### PR DESCRIPTION
Overview
----------------------------------------
Partial from #17103 

This should be a "no change" refactor that will help fixing the underlying bugs in this area per eg. https://lab.civicrm.org/dev/financial/-/issues/97

Before
----------------------------------------
- Various checks to call `recordFees()` spread over `recordFinancialAccounts()` function.
- Mixture of $trxn->property and $params['property'] but `$params` is not called by reference and is immediately copied to $trxn by `copyValues()`.

After
----------------------------------------
- `recordFees()` always called when recording financial accounts. The checks to decide whether to record fees are now in the recordFees function (and ready to be cleaned up/simplified).
- `recordFees()` works with the $trxn object instead of a mixture of $params and $trxn.

Technical Details
----------------------------------------
Explained above I think!

Comments
----------------------------------------
@eileenmcnaughton @monishdeb @jitendrapurohit Any of you able to take a look at this refactor?
