### PR TITLE
[REF] Cleanup a few instances where we use old call to get loggedInUserID

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -510,7 +510,7 @@ HERESQL;
     }
 
     $type = CRM_Utils_Array::value('type', $params, 'upcoming');
-    $userID = CRM_Core_Session::singleton()->get('userID');
+    $userID = CRM_Core_Session::getLoggedInContactID();
 
     // validate access for all cases.
     if ($allCases && !CRM_Core_Permission::check('access all cases and activities')) {
@@ -670,7 +670,7 @@ HERESQL;
       return $caseSummary;
     }
 
-    $userID = CRM_Core_Session::singleton()->get('userID');
+    $userID = CRM_Core_Session::getLoggedInContactID();
 
     //validate access for all cases.
     if ($allCases && !CRM_Core_Permission::check('access all cases and activities')) {
@@ -1269,9 +1269,9 @@ HERESQL;
         break;
       }
     }
-    $session = CRM_Core_Session::singleton();
+
     // CRM-8926 If user is not logged in, use the activity creator as userID
-    if (!($userID = $session->get('userID'))) {
+    if (!($userID = CRM_Core_Session::getLoggedInContactID())) {
       $userID = CRM_Activity_BAO_Activity::getSourceContactID($activityId);
     }
 
@@ -1403,8 +1403,7 @@ HERESQL;
    *
    */
   public static function getNextScheduledActivity($cases, $type = 'upcoming') {
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
+    $userID = CRM_Core_Session::getLoggedInContactID();
 
     $caseID = implode(',', $cases['case_id']);
     $contactID = implode(',', $cases['contact_id']);

--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -28,7 +28,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
     $this->set("context", $context);
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     parent::preProcess();
-    $session = CRM_Core_Session::singleton();
+
     if ($this->_id) {
       $permissions = [
         CRM_Core_Action::UPDATE => [
@@ -49,7 +49,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
 
       $createdID = CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $this->_id, 'created_id');
       if (!empty($permissions[$this->_action])) {
-        $this->checkPermissions($this->_action, $permissions[$this->_action]['permission'], $createdID, $session->get('userID'), $permissions[$this->_action]['actionName']);
+        $this->checkPermissions($this->_action, $permissions[$this->_action]['permission'], $createdID, CRM_Core_Session::getLoggedInContactID(), $permissions[$this->_action]['actionName']);
       }
     }
   }
@@ -169,6 +169,8 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
 
   /**
    * Process the form submission.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
     $session = CRM_Core_Session::singleton();
@@ -180,7 +182,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
 
     // store the submitted values in an array
     $params['modified_date'] = date('YmdHis');
-    $params['modified_id'] = $session->get('userID');
+    $params['modified_id'] = CRM_Core_Session::getLoggedInContactID();
     if (!empty($params['created_date'])) {
       $params['created_date'] = CRM_Utils_Date::processDate($params['created_date']);
     }
@@ -190,7 +192,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
       $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Open');
       $params['created_date'] = date('YmdHis');
       if (empty($params['created_id'])) {
-        $params['created_id'] = $session->get('userID');
+        $params['created_id'] = CRM_Core_Session::getLoggedInContactID();
       }
       $details = "{$params['title']} batch has been created by this contact.";
       $activityTypeName = 'Create Batch';
@@ -218,8 +220,8 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
       'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_status_id', 'Completed'),
       'priority_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'priority_id', 'Normal'),
       'activity_date_time' => date('YmdHis'),
-      'source_contact_id' => $session->get('userID'),
-      'source_contact_qid' => $session->get('userID'),
+      'source_contact_id' => CRM_Core_Session::getLoggedInContactID(),
+      'source_contact_qid' => CRM_Core_Session::getLoggedInContactID(),
       'details' => $details,
     ];
 

--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -53,7 +53,7 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
       $contactID = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP', $this->_id, 'contact_id');
     }
 
-    $this->_contactID = $contactID ?? $session->get('userID');
+    $this->_contactID = $contactID ?? CRM_Core_Session::getLoggedInContactID();
     if (!$this->_pageId) {
       if (!$this->_id) {
         $msg = ts('We can\'t load the requested web page due to an incomplete link. This can be caused by using your browser\'s Back button or by using an incomplete or invalid link.');

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -570,8 +570,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
               1
             ) {
               // get current user
-              $session = CRM_Core_Session::singleton();
-              if ($contactID = $session->get('userID')) {
+              if ($contactID = CRM_Core_Session::getLoggedInContactID()) {
                 $clause = "{$this->_aliases['civicrm_activity_contact']}.activity_id IN
                            (SELECT activity_id FROM civicrm_activity_contact WHERE contact_id = {$contactID})";
               }
@@ -613,6 +612,8 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
    * Build ACL clause.
    *
    * @param string $tableAlias
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildACLClause($tableAlias = 'contact_a') {
     //override for ACL( Since Contact may be source
@@ -623,8 +624,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
       return;
     }
 
-    $session = CRM_Core_Session::singleton();
-    $contactID = $session->get('userID');
+    $contactID = CRM_Core_Session::getLoggedInContactID();
     if (!$contactID) {
       $contactID = 0;
     }


### PR DESCRIPTION


Overview
----------------------------------------
Minor code clean up on a pattern we've been cleaning up for a while

Before
----------------------------------------
```CRM_Core_Session::singleton()->get('userID');```

After
----------------------------------------
```CRM_Core_Session::getLoggedInContactID();```

Technical Details
----------------------------------------


Comments
----------------------------------------

