### PR TITLE
dev/core#1706 Fix MessageTemplates to be retrievable from workflow-id->option_value…name

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1309,7 +1309,6 @@ HERESQL;
 
       list($result[CRM_Utils_Array::value('contact_id', $info)], $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
-          'groupName' => 'msg_tpl_workflow_case',
           'valueName' => 'case_activity',
           'contactId' => $info['contact_id'] ?? NULL,
           'tplParams' => $tplParams,

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -285,7 +285,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
           // send notification
           $sendTemplateParams
             = [
-              'groupName' => $this->_mode == 'auto_renew' ? 'msg_tpl_workflow_membership' : 'msg_tpl_workflow_contribution',
+              'groupName' => $this->_mode == 'auto_renew' ? '' : 'msg_tpl_workflow_contribution',
               'valueName' => $this->_mode == 'auto_renew' ? 'membership_autorenew_cancelled' : 'contribution_recurring_cancelled',
               'contactId' => $this->getSubscriptionDetails()->contact_id,
               'tplParams' => $tplParams,

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2706,7 +2706,6 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       // FIXME: take the below out of the foreach loop
       CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
-          'groupName' => 'msg_tpl_workflow_uf',
           'valueName' => 'uf_notify',
           'contactId' => $contactID,
           'tplParams' => [

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1174,7 +1174,6 @@ WHERE civicrm_event.is_active = 1
         }
 
         $sendTemplateParams = [
-          'groupName' => 'msg_tpl_workflow_event',
           'valueName' => 'event_online_receipt',
           'contactId' => $contactID,
           'isTest' => $isTest,

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1457,7 +1457,6 @@ UPDATE  civicrm_participant
 
       list($mailSent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
-          'groupName' => 'msg_tpl_workflow_event',
           'valueName' => 'participant_' . strtolower($mailType),
           'contactId' => $contactId,
           'tplParams' => [

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -316,7 +316,6 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
       'table' => 'civicrm_msg_template',
       'contactId' => $this->payer_contact_id,
       'from' => current(CRM_Core_BAO_Domain::getNameAndEmail(TRUE, TRUE)),
-      'groupName' => 'msg_tpl_workflow_event',
       'isTest' => FALSE,
       'toEmail' => $contact_details[1],
       'toName' => $contact_details[0],

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1590,7 +1590,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         }
 
         $sendTemplateParams = [
-          'groupName' => 'msg_tpl_workflow_event',
           'valueName' => 'event_offline_receipt',
           'contactId' => $contactID,
           'isTest' => !empty($this->_defaultValues['is_test']),

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -83,7 +83,9 @@ function civicrm_api3_message_template_get($params) {
  * Sends a template.
  *
  * @param array $params
+ *
  * @throws API_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_message_template_send($params) {
   // Change external param names to internal ones
@@ -97,12 +99,12 @@ function civicrm_api3_message_template_send($params) {
     }
   }
   if (empty($params['messageTemplateID'])) {
-    if (empty($params['groupName']) || empty($params['valueName'])) {
+    if (empty($params['valueName'])) {
       // Can't use civicrm_api3_verify_mandatory for this because it would give the wrong field names
       throw new API_Exception(
-        "Mandatory key(s) missing from params array: requires id or option_group_name + option_value_name",
-        "mandatory_missing",
-        ["fields" => ['id', 'option_group_name', 'option_value_name']]
+        'Mandatory key(s) missing from params array: requires id or option_group_name + option_value_name',
+        'mandatory_missing',
+        ['fields' => ['id', 'option_group_name', 'option_value_name']]
       );
     }
   }
@@ -123,11 +125,6 @@ function _civicrm_api3_message_template_send_spec(&$params) {
   $params['id']['title'] = 'Message Template ID';
   $params['id']['api.aliases'] = ['messageTemplateID', 'message_template_id'];
   $params['id']['type'] = CRM_Utils_Type::T_INT;
-
-  $params['option_group_name']['description'] = 'option group name of the template (required if no id supplied)';
-  $params['option_group_name']['title'] = 'Option Group Name';
-  $params['option_group_name']['api.aliases'] = ['groupName'];
-  $params['option_group_name']['type'] = CRM_Utils_Type::T_STRING;
 
   $params['option_value_name']['description'] = 'option value name of the template (required if no id supplied)';
   $params['option_value_name']['title'] = 'Option Value Name';

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -14,6 +14,11 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
+  /**
+   * Test message template send.
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function testCaseActivityCopyTemplate() {
     $client_id = $this->individualCreate();
     $contact_id = $this->individualCreate();
@@ -36,9 +41,8 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
       'idHash' => substr(sha1(CIVICRM_SITE_KEY . '1234'), 0, 7),
     ];
 
-    list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
+    list($sent, $subject, $message) = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
-        'groupName' => 'msg_tpl_workflow_case',
         'valueName' => 'case_activity',
         'contactId' => $contact_id,
         'tplParams' => $tplParams,


### PR DESCRIPTION
Overview
----------------------------------------
API / Pseudoconstant support for MessageTemplate.workflow_id in transitional form

Before
----------------------------------------
Not possible to pass workflow_id:name or workflow_id:label when retrieving message templates

After
----------------------------------------

Can use
 ```$messageTemplate = MessageTemplate::get()
      ->setCheckPermissions(FALSE)
      ->addSelect('msg_subject', 'msg_text', 'msg_html', 'pdf_format_id', 'id')
      ->addWhere('is_default', '=', 1);
      ->addWhere('workflow_id:name', '=', 'case_activity');
```

Technical Details
----------------------------------------
This adds support for translating workflow_id to name or label in it's current schema & makes it easier for
us to modify the schema to use our normal structure.

Note I implemented the handling in buildOptions as putting a pseudoconstant callback
in doesn't allow different contexts. The hope is that with the code no longer
relying on the different option_groups being used we can do an upgrade script to
fix the structure to be a single option group and to refer to the value
field like others do.

Also note this DOES mean that we are no longer passing the optionGroup to the hook.  I will email the dev list on that

Comments
----------------------------------------


https://lab.civicrm.org/dev/core/-/issues/1706