### PR TITLE
Fix Dedupe entity_tag mangling bug

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2427,6 +2427,8 @@ SELECT contact_id
    *
    * Refer to CRM-17454 for information on the danger of querying the information
    * schema to derive this.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getReferencesToContactTable() {
     if (isset(\Civi::$statics[__CLASS__]) && isset(\Civi::$statics[__CLASS__]['contact_references'])) {
@@ -2441,11 +2443,28 @@ SELECT contact_id
     }
     self::appendCustomTablesExtendingContacts($contactReferences);
     self::appendCustomContactReferenceFields($contactReferences);
-
-    // FixME for time being adding below line statically as no Foreign key constraint defined for table 'civicrm_entity_tag'
-    $contactReferences['civicrm_entity_tag'][] = 'entity_id';
     \Civi::$statics[__CLASS__]['contact_references'] = $contactReferences;
     return \Civi::$statics[__CLASS__]['contact_references'];
+  }
+
+  /**
+   * Get all dynamic references to the given table.
+   *
+   * @param string $tableName
+   *
+   * @return array
+   */
+  public static function getDynamicReferencesToTable($tableName) {
+    if (!isset(\Civi::$statics[__CLASS__]['contact_references_dynamic'][$tableName])) {
+      \Civi::$statics[__CLASS__]['contact_references_dynamic'][$tableName] = [];
+      $coreReferences = CRM_Core_DAO::getReferencesToTable($tableName);
+      foreach ($coreReferences as $coreReference) {
+        if ($coreReference instanceof \CRM_Core_Reference_Dynamic) {
+          \Civi::$statics[__CLASS__]['contact_references_dynamic'][$tableName][$coreReference->getReferenceTable()][] = $coreReference->getReferenceKey();
+        }
+      }
+    }
+    return \Civi::$statics[__CLASS__]['contact_references_dynamic'][$tableName];
   }
 
   /**

--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -110,4 +110,31 @@ class CRM_Dedupe_MergeHandler {
     return $relTables;
   }
 
+  /**
+   * Get an array of tables that have a dynamic reference to the contact table.
+   *
+   * This would be the case when the table uses entity_table + entity_id rather than an FK.
+   *
+   * There are a number of tables that 'could' but don't have contact related data so we
+   * do a cached check for this, ensuring the query is only done once per batch run.
+   *
+   * @return array
+   */
+  public function getTablesDynamicallyRelatedToContactTable() {
+    if (!isset(\Civi::$statics[__CLASS__]['dynamic'])) {
+      \Civi::$statics[__CLASS__]['dynamic'] = [];
+      foreach (CRM_Core_DAO::getDynamicReferencesToTable('civicrm_contact') as $tableName => $field) {
+        $sql[] = "(SELECT '$tableName' as civicrm_table, '{$field[0]}' as field_name FROM $tableName WHERE entity_table = 'civicrm_contact' LIMIT 1)";
+      }
+      $sqlString = implode(' UNION ', $sql);
+      if ($sqlString) {
+        $result = CRM_Core_DAO::executeQuery($sqlString);
+        while ($result->fetch()) {
+          \Civi::$statics[__CLASS__]['dynamic'][$result->civicrm_table] = $result->field_name;
+        }
+      }
+    }
+    return \Civi::$statics[__CLASS__]['dynamic'];
+  }
+
 }

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -1041,6 +1041,10 @@ COLS;
    */
   public function getLogTablesForContact() {
     $tables = array_keys(CRM_Core_DAO::getReferencesToContactTable());
+    // This additional hardcoding has been moved from getReferencesToContactTable
+    // to here as it is not needed in the other place where the function is called.
+    // It may not be needed here either...
+    $tables[] = 'civicrm_entity_tag';
     return array_intersect($tables, $this->tables);
   }
 

--- a/Civi/Api4/EntityTag.php
+++ b/Civi/Api4/EntityTag.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4;

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -149,6 +149,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * Test the batch merge.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testBatchMergeSelectedDuplicates() {
     $this->createDupeContacts();
@@ -283,23 +285,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
    */
   public function testGetCidRefs() {
     $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, 'Contacts');
-    $this->assertEquals(array_merge($this->getStaticCIDRefs(), $this->getHackedInCIDRef()), CRM_Dedupe_Merger::cidRefs());
-    $this->assertEquals(array_merge($this->getCalculatedCIDRefs(), $this->getHackedInCIDRef()), CRM_Dedupe_Merger::cidRefs());
-  }
-
-  /**
-   * Get the list of not-really-cid-refs that are currently hacked in.
-   *
-   * This is hacked into getCIDs function.
-   *
-   * @return array
-   */
-  public function getHackedInCIDRef() {
-    return [
-      'civicrm_entity_tag' => [
-        0 => 'entity_id',
-      ],
-    ];
+    $this->assertEquals($this->getStaticCIDRefs(), CRM_Dedupe_Merger::cidRefs());
+    $this->assertEquals($this->getCalculatedCIDRefs(), CRM_Dedupe_Merger::cidRefs());
   }
 
   /**
@@ -307,6 +294,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
    *
    * It turns out there are 2 code paths retrieving this data so my initial
    * focus is on ensuring they match.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetMatches() {
     $this->setupMatchData();
@@ -336,6 +325,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * Test results are returned when criteria are passed in.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetMatchesCriteriaMatched() {
     $this->setupMatchData();
@@ -348,6 +339,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * Test results are returned when criteria are passed in & limit is  respected.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetMatchesCriteriaMatchedWithLimit() {
     $this->setupMatchData();
@@ -361,6 +354,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * Test results are returned when criteria are passed in & limit is  respected.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetMatchesCriteriaMatchedWithSearchLimit() {
     $this->setupMatchData();
@@ -374,6 +369,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * Test getting matches where there are  no criteria.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetMatchesNoCriteria() {
     $this->setupMatchData();
@@ -385,6 +382,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * Test getting matches with a limit in play.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetMatchesNoCriteriaButLimit() {
     $this->setupMatchData();
@@ -614,6 +613,9 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
    *
    * Note the handling is silly - we are testing to lock in over short term
    * changes not to imply any contract on the function.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testGetRowsElementsAndInfoSpecialInfo() {
     $contact1 = $this->individualCreate([
@@ -702,6 +704,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
   /**
    * CRM-19653 : Test that custom field data should/shouldn't be overriden on
    *   selecting/not selecting option to migrate data respectively
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCustomDataOverwrite() {
     // Create Custom Field
@@ -771,7 +775,16 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * dev/core#996 Ensure that the oldest created date is retained even if duplicates have been flipped
+   *
    * @dataProvider createdDateMergeCases
+   *
+   * @param $keepContactKey
+   * @param $duplicateContactKey
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testCreatedDatePostMerge($keepContactKey, $duplicateContactKey) {
     $this->setupMatchData();

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -929,6 +929,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @return int
    *   id of created pledge
+   *
+   * @throws \CRM_Core_Exception
    */
   public function pledgeCreate($params) {
     $params = array_merge([
@@ -954,6 +956,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * Delete contribution.
    *
    * @param int $pledgeId
+   *
+   * @throws \CRM_Core_Exception
    */
   public function pledgeDelete($pledgeId) {
     $params = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby the merge script alters non-contact entity tags, changing the entity they are related to

Before
----------------------------------------
Start with a contact & an activity with the same id 

Assign a contact entity tag to the contact and an activity entity tag to the activity. 

Merge the contact with another contact, note that the entity_id is updated on the activity entity_tag too



After
----------------------------------------
Only the contact entity tag is updated.

Technical Details
----------------------------------------
I identified this bug in testing removing the UPDATE IGNORE + DELETE in #17072. 

entity_tag is hack-added to the array of tables that interact with contact - resulting in it passing through the UPDATE without the WHERE entity_table = ...

The function with the hack-add is called from 2 places. We know it is unwanted in 1 so I moved it to the other place (being unsure if it is useful there this should give  no change)

civicrm_entity_tag was missing from the array of tables that are entity_table-linked to contacts. I switched to using discovery rather than hard-coding but I added caching to limit it to once per batch script 

Comments
----------------------------------------
@pfigel 
