### PR TITLE
dev/translation#39 - Fix `core:install --lang`. Realign boot plugins.

### DIFF
--- a/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
+++ b/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
@@ -2,7 +2,15 @@
 /**
  * @file
  *
- * Perform the first system bootstrap.
+ * Perform the full bootstrap.
+ *
+ * GOAL: All the standard services (database, DAOs, translations, settings, etc) should be loaded.
+ *
+ * MECHANICS: This is basically calls `CRM_Core_Config::singleton(TRUE,TRUE)`.
+ *
+ * NOTE: This is technically a *reboot*. `Preboot` started things off, but it
+ * booted with `CRM_Core_Config::singleton($loadFromDB==FALSE)`. Now, the DB is
+ * populated, so we can teardown the preboot stuff and start again with `$loadFromDB==TRUE`.
  */
 
 if (!defined('CIVI_SETUP')) {
@@ -13,19 +21,9 @@ if (!defined('CIVI_SETUP')) {
   ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
     \Civi\Setup::log()->info(sprintf('[%s] Bootstrap CiviCRM', basename(__FILE__)));
 
-    if (!defined('CIVICRM_SETTINGS_PATH')) {
-      define('CIVICRM_SETTINGS_PATH', $e->getModel()->settingsPath);
-    }
+    \CRM_Core_I18n::$SQL_ESCAPER = NULL;
+    unset(\Civi::$statics['testPreInstall']);
 
-    if (realpath(CIVICRM_SETTINGS_PATH) !== realpath($e->getModel()->settingsPath)) {
-      throw new \RuntimeException(sprintf("Cannot boot: The civicrm.settings.php path appears inconsistent (%s vs %s)", CIVICRM_SETTINGS_PATH, $e->getModel()->settingsPath));
-    }
-
-    include_once CIVICRM_SETTINGS_PATH;
-
-    require_once 'CRM/Core/ClassLoader.php';
-    CRM_Core_ClassLoader::singleton()->register();
-
-    CRM_Core_Config::singleton(TRUE);
+    CRM_Core_Config::singleton(TRUE, TRUE);
 
   }, \Civi\Setup::PRIORITY_MAIN - 200);

--- a/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
+++ b/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
@@ -6,7 +6,7 @@
  *
  * GOAL: All the standard services (database, DAOs, translations, settings, etc) should be loaded.
  *
- * MECHANICS: This is basically calls `CRM_Core_Config::singleton(TRUE,TRUE)`.
+ * MECHANICS: This basically calls `CRM_Core_Config::singleton(TRUE,TRUE)`.
  *
  * NOTE: This is technically a *reboot*. `Preboot` started things off, but it
  * booted with `CRM_Core_Config::singleton($loadFromDB==FALSE)`. Now, the DB is

--- a/setup/plugins/installDatabase/InstallSchema.civi-setup.php
+++ b/setup/plugins/installDatabase/InstallSchema.civi-setup.php
@@ -68,11 +68,6 @@ class InstallSchemaPlugin implements \Symfony\Component\EventDispatcher\EventSub
     $sqlPath = $model->srcPath . DIRECTORY_SEPARATOR . 'sql';
     $spec = $this->loadSpecification($model->srcPath);
 
-    $conn = \Civi\Setup\DbUtil::connect($model->db);
-    \CRM_Core_I18n::$SQL_ESCAPER = function($text) use ($conn) {
-      return $conn->escape_string($text);
-    };
-
     \Civi\Setup::log()->info(sprintf('[%s] Load basic tables', basename(__FILE__)));
     \Civi\Setup\DbUtil::sourceSQL($model->db, \Civi\Setup\SchemaGenerator::generateCreateSql($model->srcPath, $spec->database, $spec->tables));
 
@@ -89,11 +84,6 @@ class InstallSchemaPlugin implements \Symfony\Component\EventDispatcher\EventSub
       \Civi\Setup::log()->info(sprintf('[%s] Load basic data', basename(__FILE__)));
       \Civi\Setup\DbUtil::sourceSQL($model->db, \Civi\Setup\SchemaGenerator::generateBasicData($model->srcPath));
     }
-
-    require_once $model->settingsPath;
-    \Civi\Core\Container::boot(TRUE);
-
-    \CRM_Core_I18n::$SQL_ESCAPER = NULL;
   }
 
   /**

--- a/setup/plugins/installDatabase/Preboot.civi-setup.php
+++ b/setup/plugins/installDatabase/Preboot.civi-setup.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @file
+ *
+ * Perform an initial, partial bootstrap.
+ *
+ * GOAL: This should provide sufficient services for `InstallSchema` to generate
+ * For example, `ts()` needs to be online..
+ *
+ * MECHANICS: This basically loads `civicrm.settings.php` and calls
+ * `CRM_Core_Config::singleton(FALSE,TRUE)`.
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.checkRequirements', function (\Civi\Setup\Event\CheckRequirementsEvent $e) {
+
+  });
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Load minimal (non-DB) services', basename(__FILE__)));
+
+    if (!defined('CIVICRM_SETTINGS_PATH')) {
+      define('CIVICRM_SETTINGS_PATH', $e->getModel()->settingsPath);
+    }
+
+    if (realpath(CIVICRM_SETTINGS_PATH) !== realpath($e->getModel()->settingsPath)) {
+      throw new \RuntimeException(sprintf("Cannot boot: The civicrm.settings.php path appears inconsistent (%s vs %s)", CIVICRM_SETTINGS_PATH, $e->getModel()->settingsPath));
+    }
+
+    include_once CIVICRM_SETTINGS_PATH;
+
+    require_once 'CRM/Core/ClassLoader.php';
+    CRM_Core_ClassLoader::singleton()->register();
+
+    $conn = \Civi\Setup\DbUtil::connect($e->getModel()->db);
+    \CRM_Core_I18n::$SQL_ESCAPER = function($text) use ($conn) {
+      return $conn->escape_string($text);
+    };
+
+    \Civi::$statics['testPreInstall'] = 1;
+
+    CRM_Core_Config::singleton(FALSE, TRUE);
+
+  }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/installDatabase/Preboot.civi-setup.php
+++ b/setup/plugins/installDatabase/Preboot.civi-setup.php
@@ -5,7 +5,7 @@
  * Perform an initial, partial bootstrap.
  *
  * GOAL: This should provide sufficient services for `InstallSchema` to generate
- * For example, `ts()` needs to be online..
+ * For example, `ts()` needs to be online.
  *
  * MECHANICS: This basically loads `civicrm.settings.php` and calls
  * `CRM_Core_Config::singleton(FALSE,TRUE)`.


### PR DESCRIPTION
Overview
--------

Suppose you run a command like:

```
cv core:install --lang=fr_FR --cms-base-url=http://example.com/
```

This fixes that use-case by realigning some of the bootstrap steps under `setup/plugins/installDatabase/*`.

This is a variation inspired by @demeritcowboy's #17214.

Before
------

* The above `core:install` command crashes because the `paths` service is unavailable.

* The `civi.setup.installDatabase` begins with these two steps:

    1. `InstallSchema.civi-setup.php` manipulates some global options (to make certain services work), and it also installs the schema, and it also reboots the `Container`.
    2. `BootstrapCivi.civi-setup.php` tries to boot again - e.g. it loads `civicrm.settings.php` and calls `CRM_Core_Config::singleton($loadFromDB=TRUE)`. But this is suspect because it neglects to set `$force=TRUE`.

After
-----

* The above `core:install` command runs.

* The `civi.setup.installDatabase` begins with these *three* steps:

    1. `Preboot.civi-setup.php` starts the system in a *partially booted* mode (ie with `$loadFromDB==FALSE`).
    2. `InstallSchema.civi-setup.php` just installs the schema.
    3. `BootstrapCivi.civi-setup.php` switches the system to a fully booted mode (ie with `$loadFromDB==TRUE`).

The essence of the change is to move some parts of `InstallSchema` and `BootstrapCivi` to a plugin `Preboot`, creating a sharper distinction between partial/preboot mode and the full/standard/bootstrapped mode.

Technical details
-----------------

When working with `setup/plugins/**`, I find it helpful to use the `--debug-event` option to see the active plugins, e.g.

```
$ cv core:install --lang fr_FR --cms-base-url='http://dmaster.bknix:8001' --debug-event=
civi.setup.installDatabase

[Event] civi.setup.installDatabase
+-------+------------------------------------------------------------------------------------+
| Order | Callable                                                                           |
+-------+------------------------------------------------------------------------------------+
| #1    | closure(civicrm/setup/plugins/common/LogEvents.civi-setup.php@31)                  |
| #2    | InstallSchemaPlugin->installDatabase()                                             |
| #3    | closure(civicrm/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php@13)     |
| #4    | closure(civicrm/setup/plugins/installDatabase/SetLanguage.civi-setup.php@13)       |
| #5    | closure(civicrm/setup/plugins/installDatabase/InstallComponents.civi-setup.php@13) |
| #6    | closure(civicrm/setup/plugins/installDatabase/InstallExtensions.civi-setup.php@13) |
...
+-------+------------------------------------------------------------------------------------+
```

I tested this on a D7 build. My dev/test loop was basically these steps:

```
cv core:uninstall -f
cv core:install --lang fr_FR --cms-base-url='http://dmaster.bknix:8001' -vvv
echo 'select name, label, value from civicrm_option_value where name like "Meet%"' | cv sql
```

If the install succeeded, then the SQL command would display localized
labels for "Meeting" ("Reunion").
