### PR TITLE
dev/core#1716 add customPre hook

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -47,25 +47,31 @@ class CRM_Core_BAO_CustomValueTable {
         $set = [];
         $params = [];
         $count = 1;
-        foreach ($fields as $field) {
-          if (!$sqlOP) {
-            $entityID = $field['entity_id'];
-            $hookID = $field['custom_group_id'];
-            $isMultiple = $field['is_multiple'];
-            if (array_key_exists('id', $field)) {
-              $sqlOP = "UPDATE $tableName ";
-              $where = " WHERE  id = %{$count}";
-              $params[$count] = [$field['id'], 'Integer'];
-              $count++;
-              $hookOP = 'edit';
-            }
-            else {
-              $sqlOP = "INSERT INTO $tableName ";
-              $where = NULL;
-              $hookOP = 'create';
-            }
-          }
 
+        $firstField = reset($fields);
+        $entityID = $firstField['entity_id'];
+        $hookID = $firstField['custom_group_id'];
+        $isMultiple = $firstField['is_multiple'];
+        if (array_key_exists('id', $firstField)) {
+          $sqlOP = "UPDATE $tableName ";
+          $where = " WHERE  id = %{$count}";
+          $params[$count] = [$firstField['id'], 'Integer'];
+          $count++;
+          $hookOP = 'edit';
+        }
+        else {
+          $sqlOP = "INSERT INTO $tableName ";
+          $where = NULL;
+          $hookOP = 'create';
+        }
+
+        CRM_Utils_Hook::customPre($hookOP,
+          $hookID,
+          $entityID,
+          $fields
+        );
+
+        foreach ($fields as $field) {
           // fix the value before we store it
           $value = $field['value'];
           $type = $field['type'];

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -542,6 +542,26 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called before a db write on a custom table.
+   *
+   * @param string $op
+   *   The type of operation being performed.
+   * @param string $groupID
+   *   The custom group ID.
+   * @param object $entityID
+   *   The entityID of the row in the custom table.
+   * @param array $params
+   *   The parameters that were sent into the calling function.
+   *
+   * @return null
+   *   the return value is ignored
+   */
+  public static function customPre($op, $groupID, $entityID, &$params) {
+    return self::singleton()
+      ->invoke(['op', 'groupID', 'entityID', 'params'], $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_customPre');
+  }
+
+  /**
    * This hook is called when composing the ACL where clause to restrict
    * visibility of contacts to the logged in user
    *


### PR DESCRIPTION
Overview
----------------------------------------
Create new customPre hook which is fired before a write to custom data tables. This allows modifications of the params before being saved, as well as the ability to compare existing and new values before an update.

https://lab.civicrm.org/dev/core/-/issues/1716

Before
----------------------------------------
Currently there is no way to impact or observe custom data before it is saved.

After
----------------------------------------
You are now able to interact with custom data before it's saved.

Technical Details
----------------------------------------
See discussion here: https://civicrm.stackexchange.com/questions/35354/is-there-a-hook-to-impact-custom-data-before-its-saved/35364#35364
The hook follows the pattern of the existing custom hook exactly. 
