### PR TITLE
Switch cc field on emailTrait to use entity reference

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -128,7 +128,6 @@ CRM.$(function($) {
     ccContact = {if $ccContact}{$ccContact}{else}''{/if};
   {literal}
   emailSelect('#to', toContact);
-  emailSelect('#cc_id', ccContact);
 });
 
 

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -109,6 +109,7 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
       'from_email_address' => $loggedInEmail['id'],
       'subject' => 'Really interesting stuff',
       'bcc_id' => $bcc,
+      'cc_id' => '',
     ]));
     $mut->checkMailLog([
       'This is a test Signature',


### PR DESCRIPTION
Overview
----------------------------------------
Extend https://github.com/civicrm/civicrm-core/pull/17064 to cc field

Before
----------------------------------------
cc field uses custom js

After
----------------------------------------
cc field uses entity reference

Technical Details
----------------------------------------
Per #17064 - note this only affects the cc field - I have left the to field for now as it will be a bigger code cleanup

Comments
----------------------------------------
@colemanw 
