### PR TITLE
dev/translation#39 - Crash when using cv core:install with --lang

### DIFF
--- a/setup/plugins/installDatabase/InstallSchema.civi-setup.php
+++ b/setup/plugins/installDatabase/InstallSchema.civi-setup.php
@@ -87,6 +87,14 @@ class InstallSchemaPlugin implements \Symfony\Component\EventDispatcher\EventSub
       global $tsLocale;
       $tsLocale = $seedLanguage;
       \Civi\Setup::log()->info(sprintf('[%s] Load basic data', basename(__FILE__)));
+      // We need to load the container now otherwise smarty calls to {ts}
+      // inside the sql templates trigger a call to find the l10n path, which
+      // can't be done if there's no container to ask. But we need to boot with
+      // FALSE to prevent it trying to load from the database since it doesn't
+      // exist yet since loading the database is what we're trying to do here!
+      require_once $model->settingsPath;
+      \Civi\Core\Container::boot(FALSE);
+
       \Civi\Setup\DbUtil::sourceSQL($model->db, \Civi\Setup\SchemaGenerator::generateBasicData($model->srcPath));
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/translation/-/issues/39

There's a chicken and egg problem when trying to install in another language. It can't request the path to the l10n files when trying to do on-the-fly translation of the database files because the necessary booting hasn't happened yet.

To test this, get to the point where you have a CMS installed and you're about to install civi, and [download the l10n](https://download.civicrm.org/latest/civicrm-NIGHTLY-l10n.tar.gz) files if you don't have them unpacked already and extract them in the civicrm folder. Note the translated sql files aren't used here, just the l10n .mo files.

If you don't have `cv` installed you'll need cv.

If you're setting yourself up using a method that installs civi for you along with the CMS so that civi gets installed already, then you can add `-f` to the command below to overwrite. Replace `aa_AA` with whatever language you want, except en_US.

If you're using drupal don't forget to make sites/default writeable.

`cv core:install -vvv --cms-base-url=http://your.site.url/ --lang=aa_AA`

Before
----------------------------------------

The above will crash in the middle of "Load basic data".

After
----------------------------------------

Success.

Technical Details
----------------------------------------

See lab ticket.

Comments
----------------------------------------

While it's not necessary for this patch, a related issue is https://github.com/civicrm/cv/issues/72, and with a small hack to `cv` this PR also facilitates specifying a different location for the l10n files than the default civi root folder. To hack, change [this line](https://github.com/civicrm/cv/blob/v0.3.2/src/Util/SetupCommandTrait.php#L159) to use a '+' instead of a '.', and then add the below option to the command above. 

`-m paths+civicrm.l10n+path=/your/custom/path/to/l10n`

I looked at writing a unit test but I couldn't see how to do one without trying to clear civicrm_domain, but it has foreign keys to a bunch of stuff so to do it properly really requires a blank database. I think a test might be possible in here https://github.com/civicrm/cv/blob/v0.3.2/tests/Command/CoreLifecycleTest.php#L34, but that seemed like a difficult environment to set up and I'm not sure if those tests run anywhere.