### PR TITLE
Gitlab issue template - Ask for link to stackexchange or chat conversations

### DIFF
--- a/.gitlab/issue_templates/problem.md
+++ b/.gitlab/issue_templates/problem.md
@@ -2,6 +2,8 @@ Overview
 ----------------------------------------
 _Please describe your problem or bug in detail._
 
+_If you have already posted on https://civicrm.stackexchange.com or https://chat.civicrm.org, please include the link to that conversation._
+
 Reproduction steps
 ----------------------------------------
 1. Click on **Contacts -> New Individual**.


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes people will post on e.g. stackexchange, and then make a lab ticket and not reference the previous conversation. It's helpful for both the poster and responders to not have to go through the same steps that have already been done earlier, and sometimes there are valuable clues in the original conversation. This updates the issue template to ask them to include a link to that conversation.


