### PR TITLE
dev/core#1460, dev/core#1713 - Categorical fix for upgrade<=>hook issues

### DIFF
--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Upgrade_DispatchPolicy {
+
+  /**
+   * Determine the dispatch policy
+   *
+   * @param string $phase
+   *   Ex: 'upgrade.main' or 'upgrade.finish'.
+   * @return array
+   * @see \Civi\Core\CiviEventDispatcher::setDispatchPolicy()
+   */
+  public static function get($phase) {
+
+    // Should hooks dispatch while applying CiviCRM DB upgrades? The answer is
+    // mixed: it depends on the specific hook and the specific upgrade-step.
+    //
+    // Some example considerations:
+    // - If the "log_civicrm_*" tables and triggers are to be reconciled during
+    //   the upgrade, then one probably needs access to the list of tables and
+    //   triggers defined by extensions. These are provided by hooks.
+    // - If a hook fires while the DB has stale schema, and if the hook's logic
+    //   has a direct (SQL) or indirect (BAO/API) dependency on the schema, then
+    //   the hook is prone to fail. (Ex: CiviCRM 4.x and the migration from
+    //   civicrm_domain.config_backend to civicrm_setting.)
+    // - If *any* hook from an extension is called, then it may use classes
+    //   from the same extension, so the classloader / include-path / hook_config
+    //   should be operational.
+    // - If there is a general system flush at the end of the upgrade (to rebuild
+    //   important data-structures -- routing tables, container cache, metadata
+    //   cache, etc), then there's a huge number of hooks that should fire.
+    // - When hooks (or variations like "rules") are used to define business-logic,
+    //   they probably are not intended to fire during DB upgrade. Then again,
+    //   upgrade-logic is usually written with lower-level semantics that avoid firing hooks.
+    //
+    // Related discussions:
+    // - https://github.com/civicrm/civicrm-core/pull/13551
+    // - https://lab.civicrm.org/dev/core/issues/1449
+    // - https://lab.civicrm.org/dev/core/issues/1460
+
+    $strict = getenv('CIVICRM_UPGRADE_STRICT') || CRM_Utils_Constant::value('CIVICRM_UPGRADE_STRICT');
+    $policies = [];
+
+    // The "upgrade.main" policy applies during the planning and incremental revisions.
+    // It's more restrictive, preventing interference from unexpected callpaths.
+    $policies['upgrade.main'] = [
+      'hook_civicrm_config' => 'run',
+      '/^hook_civicrm_(pre|post)$/' => 'drop',
+      '/^hook_civicrm_/' => $strict ? 'warn-drop' : 'drop',
+      '/^civi\./' => 'run',
+      '/./' => $strict ? 'warn-drop' : 'drop',
+    ];
+
+    // The "upgrade.finish" policy applies at the end while performing the final clear/rebuild.
+    // It's more permissive, allowing more data-structures to rehydrate correctly.
+    $policies['upgrade.finish'] = [
+      '/^hook_civicrm_(pre|post)$/' => 'drop',
+      '/./' => 'run',
+    ];
+
+    // For comparison, "upgrade.old" is an estimation of the previous policy. It
+    // was applied at all times during the upgrade.
+    $policies['upgrade.old'] = [
+      'hook_civicrm_alterSettingsFolders' => 'run',
+      'hook_civicrm_alterSettingsMetaData' => 'run',
+      'hook_civicrm_triggerInfo' => 'run',
+      'hook_civicrm_alterLogTables' => 'run',
+      'hook_civicrm_container' => 'run',
+      'hook_civicrm_permission' => 'run',
+      'hook_civicrm_managed' => 'run',
+      'hook_civicrm_config' => 'run',
+      '/^hook_civicrm_(pre|post)$/' => 'drop',
+      '/^hook_civicrm_/' => 'drop',
+      '/^civi\./' => 'run',
+      '/./' => 'run',
+    ];
+
+    return $policies['upgrade.old'];
+    // return $policies[$phase];
+  }
+
+}

--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -89,8 +89,8 @@ class CRM_Upgrade_DispatchPolicy {
       '/./' => 'run',
     ];
 
-    return $policies['upgrade.old'];
-    // return $policies[$phase];
+    // return $policies['upgrade.old'];
+    return $policies[$phase];
   }
 
 }

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -779,17 +779,8 @@ SET    version = '$version'
     // Seems extraneous in context, but we'll preserve old behavior
     $upgrade->setVersion($latestVer);
 
-    // TODO: Consider running a general system flush instead of piecemeal flushes.
-    // Historically, that would not have worked well because hooks are restricted
-    // in upgrade-mode. But the dispatch-policy for 'upgrade.finish' is probably
-    // more suitable.
-
-    // Clear cached metadata.
-    Civi::service('settings_manager')->flush();
-
-    // cleanup caches CRM-8739
-    $config = CRM_Core_Config::singleton();
-    $config->cleanupCaches(1);
+    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, TRUE);
+    // NOTE: triggerRebuild is FALSE becaues it will run again in a moment (via fixSchemaDifferences).
 
     $versionCheck = new CRM_Utils_VersionCheck();
     $versionCheck->flushCache();
@@ -797,8 +788,6 @@ SET    version = '$version'
     // Rebuild all triggers and re-enable logging if needed
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
-
-    CRM_Core_ManagedEntities::singleton(TRUE)->reconcile(TRUE);
   }
 
   /**

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -86,7 +86,6 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
 
     // All cached content needs to be cleared because the civi codebase was just replaced
     CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
-    CRM_Core_Menu::store();
 
     // cleanup only the templates_c directory
     $config->cleanup(1, FALSE);

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -29,6 +29,18 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
   private $autoListeners = [];
 
   /**
+   * @var array|null
+   *   Array(string $eventName => string $action)
+   */
+  private $dispatchPolicyExact = NULL;
+
+  /**
+   * @var array|null
+   *   Array(string $eventRegex => string $action)
+   */
+  private $dispatchPolicyRegex = NULL;
+
+  /**
    * Determine whether $eventName should delegate to the CMS hook system.
    *
    * @param string $eventName
@@ -43,6 +55,35 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
    * @inheritDoc
    */
   public function dispatch($eventName, Event $event = NULL) {
+    // Dispatch policies add systemic overhead and (normally) should not be evaluated. JNZ.
+    if ($this->dispatchPolicyRegex !== NULL) {
+      switch ($mode = $this->checkDispatchPolicy($eventName)) {
+        case 'run':
+          // Continue on the normal execution.
+          break;
+
+        case 'drop':
+          // Quietly ignore the event.
+          return $event;
+
+        case 'warn':
+          // Run the event, but complain about it.
+          error_log("Unexpectedly dispatching event \"$eventName\".");
+          break;
+
+        case 'warn-drop':
+          // Ignore the event, but complaint about it.
+          error_log("Unexpectedly dispatching event \"$eventName\".");
+          return $event;
+
+        case 'fail':
+          throw new \RuntimeException("The dispatch policy prohibits event \"$eventName\".");
+
+        default:
+          throw new \RuntimeException("The dispatch policy for \"$eventName\" is unrecognized ($mode).");
+
+      }
+    }
     $this->bindPatterns($eventName);
     return parent::dispatch($eventName, $event);
   }
@@ -130,6 +171,68 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
         ], self::DEFAULT_HOOK_PRIORITY);
       }
     }
+  }
+
+  /**
+   * The dispatch policy allows you to filter certain events.
+   * This can be useful during upgrades or debugging.
+   *
+   * Enforcement will add systemic overhead, so this should normally be NULL.
+   *
+   * @param array|null $dispatchPolicy
+   *   Each key is either the string-literal name of an event, or a regex delimited by '/'.
+   *   Each value is one of: 'run', 'drop', 'warn', 'fail'.
+   *   Exact name matches take precedence over regexes. Regexes are evaluated in order.
+   *
+   *   Ex: ['hook_civicrm_pre' => 'fail']
+   *   Ex: ['/^hook_/' => 'warn']
+   *
+   * @return static
+   */
+  public function setDispatchPolicy($dispatchPolicy) {
+    if (is_array($dispatchPolicy)) {
+      // Split $dispatchPolicy in two (exact rules vs regex rules).
+      $this->dispatchPolicyExact = [];
+      $this->dispatchPolicyRegex = [];
+      foreach ($dispatchPolicy as $pattern => $action) {
+        if ($pattern[0] === '/') {
+          $this->dispatchPolicyRegex[$pattern] = $action;
+        }
+        else {
+          $this->dispatchPolicyExact[$pattern] = $action;
+        }
+      }
+    }
+    else {
+      $this->dispatchPolicyExact = NULL;
+      $this->dispatchPolicyRegex = NULL;
+    }
+
+    return $this;
+  }
+
+  //  /**
+  //   * @return array|NULL
+  //   */
+  //  public function getDispatchPolicy() {
+  //    return  $this->dispatchPolicyRegex === NULL ? NULL : array_merge($this->dispatchPolicyExact, $this->dispatchPolicyRegex);
+  //  }
+
+  /**
+   * @param string $eventName
+   * @return string
+   *   Ex: 'run', 'drop', 'fail'
+   */
+  protected function checkDispatchPolicy($eventName) {
+    if (isset($this->dispatchPolicyExact[$eventName])) {
+      return $this->dispatchPolicyExact[$eventName];
+    }
+    foreach ($this->dispatchPolicyRegex as $eventPat => $action) {
+      if ($eventPat[0] === '/' && preg_match($eventPat, $eventName)) {
+        return $action;
+      }
+    }
+    return 'fail';
   }
 
 }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -330,6 +330,10 @@ class Container {
    */
   public function createEventDispatcher($container) {
     $dispatcher = new CiviEventDispatcher($container);
+    if (\CRM_Core_Config::isUpgradeMode()) {
+      $dispatcher->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get('upgrade.main'));
+    }
+
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, ['\Civi\Core\DatabaseInitializer', 'initialize']);
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, ['\Civi\Core\LocalizationInitializer', 'initialize']);

--- a/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
+++ b/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Civi\Core;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class CiviEventDispatcherTest
+ * @package Civi\Core
+ * @group headless
+ */
+class CiviEventDispatcherTest extends \CiviUnitTestCase {
+
+  public function testDispatchPolicy_run() {
+    $d = new CiviEventDispatcher(\Civi::container());
+    $d->setDispatchPolicy([
+      'hook_civicrm_fakeRunnable' => 'run',
+    ]);
+    $calls = [];
+    $d->addListener('hook_civicrm_fakeRunnable', function() use (&$calls) {
+      $calls['hook_civicrm_fakeRunnable'] = 1;
+    });
+    $d->dispatch('hook_civicrm_fakeRunnable', new GenericHookEvent());
+    $this->assertEquals(1, $calls['hook_civicrm_fakeRunnable']);
+  }
+
+  public function testDispatchPolicy_drop() {
+    $d = new CiviEventDispatcher(\Civi::container());
+    $d->setDispatchPolicy([
+      '/^hook_civicrm_fakeDr/' => 'drop',
+    ]);
+    $calls = [];
+    $d->addListener('hook_civicrm_fakeDroppable', function() use (&$calls) {
+      $calls['hook_civicrm_fakeDroppable'] = 1;
+    });
+    $d->dispatch('hook_civicrm_fakeDroppable', new GenericHookEvent());
+    $this->assertTrue(!isset($calls['hook_civicrm_fakeDroppable']));
+  }
+
+  public function testDispatchPolicy_fail() {
+    $d = new CiviEventDispatcher(\Civi::container());
+    $d->setDispatchPolicy([
+      '/^hook_civicrm_fakeFa/' => 'fail',
+    ]);
+    try {
+      $d->dispatch('hook_civicrm_fakeFailure', new GenericHookEvent());
+      $this->fail('Expected exception');
+    }
+    catch (\Exception $e) {
+      $this->assertRegExp(';The dispatch policy prohibits event;', $e->getMessage());
+    }
+  }
+
+}

--- a/tests/phpunit/E2E/Core/HookTest.php
+++ b/tests/phpunit/E2E/Core/HookTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace E2E\Core;
+
+/**
+ * Class HookTest
+ * @package E2E\Core
+ * @group e2e
+ */
+class HookTest extends \CiviEndToEndTestCase {
+
+  /**
+   * This test ensures that CRM_Utils_Hook::invoke() dispatches via Symfony.
+   *
+   * This should be *in*addition* to dispatching through the UF event system,
+   * although the mechanics depend on the UF, so that part has to be tested per-UF.
+   *
+   * This uses the canonical form, `CRM_Utils_Hook::invoke(string[] $names...)`
+   */
+  public function testSymfonyListener_names() {
+    $calls = 0;
+    \Civi::dispatcher()
+      ->addListener('hook_civicrm_e2eHookExample', function ($e) use (&$calls) {
+        $calls++;
+        $e->a['foo'] = 'a.name';
+        $e->b->bar = 'b.name';
+      });
+    $a = [];
+    $b = new \stdClass();
+    $this->hookStub(['a', 'b'], $a, $b);
+    $this->assertEquals(1, $calls);
+    $this->assertEquals('a.name', $a['foo']);
+    $this->assertEquals('b.name', $b->bar);
+  }
+
+  /**
+   * This test ensures that CRM_Utils_Hook::invoke() dispatches via Symfony.
+   *
+   * This should be *in*addition* to dispatching through the UF event system,
+   * although the mechanics depend on the UF, so that part has to be tested per-UF.
+   *
+   * This uses the deprecated form, `CRM_Utils_Hook::invoke(int $count...)`
+   */
+  public function testSymfonyListener_int() {
+    $calls = 0;
+    \Civi::dispatcher()
+      ->addListener('hook_civicrm_e2eHookExample', function ($e) use (&$calls) {
+        $calls++;
+        $e->arg1['foo'] = 'a.num';
+        $e->arg2->bar = 'b.num';
+      });
+    $a = [];
+    $b = new \stdClass();
+    $this->hookStub(2, $a, $b);
+    $this->assertEquals(1, $calls);
+    $this->assertEquals('a.num', $a['foo']);
+    $this->assertEquals('b.num', $b->bar);
+  }
+
+  /**
+   * @param mixed $names
+   * @param array $a
+   * @param \stdClass $b
+   * @return mixed
+   */
+  private function hookStub($names, &$a, $b) {
+    return \CRM_Utils_Hook::singleton()
+      ->invoke($names, $a, $b, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject,
+        'civicrm_e2eHookExample');
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Over the past 10 or so releases, we've had a slow game of whack-a-mole involving the upgrader - e.g. in response to buggy interactions between the upgrader and extensions, we would gradually change the list of hooks that are allowed to execute within "upgrade mode" (eg 62f662b002e4f8b6cfbdbd2b9d0c03712f2441fa, 1b4ddd9df02dbab9a19971d94c9491185595091d, 912511a359680eb72b15c595b5091fa03f8687f2, b5cf5699202dba6ee7cec29e21d7546b01d7d18d, a6ee76f8e96b9b0b9e71c267502a0b6bcc8fac8c). The game isn't done yet - eg [dev/core#1713](https://lab.civicrm.org/dev/core/-/issues/1713) is another similar issue. [dev/core#1460](https://lab.civicrm.org/dev/core/issues/1460) is an open issue asking how (generally) to address this topic.

This PR responds generally to dev/core#1460  and specifically to dev/core#1713. It aims at a solution which doesn't require as much maintenance for latent bugs. The essence of the change is:

* Distinguish between a conservative/closed phase (when the system is out-of-date and hooks are very limited) and a liberal/open phase (when the system is mostly up-to-date and hooks are largely allowed).
* At the end of the upgrade (in the liberal phase), do a standard *system flush* with all normal hooks (i.e. the same as `civicrm/clearcache` or `System.flush` API or `cv flush`).

During the rest of the discussion, it may help to consider that the upgrade logic is not monolithic - it comes in a few steps.

<img width="579" alt="Screen Shot 2020-04-22 at 12 55 57 PM" src="https://user-images.githubusercontent.com/1336047/80027464-abc60c00-8498-11ea-8b90-4a7920950d29.png">

Before
----------------------------------------

While executing the upgrade process, all hooks are subject to a filtering policy - n.b. by default, all hooks are dropped/ignored, but there are exceptions: the whitelist (`$upgradeFriendlyHooks`) specifies that certain hooks are allowed to run. This policy applies to all steps of the upgrade (planning, incrementing, and finalization).

If you find that some data-structure is misbuilt because the necessary hook didn't fire during upgrade, then you must add it to `$upgradeFriendlyHooks`. (*And cross your fingers that it's not a super-generic hook -- like `hook_civicrm_pre` -- which might be problematic one way and necessary in another way.*)

After
----------------------------------------

While executing the upgrade process, there are two phases:

* __Conservative/Closed Phase__: During early parts of the upgrade, the core schema is in an unreliable state (with schema+code having mismatched versions), so we cannot have much confidence in which code (which APIs, which BAOs, which hooks, which hook-listeners) will work correctly. 
    * This phase uses a hook-dispatch-policy called `upgrade.main`.
    * This phase is fairly restrictive - by default, all hooks are dropped/ignored, but there's a whitelist of ~1 allowed hook. 
    * The restrictive policy prevents unexpected interactions/interference during low-level operations.
* __Liberal/Open Phase__: During later parts of the upgrade, we know that the core schema has gone through all its updates (ie the schema+code have matching versions), so we have more confidence that most code will work.
    * This phase uses a hook-dispatch-policy called `upgrade.finish`.
    * This phase is fairly permissive -- by default, all hooks are allowed, but there's a blacklist of ~2 hooks. (TBH, even those exceptions may not be needed - but carrying them forward seemed like the slightly safer gamble.)
    * This open policy allows more data-structures to rehydrate correctly.

Technical Details
----------------------------------------

Like `$upgradeFriendlyHooks`, the `upgrade.main` and `upgrade.finish` policies are also arrays, and they also list valid hooks. However, the signature has changed a bit (now: `[string $eventNameRegex => string $action]`). You can match events using a regex (e.g. `/^hook_civicrm_(pre|post)/`) and give more nuanced actions, e.g.

* `run`: Allow any matching hooks to run
* `warn`: Allow any matching hooks to run, but emit a warning that the hook was not expected
* `drop`: Quietly drop/ignore any matching hooks
* `warn-drop`: Emit a warning about the hook, and drop/ignore it.
* `fail`: Throw an exception if any matching hooks are invoked

Comments
----------------------------------------

(A) In broad terms, this should reduce the number of required exceptions -- instead of 1 rule with 10+ exceptions, there are 2 rules with ~2 exceptions.

(B) Incidentally, this PR also brings the upgrader into closer alignment with the familiar "system flush" operation. Intuitively, as a developer or admin, you'd expect that the upgrader would do a system flush -- and it *sort of* did. The upgrader's `doFinish()` pantomimed parts of "system flush", but a full flush would be precarious because most hooks weren't running. With this PR's approach, `doFinish()` now allows most hooks to run, so you can do a full/proper "system flush".

(C) This branch includes a few distinct commits, and they're... not small. 🙃  I can split off bits for smaller PRs. But I wanted to share the big picture first - because otherwise the individual commits won't seem too useful.

(D) I've done some testing of the use-case from https://lab.civicrm.org/dev/core/-/issues/1713 as well as running the upgrader with fairly old databases.