### PR TITLE
Msg template rendered content api

### DIFF
--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -328,33 +328,6 @@ class CRM_Core_Form_Task_PDFLetterCommon {
   }
 
   /**
-   * Render html from rows
-   *
-   * @param $rows
-   * @param string $msgPart
-   *   The name registered with the TokenProcessor
-   * @param array $formValues
-   *   The values submitted through the form
-   *
-   * @return array
-   *   If formValues['is_unit_test'] is true, otherwise outputs document to browser
-   */
-  public static function renderFromRows($rows, $msgPart, $formValues) {
-    $html = [];
-    foreach ($rows as $row) {
-      $html[] = $row->render($msgPart);
-    }
-
-    if (!empty($formValues['is_unit_test'])) {
-      return $html;
-    }
-
-    if (!empty($html)) {
-      self::outputFromHtml($formValues, $html);
-    }
-  }
-
-  /**
    * List the available tokens
    * @return array of token name => label
    */

--- a/Civi/Api4/Action/MessageTemplate/Render.php
+++ b/Civi/Api4/Action/MessageTemplate/Render.php
@@ -1,0 +1,173 @@
+<?php
+
+
+namespace Civi\Api4\Action\MessageTemplate;
+
+use Civi\Api4\Generic\Result;
+use Civi\Token\TokenProcessor;
+
+/**
+ * Class Render.
+ *
+ * Get the content of an email for the given template text, rendering tokens.
+ *
+ * @method int setMessageTemplateId(int $messageTemplateID) Set Message Template ID.
+ * @method int getMessageTemplateId(int $messageTemplateID) Get Message Template ID.
+ * @method string setMessageSubject(string $messageSubject) Set Message Subject
+ * @method string getMessageSubject(string $messageSubject) Get Message Subject
+ * @method string setMessageHtml(string $messageHtml) Set Message Html
+ * @method string getMessageHtml string $messageHtml) Get Message Html
+ * @method string setMessageText(string $messageHtml) Set Message Text
+ * @method string getMessageText string $messageHtml) Get Message Text
+ * @method string getMessages(array $stringToParse) Get array of adhoc strings to parse.
+ * @method string setMessages(array $stringToParse) Set array of adhoc strings to parse.
+ * @method array setEntity(string $entity) Set entity.
+ * @method array getEntity(string $entity) Get entity.
+ * @method array setEntityIds(array $entityIds) Set entity IDs
+ * @method array getEntityIds(array $entityIds) Get entity IDs
+ */
+class Render extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * ID of message template.
+   *
+   * It is necessary to pass this or at least one string.
+   *
+   * @var int
+   */
+  protected $messageTemplateId;
+
+  /**
+   * Ad hoc html strings to parse.
+   *
+   * Array of adhoc strings arrays to pass e.g
+   *  [
+   *    ['string' => 'Dear {contact.first_name}', 'format' => 'text/html', 'key' => 'greeting'],
+   *    ['string' => 'Also known as {contact.first_name}', 'format' => 'text/plain', 'key' => 'nick_name'],
+   * ]
+   *
+   * If no provided the key will default to 'string' and the format will default to 'text'
+   *
+   * @var array
+   */
+  protected $messages = [];
+
+  /**
+   * String to be returned as the subject.
+   *
+   * @var string
+   */
+  protected $messageSubject;
+
+  /**
+   * String to be returned as the subject.
+   *
+   * @var string
+   */
+  protected $messageText;
+
+  /**
+   * String to be returned as the subject.
+   *
+   * @var string
+   */
+  protected $messageHtml;
+
+  /**
+   * Entity for which tokens need to be resolved.
+   *
+   * This is required if tokens related to the entity are to be parsed and the entity cannot
+   * be derived from the message_template.
+   *
+   * Only Activity is currently supported in this initial implementation.
+   *
+   * @var string
+   *
+   * @options Activity
+   *
+   */
+  protected $entity;
+
+  /**
+   * An array of one of more ids for which the html should be rendered.
+   *
+   * These will be the keys of the returned results.
+   *
+   * @var array
+   */
+  protected $entityIds = [];
+
+  /**
+   * @inheritDoc
+   */
+  public function _run(Result $result) {
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      // Only activities, for now.... @todo - extend...
+      'schema' => [$this->getEntity() => $this->getEntityKey()],
+    ]);
+
+    foreach ($this->getEntityIds() as $entity => $ids) {
+      foreach ($this->getStringsToParse() as $fieldKey => $textField) {
+        if (empty($textField['string'])) {
+          continue;
+        }
+        foreach ($ids as $id) {
+          $tokenProcessor->addRow()->context($this->getEntityKey(), $id);
+          $tokenProcessor->addMessage($fieldKey, $textField['string'], $textField['format']);
+          $tokenProcessor->evaluate();
+          foreach ($tokenProcessor->getRows() as $row) {
+            /* @var \Civi\Token\TokenRow $row */
+            $result[$id][$fieldKey] = $row->render($fieldKey);
+          }
+        }
+      }
+
+    }
+  }
+
+  /**
+   * Array holding
+   *  - string String to parse, required
+   *  - key Key to key by in results, defaults to 'string'
+   *  - format - format passed to token providers.
+   *
+   * @param array $stringDetails
+   *
+   * @return \Civi\Api4\Action\MessageTemplate\Render
+   */
+  public function addMessage(array $stringDetails) {
+    $this->messages[] = $stringDetails;
+    return $this;
+  }
+
+  /**
+   * Get the strings to render civicrm tokens for.
+   *
+   * @return array
+   */
+  protected function getStringsToParse(): array {
+    $textFields = [
+      'msg_html' => ['string' => $this->getMessageHtml(), 'format' => 'text/html', 'key' => 'msg_html'],
+      'msg_subject' => ['string' => $this->getMessageSubject(), 'format' => 'text/plain', 'key' => 'msg_subject'],
+      'msg_text' => ['string' => $this->getMessageText(), 'format' => 'text/plain', 'key' => 'msg_text'],
+    ];
+    foreach ($this->getMessages() as $message) {
+      $message['key']  = $message['key'] ?? 'string';
+      $message['format'] = $message['format'] ?? 'text/plain';
+      $textFields[$message['key']] = $message;
+    }
+    return $textFields;
+  }
+
+  /**
+   * Get the key to use for the entity ID field.
+   *
+   * @return string
+   */
+  protected function getEntityKey(): string {
+    return strtolower($this->getEntity()) . '_id';
+  }
+
+}

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4\Generic;

--- a/Civi/Api4/MessageTemplate.php
+++ b/Civi/Api4/MessageTemplate.php
@@ -27,4 +27,13 @@ namespace Civi\Api4;
  */
 class MessageTemplate extends Generic\DAOEntity {
 
+  /**
+   * @return \Civi\Api4\Action\MessageTemplate\Render
+   *
+   * @throws \API_Exception
+   */
+  public static function render() {
+    return new Action\MessageTemplate\Render(__CLASS__, __FUNCTION__);
+  }
+
 }

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -20,6 +20,7 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
   public function testCreateDocumentBasicTokens() {
     $activity = $this->activityCreate();
@@ -44,11 +45,19 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test custom field tokens are rendered.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
   public function testCreateDocumentCustomFieldTokens() {
     // Set up custom group, and field
     // returns custom_group_id, custom_field_id, custom_field_option_group_id, custom_field_group_options
-    $cg = $this->entityCustomGroupWithSingleStringMultiSelectFieldCreate("MyCustomField", "ActivityTest.php");
+    $cg = $this->entityCustomGroupWithSingleStringMultiSelectFieldCreate('MyCustomField', 'ActivityTest.php');
     $cf = 'custom_' . $cg['custom_field_id'];
+    $activities = [];
     foreach (array_keys($cg['custom_field_group_options']) as $option) {
       $activity = $this->activityCreate([$cf => $option]);
       $activities[] = [
@@ -61,11 +70,11 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     $activityIds = CRM_Utils_Array::collect('id', $activities);
     $output = CRM_Activity_Form_Task_PDFLetterCommon::createDocument($activityIds, $html_message, ['is_unit_test' => TRUE]);
     // Should have one row of output per activity
-    $this->assertEquals(count($activities), count($output));
+    $this->assertCount(count($activities), $output);
 
     // Check each line has the correct substitution
     foreach ($output as $key => $line) {
-      $this->assertEquals($line, "Custom: " . $cg['custom_field_group_options'][$activities[$key]['option']]);
+      $this->assertEquals($line, 'Custom: ' . $cg['custom_field_group_options'][$activities[$key]['option']]);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a new proposed apiv4 api:

MessageTemplate::render

Before
----------------------------------------

After
----------------------------------------
Api created...
```
    $result = \Civi\Api4\MessageTemplate::render()
      ->addMessage(['string' => $html_message, 'format' => 'text/html', 'key' => 'html_string'])
      ->setEntity('Activity')
      ->setEntityIds(['Activity' => $activityIds])
      ->setCheckPermissions(FALSE)
      ->execute();

    $html = [];
    foreach ($result as $htmDetail) {
      $html[] = $htmDetail['html_string'];
    }
```

Technical Details
----------------------------------------
In conjunction with looking at #16983 and also the general mess around message templates (and some thoughts I have about using them), I think we should look at an api for them. I think the ```render``` needs to be one action but we should probably have other actions like ```send``` and ```pdf``` or ```output``` - where pdf is an option at a later point.

Note that for retrieving un-rendered fieldMessageTemplate::get remains the goto- this new api for getting content parsed for CiviCRM (but not currently Smarty) tokens. It should parse one or more ad hoc strings or, if message_template_id is passed in, retrieve and parse the message template strings (this is not yet implemented).

When I added Contribution.sendConfirmation a long long time ago I feel like it was suggested there could be some security concerns - so this might need a bit of tightening so it doesn't return fields that should not otherwise be visible. At the moment Smarty is just not parsed because we would need to actively set context to smarty for that to work (and that needs more thought).

We will need to agree how this should look....

I chose the MessageTemplate entity as it made sense to me that we would want to be able to passing in the message_template identifier rather than a string, in which case we would also return the fields for the message template (msg_html, msg_text, msg_subject)

Also - it has the functions ```setEntityIDs``` and ```setEntity```  - note that in future we might want dependent entities - e.g the main entity is membership but there might be a contribution & we might use setEntities along with  setRelatedEntityIds to handle that

Note this includes https://github.com/civicrm/civicrm-core/pull/17161

Comments
----------------------------------------
Also note I've updated existing tested code to call this api to provide the first round of test cover

@colemanw @totten @mattwire @demerit @adyun @seamuselee001
