### PR TITLE
Move batch-form support code back to the form

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -565,9 +565,27 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           }
         }
         $value['line_item'] = $lineItem;
-        $value['skipCleanMoney'] = TRUE;
+
         //finally call contribution create for all the magic
         $contribution = CRM_Contribute_BAO_Contribution::create($value);
+        // This code to retrieve the contribution has been moved here from the contribution create
+        // api. It may not be required.
+        $titleFields = [
+          'contact_id',
+          'total_amount',
+          'currency',
+          'financial_type_id',
+        ];
+        $retrieveRequired = 0;
+        foreach ($titleFields as $titleField) {
+          if (!isset($contribution->$titleField)) {
+            $retrieveRequired = 1;
+            break;
+          }
+        }
+        if ($retrieveRequired == 1) {
+          $contribution->find(TRUE);
+        }
         $batchTypes = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'type_id', ['flip' => 1], 'validate');
         if (!empty($this->_batchInfo['type_id']) && ($this->_batchInfo['type_id'] == $batchTypes['Pledge Payment'])) {
           $adjustTotalAmount = FALSE;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -508,27 +508,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       CRM_Core_BAO_Note::add($noteParams);
     }
 
-    // make entry in batch entity batch table
-    if (!empty($params['batch_id'])) {
-      // in some update cases we need to get extra fields - ie an update that doesn't pass in all these params
-      $titleFields = [
-        'contact_id',
-        'total_amount',
-        'currency',
-        'financial_type_id',
-      ];
-      $retrieveRequired = 0;
-      foreach ($titleFields as $titleField) {
-        if (!isset($contribution->$titleField)) {
-          $retrieveRequired = 1;
-          break;
-        }
-      }
-      if ($retrieveRequired == 1) {
-        $contribution->find(TRUE);
-      }
-    }
-
     CRM_Contribute_BAO_ContributionSoft::processSoftContribution($params, $contribution);
 
     $transaction->commit();


### PR DESCRIPTION


Overview
----------------------------------------
I've dug around onn this and there is no reason for this code to be in the BAO - it is only
relevant to support this form & should live there. Longer term the form should call
api v4....

Before
----------------------------------------
Contribution BAO retrieves extra fields

After
----------------------------------------
The form that needs them does it

Technical Details
----------------------------------------


Comments
----------------------------------------
per comments on https://github.com/civicrm/civicrm-core/pull/17115
