### PR TITLE
dev/user-interface#19 - Remove leftover description text on contribution form mistakenly left in

### DIFF
--- a/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
@@ -17,7 +17,6 @@
             <span class="description">{ts}Non-deductible portion of this contribution.{/ts}</span></td></tr>
         <tr class="crm-contribution-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html|crmMoney:$currency:'XXX':'YYY'}<br />
             <span class="description">{ts}Processing fee for this transaction (if applicable).{/ts}</span></td></tr>
-            <span class="description">{ts}Net value of the contribution (Total Amount minus Fee).{/ts}</span></td></tr>
         <tr class="crm-contribution-form-block-invoice_id"><td class="label">{$form.invoice_id.label}</td><td{$valueStyle}>{$form.invoice_id.html}<br />
             <span class="description">{ts}Unique internal reference ID for this contribution.{/ts}</span></td></tr>
         <tr class="crm-contribution-form-block-creditnote_id"><td class="label">{$form.creditnote_id.label}</td><td{$valueStyle}>{$form.creditnote_id.html}<br />


### PR DESCRIPTION
Overview
----------------------------------------
This commit https://github.com/civicrm/civicrm-core/commit/3533db2e579dbc94176ab16a1d64a201468efe4b#diff-b2428247b414b914ab6f6dbe3f02c9bb  removed the Net Amount field from the additional details section on contribution forms, but left in part of the table row containing the description, so it sits in limbo at the top of the section. See https://lab.civicrm.org/dev/user-interface/-/issues/19
