### PR TITLE
(REF) dev/core#1744 - Cleanup event naming

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -36,7 +36,7 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule {
 
     if ($_action_mapping === NULL) {
       $event = \Civi::dispatcher()
-        ->dispatch(\Civi\ActionSchedule\Events::MAPPINGS,
+        ->dispatch('civi.actionSchedule.getMappings',
           new \Civi\ActionSchedule\Event\MappingRegisterEvent());
       $_action_mapping = $event->getMappings();
     }
@@ -516,7 +516,7 @@ FROM civicrm_action_schedule cas
 
     \Civi::dispatcher()
       ->dispatch(
-        \Civi\ActionSchedule\Events::MAILING_QUERY,
+        'civi.actionSchedule.prepareMailingQuery',
         new \Civi\ActionSchedule\Event\MailingQueryEvent($actionSchedule, $mapping, $select)
       );
 

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -560,7 +560,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     }
 
     // OK, this looks new.
-    Civi::dispatcher()->dispatch(\Civi\Core\Event\SystemInstallEvent::EVENT_NAME, new \Civi\Core\Event\SystemInstallEvent());
+    Civi::dispatcher()->dispatch('civi.core.install', new \Civi\Core\Event\SystemInstallEvent());
     Civi::settings()->set('installed', 1);
   }
 

--- a/Civi/API/Event/AuthorizeEvent.php
+++ b/Civi/API/Event/AuthorizeEvent.php
@@ -14,6 +14,12 @@ namespace Civi\API\Event;
 /**
  * Class AuthorizeEvent
  * @package Civi\API\Event
+ *
+ * Determine whether the API request is allowed for the current user.
+ * For successful execution, at least one listener must invoke
+ * $event->authorize().
+ *
+ * Event name: 'civi.api.authorize'
  */
 class AuthorizeEvent extends Event {
   /**

--- a/Civi/API/Event/ExceptionEvent.php
+++ b/Civi/API/Event/ExceptionEvent.php
@@ -12,8 +12,9 @@
 namespace Civi\API\Event;
 
 /**
- * Class ExceptionEvent
- * @package Civi\API\Event
+ * Handle any exceptions that occur while processing an API request.
+ *
+ * Event name: 'civi.api.exception'
  */
 class ExceptionEvent extends Event {
 

--- a/Civi/API/Event/PrepareEvent.php
+++ b/Civi/API/Event/PrepareEvent.php
@@ -16,6 +16,10 @@ use Civi\API\Provider\WrappingProvider;
 /**
  * Class PrepareEvent
  * @package Civi\API\Event
+ *
+ * Apply any pre-execution filtering to the API request.
+ *
+ * Event name: 'civi.api.prepare'
  */
 class PrepareEvent extends Event {
 

--- a/Civi/API/Event/ResolveEvent.php
+++ b/Civi/API/Event/ResolveEvent.php
@@ -14,6 +14,12 @@ namespace Civi\API\Event;
 /**
  * Class ResolveEvent
  * @package Civi\API\Event
+ *
+ * Determine which API provider executes the given request. For successful
+ * execution, at least one listener must invoke
+ * $event->setProvider($provider).
+ *
+ * Event name: 'civi.api.resolve'
  */
 class ResolveEvent extends Event {
 

--- a/Civi/API/Event/RespondEvent.php
+++ b/Civi/API/Event/RespondEvent.php
@@ -14,6 +14,10 @@ namespace Civi\API\Event;
 /**
  * Class RespondEvent
  * @package Civi\API\Event
+ *
+ * Apply post-execution filtering to the API request/response.
+ *
+ * Event name: 'civi.api.respond'
  */
 class RespondEvent extends Event {
   /**

--- a/Civi/API/Events.php
+++ b/Civi/API/Events.php
@@ -22,27 +22,20 @@ namespace Civi\API;
 class Events {
 
   /**
-   * Determine whether the API request is allowed for the current user.
-   * For successful execution, at least one listener must invoke
-   * $event->authorize().
-   *
    * @see AuthorizeEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const AUTHORIZE = 'civi.api.authorize';
 
   /**
-   * Determine which API provider executes the given request. For successful
-   * execution, at least one listener must invoke
-   * $event->setProvider($provider).
-   *
    * @see ResolveEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const RESOLVE = 'civi.api.resolve';
 
   /**
-   * Apply pre-execution logic
-   *
    * @see PrepareEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const PREPARE = 'civi.api.prepare';
 
@@ -50,6 +43,7 @@ class Events {
    * Apply post-execution logic
    *
    * @see RespondEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const RESPOND = 'civi.api.respond';
 
@@ -57,6 +51,7 @@ class Events {
    * Handle any exceptions.
    *
    * @see ExceptionEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const EXCEPTION = 'civi.api.exception';
 
@@ -80,11 +75,11 @@ class Events {
    */
   public static function allEvents() {
     return [
-      self::AUTHORIZE,
-      self::EXCEPTION,
-      self::PREPARE,
-      self::RESOLVE,
-      self::RESPOND,
+      'civi.api.authorize',
+      'civi.api.exception',
+      'civi.api.prepare',
+      'civi.api.resolve',
+      'civi.api.respond',
     ];
   }
 
@@ -93,11 +88,11 @@ class Events {
    * @see \CRM_Utils_Hook::eventDefs
    */
   public static function hookEventDefs($e) {
-    $e->inspector->addEventClass(self::AUTHORIZE, 'Civi\API\Event\AuthorizeEvent');
-    $e->inspector->addEventClass(self::EXCEPTION, 'Civi\API\Event\ExceptionEvent');
-    $e->inspector->addEventClass(self::PREPARE, 'Civi\API\Event\PrepareEvent');
-    $e->inspector->addEventClass(self::RESOLVE, 'Civi\API\Event\ResolveEvent');
-    $e->inspector->addEventClass(self::RESPOND, 'Civi\API\Event\RespondEvent');
+    $e->inspector->addEventClass('civi.api.authorize', 'Civi\API\Event\AuthorizeEvent');
+    $e->inspector->addEventClass('civi.api.exception', 'Civi\API\Event\ExceptionEvent');
+    $e->inspector->addEventClass('civi.api.prepare', 'Civi\API\Event\PrepareEvent');
+    $e->inspector->addEventClass('civi.api.resolve', 'Civi\API\Event\ResolveEvent');
+    $e->inspector->addEventClass('civi.api.respond', 'Civi\API\Event\RespondEvent');
   }
 
 }

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -83,7 +83,7 @@ class Kernel {
     }
     catch (\Exception $e) {
       if ($apiRequest) {
-        $this->dispatcher->dispatch(Events::EXCEPTION, new ExceptionEvent($e, NULL, $apiRequest, $this));
+        $this->dispatcher->dispatch('civi.api.exception', new ExceptionEvent($e, NULL, $apiRequest, $this));
       }
 
       if ($e instanceof \PEAR_Exception) {
@@ -197,7 +197,7 @@ class Kernel {
    */
   public function resolve($apiRequest) {
     /** @var \Civi\API\Event\ResolveEvent $resolveEvent */
-    $resolveEvent = $this->dispatcher->dispatch(Events::RESOLVE, new ResolveEvent($apiRequest, $this));
+    $resolveEvent = $this->dispatcher->dispatch('civi.api.resolve', new ResolveEvent($apiRequest, $this));
     $apiRequest = $resolveEvent->getApiRequest();
     if (!$resolveEvent->getApiProvider()) {
       throw new \Civi\API\Exception\NotImplementedException("API (" . $apiRequest['entity'] . ", " . $apiRequest['action'] . ") does not exist (join the API team and implement it!)");
@@ -216,7 +216,7 @@ class Kernel {
    */
   public function authorize($apiProvider, $apiRequest) {
     /** @var \Civi\API\Event\AuthorizeEvent $event */
-    $event = $this->dispatcher->dispatch(Events::AUTHORIZE, new AuthorizeEvent($apiProvider, $apiRequest, $this));
+    $event = $this->dispatcher->dispatch('civi.api.authorize', new AuthorizeEvent($apiProvider, $apiRequest, $this));
     if (!$event->isAuthorized()) {
       throw new \Civi\API\Exception\UnauthorizedException("Authorization failed");
     }
@@ -235,7 +235,7 @@ class Kernel {
    */
   public function prepare($apiProvider, $apiRequest) {
     /** @var \Civi\API\Event\PrepareEvent $event */
-    $event = $this->dispatcher->dispatch(Events::PREPARE, new PrepareEvent($apiProvider, $apiRequest, $this));
+    $event = $this->dispatcher->dispatch('civi.api.prepare', new PrepareEvent($apiProvider, $apiRequest, $this));
     return [$event->getApiProvider(), $event->getApiRequest()];
   }
 
@@ -253,7 +253,7 @@ class Kernel {
    */
   public function respond($apiProvider, $apiRequest, $result) {
     /** @var \Civi\API\Event\RespondEvent $event */
-    $event = $this->dispatcher->dispatch(Events::RESPOND, new RespondEvent($apiProvider, $apiRequest, $result, $this));
+    $event = $this->dispatcher->dispatch('civi.api.respond', new RespondEvent($apiProvider, $apiRequest, $result, $this));
     return $event->getResponse();
   }
 

--- a/Civi/API/Provider/AdhocProvider.php
+++ b/Civi/API/Provider/AdhocProvider.php
@@ -27,10 +27,10 @@ class AdhocProvider implements EventSubscriberInterface, ProviderInterface {
     // to override standard implementations -- which is
     // handy for testing/mocking.
     return [
-      Events::RESOLVE => [
+      'civi.api.resolve' => [
         ['onApiResolve', Events::W_EARLY],
       ],
-      Events::AUTHORIZE => [
+      'civi.api.authorize' => [
         ['onApiAuthorize', Events::W_EARLY],
       ],
     ];

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -25,7 +25,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
    */
   public static function getSubscribedEvents() {
     return [
-      Events::RESOLVE => [
+      'civi.api.resolve' => [
         ['onApiResolve', Events::W_MIDDLE],
       ],
     ];

--- a/Civi/API/Provider/ReflectionProvider.php
+++ b/Civi/API/Provider/ReflectionProvider.php
@@ -24,11 +24,11 @@ class ReflectionProvider implements EventSubscriberInterface, ProviderInterface 
    */
   public static function getSubscribedEvents() {
     return [
-      Events::RESOLVE => [
+      'civi.api.resolve' => [
         // TODO decide if we really want to override others
         ['onApiResolve', Events::W_EARLY],
       ],
-      Events::AUTHORIZE => [
+      'civi.api.authorize' => [
         // TODO decide if we really want to override others
         ['onApiAuthorize', Events::W_EARLY],
       ],

--- a/Civi/API/Provider/StaticProvider.php
+++ b/Civi/API/Provider/StaticProvider.php
@@ -29,10 +29,10 @@ class StaticProvider extends AdhocProvider {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::RESOLVE => [
+      'civi.api.resolve' => [
         ['onApiResolve', Events::W_MIDDLE],
       ],
-      Events::AUTHORIZE => [
+      'civi.api.authorize' => [
         ['onApiAuthorize', Events::W_MIDDLE],
       ],
     ];

--- a/Civi/API/Subscriber/APIv3SchemaAdapter.php
+++ b/Civi/API/Subscriber/APIv3SchemaAdapter.php
@@ -25,7 +25,7 @@ class APIv3SchemaAdapter implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::PREPARE => [
+      'civi.api.prepare' => [
         ['onApiPrepare', Events::W_MIDDLE],
         ['onApiPrepare_validate', Events::W_LATE],
       ],

--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -40,7 +40,7 @@ class ChainSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::RESPOND => ['onApiRespond', Events::W_EARLY],
+      'civi.api.respond' => ['onApiRespond', Events::W_EARLY],
     ];
   }
 

--- a/Civi/API/Subscriber/DebugSubscriber.php
+++ b/Civi/API/Subscriber/DebugSubscriber.php
@@ -11,7 +11,6 @@
 
 namespace Civi\API\Subscriber;
 
-use Civi\API\Events;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -30,8 +29,8 @@ class DebugSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::PREPARE => ['onApiPrepare', 999],
-      Events::RESPOND => ['onApiRespond', -999],
+      'civi.api.prepare' => ['onApiPrepare', 999],
+      'civi.api.respond' => ['onApiRespond', -999],
     ];
   }
 

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -36,7 +36,7 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::AUTHORIZE => [
+      'civi.api.authorize' => [
         ['onApiAuthorize', Events::W_EARLY],
       ],
     ];

--- a/Civi/API/Subscriber/I18nSubscriber.php
+++ b/Civi/API/Subscriber/I18nSubscriber.php
@@ -32,8 +32,8 @@ class I18nSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::PREPARE => ['onApiPrepare', Events::W_MIDDLE],
-      Events::RESPOND => ['onApiRespond', Events::W_LATE],
+      'civi.api.prepare' => ['onApiPrepare', Events::W_MIDDLE],
+      'civi.api.respond' => ['onApiRespond', Events::W_LATE],
     ];
   }
 

--- a/Civi/API/Subscriber/PermissionCheck.php
+++ b/Civi/API/Subscriber/PermissionCheck.php
@@ -26,7 +26,7 @@ class PermissionCheck implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::AUTHORIZE => [
+      'civi.api.authorize' => [
         ['onApiAuthorize', Events::W_LATE],
       ],
     ];

--- a/Civi/API/Subscriber/TransactionSubscriber.php
+++ b/Civi/API/Subscriber/TransactionSubscriber.php
@@ -34,9 +34,9 @@ class TransactionSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::PREPARE => ['onApiPrepare', Events::W_EARLY],
-      Events::RESPOND => ['onApiRespond', Events::W_MIDDLE],
-      Events::EXCEPTION => ['onApiException', Events::W_EARLY],
+      'civi.api.prepare' => ['onApiPrepare', Events::W_EARLY],
+      'civi.api.respond' => ['onApiRespond', Events::W_MIDDLE],
+      'civi.api.exception' => ['onApiException', Events::W_EARLY],
     ];
   }
 

--- a/Civi/API/Subscriber/WhitelistSubscriber.php
+++ b/Civi/API/Subscriber/WhitelistSubscriber.php
@@ -30,8 +30,8 @@ class WhitelistSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::AUTHORIZE => ['onApiAuthorize', Events::W_EARLY],
-      Events::RESPOND => ['onApiRespond', Events::W_MIDDLE],
+      'civi.api.authorize' => ['onApiAuthorize', Events::W_EARLY],
+      'civi.api.respond' => ['onApiRespond', Events::W_MIDDLE],
     ];
   }
 

--- a/Civi/API/Subscriber/WrapperAdapter.php
+++ b/Civi/API/Subscriber/WrapperAdapter.php
@@ -26,8 +26,8 @@ class WrapperAdapter implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::PREPARE => ['onApiPrepare', Events::W_MIDDLE],
-      Events::RESPOND => ['onApiRespond', Events::W_EARLY * 2],
+      'civi.api.prepare' => ['onApiPrepare', Events::W_MIDDLE],
+      'civi.api.respond' => ['onApiRespond', Events::W_EARLY * 2],
     ];
   }
 

--- a/Civi/ActionSchedule/Event/MailingQueryEvent.php
+++ b/Civi/ActionSchedule/Event/MailingQueryEvent.php
@@ -37,6 +37,8 @@ use Symfony\Component\EventDispatcher\Event;
  *
  * (Note: When adding more JOINs, it seems typical to use !casMailingJoinType, although
  * some hard-code a LEFT JOIN. Don't have an explanation for why.)
+ *
+ * Event name: 'civi.actionSchedule.prepareMailingQuery'
  */
 class MailingQueryEvent extends Event {
 

--- a/Civi/ActionSchedule/Event/MappingRegisterEvent.php
+++ b/Civi/ActionSchedule/Event/MappingRegisterEvent.php
@@ -9,6 +9,8 @@ use Symfony\Component\EventDispatcher\Event;
  * @package Civi\ActionSchedule\Event
  *
  * Register any available mappings.
+ *
+ * Event name: 'civi.actionSchedule.getMappings'
  */
 class MappingRegisterEvent extends Event {
 

--- a/Civi/ActionSchedule/Events.php
+++ b/Civi/ActionSchedule/Events.php
@@ -4,15 +4,14 @@ namespace Civi\ActionSchedule;
 class Events {
 
   /**
-   * Register any available mappings.
-   *
-   * @see EntityListEvent
+   * @see \Civi\ActionSchedule\Event\MappingRegisterEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const MAPPINGS = 'civi.actionSchedule.getMappings';
 
   /**
-   * Prepare the pre-mailing query. This query loads details about
-   * the contact/entity so that they're available for mail-merge.
+   * @see \Civi\ActionSchedule\Event\MailingQueryEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const MAILING_QUERY = 'civi.actionSchedule.prepareMailingQuery';
 

--- a/Civi/Api4/Event/Subscriber/Generic/AbstractPrepareSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/Generic/AbstractPrepareSubscriber.php
@@ -22,7 +22,6 @@
 namespace Civi\Api4\Event\Subscriber\Generic;
 
 use Civi\API\Event\PrepareEvent;
-use Civi\API\Events;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 abstract class AbstractPrepareSubscriber implements EventSubscriberInterface {
@@ -32,7 +31,7 @@ abstract class AbstractPrepareSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::PREPARE => 'onApiPrepare',
+      'civi.api.prepare' => 'onApiPrepare',
     ];
   }
 

--- a/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
@@ -26,7 +26,7 @@ class PermissionCheckSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::AUTHORIZE => [
+      'civi.api.authorize' => [
         ['onApiAuthorize', Events::W_LATE],
       ],
     ];

--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -31,7 +31,7 @@ class ActionObjectProvider implements EventSubscriberInterface, ProviderInterfac
     // to override standard implementations -- which is
     // handy for testing/mocking.
     return [
-      Events::RESOLVE => [
+      'civi.api.resolve' => [
         ['onApiResolve', Events::W_EARLY],
       ],
     ];

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -362,12 +362,12 @@ class Container {
       'CRM_Core_LegacyErrorHandler',
       'handleException',
     ], -200);
-    $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Activity_ActionMapping', 'onRegisterActionMappings']);
-    $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Contact_ActionMapping', 'onRegisterActionMappings']);
-    $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Contribute_ActionMapping_ByPage', 'onRegisterActionMappings']);
-    $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Contribute_ActionMapping_ByType', 'onRegisterActionMappings']);
-    $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Event_ActionMapping', 'onRegisterActionMappings']);
-    $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, ['CRM_Member_ActionMapping', 'onRegisterActionMappings']);
+    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Activity_ActionMapping', 'onRegisterActionMappings']);
+    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contact_ActionMapping', 'onRegisterActionMappings']);
+    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contribute_ActionMapping_ByPage', 'onRegisterActionMappings']);
+    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contribute_ActionMapping_ByType', 'onRegisterActionMappings']);
+    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Event_ActionMapping', 'onRegisterActionMappings']);
+    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Member_ActionMapping', 'onRegisterActionMappings']);
 
     return $dispatcher;
   }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -1,7 +1,6 @@
 <?php
 namespace Civi\Core;
 
-use Civi\Core\Event\SystemInstallEvent;
 use Civi\Core\Lock\LockManager;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -334,9 +333,9 @@ class Container {
       $dispatcher->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get('upgrade.main'));
     }
 
-    $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, ['\Civi\Core\InstallationCanary', 'check']);
-    $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, ['\Civi\Core\DatabaseInitializer', 'initialize']);
-    $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, ['\Civi\Core\LocalizationInitializer', 'initialize']);
+    $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
+    $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);
+    $dispatcher->addListener('civi.core.install', ['\Civi\Core\LocalizationInitializer', 'initialize']);
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
     $dispatcher->addListener('hook_civicrm_pre', ['\Civi\Core\Event\PreEvent', 'dispatchSubevent'], 100);
     $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);

--- a/Civi/Core/Event/SystemInstallEvent.php
+++ b/Civi/Core/Event/SystemInstallEvent.php
@@ -19,6 +19,8 @@ class SystemInstallEvent extends \Symfony\Component\EventDispatcher\Event {
 
   /**
    * The SystemInstallEvent fires once after installation - during the first page-view.
+   *
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const EVENT_NAME = 'civi.core.install';
 
@@ -27,7 +29,7 @@ class SystemInstallEvent extends \Symfony\Component\EventDispatcher\Event {
    * @see \CRM_Utils_Hook::eventDefs
    */
   public static function hookEventDefs($e) {
-    $e->inspector->addEventClass(self::EVENT_NAME, __CLASS__);
+    $e->inspector->addEventClass('civi.core.install', __CLASS__);
   }
 
 }

--- a/Civi/Token/AbstractTokenSubscriber.php
+++ b/Civi/Token/AbstractTokenSubscriber.php
@@ -41,8 +41,8 @@ abstract class AbstractTokenSubscriber implements EventSubscriberInterface {
 
   public static function getSubscribedEvents() {
     return [
-      Events::TOKEN_REGISTER => 'registerTokens',
-      Events::TOKEN_EVALUATE => 'evaluateTokens',
+      'civi.token.list' => 'registerTokens',
+      'civi.token.eval' => 'evaluateTokens',
       \Civi\ActionSchedule\Events::MAILING_QUERY => 'alterActionScheduleQuery',
     ];
   }

--- a/Civi/Token/AbstractTokenSubscriber.php
+++ b/Civi/Token/AbstractTokenSubscriber.php
@@ -43,7 +43,7 @@ abstract class AbstractTokenSubscriber implements EventSubscriberInterface {
     return [
       'civi.token.list' => 'registerTokens',
       'civi.token.eval' => 'evaluateTokens',
-      \Civi\ActionSchedule\Events::MAILING_QUERY => 'alterActionScheduleQuery',
+      'civi.actionSchedule.prepareMailingQuery' => 'alterActionScheduleQuery',
     ];
   }
 

--- a/Civi/Token/Event/TokenRegisterEvent.php
+++ b/Civi/Token/Event/TokenRegisterEvent.php
@@ -18,6 +18,8 @@ namespace Civi\Token\Event;
  *   'label' => ts('Default Profile URL (View Mode)'),
  * ));
  * @endcode
+ *
+ * Event name: 'civi.token.list'
  */
 class TokenRegisterEvent extends TokenEvent {
 

--- a/Civi/Token/Event/TokenRenderEvent.php
+++ b/Civi/Token/Event/TokenRenderEvent.php
@@ -5,13 +5,15 @@ namespace Civi\Token\Event;
  * Class TokenRenderEvent
  * @package Civi\Token\Event
  *
- * A TokenRenderEvent is fired after the TokenProcessor has rendered
- * a message.
+ * Perform post-processing on a rendered message. A TokenRenderEvent is fired
+ * after the TokenProcessor has rendered a message.
  *
- * The render event may be used for post-processing the text, but
+ * WARNING: The render event may be used for post-processing the text, but
  * it's very difficult to do substantive work in a secure, robust
  * way within this event. The event primarily exists to facilitate
  * a transition of some legacy code.
+ *
+ * Event name: 'civi.token.render'
  */
 class TokenRenderEvent extends TokenEvent {
 

--- a/Civi/Token/Event/TokenValueEvent.php
+++ b/Civi/Token/Event/TokenValueEvent.php
@@ -32,6 +32,7 @@ namespace Civi\Token\Event;
  * }
  * @encode
  *
+ * Event name: 'civi.token.eval'
  */
 class TokenValueEvent extends TokenEvent {
 

--- a/Civi/Token/Events.php
+++ b/Civi/Token/Events.php
@@ -4,28 +4,20 @@ namespace Civi\Token;
 
 class Events {
   /**
-   * Create a list of supported tokens.
-   *
    * @see \Civi\Token\Event\TokenRegisterEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const TOKEN_REGISTER = 'civi.token.list';
 
   /**
-   * Create a list of supported tokens.
-   *
    * @see \Civi\Token\Event\TokenValueEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const TOKEN_EVALUATE = 'civi.token.eval';
 
   /**
-   * Perform post-processing on a rendered message.
-   *
-   * WARNING: It is difficult to develop robust,
-   * secure code using this stage. However, we need
-   * to support it during a transitional period
-   * while the token logic is reorganized.
-   *
    * @see \Civi\Token\Event\TokenRenderEvent
+   * @deprecated - You may simply use the event name directly. dev/core#1744
    */
   const TOKEN_RENDER = 'civi.token.render';
 

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -25,8 +25,8 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      Events::TOKEN_EVALUATE => 'onEvaluate',
-      Events::TOKEN_RENDER => 'onRender',
+      'civi.token.eval' => 'onEvaluate',
+      'civi.token.render' => 'onRender',
     ];
   }
 

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -306,7 +306,7 @@ class TokenProcessor {
     if ($this->tokens === NULL) {
       $this->tokens = [];
       $event = new TokenRegisterEvent($this, ['entity' => 'undefined']);
-      $this->dispatcher->dispatch(Events::TOKEN_REGISTER, $event);
+      $this->dispatcher->dispatch('civi.token.list', $event);
     }
     return $this->tokens;
   }
@@ -332,7 +332,7 @@ class TokenProcessor {
    */
   public function evaluate() {
     $event = new TokenValueEvent($this);
-    $this->dispatcher->dispatch(Events::TOKEN_EVALUATE, $event);
+    $this->dispatcher->dispatch('civi.token.eval', $event);
     return $this;
   }
 
@@ -371,7 +371,7 @@ class TokenProcessor {
     $event->context = $row->context;
     $event->row = $row;
     $event->string = strtr($message['string'], $filteredTokens);
-    $this->dispatcher->dispatch(Events::TOKEN_RENDER, $event);
+    $this->dispatcher->dispatch('civi.token.render', $event);
     return $event->string;
   }
 

--- a/tests/phpunit/Civi/API/Event/PrepareEventTest.php
+++ b/tests/phpunit/Civi/API/Event/PrepareEventTest.php
@@ -2,7 +2,6 @@
 namespace Civi\API\Event;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Civi\API\Events;
 use Civi\API\Kernel;
 
 /**
@@ -45,7 +44,7 @@ class PrepareEventTest extends \CiviUnitTestCase {
    * @dataProvider getPrepareExamples
    */
   public function testOnPrepare($onPrepare, $inputApiCall, $expectResult) {
-    $this->dispatcher->addListener(Events::PREPARE, [$this, $onPrepare]);
+    $this->dispatcher->addListener('civi.api.prepare', [$this, $onPrepare]);
     $this->kernel->registerApiProvider($this->createWidgetFrobnicateProvider());
     $result = call_user_func_array([$this->kernel, 'runSafe'], $inputApiCall);
     $this->assertEquals($expectResult, $result['values']);

--- a/tests/phpunit/Civi/API/KernelTest.php
+++ b/tests/phpunit/Civi/API/KernelTest.php
@@ -39,10 +39,10 @@ class KernelTest extends \CiviUnitTestCase {
     ]);
 
     $expectedEventSequence = [
-      ['name' => Events::RESOLVE, 'class' => 'Civi\API\Event\ResolveEvent'],
-      ['name' => Events::AUTHORIZE, 'class' => 'Civi\API\Event\AuthorizeEvent'],
-      ['name' => Events::PREPARE, 'class' => 'Civi\API\Event\PrepareEvent'],
-      ['name' => Events::RESPOND, 'class' => 'Civi\API\Event\RespondEvent'],
+      ['name' => 'civi.api.resolve', 'class' => 'Civi\API\Event\ResolveEvent'],
+      ['name' => 'civi.api.authorize', 'class' => 'Civi\API\Event\AuthorizeEvent'],
+      ['name' => 'civi.api.prepare', 'class' => 'Civi\API\Event\PrepareEvent'],
+      ['name' => 'civi.api.respond', 'class' => 'Civi\API\Event\RespondEvent'],
     ];
     $this->assertEquals($expectedEventSequence, $this->actualEventSequence);
     $this->assertEquals('frob', $result['values'][98]);
@@ -50,10 +50,10 @@ class KernelTest extends \CiviUnitTestCase {
 
   public function testResolveException() {
     $test = $this;
-    $this->dispatcher->addListener(Events::RESOLVE, function () {
+    $this->dispatcher->addListener('civi.api.resolve', function () {
       throw new \API_Exception('Oh My God', 'omg', ['the' => 'badzes']);
     }, Events::W_EARLY);
-    $this->dispatcher->addListener(Events::EXCEPTION, function (\Civi\API\Event\ExceptionEvent $event) use ($test) {
+    $this->dispatcher->addListener('civi.api.exception', function (\Civi\API\Event\ExceptionEvent $event) use ($test) {
       $test->assertEquals('Oh My God', $event->getException()->getMessage());
     });
 
@@ -63,8 +63,8 @@ class KernelTest extends \CiviUnitTestCase {
     ]);
 
     $expectedEventSequence = [
-      ['name' => Events::RESOLVE, 'class' => 'Civi\API\Event\ResolveEvent'],
-      ['name' => Events::EXCEPTION, 'class' => 'Civi\API\Event\ExceptionEvent'],
+      ['name' => 'civi.api.resolve', 'class' => 'Civi\API\Event\ResolveEvent'],
+      ['name' => 'civi.api.exception', 'class' => 'Civi\API\Event\ExceptionEvent'],
     ];
     $this->assertEquals($expectedEventSequence, $this->actualEventSequence);
     $this->assertEquals('Oh My God', $result['error_message']);

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -22,8 +22,8 @@ class TokenProcessorTest extends \CiviUnitTestCase {
     $this->useTransaction(TRUE);
     parent::setUp();
     $this->dispatcher = new EventDispatcher();
-    $this->dispatcher->addListener(Events::TOKEN_REGISTER, [$this, 'onListTokens']);
-    $this->dispatcher->addListener(Events::TOKEN_EVALUATE, [$this, 'onEvalTokens']);
+    $this->dispatcher->addListener('civi.token.list', [$this, 'onListTokens']);
+    $this->dispatcher->addListener('civi.token.eval', [$this, 'onEvalTokens']);
     $this->counts = [
       'onListTokens' => 0,
       'onEvalTokens' => 0,


### PR DESCRIPTION
Overview
----------------------------------------

This is a cleanup in that it consolidates the code-style by which certain events are organized.

Discussion/rationale: https://lab.civicrm.org/dev/core/-/issues/1744

Before
----------------------------------------

For any given event, there are up to 3 distinct names -- the class-name (eg `TokenRegisterEvent`), the event-name (eg `civi.token.list`), and the constant-name (eg `TOKEN_REGISTER`).

The usage of event-name vs constant-name is inconsistent. You find numerous examples of both these formulations in `civicrm-core`

```php
// Reference an event directly by its literal name
Civi::dispatcher()->addListener('civi.token.list', $callback);
Civi::dispatcher()->dispatch('civi.token.list', $event);

// Reference an event indirectly by a constant
Civi::dispatcher()->addListener(Civi\Token\Events::TOKEN_REGISTER, $callback);
Civi::dispatcher()->dispatch(Civi\Token\Events::TOKEN_REGISTER, $event);
```

After
----------------------------------------

The constants are mostly removed/deprecated. This string-literal formulation is canonical:

```php
Civi::dispatcher()->addListener('civi.token.list', $callback);
Civi::dispatcher()->dispatch('civi.token.list', $event);
```

Technical Details
----------------------------------------

Normalizing/consolidating this involved a few changes:

* (REF) Search/replace - Simply substitute the constant with its value
* (NFC) Mark the old constant as `@deprecated`, but retain it for any third-party code or any unrecognized edge-cases.
* (NFC) Consolidate docblocks - Each event had a constant (`TOKEN_REGISTER`) and a class (`TokenRegisterEvent`). Docblocks describing the event could be on either.  Any docblocks on the constant have been moved into the corresponding class.