### PR TITLE
[REF] Minor extraction

### DIFF
--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -350,14 +350,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
     }
 
     if (!empty($html)) {
-      $type = $formValues['document_type'];
-
-      if ($type === 'pdf') {
-        CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
-      }
-      else {
-        CRM_Utils_PDF_Document::html2doc($html, "CiviLetter.$type", $formValues);
-      }
+      self::outputFromHtml($formValues, $html);
     }
   }
 
@@ -369,6 +362,21 @@ class CRM_Core_Form_Task_PDFLetterCommon {
     $class = get_called_class();
     if (method_exists($class, 'createTokenProcessor')) {
       return $class::createTokenProcessor()->listTokens();
+    }
+  }
+
+  /**
+   * Output the pdf or word document from the generated html.
+   *
+   * @param array $formValues
+   * @param array $html
+   */
+  protected static function outputFromHtml($formValues, array $html) {
+    if ($formValues['document_type'] === 'pdf') {
+      CRM_Utils_PDF_Utils::html2pdf($html, 'CiviLetter.pdf', FALSE, $formValues);
+    }
+    else {
+      CRM_Utils_PDF_Document::html2doc($html, 'CiviLetter.' . $formValues['document_type'], $formValues);
     }
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Extract the code that renders the generated html it pdfs or word docs

Before
----------------------------------------
Longer function

After
----------------------------------------
Minor extraction

Technical Details
----------------------------------------
I'm not convinced the break down of the functions is right at the moment. I think we have the stage of rendering html from the ids & a follow up stage doing the output - hence the function that calls the render function needs to re-incorporate the first part of the render function in a later change

Comments
----------------------------------------

