### PR TITLE
dev/core#1681 Add in deprecation notice for Systems using MySQL versions before 5.7 and require 5.5 for install

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -45,6 +45,20 @@ class CRM_Upgrade_Incremental_General {
   const MIN_INSTALL_PHP_VER = '7.1.0';
 
   /**
+   * The minimum recommended MySQL/MariaDB version.
+   *
+   * A site running an earlier version will be told to upgrade.
+   */
+  const MIN_RECOMMENDED_MYSQL_VER = '5.7';
+
+  /**
+   * The minimum MySQL/MariaDB version required to install Civi.
+   *
+   * @see install/index.php
+   */
+  const MIN_INSTALL_MYSQL_VER = '5.5';
+
+  /**
    * Compute any messages which should be displayed before upgrade.
    *
    * @param string $preUpgradeMessage

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -935,4 +935,22 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     return $messages;
   }
 
+  public function checkMysqlVersion() {
+    $messages = [];
+    $version = CRM_Utils_SQL::getDatabaseVersion();
+    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), '5.7', '<')) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('This system uses MySQL/MariaDB version %1. To ensure the continued operation of CiviCRM, upgrade your server now. At least MySQL version %2 or MariaDB version %3 is recommended', [
+          1 => $version,
+          2 => '5.7',
+          3 => '10.1',
+        ]),
+        ts('MySQL Out of date'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+  }
+
 }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -938,12 +938,14 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   public function checkMysqlVersion() {
     $messages = [];
     $version = CRM_Utils_SQL::getDatabaseVersion();
-    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), '5.7', '<')) {
+    $minInstallVersion = CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER;
+    $minRecommendedVersion = CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_MYSQL_VER;
+    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minInstallVersion, '<')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('This system uses MySQL/MariaDB version %1. To ensure the continued operation of CiviCRM, upgrade your server now. At least MySQL version %2 or MariaDB version %3 is recommended', [
           1 => $version,
-          2 => '5.7',
+          2 => $minRecommendedVersion,
           3 => '10.1',
         ]),
         ts('MySQL Out of date'),
@@ -951,6 +953,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         'fa-server'
       );
     }
+    return $messages;
   }
 
 }

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -291,7 +291,7 @@ class Requirements {
    * @return array
    */
   public function checkMysqlVersion(array $db_config) {
-    $min = '5.1';
+    $min = CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER;
     $results = [
       'title' => 'CiviCRM MySQL Version',
       'severity' => $this::REQUIREMENT_OK,

--- a/install/index.php
+++ b/install/index.php
@@ -480,11 +480,11 @@ class InstallRequirements {
         )
       )
       ) {
-        @$this->requireMySQLVersion("5.1",
+        @$this->requireMySQLVersion(CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER,
           array(
             ts("MySQL %1 Configuration", array(1 => $dbName)),
-            ts("MySQL version at least %1", array(1 => '5.1')),
-            ts("MySQL version %1 or higher is required, you are running MySQL %2.", array(1 => '5.1', 2 => mysqli_get_server_info($this->conn))),
+            ts("MySQL version at least %1", array(1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER)),
+            ts("MySQL version %1 or higher is required, you are running MySQL %2.", array(1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER, 2 => mysqli_get_server_info($this->conn))),
             ts("MySQL %1", array(1 => mysqli_get_server_info($this->conn))),
           )
         );


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds in a system check for CiviCRM installs using MySQL versions before 5.7. This also sets the minimum install version to be 5.5 but we could make it 5.7 instead if preferred.

See also: https://lab.civicrm.org/dev/core/-/issues/1681

Before
----------------------------------------
No status check around MySQL version and minimum install version if MySQL 5.1

After
----------------------------------------
status check around MySQL version and minimum install version if MySQL 5.5

ping @eileenmcnaughton @totten 