### PR TITLE
Fix admin page url for "conference slots" option values

### DIFF
--- a/CRM/Event/xml/Menu/Event.xml
+++ b/CRM/Event/xml/Menu/Event.xml
@@ -134,11 +134,10 @@
      <weight>399</weight>
   </item>
   <item>
-     <path>civicrm/admin/conference_slots</path>
+     <path>civicrm/admin/options/conference_slot</path>
      <title>Conference Slot Labels</title>
      <page_callback>CRM_Admin_Page_Options</page_callback>
      <desc>Define conference slots and labels.</desc>
-     <path_arguments>group=conference_slot</path_arguments>
      <access_arguments>administer CiviCRM,access CiviEvent</access_arguments>
      <adminGroup>CiviEvent</adminGroup>
      <weight>415</weight>


### PR DESCRIPTION
Overview
----------------------------------------
I admit I have no idea what it's for but there's a link on the administration console page for Conference Slot Labels that has the wrong url.

![Untitled](https://user-images.githubusercontent.com/2967821/80898624-a0ae7f80-8cd3-11ea-8970-f5271bf9d429.gif)


Before
----------------------------------------
Link redirects to the list of option groups.

After
----------------------------------------
Link goes to the conference slot labels options.

Technical Details
----------------------------------------
Wrong. Link.

Comments
----------------------------------------

