### PR TITLE
Add a "report output handler", so that we can start untangling the PDF, CSV

### DIFF
--- a/CRM/Report/Output/Csv.php
+++ b/CRM/Report/Output/Csv.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+class CRM_Report_Output_Csv implements CRM_Report_Output_Interface {
+
+  /**
+   * Reference of the report instance.
+   */
+  protected $report;
+
+  /**
+   * @inheritDoc
+   */
+  public function __construct(&$report) {
+    $report->printOnly = TRUE;
+    $report->absoluteUrl = TRUE;
+    $report->setAddPaging(FALSE);
+
+    $this->report = $report;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function supportsSqlDeveloperTab() {
+    return FALSE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function generateOutput(&$rows = NULL) {
+    CRM_Report_Utils_Report::export2csv($this->report, $rows);
+  }
+
+}

--- a/CRM/Report/Output/Interface.php
+++ b/CRM/Report/Output/Interface.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ * CRM_Report_Output_Interface implements helper functions to determine what to
+ * do with the report data, such as displaying on the screen, printing, pdf,
+ * csv, etc. Extensions can also provide their own implementations, such as the
+ * civiexportexcel extension.
+ */
+interface CRM_Report_Output_Interface {
+
+  /**
+   * Class constructor.
+   *
+   * @param CRM_Report_Form
+   */
+  public function __construct(&$report);
+
+  /**
+   * Checks if the output method supports the SQL developer tab.
+   *
+   * @return bool
+   */
+  public function supportsSqlDeveloperTab();
+
+  /**
+   * Generate the output.
+   *
+   * @param array
+   */
+  public function generateOutput(&$rows = NULL);
+
+}

--- a/CRM/Report/Output/Pdf.php
+++ b/CRM/Report/Output/Pdf.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+class CRM_Report_Output_Pdf implements CRM_Report_Output_Interface {
+
+  /**
+   * Reference of the report instance.
+   */
+  protected $report;
+
+  /**
+   * @inheritDoc
+   */
+  public function __construct(&$report) {
+    $report->printOnly = TRUE;
+    $report->absoluteUrl = TRUE;
+    $report->setAddPaging(FALSE);
+
+    $this->report = $report;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function supportsSqlDeveloperTab() {
+    return FALSE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function generateOutput(&$rows = NULL) {
+    $content = $this->report->compileContent();
+    $id = $this->report->getID();
+    $url = CRM_Utils_System::url("civicrm/report/instance/{$id}", "reset=1", TRUE);
+
+    // Nb. Once upon a time we used a package called Open Flash Charts to
+    // draw charts, and we had a feature whereby a browser could send the
+    // server a PNG version of the chart, which could then be included in a
+    // PDF by including <img> tags in the HTML for the conversion below.
+    //
+    // This feature stopped working when browsers stopped supporting Flash,
+    // and although we have a different client-side charting library in
+    // place, we decided not to reimplement the (rather convoluted)
+    // browser-sending-rendered-chart-to-server process.
+    //
+    // If this feature is required in future we should find a better way to
+    // render charts on the server side, e.g. server-created SVG.
+    CRM_Utils_PDF_Utils::html2pdf($content, "CiviReport.pdf", FALSE, ['orientation' => 'landscape']);
+
+    CRM_Utils_System::civiExit();
+  }
+
+}


### PR DESCRIPTION
.. and email code, and allow extensions to implement their own methods (ex: Excel
Export).

Overview
----------------------------------------

Early attempt at untangling the Report code, so that it can be more easily pluggable.

Context: the "Export to Excel" extension (which has a fairly large user-base) requires a patch on core so that all reports export correctly:

https://lab.civicrm.org/extensions/civiexportexcel/-/blob/master/civiexportexcel-core.patch

As you can see, it really doesn't take much to make report export pluggable. Extensions can already add custom actions, but they can't influence the "outputMode".

I would appreciate feedback since:

- My understanding of object oriented programming is duct-tape-ish at best.
- I didn't feel like hooks were a right fit. This is more similar to a Payment Processor. At the same time, it might be introducing a new kind of pattern in CiviCRM, and maybe there is another pattern that already fits.

Ideally, I would like to start small, then implement this in the Export to Excel extension, iterate a bit (figure out if more methods should be added for other use-cases, then write good documentation.

Before
----------------------------------------

Impossible to export into anything else than CSV or PDF.

After
----------------------------------------

Extension authors can provide custom actions.
