### PR TITLE
dev/core#1742 Expose CiviCRM Database details for views configuration…

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -56,9 +56,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
       }
     }
 
-    if (
-      function_exists('module_exists') &&
-      module_exists('views') &&
+    if ($config->userSystem->viewsExists() &&
       (
         $config->dsn != $config->userFrameworkDSN || !empty($drupal_prefix)
       )

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -986,4 +986,13 @@ abstract class CRM_Utils_System_Base {
     return NULL;
   }
 
+  /**
+   * Determine if the Views module exists.
+   *
+   * @return bool
+   */
+  public function viewsExists() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -803,4 +803,16 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return user_role_names();
   }
 
+  /**
+   * Determine if the Views module exists.
+   *
+   * @return bool
+   */
+  public function viewsExists() {
+    if (\Drupal::moduleHandler()->moduleExists('views')) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -687,4 +687,16 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return array_combine(user_roles(), user_roles());
   }
 
+  /**
+   * Determine if the Views module exists.
+   *
+   * @return bool
+   */
+  public function viewsExists() {
+    if (function_exists('module_exists') && module_exists('views')) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }


### PR DESCRIPTION
… in Drupal 8 as well as in Drupal 7 and Backdrop

Overview
----------------------------------------
This exposes the necessary database configuration needed to be added to settings.php for views to work with CiviCRM tables when CiviCRM is in a different schema for Drupal 8 as well as Drupal 7 and Backdrop

Before
----------------------------------------
Views DB config only showing on Drupal 7 and Backdrop

After
----------------------------------------
Views DB config shows on Drupal 8/7 and Backdrop

ping @MikeyMJCO @jackrabbithanna 