### PR TITLE
dev/mail#62 - Mailing Error when civicrm_mailing_group has duplicate …

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -120,7 +120,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     $mailingGroup = new CRM_Mailing_DAO_MailingGroup();
     $recipientsGroup = $excludeSmartGroupIDs = $includeSmartGroupIDs = $priorMailingIDs = [];
     $dao = CRM_Utils_SQL_Select::from('civicrm_mailing_group')
-      ->select('GROUP_CONCAT(entity_id SEPARATOR ",") as group_ids, group_type, entity_table')
+      ->select('GROUP_CONCAT(DISTINCT entity_id SEPARATOR ",") as group_ids, group_type, entity_table')
       ->where('mailing_id = #mailing_id AND entity_table RLIKE "^civicrm_(group.*|mailing)$" ')
       ->groupBy(['group_type', 'entity_table'])
       ->param('!groupTableName', CRM_Contact_BAO_Group::getTableName())


### PR DESCRIPTION
…entries of recipient groups

Overview
----------------------------------------
Mailing Error when civicrm_mailing_group has duplicate entries of recipient groups

Before
----------------------------------------
Details on Gitlab - https://lab.civicrm.org/dev/mail/-/issues/62

![image](https://user-images.githubusercontent.com/5929648/79853855-37329500-83e6-11ea-98b0-ca89e250c8ba.png)

After
----------------------------------------
max length of group_concat error is avoided by removing duplicate ids in it. The mailing is loaded and sent correctly.

Technical Details
----------------------------------------
The group_concat is still an issue if number of groups are more. But maybe, its too rare to include more than >250 groups in a single mailing? Assuming each group id is 2-3 char long with `,` separating them in group_concat. 

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/mail/-/issues/62