### PR TITLE
Fix loading, saving, and upgrade of CiviContribute settings

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyFour.php
@@ -63,6 +63,11 @@ class CRM_Upgrade_Incremental_php_FiveTwentyFour extends CRM_Upgrade_Incremental
     );
   }
 
+  public function upgrade_5_24_6($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Convert CiviContribute settings', 'updateContributeSettings');
+  }
+
   /**
    * Install sequentialCreditNotes extension.
    *

--- a/CRM/Upgrade/Incremental/sql/5.24.6.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.24.6.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.24.6 during upgrade *}

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -168,6 +168,7 @@ class SettingsBag {
         [$this->defaults, $this->values, $this->mandatory]
       );
     }
+    $this->combined['contribution_invoice_settings'] = $this->getContributionSettings();
     return $this->combined;
   }
 

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -287,6 +287,9 @@ class SettingsBag {
     if ($key === 'contribution_invoice_settings') {
       foreach (SettingsBag::getContributionInvoiceSettingKeys() as $possibleKeyName => $settingName) {
         $keyValue = $value[$possibleKeyName] ?? '';
+        if ($possibleKeyName === 'invoicing' && is_array($keyValue)) {
+          $keyValue = $keyValue['invoicing'];
+        }
         $this->set($settingName, $keyValue);
       }
       return TRUE;
@@ -302,7 +305,15 @@ class SettingsBag {
   public function computeVirtual() {
     $contributionSettings = [];
     foreach (SettingsBag::getContributionInvoiceSettingKeys() as $keyName => $settingName) {
-      $contributionSettings[$keyName] = $this->get($settingName);
+      switch ($keyName) {
+        case 'invoicing':
+          $contributionSettings[$keyName] = $this->get($settingName) ? [$keyName => 1] : 0;
+          break;
+
+        default:
+          $contributionSettings[$keyName] = $this->get($settingName);
+          break;
+      }
     }
     return ['contribution_invoice_settings' => $contributionSettings];
   }

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,6 +15,15 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 5.24.6
+
+Released April 29, 2020
+
+- **[Synopsis](release-notes/5.24.6.md#synopsis)**
+- **[Bugs resolved](release-notes/5.24.6.md#bugs)**
+- **[Credits](release-notes/5.24.6.md#credits)**
+- **[Feedback](release-notes/5.24.6.md#feedback)**
+
 ## CiviCRM 5.24.5
 
 Released April 22, 2020

--- a/release-notes/5.24.6.md
+++ b/release-notes/5.24.6.md
@@ -1,0 +1,41 @@
+# CiviCRM 5.24.6
+
+Released April 29, 2020
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |         |
+|:--------------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                                   |   no    |
+| Change the database schema?                                     |   no    |
+| Alter the API?                                                  |   no    |
+| Require attention to configuration options?                     | **yes** |
+| Fix problems installing or upgrading to a previous version?     | **yes** |
+| Introduce features?                                             |   no    |
+| **Fix bugs?**                                                   | **yes** |
+
+## <a name="bugs"></a>Bugs resolved
+
+* **_CiviContribute_: The "Tax and Invoice" settings are not consistently saved/loaded/upgraded ([dev/core#1724](https://lab.civicrm.org/dev/core/-/issues/1724): [#17188](https://github.com/civicrm/civicrm-core/pull/17188))**
+
+  In the screen "Administer => CiviContribute => CiviContribute Component Settings", the settings for "Enable Tax and
+  Invoicing" (et al) may have been loaded/saved incorrectly.  If you rely on the settings, and if you've previously
+  used an affected version (5.23.0 - 5.24.5), then you may wish to review the settings to ensure they are correct.
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+Wikimedia Foundation - Eileen McNaughton; Tadpole Collective - Kevin
+Cristiano; JMA Consulting - Seamus Lee; CiviCRM - Tim Otten
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Tim Otten and Andrew Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -41,17 +41,8 @@ return [
     'group' => 'contribute',
     'name' => 'contribution_invoice_settings',
     'type' => 'Array',
-    'default' => [
-      'invoice_prefix' => 'INV_',
-      'credit_notes_prefix' => 'CN_',
-      'due_date' => '10',
-      'due_date_period' => 'days',
-      'notes' => '',
-      'tax_term' => 'Sales Tax',
-      'tax_display_settings' => 'Inclusive',
-    ],
     'add' => '4.7',
-    'title' => ts('Deprecated setting'),
+    'title' => ts('Deprecated, virtualized setting'),
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
@@ -74,6 +65,7 @@ return [
     'settings_pages' => ['contribute' => ['weight' => 90]],
   ],
   'invoice_prefix' => [
+    'default' => 'INV_',
     'html_type' => 'text',
     'name' => 'invoice_prefix',
     'add' => '5.23',
@@ -84,6 +76,7 @@ return [
     'is_contact' => 0,
   ],
   'invoice_due_date' => [
+    'default' => '10',
     'name' => 'invoice_due_date',
     'html_type' => 'text',
     'title' => ts('Due Date'),
@@ -93,6 +86,7 @@ return [
     'is_contact' => 0,
   ],
   'invoice_due_date_period' => [
+    'default' => 'days',
     'html_type' => 'select',
     'name' => 'invoice_due_date_period',
     'title' => ts('For transmission'),
@@ -110,6 +104,7 @@ return [
     ],
   ],
   'invoice_notes' => [
+    'default' => '',
     'name' => 'invoice_notes',
     'html_type' => 'wysiwyg',
     'title' => ts('Notes or Standard Terms'),
@@ -131,6 +126,7 @@ return [
     'description' => ts('Should a pdf invoice be emailed automatically?'),
   ],
   'tax_term' => [
+    'default' => 'Sales Tax',
     'name' => 'tax_term',
     'html_type' => 'text',
     'add' => '5.23',
@@ -140,6 +136,7 @@ return [
     'is_contact' => 0,
   ],
   'tax_display_settings' => [
+    'default' => 'Inclusive',
     'html_type' => 'select',
     'name' => 'tax_display_settings',
     'type' => CRM_Utils_Type::T_STRING,

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -398,7 +398,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.24.5',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.24.6',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -79,6 +79,7 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
       'notes' => '<p>Give me money</p>',
       'tax_term' => 'Extortion',
       'tax_display_settings' => 'Exclusive',
+      // NOTE: This form of `invoicing` is accepted, but it may be normalized to the idiomatic form with a nested array.
       'invoicing' => 1,
       'is_email_pdf' => '1',
     ];
@@ -88,7 +89,7 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
     $getVersion = $this->callAPISuccessGetValue('Setting', ['name' => 'contribution_invoice_settings']);
     $this->assertEquals($settingsFromAPI, $settingsFromGet);
     $this->assertAPIArrayComparison($getVersion, $settingsFromGet);
-    $this->assertEquals($contributionSettings, $settingsFromGet);
+    $this->assertEquals(['invoicing' => ['invoicing' => 1]] + $contributionSettings, $settingsFromGet);
 
     // These are the preferred retrieval methods.
     $this->assertEquals('G_', Civi::settings()->get('invoice_prefix'));

--- a/tests/phpunit/Civi/Core/SettingsBagTest.php
+++ b/tests/phpunit/Civi/Core/SettingsBagTest.php
@@ -30,4 +30,50 @@ class SettingsBagTest extends \CiviUnitTestCase {
     $this->assertEquals(0, $settingsBag->get('enable_innodb_fts'));
   }
 
+  /**
+   * The setting "contribution_invoice_settings" is actually a virtual value built on other settings.
+   * Check that various updates work as expected.
+   */
+  public function testVirtualContributionSetting_explicit() {
+    $s = \Civi::settings();
+
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+
+    $s->set('invoice_due_date', 20);
+    $this->assertEquals(20, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(20, $s->get('invoice_due_date'));
+    $this->assertEquals(20, $s->getExplicit('invoice_due_date'));
+
+    $s->set('contribution_invoice_settings', array_merge($s->get('contribution_invoice_settings'), [
+      'due_date' => 30,
+    ]));
+    $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(30, $s->get('invoice_due_date'));
+    $this->assertEquals(30, $s->getExplicit('invoice_due_date'));
+
+    $s->revert('invoice_due_date');
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+  }
+
+  /**
+   * The setting "contribution_invoice_settings" is actually a virtual value built on other settings.
+   * Check that mandatory values ($civicrm_settings) are respected.
+   */
+  public function testVirtualContributionSetting_mandatory() {
+    $s = \Civi::settings();
+    $this->assertEquals(10, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(10, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+
+    $s->loadMandatory(['invoice_due_date' => 30]);
+
+    $this->assertEquals(30, $s->get('contribution_invoice_settings')['due_date']);
+    $this->assertEquals(30, $s->get('invoice_due_date'));
+    $this->assertEquals(NULL, $s->getExplicit('invoice_due_date'));
+  }
+
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -258,6 +258,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test the 'return' param works for all fields.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGetContributionReturnFunctionality() {
     $params = $this->_params;

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.24.5</version_no>
+  <version_no>5.24.6</version_no>
 </version>


### PR DESCRIPTION
Backport #17188 from 5.25 RC to 5.24 stable.

Note: There is an upgrader step, `updateContributeSettings()`, which was previously defined. This step is invoked by both PRs (5.25 RC and 5.24 stable) . The upgrade logic in `updateContributeSettings()` functions as a "*fill*" operation (i.e. converting data from legacy format but *not* overwriting newer settings), so it should be safe to re-run in multiple upgrades.