### PR TITLE
Invoice action not shown when invoicing enabled

### DIFF
--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -112,8 +112,7 @@ class CRM_Contribute_Task extends CRM_Core_Task {
       }
 
       // remove action "Invoices - print or email"
-      $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
+      $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();
       if (!$invoicing) {
         unset(self::$_tasks[self::PDF_INVOICE]);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Cannot see 'Invoices - print or email' option on Find contribution actions even though Invoicing is enabled

@eileenmcnaughton @mattwire 
