### PR TITLE
[REF] Consistently lookup dispatcher via `Civi::dispatcher()`

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -25,14 +25,16 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule {
   /**
    * @param array $filters
    *   Filter by property (e.g. 'id').
+   *
    * @return array
    *   Array(scalar $id => Mapping $mapping).
+   * @throws \CRM_Core_Exception
    */
   public static function getMappings($filters = NULL) {
     static $_action_mapping;
 
     if ($_action_mapping === NULL) {
-      $event = \Civi\Core\Container::singleton()->get('dispatcher')
+      $event = \Civi::dispatcher()
         ->dispatch(\Civi\ActionSchedule\Events::MAPPINGS,
           new \Civi\ActionSchedule\Event\MappingRegisterEvent());
       $_action_mapping = $event->getMappings();
@@ -507,7 +509,7 @@ FROM civicrm_action_schedule cas
       $select->where("e.id = reminder.entity_id OR reminder.entity_table = 'civicrm_contact'");
     }
 
-    \Civi\Core\Container::singleton()->get('dispatcher')
+    \Civi::dispatcher()
       ->dispatch(
         \Civi\ActionSchedule\Events::MAILING_QUERY,
         new \Civi\ActionSchedule\Event\MailingQueryEvent($actionSchedule, $mapping, $select)
@@ -644,7 +646,7 @@ FROM civicrm_action_schedule cas
    * @return \Civi\Token\TokenProcessor
    */
   protected static function createTokenProcessor($schedule, $mapping) {
-    $tp = new \Civi\Token\TokenProcessor(\Civi\Core\Container::singleton()->get('dispatcher'), [
+    $tp = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), [
       'controller' => __CLASS__,
       'actionSchedule' => $schedule,
       'actionMapping' => $mapping,

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -560,7 +560,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     }
 
     // OK, this looks new.
-    Civi::service('dispatcher')->dispatch(\Civi\Core\Event\SystemInstallEvent::EVENT_NAME, new \Civi\Core\Event\SystemInstallEvent());
+    Civi::dispatcher()->dispatch(\Civi\Core\Event\SystemInstallEvent::EVENT_NAME, new \Civi\Core\Event\SystemInstallEvent());
     Civi::settings()->set('installed', 1);
   }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -545,28 +545,28 @@ class CRM_Core_DAO extends DB_DataObject {
     if (!empty($this->id)) {
       if ($hook) {
         $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);
-        \Civi::service('dispatcher')->dispatch("civi.dao.preUpdate", $preEvent);
+        \Civi::dispatcher()->dispatch("civi.dao.preUpdate", $preEvent);
       }
 
       $result = $this->update();
 
       if ($hook) {
         $event = new \Civi\Core\DAO\Event\PostUpdate($this, $result);
-        \Civi::service('dispatcher')->dispatch("civi.dao.postUpdate", $event);
+        \Civi::dispatcher()->dispatch("civi.dao.postUpdate", $event);
       }
       $this->clearDbColumnValueCache();
     }
     else {
       if ($hook) {
         $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);
-        \Civi::service('dispatcher')->dispatch("civi.dao.preInsert", $preEvent);
+        \Civi::dispatcher()->dispatch("civi.dao.preInsert", $preEvent);
       }
 
       $result = $this->insert();
 
       if ($hook) {
         $event = new \Civi\Core\DAO\Event\PostUpdate($this, $result);
-        \Civi::service('dispatcher')->dispatch("civi.dao.postInsert", $event);
+        \Civi::dispatcher()->dispatch("civi.dao.postInsert", $event);
       }
     }
     $this->free();
@@ -605,12 +605,12 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function delete($useWhere = FALSE) {
     $preEvent = new \Civi\Core\DAO\Event\PreDelete($this);
-    \Civi::service('dispatcher')->dispatch("civi.dao.preDelete", $preEvent);
+    \Civi::dispatcher()->dispatch("civi.dao.preDelete", $preEvent);
 
     $result = parent::delete($useWhere);
 
     $event = new \Civi\Core\DAO\Event\PostDelete($this, $result);
-    \Civi::service('dispatcher')->dispatch("civi.dao.postDelete", $event);
+    \Civi::dispatcher()->dispatch("civi.dao.postDelete", $event);
     $this->free();
 
     $this->clearDbColumnValueCache();

--- a/CRM/Cxn/ApiRouter.php
+++ b/CRM/Cxn/ApiRouter.php
@@ -59,7 +59,7 @@ class CRM_Cxn_ApiRouter {
     }
 
     $whitelist = \Civi\API\WhitelistRule::createAll($cxn['perm']['api']);
-    \Civi::service('dispatcher')
+    \Civi::dispatcher()
       ->addSubscriber(new \Civi\API\Subscriber\WhitelistSubscriber($whitelist));
     CRM_Core_Config::singleton()->userPermissionTemp = new CRM_Core_Permission_Temp();
     if ($cxn['perm']['grant'] === '*') {

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -317,7 +317,7 @@ class CRM_Utils_System {
       'absolute' => $absolute,
       'isSSL' => $isSSL,
     ]);
-    Civi::service('dispatcher')->dispatch('hook_civicrm_alterExternUrl', $event);
+    Civi::dispatcher()->dispatch('hook_civicrm_alterExternUrl', $event);
     return urldecode(CRM_Utils_Url::unparseUrl($event->url));
   }
 

--- a/Civi/Core/Event/GenericHookEvent.php
+++ b/Civi/Core/Event/GenericHookEvent.php
@@ -40,7 +40,7 @@ namespace Civi\Core\Event;
  * $event->bang->objProperty = 'abcd';
  *
  * // Dispatching an event.
- * Civi::service('dispatcher')->dispatch('hook_civicrm_foo', $event);
+ * Civi::dispatcher()->dispatch('hook_civicrm_foo', $event);
  * @endCode
  *
  * Design Discussion:

--- a/Civi/Core/Event/PostEvent.php
+++ b/Civi/Core/Event/PostEvent.php
@@ -25,7 +25,7 @@ class PostEvent extends GenericHookEvent {
    * @param \Civi\Core\Event\PostEvent $event
    */
   public static function dispatchSubevent(PostEvent $event) {
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_post::" . $event->entity, $event);
+    \Civi::dispatcher()->dispatch("hook_civicrm_post::" . $event->entity, $event);
   }
 
   /**

--- a/Civi/Core/Event/PreEvent.php
+++ b/Civi/Core/Event/PreEvent.php
@@ -25,7 +25,7 @@ class PreEvent extends GenericHookEvent {
    * @param \Civi\Core\Event\PreEvent $event
    */
   public static function dispatchSubevent(PreEvent $event) {
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_pre::" . $event->entity, $event);
+    \Civi::dispatcher()->dispatch("hook_civicrm_pre::" . $event->entity, $event);
   }
 
   /**

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -43,7 +43,7 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     ]);
     $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
 
-    $p = new \Civi\Token\TokenProcessor(Civi::service('dispatcher'), [
+    $p = new \Civi\Token\TokenProcessor(Civi::dispatcher(), [
       'mailingId' => $mailing->id,
     ]);
     $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
@@ -80,7 +80,7 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     ]);
     $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
 
-    $p = new \Civi\Token\TokenProcessor(Civi::service('dispatcher'), [
+    $p = new \Civi\Token\TokenProcessor(Civi::dispatcher(), [
       'mailing' => $mailing,
     ]);
     $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
@@ -126,7 +126,7 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     ]);
     $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
 
-    $p = new \Civi\Token\TokenProcessor(Civi::service('dispatcher'), [
+    $p = new \Civi\Token\TokenProcessor(Civi::dispatcher(), [
       'mailing' => $mailing,
     ]);
     $p->addMessage('example', $inputTemplateText, $inputTemplateFormat);

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -138,7 +138,7 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
    * @dataProvider getExternURLs
    */
   public function testAlterExternUrlHook($path, $expected) {
-    Civi::service('dispatcher')->addListener('hook_civicrm_alterExternUrl', [$this, 'hook_civicrm_alterExternUrl']);
+    Civi::dispatcher()->addListener('hook_civicrm_alterExternUrl', [$this, 'hook_civicrm_alterExternUrl']);
     $externUrl = CRM_Utils_System::externUrl($path, $expected['query']);
     $this->assertContains('path/altered/by/hook', $externUrl, 'Hook failed to alter URL path');
     $this->assertContains($expected['query'] . '&thisWas=alteredByHook', $externUrl, 'Hook failed to alter URL query');

--- a/tests/phpunit/Civi/Core/Event/GenericHookEventTest.php
+++ b/tests/phpunit/Civi/Core/Event/GenericHookEventTest.php
@@ -44,7 +44,7 @@ class GenericHookEventTest extends \CiviUnitTestCase {
   public function testDispatch() {
     \CRM_Utils_Hook::singleton()->setHook('civicrm_ghet',
       [$this, 'hook_civicrm_ghet']);
-    \Civi::service('dispatcher')->addListener('hook_civicrm_ghet',
+    \Civi::dispatcher()->addListener('hook_civicrm_ghet',
       [$this, 'onGhet']);
 
     $roString = 'readonly';


### PR DESCRIPTION
Overview
----------------------------------------
Minor code standardisation

Before
----------------------------------------
We have are using 3 ways of getting the dispatcher

1. `Civi\Core\Container::singleton()->get('dispatcher')`
2. `Civi::service('dispatcher')`
3. `Civi::dispatcher()`

Tim confirms there is no functional difference

After
----------------------------------------
All instances call Civi::dispatcher()


Technical Details
----------------------------------------
From @totten on chat

"they're the same thing 

Civi::dispatcher() is just a little prettier

e.g. the IDE is smarter about completing with ::dispatcher()

historically, ::service(...) was around before ::dispatcher()

and ::service(...) is a more generic facility.
you don't want to add every random little object as new wrapper method in Civi.php, but dispatcher is a really common+central thing"



Comments
----------------------------------------
From https://github.com/civicrm/civicrm-core/pull/16983 but I needed to clarify this & so doing did it throughout
