### PR TITLE
[NFC] Superficial code clean up

### DIFF
--- a/CRM/Activity/Form/Task/PDFLetterCommon.php
+++ b/CRM/Activity/Form/Task/PDFLetterCommon.php
@@ -45,7 +45,8 @@ class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLette
    * @param  array $activityIds  array of activity ids
    * @param  string $html_message message text with tokens
    * @param  array $formValues   formValues from the form
-   * @return void
+   *
+   * @return string
    */
   public static function createDocument($activityIds, $html_message, $formValues) {
     $tp = self::createTokenProcessor();
@@ -61,13 +62,15 @@ class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLette
 
   /**
    * Create a token processor
+   *
+   * @return \Civi\Token\TokenProcessor
    */
   public static function createTokenProcessor() {
-    return new TokenProcessor(\Civi::dispatcher(), array(
+    return new TokenProcessor(\Civi::dispatcher(), [
       'controller' => get_class(),
       'smarty' => FALSE,
       'schema' => ['activityId'],
-    ));
+    ]);
   }
 
 }

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -223,6 +223,9 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    * @param array $formValues
    *
    * @return string $html_message
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function processTemplate(&$formValues) {
     $html_message = $formValues['html_message'] ?? NULL;
@@ -326,15 +329,18 @@ class CRM_Core_Form_Task_PDFLetterCommon {
 
   /**
    * Render html from rows
-   * @param  array $rows   Array of \Civi\Token\TokenRow
-   * @param  string $msgPart The name registered with the TokenProcessor
-   * @param  string $formValues The values submitted through the form
-   * @return string
-   *   $html if formValues['is_unit_test'] is true, otherwise outputs document to browser
    *
+   * @param $rows
+   * @param string $msgPart
+   *   The name registered with the TokenProcessor
+   * @param array $formValues
+   *   The values submitted through the form
+   *
+   * @return array
+   *   If formValues['is_unit_test'] is true, otherwise outputs document to browser
    */
   public static function renderFromRows($rows, $msgPart, $formValues) {
-    $html = array();
+    $html = [];
     foreach ($rows as $row) {
       $html[] = $row->render($msgPart);
     }
@@ -346,7 +352,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
     if (!empty($html)) {
       $type = $formValues['document_type'];
 
-      if ($type == 'pdf') {
+      if ($type === 'pdf') {
         CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
       }
       else {

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -15,19 +15,25 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
+  /**
+   * Test create a document with basic tokens.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
   public function testCreateDocumentBasicTokens() {
     $activity = $this->activityCreate();
     $data = [
-      ["Subject: {activity.subject}", "Subject: Discussion on warm beer"],
-      ["Date: {activity.activity_date_time}", "Date: " . \CRM_Utils_Date::customFormat(date('Ymd')) . " 12:00 AM"],
-      ["Duration: {activity.duration}", "Duration: 90"],
-      ["Location: {activity.location}", "Location: Baker Street"],
-      ["Details: {activity.details}", "Details: Lets schedule a meeting"],
-      ["Status ID: {activity.status_id}", "Status ID: 1"],
-      ["Status: {activity.status}", "Status: Scheduled"],
-      ["Activity Type ID: {activity.activity_type_id}", "Activity Type ID: 1"],
-      ["Activity Type: {activity.activity_type}", "Activity Type: Meeting"],
-      ["Activity ID: {activity.activity_id}", "Activity ID: " . $activity['id']],
+      ['Subject: {activity.subject}', 'Subject: Discussion on warm beer'],
+      ['Date: {activity.activity_date_time}', 'Date: ' . \CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM'],
+      ['Duration: {activity.duration}', 'Duration: 90'],
+      ['Location: {activity.location}', 'Location: Baker Street'],
+      ['Details: {activity.details}', 'Details: Lets schedule a meeting'],
+      ['Status ID: {activity.status_id}', 'Status ID: 1'],
+      ['Status: {activity.status}', 'Status: Scheduled'],
+      ['Activity Type ID: {activity.activity_type_id}', 'Activity Type ID: 1'],
+      ['Activity Type: {activity.activity_type}', 'Activity Type: Meeting'],
+      ['Activity ID: {activity.activity_id}', 'Activity ID: ' . $activity['id']],
     ];
     $html_message = "\n" . implode("\n", CRM_Utils_Array::collect('0', $data)) . "\n";
     $output = CRM_Activity_Form_Task_PDFLetterCommon::createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1395,6 +1395,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param array $params
    *
    * @return array|int
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function activityCreate($params = []) {
     $params = array_merge([


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup on comment blocks, use of double quotes, failure to do strict comparison, formatting

Before
----------------------------------------
array()
"blah"
$blah == 'pdf'

After
----------------------------------------
[]
'blah'
$blah === 'pdf'

Technical Details
----------------------------------------


Comments
----------------------------------------

