### PR TITLE
Fetch line items from correct contribution when repeating a contribution

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -114,26 +114,22 @@ class CRM_Price_BAO_PriceSet extends CRM_Price_DAO_PriceSet {
    *
    */
   public static function getDefaultPriceSet($entity = 'contribution') {
-    if (!empty(self::$_defaultPriceSet[$entity])) {
-      return self::$_defaultPriceSet[$entity];
+    if (isset(\Civi::$statics[__CLASS__][$entity])) {
+      return \Civi::$statics[__CLASS__][$entity];
     }
-    $entityName = 'default_contribution_amount';
-    if ($entity == 'membership') {
-      $entityName = 'default_membership_type_amount';
-    }
+    $priceSetName = ($entity === 'membership') ? 'default_membership_type_amount' : 'default_contribution_amount';
 
     $sql = "
 SELECT      ps.id AS setID, pfv.price_field_id AS priceFieldID, pfv.id AS priceFieldValueID, pfv.name, pfv.label, pfv.membership_type_id, pfv.amount, pfv.financial_type_id
 FROM        civicrm_price_set ps
 LEFT JOIN   civicrm_price_field pf ON pf.`price_set_id` = ps.id
 LEFT JOIN   civicrm_price_field_value pfv ON pfv.price_field_id = pf.id
-WHERE       ps.name = '{$entityName}'
+WHERE       ps.name = '{$priceSetName}'
 ";
 
     $dao = CRM_Core_DAO::executeQuery($sql);
-    self::$_defaultPriceSet[$entity] = [];
     while ($dao->fetch()) {
-      self::$_defaultPriceSet[$entity][$dao->priceFieldValueID] = [
+      \Civi::$statics[__CLASS__][$entity][$dao->priceFieldValueID] = [
         'setID' => $dao->setID,
         'priceFieldID' => $dao->priceFieldID,
         'name' => $dao->name,
@@ -145,7 +141,7 @@ WHERE       ps.name = '{$entityName}'
       ];
     }
 
-    return self::$_defaultPriceSet[$entity];
+    return \Civi::$statics[__CLASS__][$entity];
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -14,8 +14,14 @@
  * @group headless
  */
 class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
-  protected $_params = [];
 
+  use CRMTraits_Financial_OrderTrait;
+
+  /**
+   * Set up for test.
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function setUp() {
     parent::setUp();
     $this->_ids['payment_processor'] = $this->paymentProcessorCreate();
@@ -49,14 +55,21 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     ];
   }
 
+  /**
+   * Cleanup after test.
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function teardown() {
-    $this->quickCleanup(['civicrm_contribution_recur', 'civicrm_payment_processor']);
+    $this->quickCleanUpFinancialEntities();
   }
 
   /**
    * Test that an object can be retrieved & saved (per CRM-14986).
    *
    * This has been causing a DB error so we are checking for absence of error
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testFindSave() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
@@ -71,6 +84,8 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    * Test cancellation works per CRM-14986.
    *
    * We are checking for absence of error.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCancelRecur() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
@@ -80,6 +95,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
   /**
    * Test checking if contribution recur object can allow for changes to financial types.
    *
+   * @throws \CRM_Core_Exception
    */
   public function testSupportFinancialTypeChange() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
@@ -98,6 +114,8 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
 
   /**
    * Test we don't change unintended fields on API edit
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testUpdateRecur() {
     $createParams = $this->_params;
@@ -117,6 +135,10 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
   /**
    * Check test contributions aren't picked up as template for non-test recurs
    *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testGetTemplateContributionMatchTest1() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
@@ -150,6 +172,10 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
   /**
    * Check non-test contributions aren't picked up as template for test recurs
    *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testGetTemplateContributionMatchTest() {
     $params = $this->_params;
@@ -187,6 +213,10 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
   /**
    * Test that is_template contribution is used where available
    *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testGetTemplateContributionNewTemplate() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
@@ -216,6 +246,236 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $fetchedTemplate = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionRecur['id']);
     // Fetched template should be the is_template, not the latest contrib
     $this->assertEquals($fetchedTemplate['id'], $templateContrib['id']);
+  }
+
+  /**
+   * Test to check if correct membership is auto renewed.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testAutoRenewalWhenOneMemberIsDeceased() {
+    $contactId1 = $this->individualCreate();
+    $contactId2 = $this->individualCreate();
+    $membershipOrganizationId = $this->organizationCreate();
+
+    $this->createExtraneousContribution();
+    $this->callAPISuccess('Contribution', 'create', [
+      'contact_id' => $contactId1,
+      'receive_date' => '2010-01-20',
+      'financial_type_id' => 'Member Dues',
+      'contribution_status_id' => 'Completed',
+      'total_amount' => 150,
+    ]);
+
+    // create membership type
+    $membershipTypeId1 = $this->callAPISuccess('MembershipType', 'create', [
+      'domain_id' => 1,
+      'member_of_contact_id' => $membershipOrganizationId,
+      'financial_type_id' => 'Member Dues',
+      'duration_unit' => 'month',
+      'duration_interval' => 1,
+      'period_type' => 'rolling',
+      'minimum_fee' => 100,
+      'name' => 'Parent',
+    ])['id'];
+
+    $membershipTypeID = $this->callAPISuccess('MembershipType', 'create', [
+      'domain_id' => 1,
+      'member_of_contact_id' => $membershipOrganizationId,
+      'financial_type_id' => 'Member Dues',
+      'duration_unit' => 'month',
+      'duration_interval' => 1,
+      'period_type' => 'rolling',
+      'minimum_fee' => 50,
+      'name' => 'Child',
+    ])['id'];
+
+    $contactIDs = [
+      $contactId1 => $membershipTypeId1,
+      $contactId2 => $membershipTypeID,
+    ];
+
+    $contributionRecurId = $this->callAPISuccess('contribution_recur', 'create', $this->_params)['id'];
+
+    $priceFields = CRM_Price_BAO_PriceSet::getDefaultPriceSet('membership');
+
+    // prepare order api params.
+    $params = [
+      'contact_id' => $contactId1,
+      'receive_date' => '2010-01-20',
+      'financial_type_id' => 'Member Dues',
+      'contribution_status_id' => 'Pending',
+      'contribution_recur_id' => $contributionRecurId,
+      'total_amount' => 150,
+      'api.Payment.create' => ['total_amount' => 150],
+    ];
+
+    foreach ($priceFields as $priceField) {
+      $lineItems = [];
+      $contactId = array_search($priceField['membership_type_id'], $contactIDs);
+      $lineItems[1] = [
+        'price_field_id' => $priceField['priceFieldID'],
+        'price_field_value_id' => $priceField['priceFieldValueID'],
+        'label' => $priceField['label'],
+        'field_title' => $priceField['label'],
+        'qty' => 1,
+        'unit_price' => $priceField['amount'],
+        'line_total' => $priceField['amount'],
+        'financial_type_id' => $priceField['financial_type_id'],
+        'entity_table' => 'civicrm_membership',
+        'membership_type_id' => $priceField['membership_type_id'],
+      ];
+      $params['line_items'][] = [
+        'line_item' => $lineItems,
+        'params' => [
+          'contact_id' => $contactId,
+          'membership_type_id' => $priceField['membership_type_id'],
+          'source' => 'Payment',
+          'join_date' => '2020-04-28',
+          'start_date' => '2020-04-28',
+          'contribution_recur_id' => $contributionRecurId,
+          'status_id' => 'Pending',
+          'is_override' => 1,
+        ],
+      ];
+    }
+    $order = $this->callAPISuccess('Order', 'create', $params);
+    $contributionId = $order['id'];
+    $membershipId1 = $this->callAPISuccessGetValue('Membership', [
+      'contact_id' => $contactId1,
+      'membership_type_id' => $membershipTypeId1,
+      'return' => 'id',
+    ]);
+
+    $membershipId2 = $this->callAPISuccessGetValue('Membership', [
+      'contact_id' => $contactId2,
+      'membership_type_id' => $membershipTypeID,
+      'return' => 'id',
+    ]);
+
+    // First renewal (2nd payment).
+    $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'original_contribution_id' => $contributionId,
+      'contribution_status_id' => 'Completed',
+    ]);
+
+    // Second Renewal (3rd payment).
+    $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'original_contribution_id' => $contributionId,
+      'contribution_status_id' => 'Completed',
+    ]);
+
+    // Third renewal (4th payment).
+    $this->callAPISuccess('Contribution', 'repeattransaction', ['original_contribution_id' => $contributionId, 'contribution_status_id' => 'Completed']);
+
+    // check line item and membership payment count.
+    $this->validateAllCounts($membershipId1, 4);
+    $this->validateAllCounts($membershipId2, 4);
+
+    // check membership end date.
+    foreach ([$membershipId1, $membershipId2] as $mId) {
+      $endDate = $this->callAPISuccessGetValue('Membership', [
+        'id' => $mId,
+        'return' => 'end_date',
+      ]);
+      $this->assertEquals($endDate, '2020-08-27', ts('End date incorrect.'));
+    }
+
+    // At this moment Contact 2 is deceased, but we wait until payment is recorded in civi before marking the contact deceased.
+    // At payment Gateway we update the amount from 150 to 100
+    // IPN is recorded for subsequent payment (5th payment).
+    $contribution = $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'original_contribution_id' => $contributionId,
+      'contribution_status_id' => 'Completed',
+      'total_amount' => '100',
+    ]);
+
+    // now we mark the contact2 as deceased.
+    $this->callAPISuccess('Contact', 'create', [
+      'id' => $contactId2,
+      'is_deceased' => 1,
+    ]);
+
+    // We delete latest membership payment and line item.
+    $lineItemId = $this->callAPISuccessGetValue('LineItem', [
+      'contribution_id' => $contribution['id'],
+      'entity_id' => $membershipId2,
+      'entity_table' => 'civicrm_membership',
+      'return' => 'id',
+    ]);
+
+    // No api to delete membership payment.
+    CRM_Core_DAO::executeQuery('
+      DELETE FROM civicrm_membership_payment
+      WHERE contribution_id = %1
+        AND membership_id = %2
+    ', [
+      1 => [$contribution['id'], 'Integer'],
+      2 => [$membershipId2, 'Integer'],
+    ]);
+
+    $this->callAPISuccess('LineItem', 'delete', [
+      'id' => $lineItemId,
+    ]);
+
+    // set membership recurring to null.
+    $this->callAPISuccess('Membership', 'create', [
+      'id' => $membershipId2,
+      'contribution_recur_id' => NULL,
+    ]);
+
+    // check line item and membership payment count.
+    $this->validateAllCounts($membershipId1, 5);
+    $this->validateAllCounts($membershipId2, 4);
+
+    $checkAgainst = $this->callAPISuccessGetSingle('Membership', [
+      'id' => $membershipId2,
+      'return' => ['end_date', 'status_id'],
+    ]);
+
+    // record next subsequent payment (6th payment).
+    $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'original_contribution_id' => $contributionId,
+      'contribution_status_id' => 'Completed',
+      'total_amount' => '100',
+    ]);
+
+    // check membership id 1 is renewed
+    $endDate = $this->callAPISuccessGetValue('Membership', [
+      'id' => $membershipId1,
+      'return' => 'end_date',
+    ]);
+    $this->assertEquals($endDate, '2020-10-27', ts('End date incorrect.'));
+    // check line item and membership payment count.
+    $this->validateAllCounts($membershipId1, 6);
+    $this->validateAllCounts($membershipId2, 4);
+
+    // check if membership status and end date is not changed.
+    $membership2 = $this->callAPISuccessGetSingle('Membership', [
+      'id' => $membershipId2,
+      'return' => ['end_date', 'status_id'],
+    ]);
+    $this->assertSame($membership2, $checkAgainst);
+  }
+
+  /**
+   * Check line item and membership payment count.
+   *
+   * @param int $membershipId
+   * @param int $count
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function validateAllCounts($membershipId, $count) {
+    $memPayParams = [
+      'membership_id' => $membershipId,
+    ];
+    $lineItemParams = [
+      'entity_id' => $membershipId,
+      'entity_table' => 'civicrm_membership',
+    ];
+    $this->callAPISuccessGetCount('LineItem', $lineItemParams, $count);
+    $this->callAPISuccessGetCount('MembershipPayment', $memPayParams, $count);
   }
 
 }

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -180,6 +180,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
 
   /**
    * Test IPN response updates contribution_recur & contribution for first & second contribution
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testIPNPaymentRecurSuccessSuppliedReceiveDate() {
     $this->setupRecurringPaymentProcessorTransaction();
@@ -242,6 +244,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
 
   /**
    * Test IPN response mails don't leak.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testIPNPaymentMembershipRecurSuccessNoLeakage() {
     $mut = new CiviMailUtils($this, TRUE);
@@ -377,9 +381,9 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
    */
   public function getRecurTransaction($params = []) {
     return array_merge([
-      "x_amount" => "200.00",
+      'x_amount' => '200.00',
       "x_country" => 'US',
-      "x_phone" => "",
+      'x_phone' => "",
       "x_fax" => "",
       "x_email" => "me@gmail.com",
       "x_description" => "lots of money",

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -28,7 +28,7 @@ trait CRMTraits_Financial_OrderTrait {
     $this->ids['contact'][0] = $this->individualCreate();
     $this->ids['membership_type'][0] = $this->membershipTypeCreate();
 
-    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge([
+    $contributionRecur = $this->callAPISuccess('ContributionRecur', 'create', array_merge([
       'contact_id' => $this->_contactID,
       'amount' => 1000,
       'sequential' => 1,
@@ -97,7 +97,7 @@ trait CRMTraits_Financial_OrderTrait {
    */
   protected function createExtraneousContribution() {
     $this->contributionCreate([
-      'contact_id' => $this->_contactID,
+      'contact_id' => $this->individualCreate(),
       'is_test' => 1,
       'financial_type_id' => 1,
       'invoice_id' => 'abcd',


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/16826

Before
----------------------------------------
The code was correctly calculating the contribution to use as a template, but allowing a different contribution to be the potential line item source

After
----------------------------------------
line items retrieved from template contribution

Technical Details
----------------------------------------


Comments
----------------------------------------
@pradpnayak I've taken your test but am using a different fix which bypasses rather than changes the code you were touching

