### PR TITLE
(dev/core#1740) Cumulative contributions not being calculated with th…

### DIFF
--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -245,7 +245,7 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
           'name' => ts('Cumulative'),
           'title' => ts('Cumulative'),
           'url' => $urlString,
-          'qs' => "{$urlParams}&receive_date_low=&receive_date_high=$now",
+          'qs' => "{$urlParams}",
           'uniqueName' => 'cumulative',
         ),
       );


### PR DESCRIPTION
…e correct criteria

Overview
----------------------------------------
This is a regression in CiviCRM. I have confirmed the same in dmaster.

Steps to replicate:

* Go to Contributions > Online Contribution Pages > Contributions > Cumulative
* Check the criteria for Date Receipt, it doesn't account for **end of** today's date but the start of today and all the contributions done today will NOT be listed.

Before
----------------------------------------
![dmaster](https://user-images.githubusercontent.com/3455173/80978386-990de880-8e43-11ea-9a6b-2ae4583b65a3.png)


After
----------------------------------------
shows all contributions made through the chosen page