### PR TITLE
[REF] Make apiv3-specific helper generally available.

### DIFF
--- a/CRM/Admin/Page/APIExplorer.php
+++ b/CRM/Admin/Page/APIExplorer.php
@@ -177,7 +177,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
     // Fetch block for a specific action
     else {
       $action = strtolower($action);
-      $fnName = 'civicrm_api3_' . _civicrm_api_get_entity_name_from_camel($entity) . '_' . $action;
+      $fnName = 'civicrm_api3_' . CRM_Utils_String::convertEntityToLowerCase($entity) . '_' . $action;
       // Support the alternate "1 file per action" structure
       $actionFile = "api/v3/$entity/" . ucfirst($action) . '.php';
       $actionFileContents = file_get_contents("api/v3/$entity/" . ucfirst($action) . '.php', FILE_USE_INCLUDE_PATH);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -120,6 +120,31 @@ class CRM_Utils_String {
   }
 
   /**
+   * Convert CamelCase to snake_case, with special handling for some entity names.
+   *
+   * Eg. Activity returns activity
+   *     UFGroup returns uf_group
+   *     OptionValue returns option_value
+   *
+   * @param string $entity
+   *
+   * @return string
+   */
+  public static function convertEntityToLowerCase(string $entity): string {
+    if ($entity === strtolower($entity)) {
+      return $entity;
+    }
+    if ($entity === 'PCP') {
+      return 'pcp';
+    }
+    return strtolower(ltrim(str_replace('U_F',
+      'uf',
+      // That's CamelCase, beside an odd UFCamel that is expected as uf_camel
+      preg_replace('/(?=[A-Z])/', '_$0', $entity)
+    ), '_'));
+  }
+
+  /**
    * Takes a variable name and munges it randomly into another variable name.
    *
    * @param string $name

--- a/api/api.php
+++ b/api/api.php
@@ -281,22 +281,15 @@ function _civicrm_api_replace_variable($value, $parentResult, $separator) {
  *
  * @return string
  *   Entity name in underscore separated format.
+ *
+ * @deprecated
  */
 function _civicrm_api_get_entity_name_from_camel($entity) {
-  if (!$entity || $entity === strtolower($entity)) {
-    return $entity;
+  if (!$entity) {
+    // @todo - this should not be called when empty.
+    return '';
   }
-  elseif ($entity == 'PCP') {
-    return 'pcp';
-  }
-  else {
-    $entity = ltrim(strtolower(str_replace('U_F',
-          'uf',
-          // That's CamelCase, beside an odd UFCamel that is expected as uf_camel
-          preg_replace('/(?=[A-Z])/', '_$0', $entity)
-        )), '_');
-  }
-  return $entity;
+  return CRM_Utils_String::convertEntityToLowerCase($entity);
 }
 
 /**

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2367,7 +2367,7 @@ function _civicrm_api3_api_resolve_alias($entity, $fieldName, $action = 'create'
   if (strpos($fieldName, 'custom_') === 0 && is_numeric($fieldName[7])) {
     return $fieldName;
   }
-  if ($fieldName == _civicrm_api_get_entity_name_from_camel($entity) . '_id') {
+  if ($fieldName === (CRM_Utils_String::convertEntityToLowerCase($entity) . '_id')) {
     return 'id';
   }
   $result = civicrm_api($entity, 'getfields', [


### PR DESCRIPTION


Overview
----------------------------------------
Internal code cleanup - Make apiv3-specific helper generally available.

Before
----------------------------------------
No alternative to the discourages ```_civicrm_api_get_entity_name_from_camel```

After
----------------------------------------
Recommended alternative ```CRM_Core_DAO::getEntityNameFromCamelName```

Technical Details
----------------------------------------
This function should only be called from apiv3 but it's prevalence suggests it's more
generally useful. I have only done a couple of sample switches to use it. I think the
apiv4 one could in theory result in an error as is since there is no require_once for the
utils.php file

Comments
----------------------------------------
Once merged we ca switch across other calls & more noisily deprecate the function