### PR TITLE
dev/membership#24 Don't hide disabled memberships from the contact membership tab

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1579,11 +1579,6 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @return null|string
    */
   public static function getContactMembershipCount($contactID, $activeOnly = FALSE) {
-    CRM_Financial_BAO_FinancialType::getAvailableMembershipTypes($membershipTypes);
-    $addWhere = " AND membership_type_id IN (0)";
-    if (!empty($membershipTypes)) {
-      $addWhere = " AND membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";
-    }
     $select = "SELECT count(*) FROM civicrm_membership ";
     $where = "WHERE civicrm_membership.contact_id = {$contactID} AND civicrm_membership.is_test = 0 ";
 
@@ -1593,7 +1588,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
       $where .= " and civicrm_membership_status.is_current_member = 1";
     }
 
-    $query = $select . $where . $addWhere;
+    $query = $select . $where;
     return CRM_Core_DAO::singleValueQuery($query);
   }
 

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -33,17 +33,9 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    * called when action is browse.
    */
   public function browse() {
-    $links = self::links('all', $this->_isPaymentProcessor, $this->_accessContribution);
-    CRM_Financial_BAO_FinancialType::getAvailableMembershipTypes($membershipTypes);
-    $addWhere = "membership_type_id IN (0)";
-    if (!empty($membershipTypes)) {
-      $addWhere = "membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";
-    }
-
     $membership = [];
     $dao = new CRM_Member_DAO_Membership();
     $dao->contact_id = $this->_contactId;
-    $dao->whereAdd($addWhere);
     $dao->find();
 
     //CRM--4418, check for view, edit, delete


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/membership/issues/24

Stop hiding disabled memberships on the member tab.

The most common use-case for disabling a membership type seems to be because it is no longer a "current" membership for the organisation - but there may well still be many valid memberships of that type.

Before
----------------------------------------
- Memberships that are found via search etc. "disappear" when you click through to the contact record which is pretty confusing for the user!

After
----------------------------------------
Memberships that are found via search etc. are still there when you click through to the contact record.

Technical Details
----------------------------------------
Memberships with a disabled membership type were not shown on the membership tab but were shown in searches and calculations etc. still performed. We remove the extra SQL WHERE parameters so the disabled memberships are no longer excluded from the contact membership tab.

Comments
----------------------------------------
1. To test, create a membership on a contact.
1. Disable the membership type.
1. Search for that membership.
1. Click on the membership and see that it is not visible in the contacts membership tab (with this PR it is visible).

@alifrumin This fixes your issue on lab. Please could you review?

