### PR TITLE
OptionValues - Munge custom value names and return names in validate context

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -223,7 +223,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       if (!empty($this->option_group_id)) {
         $options = CRM_Core_OptionGroup::valuesByID(
-        $this->option_group_id, FALSE, FALSE, FALSE, 'label', !($context == 'validate' || $context == 'get')
+        $this->option_group_id, FALSE, FALSE, FALSE, $context == 'validate' ? 'name' : 'label', !($context == 'validate' || $context == 'get')
         );
       }
       elseif ($this->data_type === 'StateProvince') {

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -55,18 +55,10 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    * @param array $params
    */
   public static function setDefaults(&$params) {
-    if (CRM_Utils_Array::value('label', $params, NULL) === NULL) {
-      $params['label'] = $params['name'];
-    }
-    if (CRM_Utils_Array::value('name', $params, NULL) === NULL) {
-      $params['name'] = CRM_Utils_String::titleToVar($params['label']);
-    }
-    if (CRM_Utils_Array::value('weight', $params, NULL) === NULL) {
-      $params['weight'] = self::getDefaultWeight($params);
-    }
-    if (CRM_Utils_Array::value('value', $params, NULL) === NULL) {
-      $params['value'] = self::getDefaultValue($params);
-    }
+    $params['label'] = $params['label'] ?? $params['name'];
+    $params['name'] = $params['name'] ?? CRM_Utils_String::titleToVar($params['label']);
+    $params['weight'] = $params['weight'] ?? self::getDefaultWeight($params);
+    $params['value'] = $params['value'] ?? self::getDefaultValue($params);
   }
 
   /**

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -59,7 +59,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
       $params['label'] = $params['name'];
     }
     if (CRM_Utils_Array::value('name', $params, NULL) === NULL) {
-      $params['name'] = $params['label'];
+      $params['name'] = CRM_Utils_String::titleToVar($params['label']);
     }
     if (CRM_Utils_Array::value('weight', $params, NULL) === NULL) {
       $params['weight'] = self::getDefaultWeight($params);

--- a/tests/phpunit/Civi/CCase/SequenceListenerTest.php
+++ b/tests/phpunit/Civi/CCase/SequenceListenerTest.php
@@ -70,14 +70,14 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     \CRM_Utils_Time::setTime('2013-11-30 03:00:00');
     $this->callApiSuccess('Activity', 'create', [
       'id' => self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'id'),
-      'status_id' => $actStatuses['Skip Activity'],
+      'status_id' => $actStatuses['Skip_Activity'],
     ]);
     $analyzer->flush();
     $this->assertEquals($caseStatuses['Open'], self::ag($analyzer->getCase(), 'status_id'));
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip_Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Scheduled'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
 
@@ -94,7 +94,7 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip_Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Scheduled'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
     $this->assertApproxTime('2013-11-30 04:00:00', self::ag($analyzer->getSingleActivity('Follow up'), 'activity_date_time'));
@@ -110,7 +110,7 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip_Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
     $this->assertApproxTime('2013-11-30 04:00:00', self::ag($analyzer->getSingleActivity('Follow up'), 'activity_date_time'));
@@ -127,7 +127,7 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip_Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
     $this->assertApproxTime('2013-11-30 04:00:00', self::ag($analyzer->getSingleActivity('Follow up'), 'activity_date_time'));

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -397,9 +397,9 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     $this->callAPISuccess('OptionValue', 'create', [
       'value' => 'one-modified',
       'option_group_id' => $selectField['option_group_id'],
-      'name' => 'string 1',
+      'label' => 'string 1',
       'options' => [
-        'match-mandatory' => ['option_group_id', 'name'],
+        'match-mandatory' => ['option_group_id', 'label'],
       ],
     ]);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a couple core bugs, where option value names were not being munged by default,
and custom field options were not being returned correctly in the `validate` context.

This is the core change as part of APIV4 work
See https://lab.civicrm.org/dev/core/-/issues/1705

Before
----------------------------------------
Incorrect optionValue results returned from custom fields in `validate` context.
Auto-generated optionValue names not being munged correctlly.

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
Should be fixed now.