### PR TITLE
Add payment processor to details on list of recurring contributions

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
@@ -14,6 +14,7 @@
       <th scope="col">{ts}Frequency{/ts}</th>
       <th scope="col">{ts}Start Date{/ts}</th>
       <th scope="col">{ts}Installments{/ts}</th>
+      <th scope="col">{ts}Payment Processor{/ts}</th>
       <th scope="col">{ts}Status{/ts}</th>
       <th scope="col"></th>
     </tr>
@@ -25,6 +26,7 @@
         <td>{ts}Every{/ts} {$row.frequency_interval} {$row.frequency_unit} </td>
         <td>{$row.start_date|crmDate}</td>
         <td>{$row.installments}</td>
+        <td>{$row.payment_processor}</td>
         <td>{$row.contribution_status}</td>
         <td>{$row.action|replace:'xx':$row.recurId}</td>
       </tr>


### PR DESCRIPTION
Overview
----------------------------------------
When admin staff look at the list of recurring contributions and a contact has more than one it can be quite important to know the payment processor. Eg. "The one I paid by Stripe" or "The direct debit".

Currently you have to view the detail of each one to find out which it was.

Before
----------------------------------------
Have to view the recur to find out what type of payment processor it is.

After
----------------------------------------
Shown in the list. This is even more useful when viewing a membership which shows contributions/recurring contributions at the bottom - so you can see at a glance how the membership is being paid.
![image](https://user-images.githubusercontent.com/2052161/80429935-1fc34280-88e5-11ea-9340-118fa7f4692e.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
@wmortada @artfulrobot @bhahumanists I feel you might be interested?
