### PR TITLE
dev/core#1738 Fix opening specific contribution page tab from Manage Contribution Pages

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -33,6 +33,14 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
   const NUM_OPTION = 11;
 
   /**
+   * Set variables up before form is built.
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->setSelectedChild('amount');
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {

--- a/CRM/Contribute/Form/ContributionPage/Custom.php
+++ b/CRM/Contribute/Form/ContributionPage/Custom.php
@@ -20,6 +20,14 @@
 class CRM_Contribute_Form_ContributionPage_Custom extends CRM_Contribute_Form_ContributionPage {
 
   /**
+   * Set variables up before form is built.
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->setSelectedChild('custom');
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {

--- a/CRM/Contribute/Form/ContributionPage/Premium.php
+++ b/CRM/Contribute/Form/ContributionPage/Premium.php
@@ -21,6 +21,14 @@
 class CRM_Contribute_Form_ContributionPage_Premium extends CRM_Contribute_Form_ContributionPage {
 
   /**
+   * Set variables up before form is built.
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->setSelectedChild('premium');
+  }
+
+  /**
    * Set default values for the form.
    */
   public function setDefaultValues() {

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -21,6 +21,7 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
    */
   public function preProcess() {
     parent::preProcess();
+    $this->setSelectedChild('settings');
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionPage/ThankYou.php
+++ b/CRM/Contribute/Form/ContributionPage/ThankYou.php
@@ -21,6 +21,14 @@
 class CRM_Contribute_Form_ContributionPage_ThankYou extends CRM_Contribute_Form_ContributionPage {
 
   /**
+   * Set variables up before form is built.
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->setSelectedChild('thankyou');
+  }
+
+  /**
    * Set default values for the form.
    *
    * Note that in edit/view mode the default values are retrieved from the database.

--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -21,6 +21,7 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
 
   public function preProcess() {
     parent::preProcess();
+    $this->setSelectedChild('widget');
 
     $this->_widget = new CRM_Contribute_DAO_Widget();
     $this->_widget->contribution_page_id = $this->_id;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2571,4 +2571,19 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     ]);
   }
 
+  /**
+   * Set the active tab
+   *
+   * @param string $default
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function setSelectedChild($default = NULL) {
+    $selectedChild = CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $this, FALSE, $default);
+    if (!empty($selectedChild)) {
+      $this->set('selectedChild', $selectedChild);
+      $this->assign('selectedChild', $selectedChild);
+    }
+  }
+
 }

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -85,21 +85,6 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
   }
 
   /**
-   * Set the active tab
-   *
-   * @param string $default
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function setSelectedChild($default = NULL) {
-    $selectedChild = CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $this, FALSE, $default);
-    if (!empty($selectedChild)) {
-      $this->set('selectedChild', $selectedChild);
-      $this->assign('selectedChild', $selectedChild);
-    }
-  }
-
-  /**
    * Set variables up before form is built.
    */
   public function preProcess() {

--- a/CRM/Friend/Form/Contribute.php
+++ b/CRM/Friend/Form/Contribute.php
@@ -32,6 +32,7 @@ class CRM_Friend_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
 
   public function preProcess() {
     parent::preProcess();
+    $this->setSelectedChild('friend');
   }
 
   /**

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -10,12 +10,6 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-/**
  * form to process actions on Membership
  */
 class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPage {
@@ -27,14 +21,18 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
   protected $_memPriceSetId = NULL;
 
   /**
+   * Set variables up before form is built.
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->setSelectedChild('membership');
+  }
+
+  /**
    * Set default values for the form. Note that in edit/view mode
    * the default values are retrieved from the database
-   *
-   *
-   * @return void
    */
   public function setDefaultValues() {
-    //parent::setDefaultValues();
     $defaults = [];
     if (isset($this->_id)) {
       $defaults = CRM_Member_BAO_Membership::getMembershipBlock($this->_id);
@@ -94,7 +92,8 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
   /**
    * Build the form object.
    *
-   * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function buildQuickForm() {
     $membershipTypes = CRM_Member_BAO_MembershipType::getMembershipTypes();
@@ -207,12 +206,13 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
    *
    * @param array $params
    *   (ref.) an assoc array of name/value pairs.
-   *
    * @param $files
    * @param int $contributionPageId
    *
    * @return bool|array
    *   mixed true or array of errors
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function formRule($params, $files, $contributionPageId = NULL) {
     $errors = [];
@@ -315,8 +315,6 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
 
   /**
    * Process the form.
-   *
-   * @return void
    */
   public function postProcess() {
     // get the submitted form values.

--- a/CRM/PCP/Form/Contribute.php
+++ b/CRM/PCP/Form/Contribute.php
@@ -32,6 +32,7 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
 
   public function preProcess() {
     parent::preProcess();
+    $this->setSelectedChild('pcp');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/1738 ping @jitendrapurohit 

Before
----------------------------------------
Stopped working for contribution pages following #17066

After
----------------------------------------
Works again.

Technical Details
----------------------------------------
This is now consistent with how manage event tabs work! It would be simpler if both events and contribution pages used the selectedChild parameter instead of their own URLs for each tab but that is a much bigger change.

Comments
----------------------------------------
@jitendrapurohit @eileenmcnaughton fix for unreleased regression