### PR TITLE
Cleanup core pseudoconstant buildOptions

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -545,7 +545,7 @@ SELECT g.*
     }
 
     if ($allGroups == NULL) {
-      $allGroups = CRM_Contact_BAO_Contact::buildOptions('group_id', NULL, ['onlyActive' => FALSE]);
+      $allGroups = CRM_Contact_BAO_Contact::buildOptions('group_id', 'get');
     }
 
     $acls = CRM_ACL_BAO_Cache::build($contactID);

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -779,8 +779,7 @@ AND    contact_id IN ( $contactStr )
    * @return array|bool
    */
   public static function buildOptions($fieldName, $context = NULL, $props = []) {
-
-    $options = CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $props, $context);
+    $options = CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, [], $context);
 
     // Sort group list by hierarchy
     // TODO: This will only work when api.entity is "group_contact". What about others?

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -955,31 +955,20 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
   }
 
   /**
-   * Get options for the called BAO object's field.
-   *
-   * This function can be overridden by each BAO to add more logic related to context.
-   * The overriding function will generally call the lower-level CRM_Core_PseudoConstant::get
-   *
-   * @param string $fieldName
-   * @param string $context
-   * @see CRM_Core_DAO::buildOptionsContext
-   * @param array $props
-   *   whatever is known about this bao object.
-   *
-   * @return array|bool
+   * @inheritDoc
    */
   public static function buildOptions($fieldName, $context = NULL, $props = []) {
-
+    $params = [];
     switch ($fieldName) {
       case 'payment_processor_id':
         if (isset(\Civi::$statics[__CLASS__]['buildoptions_payment_processor_id'])) {
           return \Civi::$statics[__CLASS__]['buildoptions_payment_processor_id'];
         }
         $baoName = 'CRM_Contribute_BAO_ContributionRecur';
-        $props['condition']['test'] = "is_test = 0";
-        $liveProcessors = CRM_Core_PseudoConstant::get($baoName, $fieldName, $props, $context);
-        $props['condition']['test'] = "is_test != 0";
-        $testProcessors = CRM_Core_PseudoConstant::get($baoName, $fieldName, $props, $context);
+        $params['condition']['test'] = "is_test = 0";
+        $liveProcessors = CRM_Core_PseudoConstant::get($baoName, $fieldName, $params, $context);
+        $params['condition']['test'] = "is_test != 0";
+        $testProcessors = CRM_Core_PseudoConstant::get($baoName, $fieldName, $params, $context);
         foreach ($testProcessors as $key => $value) {
           if ($context === 'validate') {
             // @fixme: Ideally the names would be different in the civicrm_payment_processor table but they are not.
@@ -995,7 +984,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
         \Civi::$statics[__CLASS__]['buildoptions_payment_processor_id'] = $allProcessors;
         return $allProcessors;
     }
-    return parent::buildOptions($fieldName, $context, $props);
+    return CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
   }
 
 }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2570,14 +2570,16 @@ SELECT contact_id
    * @param string $context
    * @see CRM_Core_DAO::buildOptionsContext
    * @param array $props
-   *   whatever is known about this bao object.
+   *   Raw field values; whatever is known about this bao object.
+   *
+   * Note: $props can contain unsanitized input and should not be passed directly to CRM_Core_PseudoConstant::get
    *
    * @return array|bool
    */
   public static function buildOptions($fieldName, $context = NULL, $props = []) {
     // If a given bao does not override this function
     $baoName = get_called_class();
-    return CRM_Core_PseudoConstant::get($baoName, $fieldName, $props, $context);
+    return CRM_Core_PseudoConstant::get($baoName, $fieldName, [], $context);
   }
 
   /**

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -113,6 +113,7 @@ class CRM_Financial_BAO_FinancialAccount extends CRM_Financial_DAO_FinancialAcco
       $op = 'edit';
     }
     CRM_Utils_Hook::post($op, 'FinancialAccount', $financialAccount->id, $financialAccount);
+    CRM_Core_PseudoConstant::flush();
 
     return $financialAccount;
   }

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -419,7 +419,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
         $publicOptionCount = $_flagOption = $_rowError = 0;
 
         $_showHide = new CRM_Core_ShowHideBlocks('', '');
-        $visibilityOptions = CRM_Price_BAO_PriceFieldValue::buildOptions('visibility_id', NULL, ['labelColumn' => 'name']);
+        $visibilityOptions = CRM_Price_BAO_PriceFieldValue::buildOptions('visibility_id', 'validate');
 
         for ($index = 1; $index <= self::NUM_OPTION; $index++) {
 

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -286,7 +286,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
     }
 
     $priceField = CRM_Price_BAO_PriceField::findById($fields['fieldId']);
-    $visibilityOptions = CRM_Price_BAO_PriceFieldValue::buildOptions('visibility_id', NULL, ['labelColumn' => 'name']);
+    $visibilityOptions = CRM_Core_PseudoConstant::get('CRM_Price_BAO_PriceFieldValue', 'visibility_id', ['labelColumn' => 'name']);
 
     $publicCount = 0;
     $options = CRM_Price_BAO_PriceField::getOptions($priceField->id);

--- a/tests/phpunit/CRM/Price/Form/FieldTest.php
+++ b/tests/phpunit/CRM/Price/Form/FieldTest.php
@@ -11,7 +11,7 @@ class CRM_Price_Form_FieldTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
 
-    $this->visibilityOptionsKeys = CRM_Price_BAO_PriceFieldValue::buildOptions('visibility_id', NULL, [
+    $this->visibilityOptionsKeys = CRM_Core_PseudoConstant::get('CRM_Price_BAO_PriceFieldValue', 'visibility_id', [
       'labelColumn' => 'name',
       'flip' => TRUE,
     ]);

--- a/tests/phpunit/CRM/Price/Form/OptionTest.php
+++ b/tests/phpunit/CRM/Price/Form/OptionTest.php
@@ -15,10 +15,10 @@ class CRM_Price_Form_OptionTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
 
-    $this->visibilityOptions = CRM_Price_BAO_PriceFieldValue::buildOptions('visibility_id', NULL, [
+    $this->visibilityOptions = CRM_Core_PseudoConstant::get('CRM_Price_BAO_PriceFieldValue', 'visibility_id', [
       'labelColumn' => 'name',
     ]);
-    $this->visibilityOptionsKeys = CRM_Price_BAO_PriceFieldValue::buildOptions('visibility_id', NULL, [
+    $this->visibilityOptionsKeys = CRM_Core_PseudoConstant::get('CRM_Price_BAO_PriceFieldValue', 'visibility_id', [
       'labelColumn' => 'name',
       'flip' => TRUE,
     ]);

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1447,7 +1447,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $pcp2 = CRM_PCP_BAO_PCP::create($pcpParams);
 
     // Get soft credit types, with the name column as the key.
-    $soft_credit_types = CRM_Contribute_BAO_ContributionSoft::buildOptions("soft_credit_type_id", NULL, ["flip" => TRUE, 'labelColumn' => 'name']);
+    $soft_credit_types = CRM_Core_PseudoConstant::get('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', ['flip' => TRUE, 'labelColumn' => 'name']);
     $pcp_soft_credit_type_id = $soft_credit_types['pcp'];
 
     // Create two contributions assigned to this contribution page and


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up variables being passed around buildOptions to prevent leakage.

Comments
----------------------------------------
There's been some confusion about the `$params` and `$props` variables, but they are not the same.
