### PR TITLE
[NFC] Test cleanup

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -409,8 +409,10 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    *   Parameters that should be overriden. Add unit tests if using parameters other than total_amount & financial_type_id.
    *
    * @return array
+   *
    * @throws \CiviCRM_API3_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
+   * @throws \API_Exception
    */
   public static function getTemplateContribution($id, $overrides = []) {
     // use api3 because api4 doesn't handle ContributionRecur yet...


### PR DESCRIPTION
Overview
----------------------------------------
Test cleanup, also involves fixing some tests where some of the contributions are malformed, but using Contribution.repeattransaction to get them right 

Before
----------------------------------------
In some tests the second contribution is created with line items that have the table as contribution rather than membership - locking in a bug

After
----------------------------------------
Tests have legitimately formed contributions

Technical Details
----------------------------------------
Test set up issue is apparent when the line items are fixed per https://github.com/civicrm/civicrm-core/pull/17220

Comments
----------------------------------------
