### PR TITLE
[REF] Reduce boilerplate code in BAO add/create functions

### DIFF
--- a/CRM/Batch/BAO/EntityBatch.php
+++ b/CRM/Batch/BAO/EntityBatch.php
@@ -20,20 +20,10 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
    * Create entity batch entry.
    *
    * @param array $params
-   * @return array
+   * @return CRM_Batch_DAO_EntityBatch
    */
-  public static function create(&$params) {
-    $op = 'edit';
-    $entityId = $params['id'] ?? NULL;
-    if (!$entityId) {
-      $op = 'create';
-    }
-    CRM_Utils_Hook::pre($op, 'EntityBatch', $entityId, $params);
-    $entityBatch = new CRM_Batch_DAO_EntityBatch();
-    $entityBatch->copyValues($params);
-    $entityBatch->save();
-    CRM_Utils_Hook::post($op, 'EntityBatch', $entityBatch->id, $entityBatch);
-    return $entityBatch;
+  public static function create($params) {
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -106,38 +106,26 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   }
 
   /**
-   * Save the values of a domain.
+   * Update a domain.
    *
    * @param array $params
    * @param int $id
    *
    * @return CRM_Core_DAO_Domain
    */
-  public static function edit(&$params, &$id) {
-    CRM_Utils_Hook::pre('edit', 'Domain', CRM_Utils_Array::value('id', $params), $params);
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->id = $id;
-    $domain->copyValues($params);
-    $domain->save();
-    CRM_Utils_Hook::post('edit', 'Domain', $domain->id, $domain);
-    return $domain;
+  public static function edit($params, $id) {
+    $params['id'] = $id;
+    return self::writeRecord($params);
   }
 
   /**
-   * Create a new domain.
+   * Create or update domain.
    *
    * @param array $params
-   *
    * @return CRM_Core_DAO_Domain
    */
   public static function create($params) {
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'Domain', CRM_Utils_Array::value('id', $params), $params);
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->copyValues($params);
-    $domain->save();
-    CRM_Utils_Hook::post($hook, 'Domain', $domain->id, $domain);
-    return $domain;
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Core/BAO/IM.php
+++ b/CRM/Core/BAO/IM.php
@@ -23,24 +23,13 @@
 class CRM_Core_BAO_IM extends CRM_Core_DAO_IM {
 
   /**
-   * Takes an associative array and adds im.
+   * Create or update IM record.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
-   * @return object
-   *   CRM_Core_BAO_IM object on success, null otherwise
+   * @return CRM_Core_DAO_IM
    */
-  public static function add(&$params) {
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'IM', CRM_Utils_Array::value('id', $params), $params);
-
-    $im = new CRM_Core_DAO_IM();
-    $im->copyValues($params);
-    $im->save();
-
-    CRM_Utils_Hook::post($hook, 'IM', $im->id, $im);
-    return $im;
+  public static function add($params) {
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -23,24 +23,13 @@
 class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID {
 
   /**
-   * Takes an associative array and adds OpenID.
+   * Create or update OpenID record.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
-   * @return object
-   *   CRM_Core_BAO_OpenID object on success, null otherwise
+   * @return CRM_Core_DAO_OpenID
    */
-  public static function add(&$params) {
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'OpenID', CRM_Utils_Array::value('id', $params), $params);
-
-    $openId = new CRM_Core_DAO_OpenID();
-    $openId->copyValues($params);
-    $openId->save();
-
-    CRM_Utils_Hook::post($hook, 'OpenID', $openId->id, $openId);
-    return $openId;
+  public static function add($params) {
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -134,37 +134,17 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
   }
 
   /**
-   * Save records in civicrm_recurring_entity table.
+   * Create or update a RecurringEntity.
    *
    * @param array $params
-   *   Reference array contains the values submitted by the form.
-   *
-   * @return object
+   * @return CRM_Core_DAO_RecurringEntity
    */
-  public static function add(&$params) {
-    if (!empty($params['id'])) {
-      CRM_Utils_Hook::pre('edit', 'RecurringEntity', $params['id'], $params);
-    }
-    else {
-      CRM_Utils_Hook::pre('create', 'RecurringEntity', NULL, $params);
-    }
-
-    $daoRecurringEntity = new CRM_Core_DAO_RecurringEntity();
-    $daoRecurringEntity->copyValues($params);
-    $daoRecurringEntity->find(TRUE);
-    $result = $daoRecurringEntity->save();
-
-    if (!empty($params['id'])) {
-      CRM_Utils_Hook::post('edit', 'RecurringEntity', $daoRecurringEntity->id, $daoRecurringEntity);
-    }
-    else {
-      CRM_Utils_Hook::post('create', 'RecurringEntity', $daoRecurringEntity->id, $daoRecurringEntity);
-    }
-    return $result;
+  public static function add($params) {
+    return self::writeRecord($params);
   }
 
   /**
-   * Wrapper for the function add() to add entry in recurring entity
+   * Convenience wrapper for self::writeRecord
    *
    * @param int $parentId
    *   Parent entity id .
@@ -173,17 +153,15 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
    * @param string $entityTable
    *   Name of the entity table .
    *
-   *
-   * @return object
+   * @return CRM_Core_DAO_RecurringEntity
    */
   public static function quickAdd($parentId, $entityId, $entityTable) {
-    $params
-      = [
-        'parent_id' => $parentId,
-        'entity_id' => $entityId,
-        'entity_table' => $entityTable,
-      ];
-    return self::add($params);
+    $params = [
+      'parent_id' => $parentId,
+      'entity_id' => $entityId,
+      'entity_table' => $entityTable,
+    ];
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -21,23 +21,13 @@
 class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
 
   /**
-   * Takes an associative array and adds im.
+   * Create or update Website record.
    *
    * @param array $params
-   *   an assoc array of name/value pairs.
-   *
-   * @return CRM_Core_BAO_Website
+   * @return CRM_Core_DAO_Website
    */
   public static function add($params) {
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'Website', CRM_Utils_Array::value('id', $params), $params);
-
-    $website = new CRM_Core_DAO_Website();
-    $website->copyValues($params);
-    $website->save();
-
-    CRM_Utils_Hook::post($hook, 'Website', $website->id, $website);
-    return $website;
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -26,23 +26,13 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
   }
 
   /**
-   * Add the membership Blocks.
+   * Create or update a MembershipBlock.
    *
    * @param array $params
-   *   Reference array contains the values submitted by the form.
-   *
-   *
-   * @return object
+   * @return CRM_Member_DAO_MembershipBlock
    */
-  public static function create(&$params) {
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'MembershipBlock', CRM_Utils_Array::value('id', $params), $params);
-    $dao = new CRM_Member_DAO_MembershipBlock();
-    $dao->copyValues($params);
-    $dao->id = $params['id'] ?? NULL;
-    $dao->save();
-    CRM_Utils_Hook::post($hook, 'MembershipBlock', $dao->id, $dao);
-    return $dao;
+  public static function create($params) {
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -33,32 +33,13 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
   private static $visibilityOptionsKeys;
 
   /**
-   * Takes an associative array and creates a price field object.
-   *
-   * the function extract all the params it needs to initialize the create a
-   * price field object. the params array could contain additional unused name/value
-   * pairs
+   * Create or update a PriceField.
    *
    * @param array $params
-   *   (reference) an assoc array of name/value pairs.
-   *
-   * @return CRM_Price_BAO_PriceField
+   * @return CRM_Price_DAO_PriceField
    */
-  public static function add(&$params) {
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'PriceField', CRM_Utils_Array::value('id', $params), $params);
-
-    $priceFieldBAO = new CRM_Price_BAO_PriceField();
-
-    $priceFieldBAO->copyValues($params);
-
-    if ($id = CRM_Utils_Array::value('id', $params)) {
-      $priceFieldBAO->id = $id;
-    }
-
-    $priceFieldBAO->save();
-    CRM_Utils_Hook::post($hook, 'PriceField', $priceFieldBAO->id, $priceFieldBAO);
-    return $priceFieldBAO;
+  public static function add($params) {
+    return self::writeRecord($params);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Use the new CRM_Core_DAO::writeRecord function to eliminate some boilerplate create/add functions.

Before
----------------------------------------
Redundant, boilerplate functions.

After
----------------------------------------
Gone :zap: 

Technical Details
----------------------------------------
These functions are all empty in that they don't contain any additional logic.
Next step is to do this same thing to some other BAO functions that *do* contain additional logic, and move that logic to pre/post hook callbacks.