### PR TITLE
dev/core#1705 APIv4 - Support pseudoconstant lookups

### DIFF
--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -120,7 +120,7 @@ abstract class AbstractGetAction extends AbstractQueryAction {
    * Checks the SELECT, WHERE and ORDER BY params to see what fields are needed.
    *
    * Note that if no SELECT clause has been set then all fields should be selected
-   * and this function will always return TRUE.
+   * and this function will return TRUE for field expressions that don't contain a :pseudoconstant suffix.
    *
    * @param string ...$fieldNames
    *   One or more field names to check (uses OR if multiple)
@@ -128,7 +128,7 @@ abstract class AbstractGetAction extends AbstractQueryAction {
    *   Returns true if any given fields are in use.
    */
   protected function _isFieldSelected(string ...$fieldNames) {
-    if (!$this->select || array_intersect($fieldNames, array_merge($this->select, array_keys($this->orderBy)))) {
+    if ((!$this->select && strpos($fieldNames[0], ':') === FALSE) || array_intersect($fieldNames, array_merge($this->select, array_keys($this->orderBy)))) {
       return TRUE;
     }
     return $this->_whereContains($fieldNames);

--- a/Civi/Api4/Generic/BasicCreateAction.php
+++ b/Civi/Api4/Generic/BasicCreateAction.php
@@ -58,6 +58,7 @@ class BasicCreateAction extends AbstractCreateAction {
    * @param \Civi\Api4\Generic\Result $result
    */
   public function _run(Result $result) {
+    $this->formatWriteValues($this->values);
     $this->validateValues();
     $result->exchangeArray([$this->writeRecord($this->values)]);
   }

--- a/Civi/Api4/Generic/BasicGetAction.php
+++ b/Civi/Api4/Generic/BasicGetAction.php
@@ -22,6 +22,7 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
+use Civi\Api4\Utils\FormattingUtil;
 
 /**
  * Retrieve $ENTITIES based on criteria specified in the `where` parameter.
@@ -59,6 +60,7 @@ class BasicGetAction extends AbstractGetAction {
     $this->setDefaultWhereClause();
     $this->expandSelectClauseWildcards();
     $values = $this->getRecords();
+    $this->formatRawValues($values);
     $result->exchangeArray($this->queryArray($values));
   }
 
@@ -100,6 +102,33 @@ class BasicGetAction extends AbstractGetAction {
       return call_user_func($this->getter, $this);
     }
     throw new NotImplementedException('Getter function not found for api4 ' . $this->getEntityName() . '::' . $this->getActionName());
+  }
+
+  /**
+   * Evaluate :pseudoconstant suffix expressions and replace raw values with option values
+   *
+   * @param $records
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function formatRawValues(&$records) {
+    // Pad $records and $fields with pseudofields
+    $fields = $this->entityFields();
+    foreach ($records as &$values) {
+      foreach ($this->entityFields() as $field) {
+        if (!empty($field['options'])) {
+          foreach (array_keys(FormattingUtil::$pseudoConstantContexts) as $suffix) {
+            $pseudofield = $field['name'] . ':' . $suffix;
+            if (!isset($values[$pseudofield]) && isset($values[$field['name']]) && $this->_isFieldSelected($pseudofield)) {
+              $values[$pseudofield] = $values[$field['name']];
+              $fields[$pseudofield] = $field;
+            }
+          }
+        }
+      }
+    }
+    // Swap raw values with pseudoconstants
+    FormattingUtil::formatOutputValues($records, $fields, $this->getEntityName(), $this->getActionName());
   }
 
 }

--- a/Civi/Api4/Generic/BasicSaveAction.php
+++ b/Civi/Api4/Generic/BasicSaveAction.php
@@ -60,10 +60,13 @@ class BasicSaveAction extends AbstractSaveAction {
    * @param \Civi\Api4\Generic\Result $result
    */
   public function _run(Result $result) {
-    $this->validateValues();
-    foreach ($this->records as $record) {
+    foreach ($this->records as &$record) {
       $record += $this->defaults;
-      $result[] = $this->writeRecord($record);
+      $this->formatWriteValues($record);
+    }
+    $this->validateValues();
+    foreach ($this->records as $item) {
+      $result[] = $this->writeRecord($item);
     }
     if ($this->reload) {
       /** @var BasicGetAction $get */

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -61,6 +61,7 @@ class BasicUpdateAction extends AbstractUpdateAction {
    * @throws \Civi\API\Exception\NotImplementedException
    */
   public function _run(Result $result) {
+    $this->formatWriteValues($this->values);
     foreach ($this->getBatchRecords() as $item) {
       $result[] = $this->writeRecord($this->values + $item);
     }

--- a/Civi/Api4/Generic/DAOCreateAction.php
+++ b/Civi/Api4/Generic/DAOCreateAction.php
@@ -34,6 +34,7 @@ class DAOCreateAction extends AbstractCreateAction {
    * @inheritDoc
    */
   public function _run(Result $result) {
+    $this->formatWriteValues($this->values);
     $this->validateValues();
     $params = $this->values;
     $this->fillDefaults($params);

--- a/Civi/Api4/Generic/DAOSaveAction.php
+++ b/Civi/Api4/Generic/DAOSaveAction.php
@@ -37,6 +37,7 @@ class DAOSaveAction extends AbstractSaveAction {
   public function _run(Result $result) {
     foreach ($this->records as &$record) {
       $record += $this->defaults;
+      $this->formatWriteValues($record);
       if (empty($record['id'])) {
         $this->fillDefaults($record);
       }

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -42,6 +42,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
    * @inheritDoc
    */
   public function _run(Result $result) {
+    $this->formatWriteValues($this->values);
     // Add ID from values to WHERE clause and check for mismatch
     if (!empty($this->values['id'])) {
       $wheres = array_column($this->where, NULL, 0);

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -199,8 +199,17 @@ trait ArrayQueryActionTrait {
       $values = [['row_count' => count($values)]];
     }
     elseif ($this->getSelect()) {
+      // Return only fields specified by SELECT
       foreach ($values as &$value) {
         $value = array_intersect_key($value, array_flip($this->getSelect()));
+      }
+    }
+    else {
+      // With no SELECT specified, return all values that are keyed by plain field name; omit those with :pseudoconstant suffixes
+      foreach ($values as &$value) {
+        $value = array_filter($value, function($key) {
+          return strpos($key, ':') === FALSE;
+        }, ARRAY_FILTER_USE_KEY);
       }
     }
     return $values;

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -175,6 +175,7 @@ trait DAOActionTrait {
       }
 
       list($customGroup, $customField) = explode('.', $name);
+      list($customField, $option) = array_pad(explode(':', $customField), 2, NULL);
 
       $customFieldId = \CRM_Core_BAO_CustomField::getFieldValue(
         \CRM_Core_DAO_CustomField::class,
@@ -197,6 +198,11 @@ trait DAOActionTrait {
 
       // todo are we sure we don't want to allow setting to NULL? need to test
       if ($customFieldId && NULL !== $value) {
+
+        if ($option) {
+          $options = FormattingUtil::getPseudoconstantList($this->getEntityName(), 'custom_' . $customFieldId, $option, $params, $this->getActionName());
+          $value = FormattingUtil::replacePseudoconstant($options, $value, TRUE);
+        }
 
         if ($customFieldType == 'CheckBox') {
           // this function should be part of a class

--- a/tests/phpunit/api/v4/Action/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Action/PseudoconstantTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+
+namespace api\v4\Action;
+
+use Civi\Api4\Address;
+use Civi\Api4\Contact;
+use Civi\Api4\Activity;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+use Civi\Api4\Email;
+use Civi\Api4\OptionValue;
+
+/**
+ * @group headless
+ */
+class PseudoconstantTest extends BaseCustomValueTest {
+
+  public function testOptionValue() {
+    $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
+    $subject = uniqid('subject');
+    OptionValue::create()
+      ->addValue('option_group_id:name', 'activity_type')
+      ->addValue('label', 'Fake')
+      ->execute();
+
+    Activity::create()
+      ->addValue('activity_type_id:name', 'Fake')
+      ->addValue('source_contact_id', $cid)
+      ->addValue('subject', $subject)
+      ->execute();
+
+    $act = Activity::get()
+      ->addWhere('activity_type_id:name', '=', 'Fake')
+      ->addWhere('subject', '=', $subject)
+      ->addSelect('activity_type_id:label')
+      ->addSelect('activity_type_id')
+      ->execute();
+
+    $this->assertCount(1, $act);
+    $this->assertEquals('Fake', $act[0]['activity_type_id:label']);
+    $this->assertTrue(is_numeric($act[0]['activity_type_id']));
+  }
+
+  public function testAddressOptions() {
+    $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'addr')->execute()->first()['id'];
+    Address::save()
+      ->addRecord([
+        'contact_id' => $cid,
+        'state_province_id:abbr' => 'CA',
+        'country_id:label' => 'United States',
+        'street_address' => '1',
+      ])
+      ->addRecord([
+        'contact_id' => $cid,
+        'state_province_id:abbr' => 'CA',
+        'country_id:label' => 'Uruguay',
+        'street_address' => '2',
+      ])
+      ->addRecord([
+        'contact_id' => $cid,
+        'state_province_id:abbr' => 'CA',
+        'country_id:abbr' => 'ES',
+        'street_address' => '3',
+      ])
+      ->execute();
+
+    $addr = Address::get()
+      ->addWhere('contact_id', '=', $cid)
+      ->addSelect('state_province_id:abbr', 'state_province_id:name', 'country_id:label', 'country_id:name')
+      ->addOrderBy('street_address')
+      ->execute();
+
+    $this->assertCount(3, $addr);
+
+    // US - California
+    $this->assertEquals('CA', $addr[0]['state_province_id:abbr']);
+    $this->assertEquals('California', $addr[0]['state_province_id:name']);
+    $this->assertEquals('US', $addr[0]['country_id:name']);
+    $this->assertEquals('United States', $addr[0]['country_id:label']);
+    // Uruguay - Canelones
+    $this->assertEquals('CA', $addr[1]['state_province_id:abbr']);
+    $this->assertEquals('Canelones', $addr[1]['state_province_id:name']);
+    $this->assertEquals('UY', $addr[1]['country_id:name']);
+    $this->assertEquals('Uruguay', $addr[1]['country_id:label']);
+    // Spain - Cádiz
+    $this->assertEquals('CA', $addr[2]['state_province_id:abbr']);
+    $this->assertEquals('Cádiz', $addr[2]['state_province_id:name']);
+    $this->assertEquals('ES', $addr[2]['country_id:name']);
+    $this->assertEquals('Spain', $addr[2]['country_id:label']);
+  }
+
+  public function testCustomOptions() {
+    CustomGroup::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('name', 'myPseudoconstantTest')
+      ->addValue('extends', 'Individual')
+      ->addChain('field', CustomField::create()
+        ->addValue('custom_group_id', '$id')
+        ->addValue('option_values', ['r' => 'red', 'g' => 'green', 'b' => 'blue'])
+        ->addValue('label', 'Color')
+        ->addValue('html_type', 'Select')
+      )->execute();
+
+    $cid = Contact::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'col')
+      ->addValue('myPseudoconstantTest.Color:label', 'blue')
+      ->execute()->first()['id'];
+
+    $result = Contact::get()
+      ->setCheckPermissions(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addSelect('myPseudoconstantTest.Color:label', 'myPseudoconstantTest.Color')
+      ->execute()->first();
+
+    $this->assertEquals('blue', $result['myPseudoconstantTest.Color:label']);
+    $this->assertEquals('b', $result['myPseudoconstantTest.Color']);
+  }
+
+  public function testJoinOptions() {
+    $cid1 = Contact::create()->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'Tom')
+      ->addValue('gender_id:label', 'Male')
+      ->addChain('email', Email::create()->setValues(['contact_id' => '$id', 'email' => 'tom@example.com', 'location_type_id:name' => 'Work']))
+      ->execute()->first()['id'];
+    $cid2 = Contact::create()->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'Sue')
+      ->addValue('gender_id:name', 'Female')
+      ->addChain('email', Email::create()->setValues(['contact_id' => '$id', 'email' => 'sue@example.com', 'location_type_id:name' => 'Home']))
+      ->execute()->first()['id'];
+    $cid3 = Contact::create()->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'Pat')
+      ->addChain('email', Email::create()->setValues(['contact_id' => '$id', 'email' => 'pat@example.com', 'location_type_id:name' => 'Home']))
+      ->execute()->first()['id'];
+
+    $emails = Email::get()
+      ->addSelect('location_type_id:name', 'contact.gender_id:label', 'email', 'contact_id')
+      ->addWhere('contact_id', 'IN', [$cid1, $cid2, $cid3])
+      ->addWhere('contact.gender_id:label', 'IN', ['Male', 'Female'])
+      ->execute()->indexBy('contact_id');
+    $this->assertCount(2, $emails);
+    $this->assertEquals('Work', $emails[$cid1]['location_type_id:name']);
+    $this->assertEquals('Home', $emails[$cid2]['location_type_id:name']);
+    $this->assertEquals('Male', $emails[$cid1]['contact.gender_id:label']);
+    $this->assertEquals('Female', $emails[$cid2]['contact.gender_id:label']);
+
+    $emails = Email::get()
+      ->addSelect('location_type_id:name', 'contact.gender_id:label', 'email', 'contact_id')
+      ->addWhere('contact_id', 'IN', [$cid1, $cid2, $cid3])
+      ->addWhere('location_type_id:name', 'IN', ['Home'])
+      ->execute()->indexBy('contact_id');
+    $this->assertCount(2, $emails);
+    $this->assertEquals('Home', $emails[$cid2]['location_type_id:name']);
+    $this->assertEquals('Home', $emails[$cid3]['location_type_id:name']);
+    $this->assertEquals('Female', $emails[$cid2]['contact.gender_id:label']);
+    $this->assertNull($emails[$cid3]['contact.gender_id:label']);
+  }
+
+}

--- a/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
+++ b/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
@@ -38,13 +38,13 @@ class MockBasicEntity extends Generic\AbstractEntity {
       return [
         [
           'name' => 'id',
-          'type' => 'Integer',
+          'data_type' => 'Integer',
         ],
         [
           'name' => 'group',
           'options' => [
-            'one' => 'One',
-            'two' => 'Two',
+            'one' => 'First',
+            'two' => 'Second',
           ],
         ],
         [
@@ -58,6 +58,7 @@ class MockBasicEntity extends Generic\AbstractEntity {
         ],
         [
           'name' => 'weight',
+          'data_type' => 'Integer',
         ],
       ];
     });


### PR DESCRIPTION
Overview
----------------------------------------
Access field option lists via APIv4, works for both inputs and outputs (note that for APIv3 it only works for inputs).
See discussion at https://lab.civicrm.org/dev/core/-/issues/1705

Before
----------------------------------------
APIv4 could only input/output a field's raw value.

After
----------------------------------------
Adding a suffix beginning with `:` to a field name tells the api to convert the raw value to/from an option name or label. Currently supported suffixes are `:name`, `:label`, and `:abbr` (abbr applies to a handful of fields like state_province).

Technical Details
----------------------------------------
Tests include converting names of states based on the name of a country, which goes off the chainSelect metadata to tell the api which variables to replace first so e.g. we know the `country_id` before attempting to lookup the list of states.