### PR TITLE
dev/core#1723 - Adv Search - Reciprocal relationship search with custom fields leads to error

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4191,7 +4191,7 @@ WHERE  $smartGroupClause
     if (self::$_relType == 'reciprocal') {
       $where = [];
       self::$_relationshipTempTable = $relationshipTempTable = CRM_Utils_SQL_TempTable::build()
-        ->createWithColumns("`contact_id` int(10) unsigned NOT NULL DEFAULT '0', `contact_id_alt` int(10) unsigned NOT NULL DEFAULT '0', relationship_id int unsigned, KEY `contact_id` (`contact_id`), KEY `contact_id_alt` (`contact_id_alt`)")
+        ->createWithColumns("`contact_id` int(10) unsigned NOT NULL DEFAULT '0', `contact_id_alt` int(10) unsigned NOT NULL DEFAULT '0', id int unsigned, KEY `contact_id` (`contact_id`), KEY `contact_id_alt` (`contact_id_alt`)")
         ->getName();
       if ($nameClause) {
         $where[$grouping][] = " sort_name $nameClause ";
@@ -4207,7 +4207,7 @@ WHERE  $smartGroupClause
       $groupJoinTable = "contact_b";
       $groupJoinColumn = "id";
     }
-    $allRelationshipType = CRM_Contact_BAO_Relationship::getContactRelationshipType(NULL, 'null', NULL, NULL, TRUE);
+    $allRelationshipType = CRM_Contact_BAO_Relationship::getContactRelationshipType(NULL, 'null', NULL, NULL, TRUE, 'label', FALSE);
     if ($nameClause || !$targetGroup) {
       if (!empty($relationType)) {
         $relQill = '';
@@ -4315,7 +4315,7 @@ civicrm_relationship.start_date > {$today}
         $whereClause = str_replace('contact_b', 'c', $whereClause);
       }
       $sql = "
-        INSERT INTO {$relationshipTempTable} (contact_id, contact_id_alt, relationship_id)
+        INSERT INTO {$relationshipTempTable} (contact_id, contact_id_alt, id)
           (SELECT contact_id_b as contact_id, contact_id_a as contact_id_alt, civicrm_relationship.id
             FROM civicrm_relationship
             INNER JOIN  civicrm_contact c ON civicrm_relationship.contact_id_a = c.id


### PR DESCRIPTION
Overview
----------------------------------------
Reciprocal relationship search with custom fields leads to an error on Advanced search

Before
----------------------------------------
See steps to replicate on gitlab - https://lab.civicrm.org/dev/core/-/issues/1723

![image](https://user-images.githubusercontent.com/5929648/79860150-ce501a80-83ef-11ea-8a80-717919dfe71b.png)

After
----------------------------------------
Search results are loaded correctly.


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/1723

relates to changes done in https://github.com/civicrm/civicrm-core/pull/15793