### PR TITLE
install/index.php - Fix leak which breaks compatibility with current Backdrop

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -151,7 +151,7 @@ if (isset($_REQUEST['seedLanguage']) and isset($langs[$_REQUEST['seedLanguage']]
   $tsLocale = $_REQUEST['seedLanguage'];
 }
 
-$config = CRM_Core_Config::singleton(FALSE);
+CRM_Core_Config::singleton(FALSE);
 $GLOBALS['civicrm_default_error_scope'] = NULL;
 
 // The translation files are in the parent directory (l10n)

--- a/release-notes/5.25.0.md
+++ b/release-notes/5.25.0.md
@@ -81,6 +81,9 @@ Released May 6, 2020
   functions, but this first PR adds support for the aggregate functions `AVG`,
   `COUNT`, `MAX`, `MIN`, and `SUM`.
 
+- **install/index.php - Fix leak which breaks compatibility with current Backdrop
+  ([#17249](https://github.com/civicrm/civicrm-core/pull/17249))**
+
 ### CiviContribute
 
 - **Partial Refunds (Work towards


### PR DESCRIPTION
Overview
----------------------------------------

While doing the run-down for 5.25.0, I found that the Backdrop wasn't installing.

Before
----------------------------------------

If you open `install/index.php` and submit MySQL credentials, the installation fails with:

<img width="1228" alt="Screen Shot 2020-05-06 at 8 55 36 PM" src="https://user-images.githubusercontent.com/1336047/81254064-f4c0a900-8fde-11ea-8c5e-72cbe16d3265.png">

After
----------------------------------------

Installation works.

Technical Details
----------------------------------------

The issue is that newer versions of Backdrop define a global `$config`, and the installer leaks a copy of `$config` into the global namespace.

This is another variant of the issue in #16702