### PR TITLE
[NFC] Add sr-only class for content only for screen readers

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -5,6 +5,20 @@
  * Other civi blocks outside the main container also have the class crm-container (but not the id)
  * All styles should start with .crm-container unless they are specific to the main div only
  */
+
+/* Use this class to hide text that should only be there for screen readers */
+.sr-only {
+   border: 0;
+   clip: rect(1px, 1px, 1px, 1px);
+   clip-path: inset(50%);
+   height: 1px;
+   width: 1px;
+   margin: -1px;
+   overflow: hidden;
+   padding: 0;
+   position: absolute;
+}
+
 .crm-container input {
   box-sizing: content-box;
 }


### PR DESCRIPTION
Overview
----------------------------------------
There are many places where an icon is used to visually indicate something important.  However, someone using a screen reader will not know what the icon is.

Historically, we had used image icons with alt text to handle this, but with modern icon frameworks, we can't do that.  Instead, the best practice is to add a `<span>` or other element where CSS will hide it.

This adds the `sr-only` class for something that should be seen by screen readers only.

Before
----------------------------------------
```html
{if $row.is_default eq 1}
  <img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>
{/if}
```

After
----------------------------------------
```html
{if $row.is_default eq 1}
  <i class="crm-i fa-check" title="{ts}Default{/ts}"></i><span class="sr-only">{ts}Default{/ts</span>
{/if}
```

Technical Details
----------------------------------------
You might think that `visibility: hidden` or `display: none` would be natural ways to hide stuff, but screen readers don't read those (in order to allow for something that really should be hidden from everyone).  Instead this new standard method clips the element to one square pixel, nudges it out by a pixel, and hides overflow.

Comments
----------------------------------------
For reference, see:
- https://webaim.org/techniques/css/invisiblecontent/
- https://www.nomensa.com/blog/2017/how-improve-web-accessibility-hiding-elements
