### PR TITLE
Fix logic for job log cleanup and make SQL safer

### DIFF
--- a/CRM/Core/BAO/Job.php
+++ b/CRM/Core/BAO/Job.php
@@ -117,15 +117,16 @@ class CRM_Core_BAO_Job extends CRM_Core_DAO_Job {
     // Prevent the job log from getting too big
     // For now, keep last minDays days and at least maxEntries records
     $query = 'SELECT COUNT(*) FROM civicrm_job_log';
-    $count = CRM_Core_DAO::singleValueQuery($query);
+    $count = (int) CRM_Core_DAO::singleValueQuery($query);
 
     if ($count <= $maxEntriesToKeep) {
       return;
     }
 
-    $count = $count - $maxEntriesToKeep;
+    $count = $count - (int) $maxEntriesToKeep;
 
-    $query = "DELETE FROM civicrm_job_log WHERE run_time < SUBDATE(NOW(), $minDaysToKeep) LIMIT $count";
+    $minDaysToKeep = (int) $minDaysToKeep;
+    $query = "DELETE FROM civicrm_job_log WHERE run_time < SUBDATE(NOW(), $minDaysToKeep) ORDER BY id LIMIT $count";
     CRM_Core_DAO::executeQuery($query);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

There's a function `CRM_Core_BAO_Job::cleanup()` which is only called by api3 `Job.Cleanup` that is supposed to trim the job log to preserve only the latest 30 days' entries and any that are older if there's more than 1000 entries.


Before
----------------------------------------

If there were old logs that needed trimming, it would delete from them randomly. e.g.

if you had these jobs

1. old
2. old
3. old
4. young
5. young

and it was to keep 3 jobs, it would reason it needed to delete 2 jobs, and would then delete 2 of the old jobs *at random*.


After
----------------------------------------

It will now delete the *oldest* jobs (going on the ID field), instead of random ones.

Technical Details
----------------------------------------

The original delete query did not have an ORDER BY. It was probably assuming records would come out in order of primary ID, which is typical, but not guaranteed without an ORDER BY.

I also added some casts to ensure the passed-in parameters were integers because they are used in the SQL directly. I don't consider this a security issue because the only public way to call this code is via the API and there aren't any user-configurable params that are used as inputs. But still, we have some standards, and this will prevent anyone from writing other code that calls the cleanup function from accidentally injecting something bad into the SQL.

