### PR TITLE
 Fix loading, saving, and upgrade of CiviContribute settings

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyFive.php
@@ -79,6 +79,11 @@ class CRM_Upgrade_Incremental_php_FiveTwentyFive extends CRM_Upgrade_Incremental
     $this->addTask('Convert Report Form dates from jcalander to datepicker', 'convertReportsJcalendarToDatePicker');
   }
 
+  public function upgrade_5_25_beta3($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Convert CiviContribute settings', 'updateContributeSettings');
+  }
+
   /**
    * Convert date fields stored in civicrm_report_instance to that format for datepicker
    */

--- a/CRM/Upgrade/Incremental/sql/5.25.beta3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.25.beta3.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.25.beta3 during upgrade *}

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -168,6 +168,7 @@ class SettingsBag {
         [$this->defaults, $this->values, $this->mandatory]
       );
     }
+    $this->combined['contribution_invoice_settings'] = $this->getContributionSettings();
     return $this->combined;
   }
 

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -287,6 +287,9 @@ class SettingsBag {
     if ($key === 'contribution_invoice_settings') {
       foreach (SettingsBag::getContributionInvoiceSettingKeys() as $possibleKeyName => $settingName) {
         $keyValue = $value[$possibleKeyName] ?? '';
+        if ($possibleKeyName === 'invoicing' && is_array($keyValue)) {
+          $keyValue = $keyValue['invoicing'];
+        }
         $this->set($settingName, $keyValue);
       }
       return TRUE;
@@ -302,7 +305,15 @@ class SettingsBag {
   public function computeVirtual() {
     $contributionSettings = [];
     foreach (SettingsBag::getContributionInvoiceSettingKeys() as $keyName => $settingName) {
-      $contributionSettings[$keyName] = $this->get($settingName);
+      switch ($keyName) {
+        case 'invoicing':
+          $contributionSettings[$keyName] = $this->get($settingName) ? [$keyName => 1] : 0;
+          break;
+
+        default:
+          $contributionSettings[$keyName] = $this->get($settingName);
+          break;
+      }
     }
     return ['contribution_invoice_settings' => $contributionSettings];
   }

--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -41,17 +41,8 @@ return [
     'group' => 'contribute',
     'name' => 'contribution_invoice_settings',
     'type' => 'Array',
-    'default' => [
-      'invoice_prefix' => 'INV_',
-      'credit_notes_prefix' => 'CN_',
-      'due_date' => '10',
-      'due_date_period' => 'days',
-      'notes' => '',
-      'tax_term' => 'Sales Tax',
-      'tax_display_settings' => 'Inclusive',
-    ],
     'add' => '4.7',
-    'title' => ts('Deprecated setting'),
+    'title' => ts('Deprecated, virtualized setting'),
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
@@ -74,6 +65,7 @@ return [
     'settings_pages' => ['contribute' => ['weight' => 90]],
   ],
   'invoice_prefix' => [
+    'default' => 'INV_',
     'html_type' => 'text',
     'name' => 'invoice_prefix',
     'add' => '5.23',
@@ -84,6 +76,7 @@ return [
     'is_contact' => 0,
   ],
   'invoice_due_date' => [
+    'default' => '10',
     'name' => 'invoice_due_date',
     'html_type' => 'text',
     'title' => ts('Due Date'),
@@ -93,6 +86,7 @@ return [
     'is_contact' => 0,
   ],
   'invoice_due_date_period' => [
+    'default' => 'days',
     'html_type' => 'select',
     'name' => 'invoice_due_date_period',
     'title' => ts('For transmission'),
@@ -110,6 +104,7 @@ return [
     ],
   ],
   'invoice_notes' => [
+    'default' => '',
     'name' => 'invoice_notes',
     'html_type' => 'wysiwyg',
     'title' => ts('Notes or Standard Terms'),
@@ -131,6 +126,7 @@ return [
     'description' => ts('Should a pdf invoice be emailed automatically?'),
   ],
   'tax_term' => [
+    'default' => 'Sales Tax',
     'name' => 'tax_term',
     'html_type' => 'text',
     'add' => '5.23',
@@ -140,6 +136,7 @@ return [
     'is_contact' => 0,
   ],
   'tax_display_settings' => [
+    'default' => 'Inclusive',
     'html_type' => 'select',
     'name' => 'tax_display_settings',
     'type' => CRM_Utils_Type::T_STRING,

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -398,7 +398,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.25.beta2',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.25.beta3',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -79,6 +79,7 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
       'notes' => '<p>Give me money</p>',
       'tax_term' => 'Extortion',
       'tax_display_settings' => 'Exclusive',
+      // NOTE: This form of `invoicing` is accepted, but it may be normalized to the idiomatic form with a nested array.
       'invoicing' => 1,
       'is_email_pdf' => '1',
     ];
@@ -88,7 +89,7 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
     $getVersion = $this->callAPISuccessGetValue('Setting', ['name' => 'contribution_invoice_settings']);
     $this->assertEquals($settingsFromAPI, $settingsFromGet);
     $this->assertAPIArrayComparison($getVersion, $settingsFromGet);
-    $this->assertEquals($contributionSettings, $settingsFromGet);
+    $this->assertEquals(['invoicing' => ['invoicing' => 1]] + $contributionSettings, $settingsFromGet);
 
     // These are the preferred retrieval methods.
     $this->assertEquals('G_', Civi::settings()->get('invoice_prefix'));

--- a/tests/phpunit/Civi/Core/SettingsBagTest.php
+++ b/tests/phpunit/Civi/Core/SettingsBagTest.php
@@ -30,4 +30,50 @@ class SettingsBagTest extends \CiviUnitTestCase {
     $this->assertEquals(0, $settingsBag->get('enable_innodb_fts'));
   }
 
+  /**
+   * The setting "contribution_invoice_settings" is actually a virtual value built on other settings.
+   * Check that various updates work as expected.
+   */
+  public function testVirtualContributionSetting_explicit() {
+    $s = \Civi::settings();
+
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+
+    $s->set('invoice_due_date', 20);
+    $this->assertEquals(20, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(20, $s->get('invoice_due_date'));
+    $this->assertEquals(20, $s->getExplicit('invoice_due_date'));
+
+    $s->set('contribution_invoice_settings', array_merge($s->get('contribution_invoice_settings'), [
+      'due_date' => 30,
+    ]));
+    $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(30, $s->get('invoice_due_date'));
+    $this->assertEquals(30, $s->getExplicit('invoice_due_date'));
+
+    $s->revert('invoice_due_date');
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+  }
+
+  /**
+   * The setting "contribution_invoice_settings" is actually a virtual value built on other settings.
+   * Check that mandatory values ($civicrm_settings) are respected.
+   */
+  public function testVirtualContributionSetting_mandatory() {
+    $s = \Civi::settings();
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+
+    $s->loadMandatory(['invoice_due_date' => 30]);
+
+    $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(30, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+  }
+
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -258,6 +258,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test the 'return' param works for all fields.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetContributionReturnFunctionality() {
     $params = $this->_params;

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.25.beta2</version_no>
+  <version_no>5.25.beta3</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------

Historically, preferences related to tax and invoice were stored in the setting `contribution_invoice_settings`. Circa 5.23, `contribution_invoice_settings` was deprecated and decomposed into several smaller settings  (`invoice_due_date`, `tax_term`, etc) . There is a transitional mechanism to convert between the old-style/large setting and the new-style/small settings, but it has issues. This PR updates the transitional mechanism.
 
This patch should fix transitional issues for most deployments. However, if you rely on the "CiviContribute Component Settings" to customize the "Tax and Invoicing" options, and if you've previously used an affected version (5.23.0 - 5.24.5), then you may wish to review the settings to ensure they are correct.

See also:

* Previous draft - #17180
* https://lab.civicrm.org/dev/core/-/issues/1724 

Before
----------------------------------------

1. The page "CiviContribute Component Settings` does not reliably save/load the values under "Enable Tax and Invoicing".
2. If you start with an older version (eg 5.22), customize `contribution_invoice_settings`, and upgrade... then the settings are *not* converted.
3. Depending on the order in which settings are read and written, the values may not be consistent in the new-style settings and old-style settings.
4. Explicit-values are stored in new-style settings (`invoice_due_date`, `tax_term`, etc), but default-values are defined in old-style `contribution_invoice_settings` - leading to inconsistent behavior.
5. The values in `contribution_invoice_settings` do not reflect overrides (`$civicrm_settings`).

After
----------------------------------------

1. The page "CiviContribute Component Settings` does reliably save/load the values under "Enable Tax and Invoicing".
2. If you start with an older version (eg 5.22), customize `contribution_invoice_settings`, and upgrade... then the settings *are* converted.
3. One may more freely interchange old-style and new-style.
4. Both default-values and explicit-values are tracked in the new-style settings. Values never come from the old-style setting, which is purely virtual.
5. Any mix of default-values, explicit-values, and mandatory/override-values can be reflected in `contribution_invoice_settings`.

Comments
----------------------------------------

Why does the "Overview" suggest that admins review the "CiviContribute Component Settings"? As a precaution. The main consideration would arise if someone attempted to *reconfigure* the options while using a version (5.23.0-5.24.5) where the form didn't save reliably. That could produce confusion. The clearest antidote is to simply check the final settings and see if they are correct.