### PR TITLE
dev/core#1724 Fix Changes to CiviContribute Component Settings not saved

### DIFF
--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -168,6 +168,7 @@ class SettingsBag {
         [$this->defaults, $this->values, $this->mandatory]
       );
     }
+    $this->combined['contribution_invoice_settings'] = $this->getContributionSettings();
     return $this->combined;
   }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -258,6 +258,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test the 'return' param works for all fields.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetContributionReturnFunctionality() {
     $params = $this->_params;


### PR DESCRIPTION


Overview
----------------------------------------
Fixes a bug whereby the saved values for the fields that were historically stored as 'contribution_invoice_settings' were not always retrieved

Before
----------------------------------------
'contribution_invoice_settings' is no longer a setting but the settings that were part of it were still retrieved by Setting::get(). This is tested as working. However depending on the order of events sometimes they were not retrieved. This is apparent when saving and reloading a field like 'invoice_prefix' on the contribution settings page.

After
----------------------------------------
More reliably retrieved. The recommendation remains to replace any calls that retrieve these settings e.g 
```
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -85,10 +85,8 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
     ];
 
     if ($taxTrxnID) {
-      $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $taxTerm = $invoiceSettings['tax_term'] ?? NULL;
       $params['amount'] = $lineItem->tax_amount;
-      $params['description'] = $taxTerm;
+      $params['description'] = Civi::settings()->get('tax_term');
       $accountRelName = 'Sales Tax Account is';

```

Technical Details
----------------------------------------
It seems that, depending on the order in which settings are loaded, this is not always populated. Moving it here
addresses, although medium term we should address all references to it

Comments
----------------------------------------
FYI @monishdeb you might access contribution_invoice_settings in your extensions....
