### PR TITLE
Api4 AJAX endpoint: allow either access CiviCRM or access AJAX API

### DIFF
--- a/CRM/Core/xml/Menu/Api4.xml
+++ b/CRM/Core/xml/Menu/Api4.xml
@@ -3,7 +3,7 @@
   <item>
     <path>civicrm/ajax/api4</path>
     <page_callback>CRM_Api4_Page_AJAX</page_callback>
-    <access_arguments>access AJAX API</access_arguments>
+    <access_arguments>access CiviCRM;access AJAX API</access_arguments>
   </item>
   <item>
     <path>civicrm/api4</path>


### PR DESCRIPTION
Overview
----------------------------------------
This is an intra-RC regression.  In #16705 the permissions for the APIv4 AJAX endpoint were altered to allow the `access AJAX API` permission, but in doing so, it no longer allowed users with only `access CiviCRM`.  This allows either.

Before
----------------------------------------
Users need `access AJAX API` to use the AJAX APIv4 endpoint.  Having just `access CiviCRM` won't cut it anymore.

After
----------------------------------------
Either permission will make it work, matching APIv3.

Technical Details
----------------------------------------
The `access AJAX API` is intended as an alternative to `access CiviCRM` for sites that want certain roles to be able to use the API via AJAX but not be able to go to the CiviCRM backend.  Most admin users will not have `access AJAX API` because it's redundant.
