### PR TITLE
APIv4 - Fix schema map to use canonical field names

### DIFF
--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -70,8 +70,8 @@ class SchemaMapBuilder {
     /** @var \CRM_Core_DAO $daoName */
     foreach (AllCoreTables::get() as $daoName => $data) {
       $table = new Table($data['table']);
-      foreach ($daoName::fields() as $field => $fieldData) {
-        $this->addJoins($table, $field, $fieldData);
+      foreach ($daoName::fields() as $fieldData) {
+        $this->addJoins($table, $fieldData['name'], $fieldData);
       }
       $map->addTable($table);
       if (in_array($data['name'], $this->apiEntities)) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug in SchemaMapBuilder where it was accidentally using "unique names"
which do not map to the real names of db columns.
See https://lab.civicrm.org/dev/core/-/issues/1563

Before
----------------------------------------
Wrong field names causing some broken joins.

After
----------------------------------------
Fixed.

Note
-------------------
Implicit multi-joins are no longer displayed in the API Explorer per #17205 so the original bug is no longer reproducible in the UI.