### PR TITLE
dev/core#1717 - Fix SMTP failure involving `disconnect()` method

### DIFF
--- a/CRM/Utils/Mail/FilteredPearMailer.php
+++ b/CRM/Utils/Mail/FilteredPearMailer.php
@@ -109,4 +109,11 @@ class CRM_Utils_Mail_FilteredPearMailer extends Mail {
     unset($this->_delegate->{$name});
   }
 
+  public function disconnect() {
+    if (is_callable([$this->_delegate, 'disconnect'])) {
+      return $this->_delegate->disconnect();
+    }
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
v5.24 introduced a new Mailer utility, `CRM_Utils_Mail_FilteredPearMailer`, which is essentially a wrapper around `Mail_Smtp`, `Mail_mail` and `Mail_sendmail`. This allowed us to inject some of our customisation on top of PEAR `Mail` (and remove some patch-files).

However, `FilteredPearMailer` did not implement the SMTP-specific `disconnect` method (used by some error-handling code for flexmailer and Mailing BAO - https://github.com/civicrm/civicrm-core/blob/master/CRM/Mailing/BAO/MailingJob.php#L668).

Before
----------------------------------------
Disconnect method not implemented on wrapper factory

After
----------------------------------------
Disconnect method is implemented

ping @eileenmcnaughton @totten @aydun @jaapjansma