### PR TITLE
utf8mb4 - If strict mode enabled query will fail if KEY_BLOCK_SIZE is not 0

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -866,7 +866,7 @@ MODIFY      {$columnName} varchar( $length )
       }
       $query .= " CHARACTER SET = $newCharSet COLLATE = $tableCollation";
       if ($param['Engine'] === 'InnoDB') {
-        $query .= ' ROW_FORMAT = Dynamic';
+        $query .= ' ROW_FORMAT = Dynamic KEY_BLOCK_SIZE = 0';
       }
       // Disable i18n rewrite.
       CRM_Core_DAO::executeQuery($query, $params, TRUE, NULL, FALSE, FALSE);


### PR DESCRIPTION
Overview
----------------------------------------
If strict mode enabled query will fail if KEY_BLOCK_SIZE is not 0 (ie. ROW_FORMAT was "Compressed" or another that uses KEY_BLOCK_SIZE parameter).

Before
----------------------------------------
System.utf8conversion crashes if KEY_BLOCK_SIZE > 0.

After
----------------------------------------
System.utf8conversion converts to ROW_FORMAT=Dynamic if KEY_BLOCK_SIZE > 0.

Technical Details
----------------------------------------
See https://mariadb.com/kb/en/innodb-strict-mode/

Comments
----------------------------------------
@mfb