### PR TITLE
(WIP) Fix contribution settings (with array settings as canonical)

### DIFF
--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -284,11 +284,12 @@ class SettingsBag {
    *   TRUE if $key is a virtualized setting. FALSE if it is a normal setting.
    */
   public function updateVirtual($key, $value) {
-    if ($key === 'contribution_invoice_settings') {
-      foreach (SettingsBag::getContributionInvoiceSettingKeys() as $possibleKeyName => $settingName) {
-        $keyValue = $value[$possibleKeyName] ?? '';
-        $this->set($settingName, $keyValue);
-      }
+    $invoiceKeys = SettingsBag::getContributionInvoiceSettingKeys();
+    $internalKey = array_search($key, $invoiceKeys);
+    if ($internalKey !== FALSE) {
+      $invoiceSettings = $this->get('contribution_invoice_settings');
+      $invoiceSettings[$internalKey] = $value;
+      $this->set('contribution_invoice_settings', $invoiceSettings);
       return TRUE;
     }
     return FALSE;
@@ -300,11 +301,12 @@ class SettingsBag {
    * @return array
    */
   public function computeVirtual() {
-    $contributionSettings = [];
+    $invoice = $this->get('contribution_invoice_settings');
+    $virtuals = [];
     foreach (SettingsBag::getContributionInvoiceSettingKeys() as $keyName => $settingName) {
-      $contributionSettings[$keyName] = $this->get($settingName);
+      $virtuals[$settingName] = $invoice[$keyName] ?? '';
     }
-    return ['contribution_invoice_settings' => $contributionSettings];
+    return $virtuals;
   }
 
   /**

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -168,6 +168,7 @@ class SettingsBag {
         [$this->defaults, $this->values, $this->mandatory]
       );
     }
+    $this->combined['contribution_invoice_settings'] = $this->getContributionSettings();
     return $this->combined;
   }
 

--- a/tests/phpunit/Civi/Core/SettingsBagTest.php
+++ b/tests/phpunit/Civi/Core/SettingsBagTest.php
@@ -30,4 +30,50 @@ class SettingsBagTest extends \CiviUnitTestCase {
     $this->assertEquals(0, $settingsBag->get('enable_innodb_fts'));
   }
 
+  /**
+   * The setting "contribution_invoice_settings" is actually a virtual value built on other settings.
+   * Check that various updates work as expected.
+   */
+  public function testVirtualContributionSetting_explicit() {
+    $s = \Civi::settings();
+
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+
+    $s->set('invoice_due_date', 20);
+    $this->assertEquals(20, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(20, $s->get('invoice_due_date'));
+    $this->assertEquals(20, $s->getExplicit('invoice_due_date'));
+
+    $s->set('contribution_invoice_settings', array_merge($s->get('contribution_invoice_settings'), [
+      'due_date' => 30,
+    ]));
+    $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(30, $s->get('invoice_due_date'));
+    $this->assertEquals(30, $s->getExplicit('invoice_due_date'));
+
+    $s->revert('invoice_due_date');
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+  }
+
+  /**
+   * The setting "contribution_invoice_settings" is actually a virtual value built on other settings.
+   * Check that mandatory values ($civicrm_settings) are respected.
+   */
+  public function testVirtualContributionSetting_mandatory() {
+    $s = \Civi::settings();
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+
+    $s->loadMandatory(['invoice_due_date' => 30]);
+
+    $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(30, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+  }
+
 }

--- a/tests/phpunit/Civi/Core/SettingsBagTest.php
+++ b/tests/phpunit/Civi/Core/SettingsBagTest.php
@@ -39,24 +39,20 @@ class SettingsBagTest extends \CiviUnitTestCase {
 
     $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
     $this->assertEquals(10, $s->get('invoice_due_date'));
-    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
 
     $s->set('invoice_due_date', 20);
     $this->assertEquals(20, $s->get('contribution_invoice_settings')['due_date']);
     $this->assertEquals(20, $s->get('invoice_due_date'));
-    $this->assertEquals(20, $s->getExplicit('invoice_due_date'));
 
     $s->set('contribution_invoice_settings', array_merge($s->get('contribution_invoice_settings'), [
       'due_date' => 30,
     ]));
     $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
     $this->assertEquals(30, $s->get('invoice_due_date'));
-    $this->assertEquals(30, $s->getExplicit('invoice_due_date'));
 
-    $s->revert('invoice_due_date');
+    $s->revert('contribution_invoice_settings');
     $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
     $this->assertEquals(10, $s->get('invoice_due_date'));
-    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
   }
 
   /**
@@ -69,7 +65,7 @@ class SettingsBagTest extends \CiviUnitTestCase {
     $this->assertEquals(10, $s->get('invoice_due_date'));
     $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
 
-    $s->loadMandatory(['invoice_due_date' => 30]);
+    $s->loadMandatory(['contribution_invoice_settings' => ['due_date' => 30]]);
 
     $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
     $this->assertEquals(30, $s->get('invoice_due_date'));

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -258,6 +258,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test the 'return' param works for all fields.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetContributionReturnFunctionality() {
     $params = $this->_params;


### PR DESCRIPTION
Overview
----------------------------------------

Description is TODO. And needs some more testing. This is a variant of #17181 which treats the array `contribution_invoice_settings` as canonical (using its default values), and it treats the itemized settings (`invoice_due_date`, etal) as virtual.