### PR TITLE
APIv4 - Don't advertise implicit multi-joins in Explorer

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -10,6 +10,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Service\Schema\Joinable\Joinable;
+
 /**
  *
  * @package CRM
@@ -22,11 +24,18 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
   public function run() {
     $apiDoc = new ReflectionFunction('civicrm_api4');
     $groupOptions = civicrm_api4('Group', 'getFields', ['loadOptions' => TRUE, 'select' => ['options', 'name'], 'where' => [['name', 'IN', ['visibility', 'group_type']]]]);
+    // Don't show n-to-many joins in Explorer
+    $entityLinks = (array) civicrm_api4('Entity', 'getLinks', [], ['entity' => 'links']);
+    foreach ($entityLinks as $entity => $links) {
+      $entityLinks[$entity] = array_filter($links, function($link) {
+        return $link['joinType'] != Joinable::JOIN_TYPE_ONE_TO_MANY;
+      });
+    }
     $vars = [
       'operators' => \CRM_Core_DAO::acceptedSQLOperators(),
       'basePath' => Civi::resources()->getUrl('civicrm'),
       'schema' => (array) \Civi\Api4\Entity::get()->setChain(['fields' => ['$name', 'getFields']])->execute(),
-      'links' => (array) \Civi\Api4\Entity::getLinks()->execute(),
+      'links' => $entityLinks,
       'docs' => \Civi\Api4\Utils\ReflectionUtils::parseDocBlock($apiDoc->getDocComment()),
       'groupOptions' => array_column((array) $groupOptions, 'options', 'name'),
     ];

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -138,9 +138,8 @@
     }
 
     function addJoins(fieldList, addWildcard) {
-      var fields = _.cloneDeep(fieldList),
-        fks = _.findWhere(links, {entity: $scope.entity}) || {};
-      _.each(fks.links, function(link) {
+      var fields = _.cloneDeep(fieldList);
+      _.each(links[$scope.entity], function(link) {
         var linkFields = _.cloneDeep(entityFields(link.entity)),
           wildCard = addWildcard ? [{id: link.alias + '.*', text: link.alias + '.*', 'description': 'All core ' + link.entity + ' fields'}] : [];
         if (linkFields) {
@@ -1066,8 +1065,7 @@
         return comboName;
       }
       var linkName = fieldNames.shift(),
-        entityLinks = _.findWhere(links, {entity: entity}).links,
-        newEntity = _.findWhere(entityLinks, {alias: linkName}).entity;
+        newEntity = _.findWhere(links[entity], {alias: linkName}).entity;
       return get(newEntity, fieldNames);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
These joins are problematic and may be removed. The Explorer should not display them.

Before
----------------------------------------
Now you see them.

After
----------------------------------------
Now you don't.

Technical Details
----------------------------------------
This is the first step in deprecation. This doesn't remove support for them, just visibility.