### PR TITLE
dev/core#1460 - CiviEventDispatcher - Add policy options

### DIFF
--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -29,6 +29,18 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
   private $autoListeners = [];
 
   /**
+   * @var array|null
+   *   Array(string $eventName => string $action)
+   */
+  private $dispatchPolicyExact = NULL;
+
+  /**
+   * @var array|null
+   *   Array(string $eventRegex => string $action)
+   */
+  private $dispatchPolicyRegex = NULL;
+
+  /**
    * Determine whether $eventName should delegate to the CMS hook system.
    *
    * @param string $eventName
@@ -43,6 +55,35 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
    * @inheritDoc
    */
   public function dispatch($eventName, Event $event = NULL) {
+    // Dispatch policies add systemic overhead and (normally) should not be evaluated. JNZ.
+    if ($this->dispatchPolicyRegex !== NULL) {
+      switch ($mode = $this->checkDispatchPolicy($eventName)) {
+        case 'run':
+          // Continue on the normal execution.
+          break;
+
+        case 'drop':
+          // Quietly ignore the event.
+          return $event;
+
+        case 'warn':
+          // Run the event, but complain about it.
+          error_log("Unexpectedly dispatching event \"$eventName\".");
+          break;
+
+        case 'warn-drop':
+          // Ignore the event, but complaint about it.
+          error_log("Unexpectedly dispatching event \"$eventName\".");
+          return $event;
+
+        case 'fail':
+          throw new \RuntimeException("The dispatch policy prohibits event \"$eventName\".");
+
+        default:
+          throw new \RuntimeException("The dispatch policy for \"$eventName\" is unrecognized ($mode).");
+
+      }
+    }
     $this->bindPatterns($eventName);
     return parent::dispatch($eventName, $event);
   }
@@ -130,6 +171,68 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
         ], self::DEFAULT_HOOK_PRIORITY);
       }
     }
+  }
+
+  /**
+   * The dispatch policy allows you to filter certain events.
+   * This can be useful during upgrades or debugging.
+   *
+   * Enforcement will add systemic overhead, so this should normally be NULL.
+   *
+   * @param array|null $dispatchPolicy
+   *   Each key is either the string-literal name of an event, or a regex delimited by '/'.
+   *   Each value is one of: 'run', 'drop', 'warn', 'fail'.
+   *   Exact name matches take precedence over regexes. Regexes are evaluated in order.
+   *
+   *   Ex: ['hook_civicrm_pre' => 'fail']
+   *   Ex: ['/^hook_/' => 'warn']
+   *
+   * @return static
+   */
+  public function setDispatchPolicy($dispatchPolicy) {
+    if (is_array($dispatchPolicy)) {
+      // Split $dispatchPolicy in two (exact rules vs regex rules).
+      $this->dispatchPolicyExact = [];
+      $this->dispatchPolicyRegex = [];
+      foreach ($dispatchPolicy as $pattern => $action) {
+        if ($pattern[0] === '/') {
+          $this->dispatchPolicyRegex[$pattern] = $action;
+        }
+        else {
+          $this->dispatchPolicyExact[$pattern] = $action;
+        }
+      }
+    }
+    else {
+      $this->dispatchPolicyExact = NULL;
+      $this->dispatchPolicyRegex = NULL;
+    }
+
+    return $this;
+  }
+
+  //  /**
+  //   * @return array|NULL
+  //   */
+  //  public function getDispatchPolicy() {
+  //    return  $this->dispatchPolicyRegex === NULL ? NULL : array_merge($this->dispatchPolicyExact, $this->dispatchPolicyRegex);
+  //  }
+
+  /**
+   * @param string $eventName
+   * @return string
+   *   Ex: 'run', 'drop', 'fail'
+   */
+  protected function checkDispatchPolicy($eventName) {
+    if (isset($this->dispatchPolicyExact[$eventName])) {
+      return $this->dispatchPolicyExact[$eventName];
+    }
+    foreach ($this->dispatchPolicyRegex as $eventPat => $action) {
+      if ($eventPat[0] === '/' && preg_match($eventPat, $eventName)) {
+        return $action;
+      }
+    }
+    return 'fail';
   }
 
 }

--- a/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
+++ b/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Civi\Core;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class CiviEventDispatcherTest
+ * @package Civi\Core
+ * @group headless
+ */
+class CiviEventDispatcherTest extends \CiviUnitTestCase {
+
+  public function testDispatchPolicy_run() {
+    $d = new CiviEventDispatcher(\Civi::container());
+    $d->setDispatchPolicy([
+      'hook_civicrm_fakeRunnable' => 'run',
+    ]);
+    $calls = [];
+    $d->addListener('hook_civicrm_fakeRunnable', function() use (&$calls) {
+      $calls['hook_civicrm_fakeRunnable'] = 1;
+    });
+    $d->dispatch('hook_civicrm_fakeRunnable', new GenericHookEvent());
+    $this->assertEquals(1, $calls['hook_civicrm_fakeRunnable']);
+  }
+
+  public function testDispatchPolicy_drop() {
+    $d = new CiviEventDispatcher(\Civi::container());
+    $d->setDispatchPolicy([
+      '/^hook_civicrm_fakeDr/' => 'drop',
+    ]);
+    $calls = [];
+    $d->addListener('hook_civicrm_fakeDroppable', function() use (&$calls) {
+      $calls['hook_civicrm_fakeDroppable'] = 1;
+    });
+    $d->dispatch('hook_civicrm_fakeDroppable', new GenericHookEvent());
+    $this->assertTrue(!isset($calls['hook_civicrm_fakeDroppable']));
+  }
+
+  public function testDispatchPolicy_fail() {
+    $d = new CiviEventDispatcher(\Civi::container());
+    $d->setDispatchPolicy([
+      '/^hook_civicrm_fakeFa/' => 'fail',
+    ]);
+    try {
+      $d->dispatch('hook_civicrm_fakeFailure', new GenericHookEvent());
+      $this->fail('Expected exception');
+    }
+    catch (\Exception $e) {
+      $this->assertRegExp(';The dispatch policy prohibits event;', $e->getMessage());
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This updates the `CiviEventDispatcher` with a method `setDispatchPolicy()` that can be used to dynamically toggle support for specific events/hooks.

This is intended for use in upgrades and debugging - not for general runtime use. It aims to support https://lab.civicrm.org/dev/core/issues/1460 and is an excerpt from #17126.

Before
----------------------------------------

Any call to `Civi::dispatcher()->dispatch('x'...)` will unconditionally dispatch the event `x`.

After
----------------------------------------

Under normal conditions, the dispatch-policy is `NULL`. Any call to `Civi::dispatcher()->dispatch('x'...)` will dispatch the event `x`.

Under special conditions (upgrading or debugging), you may set a dispatch-policy to specify which events will be supported.


Technical Details
----------------------------------------

The `setDispatchPolicy()` function takes an array (`[string $eventNameRegex => string $action]`) To see how this array works, let's consider an example policy:

```php
[
      /*1*/ 'hook_civicrm_config' => 'warn',
      /*2*/ '/^hook_civicrm_/'    => 'drop',
      /*3*/ '/^civi\./'           => 'run',
]
```

Now what happens as different events are run?

```php
Civi::dispatcher()->dispatch('civi.dao.preDelete', ...);
// ^^ Matches #3. This event will run normally.

Civi::dispatcher()->dispatch('hook_civicrm_config', ...);
// ^^ Matches #1. This event will run, but it will log a warning.

Civi::dispatcher()->dispatch('hook_civicrm_alterMailer', ...);
// ^^ Matches #2. This event will be dropped/ignored. No listeners are actually called.
```
