### PR TITLE
Proceeding to confirmation page should be a "next" button not a check

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -479,10 +479,14 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (!($allAreBillingModeProcessors && !$this->_values['is_pay_later'])) {
       $submitButton = [
         'type' => 'upload',
-        'name' => !empty($this->_values['is_confirm_enabled']) ? ts('Review your contribution') : ts('Contribute'),
+        'name' => ts('Contribute'),
         'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
         'isDefault' => TRUE,
       ];
+      if (!empty($this->_values['is_confirm_enabled'])) {
+        $submitButton['name'] = ts('Review your contribution');
+        $submitButton['icon'] = 'fa-chevron-right';
+      }
       // Add submit-once behavior when confirm page disabled
       if (empty($this->_values['is_confirm_enabled'])) {
         $this->submitOnce = TRUE;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -467,25 +467,24 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
       // CRM-11182 - Optional confirmation screen
       // Change button label depending on whether the next action is confirm or register
+      $buttonParams = [
+        'type' => 'upload',
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,
+      ];
       if (
         !$this->_values['event']['is_multiple_registrations']
         && !$this->_values['event']['is_monetary']
         && !$this->_values['event']['is_confirm_enabled']
       ) {
-        $buttonLabel = ts('Register');
+        $buttonParams['name'] = ts('Register');
       }
       else {
-        $buttonLabel = ts('Review your registration');
+        $buttonParams['name'] = ts('Review your registration');
+        $buttonParams['icon'] = 'fa-chevron-right';
       }
 
-      $this->addButtons([
-        [
-          'type' => 'upload',
-          'name' => $buttonLabel,
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-        ],
-      ]);
+      $this->addButtons([$buttonParams]);
     }
 
     $this->addFormRule(['CRM_Event_Form_Registration_Register', 'formRule'], $this);


### PR DESCRIPTION
Overview
----------------------------------------
Following on [dev/core#1613](https://lab.civicrm.org/dev/core/issues/1613) and #16651, I realized that a check mark can mislead someone to thinking that the button to proceed to a confirmation page is actually completing a contribution.  Instead, they should be right chevrons--you're not done yet.

(This was also the inspiration for my terrible journey down the road of angle quotes in #17245 .)

Before
----------------------------------------
![Screenshot_2020-05-06 Rain-forest Cup Youth Soccer Tournament reviewbuttons](https://user-images.githubusercontent.com/1682375/81241062-3fd6be00-8fd7-11ea-9f1d-451df979d3d2.png)
![Screenshot_2020-05-06 Help Support CiviCRM reviewbuttons](https://user-images.githubusercontent.com/1682375/81241063-406f5480-8fd7-11ea-97db-bfdb4c301e83.png)

After
----------------------------------------
![Screenshot_2020-05-06 Rain-forest Cup Youth Soccer Tournament reviewbuttons(1)](https://user-images.githubusercontent.com/1682375/81241076-4bc28000-8fd7-11ea-88a6-d4551d8f43d7.png)
![Screenshot_2020-05-06 Help Support CiviCRM reviewbuttons(1)](https://user-images.githubusercontent.com/1682375/81241077-4bc28000-8fd7-11ea-8907-570edc5d6eb8.png)


Technical Details
----------------------------------------
The button `subName` attribute seems to be a nice helper here.  I don't think it has any side effects.
