### PR TITLE
Change contactId to contact_id for tokenProcessor context - follow-up from #17161

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -547,7 +547,7 @@ FROM civicrm_action_schedule cas
     $sms_body_text = $tokenRow->render('sms_body_text');
 
     $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID') ? $session->get('userID') : $tokenRow->context['contactId'];
+    $userID = $session->get('userID') ? $session->get('userID') : $tokenRow->context['contact_id'];
     $smsParams = [
       'To' => $toPhoneNumber,
       'provider_id' => $schedule->sms_provider_id,
@@ -566,7 +566,7 @@ FROM civicrm_action_schedule cas
     $activity = CRM_Activity_BAO_Activity::create($activityParams);
 
     try {
-      CRM_Activity_BAO_Activity::sendSMSMessage($tokenRow->context['contactId'],
+      CRM_Activity_BAO_Activity::sendSMSMessage($tokenRow->context['contact_id'],
         $sms_body_text,
         $smsParams,
         $activity->id,

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -49,11 +49,11 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $messageTokens = $e->getTokenProcessor()->getMessageTokens();
 
     foreach ($e->getRows() as $row) {
-      if (empty($row->context['contactId'])) {
+      if (empty($row->context['contact_id'])) {
         continue;
       }
       /** @var int $contactId */
-      $contactId = $row->context['contactId'];
+      $contactId = $row->context['contact_id'];
       if (empty($row->context['contact'])) {
         $params = [
           ['contact_id', '=', $contactId, 0, 0],
@@ -63,7 +63,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $contact = reset($contact);
         if (!$contact || is_a($contact, 'CRM_Core_Error')) {
           // FIXME: Need to differentiate errors which kill the batch vs the individual row.
-          \Civi::log()->debug("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
+          \Civi::log()->debug("Failed to generate token data. Invalid contact ID: " . $row->context['contact_id']);
           continue;
         }
 

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -58,7 +58,7 @@ class TokenProcessor {
    *   - schema: array, a list of fields that will be provided for each row.
    *     This is automatically populated with any general context
    *     keys, but you may need to add extra keys for token-row data.
-   *     ex: ['contactId', 'activity_id']. (Note we are standardising on the latter).
+   *     ex: ['contact_id', 'activity_id'].
    */
   public $context;
 


### PR DESCRIPTION
Overview
----------------------------------------
@aydun @eileenmcnaughton This is a follow up to #17161 that changes tokenProcessor context for `contactId` to `contact_id` so we don't have inconsistency in CiviCRM core.

Before
----------------------------------------
Inconsistent as we have `contactId` and `activity_id`.

After
----------------------------------------
Consistent.

Technical Details
----------------------------------------
It was decided in #17161 to change the format.

Comments
----------------------------------------
