### PR TITLE
Fix adding languages in multilingual

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -161,10 +161,10 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
 
     //cache contact fields retaining localized titles
     //though we changed localization, so reseting cache.
-    Civi::cache('fields')->flush();
+    Civi::cache('fields')->clear();
 
     //CRM-8559, cache navigation do not respect locale if it is changed, so reseting cache.
-    Civi::cache('navigation')->flush();
+    Civi::cache('navigation')->clear();
     // reset ACL and System caches
     CRM_Core_BAO_Cache::resetCaches();
 

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -168,23 +168,6 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     // reset ACL and System caches
     CRM_Core_BAO_Cache::resetCaches();
 
-    // we do this only to initialize monetary decimal point and thousand separator
-    $config = CRM_Core_Config::singleton();
-
-    // save enabled currencies and default currency in option group 'currencies_enabled'
-    // CRM-1496
-    if (empty($values['currencyLimit'])) {
-      $values['currencyLimit'] = [$values['defaultCurrency']];
-    }
-    elseif (!in_array($values['defaultCurrency'], $values['currencyLimit'])) {
-      $values['currencyLimit'][] = $values['defaultCurrency'];
-    }
-
-    self::updateEnabledCurrencies($values['currencyLimit'], $values['defaultCurrency']);
-
-    // unset currencyLimit so we dont store there
-    unset($values['currencyLimit']);
-
     // make the site multi-lang if requested
     if (!empty($values['makeMultilingual'])) {
       CRM_Core_I18n_Schema::makeMultilingual($values['lcMessages']);
@@ -213,6 +196,21 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
 
     // if we manipulated the language list, return to the localization admin screen
     $return = (bool) (CRM_Utils_Array::value('makeMultilingual', $values) or CRM_Utils_Array::value('addLanguage', $values));
+
+    // Update enabled currencies
+    // we do this only to initialize monetary decimal point and thousand separator
+    $config = CRM_Core_Config::singleton();
+    // save enabled currencies and default currency in option group 'currencies_enabled'
+    // CRM-1496
+    if (empty($values['currencyLimit'])) {
+      $values['currencyLimit'] = [$values['defaultCurrency']];
+    }
+    elseif (!in_array($values['defaultCurrency'], $values['currencyLimit'])) {
+      $values['currencyLimit'][] = $values['defaultCurrency'];
+    }
+    self::updateEnabledCurrencies($values['currencyLimit'], $values['defaultCurrency']);
+    // unset currencyLimit so we dont store there
+    unset($values['currencyLimit']);
 
     $filteredValues = $values;
     unset($filteredValues['makeMultilingual']);

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -439,8 +439,6 @@ WHERE  v.option_group_id = g.id
 
   /**
    * Creates a new option group with the passed in values.
-   * @TODO: Should update the group if it already exists intelligently, so multi-lingual is
-   * not messed up. Currently deletes the old group
    *
    * @param string $groupName
    *   The name of the option group - make sure there is no conflict.
@@ -464,10 +462,10 @@ WHERE  v.option_group_id = g.id
    *   the option group ID
    */
   public static function createAssoc($groupName, &$values, &$defaultID, $groupTitle = NULL) {
-    self::deleteAssoc($groupName);
     if (!empty($values)) {
       $group = new CRM_Core_DAO_OptionGroup();
       $group->name = $groupName;
+      $group->find(TRUE);
       $group->title = empty($groupTitle) ? $groupName : $groupTitle;
       $group->is_reserved = 1;
       $group->is_active = 1;
@@ -476,8 +474,9 @@ WHERE  v.option_group_id = g.id
       foreach ($values as $v) {
         $value = new CRM_Core_DAO_OptionValue();
         $value->option_group_id = $group->id;
-        $value->label = $v['label'];
         $value->value = $v['value'];
+        $value->find(TRUE);
+        $value->label = $v['label'];
         $value->name = $v['name'] ?? NULL;
         $value->description = $v['description'] ?? NULL;
         $value->weight = $v['weight'] ?? NULL;
@@ -502,8 +501,11 @@ WHERE  v.option_group_id = g.id
    * @param $values
    * @param bool $flip
    * @param string $field
+   *
+   * @deprecated
    */
   public static function getAssoc($groupName, &$values, $flip = FALSE, $field = 'name') {
+    CRM_Core_Error::deprecatedFunctionWarning('unused function');
     $query = "
 SELECT v.id as amount_id, v.value, v.label, v.name, v.description, v.weight
   FROM civicrm_option_group g,
@@ -546,8 +548,11 @@ ORDER BY v.weight
   /**
    * @param string $groupName
    * @param string $operator
+   *
+   * @deprecated
    */
   public static function deleteAssoc($groupName, $operator = "=") {
+    CRM_Core_Error::deprecatedFunctionWarning('unused function');
     $query = "
 DELETE g, v
   FROM civicrm_option_group g,


### PR DESCRIPTION
Overview
----------------------------------------
Adding or removing a language when multilingual is enabled fails with a DB error. This is because it deletes the "currenciesEnabled" optiongroup and values and then tries to recreate them - but in multilingual this fails because label is a required field in optionvalue for all languages but each language query will try and run a query that adds/updates an entry for it's own language (leaving a required field not set for the other language labels).

Before
----------------------------------------
Issues adding/removing languages in multilingual.

After
----------------------------------------
- Languages can be added/removed.
- Updating optionGroup/optionValues now tries to update instead of blindly deleting first.
- `currenciesEnabled` is only updated AFTER enabling/disabling multilingual - it doesn't make sense to try to do this before.

Technical Details
----------------------------------------
We use the DAO `find()` method to find existing optiongroup/values and update them.

Comments
----------------------------------------
@mlutfy @aydun @MikeyMJCO Testing welcome :-)