### PR TITLE
(REF,NFC) TokenProcessor - Minor DX improvements

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -115,9 +115,12 @@ class TokenProcessor {
   /**
    * Add a row of data.
    *
+   * @param array|NULL $context
+   *   Optionally, initialize the context for this row.
+   *   Ex: ['contact_id' => 123].
    * @return TokenRow
    */
-  public function addRow() {
+  public function addRow($context = NULL) {
     $key = $this->next++;
     $this->rowContexts[$key] = [];
     $this->rowValues[$key] = [
@@ -125,7 +128,29 @@ class TokenProcessor {
       'text/html' => [],
     ];
 
-    return new TokenRow($this, $key);
+    $row = new TokenRow($this, $key);
+    if ($context !== NULL) {
+      $row->context($context);
+    }
+    return $row;
+  }
+
+  /**
+   * Add several rows.
+   *
+   * @param array $contexts
+   *   List of rows to add.
+   *   Ex: [['contact_id'=>123], ['contact_id'=>456]]
+   * @return TokenRow[]
+   *   List of row objects
+   */
+  public function addRows($contexts) {
+    $rows = [];
+    foreach ($contexts as $context) {
+      $row = $this->addRow($context);
+      $rows[$row->tokenRow] = $row;
+    }
+    return $rows;
   }
 
   /**

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -5,60 +5,98 @@ namespace Civi\Token;
  * Class TokenRow
  * @package Civi\Token
  *
- * A TokenRow is a helper providing simplified access to the
- * TokenProcessor.
+ * A TokenRow is a helper/stub providing simplified access to the TokenProcessor.
+ * There are two common cases for using the TokenRow stub:
  *
- * A TokenRow combines two elements:
- *   - context: This is backend data provided by the controller.
- *   - tokens: This is frontend data that can be mail-merged.
- *
- * The context and tokens can be accessed using either methods
- * or attributes. The methods are appropriate for updates
- * (and generally accept a mix of arrays), and the attributes
- * are appropriate for reads.
- *
- * To update the context or the tokens, use the methods.
- * Note that the methods are fairly flexible about accepting
- * single values or arrays. If given an array, the values
- * will be merged recursively.
+ * (1) When setting up a job, you may specify general/baseline info.
+ * This is called the "context" data. Here, we create two rows:
  *
  * @code
- * $row
- *   ->context('contact_id', 123)
- *   ->context(array('contact_id' => 123))
- *   ->tokens('profile', array('viewUrl' => 'http://example.com'))
- *   ->tokens('profile', 'viewUrl, 'http://example.com');
+ * $proc->addRow()->context('contact_id', 123);
+ * $proc->addRow()->context('contact_id', 456);
+ * @endCode
  *
+ * (2) When defining a token (eg `{profile.viewUrl}`), you might read the
+ * context-data (`contact_id`) and set the token-data (`profile => viewUrl`):
+ *
+ * @code
+ * foreach ($proc->getRows() as $row) {
+ *   $row->tokens('profile', [
+ *     'viewUrl' => 'http://example.com/profile?cid=' . urlencode($row->context['contact_id'];
+ *   ]);
+ * }
+ * @endCode
+ *
+ * The context and tokens can be accessed using either methods or attributes.
+ *
+ * @code
+ * # Setting context data
+ * $row->context('contact_id', 123);
+ * $row->context(['contact_id' => 123]);
+ *
+ * # Setting token data
+ * $row->tokens('profile', ['viewUrl' => 'http://example.com/profile?cid=123']);
+ * $row->tokens('profile', 'viewUrl, 'http://example.com/profile?cid=123');
+ *
+ * # Reading context data
  * echo $row->context['contact_id'];
- * echo $row->tokens['profile']['viewUrl'];
  *
- * $row->tokens('profile', array(
- *   'viewUrl' => 'http://example.com/view/' . urlencode($row->context['contact_id'];
- * ));
- * @endcode
+ * # Reading token data
+ * echo $row->tokens['profile']['viewUrl'];
+ * @endCode
+ *
+ * Note: The methods encourage a "fluent" style. They were written for PHP 5.3
+ * (eg before short-array syntax was supported) and are fairly flexible about
+ * input notations (e.g. `context(string $key, mixed $value)` vs `context(array $keyValuePairs)`).
+ *
+ * Note: An instance of `TokenRow` is a stub which only contains references to the
+ * main data in `TokenProcessor`. There may be several `TokenRow` stubs
+ * referencing the same `TokenProcessor`. You can think of `TokenRow` objects as
+ * lightweight and disposable.
  */
 class TokenRow {
 
   /**
+   * The token-processor is where most data is actually stored.
+   *
+   * Note: Not intended for public usage. However, this is marked public to allow
+   * interaction classes in this package (`TokenProcessor`<=>`TokenRow`<=>`TokenRowContext`).
+   *
    * @var TokenProcessor
    */
   public $tokenProcessor;
 
+  /**
+   * Row ID - the record within TokenProcessor that we're accessing.
+   *
+   * @var int
+   */
   public $tokenRow;
 
+  /**
+   * The MIME type associated with new token-values.
+   *
+   * This is generally manipulated as part of a fluent chain, eg
+   *
+   * $row->format('text/plain')->token(['display_name', 'Alice Bobdaughter']);
+   *
+   * @var string
+   */
   public $format;
 
   /**
    * @var array|\ArrayAccess
    *   List of token values.
-   *   Ex: array('contact' => array('display_name' => 'Alice')).
+   *   This is a facade for the TokenProcessor::$rowValues.
+   *   Ex: ['contact' => ['display_name' => 'Alice']]
    */
   public $tokens;
 
   /**
    * @var array|\ArrayAccess
    *   List of context values.
-   *   Ex: array('controller' => 'CRM_Foo_Bar').
+   *   This is a facade for the TokenProcessor::$rowContexts.
+   *   Ex: ['controller' => 'CRM_Foo_Bar']
    */
   public $context;
 

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -31,6 +31,45 @@ class TokenProcessorTest extends \CiviUnitTestCase {
   }
 
   /**
+   * Test that a row can be added via "addRow(array $context)".
+   */
+  public function testAddRow() {
+    $p = new TokenProcessor($this->dispatcher, [
+      'controller' => __CLASS__,
+    ]);
+    $createdRow = $p->addRow(['one' => 'Apple'])
+      ->context('two', 'Banana');
+    $gotRow = $p->getRow(0);
+    foreach ([$createdRow, $gotRow] as $row) {
+      $this->assertEquals('Apple', $row->context['one']);
+      $this->assertEquals('Banana', $row->context['two']);
+    }
+  }
+
+  /**
+   * Test that multiple rows can be added via "addRows(array $contexts)".
+   */
+  public function testAddRows() {
+    $p = new TokenProcessor($this->dispatcher, [
+      'controller' => __CLASS__,
+    ]);
+    $createdRows = $p->addRows([
+      ['one' => 'Apple', 'two' => 'Banana'],
+      ['one' => 'Pomme', 'two' => 'Banane'],
+    ]);
+    $gotRow0 = $p->getRow(0);
+    foreach ([$createdRows[0], $gotRow0] as $row) {
+      $this->assertEquals('Apple', $row->context['one']);
+      $this->assertEquals('Banana', $row->context['two']);
+    }
+    $gotRow1 = $p->getRow(1);
+    foreach ([$createdRows[1], $gotRow1] as $row) {
+      $this->assertEquals('Pomme', $row->context['one']);
+      $this->assertEquals('Banane', $row->context['two']);
+    }
+  }
+
+  /**
    * Check that the TokenRow helper can correctly read/update context
    * values.
    */


### PR DESCRIPTION
Overview
----------------------------------------
This makes a few small improvements to the developer experience in the `TokenProcessor`.

Before
----------------------------------------
* Less docblocks
* When adding a recipient/target, the contextual data (eg `contact_id`) should be specified with a fluent-OOP interface. This does some autocompleting/docblocks, but it's less familiar to Civi dev's, and it requires a few extra SLOC when processing data from another source.

   ```php
   $p->addRow()->context('contact_id', 123);
   $p->addRow()->context('contact_id', 456);
   $p->addRow()->context('contact_id', 789);
   ```

After
----------------------------------------
* More docblocks
* When adding a recipient/target, the contextual data (eg `contact_id`) may optionally/alternatively be specified w/less OOP-y interface (`addRow()` or `addRows()`).

   ```php
   $p->addRow(['contact_id' => 123]);
   $p->addRow(['contact_id' => 456]);
   $p->addRow(['contact_id' => 789]);

   // or...

   $cids = [123, 456, 789];
   $p->addRows(array_map(fn($cid) => ['contact_id' => $cid], $cids));
   ```


Comments
----------------------------------------

@eileenmcnaughton 