### PR TITLE
Show email receipt status on view recurring contribution

### DIFF
--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -20,27 +20,34 @@
  */
 class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
 
-  public static $_links = NULL;
-  public $_permission = NULL;
-  public $_contactId = NULL;
-  public $_id = NULL;
-  public $_action = NULL;
+  use CRM_Core_Page_EntityPageTrait;
+
+  /**
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'ContributionRecur';
+  }
+
+  protected function getDefaultAction() {
+    return 'view';
+  }
 
   /**
    * View details of a recurring contribution.
    */
   public function view() {
-    if (empty($this->_id)) {
+    if (empty($this->getEntityId())) {
       CRM_Core_Error::statusBounce('Recurring contribution not found');
     }
 
     try {
       $contributionRecur = civicrm_api3('ContributionRecur', 'getsingle', [
-        'id' => $this->_id,
+        'id' => $this->getEntityId(),
       ]);
     }
     catch (Exception $e) {
-      CRM_Core_Error::statusBounce('Recurring contribution not found (ID: ' . $this->_id);
+      CRM_Core_Error::statusBounce('Recurring contribution not found (ID: ' . $this->getEntityId());
     }
 
     $contributionRecur['payment_processor'] = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorName(
@@ -81,21 +88,7 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
   }
 
   public function preProcess() {
-    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'view');
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
-    $this->assign('contactId', $this->_contactId);
-
-    // check logged in url permission
-    CRM_Contact_Page_View::checkUserPermission($this);
-
-    $this->assign('action', $this->_action);
-
-    if ($this->_permission == CRM_Core_Permission::EDIT && !CRM_Core_Permission::check('edit contributions')) {
-      // demote to view since user does not have edit contrib rights
-      $this->_permission = CRM_Core_Permission::VIEW;
-      $this->assign('permission', 'view');
-    }
+    $this->preProcessQuickEntityPage();
   }
 
   /**
@@ -107,7 +100,7 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
   public function run() {
     $this->preProcess();
 
-    if ($this->_action & CRM_Core_Action::VIEW) {
+    if ($this->isViewContext()) {
       $this->view();
     }
 

--- a/CRM/Core/Page/EntityPageTrait.php
+++ b/CRM/Core/Page/EntityPageTrait.php
@@ -124,8 +124,15 @@ trait CRM_Core_Page_EntityPageTrait {
     return NULL;
   }
 
+  /**
+   * @return string
+   */
+  protected function getDefaultAction() {
+    return 'browse';
+  }
+
   public function preProcessQuickEntityPage() {
-    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
+    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, $this->getDefaultAction());
     $this->assign('action', $this->getAction());
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -41,6 +41,7 @@
             <tr><td class="label">{ts}Failure Count{/ts}</td><td>{$recur.failure_count}</td></tr>
             {if $recur.invoice_id}<tr><td class="label">{ts}Failure Retry Date{/ts}</td><td>{$recur.next_sched_contribution_date|crmDate}</td></tr>{/if}
             <tr><td class="label">{ts}Auto Renew?{/ts}</td><td>{if $recur.auto_renew}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td></tr>
+            <tr><td class="label">{ts}Send receipt for each contribution?{/ts}</td><td>{if $recur.is_email_receipt}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td></tr>
             {if $recur.payment_processor}<tr><td class="label">{ts}Payment Processor{/ts}</td><td>{$recur.payment_processor}</td></tr>{/if}
             {if $recur.financial_type}<tr><td class="label">{ts}Financial Type{/ts}</td><td>{$recur.financial_type}</td></tr>{/if}
             {if $recur.campaign}<tr><td class="label">{ts}Campaign{/ts}</td><td>{$recur.campaign}</td></tr>{/if}


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
You have to use API/Database to see if email receipts will be sent for a recurring contribution.

After
----------------------------------------
You can see like this:
![image](https://user-images.githubusercontent.com/2052161/80427948-afb2bd80-88e0-11ea-93db-b6e2d5fc95ce.png)

Technical Details
----------------------------------------
There are two commits. The first converts the "View recurring contribution" page to use EntityPageTrait. This makes the code simpler and more maintainable but is not actually required for the UI change.
The second commit is a one line change to ContributionRecur.tpl to expose the value of is_email_receipt.

Comments
----------------------------------------
@adixon Does this work ok with IATs?
