### PR TITLE
[NFC/Test] - Fix typo in `if` statement that seems intended as a workaround

### DIFF
--- a/tests/phpunit/CRM/Report/FormTest.php
+++ b/tests/phpunit/CRM/Report/FormTest.php
@@ -67,7 +67,7 @@ class CRM_Report_FormTest extends CiviUnitTestCase {
    */
   public function testGetFromTo($expectedFrom, $expectedTo, $relative, $from, $to) {
     $obj = new CRM_Report_Form();
-    if (date('H-i') === '00:00') {
+    if (date('Hi') === '0000') {
       $this->markTestIncomplete('The date might have changed since the dataprovider was called. Skip to avoid flakiness');
     }
     list($calculatedFrom, $calculatedTo) = $obj->getFromTo($relative, $from, $to);


### PR DESCRIPTION
Overview
----------------------------------------
This `if` statement seems to have been added to work around false negatives around midnight, but as written it would never be true. Seems like a typo.