### PR TITLE
dev/core#1729 - Fix filters skipping on activity report

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -542,7 +542,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           }
           else {
             $op = $this->_params["{$fieldName}_op"] ?? NULL;
-            if ($op && !($fieldName == "contact_{$recordType}" && ($op != 'nnll' || $op != 'nll'))) {
+            if ($op && !($fieldName === "contact_{$recordType}" && ($op === 'nnll' || $op === 'nll'))) {
               $clause = $this->whereClause($field,
                 $op,
                 CRM_Utils_Array::value("{$fieldName}_value", $this->_params),

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1260,6 +1260,23 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the source contact filter works.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testActivityDetailsContactFilter() {
+    $this->createContactsWithActivities();
+    $params = [
+      'report_id' => 'activity',
+      'contact_source_op' => 'has',
+      'contact_source_value' => 'z',
+      'options' => ['metadata' => ['sql']],
+    ];
+    $rows = $this->callAPISuccess('report_template', 'getrows', $params);
+    $this->assertContains("civicrm_contact_source.sort_name LIKE '%z%'", $rows['metadata']['sql'][3]);
+  }
+
+  /**
    * Set up some activity data..... use some chars that challenge our utf handling.
    */
   public function createContactsWithActivities() {


### PR DESCRIPTION
Overview
----------------------------------------

On the "Activity Detail" report, setting the "Source Name" filter on a report has no effect on the results.

See also: https://lab.civicrm.org/dev/core/-/issues/1729

Before
----------------------------------------

Suppose you take these steps:

1. open Activity Details report.
2. go to "Filters" (tab)
3. "Source Name" : "Contains" : [any text]
4. Preview results

Current behaviour

* notice 80 results
* results **do not change** when changing the 'source name' filter
* no errors reported

After
----------------------------------------

Report results are filtered (based on the filter values)

Technical Details
----------------------------------------
Regression from https://github.com/civicrm/civicrm-core/pull/16672/files as the operator is wrong

ie we went from

```
($op !== 'nnll' || $op !== 'nll')
```

to

```
!($op !== 'nnll' || $op !== 'nll')
```
when it should be 

```
!($op === 'nnll' || $op === 'nll')
```

Comments
----------------------------------------
@MegaphoneJon FYI
