### PR TITLE
dev/core#1714 Fix mis-filtering on activity type

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -516,8 +516,9 @@ class CRM_Contact_BAO_Query {
       $this->_fields = array_merge($this->_fields, $fields);
 
       // add activity fields
-      $fields = CRM_Activity_BAO_Activity::exportableFields();
-      $this->_fields = array_merge($this->_fields, $fields);
+      $this->_fields = array_merge($this->_fields, CRM_Activity_BAO_Activity::exportableFields());
+      // Add hack as no unique name is defined for the field but the search form is in denial.
+      $this->_fields['activity_priority_id'] = $this->_fields['priority_id'];
 
       // add any fields provided by hook implementers
       $extFields = CRM_Contact_BAO_Query_Hook::singleton()->getFields();

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -438,10 +438,55 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test similarly handled activity fields qill and where clauses.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSearchBuilderActivityType() {
+    $queryObj = new CRM_Contact_BAO_Query([['activity_type', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.activity_type_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Activity Type = Email', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_type_id', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.activity_type_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Activity Type ID = Email', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_status', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.status_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Activity Status = Cancelled', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_status_id', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.status_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Activity Status = Cancelled', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_engagement_level', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.engagement_level = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Engagement Index = 3', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_id', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.id = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Activity ID = 3', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_campaign_id', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.campaign_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Campaign = 3', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_priority_id', '=', '3', 1, 0]]);
+    $this->assertContains('WHERE  (  ( civicrm_activity.priority_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertEquals('Priority = Low', $queryObj->_qill[1][0]);
+
+    $queryObj = new CRM_Contact_BAO_Query([['activity_subject', '=', '3', 1, 0]]);
+    $this->assertContains("WHERE  (  ( civicrm_activity.subject = '3' )", $queryObj->getSearchSQL());
+    $this->assertEquals("Subject = '3'", $queryObj->_qill[1][0]);
+  }
+
+  /**
    * Test set up to test calling the query object per GroupContactCache BAO usage.
    *
    * CRM-17254 ensure that if only the contact_id is required other fields should
    * not be appended.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testGroupContactCacheAddSearch() {
     $returnProperties = ['contact_id'];

--- a/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
@@ -19,6 +19,8 @@ class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
 
   /**
    * Test contact sub type search.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testContactSubtype() {
     foreach (['Contact_sub_type', 'Contact2__sub__type'] as $contactSubType) {
@@ -26,7 +28,7 @@ class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
         'name' => $contactSubType,
         'label' => $contactSubType,
         'is_active' => 1,
-        'parent_id' => "Individual",
+        'parent_id' => 'Individual',
       ]);
       // Contact Type api munge name in create mode
       // Therefore updating the name in update mode
@@ -39,6 +41,11 @@ class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
     $this->searchContacts('Contact2__sub__type');
   }
 
+  /**
+   * @param string $contactSubType
+   *
+   * @throws \CRM_Core_Exception
+   */
   protected function searchContacts($contactSubType) {
     // create contact
     $params = [
@@ -78,11 +85,13 @@ class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
   /**
    * Test to search based on Group type.
    * https://lab.civicrm.org/dev/core/issues/726
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testContactSearchOnGroupType() {
     $groupTypes = $this->callAPISuccess('OptionValue', 'get', [
-      'return' => ["id", "name"],
-      'option_group_id' => "group_type",
+      'return' => ['id', 'name'],
+      'option_group_id' => 'group_type',
     ])['values'];
     $groupTypes = array_column($groupTypes, 'id', 'name');
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug where the activity_type_id was being compared against the label of the option value

Before
----------------------------------------
Using Search Builder -
Choose Activity - Activity Type - = - Tell a Friend.
Actual results - 0
Choose Activity - Activity Type ID - = - Tell a Friend. (Not listed as a ID just the label)
Actual results - 92

After
----------------------------------------
Filter correctly filters

Technical Details
----------------------------------------
Most of the code in the handling for the first bunch of fields was silly. I added a test for each field to ensure they would be non-weird without it all

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1714
