### PR TITLE
Simplify recurring contribution template inheritance

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -8,80 +8,73 @@
  +--------------------------------------------------------------------+
 *}
 
-{include file="CRM/common/enableDisableApi.tpl"}
+{if $recur}
+  {if $recur.is_test}
+    <div class="help">
+      <strong>{ts}This is a TEST transaction{/ts}</strong>
+    </div>
+  {/if}
+  <div class="crm-block crm-content-block crm-recurcontrib-view-block">
+    <table class="crm-info-panel">
+      <tr>
+        <td class="label">{ts}From{/ts}</td>
+        <td class="bold"><a href="{crmURL p='civicrm/contact/view' q="cid=`$recur.contact_id`"}">{$displayName}</a></td>
+      </tr>
+      <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
+      <tr><td class="label">{ts}Frequency{/ts}</td><td>every {$recur.frequency_interval} {$recur.frequency_unit}</td></tr>
+      <tr><td class="label">{ts}Installments{/ts}</td><td>{$recur.installments}</td></tr>
+      <tr><td class="label">{ts}Status{/ts}</td><td>{$recur.contribution_status}</td></tr>
+      <tr><td class="label">{ts}Start Date{/ts}</td><td>{$recur.start_date|crmDate}</td></tr>
+      <tr><td class="label">{ts}Created Date{/ts}</td><td>{$recur.create_date|crmDate}</td></tr>
+      {if $recur.modified_date}<tr><td class="label">{ts}Modified Date{/ts}</td><td>{$recur.modified_date|crmDate}</td></tr>{/if}
+      {if $recur.cancel_date}<tr><td class="label">{ts}Cancelled Date{/ts}</td><td>{$recur.cancel_date|crmDate}</td></tr>{/if}
+      {if $recur.cancel_reason}<tr><td class="label">{ts}Cancel Reason{/ts}</td><td>{$recur.cancel_reason}</td></tr>{/if}
+      {if $recur.end_date}<tr><td class="label">{ts}End Date{/ts}</td><td>{$recur.end_date|crmDate}</td></tr>{/if}
+      {if $recur.processor_id}<tr><td class="label">{ts}Processor ID{/ts}</td><td>{$recur.processor_id}</td></tr>{/if}
+      <tr><td class="label">{ts}Transaction ID{/ts}</td><td>{$recur.trxn_id}</td></tr>
+      {if $recur.invoice_id}<tr><td class="label">{ts}Invoice ID{/ts}</td><td>{$recur.invoice_id}</td></tr>{/if}
+      <tr><td class="label">{ts}Cycle Day{/ts}</td><td>{$recur.cycle_day}</td></tr>
+      {if $recur.contribution_status_id neq 3}<tr><td class="label">{ts}Next Contribution{/ts}</td><td>{$recur.next_sched_contribution_date|crmDate}</td></tr>{/if}
+      <tr><td class="label">{ts}Failure Count{/ts}</td><td>{$recur.failure_count}</td></tr>
+      {if $recur.invoice_id}<tr><td class="label">{ts}Failure Retry Date{/ts}</td><td>{$recur.next_sched_contribution_date|crmDate}</td></tr>{/if}
+      <tr><td class="label">{ts}Auto Renew?{/ts}</td><td>{if $recur.auto_renew}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td></tr>
+      <tr><td class="label">{ts}Send receipt for each contribution?{/ts}</td><td>{if $recur.is_email_receipt}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td></tr>
+      {if $recur.payment_processor}<tr><td class="label">{ts}Payment Processor{/ts}</td><td>{$recur.payment_processor}</td></tr>{/if}
+      {if $recur.financial_type}<tr><td class="label">{ts}Financial Type{/ts}</td><td>{$recur.financial_type}</td></tr>{/if}
+      {if $recur.campaign}<tr><td class="label">{ts}Campaign{/ts}</td><td>{$recur.campaign}</td></tr>{/if}
+      {if $recur.membership_id}<tr>
+        <td class="label">{ts}Membership{/ts}</td>
+        <td><a class="crm-hover-button action-item" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$recur.membership_id`&context=membership&selectedChild=member"}'>{$recur.membership_name}</a></td>
+        </tr>
+      {/if}
+      {include file="CRM/Custom/Page/CustomDataView.tpl"}
 
-{if $action eq 4} {* when action is view *}
-    {if $recur}
-        {if $recur.is_test}
-        <div class="help">
-          <strong>{ts}This is a TEST transaction{/ts}</strong>
-        </div>
-        {/if}
-        <div class="crm-block crm-content-block crm-recurcontrib-view-block">
-          <table class="crm-info-panel">
-            <tr>
-              <td class="label">{ts}From{/ts}</td>
-              <td class="bold"><a href="{crmURL p='civicrm/contact/view' q="cid=`$recur.contact_id`"}">{$displayName}</a></td>
-            </tr>
-            <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
-            <tr><td class="label">{ts}Frequency{/ts}</td><td>every {$recur.frequency_interval} {$recur.frequency_unit}</td></tr>
-            <tr><td class="label">{ts}Installments{/ts}</td><td>{$recur.installments}</td></tr>
-            <tr><td class="label">{ts}Status{/ts}</td><td>{$recur.contribution_status}</td></tr>
-            <tr><td class="label">{ts}Start Date{/ts}</td><td>{$recur.start_date|crmDate}</td></tr>
-            <tr><td class="label">{ts}Created Date{/ts}</td><td>{$recur.create_date|crmDate}</td></tr>
-            {if $recur.modified_date}<tr><td class="label">{ts}Modified Date{/ts}</td><td>{$recur.modified_date|crmDate}</td></tr>{/if}
-            {if $recur.cancel_date}<tr><td class="label">{ts}Cancelled Date{/ts}</td><td>{$recur.cancel_date|crmDate}</td></tr>{/if}
-            {if $recur.cancel_reason}<tr><td class="label">{ts}Cancel Reason{/ts}</td><td>{$recur.cancel_reason}</td></tr>{/if}
-            {if $recur.end_date}<tr><td class="label">{ts}End Date{/ts}</td><td>{$recur.end_date|crmDate}</td></tr>{/if}
-            {if $recur.processor_id}<tr><td class="label">{ts}Processor ID{/ts}</td><td>{$recur.processor_id}</td></tr>{/if}
-            <tr><td class="label">{ts}Transaction ID{/ts}</td><td>{$recur.trxn_id}</td></tr>
-            {if $recur.invoice_id}<tr><td class="label">{ts}Invoice ID{/ts}</td><td>{$recur.invoice_id}</td></tr>{/if}
-            <tr><td class="label">{ts}Cycle Day{/ts}</td><td>{$recur.cycle_day}</td></tr>
-            {if $recur.contribution_status_id neq 3}<tr><td class="label">{ts}Next Contribution{/ts}</td><td>{$recur.next_sched_contribution_date|crmDate}</td></tr>{/if}
-            <tr><td class="label">{ts}Failure Count{/ts}</td><td>{$recur.failure_count}</td></tr>
-            {if $recur.invoice_id}<tr><td class="label">{ts}Failure Retry Date{/ts}</td><td>{$recur.next_sched_contribution_date|crmDate}</td></tr>{/if}
-            <tr><td class="label">{ts}Auto Renew?{/ts}</td><td>{if $recur.auto_renew}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td></tr>
-            <tr><td class="label">{ts}Send receipt for each contribution?{/ts}</td><td>{if $recur.is_email_receipt}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td></tr>
-            {if $recur.payment_processor}<tr><td class="label">{ts}Payment Processor{/ts}</td><td>{$recur.payment_processor}</td></tr>{/if}
-            {if $recur.financial_type}<tr><td class="label">{ts}Financial Type{/ts}</td><td>{$recur.financial_type}</td></tr>{/if}
-            {if $recur.campaign}<tr><td class="label">{ts}Campaign{/ts}</td><td>{$recur.campaign}</td></tr>{/if}
-            {if $recur.membership_id}<tr>
-              <td class="label">{ts}Membership{/ts}</td>
-              <td><a class="crm-hover-button action-item" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$recur.membership_id`&context=membership&selectedChild=member"}'>{$recur.membership_name}</a></td>
-              </tr>
-            {/if}
-            {include file="CRM/Custom/Page/CustomDataView.tpl"}
-
-          </table>
-          <div class="crm-submit-buttons"><a class="button cancel crm-form-submit" href="{crmURL p='civicrm/contact/view' q='action=browse&selectedChild=contribute'}">{ts}Done{/ts}</a></div>
-        </div>
-    {/if}
-
-  <script type="text/javascript">
-    var recurContribID = {$recur.id};
-    var contactID = {$contactId};
-    {literal}
-    CRM.$(function($) {
-      CRM.loadPage(
-        CRM.url(
-          'civicrm/contribute/contributionrecur-payments',
-          {
-            reset: 1,
-            id: recurContribID,
-            cid: contactID
-          },
-          'back'
-        ),
-        {
-          target : '#recurring-contribution-payments',
-          dialog : false
-        }
-      );
-    });
-    {/literal}
-  </script>
-  <div id="recurring-contribution-payments"></div>
+    </table>
+    <div class="crm-submit-buttons"><a class="button cancel crm-form-submit" href="{crmURL p='civicrm/contact/view' q='action=browse&selectedChild=contribute'}">{ts}Done{/ts}</a></div>
+  </div>
 {/if}
-{if $recurRows}
-  {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl"}
-{/if}
+
+<script type="text/javascript">
+  var recurContribID = {$recur.id};
+  var contactID = {$contactId};
+  {literal}
+  CRM.$(function($) {
+    CRM.loadPage(
+            CRM.url(
+                    'civicrm/contribute/contributionrecur-payments',
+                    {
+                      reset: 1,
+                      id: recurContribID,
+                      cid: contactID
+                    },
+                    'back'
+            ),
+            {
+              target : '#recurring-contribution-payments',
+              dialog : false
+            }
+    );
+  });
+  {/literal}
+</script>
+<div id="recurring-contribution-payments"></div>

--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -79,11 +79,11 @@
           {if $recur}
             <div class="crm-block crm-contact-contribute-recur crm-contact-contribute-recur-active">
               <h3>{ts}Active Recurring Contributions{/ts}</h3>
-              {include file="CRM/Contribute/Page/ContributionRecur.tpl" recurRows=$activeRecurRows}
+              {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" recurRows=$activeRecurRows}
             </div>
             <div class="crm-block crm-contact-contribute-recur crm-contact-contribute-recur-inactive">
               <h3>{ts}Inactive Recurring Contributions{/ts}</h3>
-              {include file="CRM/Contribute/Page/ContributionRecur.tpl" recurRows=$inactiveRecurRows}
+              {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" recurRows=$inactiveRecurRows}
             </div>
           {/if}
         </div>

--- a/templates/CRM/Member/Page/RecurringContributions.tpl
+++ b/templates/CRM/Member/Page/RecurringContributions.tpl
@@ -2,5 +2,5 @@
   <div class="solid-border-top">
     <br /><label>{ts 1=$displayName}Recurring Contributions{/ts}</label>
   </div>
-  {include file="CRM/Contribute/Page/ContributionRecur.tpl" action=16}
+  {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" action=16}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Template `CRM/Contribute/Page/ContributionRecur.tpl` is called as an intermediary for `CRM/Contribute/Page/ContributionRecurSelector.tpl` when we can just call the latter directly.

Before
----------------------------------------
Chain of templates.

After
----------------------------------------
Just call it directly and get rid of a big IF in the template.

Technical Details
----------------------------------------

Comments
----------------------------------------
Most of the change is just whitespace from removing an "if" from the template

Testing
----------------------------------------
Make sure that you can still see the list of recurring contributions in the contact summary. And make sure that you can see all the detail when you view a recurring contribution.