### PR TITLE
dev/core#1739 Enable Longitude on Address editing by default (option 12)

### DIFF
--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -99,7 +99,7 @@ return [
     'pseudoconstant' => [
       'optionGroupName' => 'address_options',
     ],
-    'default' => '123456891011',
+    'default' => '12345689101112',
     'add' => '4.1',
     'title' => ts('Address Fields'),
     'is_domain' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
This enables the Longitude Field on Address Editing by default for new installs

Before
----------------------------------------
Latitude field enabled but Longitude field not enabled on Address Editing

<img width="390" alt="Screen Shot 2020-05-06 at 12 29 57 PM" src="https://user-images.githubusercontent.com/336308/81128427-50fedb00-8f95-11ea-8a8a-a1503df00aec.png">


After
----------------------------------------
Both Latitude and Longitude field available for Address Editing by default on new installs

<img width="445" alt="Screen Shot 2020-05-06 at 12 29 15 PM" src="https://user-images.githubusercontent.com/336308/81128408-48a6a000-8f95-11ea-9831-596967269106.png">


ping @colemanw @eileenmcnaughton 