### PR TITLE
dev/core#1728 Ensure that custom fields that extend specified financi…

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -153,7 +153,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    *
    * @var array
    */
-  public $_contributionType;
+  public $_financialTypeId;
 
   /**
    * The contribution values if an existing contribution
@@ -289,7 +289,20 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
       $this->_noteID = $daoNote->id;
       $values['note'] = $daoNote->note;
     }
-    $this->_contributionType = $values['financial_type_id'];
+    $this->getFinancialTypeId();
+  }
+
+  /**
+   * Get the financial Type ID for the contribution either from the submitted values or from the contribution values if possible
+   */
+  protected function getFinancialTypeId() {
+    // dev/core#1728 Ensure that if we are returned to the form for a formError that any custom fields based on the selected financial type are loaded.
+    if (!empty($this->_submittedValues['financial_type_id'])) {
+      $this->_financialTypeId = $this->_submittedValues['financial_type_id'];
+    }
+    if (!empty($this->_values['financial_type_id'])) {
+      $this->_financialTypeId = $this->_values['financial_type_id'];
+    }
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -78,11 +78,11 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   public $_params;
 
   /**
-   * Store the contribution Type ID
+   * Store the contribution Financial Type ID
    *
    * @var array
    */
-  public $_contributionType;
+  public $_financialTypeId;
 
   /**
    * The contribution values if an existing contribution
@@ -382,8 +382,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
     }
 
-    if ($this->_contributionType) {
-      $defaults['financial_type_id'] = $this->_contributionType;
+    $this->getFinancialTypeId();
+    if (!empty($this->_financialTypeId)) {
+      $defaults['financial_type_id'] = $this->_financialTypeId;
     }
 
     if (empty($defaults['payment_instrument_id'])) {
@@ -612,7 +613,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     //need to assign custom data type and subtype to the template
     $this->assign('customDataType', 'Contribution');
-    $this->assign('customDataSubType', $this->_contributionType);
+    $this->assign('customDataSubType', $this->_financialTypeId);
     $this->assign('entityID', $this->_id);
 
     $contactField = $this->addEntityRef('contact_id', ts('Contributor'), ['create' => TRUE, 'api' => ['extra' => ['email']]], TRUE);


### PR DESCRIPTION
…al type are loaded when form errors on back office contribution form

Overview
----------------------------------------
This Fixes a bug where by if the backoffice contribution form returns an error and the selected financial type has custom fields that extend it they are not properly loaded when the form re-loads

Before
----------------------------------------
Custom fields are not properly loaded

After
----------------------------------------
Customfields are properly loaded on the backoffice contribution edit screen

Technical Details
----------------------------------------
It would seem that $this->_contributionType is only set when editing a contribution already and therefor it doesn't properly work for the situation where by there is a form error on the form and custom fields go missing

Detailed steps for reproducing can be found on the lab ticket https://lab.civicrm.org/dev/core/-/issues/1728

ping @eileenmcnaughton @mattwire @monishdeb 
