### PR TITLE
Allow the payment processor to override how the recurring contribution gets updated

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -814,63 +814,6 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
   }
 
   /**
-   * Update recurring contribution based on incoming payment.
-   *
-   * Do not rename or move this function without updating https://issues.civicrm.org/jira/browse/CRM-17655.
-   *
-   * @param int $recurringContributionID
-   * @param string $paymentStatus
-   *   Payment status - this correlates to the machine name of the contribution status ID ie
-   *   - Completed
-   *   - Failed
-   * @param string $effectiveDate
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  public static function updateOnNewPayment($recurringContributionID, $paymentStatus, $effectiveDate) {
-
-    $effectiveDate = $effectiveDate ? date('Y-m-d', strtotime($effectiveDate)) : date('Y-m-d');
-    if (!in_array($paymentStatus, ['Completed', 'Failed'])) {
-      return;
-    }
-    $params = [
-      'id' => $recurringContributionID,
-      'return' => [
-        'contribution_status_id',
-        'next_sched_contribution_date',
-        'frequency_unit',
-        'frequency_interval',
-        'installments',
-        'failure_count',
-      ],
-    ];
-
-    $existing = civicrm_api3('ContributionRecur', 'getsingle', $params);
-
-    if ($paymentStatus == 'Completed'
-      && CRM_Contribute_PseudoConstant::contributionStatus($existing['contribution_status_id'], 'name') == 'Pending') {
-      $params['contribution_status_id'] = 'In Progress';
-    }
-    if ($paymentStatus == 'Failed') {
-      $params['failure_count'] = $existing['failure_count'];
-    }
-    $params['modified_date'] = date('Y-m-d H:i:s');
-
-    if (!empty($existing['installments']) && self::isComplete($recurringContributionID, $existing['installments'])) {
-      $params['contribution_status_id'] = 'Completed';
-    }
-    else {
-      // Only update next sched date if it's empty or 'just now' because payment processors may be managing
-      // the scheduled date themselves as core did not previously provide any help.
-      if (empty($existing['next_sched_contribution_date']) || strtotime($existing['next_sched_contribution_date']) ==
-        strtotime($effectiveDate)) {
-        $params['next_sched_contribution_date'] = date('Y-m-d', strtotime('+' . $existing['frequency_interval'] . ' ' . $existing['frequency_unit'], strtotime($effectiveDate)));
-      }
-    }
-    civicrm_api3('ContributionRecur', 'create', $params);
-  }
-
-  /**
    * Is this recurring contribution now complete.
    *
    * Have all the payments expected been received now.


### PR DESCRIPTION
Overview
----------------------------------------
See #17028.

Add a standard function on the payment processor to  update the recurring contribution. Currently there is hardcoded logic that cannot be overridden and each payment processor make changes in a different way.

This will allow for update of various recurring contribution parameters (next_sched_contribution_date, cycle_day, installments, end_date) using a standard method that provides default handling and can be easily overridden if a payment processor needs to.

Per #17028 The core logic is currently broken in various circumstances and doesn't handle (eg. cycle_day) at all. This PR does not change the logic but gets the infrastructure in place so we can work on the "right" logic afterwards.

Proposed function signature:
`public function doUpdateRecurOnNewContribution($recurringContributionID, $newContributionID, $newContributionStatus, $newContributionDate)`

We *may* want to consider calling this function when the recur is first created as well.

Before
----------------------------------------
Hardcoded logic always runs. Cannot override, only modify afterwards.

After
----------------------------------------
CiviCRM provides method for default logic that can be overridden by payment processor. Easy for payment processor to use their own logic if they prefer.

Technical Details
----------------------------------------
Move the function responsible into the payment class where it can be overridden on a per processor basis if desired.

Comments
----------------------------------------
@artfulrobot @adixon @eileenmcnaughton @andrew-cormick-dockery what do you think of doing it like this? This would allow (IATS) to implement their way of handling these fields without affecting other payment processors and will allow others to use the core CiviCRM functionality by default - it also makes the code more discoverable to payment processor developers :-) Note I haven't included the changes from #17028 yet.