### PR TITLE
APIv4 - Deprecate old way of retrieving activityType/optionValue ids

### DIFF
--- a/Civi/Api4/Event/Subscriber/ActivityPreCreationSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ActivityPreCreationSubscriber.php
@@ -34,6 +34,7 @@ class ActivityPreCreationSubscriber extends Generic\PreCreationSubscriber {
   protected function modify(DAOCreateAction $request) {
     $activityType = $request->getValue('activity_type');
     if ($activityType) {
+      \CRM_Core_Error::deprecatedFunctionWarning('Use activity_type_id:name instead of activity_type in APIv4');
       $result = OptionValue::get()
         ->setCheckPermissions(FALSE)
         ->addWhere('name', '=', $activityType)

--- a/Civi/Api4/Event/Subscriber/OptionValuePreCreationSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/OptionValuePreCreationSubscriber.php
@@ -52,7 +52,7 @@ class OptionValuePreCreationSubscriber extends Generic\PreCreationSubscriber {
     if (!$optionGroupName || $request->getValue('option_group_id')) {
       return;
     }
-
+    \CRM_Core_Error::deprecatedFunctionWarning('Use option_group_id:name instead of option_group in APIv4');
     $optionGroup = OptionGroup::get()
       ->setCheckPermissions(FALSE)
       ->addSelect('id')

--- a/tests/phpunit/api/v4/DataSets/ConformanceTest.json
+++ b/tests/phpunit/api/v4/DataSets/ConformanceTest.json
@@ -35,7 +35,7 @@
   "Activity": [
     {
       "subject": "Test A Phone Activity",
-      "activity_type": "Phone Call",
+      "activity_type_id:name": "Phone Call",
       "source_contact_id": "@ref test_contact_1.id"
     }
   ]

--- a/tests/phpunit/api/v4/DataSets/DefaultDataSet.json
+++ b/tests/phpunit/api/v4/DataSets/DefaultDataSet.json
@@ -16,12 +16,12 @@
   "Activity": [
     {
       "subject": "Test Phone Activity",
-      "activity_type": "Phone Call",
+      "activity_type_id:name": "Phone Call",
       "source_contact_id": "@ref test_contact_1.id"
     },
     {
       "subject": "Another Activity",
-      "activity_type": "Meeting",
+      "activity_type_id:name": "Meeting",
       "source_contact_id": "@ref test_contact_1.id",
       "assignee_contact_id": [
         "@ref test_contact_1.id",

--- a/tests/phpunit/api/v4/DataSets/SingleContact.json
+++ b/tests/phpunit/api/v4/DataSets/SingleContact.json
@@ -11,13 +11,13 @@
   "Activity": [
     {
       "subject": "Won A Nobel Prize",
-      "activity_type": "Meeting",
+      "activity_type_id:name": "Meeting",
       "source_contact_id": "@ref test_contact_1.id",
       "@ref": "test_activity_1"
     },
     {
       "subject": "Cleaned The House",
-      "activity_type": "Meeting",
+      "activity_type_id:name": "Meeting",
       "source_contact_id": "@ref test_contact_1.id",
       "assignee_contact_id": [
         "@ref test_contact_1.id"


### PR DESCRIPTION
Overview
----------------------------------------
This deprecates some old stuff in APIv4 which was half-baked and maybe not even tested. The new pseudoconstant matching takes its place.
