### PR TITLE
[REF] Minor cleanup around action schedule code.

### DIFF
--- a/CRM/Utils/Time.php
+++ b/CRM/Utils/Time.php
@@ -32,7 +32,7 @@ class CRM_Utils_Time {
    * @param string $returnFormat
    *   Format in which date is to be retrieved.
    *
-   * @return date
+   * @return string
    */
   public static function getTime($returnFormat = 'YmdHis') {
     return date($returnFormat, self::getTimeRaw());
@@ -56,7 +56,7 @@ class CRM_Utils_Time {
    * @param string $returnFormat
    *   Format in which date is to be retrieved.
    *
-   * @return date
+   * @return string
    */
   public static function setTime($newDateTime, $returnFormat = 'YmdHis') {
     self::$_delta = strtotime($newDateTime) - time();

--- a/Civi/Api4/ActionSchedule.php
+++ b/Civi/Api4/ActionSchedule.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 


### PR DESCRIPTION


Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
CRM_Core_BAO_ActionSchedule::processQueue is only called from one place. It either succeeds or throws
an exception & the construction of a return array & handling of that array is just meaningless code

After
----------------------------------------
No return value & lack of exception is understood as success. 

Technical Details
----------------------------------------
Some additional fixes around declared return types & exceptions & using strict typing

Comments
----------------------------------------

