### PR TITLE
APIv4 - Deprecate option_value joins and display notices in Explorer

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -608,7 +608,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *
    * @param string $prefix
    *
-   * @return Log
+   * @return Log_file
    */
   public static function createDebugLogger($prefix = '') {
     self::generateLogFileName($prefix);

--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -18,6 +18,11 @@
 class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
 
   /**
+   * @var array
+   */
+  public $map;
+
+  /**
    * CRM_Core_Error_Log constructor.
    */
   public function __construct() {

--- a/Civi.php
+++ b/Civi.php
@@ -75,7 +75,7 @@ class Civi {
   }
 
   /**
-   * @return \Psr\Log\LoggerInterface
+   * @return \CRM_Core_Error_Log
    */
   public static function log() {
     return Civi\Core\Container::singleton()->get('psr_log');

--- a/Civi/API/LogObserver.php
+++ b/Civi/API/LogObserver.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace Civi\API;
+
+/**
+ * API Error Log Observer
+ *
+ * @see \CRM_Core_Error_Log
+ * @see \Civi\API\Subscriber\DebugSubscriber
+ *
+ * @package Civi\API
+ */
+class LogObserver extends \Log_observer {
+
+  /**
+   * @var array
+   */
+  private static $messages = [];
+
+  /**
+   * @see \Log::_announce
+   * @param array $event
+   */
+  public function notify($event) {
+    $levels = \Civi::log()->map;
+    $event['level'] = array_search($event['priority'], $levels);
+    // Extract [civi.tag] from message string
+    // As noted in \CRM_Core_Error_Log::log() the $context array gets prematurely converted to string with print_r() so we have to un-flatten it here
+    if (preg_match('/^(.*)\s*Array\s*\(\s*\[civi\.(\w+)] => (\w+)\s*\)/', $event['message'], $message)) {
+      $event['message'] = $message[1];
+      $event[$message[2]] = $message[3];
+    }
+    self::$messages[] = $event;
+  }
+
+  /**
+   * @return array
+   */
+  public function getMessages() {
+    return self::$messages;
+  }
+
+}

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -16,6 +16,7 @@ use Civi\Api4\Event\Events;
 use Civi\Api4\Event\PostSelectQueryEvent;
 use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Civi\Api4\Service\Schema\Joinable\OptionValueJoinable;
 use Civi\Api4\Utils\FormattingUtil;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\SelectUtil;
@@ -428,6 +429,9 @@ class Api4SelectQuery extends SelectQuery {
     foreach ($joinPath as $joinable) {
       if ($joinable->getJoinType() === Joinable::JOIN_TYPE_ONE_TO_MANY) {
         $isMany = TRUE;
+      }
+      if ($joinable instanceof OptionValueJoinable) {
+        \Civi::log()->warning('Use API pseudoconstant suffix like :name or :label instead of join.', ['civi.tag' => 'deprecated']);
       }
     }
 

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -410,7 +410,7 @@ class Container {
       \CRM_Utils_API_ReloadOption::singleton(),
       \CRM_Utils_API_MatchOption::singleton(),
     ]));
-    $dispatcher->addSubscriber(new \Civi\API\Subscriber\XDebugSubscriber());
+    $dispatcher->addSubscriber(new \Civi\API\Subscriber\DebugSubscriber());
     $kernel = new \Civi\API\Kernel($dispatcher);
 
     $reflectionProvider = new \Civi\API\Provider\ReflectionProvider($kernel);

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -169,7 +169,7 @@
       </div>
   </div>
   <div class="api4-explorer-row">
-      <div class="panel panel-warning explorer-code-panel">
+      <div class="panel panel-info explorer-code-panel">
         <ul class="panel-heading nav nav-tabs">
           <li role="presentation" ng-repeat="lang in ::langs" ng-class="{active: selectedTab.code === lang}">
             <a href ng-click="selectLang(lang)">
@@ -193,15 +193,16 @@
               <span ng-switch="status">
                 <i class="fa fa-fw fa-circle-o" ng-switch-when="default"></i>
                 <i class="fa fa-fw fa-check-circle" ng-switch-when="success"></i>
+                <i class="fa fa-fw fa-check-circle" ng-switch-when="warning"></i>
                 <i class="fa fa-fw fa-minus-circle" ng-switch-when="danger"></i>
-                <i class="fa fa-fw fa-spinner fa-pulse" ng-switch-when="warning"></i>
+                <i class="fa fa-fw fa-spinner fa-pulse" ng-switch-when="info"></i>
               </span>
               <span>{{:: ts('Result') }}</span>
             </a>
           </li>
           <li role="presentation" ng-if="::perm.accessDebugOutput" ng-class="{active: selectedTab.result === 'debug'}">
             <a href ng-click="selectedTab.result = 'debug'">
-              <i class="fa fa-fw fa-{{ debug ? 'bug' : 'circle-o' }}"></i>
+              <i class="fa fa-fw fa-{{ debug ? (status === 'warning' || status === 'danger' ? 'warning' : 'bug') : 'circle-o' }}"></i>
               <span>{{:: ts('Debug') }}</span>
             </a>
           </li>

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -669,7 +669,7 @@
     }
 
     $scope.execute = function() {
-      $scope.status = 'warning';
+      $scope.status = 'info';
       $scope.loading = true;
       $http.post(CRM.url('civicrm/ajax/api4/' + $scope.entity + '/' + $scope.action, {
         params: angular.toJson(getParams()),
@@ -680,7 +680,7 @@
         }
       }).then(function(resp) {
           $scope.loading = false;
-          $scope.status = 'success';
+          $scope.status = resp.data && resp.data.debug && resp.data.debug.log ? 'warning' : 'success';
           $scope.debug = debugFormat(resp.data);
           $scope.result = [formatMeta(resp.data), prettyPrintOne(_.escape(JSON.stringify(resp.data.values, null, 2)), 'js', 1)];
         }, function(resp) {

--- a/tests/phpunit/api/v4/Action/ComplexQueryTest.php
+++ b/tests/phpunit/api/v4/Action/ComplexQueryTest.php
@@ -50,7 +50,7 @@ class ComplexQueryTest extends UnitTestCase {
   public function testGetAllHousingSupportActivities() {
     $results = Activity::get()
       ->setCheckPermissions(FALSE)
-      ->addWhere('activity_type.name', '=', 'Phone Call')
+      ->addWhere('activity_type_id:name', '=', 'Phone Call')
       ->execute();
 
     $this->assertGreaterThan(0, count($results));

--- a/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
@@ -99,16 +99,16 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $result = Contact::get()
       ->setCheckPermissions(FALSE)
       ->addSelect('first_name')
-      ->addSelect("$group.$colorField.label")
-      ->addSelect("$group.$foodField.label")
+      ->addSelect("$group.$colorField:label")
+      ->addSelect("$group.$foodField:label")
       ->addSelect('FinancialStuff.Salary')
-      ->addWhere("$group.$foodField.label", 'IN', ['Corn', 'Potatoes'])
+      ->addWhere("$group.$foodField:label", 'IN', ['Corn', 'Potatoes'])
       ->addWhere('FinancialStuff.Salary', '>', '10000')
       ->execute()
       ->first();
 
-    $this->assertEquals('Red', $result["$group.$colorField.label"]);
-    $this->assertEquals('Corn', $result["$group.$foodField.label"]);
+    $this->assertEquals('Red', $result["$group.$colorField:label"]);
+    $this->assertEquals('Corn', $result["$group.$foodField:label"]);
     $this->assertEquals(50000, $result['FinancialStuff.Salary']);
   }
 
@@ -183,10 +183,10 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->setCheckPermissions(FALSE)
       ->addSelect('first_name')
       ->addSelect('last_name')
-      ->addSelect("$group.$colorField.label")
-      ->addSelect("$group.$foodField.label")
+      ->addSelect("$group.$colorField:label")
+      ->addSelect("$group.$foodField:label")
       ->addSelect('FinancialStuff.Salary')
-      ->addWhere("$group.$foodField.label", 'IN', ['Corn', 'Cheese'])
+      ->addWhere("$group.$foodField:label", 'IN', ['Corn', 'Cheese'])
       ->execute();
 
     $blueCheese = NULL;
@@ -196,8 +196,8 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       }
     }
 
-    $this->assertEquals('Blue', $blueCheese["$group.$colorField.label"]);
-    $this->assertEquals('Cheese', $blueCheese["$group.$foodField.label"]);
+    $this->assertEquals('Blue', $blueCheese["$group.$colorField:label"]);
+    $this->assertEquals('Cheese', $blueCheese["$group.$foodField:label"]);
     $this->assertEquals(500000, $blueCheese['FinancialStuff.Salary']);
   }
 

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -49,7 +49,7 @@ class FkJoinTest extends UnitTestCase {
   public function testThreeLevelJoin() {
     $results = Activity::get()
       ->setCheckPermissions(FALSE)
-      ->addWhere('activity_type.name', '=', 'Phone Call')
+      ->addWhere('activity_type_id:name', '=', 'Phone Call')
       ->execute();
 
     $this->assertCount(1, $results);

--- a/tests/phpunit/api/v4/Entity/ContactInterchangeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactInterchangeTest.php
@@ -217,7 +217,7 @@ class ContactInterchangeTest extends UnitTestCase implements TransactionalInterf
 
   public function readNameByActSubjectJoin_4($cid, $strs) {
     $get = ActivityContact::get()
-      ->addWhere('activity_contacts.label', '=', 'Activity Source')
+      ->addWhere('record_type_id:label', '=', 'Activity Source')
       ->addWhere('activity.subject', '=', $strs['api'])
       ->addSelect('contact.first_name')
       ->execute();
@@ -226,7 +226,7 @@ class ContactInterchangeTest extends UnitTestCase implements TransactionalInterf
 
   public function readNameByActSubjectChain_4($cid, $strs) {
     $get = ActivityContact::get()
-      ->addWhere('activity_contacts.label', '=', 'Activity Source')
+      ->addWhere('record_type_id:label', '=', 'Activity Source')
       ->addWhere('activity.subject', '=', $strs['api'])
       ->setSelect(['activity_id', 'contact_id'])
       ->setChain([
@@ -269,7 +269,7 @@ class ContactInterchangeTest extends UnitTestCase implements TransactionalInterf
 
   public function readNameByActDetailsJoin_4($cid, $strs) {
     $get = ActivityContact::get()
-      ->addWhere('activity_contacts.label', '=', 'Activity Source')
+      ->addWhere('record_type_id:label', '=', 'Activity Source')
       ->addWhere('activity.details', '=', $strs['api'])
       ->addSelect('contact.first_name')
       ->execute();
@@ -278,7 +278,7 @@ class ContactInterchangeTest extends UnitTestCase implements TransactionalInterf
 
   public function readNameByActDetailsChain_4($cid, $strs) {
     $get = ActivityContact::get()
-      ->addWhere('activity_contacts.label', '=', 'Activity Source')
+      ->addWhere('record_type_id:label', '=', 'Activity Source')
       ->addWhere('activity.details', '=', $strs['api'])
       ->setSelect(['activity_id', 'contact_id'])
       ->setChain([

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -84,7 +84,7 @@ class ContactJoinTest extends UnitTestCase {
 
   public function testJoinToPCMOptionValueWillShowLabel() {
     $options = OptionValue::get()
-      ->addWhere('option_group.name', '=', 'preferred_communication_method')
+      ->addWhere('option_group_id:name', '=', 'preferred_communication_method')
       ->execute()
       ->getArrayCopy();
 
@@ -109,14 +109,11 @@ class ContactJoinTest extends UnitTestCase {
 
     $fetchedContact = Contact::get()
       ->addWhere('id', 'IN', $contactIds)
-      ->addSelect('preferred_communication_method.label')
+      ->addSelect('preferred_communication_method:label')
       ->execute()
       ->first();
 
-    $preferredMethod = $fetchedContact['preferred_communication_method'];
-    $returnedLabels = array_column($preferredMethod, 'label');
-
-    $this->assertEquals($labels, $returnedLabels);
+    $this->assertEquals($labels, $fetchedContact['preferred_communication_method:label']);
   }
 
 }

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryComplexJoinTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryComplexJoinTest.php
@@ -54,7 +54,7 @@ class Api4SelectQueryComplexJoinTest extends UnitTestCase {
     $query->select[] = 'emails.location_type.name';
     $query->select[] = 'created_activities.contact_id';
     $query->select[] = 'created_activities.activity.subject';
-    $query->select[] = 'created_activities.activity.activity_type.name';
+    $query->select[] = 'created_activities.activity.activity_type_id:name';
     $query->where[] = ['first_name', '=', 'Single'];
     $query->where[] = ['id', '=', $this->getReference('test_contact_1')['id']];
     $results = $query->run();
@@ -72,9 +72,7 @@ class Api4SelectQueryComplexJoinTest extends UnitTestCase {
     $this->assertArrayHasKey('activity', $firstCreatedActivity);
     $firstActivity = $firstCreatedActivity['activity'];
     $this->assertContains($firstActivity['subject'], $activitySubjects);
-    $this->assertArrayHasKey('activity_type', $firstActivity);
-    $activityType = $firstActivity['activity_type'];
-    $this->assertArrayHasKey('name', $activityType);
+    $this->assertArrayHasKey('activity_type_id:name', $firstActivity);
 
     $this->assertArrayHasKey('name', $firstResult['emails'][0]['location_type']);
     $this->assertArrayHasKey('location_type_id', $firstResult['phones'][0]);

--- a/tests/phpunit/api/v4/Query/OneToOneJoinTest.php
+++ b/tests/phpunit/api/v4/Query/OneToOneJoinTest.php
@@ -50,14 +50,14 @@ class OneToOneJoinTest extends UnitTestCase {
 
     $contacts = Contact::get()
       ->addWhere('id', 'IN', [$armenianContact['id'], $basqueContact['id']])
-      ->addSelect('preferred_language.label')
+      ->addSelect('preferred_language:label')
       ->addSelect('last_name')
       ->execute()
       ->indexBy('last_name')
       ->getArrayCopy();
 
-    $this->assertEquals($contacts['One']['preferred_language.label'], 'Armenian');
-    $this->assertEquals($contacts['Two']['preferred_language.label'], 'Basque');
+    $this->assertEquals($contacts['One']['preferred_language:label'], 'Armenian');
+    $this->assertEquals($contacts['Two']['preferred_language:label'], 'Basque');
   }
 
 }

--- a/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
+++ b/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
@@ -51,18 +51,18 @@ class OptionValueJoinTest extends UnitTestCase {
     $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
     $query = new Api4SelectQuery($api);
     $query->select[] = 'first_name';
-    $query->select[] = 'preferred_communication_method.label';
+    $query->select[] = 'preferred_communication_method:label';
     $query->where[] = ['preferred_communication_method', 'IS NOT NULL'];
     $results = $query->run();
     $first = array_shift($results);
     $keys = array_keys($first);
     sort($keys);
-    $this->assertEquals(['first_name', 'id', 'preferred_communication_method'], $keys);
-    $firstPreferredMethod = array_shift($first['preferred_communication_method']);
+    $this->assertEquals(['first_name', 'id', 'preferred_communication_method:label'], $keys);
+    $firstPreferredMethod = array_shift($first['preferred_communication_method:label']);
 
     $this->assertEquals(
       'Phone',
-      $firstPreferredMethod['label']
+      $firstPreferredMethod
     );
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Deprecates old way of joining on option values in favor of pseudoconstant lookups in APIv4. Displays those deprecation notices in the API Explorer.

Before
----------------------------------------
No deprecation notices.

After
----------------------------------------
Deprecation notices triggered and displayed in API Explorer.
