### PR TITLE
Reporting #20 - correct stats when force=1 on Contribution Detail Report

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -183,6 +183,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
                 'soft_credits_only' => ts('Soft Credits Only'),
                 'both' => ts('Both'),
               ],
+              'default' => 'contributions_only',
             ],
             'receive_date' => ['operatorType' => CRM_Report_Form::OP_DATE],
             'receipt_date' => ['operatorType' => CRM_Report_Form::OP_DATE],
@@ -534,7 +535,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
       $this->noDisplayContributionOrSoftColumn = TRUE;
     }
 
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params, 'contributions_only') == 'contributions_only') {
+    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) == 'contributions_only') {
       $this->isContributionBaseMode = TRUE;
     }
     if ($this->isContributionBaseMode &&


### PR DESCRIPTION
https://lab.civicrm.org/dev/report/issues/20

Overview
----------------------------------------
When a contribution has multiple soft credits, this causes the Contribution Detail Report to be incorrect.  My previous fix, #15315, fixed the problem for the rows but not the statistics.  This fixes it for both.

Steps to replicate:
* Create a contribution with two soft credits.
* Run the contribution detail report with `force=1`: http://dmaster.localhost/civicrm/report/contribute/detail?force=1
* Note the (incorrect) total amount.
* Without changing anything, press "Refresh Results".
* Note that even though no settings have changed, the total amount is now lower (and correct).

Before
----------------------------------------
Incorrect statistics.

After
----------------------------------------
Statistics are correct.

Technical Details
----------------------------------------
The heart of the issue is that most filters, when untouched, are blank/null.  However, "Contributions or Soft Credits" can never be null, because there's no null value.  However, that's only true when the form is loaded; when the form isn't loaded (i.e. with `force=1`), the value is `NULL`.  That causes `force=1` to return different results.  By setting the default explicitly, this is avoided.  I also revert my old fix, which treats a `NULL` as `contributions_only`, since this only fixes rows and not statistics.