### PR TITLE
APIv4 - Allow field options to be returned in multiple formats

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1810,15 +1810,15 @@ WHERE  id IN ( %1, %2 )
    * @param array $params
    * @param string $value
    * @param \CRM_Core_DAO_OptionGroup $optionGroup
-   * @param string $optionName
+   * @param string $index
    * @param string $dataType
    */
-  protected static function createOptionValue(&$params, $value, CRM_Core_DAO_OptionGroup $optionGroup, $optionName, $dataType) {
+  protected static function createOptionValue(&$params, $value, CRM_Core_DAO_OptionGroup $optionGroup, $index, $dataType) {
     if (strlen(trim($value))) {
       $optionValue = new CRM_Core_DAO_OptionValue();
       $optionValue->option_group_id = $optionGroup->id;
-      $optionValue->label = $params['option_label'][$optionName];
-      $optionValue->name = CRM_Utils_String::titleToVar($params['option_label'][$optionName]);
+      $optionValue->label = $params['option_label'][$index];
+      $optionValue->name = $params['option_name'][$index] ?? CRM_Utils_String::titleToVar($params['option_label'][$index]);
       switch ($dataType) {
         case 'Money':
           $optionValue->value = CRM_Utils_Rule::cleanMoney($value);
@@ -1836,8 +1836,11 @@ WHERE  id IN ( %1, %2 )
           $optionValue->value = trim($value);
       }
 
-      $optionValue->weight = $params['option_weight'][$optionName];
-      $optionValue->is_active = CRM_Utils_Array::value($optionName, $params['option_status'], FALSE);
+      $optionValue->weight = $params['option_weight'][$index];
+      $optionValue->is_active = $params['option_status'][$index] ?? FALSE;
+      $optionValue->description = $params['option_description'][$index] ?? NULL;
+      $optionValue->color = $params['option_color'][$index] ?? NULL;
+      $optionValue->icon = $params['option_icon'][$index] ?? NULL;
       $optionValue->save();
     }
   }

--- a/Civi/Api4/Event/Subscriber/CustomFieldPreSaveSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/CustomFieldPreSaveSubscriber.php
@@ -29,22 +29,26 @@ class CustomFieldPreSaveSubscriber extends Generic\PreSaveSubscriber {
 
   public function modify(&$field, AbstractAction $request) {
     if (!empty($field['option_values'])) {
-      $weight = 0;
+      $weight = $key = 0;
+      $field['option_label'] = $field['option_value'] = $field['option_status'] = $field['option_weight'] = [];
+      $field['option_name'] = $field['option_color'] = $field['option_description'] = $field['option_icon'] = [];
       foreach ($field['option_values'] as $key => $value) {
         // Translate simple key/value pairs into full-blown option values
         if (!is_array($value)) {
           $value = [
             'label' => $value,
-            'value' => $key,
-            'is_active' => 1,
-            'weight' => $weight,
+            'id' => $key,
           ];
-          $key = $weight++;
         }
-        $field['option_label'][$key] = $value['label'];
-        $field['option_value'][$key] = $value['value'];
-        $field['option_status'][$key] = $value['is_active'];
-        $field['option_weight'][$key] = $value['weight'];
+        $weight++;
+        $field['option_label'][] = $value['label'] ?? $value['name'];
+        $field['option_name'][] = $value['name'] ?? NULL;
+        $field['option_value'][] = $value['id'];
+        $field['option_status'][] = $value['is_active'] ?? 1;
+        $field['option_weight'][] = $value['weight'] ?? $weight;
+        $field['option_color'][] = $value['color'] ?? NULL;
+        $field['option_description'][] = $value['description'] ?? NULL;
+        $field['option_icon'][] = $value['icon'] ?? NULL;
       }
     }
     $field['option_type'] = !empty($field['option_values']);

--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -57,7 +57,7 @@ trait CustomValueActionTrait {
     $result = [];
     $fields = $this->entityFields();
     foreach ($items as $item) {
-      FormattingUtil::formatWriteParams($item, $this->getEntityName(), $fields);
+      FormattingUtil::formatWriteParams($item, $fields);
 
       // Convert field names to custom_xx format
       foreach ($fields as $name => $field) {

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -125,7 +125,7 @@ trait DAOActionTrait {
 
     foreach ($items as $item) {
       $entityId = $item['id'] ?? NULL;
-      FormattingUtil::formatWriteParams($item, $this->getEntityName(), $this->entityFields());
+      FormattingUtil::formatWriteParams($item, $this->entityFields());
       $this->formatCustomParams($item, $entityId);
       $item['check_permissions'] = $this->getCheckPermissions();
 

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -382,9 +382,10 @@ class FieldSpec {
 
   /**
    * @param array $values
+   * @param array|bool $return
    * @return array
    */
-  public function getOptions($values = []) {
+  public function getOptions($values = [], $return = TRUE) {
     if (!isset($this->options) || $this->options === TRUE) {
       $fieldName = $this->getName();
 
@@ -393,16 +394,93 @@ class FieldSpec {
         $fieldName = sprintf('custom_%d', $this->getCustomFieldId());
       }
 
+      // BAO::buildOptions returns a single-dimensional list, we call that first because of the hook contract,
+      // @see CRM_Utils_Hook::fieldOptions
+      // We then supplement the data with additional properties if requested.
       $bao = CoreUtil::getBAOFromApiName($this->getEntity());
-      $options = $bao::buildOptions($fieldName, NULL, $values);
+      $optionLabels = $bao::buildOptions($fieldName, NULL, $values);
 
-      if (!is_array($options) || !$options) {
-        $options = FALSE;
+      if (!is_array($optionLabels) || !$optionLabels) {
+        $this->options = FALSE;
       }
-
-      $this->setOptions($options);
+      else {
+        $this->options = \CRM_Utils_Array::makeNonAssociative($optionLabels, 'id', 'label');
+        if (is_array($return)) {
+          self::addOptionProps($bao, $fieldName, $values, $return);
+        }
+      }
     }
     return $this->options;
+  }
+
+  /**
+   * Supplement the data from
+   *
+   * @param \CRM_Core_DAO $baoName
+   * @param string $fieldName
+   * @param array $values
+   * @param array $return
+   */
+  private function addOptionProps($baoName, $fieldName, $values, $return) {
+    // FIXME: For now, call the buildOptions function again and then combine the arrays. Not an ideal approach.
+    // TODO: Teach CRM_Core_Pseudoconstant to always load multidimensional option lists so we can get more properties like 'color' and 'icon',
+    // however that might require a change to the hook_civicrm_fieldOptions signature so that's a bit tricky.
+    if (in_array('name', $return)) {
+      $props['name'] = $baoName::buildOptions($fieldName, 'validate', $values);
+    }
+    $return = array_diff($return, ['id', 'name', 'label']);
+    // CRM_Core_Pseudoconstant doesn't know how to fetch extra stuff like icon, description, color, etc., so we have to invent that wheel here...
+    if ($return) {
+      $optionIds = implode(',', array_column($this->options, 'id'));
+      $optionIndex = array_flip(array_column($this->options, 'id'));
+      if ($this instanceof CustomFieldSpec) {
+        $optionGroupId = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $this->getCustomFieldId(), 'option_group_id');
+      }
+      else {
+        $dao = new $baoName();
+        $fieldSpec = $dao->getFieldSpec($fieldName);
+        $pseudoconstant = $fieldSpec['pseudoconstant'] ?? NULL;
+        $optionGroupName = $pseudoconstant['optionGroupName'] ?? NULL;
+        $optionGroupId = $optionGroupName ? \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $optionGroupName, 'id', 'name') : NULL;
+      }
+      if (!empty($optionGroupId)) {
+        $extraStuff = \CRM_Core_BAO_OptionValue::getOptionValuesArray($optionGroupId);
+        $keyColumn = $pseudoconstant['keyColumn'] ?? 'value';
+        foreach ($extraStuff as $item) {
+          if (isset($optionIndex[$item[$keyColumn]])) {
+            foreach ($return as $ret) {
+              $this->options[$optionIndex[$item[$keyColumn]]][$ret] = $item[$ret] ?? NULL;
+            }
+          }
+        }
+      }
+      else {
+        // Fetch the abbr if requested using context: abbreviate
+        if (in_array('abbr', $return)) {
+          $props['abbr'] = $baoName::buildOptions($fieldName, 'abbreviate', $values);
+          $return = array_diff($return, ['abbr']);
+        }
+        // Fetch anything else (color, icon, description)
+        if ($return && !empty($pseudoconstant['table']) && \CRM_Utils_Rule::commaSeparatedIntegers($optionIds)) {
+          $sql = "SELECT * FROM {$pseudoconstant['table']} WHERE id IN (%1)";
+          $query = \CRM_Core_DAO::executeQuery($sql, [1 => [$optionIds, 'CommaSeparatedIntegers']]);
+          while ($query->fetch()) {
+            foreach ($return as $ret) {
+              if (property_exists($query, $ret)) {
+                $this->options[$optionIndex[$query->id]][$ret] = $query->$ret;
+              }
+            }
+          }
+        }
+      }
+    }
+    if (isset($props)) {
+      foreach ($this->options as &$option) {
+        foreach ($props as $name => $prop) {
+          $option[$name] = $prop[$option['id']] ?? NULL;
+        }
+      }
+    }
   }
 
   /**

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -35,7 +35,7 @@ class SpecFormatter {
 
     foreach ($fields as $field) {
       if ($includeFieldOptions) {
-        $field->getOptions($values);
+        $field->getOptions($values, $includeFieldOptions);
       }
       $fieldArray[$field->getName()] = $field->toArray();
     }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -181,15 +181,16 @@ class FormattingUtil {
    * @param string $entity
    *   Name of api entity
    * @param string $fieldName
-   * @param string $optionValue
+   * @param string $valueType
+   *   name|label|abbr from self::$pseudoConstantContexts
    * @param array $params
    *   Other values for this object
    * @param string $action
    * @return array
    * @throws \API_Exception
    */
-  public static function getPseudoconstantList($entity, $fieldName, $optionValue, $params = [], $action = 'get') {
-    $context = self::$pseudoConstantContexts[$optionValue] ?? NULL;
+  public static function getPseudoconstantList($entity, $fieldName, $valueType, $params = [], $action = 'get') {
+    $context = self::$pseudoConstantContexts[$valueType] ?? NULL;
     if (!$context) {
       throw new \API_Exception('Illegal expression');
     }
@@ -198,8 +199,8 @@ class FormattingUtil {
     if ($baoName) {
       $options = $baoName::buildOptions($fieldName, $context, $params);
     }
-    // Fallback for non-bao based entities
-    if (!isset($options)) {
+    // Fallback for option lists that exist in the api but not the BAO - note: $valueType gets ignored here
+    if (!isset($options) || $options === FALSE) {
       $options = civicrm_api4($entity, 'getFields', ['action' => $action, 'loadOptions' => TRUE, 'where' => [['name', '=', $fieldName]]])[0]['options'] ?? NULL;
     }
     if (is_array($options)) {

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -34,12 +34,11 @@ class FormattingUtil {
   /**
    * Massage values into the format the BAO expects for a write operation
    *
-   * @param $params
-   * @param $entity
-   * @param $fields
+   * @param array $params
+   * @param array $fields
    * @throws \API_Exception
    */
-  public static function formatWriteParams(&$params, $entity, $fields) {
+  public static function formatWriteParams(&$params, $fields) {
     foreach ($fields as $name => $field) {
       if (!empty($params[$name])) {
         $value =& $params[$name];
@@ -47,7 +46,7 @@ class FormattingUtil {
         if ($value === 'null') {
           $value = 'Null';
         }
-        self::formatInputValue($value, $name, $field, $entity);
+        self::formatInputValue($value, $name, $field);
         // Ensure we have an array for serialized fields
         if (!empty($field['serialize'] && !is_array($value))) {
           $value = (array) $value;
@@ -81,11 +80,9 @@ class FormattingUtil {
    * @param $value
    * @param string $fieldName
    * @param array $fieldSpec
-   * @param string $entity
-   *   Ex: 'Contact', 'Domain'
    * @throws \API_Exception
    */
-  public static function formatInputValue(&$value, $fieldName, $fieldSpec, $entity) {
+  public static function formatInputValue(&$value, $fieldName, $fieldSpec) {
     // Evaluate pseudoconstant suffix
     $suffix = strpos($fieldName, ':');
     if ($suffix) {
@@ -94,11 +91,11 @@ class FormattingUtil {
     }
     elseif (is_array($value)) {
       foreach ($value as &$val) {
-        self::formatInputValue($val, $fieldName, $fieldSpec, $entity);
+        self::formatInputValue($val, $fieldName, $fieldSpec);
       }
       return;
     }
-    $fk = $fieldSpec['name'] == 'id' ? $entity : $fieldSpec['fk_entity'] ?? NULL;
+    $fk = $fieldSpec['name'] == 'id' ? $fieldSpec['entity'] : $fieldSpec['fk_entity'] ?? NULL;
 
     if ($fk === 'Domain' && $value === 'current_domain') {
       $value = \CRM_Core_Config::domainID();

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -87,11 +87,11 @@
           <fieldset ng-repeat="name in ['values', 'defaults']" ng-if="::availableParams[name]" ng-mouseenter="help(name, availableParams[name])" ng-mouseleave="help()">
             <legend>{{:: name }}<span class="crm-marker" ng-if="::availableParams[name].required"> *</span></legend>
             <div class="api4-input form-inline" ng-repeat="clause in params[name]" ng-mouseenter="help('value: ' + clause[0], fieldHelp(clause[0]))" ng-mouseleave="help(name, availableParams[name])">
-              <input class="collapsible-optgroups form-control" ng-model="clause[0]" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: fieldList(name), allowClear: true, placeholder: 'Field'}" />
+              <input class="collapsible-optgroups form-control twenty" ng-model="clause[0]" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: fieldList(name), allowClear: true, placeholder: 'Field'}" />
               <input class="form-control" ng-model="clause[1]" api4-exp-value="{field: clause[0], action: action === 'getFields' ? params.action || 'get' : action}" />
             </div>
             <div class="api4-input form-inline">
-              <input class="collapsible-optgroups form-control" ng-model="controls[name]" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: fieldList(name), placeholder: ts('Add %1', {1: name.slice(0, -1)})}"/>
+              <input class="collapsible-optgroups form-control twenty" ng-model="controls[name]" crm-ui-select="{formatResult: formatSelect2Item, formatSelection: formatSelect2Item, data: fieldList(name), placeholder: ts('Add %1', {1: name.slice(0, -1)})}"/>
             </div>
           </fieldset>
           <fieldset ng-if="::availableParams.groupBy" ng-mouseenter="help('groupBy', availableParams.groupBy)" ng-mouseleave="help()">

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -390,6 +390,17 @@
             if (name === 'values') {
               defaultVal = defaultValues(defaultVal);
             }
+            if (name === 'loadOptions' && $scope.action === 'getFields') {
+              param.options = [
+                false,
+                true,
+                ['id', 'name', 'label'],
+                ['id', 'name', 'label', 'abbr', 'description', 'color', 'icon']
+              ];
+              format = 'json';
+              defaultVal = false;
+              param.type = ['string'];
+            }
             $scope.$bindToRoute({
               expr: 'params["' + name + '"]',
               param: name,

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -207,6 +207,10 @@ div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children.opt
   width: 25em;
 }
 
+#bootstrap-theme.api4-explorer-page .form-control.twenty {
+  width: 20em;
+}
+
 /* Another weird shoreditch fix */
 #bootstrap-theme .form-inline div.checkbox {
   margin-right: 1em;

--- a/tests/phpunit/api/v4/Action/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Action/PseudoconstantTest.php
@@ -51,6 +51,12 @@ class PseudoconstantTest extends BaseCustomValueTest {
     $this->assertEquals('Fake Type', $options['Fake_Type']['label']);
 
     Activity::create()
+      ->addValue('activity_type_id:name', 'Meeting')
+      ->addValue('source_contact_id', $cid)
+      ->addValue('subject', $subject)
+      ->execute();
+
+    Activity::create()
       ->addValue('activity_type_id:name', 'Fake_Type')
       ->addValue('source_contact_id', $cid)
       ->addValue('subject', $subject)
@@ -67,6 +73,28 @@ class PseudoconstantTest extends BaseCustomValueTest {
     $this->assertCount(1, $act);
     $this->assertEquals('Fake Type', $act[0]['activity_type_id:label']);
     $this->assertEquals('Fake_Type', $act[0]['activity_type_id:name']);
+    $this->assertTrue(is_numeric($act[0]['activity_type_id']));
+
+    $act = Activity::get()
+      ->addHaving('activity_type_id:name', '=', 'Fake_Type')
+      ->addHaving('subject', '=', $subject)
+      ->addSelect('activity_type_id:label')
+      ->addSelect('activity_type_id')
+      ->addSelect('subject')
+      ->execute();
+
+    $this->assertCount(1, $act);
+    $this->assertEquals('Fake Type', $act[0]['activity_type_id:label']);
+    $this->assertTrue(is_numeric($act[0]['activity_type_id']));
+
+    $act = Activity::get()
+      ->addHaving('activity_type_id:name', '=', 'Fake_Type')
+      ->addHaving('subject', '=', $subject)
+      ->addSelect('activity_type_id')
+      ->addSelect('subject')
+      ->execute();
+
+    $this->assertCount(1, $act);
     $this->assertTrue(is_numeric($act[0]['activity_type_id']));
   }
 

--- a/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
+++ b/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
@@ -102,7 +102,7 @@ class TestCreationParameterProvider {
    * @return mixed
    */
   private function getOption(FieldSpec $field) {
-    $options = $field->getOptions();
+    $options = array_column($field->getOptions(), 'label', 'id');
     return array_rand($options);
   }
 

--- a/tests/phpunit/api/v4/Spec/SpecGathererTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecGathererTest.php
@@ -101,12 +101,12 @@ class SpecGathererTest extends UnitTestCase {
 
     $regularField = $spec->getFieldByName('contact_type');
     $this->assertNotEmpty($regularField->getOptions());
-    $this->assertContains('Individual', $regularField->getOptions());
+    $this->assertContains('Individual', array_column($regularField->getOptions([], ['id', 'label']), 'label', 'id'));
 
     $customField = $spec->getFieldByName('FavoriteThings.FavColor');
-    $this->assertNotEmpty($customField->getOptions());
-    $this->assertContains('Green', $customField->getOptions());
-    $this->assertEquals('Pink', $customField->getOptions()['p']);
+    $options = array_column($customField->getOptions([], ['id', 'name', 'label']), NULL, 'id');
+    $this->assertEquals('Green', $options['g']['name']);
+    $this->assertEquals('Pink', $options['p']['label']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Gives more flexibility about how options are returned from APIv4.
Added visibility in the API explorer.

Before
----------------------------------------
In `GetFields`, `loadOptions` is a boolean param, and the option list returned is single-dimensional.

After
----------------------------------------
In `GetFields`, `loadOptions` can be *either* a boolean or an array. If an array, the option list returned will contain the keys requested.

Technical Stuff :eyes: 
----------------------------------------
Field pseudoconstants are stored in many different places (`option_values` table, other tables, callbacks, etc.) but that all gets normalized when they pass through `DAO::buildOptions()` which returns a one-dimensional list. Well and good, but some option lists contain other info (icon, color, description...), and that flat list has been a source of growing pains.

The end goal behind this PR is to standardize what a **multi-dimensional** pseudoconstant list looks like. The idea is that regardless of how the options are stored and what the columns in that table look like, when reading/writing an option list (via the api anyway) the array keys will look like this:

- **id**: the machine name stored for this option (in the `civicrm_option_values` table this maps to `value` column, in other tables it usually maps to `id`)
- **name**: the machine name of this option (if different from id; sometimes they are the same thing)
- **label**: translatable label (the API will return this in the current language).
- **description**: text description of this option (displays in small font in select2 lists).
- **color**: e.g. `#aabbcc`
- **icon**: e.g. `crm-i fa-rocket` :rocket: 