### PR TITLE
show title on status message instead machine name

### DIFF
--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -175,7 +175,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
           unset($urlQry['snippet']);
           CRM_Utils_System::redirect(CRM_Utils_System::url(CRM_Utils_System::currentPath(), $urlQry));
         }
-        $ruleGroupName = civicrm_api3('RuleGroup', 'getvalue', ['id' => $rgid, 'return' => 'name']);
+        $ruleGroupName = civicrm_api3('RuleGroup', 'getvalue', ['id' => $rgid, 'return' => 'title']);
         CRM_Core_Session::singleton()->setStatus(ts('No possible duplicates were found using %1 rule.', [1 => $ruleGroupName]), ts('None Found'), 'info');
         $url = CRM_Utils_System::url('civicrm/contact/deduperules', 'reset=1');
         if ($context == 'search') {


### PR DESCRIPTION
Overview
----------------------------------------
When a dedupe rule is used to find duplicate contacts, if no duplicates found then it pops up with message `'No possible duplicates were found using [Rule Name] rule.'`, Some times machine and title differ and creates confusion to user when they see this message. 

This PR provides fix to use title of rule instead name 
Output:
 `'No possible duplicates were found using [Rule Title] rule.'`

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/80376522-d72e6980-8891-11ea-915e-a1e482091f48.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/80376541-deee0e00-8891-11ea-8f27-f1d1ed231641.gif)
