### PR TITLE
dev/core#1731 - Unable to import relationship

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -548,6 +548,11 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
               'website_type_id' => $this->_activeFields[$i]->_relatedContactWebsiteType,
             ];
           }
+          elseif (empty($this->_activeFields[$i]->_value) && isset($this->_activeFields[$i]->_relatedContactLocType)) {
+            if (empty($params[$this->_activeFields[$i]->_related][$this->_activeFields[$i]->_relatedContactDetails])) {
+              $params[$this->_activeFields[$i]->_related][$this->_activeFields[$i]->_relatedContactDetails] = [];
+            }
+          }
           else {
             $params[$this->_activeFields[$i]->_related][$this->_activeFields[$i]->_relatedContactDetails] = $this->_activeFields[$i]->_value;
           }


### PR DESCRIPTION
Overview
----------------------------------------
Import returns an error if relationship columns are included.

Before
----------------------------------------
See steps to replicate on gitlab - https://lab.civicrm.org/dev/core/-/issues/1731

![image](https://user-images.githubusercontent.com/5929648/80207423-baa0f000-864b-11ea-8bd8-33794e23c431.png)


After
----------------------------------------
Fixed. Import completes without any errors.

Technical Details
----------------------------------------
As there are 2 phone columns, the empty column assigns a null string to the key in `$params` leading to the above error when a value from the next column is assigned in the array format.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/1731