### PR TITLE
dev/core#1460 - Small cleanups in CiviEventDispatcher{,Test}

### DIFF
--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -29,12 +29,22 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
   private $autoListeners = [];
 
   /**
+   * A list of dispatch-policies (based on an exact-match to the event name).
+   *
+   * Note: $dispatchPolicyExact and $dispatchPolicyRegex should coexist; e.g.
+   * if one is NULL, then both are NULL. If one is an array, then both are arrays.
+   *
    * @var array|null
    *   Array(string $eventName => string $action)
    */
   private $dispatchPolicyExact = NULL;
 
   /**
+   * A list of dispatch-policies (based on an regex-match to the event name).
+   *
+   * Note: $dispatchPolicyExact and $dispatchPolicyRegex should coexist; e.g.
+   * if one is NULL, then both are NULL. If one is an array, then both are arrays.
+   *
    * @var array|null
    *   Array(string $eventRegex => string $action)
    */
@@ -155,6 +165,8 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
   }
 
   /**
+   * Attach any pattern-based listeners which may be interested in $eventName.
+   *
    * @param string $eventName
    *   Ex: 'civi.api.resolve' or 'hook_civicrm_dashboard'.
    */
@@ -174,7 +186,7 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
   }
 
   /**
-   * The dispatch policy allows you to filter certain events.
+   * Set the dispatch policy. This allows you to filter certain events.
    * This can be useful during upgrades or debugging.
    *
    * Enforcement will add systemic overhead, so this should normally be NULL.
@@ -219,7 +231,10 @@ class CiviEventDispatcher extends ContainerAwareEventDispatcher {
   //  }
 
   /**
+   * Determine whether the dispatch policy applies to a given event.
+   *
    * @param string $eventName
+   *   Ex: 'civi.api.resolve' or 'hook_civicrm_dashboard'.
    * @return string
    *   Ex: 'run', 'drop', 'fail'
    */

--- a/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
+++ b/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
@@ -20,7 +20,7 @@ class CiviEventDispatcherTest extends \CiviUnitTestCase {
     $d->addListener('hook_civicrm_fakeRunnable', function() use (&$calls) {
       $calls['hook_civicrm_fakeRunnable'] = 1;
     });
-    $d->dispatch('hook_civicrm_fakeRunnable', new GenericHookEvent());
+    $d->dispatch('hook_civicrm_fakeRunnable', GenericHookEvent::create([]));
     $this->assertEquals(1, $calls['hook_civicrm_fakeRunnable']);
   }
 
@@ -33,7 +33,7 @@ class CiviEventDispatcherTest extends \CiviUnitTestCase {
     $d->addListener('hook_civicrm_fakeDroppable', function() use (&$calls) {
       $calls['hook_civicrm_fakeDroppable'] = 1;
     });
-    $d->dispatch('hook_civicrm_fakeDroppable', new GenericHookEvent());
+    $d->dispatch('hook_civicrm_fakeDroppable', GenericHookEvent::create([]));
     $this->assertTrue(!isset($calls['hook_civicrm_fakeDroppable']));
   }
 
@@ -43,7 +43,7 @@ class CiviEventDispatcherTest extends \CiviUnitTestCase {
       '/^hook_civicrm_fakeFa/' => 'fail',
     ]);
     try {
-      $d->dispatch('hook_civicrm_fakeFailure', new GenericHookEvent());
+      $d->dispatch('hook_civicrm_fakeFailure', GenericHookEvent::create([]));
       $this->fail('Expected exception');
     }
     catch (\Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to the recently merged #17127 to address a couple small issues.

Before
----------------------------------------

* The unit test `CiviEventDispatcherTest` passes on some versions of PHP but raises a warning on others versions (*This is because the `GenericHootEvent`s aren't fully specified, leading to a call to `count()` on null value. See also: https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=max,CIVIVER=master,SUITES=phpunit-civi,label=bknix-tmp/7995/testReport/Civi.Core/CiviEventDispatcherTest/testDispatchPolicy_run/*)
* Some of the docblocks in `CiviEventDispatcher` have type-info but don't have "summary" lines.

After
----------------------------------------
* The unit test `CiviEventDispatcherTest` passes in more PHP environments.
* Some of the docblocks in `CiviEventDispatcher` have type-info but don't have "summary" lines.
