### PR TITLE
(NFC) Remove $Id$ artifacts from old SCM

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -16,8 +16,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 class CRM_Core_Action {
 

--- a/CRM/Core/Base.php
+++ b/CRM/Core/Base.php
@@ -16,8 +16,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 require_once 'CRM/Core/I18n.php';

--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 require_once 'HTML/QuickForm/Renderer/ArraySmarty.php';

--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 class CRM_Core_I18n_Form extends CRM_Core_Form {
 

--- a/CRM/Core/I18n/NativeGettext.php
+++ b/CRM/Core/I18n/NativeGettext.php
@@ -13,7 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
  *
  * Convenience class for PHP-Gettext compatibility.
  */

--- a/CRM/Core/I18n/PseudoConstant.php
+++ b/CRM/Core/I18n/PseudoConstant.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 class CRM_Core_I18n_PseudoConstant {
 

--- a/CRM/Core/I18n/SchemaStructure_4_2_alpha1.php
+++ b/CRM/Core/I18n/SchemaStructure_4_2_alpha1.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 class CRM_Core_I18n_SchemaStructure_4_2_alpha1 {
 

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4\Generic;

--- a/Civi/Api4/Generic/AbstractBatchAction.php
+++ b/Civi/Api4/Generic/AbstractBatchAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4\Generic;

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Generic/BasicGetAction.php
+++ b/Civi/Api4/Generic/BasicGetAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Generic/BasicReplaceAction.php
+++ b/Civi/Api4/Generic/BasicReplaceAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/ACLCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ACLCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/ActivityCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivityCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/CampaignCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/CampaignCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/Civi/Api4/Service/Spec/Provider/OptionValueCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/OptionValueCreationSpecProvider.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/tests/phpunit/api/v4/Action/NullValueTest.php
+++ b/tests/phpunit/api/v4/Action/NullValueTest.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/tests/phpunit/api/v4/Traits/TableDropperTrait.php
+++ b/tests/phpunit/api/v4/Traits/TableDropperTrait.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/tests/phpunit/api/v4/Traits/TestDataLoaderTrait.php
+++ b/tests/phpunit/api/v4/Traits/TestDataLoaderTrait.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 

--- a/tests/phpunit/api/v4/UnitTestCase.php
+++ b/tests/phpunit/api/v4/UnitTestCase.php
@@ -14,8 +14,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 


### PR DESCRIPTION
Overview
----------------------------------------
A few more instances of old svn notation removed

Before
----------------------------------------
``` * $Id$```

After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------

