### PR TITLE
Convert fatals to statusBounces in case forms

### DIFF
--- a/CRM/Case/Form/Activity/ChangeCaseStartDate.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStartDate.php
@@ -27,10 +27,10 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
    */
   public static function preProcess(&$form) {
     if (!isset($form->_caseId)) {
-      CRM_Core_Error::fatal(ts('Case Id not found.'));
+      CRM_Core_Error::statusBounce(ts('Case Id not found.'));
     }
     if (count($form->_caseId) != 1) {
-      CRM_Core_Resources::fatal(ts('Expected one case-type'));
+      CRM_Core_Error::statusBounce(ts('Expected one case-type'));
     }
   }
 
@@ -128,7 +128,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
       !$caseId ||
       !$caseType
     ) {
-      CRM_Core_Error::fatal('Required parameter missing for ChangeCaseType - end post processing');
+      CRM_Core_Error::statusBounce('Required parameter missing for ChangeCaseType - end post processing');
     }
 
     $config = CRM_Core_Config::singleton();
@@ -199,7 +199,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
 
       $newActivity = CRM_Activity_BAO_Activity::create($openCaseParams);
       if (is_a($newActivity, 'CRM_Core_Error')) {
-        CRM_Core_Error::fatal('Unable to update Open Case activity');
+        CRM_Core_Error::statusBounce('Unable to update Open Case activity');
       }
       else {
         // Create linkage to case

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -27,7 +27,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
    */
   public static function preProcess(&$form) {
     if (!isset($form->_caseId)) {
-      CRM_Core_Error::fatal(ts('Case Id not found.'));
+      CRM_Core_Error::statusBounce(ts('Case Id not found.'));
     }
 
     $form->addElement('checkbox', 'updateLinkedCases', NULL, NULL, ['class' => 'select-row']);

--- a/CRM/Case/Form/Activity/ChangeCaseType.php
+++ b/CRM/Case/Form/Activity/ChangeCaseType.php
@@ -27,7 +27,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
    */
   public static function preProcess(&$form) {
     if (!isset($form->_caseId)) {
-      CRM_Core_Error::fatal(ts('Case Id not found.'));
+      CRM_Core_Error::statusBounce(ts('Case Id not found.'));
     }
   }
 
@@ -134,7 +134,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
       !$params['case_type_id'] ||
       !$caseType
     ) {
-      CRM_Core_Error::fatal('Required parameter missing for ChangeCaseType - end post processing');
+      CRM_Core_Error::statusBounce('Required parameter missing for ChangeCaseType - end post processing');
     }
 
     $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');

--- a/CRM/Case/Form/Activity/LinkCases.php
+++ b/CRM/Case/Form/Activity/LinkCases.php
@@ -27,10 +27,10 @@ class CRM_Case_Form_Activity_LinkCases {
    */
   public static function preProcess(&$form) {
     if (empty($form->_caseId)) {
-      CRM_Core_Error::fatal(ts('Case Id not found.'));
+      CRM_Core_Error::statusBounce(ts('Case Id not found.'));
     }
     if (count($form->_caseId) != 1) {
-      CRM_Core_Resources::fatal(ts('Expected one case-type'));
+      CRM_Core_Error::statusBounce(ts('Expected one case-type'));
     }
 
     $caseId = CRM_Utils_Array::first($form->_caseId);

--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -260,18 +260,18 @@ class CRM_Case_Form_Activity_OpenCase {
     $isMultiClient = $xmlProcessorProcess->getAllowMultipleCaseClients();
 
     if (!$isMultiClient && !$form->_currentlyViewedContactId) {
-      throw new CRM_Core_Exception('Required parameter missing for OpenCase - end post processing');
+      CRM_Core_Error::statusBounce('Required parameter missing for OpenCase - end post processing');
     }
 
     if (!$form->_currentUserId || !$params['case_id'] || !$params['case_type']) {
-      throw new CRM_Core_Exception('Required parameter missing for OpenCase - end post processing');
+      CRM_Core_Error::statusBounce('Required parameter missing for OpenCase - end post processing');
     }
 
     // 1. create case-contact
     if ($isMultiClient && $form->_context == 'standalone') {
       foreach ($params['client_id'] as $cliId) {
         if (empty($cliId)) {
-          throw new CRM_Core_Exception('client_id cannot be empty for OpenCase - end post processing');
+          CRM_Core_Error::statusBounce('client_id cannot be empty for OpenCase - end post processing');
         }
         $contactParams = [
           'case_id' => $params['case_id'],

--- a/CRM/Case/Form/ActivityToCase.php
+++ b/CRM/Case/Form/ActivityToCase.php
@@ -22,11 +22,13 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
 
   /**
    * Build all the data structures needed to build the form.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     $this->_activityId = CRM_Utils_Request::retrieve('activityId', 'Positive');
     if (!$this->_activityId) {
-      CRM_Core_Error::fatal('required activity id is missing.');
+      throw new CRM_Core_Exception('required activity id is missing.');
     }
 
     $this->_currentCaseId = CRM_Utils_Request::retrieve('caseId', 'Positive');
@@ -46,11 +48,12 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
   }
 
   /**
-   * Set default values for the form. For edit/view mode
-   * the default values are retrieved from the database
-   *
+   * Set default values for the form. For edit/view mode.
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function setDefaultValues() {
     $defaults = [];


### PR DESCRIPTION
Overview
----------------------------------------
Replaces calls to fatal with statusBounce where they are in the case forms

Before
----------------------------------------
CRM_Core_Error::fatal

After
----------------------------------------
CRM_Core_Error::statusBounce

Technical Details
----------------------------------------
In general users should experience the bounce message whereas code should catch exceptions. So in the form layer it's ```CRM_Core_Error::statusBounce``` and in the BAO ```throw new CRM_Core_Exception``` and ```CRM_Core_Error::fatal``` is oh-so-2014

I'm just assuming form layer due to the folder these are in

Comments
----------------------------------------
@demeritcowboy 
