### PR TITLE
dev/core#1722 Allow for first name and last name to be searched on

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -245,6 +245,8 @@ class CRM_Contact_Form_Search_Criteria {
   public static function getSearchFieldMetadata() {
     $fields = [
       'sort_name' => ['title' => ts('Complete OR Partial Name'), 'template_grouping' => 'basic'],
+      'first_name' => ['template_grouping' => 'basic'],
+      'last_name' => ['template_grouping' => 'basic'],
       'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
       'contact_tags' => ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'template_grouping' => 'basic'],
       'created_date' => ['name' => 'created_date', 'template_grouping' => 'changeLog'],
@@ -316,7 +318,9 @@ class CRM_Contact_Form_Search_Criteria {
     $userFramework = CRM_Core_Config::singleton()->userFramework;
     return [
       // For now an empty array is still left in place for ordering.
-      'sort_name' => [],
+      'sort_name' => [
+        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',
+      ],
       'email' => ['name' => 'email'],
       'contact_type' => ['name' => 'contact_type'],
       'group' => [

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -244,7 +244,8 @@ class CRM_Contact_Form_Search_Criteria {
    */
   public static function getSearchFieldMetadata() {
     $fields = [
-      'sort_name' => ['title' => ts('Complete OR Partial Name'), 'template_grouping' => 'basic'],
+      'sort_name' => ['title' => ts('Complete OR Partial Name'), 'template_grouping' => 'basic',
+        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',],
       'first_name' => ['template_grouping' => 'basic'],
       'last_name' => ['template_grouping' => 'basic'],
       'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
@@ -318,9 +319,7 @@ class CRM_Contact_Form_Search_Criteria {
     $userFramework = CRM_Core_Config::singleton()->userFramework;
     return [
       // For now an empty array is still left in place for ordering.
-      'sort_name' => [
-        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',
-      ],
+      'sort_name' => [],
       'email' => ['name' => 'email'],
       'contact_type' => ['name' => 'contact_type'],
       'group' => [

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -244,8 +244,11 @@ class CRM_Contact_Form_Search_Criteria {
    */
   public static function getSearchFieldMetadata() {
     $fields = [
-      'sort_name' => ['title' => ts('Complete OR Partial Name'), 'template_grouping' => 'basic',
-        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',],
+      'sort_name' => [
+        'title' => ts('Complete OR Partial Name'),
+        'template_grouping' => 'basic',
+        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',
+      ],
       'first_name' => ['template_grouping' => 'basic'],
       'last_name' => ['template_grouping' => 'basic'],
       'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -357,10 +357,6 @@
         var $selection = $('.crm-quickSearchField input:checked'),
           label = $selection.parent().text(),
           value = $selection.val();
-        // These fields are not supported by advanced search
-        if (!value || value === 'first_name' || value === 'last_name') {
-          value = 'sort_name';
-        }
         $('#crm-qsearch-input').attr({name: value, placeholder: '\uf002 ' + label});
       }
       $('.crm-quickSearchField').click(function() {

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
@@ -1,0 +1,39 @@
+<div id="sortnameselect">
+  <label>{ts}Complete OR Partial Name{/ts} <span class="description">(<a href="#" id='searchbyindivflds'>{ts}search by individual name fields{/ts}</a>)</span></label><br />
+  {$form.sort_name.html}
+</div>
+<div id="indivfldselect">
+  <label>{ts}First/Last Name{/ts}<span class="description"> (<a href="#" id='searchbysortname'>{ts}search by complete or partial name{/ts}</a>)</span></label><br />
+  {$form.first_name.html} {$form.last_name.html}
+</div>
+
+{literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      function showIndivFldsSearch() {
+        $('#sortnameselect').hide();
+        $('#indivfldselect').show();
+        $('#sort_name').val('');
+        $('#first_name').removeClass('big').addClass('eight');
+        $('#last_name').removeClass('big').addClass('eight');
+        return false;
+      }
+      function showSortNameSearch() {
+        $('#indivfldselect').hide();
+        $('#sortnameselect').show();
+        $('#first_name').val('');
+        $('#last_name').val('');
+        return false;
+      }
+      $('#searchbyindivflds').click(showIndivFldsSearch);
+      $('#searchbysortname').click(showSortNameSearch);
+
+      if ($('#first_name').val() || $('#last_name').val()) {
+        showIndivFldsSearch();
+      }
+      else {
+        showSortNameSearch();
+      }
+    });
+  </script>
+{/literal}

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -144,10 +144,6 @@ $('#civicrm-menu').ready(function() {
     var $selection = $('.crm-quickSearchField input:checked'),
       label = $selection.parent().text(),
       value = $selection.val();
-    // These fields are not supported by advanced search
-    if (!value || value === 'first_name' || value === 'last_name') {
-      value = 'sort_name';
-    }
     $('#sort_name_navigation').attr({name: value, placeholder: label});
   }
   $('.crm-quickSearchField').click(function() {


### PR DESCRIPTION
Overview
----------------------------------------
Currently, only the sort_name field is exposed to Advanced Search. As a result it's not possible to search by first or last name specifically. In addition, while you can choose first or last name from the quick search option list, selecting one of those options and clicking Enter passes the value to the sort_name field -- where you lose that field-specific filter.

We should add the first/last name fields to Advanced Search and pass values from quick search (when selected) to the appropriate fields.

1. Create two contacts, one with "Jones" in the first name field, one with it in the last name field
2. From quick search, select first name, enter Jones, and click Enter

The search results will include contacts with Jones in either the first or last name if you have wildcard enabled. If you have wildcard disabled, only records with that value starting the last name will be returned (the opposite of what you were attempting to do via quick search).

Before
----------------------------------------
No way to search first or last name. When searching using those filters in quick search, the parameters are passed to sort name in advanced search.

After
----------------------------------------
First/last are now available to advanced search, and quick search filters are passed to the appropriate field.

Technical Details
----------------------------------------
UI toggle follows the pattern of group name/group type.
